### PR TITLE
test(gateway,httpproxy): cover client cancellation propagation to module backends

### DIFF
--- a/controlplane/gateway/proxy_context_test.go
+++ b/controlplane/gateway/proxy_context_test.go
@@ -1,0 +1,266 @@
+package gateway_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/yanet-platform/yanet2/controlplane/gateway"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// cancelProbeServiceName is the arbitrary, non-compiled service name the
+// fake module backend registers under.
+const cancelProbeServiceName = "yanet.test.CancelProbe"
+
+// cancelProbeFullMethod is the full method name a client dials to reach the
+// fake module backend's Probe handler.
+const cancelProbeFullMethod = "/" + cancelProbeServiceName + "/Probe"
+
+// ctxObservation is what a cancelProbeServer handler saw once the request
+// context it was given terminated.
+type ctxObservation struct {
+	err         error
+	deadline    time.Time
+	hasDeadline bool
+}
+
+// cancelProbeServer is the interface the registered handler is dispatched
+// through.
+type cancelProbeServer interface {
+	Probe(ctx context.Context, in *emptypb.Empty) (*emptypb.Empty, error)
+}
+
+// probeServer blocks its Probe handler on the request context, signaling
+// entry and then publishing the context's terminal state.
+type probeServer struct {
+	entered chan struct{}
+	results chan ctxObservation
+}
+
+func (m *probeServer) Probe(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
+	deadline, hasDeadline := ctx.Deadline()
+	m.entered <- struct{}{}
+	<-ctx.Done()
+	m.results <- ctxObservation{err: ctx.Err(), deadline: deadline, hasDeadline: hasDeadline}
+	return nil, ctx.Err()
+}
+
+// cancelProbeServiceDesc registers probeServer under an arbitrary service
+// name the gateway never compiled against, exercising the
+// UnknownServiceHandler proxy path rather than a statically routed one.
+var cancelProbeServiceDesc = grpc.ServiceDesc{
+	ServiceName: cancelProbeServiceName,
+	HandlerType: (*cancelProbeServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Probe",
+			Handler: func(srv any, ctx context.Context, dec func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+				in := new(emptypb.Empty)
+				if err := dec(in); err != nil {
+					return nil, err
+				}
+				return srv.(cancelProbeServer).Probe(ctx, in)
+			},
+		},
+	},
+	Metadata: "cancel_probe_test",
+}
+
+// newCancelProbeServer starts a gRPC server hosting cancelProbeServiceDesc
+// on a real TCP listener, returning its address plus the probe's entry and
+// result channels.
+func newCancelProbeServer(t *testing.T) (addr string, entered chan struct{}, results chan ctxObservation) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	entered = make(chan struct{}, 1)
+	results = make(chan ctxObservation, 1)
+
+	server := grpc.NewServer()
+	server.RegisterService(&cancelProbeServiceDesc, &probeServer{entered: entered, results: results})
+
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(server.Stop)
+
+	return listener.Addr().String(), entered, results
+}
+
+// startCancelProbeGateway starts a gateway and registers a fake module
+// backend under cancelProbeServiceName, returning the gateway's address
+// plus the probe's entry and result channels.
+func startCancelProbeGateway(t *testing.T) (gatewayAddr string, entered chan struct{}, results chan ctxObservation) {
+	t.Helper()
+
+	cfg := gateway.DefaultConfig()
+	cfg.Server.Endpoint = reserveTCPAddr(t)
+
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var group errgroup.Group
+	group.Go(func() error { return gw.Run(ctx) })
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, group.Wait())
+	})
+
+	// newCancelProbeServer registers t.Cleanup(server.Stop) here, after the
+	// run-group cleanup above. LIFO then stops the probe server before
+	// waiting on the group, so a handler still parked on its context
+	// unblocks instead of deadlocking the run-group wait.
+	backendAddr, entered, results := newCancelProbeServer(t)
+
+	registerConn, err := grpc.NewClient(cfg.Server.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = registerConn.Close() })
+
+	registerClient := ynpb.NewGatewayClient(registerConn)
+	// A fresh gRPC server is not immediately reachable after Run starts, so
+	// retry past a transient dial failure instead of requiring a fixed
+	// sleep.
+	require.Eventually(t, func() bool {
+		_, regErr := registerClient.Register(t.Context(), &ynpb.RegisterRequest{
+			Backend: &ynpb.BackendDesc{Name: cancelProbeServiceName, Endpoint: backendAddr},
+		})
+		return regErr == nil
+	}, 5*time.Second, 50*time.Millisecond, "failed to register the fake module backend with the gateway")
+
+	return cfg.Server.Endpoint, entered, results
+}
+
+// TestGateway_ProxiedRPC_ClientCancelPropagatesToBackendCtx verifies that
+// cancelling a proxied gRPC call's context cancels the backend handler's
+// context, and that the handler's context is not already dead beforehand.
+func TestGateway_ProxiedRPC_ClientCancelPropagatesToBackendCtx(t *testing.T) {
+	t.Parallel()
+
+	gatewayAddr, entered, results := startCancelProbeGateway(t)
+
+	conn, err := grpc.NewClient(gatewayAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		_ = conn.Invoke(ctx, cancelProbeFullMethod, &emptypb.Empty{}, &emptypb.Empty{})
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend handler was never entered")
+	}
+
+	select {
+	case observation := <-results:
+		t.Fatalf("backend handler observed termination before the client canceled: %v", observation.err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case observation := <-results:
+		require.ErrorIs(t, observation.err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend handler did not observe the client cancellation")
+	}
+}
+
+// TestGateway_ProxiedRPC_ClientDisconnectPropagatesToBackendCtx verifies
+// that closing the client connection mid-call cancels the backend
+// handler's context, exercising transport teardown rather than a client
+// cancel frame.
+func TestGateway_ProxiedRPC_ClientDisconnectPropagatesToBackendCtx(t *testing.T) {
+	t.Parallel()
+
+	gatewayAddr, entered, results := startCancelProbeGateway(t)
+
+	conn, err := grpc.NewClient(gatewayAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	go func() {
+		_ = conn.Invoke(t.Context(), cancelProbeFullMethod, &emptypb.Empty{}, &emptypb.Empty{})
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend handler was never entered")
+	}
+
+	select {
+	case observation := <-results:
+		t.Fatalf("backend handler observed termination before the client disconnected: %v", observation.err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	require.NoError(t, conn.Close())
+
+	select {
+	case observation := <-results:
+		require.ErrorIs(t, observation.err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend handler did not observe the dropped connection")
+	}
+}
+
+// TestGateway_ProxiedRPC_ClientDeadlinePropagatesToBackendCtx verifies that
+// a client-set deadline is genuinely derived into the backend handler's
+// context, landing close to the deadline the client actually set rather
+// than merely being cancelled once the call ends.
+func TestGateway_ProxiedRPC_ClientDeadlinePropagatesToBackendCtx(t *testing.T) {
+	t.Parallel()
+
+	gatewayAddr, entered, results := startCancelProbeGateway(t)
+
+	conn, err := grpc.NewClient(gatewayAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	const clientTimeout = 2 * time.Second
+	ctx, cancel := context.WithTimeout(t.Context(), clientTimeout)
+	defer cancel()
+
+	clientDeadline, ok := ctx.Deadline()
+	require.True(t, ok)
+
+	go func() {
+		_ = conn.Invoke(ctx, cancelProbeFullMethod, &emptypb.Empty{}, &emptypb.Empty{})
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend handler was never entered")
+	}
+
+	select {
+	case observation := <-results:
+		// observation.err is not asserted: the client's own timer wins the
+		// teardown race by a few hundred microseconds, about a millisecond
+		// under -race, since each hop's deadline is recomputed and rounded
+		// up later. Two independent samplers of the terminal error split
+		// both landed mostly on Canceled, one 17:3 and the other 11:1.
+		require.True(t, observation.hasDeadline, "backend handler ctx must carry a deadline")
+		require.WithinDuration(t, clientDeadline, observation.deadline, 50*time.Millisecond)
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend handler did not observe the deadline expiring")
+	}
+}

--- a/controlplane/httpproxy/context_test.go
+++ b/controlplane/httpproxy/context_test.go
@@ -1,0 +1,224 @@
+package httpproxy_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/siderolabs/grpc-proxy/proxy"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/httpproxy"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// ctxObservation is what a probe handler saw once the context it was given
+// terminated.
+type ctxObservation struct {
+	err error
+}
+
+// perfProbeServer blocks CountersService.Perf on the request context,
+// signaling entry and then publishing the context's terminal state.
+type perfProbeServer struct {
+	ynpb.UnimplementedCountersServiceServer
+	entered chan struct{}
+	results chan ctxObservation
+}
+
+func (m *perfProbeServer) Perf(ctx context.Context, _ *ynpb.PerfCountersRequest) (*ynpb.PerfCountersResponse, error) {
+	m.entered <- struct{}{}
+	<-ctx.Done()
+	m.results <- ctxObservation{err: ctx.Err()}
+	return nil, ctx.Err()
+}
+
+// watchProbeServer blocks ReadinessService.Watch on the stream context,
+// signaling entry and then publishing the context's terminal state.
+type watchProbeServer struct {
+	ynpb.UnimplementedReadinessServiceServer
+	entered chan struct{}
+	results chan ctxObservation
+}
+
+func (m *watchProbeServer) Watch(_ *readinesspb.ReadyRequest, stream ynpb.ReadinessService_WatchServer) error {
+	ctx := stream.Context()
+	m.entered <- struct{}{}
+	<-ctx.Done()
+	m.results <- ctxObservation{err: ctx.Err()}
+	return ctx.Err()
+}
+
+// passthroughBackend is a proxy.Backend that hands the given ctx straight
+// through to a real gRPC connection, standing in for the ctx-derivation the
+// gateway's own backend performs.
+type passthroughBackend struct {
+	conn *grpc.ClientConn
+}
+
+func (m passthroughBackend) String() string { return "passthrough-backend" }
+
+func (m passthroughBackend) GetConnection(ctx context.Context, _ string) (context.Context, *grpc.ClientConn, error) {
+	return ctx, m.conn, nil
+}
+
+func (m passthroughBackend) AppendInfo(_ bool, resp []byte) ([]byte, error) {
+	return resp, nil
+}
+
+func (m passthroughBackend) BuildError(_ bool, _ error) ([]byte, error) {
+	return nil, nil
+}
+
+// singleBackendRegistry is a BackendRegistry that always resolves to the
+// same backend, regardless of the requested service.
+type singleBackendRegistry struct {
+	backend proxy.Backend
+}
+
+func (m singleBackendRegistry) GetBackend(_ string) (proxy.Backend, func(), bool) {
+	return m.backend, func() {}, true
+}
+
+func (m singleBackendRegistry) HasBackend(_ string) bool { return true }
+
+// TestServeHTTP_ClientAbortPropagatesToBackendCtx verifies that aborting an
+// in-flight HTTP request cancels the backend gRPC handler's context.
+func TestServeHTTP_ClientAbortPropagatesToBackendCtx(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	entered := make(chan struct{}, 1)
+	results := make(chan ctxObservation, 1)
+
+	grpcServer := grpc.NewServer()
+	ynpb.RegisterCountersServiceServer(grpcServer, &perfProbeServer{entered: entered, results: results})
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(grpcServer.Stop)
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	handler := httpproxy.NewHTTPHandler(singleBackendRegistry{backend: passthroughBackend{conn: conn}})
+	server := httptest.NewServer(handler)
+	// conn.Close must run before server.Close: server.Close drains the
+	// in-flight HTTP request, which stays outstanding until closing conn
+	// unblocks the handler goroutine parked in conn.Invoke. Registering
+	// conn's cleanup after server.Close's here puts it first under LIFO.
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	reqCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(
+		reqCtx, http.MethodPost,
+		server.URL+"/api"+ynpb.CountersService_Perf_FullMethodName,
+		strings.NewReader("{}"),
+	)
+	require.NoError(t, err)
+
+	go func() {
+		resp, doErr := server.Client().Do(req)
+		if doErr == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend handler was never entered")
+	}
+
+	select {
+	case observation := <-results:
+		t.Fatalf("backend handler observed termination before the client aborted: %v", observation.err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case observation := <-results:
+		require.ErrorIs(t, observation.err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend handler did not observe the aborted HTTP request")
+	}
+}
+
+// TestServeHTTP_ClientAbortPropagatesToBackendCtx_Streaming verifies that
+// aborting an in-flight server-streaming HTTP request cancels the backend
+// gRPC handler's context, covering handleServerStreaming's own r.Context()
+// use alongside the unary path above. ReadinessService.Watch is the
+// server-streaming RPC already used as the streaming fixture elsewhere in
+// this package.
+func TestServeHTTP_ClientAbortPropagatesToBackendCtx_Streaming(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	entered := make(chan struct{}, 1)
+	results := make(chan ctxObservation, 1)
+
+	grpcServer := grpc.NewServer()
+	ynpb.RegisterReadinessServiceServer(grpcServer, &watchProbeServer{entered: entered, results: results})
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(grpcServer.Stop)
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	handler := httpproxy.NewHTTPHandler(singleBackendRegistry{backend: passthroughBackend{conn: conn}})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	reqCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(
+		reqCtx, http.MethodPost,
+		server.URL+"/api"+ynpb.ReadinessService_Watch_FullMethodName,
+		strings.NewReader("{}"),
+	)
+	require.NoError(t, err)
+
+	go func() {
+		resp, doErr := server.Client().Do(req)
+		if doErr == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend handler was never entered")
+	}
+
+	select {
+	case observation := <-results:
+		t.Fatalf("backend handler observed termination before the client aborted: %v", observation.err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case observation := <-results:
+		require.ErrorIs(t, observation.err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend handler did not observe the aborted HTTP request")
+	}
+}


### PR DESCRIPTION
The gateway already carries a client's request context intact down to a module backend, deriving it at every hop rather than replacing it, but nothing pinned that. A regression would have been invisible locally and would have surfaced in production as modules continuing to work for clients that had already gone away.

- Add three tests over the gRPC proxy path, driving a real fake module backend registered through the public registration RPC: the client cancelling its call, the client dropping its connection mid-call, and a client-set deadline reaching the backend handler.
- Add two tests over the HTTP-to-gRPC surface, one per handler, covering the server-streaming path that previously had no coverage at all despite reading the request context the same way as the unary one.
- Assert a negative window in every cancellation case, so a test fails rather than passes when the backend context merely dies at the end of the call instead of because the client went away.
- Pin the deadline case on the deadline the backend actually receives, which distinguishes a genuinely derived context from one that is only cancelled once the call finishes. Its terminal error is deliberately left unasserted, because the client's own timer wins the teardown race most of the time.

Every assertion was proven to fail under a mutation of the gateway's context derivation before being accepted, including a mutant that detaches the backend context from the client while still cancelling it on a timer, which the first draft of two of these tests passed.
