### PR TITLE
fix(controlplane): require an explicit dataplane instance for every module

### DIFF
--- a/common/go/xcfg/known_keys.go
+++ b/common/go/xcfg/known_keys.go
@@ -14,6 +14,13 @@ var yamlNodeType = reflect.TypeFor[yaml.Node]()
 
 var yamlUnmarshalerType = reflect.TypeFor[yaml.Unmarshaler]()
 
+// walkableType is implemented by a wrapper whose keys decode into a
+// different type than the wrapper itself, such as Optional[T], so the walk
+// can check that type's fields instead of stopping at isOpaqueToWalk.
+type walkableType interface {
+	WalkType() reflect.Type
+}
+
 // mergeTag is the resolved tag yaml.v3 assigns to a "<<" merge key.
 const mergeTag = "!!merge"
 
@@ -77,6 +84,10 @@ func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, unknown *[]stri
 		t = t.Elem()
 	}
 	if t.Kind() == reflect.Interface || t == yamlNodeType {
+		return
+	}
+	if wt, ok := reflect.Zero(t).Interface().(walkableType); ok {
+		walkKnownKeys(node, wt.WalkType(), path, unknown, visiting)
 		return
 	}
 	if isOpaqueToWalk(t) {

--- a/common/go/xcfg/known_keys.go
+++ b/common/go/xcfg/known_keys.go
@@ -12,19 +12,28 @@ import (
 
 var yamlNodeType = reflect.TypeFor[yaml.Node]()
 
+var yamlUnmarshalerType = reflect.TypeFor[yaml.Unmarshaler]()
+
 // mergeTag is the resolved tag yaml.v3 assigns to a "<<" merge key.
 const mergeTag = "!!merge"
 
 // CheckKnownKeys reports every YAML mapping key in data that has no matching
 // field in T.
 //
-// Unlike WithKnownFields, it walks the parsed node tree directly against T's
-// reflected shape instead of driving yaml.v3's own strict decoder, so it
-// keeps working across a field whose type implements UnmarshalYAML by
-// re-decoding through a fresh, non-strict decoder — the case
-// WithKnownFields is blind to. All unknown keys are collected into one
-// error, each as a dotted path rooted at the document.
+// It walks the parsed node tree directly against T's reflected shape
+// instead of driving yaml.v3's own strict decoder, so it keeps working
+// across a field whose type implements UnmarshalYAML by re-decoding
+// through a fresh, non-strict decoder. WithKnownFields runs the same walk
+// as part of Decode. All unknown keys are collected into one error, each
+// as a dotted path rooted at the document.
 func CheckKnownKeys[T any](data []byte) error {
+	return checkKnownKeys(data, reflect.TypeFor[T]())
+}
+
+// checkKnownKeys drives the same walk as CheckKnownKeys against a
+// reflect.Type, letting Decode reuse it for a destination value's runtime
+// type without a type parameter.
+func checkKnownKeys(data []byte, t reflect.Type) error {
 	var doc yaml.Node
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return fmt.Errorf("failed to parse yaml document: %w", err)
@@ -34,7 +43,7 @@ func CheckKnownKeys[T any](data []byte) error {
 	}
 
 	var unknown []string
-	walkKnownKeys(doc.Content[0], reflect.TypeFor[T](), "", &unknown, map[*yaml.Node]bool{})
+	walkKnownKeys(doc.Content[0], t, "", &unknown, map[*yaml.Node]bool{})
 	if len(unknown) == 0 {
 		return nil
 	}
@@ -68,6 +77,9 @@ func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, unknown *[]stri
 		t = t.Elem()
 	}
 	if t.Kind() == reflect.Interface || t == yamlNodeType {
+		return
+	}
+	if isOpaqueToWalk(t) {
 		return
 	}
 
@@ -151,6 +163,27 @@ func joinPath(path, key string) string {
 		return key
 	}
 	return path + "." + key
+}
+
+// isOpaqueToWalk reports whether t is a struct with no exported fields
+// whose pointer implements yaml.Unmarshaler.
+//
+// Such a type decodes entirely through its own method rather than the
+// default struct decoder, so the walk has no field set to check a mapping's
+// keys against and must leave them unreported. The implements-Unmarshaler
+// half of the check keeps a plain struct that only has unexported fields
+// and no custom decoding — which really does drop every key silently —
+// reported as unknown.
+func isOpaqueToWalk(t reflect.Type) bool {
+	if t.Kind() != reflect.Struct {
+		return false
+	}
+	for idx := range t.NumField() {
+		if t.Field(idx).IsExported() {
+			return false
+		}
+	}
+	return reflect.PointerTo(t).Implements(yamlUnmarshalerType)
 }
 
 // fieldSet maps a YAML key name to the Go type that decodes it.

--- a/common/go/xcfg/known_keys_test.go
+++ b/common/go/xcfg/known_keys_test.go
@@ -289,3 +289,30 @@ func Test_CheckKnownKeys_UnexportedStructWithUnmarshalYAMLNotFlagged(t *testing.
 	require.Equal(t, "x", out.Sub.Unwrap().A)
 	require.Equal(t, "y", out.Sub.Unwrap().B)
 }
+
+type optionalWrapped struct {
+	Sub xcfg.Optional[requiredWrappedInner] `yaml:"sub"`
+}
+
+// Test_CheckKnownKeys_OptionalSeesThroughToWrappedFields asserts that a
+// stray key nested inside an Optional[T] block is still reported.
+//
+// Optional[T] has the same unexported-field, UnmarshalYAML shape as
+// Required[T], which the previous test proves is otherwise treated as
+// opaque to the walk. Without Optional's WalkType hook this key would be
+// silently accepted instead, undoing WithKnownFields for every optional
+// module or device block.
+func Test_CheckKnownKeys_OptionalSeesThroughToWrappedFields(t *testing.T) {
+	input := "sub:\n  a: x\n  b: y\n  bogus: z\n"
+	err := xcfg.CheckKnownKeys[optionalWrapped]([]byte(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sub.bogus")
+}
+
+// Test_CheckKnownKeys_OptionalCleanDocumentNotFlagged is the positive
+// control for Test_CheckKnownKeys_OptionalSeesThroughToWrappedFields,
+// proving the hook does not over-report on a document with no stray keys.
+func Test_CheckKnownKeys_OptionalCleanDocumentNotFlagged(t *testing.T) {
+	input := "sub:\n  a: x\n  b: y\n"
+	require.NoError(t, xcfg.CheckKnownKeys[optionalWrapped]([]byte(input)))
+}

--- a/common/go/xcfg/known_keys_test.go
+++ b/common/go/xcfg/known_keys_test.go
@@ -266,3 +266,26 @@ another_free_key: value
 `
 	require.NoError(t, xcfg.CheckKnownKeys[knownKeysInlineMap]([]byte(input)))
 }
+
+type requiredWrappedInner struct {
+	A string `yaml:"a"`
+	B string `yaml:"b"`
+}
+
+type requiredWrapped struct {
+	Sub xcfg.Required[requiredWrappedInner] `yaml:"sub"`
+}
+
+func Test_CheckKnownKeys_UnexportedStructWithUnmarshalYAMLNotFlagged(t *testing.T) {
+	// Required[T] has only unexported fields but decodes a mapping through
+	// its own UnmarshalYAML — the walk must not report the mapping's keys
+	// as unknown just because Required[T] has no exported field set of its
+	// own.
+	input := "sub:\n  a: x\n  b: y\n"
+	require.NoError(t, xcfg.CheckKnownKeys[requiredWrapped]([]byte(input)))
+
+	var out requiredWrapped
+	require.NoError(t, yaml.Unmarshal([]byte(input), &out))
+	require.Equal(t, "x", out.Sub.Unwrap().A)
+	require.Equal(t, "y", out.Sub.Unwrap().B)
+}

--- a/common/go/xcfg/load.go
+++ b/common/go/xcfg/load.go
@@ -20,6 +20,14 @@ type validatable interface {
 	Validate() error
 }
 
+// validatableElem is implemented by a wrapper whose validation lives on the
+// value it wraps rather than on the wrapper itself, such as Optional[T],
+// letting validate recurse into that value under the wrapper's own dotted
+// path instead of stopping at the wrapper's unexported field.
+type validatableElem interface {
+	Elem() reflect.Value
+}
+
 // Option configures LoadConfig and Decode.
 type Option func(*options)
 
@@ -107,7 +115,6 @@ func validate(v reflect.Value, path string) error {
 		v = v.Elem()
 	}
 
-	// Check if the value itself implements validatable.
 	if v.CanAddr() {
 		if val, ok := v.Addr().Interface().(validatable); ok {
 			if err := val.Validate(); err != nil {
@@ -116,6 +123,19 @@ func validate(v reflect.Value, path string) error {
 				}
 				return &PathError{Path: path, Err: err}
 			}
+		}
+
+		// A wrapper whose wrapped value carries the validation recurses
+		// into that value under the same path, rather than being treated
+		// as a plain field with no Validate of its own. Checked after
+		// validatable so a wrapper implementing both still runs its own
+		// Validate.
+		if elemer, ok := v.Addr().Interface().(validatableElem); ok {
+			ev := elemer.Elem()
+			if !ev.IsValid() {
+				return nil
+			}
+			return validate(ev, path)
 		}
 	}
 

--- a/common/go/xcfg/load.go
+++ b/common/go/xcfg/load.go
@@ -36,14 +36,11 @@ func newOptions() *options {
 // WithKnownFields rejects YAML documents that contain keys not present in
 // the destination type.
 //
-// Without this option an unknown key is silently dropped, which lets typos
-// and renamed fields go unnoticed and leaves the corresponding field at its
-// default value. With this option such a key becomes a decode error, so a
-// stale or misspelled key in a deployed config fails loudly at startup
-// instead of silently keeping a default that may be wrong for the
-// environment. Strictness does not propagate into a field whose type
-// implements a custom UnmarshalYAML that decodes via node.Decode, because
-// yaml.v3 creates a fresh, non-strict decoder for that call.
+// Without this option an unknown key is silently dropped, letting typos and
+// renamed fields go unnoticed while the corresponding field silently keeps
+// its default. With this option such a key becomes a decode error, including
+// for a key nested under a field whose type implements a custom
+// UnmarshalYAML — see CheckKnownKeys for the mechanism.
 func WithKnownFields() Option {
 	return func(o *options) {
 		o.KnownFields = true
@@ -86,6 +83,10 @@ func Decode(buf []byte, dst any, options ...Option) error {
 		dec := yaml.NewDecoder(bytes.NewReader(buf))
 		dec.KnownFields(true)
 		if err := dec.Decode(dst); err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+
+		if err := checkKnownKeys(buf, reflect.TypeOf(dst)); err != nil {
 			return err
 		}
 	} else {

--- a/common/go/xcfg/load_test.go
+++ b/common/go/xcfg/load_test.go
@@ -2,9 +2,11 @@ package xcfg
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func Test_Load_Valid(t *testing.T) {
@@ -273,6 +275,58 @@ func Test_Decode_KnownFields_StillValidates(t *testing.T) {
 	var pathErr *PathError
 	require.ErrorAs(t, err, &pathErr)
 	require.Equal(t, "path", pathErr.Path)
+}
+
+// customUnmarshalInner mirrors a module Config's UnmarshalYAML: it
+// re-decodes through a plain alias, which is the shape yaml.v3's own
+// KnownFields decoder cannot see through.
+type customUnmarshalInner struct {
+	Addr NonEmptyString `yaml:"addr"`
+}
+
+func (m *customUnmarshalInner) UnmarshalYAML(node *yaml.Node) error {
+	type plain customUnmarshalInner
+	return node.Decode((*plain)(m))
+}
+
+func Test_Decode_KnownFields_ReachesCustomUnmarshalYAML(t *testing.T) {
+	// An unknown key nested under a field whose type implements
+	// UnmarshalYAML via node.Decode must still be caught with
+	// WithKnownFields, and must still be silently ignored without it.
+	type Config struct {
+		Name  NonEmptyString       `yaml:"name"`
+		Inner customUnmarshalInner `yaml:"inner"`
+	}
+
+	input := []byte("name: foo\ninner:\n  addr: bar\n  bogus: true\n")
+
+	var lenient Config
+	require.NoError(t, Decode(input, &lenient))
+
+	var strict Config
+	err := Decode(input, &strict, WithKnownFields())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "inner.bogus")
+}
+
+func Test_LoadConfig_KnownFields_ReachesCustomUnmarshalYAML(t *testing.T) {
+	// LoadConfig delegates to Decode, so the same reflection-walk coverage
+	// must hold when driven through a file path rather than an in-memory
+	// buffer.
+	type Config struct {
+		Name  NonEmptyString       `yaml:"name"`
+		Inner customUnmarshalInner `yaml:"inner"`
+	}
+
+	path := t.TempDir() + "/config.yaml"
+	require.NoError(t, os.WriteFile(path, []byte("name: foo\ninner:\n  addr: bar\n  bogus: true\n"), 0o600))
+
+	_, err := LoadConfig[Config](path)
+	require.NoError(t, err)
+
+	_, err = LoadConfig[Config](path, WithKnownFields())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "inner.bogus")
 }
 
 func Test_Load_LineErrorUnwrapsFromPathError(t *testing.T) {

--- a/common/go/xcfg/optional.go
+++ b/common/go/xcfg/optional.go
@@ -1,0 +1,85 @@
+package xcfg
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Optional is a wrapper around a value that may be absent from the source
+// document entirely, distinguishing that absence from a present zero value.
+type Optional[T any] struct {
+	v *T
+}
+
+// NewOptional wraps v as present.
+func NewOptional[T any](v T) Optional[T] {
+	return Optional[T]{v: &v}
+}
+
+// Unwrap returns the underlying value, or nil if the key was absent from
+// the document.
+func (m Optional[T]) Unwrap() *T {
+	return m.v
+}
+
+// String implements fmt.Stringer.
+func (m Optional[T]) String() string {
+	if m.v == nil {
+		return "<absent>"
+	}
+	return fmt.Sprint(*m.v)
+}
+
+// MarshalYAML implements yaml.Marshaler for round-trip serialization.
+func (m Optional[T]) MarshalYAML() (any, error) {
+	return m.v, nil
+}
+
+// MarshalJSON implements json.Marshaler.
+//
+// Without it, zap.Any's reflect-based encoding sees only the unexported
+// field and renders every Optional the same regardless of presence. This
+// delegates to the wrapped pointer so an absent value logs as null and a
+// present one logs as the value it wraps.
+func (m Optional[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.v)
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+//
+// An absent key never calls this method, so m.v stays nil. A present one
+// seeds a new T with its Default before decoding, so an omitted field
+// within it keeps that default.
+func (m *Optional[T]) UnmarshalYAML(node *yaml.Node) error {
+	v := new(T)
+	if d, ok := any(v).(defaultable); ok {
+		d.Default()
+	}
+	if err := node.Decode(v); err != nil {
+		return err
+	}
+	m.v = v
+	return nil
+}
+
+// WalkType implements walkableType, letting the unknown-key walker in
+// known_keys.go see through Optional to check T's own fields instead of
+// treating it as opaque.
+func (m Optional[T]) WalkType() reflect.Type {
+	return reflect.TypeFor[T]()
+}
+
+// Elem implements validatableElem, letting validate in load.go recurse into
+// the wrapped value's own fields under Optional's own dotted path.
+//
+// An absent Optional returns a zero Value, which validate treats as
+// nothing to check.
+func (m Optional[T]) Elem() reflect.Value {
+	if m.v == nil {
+		return reflect.Value{}
+	}
+	return reflect.ValueOf(m.v).Elem()
+}

--- a/common/go/xcfg/optional_test.go
+++ b/common/go/xcfg/optional_test.go
@@ -1,0 +1,111 @@
+package xcfg_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+)
+
+type optionalInner struct {
+	Name string `yaml:"name"`
+	Port int    `yaml:"port"`
+}
+
+func (m *optionalInner) Default() {
+	*m = optionalInner{Port: 8080}
+}
+
+// Test_Optional_AbsentKeyUnwrapsNil asserts that a document omitting the key
+// entirely leaves Unwrap returning nil, distinguishing absence from a
+// present zero value.
+func Test_Optional_AbsentKeyUnwrapsNil(t *testing.T) {
+	var out struct {
+		V xcfg.Optional[optionalInner] `yaml:"v"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("{}"), &out))
+	require.Nil(t, out.V.Unwrap())
+}
+
+// Test_Optional_PresentKeySeedsDefaultsBeforeDecode asserts that a present
+// key first seeds the wrapped value with its Default before decoding, so an
+// omitted field within it keeps that default rather than a zero value.
+func Test_Optional_PresentKeySeedsDefaultsBeforeDecode(t *testing.T) {
+	var out struct {
+		V xcfg.Optional[optionalInner] `yaml:"v"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("v:\n  name: foo\n"), &out))
+	require.NotNil(t, out.V.Unwrap())
+	require.Equal(t, "foo", out.V.Unwrap().Name)
+	require.Equal(t, 8080, out.V.Unwrap().Port)
+}
+
+// Test_Optional_NewOptionalRoundTrip asserts that a value built with
+// NewOptional decodes back to the same value through YAML.
+func Test_Optional_NewOptionalRoundTrip(t *testing.T) {
+	type doc struct {
+		V xcfg.Optional[optionalInner] `yaml:"v"`
+	}
+
+	original := doc{V: xcfg.NewOptional(optionalInner{Name: "bar", Port: 1})}
+
+	buf, err := yaml.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded doc
+	require.NoError(t, yaml.Unmarshal(buf, &decoded))
+	require.Equal(t, original.V.Unwrap(), decoded.V.Unwrap())
+}
+
+// Test_Optional_JSONDistinguishesAbsentFromPresent asserts that
+// MarshalJSON, which zap.Any relies on to log a config, renders an absent
+// Optional as null and a present one as the value it wraps, rather than
+// collapsing both to "{}" through the unexported field.
+func Test_Optional_JSONDistinguishesAbsentFromPresent(t *testing.T) {
+	var absent struct {
+		V xcfg.Optional[optionalInner] `yaml:"v"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("{}"), &absent))
+	buf, err := json.Marshal(absent.V)
+	require.NoError(t, err)
+	require.JSONEq(t, "null", string(buf))
+
+	present := xcfg.NewOptional(optionalInner{Name: "foo", Port: 1})
+	buf, err = json.Marshal(present)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"Name":"foo","Port":1}`, string(buf))
+}
+
+type optionalWithRequired struct {
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
+}
+
+// Test_Optional_DecodeValidatesWrappedField asserts that xcfg.Decode
+// recurses into a present Optional's own fields and reports a dotted path
+// rooted at the wrapper, proving validation is not swallowed by Optional's
+// unexported field the way an unrelated struct field would be.
+func Test_Optional_DecodeValidatesWrappedField(t *testing.T) {
+	type doc struct {
+		Module xcfg.Optional[optionalWithRequired] `yaml:"module"`
+	}
+
+	var out doc
+	err := xcfg.Decode([]byte("module: {}\n"), &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "module.instance_id")
+}
+
+// Test_Optional_DecodeAbsentSkipsValidation asserts that xcfg.Decode raises
+// no error for a document that omits the Optional entirely, even though its
+// wrapped type has a Required field.
+func Test_Optional_DecodeAbsentSkipsValidation(t *testing.T) {
+	type doc struct {
+		Module xcfg.Optional[optionalWithRequired] `yaml:"module"`
+	}
+
+	var out doc
+	require.NoError(t, xcfg.Decode([]byte("{}\n"), &out))
+}

--- a/common/go/xcfg/required.go
+++ b/common/go/xcfg/required.go
@@ -1,6 +1,7 @@
 package xcfg
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
@@ -41,6 +42,15 @@ func (m Required[T]) Validate() error {
 // MarshalYAML implements yaml.Marshaler for round-trip serialization.
 func (m Required[T]) MarshalYAML() (any, error) {
 	return m.v, nil
+}
+
+// MarshalJSON implements json.Marshaler.
+//
+// Without it, zap.Any's reflect-based encoding sees only the unexported
+// fields and renders every Required the same regardless of its value. This
+// delegates to the wrapped value so it logs the same as an unwrapped T.
+func (m Required[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.v)
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler, recording that a value was

--- a/common/go/xcfg/required.go
+++ b/common/go/xcfg/required.go
@@ -1,0 +1,56 @@
+package xcfg
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Required is a wrapper around a value that ensures it was set explicitly in
+// the source document, distinguishing an explicit zero value from an absent
+// one.
+type Required[T any] struct {
+	v   T
+	set bool
+}
+
+// NewRequired creates a new Required, marking it as explicitly set.
+func NewRequired[T any](v T) Required[T] {
+	return Required[T]{v: v, set: true}
+}
+
+// Unwrap returns the underlying value.
+func (m Required[T]) Unwrap() T {
+	return m.v
+}
+
+// String implements fmt.Stringer.
+func (m Required[T]) String() string {
+	return fmt.Sprint(m.v)
+}
+
+// Validate checks that the value was set explicitly.
+func (m Required[T]) Validate() error {
+	if !m.set {
+		return fmt.Errorf("value must be set explicitly")
+	}
+
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler for round-trip serialization.
+func (m Required[T]) MarshalYAML() (any, error) {
+	return m.v, nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler, recording that a value was
+// decoded.
+func (m *Required[T]) UnmarshalYAML(node *yaml.Node) error {
+	var out T
+	if err := node.Decode(&out); err != nil {
+		return fmt.Errorf("failed to decode required value: %w", err)
+	}
+
+	*m = Required[T]{v: out, set: true}
+	return nil
+}

--- a/common/go/xcfg/required_test.go
+++ b/common/go/xcfg/required_test.go
@@ -1,0 +1,92 @@
+package xcfg_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+)
+
+// Test_Required_UnmarshalAcceptsExplicitValue asserts that an explicit value
+// decodes and validates successfully.
+func Test_Required_UnmarshalAcceptsExplicitValue(t *testing.T) {
+	var out struct {
+		V xcfg.Required[uint32] `yaml:"v"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("v: 3"), &out))
+	require.NoError(t, out.V.Validate())
+	require.Equal(t, uint32(3), out.V.Unwrap())
+}
+
+// Test_Required_UnmarshalAcceptsExplicitZero asserts that an explicit zero
+// value is accepted, unlike NonZero.
+func Test_Required_UnmarshalAcceptsExplicitZero(t *testing.T) {
+	var out struct {
+		V xcfg.Required[uint32] `yaml:"v"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("v: 0"), &out))
+	require.NoError(t, out.V.Validate())
+	require.Equal(t, uint32(0), out.V.Unwrap())
+}
+
+// Test_Required_ValidateRejectsAbsentKey asserts that a document that omits
+// the key entirely fails validation.
+func Test_Required_ValidateRejectsAbsentKey(t *testing.T) {
+	var out struct {
+		V xcfg.Required[uint32] `yaml:"v"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("{}"), &out))
+	require.Error(t, out.V.Validate())
+}
+
+// Test_Required_ValidateRejectsNullValue asserts that a YAML null value,
+// which yaml.v3 does not route through UnmarshalYAML, also fails validation.
+func Test_Required_ValidateRejectsNullValue(t *testing.T) {
+	var out struct {
+		V xcfg.Required[uint32] `yaml:"v"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("v:"), &out))
+	require.Error(t, out.V.Validate())
+}
+
+// Test_Required_UnmarshalRejectsMalformedScalar asserts that a value that
+// cannot decode into the target type fails to unmarshal.
+func Test_Required_UnmarshalRejectsMalformedScalar(t *testing.T) {
+	var out struct {
+		V xcfg.Required[uint32] `yaml:"v"`
+	}
+	require.Error(t, yaml.Unmarshal([]byte("v: not-a-number"), &out))
+}
+
+// Test_Required_YAMLRoundTrip asserts that a marshaled Required decodes back
+// to the same explicit value.
+func Test_Required_YAMLRoundTrip(t *testing.T) {
+	type doc struct {
+		V xcfg.Required[uint32] `yaml:"v"`
+	}
+
+	original := doc{V: xcfg.NewRequired(uint32(5))}
+
+	buf, err := yaml.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded doc
+	require.NoError(t, yaml.Unmarshal(buf, &decoded))
+	require.Equal(t, original.V.Unwrap(), decoded.V.Unwrap())
+	require.NoError(t, decoded.V.Validate())
+}
+
+// Test_Required_LoadRejectsMissing asserts that xcfg.Decode surfaces a
+// dotted path naming the missing field.
+func Test_Required_LoadRejectsMissing(t *testing.T) {
+	type cfg struct {
+		Count xcfg.Required[int] `yaml:"count"`
+	}
+
+	var out cfg
+	err := xcfg.Decode([]byte("{}"), &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "count")
+}

--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -28,8 +28,12 @@ import (
 type serviceConstructor func() (gateway.Service, error)
 
 type serviceFactory struct {
-	name string
-	new  serviceConstructor
+	Name string
+	// Configured reports whether the corresponding config block was
+	// present in the loaded document. A factory with Configured == false
+	// is skipped: no service is constructed and no agent is attached.
+	Configured bool
+	New        serviceConstructor
 }
 
 // Bundle is the standard YANET distribution bundle of built-in modules and
@@ -87,80 +91,93 @@ func buildServices(
 ) ([]gateway.Service, error) {
 	factories := []serviceFactory{
 		{
-			name: "route module",
-			new: func() (gateway.Service, error) {
+			Name:       "route module",
+			Configured: modulesCfg.Route != nil,
+			New: func() (gateway.Service, error) {
 				return route.NewRouteModule(modulesCfg.Route, route.WithLog(log))
 			},
 		},
 		{
-			name: "route mpls module",
-			new: func() (gateway.Service, error) {
+			Name:       "route mpls module",
+			Configured: modulesCfg.RouteMPLS != nil,
+			New: func() (gateway.Service, error) {
 				return route_mpls.NewRouteMPLSModule(modulesCfg.RouteMPLS, route_mpls.WithLog(log))
 			},
 		},
 		{
-			name: "decap module",
-			new: func() (gateway.Service, error) {
+			Name:       "decap module",
+			Configured: modulesCfg.Decap != nil,
+			New: func() (gateway.Service, error) {
 				return decap.NewDecapModule(modulesCfg.Decap, decap.WithLog(log))
 			},
 		},
 		{
-			name: "dscp module",
-			new: func() (gateway.Service, error) {
+			Name:       "dscp module",
+			Configured: modulesCfg.DSCP != nil,
+			New: func() (gateway.Service, error) {
 				return dscp.NewDSCPModule(modulesCfg.DSCP, dscp.WithLog(log))
 			},
 		},
 		{
-			name: "forward module",
-			new: func() (gateway.Service, error) {
+			Name:       "forward module",
+			Configured: modulesCfg.Forward != nil,
+			New: func() (gateway.Service, error) {
 				return forward.NewForwardModule(modulesCfg.Forward, forward.WithLog(log))
 			},
 		},
 		{
-			name: "mirror module",
-			new: func() (gateway.Service, error) {
+			Name:       "mirror module",
+			Configured: modulesCfg.Mirror != nil,
+			New: func() (gateway.Service, error) {
 				return mirror.NewMirrorModule(modulesCfg.Mirror, mirror.WithLog(log))
 			},
 		},
 		{
-			name: "nat64 module",
-			new: func() (gateway.Service, error) {
+			Name:       "nat64 module",
+			Configured: modulesCfg.NAT64 != nil,
+			New: func() (gateway.Service, error) {
 				return nat64.NewNAT64Module(modulesCfg.NAT64, nat64.WithLog(log))
 			},
 		},
 		{
-			name: "pdump module",
-			new: func() (gateway.Service, error) {
+			Name:       "pdump module",
+			Configured: modulesCfg.Pdump != nil,
+			New: func() (gateway.Service, error) {
 				return pdump.NewPdumpModule(modulesCfg.Pdump, pdump.WithLog(log))
 			},
 		},
 		{
-			name: "acl module",
-			new: func() (gateway.Service, error) {
+			Name:       "acl module",
+			Configured: modulesCfg.ACL != nil,
+			New: func() (gateway.Service, error) {
 				return acl.NewACLModule(modulesCfg.ACL, acl.WithModuleLog(log))
 			},
 		},
 		{
-			name: "blackhole module",
-			new: func() (gateway.Service, error) {
+			Name:       "blackhole module",
+			Configured: modulesCfg.Blackhole != nil,
+			New: func() (gateway.Service, error) {
 				return blackhole.NewBlackholeModule(modulesCfg.Blackhole, blackhole.WithLog(log))
 			},
 		},
 		{
-			name: "plain device",
-			new: func() (gateway.Service, error) {
+			Name:       "plain device",
+			Configured: devicesCfg.Plain != nil,
+			New: func() (gateway.Service, error) {
 				return plain.NewDevicePlainDevice(devicesCfg.Plain, plain.WithLog(log))
 			},
 		},
 		{
-			name: "vlan device",
-			new: func() (gateway.Service, error) {
+			Name:       "vlan device",
+			Configured: devicesCfg.Vlan != nil,
+			New: func() (gateway.Service, error) {
 				return vlan.NewDeviceVlanDevice(devicesCfg.Vlan, vlan.WithLog(log))
 			},
 		},
 		{
-			name: "trafgen device",
-			new: func() (gateway.Service, error) {
+			Name:       "trafgen device",
+			Configured: devicesCfg.Trafgen != nil,
+			New: func() (gateway.Service, error) {
 				return trafgen.NewTrafgenDevice(devicesCfg.Trafgen, trafgen.WithLog(log))
 			},
 		},
@@ -169,9 +186,14 @@ func buildServices(
 	services := make([]gateway.Service, 0, len(factories))
 
 	for _, factory := range factories {
-		service, err := factory.new()
+		if !factory.Configured {
+			log.Info("skipping service with no config", zap.String("service", factory.Name))
+			continue
+		}
+
+		service, err := factory.New()
 		if err != nil {
-			return nil, fmt.Errorf("failed to initialize %s: %w", factory.name, err)
+			return nil, fmt.Errorf("failed to initialize %s: %w", factory.Name, err)
 		}
 
 		services = append(services, service)

--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -92,93 +92,93 @@ func buildServices(
 	factories := []serviceFactory{
 		{
 			Name:       "route module",
-			Configured: modulesCfg.Route != nil,
+			Configured: modulesCfg.Route.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return route.NewRouteModule(modulesCfg.Route, route.WithLog(log))
+				return route.NewRouteModule(modulesCfg.Route.Unwrap(), route.WithLog(log))
 			},
 		},
 		{
 			Name:       "route mpls module",
-			Configured: modulesCfg.RouteMPLS != nil,
+			Configured: modulesCfg.RouteMPLS.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return route_mpls.NewRouteMPLSModule(modulesCfg.RouteMPLS, route_mpls.WithLog(log))
+				return route_mpls.NewRouteMPLSModule(modulesCfg.RouteMPLS.Unwrap(), route_mpls.WithLog(log))
 			},
 		},
 		{
 			Name:       "decap module",
-			Configured: modulesCfg.Decap != nil,
+			Configured: modulesCfg.Decap.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return decap.NewDecapModule(modulesCfg.Decap, decap.WithLog(log))
+				return decap.NewDecapModule(modulesCfg.Decap.Unwrap(), decap.WithLog(log))
 			},
 		},
 		{
 			Name:       "dscp module",
-			Configured: modulesCfg.DSCP != nil,
+			Configured: modulesCfg.DSCP.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return dscp.NewDSCPModule(modulesCfg.DSCP, dscp.WithLog(log))
+				return dscp.NewDSCPModule(modulesCfg.DSCP.Unwrap(), dscp.WithLog(log))
 			},
 		},
 		{
 			Name:       "forward module",
-			Configured: modulesCfg.Forward != nil,
+			Configured: modulesCfg.Forward.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return forward.NewForwardModule(modulesCfg.Forward, forward.WithLog(log))
+				return forward.NewForwardModule(modulesCfg.Forward.Unwrap(), forward.WithLog(log))
 			},
 		},
 		{
 			Name:       "mirror module",
-			Configured: modulesCfg.Mirror != nil,
+			Configured: modulesCfg.Mirror.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return mirror.NewMirrorModule(modulesCfg.Mirror, mirror.WithLog(log))
+				return mirror.NewMirrorModule(modulesCfg.Mirror.Unwrap(), mirror.WithLog(log))
 			},
 		},
 		{
 			Name:       "nat64 module",
-			Configured: modulesCfg.NAT64 != nil,
+			Configured: modulesCfg.NAT64.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return nat64.NewNAT64Module(modulesCfg.NAT64, nat64.WithLog(log))
+				return nat64.NewNAT64Module(modulesCfg.NAT64.Unwrap(), nat64.WithLog(log))
 			},
 		},
 		{
 			Name:       "pdump module",
-			Configured: modulesCfg.Pdump != nil,
+			Configured: modulesCfg.Pdump.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return pdump.NewPdumpModule(modulesCfg.Pdump, pdump.WithLog(log))
+				return pdump.NewPdumpModule(modulesCfg.Pdump.Unwrap(), pdump.WithLog(log))
 			},
 		},
 		{
 			Name:       "acl module",
-			Configured: modulesCfg.ACL != nil,
+			Configured: modulesCfg.ACL.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return acl.NewACLModule(modulesCfg.ACL, acl.WithModuleLog(log))
+				return acl.NewACLModule(modulesCfg.ACL.Unwrap(), acl.WithModuleLog(log))
 			},
 		},
 		{
 			Name:       "blackhole module",
-			Configured: modulesCfg.Blackhole != nil,
+			Configured: modulesCfg.Blackhole.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return blackhole.NewBlackholeModule(modulesCfg.Blackhole, blackhole.WithLog(log))
+				return blackhole.NewBlackholeModule(modulesCfg.Blackhole.Unwrap(), blackhole.WithLog(log))
 			},
 		},
 		{
 			Name:       "plain device",
-			Configured: devicesCfg.Plain != nil,
+			Configured: devicesCfg.Plain.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return plain.NewDevicePlainDevice(devicesCfg.Plain, plain.WithLog(log))
+				return plain.NewDevicePlainDevice(devicesCfg.Plain.Unwrap(), plain.WithLog(log))
 			},
 		},
 		{
 			Name:       "vlan device",
-			Configured: devicesCfg.Vlan != nil,
+			Configured: devicesCfg.Vlan.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return vlan.NewDeviceVlanDevice(devicesCfg.Vlan, vlan.WithLog(log))
+				return vlan.NewDeviceVlanDevice(devicesCfg.Vlan.Unwrap(), vlan.WithLog(log))
 			},
 		},
 		{
 			Name:       "trafgen device",
-			Configured: devicesCfg.Trafgen != nil,
+			Configured: devicesCfg.Trafgen.Unwrap() != nil,
 			New: func() (gateway.Service, error) {
-				return trafgen.NewTrafgenDevice(devicesCfg.Trafgen, trafgen.WithLog(log))
+				return trafgen.NewTrafgenDevice(devicesCfg.Trafgen.Unwrap(), trafgen.WithLog(log))
 			},
 		},
 	}

--- a/controlplane/bundle/cfg.go
+++ b/controlplane/bundle/cfg.go
@@ -1,8 +1,6 @@
 package bundle
 
 import (
-	"fmt"
-
 	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
 	blackhole "github.com/yanet-platform/yanet2/modules/blackhole/controlplane"
 	decap "github.com/yanet-platform/yanet2/modules/decap/controlplane"
@@ -51,69 +49,4 @@ type DevicesConfig struct {
 	Vlan *vlan.Config `yaml:"vlan"`
 	// Trafgen is the configuration for the traffic generator device.
 	Trafgen *trafgen.Config `yaml:"trafgen"`
-}
-
-// DefaultModulesConfig returns the default config for the bundled modules.
-func DefaultModulesConfig() ModulesConfig {
-	return ModulesConfig{
-		Route:     route.DefaultConfig(),
-		RouteMPLS: route_mpls.DefaultConfig(),
-		Decap:     decap.DefaultConfig(),
-		DSCP:      dscp.DefaultConfig(),
-		Forward:   forward.DefaultConfig(),
-		Mirror:    mirror.DefaultConfig(),
-		NAT64:     nat64.DefaultConfig(),
-		Pdump:     pdump.DefaultConfig(),
-		ACL:       acl.DefaultConfig(),
-		Blackhole: blackhole.DefaultConfig(),
-	}
-}
-
-// DefaultDevicesConfig returns the default config for the bundled devices.
-func DefaultDevicesConfig() DevicesConfig {
-	return DevicesConfig{
-		Plain:   plain.DefaultConfig(),
-		Vlan:    vlan.DefaultConfig(),
-		Trafgen: trafgen.DefaultConfig(),
-	}
-}
-
-// Validate validates the modules config.
-func (m *ModulesConfig) Validate() error {
-	if m.Route == nil {
-		return fmt.Errorf("route module is not configured")
-	}
-	if m.Decap == nil {
-		return fmt.Errorf("decap module is not configured")
-	}
-	if m.DSCP == nil {
-		return fmt.Errorf("dscp module is not configured")
-	}
-	if m.Forward == nil {
-		return fmt.Errorf("forward module is not configured")
-	}
-	if m.Mirror == nil {
-		return fmt.Errorf("mirror module is not configured")
-	}
-	if m.NAT64 == nil {
-		return fmt.Errorf("nat64 module is not configured")
-	}
-	if m.ACL == nil {
-		return fmt.Errorf("acl module is not configured")
-	}
-	if m.Blackhole == nil {
-		return fmt.Errorf("blackhole module is not configured")
-	}
-	return nil
-}
-
-// Validate validates the devices config.
-func (m *DevicesConfig) Validate() error {
-	if m.Plain == nil {
-		return fmt.Errorf("plain device is not configured")
-	}
-	if m.Vlan == nil {
-		return fmt.Errorf("vlan device is not configured")
-	}
-	return nil
 }

--- a/controlplane/bundle/cfg.go
+++ b/controlplane/bundle/cfg.go
@@ -1,6 +1,10 @@
 package bundle
 
 import (
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	plain "github.com/yanet-platform/yanet2/devices/plain/controlplane"
+	trafgen "github.com/yanet-platform/yanet2/devices/trafgen/controlplane"
+	vlan "github.com/yanet-platform/yanet2/devices/vlan/controlplane"
 	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
 	blackhole "github.com/yanet-platform/yanet2/modules/blackhole/controlplane"
 	decap "github.com/yanet-platform/yanet2/modules/decap/controlplane"
@@ -11,42 +15,38 @@ import (
 	pdump "github.com/yanet-platform/yanet2/modules/pdump/controlplane"
 	route_mpls "github.com/yanet-platform/yanet2/modules/route-mpls/controlplane"
 	route "github.com/yanet-platform/yanet2/modules/route/controlplane"
-
-	plain "github.com/yanet-platform/yanet2/devices/plain/controlplane"
-	trafgen "github.com/yanet-platform/yanet2/devices/trafgen/controlplane"
-	vlan "github.com/yanet-platform/yanet2/devices/vlan/controlplane"
 )
 
 // ModulesConfig describes built-in modules in the standard YANET bundle.
 type ModulesConfig struct {
 	// Route is the configuration for the route module.
-	Route *route.Config `yaml:"route"`
+	Route xcfg.Optional[route.Config] `yaml:"route"`
 	// RouteMPLS is the configuration for the route mpls module.
-	RouteMPLS *route_mpls.Config `yaml:"route-mpls"`
+	RouteMPLS xcfg.Optional[route_mpls.Config] `yaml:"route-mpls"`
 	// Decap is the configuration for the decap module.
-	Decap *decap.Config `yaml:"decap"`
+	Decap xcfg.Optional[decap.Config] `yaml:"decap"`
 	// DSCP is the configuration for the dscp module.
-	DSCP *dscp.Config `yaml:"dscp"`
+	DSCP xcfg.Optional[dscp.Config] `yaml:"dscp"`
 	// Forward is the configuration for the forward module.
-	Forward *forward.Config `yaml:"forward"`
+	Forward xcfg.Optional[forward.Config] `yaml:"forward"`
 	// Mirror is the configuration for the mirror module.
-	Mirror *mirror.Config `yaml:"mirror"`
+	Mirror xcfg.Optional[mirror.Config] `yaml:"mirror"`
 	// NAT64 is the configuration for the NAT64 module.
-	NAT64 *nat64.Config `yaml:"nat64"`
+	NAT64 xcfg.Optional[nat64.Config] `yaml:"nat64"`
 	// Pdump is the configuration for the packet dump module.
-	Pdump *pdump.Config `yaml:"pdump"`
+	Pdump xcfg.Optional[pdump.Config] `yaml:"pdump"`
 	// ACL is the configuration for the acl module.
-	ACL *acl.Config `yaml:"acl"`
+	ACL xcfg.Optional[acl.Config] `yaml:"acl"`
 	// Blackhole is the configuration for the blackhole module.
-	Blackhole *blackhole.Config `yaml:"blackhole"`
+	Blackhole xcfg.Optional[blackhole.Config] `yaml:"blackhole"`
 }
 
 // DevicesConfig describes built-in devices in the standard YANET bundle.
 type DevicesConfig struct {
 	// Plain is the configuration for the plain device.
-	Plain *plain.Config `yaml:"plain"`
+	Plain xcfg.Optional[plain.Config] `yaml:"plain"`
 	// Vlan is the configuration for the vlan device.
-	Vlan *vlan.Config `yaml:"vlan"`
+	Vlan xcfg.Optional[vlan.Config] `yaml:"vlan"`
 	// Trafgen is the configuration for the traffic generator device.
-	Trafgen *trafgen.Config `yaml:"trafgen"`
+	Trafgen xcfg.Optional[trafgen.Config] `yaml:"trafgen"`
 }

--- a/controlplane/bundle/cfg_test.go
+++ b/controlplane/bundle/cfg_test.go
@@ -1,0 +1,73 @@
+package bundle_test
+
+import (
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/bundle"
+	decap "github.com/yanet-platform/yanet2/modules/decap/controlplane"
+)
+
+// Test_Decode_OnlyListedModulesArePresent asserts that decoding a document
+// listing only two modules leaves the other eight nil, that the listed ones
+// carry the instance_id given in the document, and that a listed module
+// omitting an optional field keeps its DefaultConfig value.
+func Test_Decode_OnlyListedModulesArePresent(t *testing.T) {
+	var cfg bundle.ModulesConfig
+	err := xcfg.Decode([]byte(`
+route:
+  instance_id: 2
+acl:
+  instance_id: 3
+`), &cfg)
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.Route)
+	require.NotNil(t, cfg.ACL)
+	require.Nil(t, cfg.RouteMPLS)
+	require.Nil(t, cfg.Decap)
+	require.Nil(t, cfg.DSCP)
+	require.Nil(t, cfg.Forward)
+	require.Nil(t, cfg.Mirror)
+	require.Nil(t, cfg.NAT64)
+	require.Nil(t, cfg.Pdump)
+	require.Nil(t, cfg.Blackhole)
+
+	require.Equal(t, uint32(2), cfg.Route.InstanceID.Unwrap())
+	require.Equal(t, uint32(3), cfg.ACL.InstanceID.Unwrap())
+
+	require.Equal(t, "/dev/hugepages/yanet", cfg.Route.MemoryPath.Unwrap())
+}
+
+// Test_NewBundle_EmptyConfig_NoServicesNoAgents asserts that a bundle built
+// from all-nil module and device config attaches no agent: it constructs no
+// service at all, so it never reaches ffi.AttachSharedMemory.
+func Test_NewBundle_EmptyConfig_NoServicesNoAgents(t *testing.T) {
+	b, err := bundle.NewBundle(bundle.ModulesConfig{}, bundle.DevicesConfig{})
+	require.NoError(t, err)
+	require.Empty(t, b.Services())
+}
+
+// Test_NewBundle_ConfiguredModuleWithBadPath_FailsNamingModule is a
+// positive control for the nil-skip in buildServices: a single configured
+// module still reaches its constructor and a bad memory_path surfaces as an
+// error naming that module, proving the skip isn't silently dropping every
+// module.
+func Test_NewBundle_ConfiguredModuleWithBadPath_FailsNamingModule(t *testing.T) {
+	cfg := bundle.ModulesConfig{
+		Decap: &decap.Config{
+			InstanceID:         xcfg.NewRequired(uint32(0)),
+			MemoryPath:         xcfg.MustNonEmptyString("/nonexistent/path/for/bundle/cfg/test"),
+			MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+			Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+			GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
+		},
+	}
+
+	_, err := bundle.NewBundle(cfg, bundle.DevicesConfig{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decap module")
+}

--- a/controlplane/bundle/cfg_test.go
+++ b/controlplane/bundle/cfg_test.go
@@ -25,21 +25,21 @@ acl:
 `), &cfg)
 	require.NoError(t, err)
 
-	require.NotNil(t, cfg.Route)
-	require.NotNil(t, cfg.ACL)
-	require.Nil(t, cfg.RouteMPLS)
-	require.Nil(t, cfg.Decap)
-	require.Nil(t, cfg.DSCP)
-	require.Nil(t, cfg.Forward)
-	require.Nil(t, cfg.Mirror)
-	require.Nil(t, cfg.NAT64)
-	require.Nil(t, cfg.Pdump)
-	require.Nil(t, cfg.Blackhole)
+	require.NotNil(t, cfg.Route.Unwrap())
+	require.NotNil(t, cfg.ACL.Unwrap())
+	require.Nil(t, cfg.RouteMPLS.Unwrap())
+	require.Nil(t, cfg.Decap.Unwrap())
+	require.Nil(t, cfg.DSCP.Unwrap())
+	require.Nil(t, cfg.Forward.Unwrap())
+	require.Nil(t, cfg.Mirror.Unwrap())
+	require.Nil(t, cfg.NAT64.Unwrap())
+	require.Nil(t, cfg.Pdump.Unwrap())
+	require.Nil(t, cfg.Blackhole.Unwrap())
 
-	require.Equal(t, uint32(2), cfg.Route.InstanceID.Unwrap())
-	require.Equal(t, uint32(3), cfg.ACL.InstanceID.Unwrap())
+	require.Equal(t, uint32(2), cfg.Route.Unwrap().InstanceID.Unwrap())
+	require.Equal(t, uint32(3), cfg.ACL.Unwrap().InstanceID.Unwrap())
 
-	require.Equal(t, "/dev/hugepages/yanet", cfg.Route.MemoryPath.Unwrap())
+	require.Equal(t, "/dev/hugepages/yanet", cfg.Route.Unwrap().MemoryPath.Unwrap())
 }
 
 // Test_NewBundle_EmptyConfig_NoServicesNoAgents asserts that a bundle built
@@ -58,13 +58,13 @@ func Test_NewBundle_EmptyConfig_NoServicesNoAgents(t *testing.T) {
 // module.
 func Test_NewBundle_ConfiguredModuleWithBadPath_FailsNamingModule(t *testing.T) {
 	cfg := bundle.ModulesConfig{
-		Decap: &decap.Config{
+		Decap: xcfg.NewOptional(decap.Config{
 			InstanceID:         xcfg.NewRequired(uint32(0)),
 			MemoryPath:         xcfg.MustNonEmptyString("/nonexistent/path/for/bundle/cfg/test"),
 			MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 			Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 			GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
-		},
+		}),
 	}
 
 	_, err := bundle.NewBundle(cfg, bundle.DevicesConfig{})

--- a/controlplane/cmd/yncp-director/main.go
+++ b/controlplane/cmd/yncp-director/main.go
@@ -53,7 +53,7 @@ func main() {
 }
 
 func run(cmd Cmd) error {
-	cfg, err := xcfg.LoadConfig[yncp.Config](cmd.ConfigPath)
+	cfg, err := xcfg.LoadConfig[yncp.Config](cmd.ConfigPath, xcfg.WithKnownFields())
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}

--- a/controlplane/etc/yanet/controlplane.d/default.yaml
+++ b/controlplane/etc/yanet/controlplane.d/default.yaml
@@ -10,6 +10,9 @@ logging:
 # communicate with dataplane.
 memory_path: &memory_path /dev/hugepages/yanet
 gateway:
+  # Which dataplane instance this gateway serves. Required, 0 is a valid
+  # value but must be written down.
+  instance_id: 0
   server:
     endpoint: &gateway_endpoint "[::1]:8080"
     http_endpoint: "[::1]:8081"
@@ -50,21 +53,81 @@ gateway:
     ttl: 5m
     # How often the eviction check runs.
     sweep_interval: 30s
+# A module listed below is started and attaches an agent to the named
+# dataplane instance; a module left out is not started at all.
+# instance_id is mandatory for every listed module.
 modules:
   route:
+    instance_id: 0
     # MemoryPath is the path to the shared-memory file that is used
     # to communicate with the dataplane.
     memory_path: *memory_path
     # Memory requirements for a single FIB-push transaction.
     memory_requirements: 16MB
     endpoint: "[::1]:0"
+  route-mpls:
+    instance_id: 0
+    memory_path: *memory_path
+    memory_requirements: 16MB
+    endpoint: "[::1]:0"
   decap:
+    instance_id: 0
+    memory_path: *memory_path
+    memory_requirements: 16MB
+    endpoint: "[::1]:0"
+    gateway_endpoint: *gateway_endpoint
+  dscp:
+    instance_id: 0
+    memory_path: *memory_path
+    memory_requirements: 16MB
+    endpoint: "[::1]:0"
+    gateway_endpoint: *gateway_endpoint
+  forward:
+    instance_id: 0
+    memory_path: *memory_path
+    memory_requirements: 16MB
+    endpoint: "[::1]:0"
+    gateway_endpoint: *gateway_endpoint
+  mirror:
+    instance_id: 0
+    memory_path: *memory_path
+    memory_requirements: 16MB
+    endpoint: "[::1]:0"
+    gateway_endpoint: *gateway_endpoint
+  nat64:
+    instance_id: 0
+    memory_path: *memory_path
+    memory_requirements: 16MB
+    endpoint: "[::1]:0"
+    gateway_endpoint: *gateway_endpoint
+  pdump:
+    instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
     endpoint: "[::1]:0"
     gateway_endpoint: *gateway_endpoint
   acl:
+    instance_id: 0
     memory_path: *memory_path
     memory_requirements: 8GB
+    endpoint: "[::1]:0"
+    gateway_endpoint: *gateway_endpoint
+  blackhole:
+    instance_id: 0
+    memory_path: *memory_path
+    memory_requirements: 4MB
+    endpoint: "[::1]:0"
+    gateway_endpoint: *gateway_endpoint
+devices:
+  plain:
+    instance_id: 0
+    memory_path: *memory_path
+    memory_requirements: 16MB
+    endpoint: "[::1]:0"
+    gateway_endpoint: *gateway_endpoint
+  vlan:
+    instance_id: 0
+    memory_path: *memory_path
+    memory_requirements: 16MB
     endpoint: "[::1]:0"
     gateway_endpoint: *gateway_endpoint

--- a/controlplane/gateway/cfg.go
+++ b/controlplane/gateway/cfg.go
@@ -22,7 +22,9 @@ const defaultRegistrySweepInterval = 30 * time.Second
 // Config is the configuration for the gateway.
 type Config struct {
 	// InstanceID specifies which dataplane instance this gateway serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: it must be set explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 	// Server is the configuration for the gateway server.
 	Server ServerConfig `yaml:"server"`
 	// Auth is the configuration for authentication and authorization.

--- a/controlplane/yncp/cfg.go
+++ b/controlplane/yncp/cfg.go
@@ -1,6 +1,8 @@
 package yncp
 
 import (
+	"errors"
+
 	"go.uber.org/zap/zapcore"
 
 	"github.com/yanet-platform/yanet2/common/go/logging"
@@ -27,6 +29,17 @@ type Config struct {
 
 func (m *Config) Default() {
 	*m = *DefaultConfig()
+}
+
+// Validate rejects a document that clears the defaulted gateway block, be it
+// a bare "gateway:" key or an explicit "gateway: null", either of which
+// yaml.v3 decodes into a nil Gateway rather than leaving the default intact.
+func (m *Config) Validate() error {
+	if m.Gateway == nil {
+		return errors.New("gateway: must not be empty or null")
+	}
+
+	return nil
 }
 
 func DefaultConfig() *Config {

--- a/controlplane/yncp/cfg.go
+++ b/controlplane/yncp/cfg.go
@@ -1,8 +1,6 @@
 package yncp
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"go.uber.org/zap/zapcore"
 
 	"github.com/yanet-platform/yanet2/common/go/logging"
@@ -10,8 +8,8 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/gateway"
 )
 
-type Config config
-type config struct {
+// Config is the control plane configuration.
+type Config struct {
 	// Logging configuration.
 	Logging logging.Config `json:"logging" yaml:"logging"`
 	// MemoryPath is the path to the shared-memory file that is used to
@@ -19,9 +17,11 @@ type config struct {
 	MemoryPath string `yaml:"memory_path"`
 	// Gateway configuration.
 	Gateway *gateway.Config `json:"gateway" yaml:"gateway"`
-	// Modules configuration.
+	// Modules configuration. A module absent from the document is not
+	// started.
 	Modules bundle.ModulesConfig `json:"modules" yaml:"modules"`
-	// Devices configuration.
+	// Devices configuration. A device absent from the document is not
+	// started.
 	Devices bundle.DevicesConfig `json:"devices" yaml:"devices"`
 }
 
@@ -36,29 +36,5 @@ func DefaultConfig() *Config {
 		},
 		MemoryPath: "/dev/hugepages/yanet",
 		Gateway:    gateway.DefaultConfig(),
-		Modules:    bundle.DefaultModulesConfig(),
-		Devices:    bundle.DefaultDevicesConfig(),
 	}
-}
-
-// UnmarshalYAML serves as a proxy for validation.
-//
-// To avoid infinite recursion, the validating wrapper casts itself to the
-// private config struct. This allows the decoder to operate on it using the
-// default behavior for handling Go structs without an unmarshal method.
-func (m *Config) UnmarshalYAML(value *yaml.Node) error {
-	err := value.Decode((*config)(m))
-	if err != nil {
-		return err
-	}
-	return m.Validate()
-}
-
-// Validate validates the control plane configuration.
-func (m *Config) Validate() error {
-	err := m.Modules.Validate()
-	if err != nil {
-		return err
-	}
-	return m.Devices.Validate()
 }

--- a/controlplane/yncp/cfg_test.go
+++ b/controlplane/yncp/cfg_test.go
@@ -49,8 +49,10 @@ func Test_ShippedDefaultConfig_LoadsIntendedEnabledSet(t *testing.T) {
 // Test_ModuleWithoutInstanceID_FailsValidation asserts that a listed module
 // omitting instance_id fails with a dotted path naming that module.
 func Test_ModuleWithoutInstanceID_FailsValidation(t *testing.T) {
-	var cfg yncp.Config
-	err := xcfg.Decode([]byte("modules:\n  route: {}\n"), &cfg)
+	input := "gateway:\n  instance_id: 0\n" +
+		"modules:\n  route: {}\n"
+	cfg := yncp.DefaultConfig()
+	err := xcfg.Decode([]byte(input), cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "modules.route.instance_id")
 }
@@ -62,6 +64,24 @@ func Test_GatewayWithoutInstanceID_FailsValidation(t *testing.T) {
 	err := xcfg.Decode([]byte("gateway: {}\n"), &cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "gateway.instance_id")
+}
+
+// Test_ExplicitNullGateway_FailsValidation asserts that a document clearing
+// the defaulted gateway block, either as a bare "gateway:" key or as an
+// explicit "gateway: null", fails to load with an error naming the gateway
+// instead of panicking on a nil dereference downstream.
+func Test_ExplicitNullGateway_FailsValidation(t *testing.T) {
+	for name, input := range map[string]string{
+		"bare key":   "gateway:\n",
+		"null value": "gateway: null\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := yncp.DefaultConfig()
+			err := xcfg.Decode([]byte(input), cfg)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "gateway")
+		})
+	}
 }
 
 // Test_ModuleBlock_StrayNestedKey_RejectedByKnownFields asserts that a key

--- a/controlplane/yncp/cfg_test.go
+++ b/controlplane/yncp/cfg_test.go
@@ -11,14 +11,55 @@ import (
 )
 
 // Test_ShippedDefaultConfig_NoUnknownKeys guards the shipped default config
-// against a key that matches no field in yncp.Config.
-//
-// Config.UnmarshalYAML re-decodes through a fresh, non-strict yaml.v3
-// decoder, so xcfg.WithKnownFields cannot see a stray key here.
-// xcfg.CheckKnownKeys walks the reflected struct shape directly instead,
-// which is unaffected by that re-decode.
+// against a key that matches no field in yncp.Config, including one nested
+// inside a module or device block whose own UnmarshalYAML re-decodes
+// through a fresh yaml.v3 decoder.
 func Test_ShippedDefaultConfig_NoUnknownKeys(t *testing.T) {
 	data, err := os.ReadFile("../etc/yanet/controlplane.d/default.yaml")
 	require.NoError(t, err)
 	require.NoError(t, xcfg.CheckKnownKeys[yncp.Config](data))
+}
+
+// Test_ShippedDefaultConfig_LoadsIntendedEnabledSet asserts that the shipped
+// default config starts all ten bundled modules plus the plain and vlan
+// devices, leaves trafgen disabled, and sets an explicit gateway instance.
+func Test_ShippedDefaultConfig_LoadsIntendedEnabledSet(t *testing.T) {
+	cfg, err := xcfg.LoadConfig[yncp.Config]("../etc/yanet/controlplane.d/default.yaml")
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.Modules.Route)
+	require.NotNil(t, cfg.Modules.RouteMPLS)
+	require.NotNil(t, cfg.Modules.Decap)
+	require.NotNil(t, cfg.Modules.DSCP)
+	require.NotNil(t, cfg.Modules.Forward)
+	require.NotNil(t, cfg.Modules.Mirror)
+	require.NotNil(t, cfg.Modules.NAT64)
+	require.NotNil(t, cfg.Modules.Pdump)
+	require.NotNil(t, cfg.Modules.ACL)
+	require.NotNil(t, cfg.Modules.Blackhole)
+
+	require.NotNil(t, cfg.Devices.Plain)
+	require.NotNil(t, cfg.Devices.Vlan)
+	require.Nil(t, cfg.Devices.Trafgen)
+
+	require.NoError(t, cfg.Gateway.InstanceID.Validate())
+	require.Equal(t, uint32(0), cfg.Gateway.InstanceID.Unwrap())
+}
+
+// Test_ModuleWithoutInstanceID_FailsValidation asserts that a listed module
+// omitting instance_id fails with a dotted path naming that module.
+func Test_ModuleWithoutInstanceID_FailsValidation(t *testing.T) {
+	var cfg yncp.Config
+	err := xcfg.Decode([]byte("modules:\n  route: {}\n"), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "modules.route.instance_id")
+}
+
+// Test_GatewayWithoutInstanceID_FailsValidation asserts that a gateway block
+// omitting instance_id fails with a dotted path naming the gateway.
+func Test_GatewayWithoutInstanceID_FailsValidation(t *testing.T) {
+	var cfg yncp.Config
+	err := xcfg.Decode([]byte("gateway: {}\n"), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gateway.instance_id")
 }

--- a/controlplane/yncp/cfg_test.go
+++ b/controlplane/yncp/cfg_test.go
@@ -27,20 +27,20 @@ func Test_ShippedDefaultConfig_LoadsIntendedEnabledSet(t *testing.T) {
 	cfg, err := xcfg.LoadConfig[yncp.Config]("../etc/yanet/controlplane.d/default.yaml")
 	require.NoError(t, err)
 
-	require.NotNil(t, cfg.Modules.Route)
-	require.NotNil(t, cfg.Modules.RouteMPLS)
-	require.NotNil(t, cfg.Modules.Decap)
-	require.NotNil(t, cfg.Modules.DSCP)
-	require.NotNil(t, cfg.Modules.Forward)
-	require.NotNil(t, cfg.Modules.Mirror)
-	require.NotNil(t, cfg.Modules.NAT64)
-	require.NotNil(t, cfg.Modules.Pdump)
-	require.NotNil(t, cfg.Modules.ACL)
-	require.NotNil(t, cfg.Modules.Blackhole)
+	require.NotNil(t, cfg.Modules.Route.Unwrap())
+	require.NotNil(t, cfg.Modules.RouteMPLS.Unwrap())
+	require.NotNil(t, cfg.Modules.Decap.Unwrap())
+	require.NotNil(t, cfg.Modules.DSCP.Unwrap())
+	require.NotNil(t, cfg.Modules.Forward.Unwrap())
+	require.NotNil(t, cfg.Modules.Mirror.Unwrap())
+	require.NotNil(t, cfg.Modules.NAT64.Unwrap())
+	require.NotNil(t, cfg.Modules.Pdump.Unwrap())
+	require.NotNil(t, cfg.Modules.ACL.Unwrap())
+	require.NotNil(t, cfg.Modules.Blackhole.Unwrap())
 
-	require.NotNil(t, cfg.Devices.Plain)
-	require.NotNil(t, cfg.Devices.Vlan)
-	require.Nil(t, cfg.Devices.Trafgen)
+	require.NotNil(t, cfg.Devices.Plain.Unwrap())
+	require.NotNil(t, cfg.Devices.Vlan.Unwrap())
+	require.Nil(t, cfg.Devices.Trafgen.Unwrap())
 
 	require.NoError(t, cfg.Gateway.InstanceID.Validate())
 	require.Equal(t, uint32(0), cfg.Gateway.InstanceID.Unwrap())
@@ -62,4 +62,21 @@ func Test_GatewayWithoutInstanceID_FailsValidation(t *testing.T) {
 	err := xcfg.Decode([]byte("gateway: {}\n"), &cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "gateway.instance_id")
+}
+
+// Test_ModuleBlock_StrayNestedKey_RejectedByKnownFields asserts that a key
+// nested inside a module's own block, not just at the document's top level,
+// is rejected when loading through the director's WithKnownFields path.
+func Test_ModuleBlock_StrayNestedKey_RejectedByKnownFields(t *testing.T) {
+	input := "modules:\n  decap:\n" +
+		"    instance_id: 0\n" +
+		"    memory_path: /dev/hugepages/yanet\n" +
+		"    memory_requirements: 16MB\n" +
+		"    endpoint: \"[::1]:0\"\n" +
+		"    gateway_endpoint: \"[::1]:8080\"\n" +
+		"    bogus: z\n"
+	var cfg yncp.Config
+	err := xcfg.Decode([]byte(input), &cfg, xcfg.WithKnownFields())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "modules.decap.bogus")
 }

--- a/controlplane/yncp/director.go
+++ b/controlplane/yncp/director.go
@@ -77,7 +77,7 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 
 	log.Debug("waiting for dataplane shared memory",
 		zap.String("path", cfg.MemoryPath),
-		zap.Uint32("instance_id", cfg.Gateway.InstanceID),
+		zap.Uint32("instance_id", cfg.Gateway.InstanceID.Unwrap()),
 	)
 	waitCtx, cancel := context.WithTimeout(context.Background(), dataplaneReadyTimeout)
 	defer cancel()
@@ -91,7 +91,7 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 			}
 			shm = attached
 		}
-		if !shm.DataplaneReady(cfg.Gateway.InstanceID) {
+		if !shm.DataplaneReady(cfg.Gateway.InstanceID.Unwrap()) {
 			return errors.New("dataplane shared memory not ready")
 		}
 		return nil
@@ -103,7 +103,7 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 		)
 	}
 	log.Info("dataplane shared memory ready",
-		zap.Uint32("instance_id", cfg.Gateway.InstanceID),
+		zap.Uint32("instance_id", cfg.Gateway.InstanceID.Unwrap()),
 	)
 
 	bundle, err := bundle.NewBundle(cfg.Modules, cfg.Devices, bundle.WithLog(log))
@@ -116,22 +116,22 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 			builtin.NewLogging(opts.LogLevel, builtin.WithLoggingLog(log)),
 		),
 		gateway.WithBuiltinService(
-			builtin.NewInspect(cfg.Gateway.InstanceID, shm),
+			builtin.NewInspect(cfg.Gateway.InstanceID.Unwrap(), shm),
 		),
 		gateway.WithBuiltinService(
-			builtin.NewPipeline(cfg.Gateway.InstanceID, shm, builtin.WithPipelineLog(log)),
+			builtin.NewPipeline(cfg.Gateway.InstanceID.Unwrap(), shm, builtin.WithPipelineLog(log)),
 		),
 		gateway.WithBuiltinService(
-			builtin.NewFunction(cfg.Gateway.InstanceID, shm, builtin.WithFunctionLog(log)),
+			builtin.NewFunction(cfg.Gateway.InstanceID.Unwrap(), shm, builtin.WithFunctionLog(log)),
 		),
 		gateway.WithBuiltinService(
-			builtin.NewCounters(cfg.Gateway.InstanceID, shm, builtin.WithCountersLog(log)),
+			builtin.NewCounters(cfg.Gateway.InstanceID.Unwrap(), shm, builtin.WithCountersLog(log)),
 		),
 		gateway.WithBuiltinService(
-			builtin.NewDevice(cfg.Gateway.InstanceID, shm),
+			builtin.NewDevice(cfg.Gateway.InstanceID.Unwrap(), shm),
 		),
 		gateway.WithBuiltinService(
-			builtin.NewMemory(cfg.Gateway.InstanceID, shm),
+			builtin.NewMemory(cfg.Gateway.InstanceID.Unwrap(), shm),
 		),
 		gateway.WithLog(log),
 		gateway.WithAtomicLogLevel(opts.LogLevel),

--- a/devices/plain/controlplane/cfg.go
+++ b/devices/plain/controlplane/cfg.go
@@ -1,6 +1,8 @@
 package plain
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -8,7 +10,9 @@ import (
 // Config represents plain device configuration
 type Config struct {
 	// InstanceID specifies which dataplane instance this device serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed device must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 
 	// MemoryPath is the path to the shared memory file
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -31,4 +35,15 @@ func DefaultConfig() *Config {
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// device that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/devices/plain/controlplane/cfg.go
+++ b/devices/plain/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package plain
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -37,13 +35,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// device that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/devices/plain/controlplane/mod.go
+++ b/devices/plain/controlplane/mod.go
@@ -54,11 +54,11 @@ func NewDevicePlainDevice(cfg *Config, options ...Option) (*DevicePlainDevice, e
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("plain", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach("plain", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/devices/trafgen/controlplane/cfg.go
+++ b/devices/trafgen/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package trafgen
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -33,13 +31,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// device that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/devices/trafgen/controlplane/cfg.go
+++ b/devices/trafgen/controlplane/cfg.go
@@ -1,6 +1,8 @@
 package trafgen
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -8,7 +10,9 @@ import (
 // Config represents trafgen device configuration.
 type Config struct {
 	// InstanceID specifies which dataplane instance this device serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed device must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -27,4 +31,15 @@ func DefaultConfig() *Config {
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// device that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/devices/trafgen/controlplane/mod.go
+++ b/devices/trafgen/controlplane/mod.go
@@ -61,11 +61,11 @@ func NewTrafgenDevice(cfg *Config, options ...Option) (*TrafgenDevice, error) {
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/devices/vlan/controlplane/cfg.go
+++ b/devices/vlan/controlplane/cfg.go
@@ -1,6 +1,8 @@
 package vlan
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -8,7 +10,9 @@ import (
 // Config represents VLAN device configuration
 type Config struct {
 	// InstanceID specifies which dataplane instance this device serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed device must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 
 	// MemoryPath is the path to the shared memory file
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -31,4 +35,15 @@ func DefaultConfig() *Config {
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// device that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/devices/vlan/controlplane/cfg.go
+++ b/devices/vlan/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package vlan
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -37,13 +35,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// device that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/devices/vlan/controlplane/mod.go
+++ b/devices/vlan/controlplane/mod.go
@@ -54,11 +54,11 @@ func NewDeviceVlanDevice(cfg *Config, options ...Option) (*DeviceVlanDevice, err
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("vlan", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach("vlan", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -46,3 +46,31 @@ running instance.
 Running more than one instance needs per-instance `endpoint`, `http_endpoint`
 and `memory_path` values in each config, and the operators point at
 `[::1]:8080` in their own configs.
+
+## `instance_id` is now mandatory on the gateway and on every module and device
+
+The gateway and every module or device block in the controlplane config now require an explicit `instance_id`, naming which dataplane instance that entry serves. `0` remains a perfectly valid value, it just has to be written down. A config that omits `instance_id` anywhere it applies fails to load, and the director refuses to start.
+
+This is a dpkg conffile, so an upgrade preserves your site-modified copy of `/etc/yanet2/controlplane.d/<name>.yaml` unchanged. Since every config written before this change predates `instance_id`, the director will refuse to start right after the package upgrade until you edit it in.
+
+The same change also makes the module and device list exhaustive: a module or device left out of the config is no longer started at all, and no longer attaches a shared-memory agent. Before this change every bundled module started regardless of whether the config mentioned it, defaulting to instance 0 — which is the production defect this fixes. Add an explicit block for every module and device you actually rely on; do not assume the old implicit set still starts.
+
+1. Add `instance_id` to the `gateway:` block and to every `modules:`/`devices:` entry in your site config:
+
+   ```yaml
+   gateway:
+     instance_id: 0
+     server:
+       endpoint: "[::1]:8080"
+     ...
+   modules:
+     route:
+       instance_id: 0
+       ...
+   devices:
+     plain:
+       instance_id: 0
+       ...
+   ```
+
+2. Add a block for every module and device your deployment actually uses, even if it previously relied on the implicit default set. Use the packaged `/etc/yanet2/controlplane.d/default.yaml` as the worked example of the new shape — it lists every bundled module and the `plain`/`vlan` devices with `instance_id: 0`, but omits `trafgen`. If your deployment uses the trafgen device, add its `instance_id`-carrying block yourself; the packaged example does not do it for you.

--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -107,8 +107,6 @@ maplit:operators/route/internal/discovery/neigh/neigh.go:newOptions:map[string]s
 private:common/go/operator/operator.go:NewOperator:opts.GRPCServer.cfg:1  # legacy: encapsulate behind an exported method or field
 private:common/go/operator/operator.go:NewOperator:opts.GRPCServer.cfg:2  # legacy: encapsulate behind an exported method or field
 private:common/go/operator/operator.go:NewOperator:opts.GRPCServer.services:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/bundle/bundle.go:buildServices:factory.name:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/bundle/bundle.go:buildServices:factory.new:1  # legacy: encapsulate behind an exported method or field
 private:controlplane/gateway/gateway.go:Gateway.Run:runner.module:1  # legacy: encapsulate behind an exported method or field
 private:controlplane/gateway/gateway.go:NewGateway:entry.kind:1  # legacy: encapsulate behind an exported method or field
 private:controlplane/gateway/gateway.go:NewGateway:entry.kind:2  # legacy: encapsulate behind an exported method or field

--- a/modules/acl/controlplane/cfg.go
+++ b/modules/acl/controlplane/cfg.go
@@ -1,6 +1,8 @@
 package acl
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -8,7 +10,9 @@ import (
 // Config represents ACL module configuration
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed module must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 	// MemoryPath is the path to the shared memory file
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 	// MemoryRequirements specifies memory requirements for the module
@@ -27,4 +31,15 @@ func DefaultConfig() *Config {
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// module that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/modules/acl/controlplane/cfg.go
+++ b/modules/acl/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package acl
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -33,13 +31,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// module that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -67,11 +67,11 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/blackhole/controlplane/cfg.go
+++ b/modules/blackhole/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package blackhole
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -36,13 +34,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// module that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/modules/blackhole/controlplane/cfg.go
+++ b/modules/blackhole/controlplane/cfg.go
@@ -1,6 +1,8 @@
 package blackhole
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -8,7 +10,9 @@ import (
 // Config represents Blackhole module configuration.
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed module must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 	// MemoryPath is the path to the shared memory file.
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 	// MemoryRequirements is the amount of memory required for a single
@@ -30,4 +34,15 @@ func DefaultConfig() *Config {
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// module that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/modules/blackhole/controlplane/mod.go
+++ b/modules/blackhole/controlplane/mod.go
@@ -60,11 +60,11 @@ func NewBlackholeModule(cfg *Config, options ...Option) (*BlackholeModule, error
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/decap/controlplane/cfg.go
+++ b/modules/decap/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package decap
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -32,13 +30,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// module that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/modules/decap/controlplane/cfg.go
+++ b/modules/decap/controlplane/cfg.go
@@ -1,13 +1,17 @@
 package decap
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed module must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -26,4 +30,15 @@ func DefaultConfig() *Config {
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// module that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/modules/decap/controlplane/mod.go
+++ b/modules/decap/controlplane/mod.go
@@ -54,11 +54,11 @@ func NewDecapModule(cfg *Config, options ...Option) (*DecapModule, error) {
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("decap", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach("decap", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/dscp/controlplane/cfg.go
+++ b/modules/dscp/controlplane/cfg.go
@@ -1,13 +1,17 @@
 package dscp
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed module must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -26,4 +30,15 @@ func DefaultConfig() *Config {
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// module that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/modules/dscp/controlplane/cfg.go
+++ b/modules/dscp/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package dscp
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -32,13 +30,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// module that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/modules/dscp/controlplane/mod.go
+++ b/modules/dscp/controlplane/mod.go
@@ -55,11 +55,11 @@ func NewDSCPModule(cfg *Config, options ...Option) (*DscpModule, error) {
 
 	log.Debug(
 		"mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("dscp", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach("dscp", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/forward/controlplane/cfg.go
+++ b/modules/forward/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package forward
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -32,13 +30,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// module that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/modules/forward/controlplane/cfg.go
+++ b/modules/forward/controlplane/cfg.go
@@ -1,13 +1,17 @@
 package forward
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed module must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -26,4 +30,15 @@ func DefaultConfig() *Config {
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// module that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/modules/forward/controlplane/mod.go
+++ b/modules/forward/controlplane/mod.go
@@ -61,11 +61,11 @@ func NewForwardModule(cfg *Config, options ...Option) (*ForwardModule, error) {
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/fwstate/controlplane/cfg.go
+++ b/modules/fwstate/controlplane/cfg.go
@@ -1,6 +1,8 @@
 package fwstate
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -8,7 +10,9 @@ import (
 // Config represents FWState module configuration
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed module must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 
 	// MemoryPath is the path to the shared memory file
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -31,4 +35,15 @@ func DefaultConfig() *Config {
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// module that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/modules/fwstate/controlplane/cfg.go
+++ b/modules/fwstate/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package fwstate
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -37,13 +35,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// module that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/modules/mirror/controlplane/cfg.go
+++ b/modules/mirror/controlplane/cfg.go
@@ -1,13 +1,17 @@
 package mirror
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed module must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -26,4 +30,15 @@ func DefaultConfig() *Config {
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// module that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/modules/mirror/controlplane/cfg.go
+++ b/modules/mirror/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package mirror
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -32,13 +30,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// module that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/modules/mirror/controlplane/mod.go
+++ b/modules/mirror/controlplane/mod.go
@@ -59,11 +59,11 @@ func NewMirrorModule(cfg *Config, options ...Option) (*MirrorModule, error) {
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/nat64/controlplane/cfg.go
+++ b/modules/nat64/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package nat64
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -37,13 +35,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// module that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/modules/nat64/controlplane/cfg.go
+++ b/modules/nat64/controlplane/cfg.go
@@ -1,6 +1,8 @@
 package nat64
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -8,7 +10,9 @@ import (
 // Config represents NAT64 module configuration
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed module must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 
 	// MemoryPath is the path to the shared memory file
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -31,4 +35,15 @@ func DefaultConfig() *Config {
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// module that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/modules/nat64/controlplane/mod.go
+++ b/modules/nat64/controlplane/mod.go
@@ -54,11 +54,11 @@ func NewNAT64Module(cfg *Config, options ...Option) (*NAT64Module, error) {
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("nat64", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach("nat64", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/pdump/controlplane/cfg.go
+++ b/modules/pdump/controlplane/cfg.go
@@ -1,13 +1,17 @@
 package pdump
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed module must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -28,4 +32,15 @@ func DefaultConfig() *Config {
 		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 		DebugEBPF:          false,
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// module that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/modules/pdump/controlplane/cfg.go
+++ b/modules/pdump/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package pdump
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -34,13 +32,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// module that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/modules/pdump/controlplane/mod.go
+++ b/modules/pdump/controlplane/mod.go
@@ -62,11 +62,11 @@ func NewPdumpModule(cfg *Config, options ...Option) (*PdumpModule, error) {
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach(moduleType, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(moduleType, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/route-mpls/controlplane/cfg.go
+++ b/modules/route-mpls/controlplane/cfg.go
@@ -1,6 +1,8 @@
 package route_mpls
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -8,7 +10,9 @@ import (
 // Config holds the configuration for the route-mpls control-plane module.
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed module must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file used to communicate
 	// with the dataplane.
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -26,4 +30,15 @@ func DefaultConfig() *Config {
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// module that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/modules/route-mpls/controlplane/cfg.go
+++ b/modules/route-mpls/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package route_mpls
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -32,13 +30,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// module that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/modules/route-mpls/controlplane/mod.go
+++ b/modules/route-mpls/controlplane/mod.go
@@ -60,11 +60,11 @@ func NewRouteMPLSModule(cfg *Config, options ...Option) (*RouteMPLSModule, error
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/route/controlplane/cfg.go
+++ b/modules/route/controlplane/cfg.go
@@ -1,8 +1,6 @@
 package route
 
 import (
-	"gopkg.in/yaml.v3"
-
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -38,13 +36,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
-// module that omits an optional field keeps its default.
-//
-// The plain alias drops Config's own UnmarshalYAML method so node.Decode
-// does not recurse into this method.
-func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+// Default resets Config to DefaultConfig.
+func (m *Config) Default() {
 	*m = *DefaultConfig()
-	type plain Config
-	return node.Decode((*plain)(m))
 }

--- a/modules/route/controlplane/cfg.go
+++ b/modules/route/controlplane/cfg.go
@@ -1,6 +1,8 @@
 package route
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
@@ -8,7 +10,9 @@ import (
 // Config is the route module shim configuration.
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID uint32 `yaml:"instance_id"`
+	//
+	// Required: a listed module must set it explicitly, even to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
@@ -32,4 +36,15 @@ func DefaultConfig() *Config {
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
 	}
+}
+
+// UnmarshalYAML seeds Config with DefaultConfig before decoding, so a listed
+// module that omits an optional field keeps its default.
+//
+// The plain alias drops Config's own UnmarshalYAML method so node.Decode
+// does not recurse into this method.
+func (m *Config) UnmarshalYAML(node *yaml.Node) error {
+	*m = *DefaultConfig()
+	type plain Config
+	return node.Decode((*plain)(m))
 }

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -66,11 +66,11 @@ func NewRouteModule(cfg *Config, options ...Option) (*RouteModule, error) {
 	}
 
 	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/operators/decap/internal/operator/cfg_test.go
+++ b/operators/decap/internal/operator/cfg_test.go
@@ -12,12 +12,9 @@ import (
 )
 
 // Test_ShippedDefaultConfig_NoUnknownKeys guards the shipped default config
-// against a key that matches no field in Config.
-//
-// FunctionConfig.UnmarshalYAML re-decodes through a fresh, non-strict
-// yaml.v3 decoder, so xcfg.WithKnownFields cannot see a stray key inside a
-// functions entry. xcfg.CheckKnownKeys walks the reflected struct shape
-// directly instead, which is unaffected by that re-decode.
+// against a key that matches no field in Config, including one nested
+// inside a functions entry whose FunctionConfig.UnmarshalYAML re-decodes
+// through a fresh yaml.v3 decoder.
 func Test_ShippedDefaultConfig_NoUnknownKeys(t *testing.T) {
 	data, err := os.ReadFile("../../etc/yanet/yanet-decap-operator-default.yaml")
 	require.NoError(t, err)

--- a/tests/functional/framework/harness.go
+++ b/tests/functional/framework/harness.go
@@ -106,6 +106,7 @@ logging:
   level: debug
 
 gateway:
+  instance_id: 0
   server:
     endpoint: "0.0.0.0:8080"
   auth:
@@ -113,28 +114,42 @@ gateway:
 
 modules:
   route:
-    link_map:
-      kni0: 01:00.0
+    instance_id: 0
     memory_requirements: 8MB
   route-mpls:
+    instance_id: 0
     memory_requirements: 8MB
   decap:
+    instance_id: 0
     memory_requirements: 8MB
   dscp:
+    instance_id: 0
     memory_requirements: 8MB
   forward:
+    instance_id: 0
     memory_requirements: 8MB
   nat64:
+    instance_id: 0
     memory_requirements: 8MB
   pdump:
+    instance_id: 0
     memory_requirements: 8MB
   acl:
+    instance_id: 0
     memory_requirements: 16MB
+  mirror:
+    instance_id: 0
+    memory_requirements: 8MB
+  blackhole:
+    instance_id: 0
+    memory_requirements: 8MB
 
 devices:
   plain:
+    instance_id: 0
     memory_requirements: 8MB
   vlan:
+    instance_id: 0
     memory_requirements: 8MB
 `
 }

--- a/tests/functional/framework/harness_default_config_test.go
+++ b/tests/functional/framework/harness_default_config_test.go
@@ -29,20 +29,20 @@ func TestDefaultControlplaneConfig_StartsIntendedSet(t *testing.T) {
 	err := xcfg.Decode([]byte(framework.DefaultControlplaneConfig()), cfg, xcfg.WithKnownFields())
 	require.NoError(t, err)
 
-	require.NotNil(t, cfg.Modules.Route)
-	require.NotNil(t, cfg.Modules.RouteMPLS)
-	require.NotNil(t, cfg.Modules.Decap)
-	require.NotNil(t, cfg.Modules.DSCP)
-	require.NotNil(t, cfg.Modules.Forward)
-	require.NotNil(t, cfg.Modules.NAT64)
-	require.NotNil(t, cfg.Modules.Pdump)
-	require.NotNil(t, cfg.Modules.ACL)
-	require.NotNil(t, cfg.Modules.Mirror)
-	require.NotNil(t, cfg.Modules.Blackhole)
+	require.NotNil(t, cfg.Modules.Route.Unwrap())
+	require.NotNil(t, cfg.Modules.RouteMPLS.Unwrap())
+	require.NotNil(t, cfg.Modules.Decap.Unwrap())
+	require.NotNil(t, cfg.Modules.DSCP.Unwrap())
+	require.NotNil(t, cfg.Modules.Forward.Unwrap())
+	require.NotNil(t, cfg.Modules.NAT64.Unwrap())
+	require.NotNil(t, cfg.Modules.Pdump.Unwrap())
+	require.NotNil(t, cfg.Modules.ACL.Unwrap())
+	require.NotNil(t, cfg.Modules.Mirror.Unwrap())
+	require.NotNil(t, cfg.Modules.Blackhole.Unwrap())
 
-	require.NotNil(t, cfg.Devices.Plain)
-	require.NotNil(t, cfg.Devices.Vlan)
+	require.NotNil(t, cfg.Devices.Plain.Unwrap())
+	require.NotNil(t, cfg.Devices.Vlan.Unwrap())
 	// Trafgen is deliberately absent from the harness config, matching the
 	// shipped default: the harness never relied on it.
-	require.Nil(t, cfg.Devices.Trafgen)
+	require.Nil(t, cfg.Devices.Trafgen.Unwrap())
 }

--- a/tests/functional/framework/harness_default_config_test.go
+++ b/tests/functional/framework/harness_default_config_test.go
@@ -1,0 +1,48 @@
+package framework_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/yncp"
+	"github.com/yanet-platform/yanet2/tests/functional/framework"
+)
+
+// TestDefaultControlplaneConfig_NoUnknownKeys guards the functional harness's
+// baseline controlplane YAML against a key that matches no field in
+// yncp.Config, the same check the director now applies at startup.
+func TestDefaultControlplaneConfig_NoUnknownKeys(t *testing.T) {
+	require.NoError(t, xcfg.CheckKnownKeys[yncp.Config]([]byte(framework.DefaultControlplaneConfig())))
+}
+
+// TestDefaultControlplaneConfig_StartsIntendedSet decodes the harness's
+// baseline controlplane YAML through the same path the director's main()
+// drives, and asserts every module and device the YAML lists actually
+// starts, since an absent modules/devices key now means the module or
+// device is not started at all.
+func TestDefaultControlplaneConfig_StartsIntendedSet(t *testing.T) {
+	cfg := &yncp.Config{}
+	cfg.Default()
+
+	err := xcfg.Decode([]byte(framework.DefaultControlplaneConfig()), cfg, xcfg.WithKnownFields())
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.Modules.Route)
+	require.NotNil(t, cfg.Modules.RouteMPLS)
+	require.NotNil(t, cfg.Modules.Decap)
+	require.NotNil(t, cfg.Modules.DSCP)
+	require.NotNil(t, cfg.Modules.Forward)
+	require.NotNil(t, cfg.Modules.NAT64)
+	require.NotNil(t, cfg.Modules.Pdump)
+	require.NotNil(t, cfg.Modules.ACL)
+	require.NotNil(t, cfg.Modules.Mirror)
+	require.NotNil(t, cfg.Modules.Blackhole)
+
+	require.NotNil(t, cfg.Devices.Plain)
+	require.NotNil(t, cfg.Devices.Vlan)
+	// Trafgen is deliberately absent from the harness config, matching the
+	// shipped default: the harness never relied on it.
+	require.Nil(t, cfg.Devices.Trafgen)
+}


### PR DESCRIPTION
A module absent from the control-plane configuration was still constructed from its defaults, and its zero-valued instance made it attach a shared-memory agent to instance 0. Measured in production: a control plane configured entirely for instance 1 owned eight agents on instance 0, none of which appeared in its own configuration, each contending on a lock the operator believed was not in use.

A module or device left out of the configuration is now genuinely absent — no service is constructed and no agent is attached, and the skip is logged. One that is listed must name its dataplane instance explicitly, as must the gateway. Instance 0 remains a valid value, it simply has to be written down, which is why the new configuration type accepts an explicit zero and rejects only an absent one.

Because an absent block now decides whether a module runs at all, the director rejects a key matching no field instead of silently dropping it. Without that, a misspelled module name would quietly become a module that never starts, trading a wrong-instance attach for a silent traffic blackhole. The existing strictness option gained the reflection-based check it always claimed to perform, so a stray key nested inside a module block is caught too.

**This is a breaking configuration change.** The packaged configuration is a dpkg conffile, so a site-modified copy is preserved across the upgrade and every existing one predates this requirement: the control plane will refuse to start until each listed module, device and the gateway names its instance. Operators must also add an explicit block for every module they rely on, since the previously implicit set is no longer started. `docs/upgrade.md` carries the migration steps.

The packaged configuration now enumerates every module it used to start implicitly, plus the plain and vlan devices, so a deployment running it unmodified keeps its behaviour. The trafgen device is deliberately no longer started by default; a deployment that wants it adds the block.

The second commit removes the duplication the first one introduced. Seeding a block's defaults before decoding it had been written once per module, each copy needing a local type alias to keep the decoder from re-entering the method that called it. A generic wrapper holds the value instead: being a different type from the one it wraps, it decodes without recursion and without the alias, leaving each module a single line naming its defaults. The wrapper hides its value from both configuration walkers, so each gained a way to see through it — without that, an unknown key nested in a module block would have stopped being reported and a missing dataplane instance would have stopped being rejected, with every test still passing.

Closes #1918.