### PR TITLE
fix(counters): pin the config generation for unlocked counter value reads

### DIFF
--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1677,14 +1677,48 @@ free_counter_values(uint64_t **values, uint64_t instance_count) {
 	free(values);
 }
 
+// Copy one already-described counter's per-worker value snapshot into
+// newly allocated memory, stashed behind the handle's opaque value array.
+//
+// The caller guarantees the per-worker storages stay alive for the
+// duration of this call.
+static int
+counter_handle_copy_values(
+	struct counter_handle *dst,
+	struct counter_storage **worker_storages,
+	uint64_t worker_count,
+	uint64_t idx
+) {
+	uint64_t **values = calloc(worker_count, sizeof(*values));
+	if (values == NULL) {
+		return -1;
+	}
+	for (uint64_t w_idx = 0; w_idx < worker_count; ++w_idx) {
+		if (dst->size == 0) {
+			continue;
+		}
+		values[w_idx] = malloc(dst->size * sizeof(uint64_t));
+		if (values[w_idx] == NULL) {
+			free_counter_values(values, worker_count);
+			return -1;
+		}
+		struct counter_value_handle *handle =
+			counter_get_value_handle(idx, worker_storages[w_idx]);
+		memcpy(values[w_idx],
+		       counter_handle_get_value(handle),
+		       dst->size * sizeof(uint64_t));
+	}
+	dst->values = values;
+	return 0;
+}
+
 // Snapshot a counter's per-worker values into heap memory and stash the
 // result behind the opaque counter_handle.values.
 //
 // Each worker has its own single-instance storage. The caller gathers one
-// storage per worker into worker_storages (a plain C-pointer array). The
-// values are copied out of generation-owned shm while the caller still holds
-// cp_config_lock, so the snapshot (worker_count entries) stays valid across
-// controlplane updates until it is released by yanet_counter_handle_list_free.
+// storage per worker into worker_storages (a plain C-pointer array). These
+// storages are dataplane-owned and outlive every configuration generation,
+// so no lock or generation pin is required around this call.
 static int
 fill_counter_handle(
 	struct counter_handle *dst,
@@ -1706,110 +1740,155 @@ fill_counter_handle(
 	dst->tags = tags;
 	dst->tag_count = tag_count;
 
-	uint64_t **values = calloc(worker_count, sizeof(*values));
-	if (values == NULL) {
+	return counter_handle_copy_values(
+		dst, worker_storages, worker_count, idx
+	);
+}
+
+// Per-worker counter storages matching one tag predicate.
+//
+// Each worker's entry is a NULL-terminated array of matches, or NULL for
+// a worker without an execution context. Every worker registry is built
+// by the same execution-context traversal, so the match order is
+// identical across workers: for match index i, every worker's array
+// names the same tag set at that index.
+struct worker_counter_matches {
+	struct cp_counter_storage ***by_worker;
+	uint64_t worker_count;
+};
+
+static void
+worker_counter_matches_free(struct worker_counter_matches *matches) {
+	if (matches->by_worker == NULL) {
+		return;
+	}
+	for (uint64_t w_idx = 0; w_idx < matches->worker_count; ++w_idx) {
+		free(matches->by_worker[w_idx]);
+	}
+	free(matches->by_worker);
+	matches->by_worker = NULL;
+}
+
+// Collect the per-worker counter storages matching a tag predicate.
+//
+// The generation MUST stay pinned by the caller for the whole call, since
+// this only follows registries reachable through it.
+static int
+worker_counter_matches_collect(
+	struct cp_config_gen *config_gen,
+	uint64_t worker_count,
+	const struct counter_tag *tags,
+	size_t tag_count,
+	struct worker_counter_matches *out,
+	yanet_error **err
+) {
+	out->worker_count = worker_count;
+	out->by_worker = calloc(worker_count, sizeof(*out->by_worker));
+	if (out->by_worker == NULL) {
+		yanet_error_add(err, "malloc failed");
 		return -1;
 	}
-	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
-		if (counters[idx].size == 0) {
+
+	for (uint64_t w_idx = 0; w_idx < worker_count; ++w_idx) {
+		struct config_gen_ectx *ectx =
+			cp_config_gen_worker_ectx(config_gen, w_idx);
+		if (ectx == NULL) {
+			out->by_worker[w_idx] = NULL;
 			continue;
 		}
-		values[worker_idx] =
-			malloc(counters[idx].size * sizeof(uint64_t));
-		if (values[worker_idx] == NULL) {
-			free_counter_values(values, worker_count);
+		out->by_worker[w_idx] = cp_config_counter_storage_registry_find(
+			ADDR_OF(&ectx->counter_storage_registry),
+			tags,
+			tag_count,
+			err
+		);
+		if (out->by_worker[w_idx] == NULL) {
 			return -1;
 		}
-		struct counter_value_handle *handle = counter_get_value_handle(
-			idx, worker_storages[worker_idx]
-		);
-		memcpy(values[worker_idx],
-		       counter_handle_get_value(handle),
-		       counters[idx].size * sizeof(uint64_t));
 	}
-	dst->values = values;
 	return 0;
 }
 
-struct counter_handle_list *
-yanet_get_counters_by_tags(
-	struct dp_config *dp_config,
-	const struct counter_tag *tags,
-	size_t tag_count,
-	const char *const *query,
-	size_t query_count,
-	yanet_error **err
+// Bookkeeping needed to find a matched counter's per-worker storages again
+// during the value-copy pass, since a handle list keeps only a counter's
+// name, size, generation and tags.
+struct matched_counter {
+	size_t m_idx;
+	uint64_t r_idx;
+};
+
+// Allocate a handle list sized for match_count handles and zero it.
+//
+// Sets instance_count and count on success. The caller still owns filling
+// in each handle.
+static struct counter_handle_list *
+counter_handle_list_alloc(
+	uint64_t instance_count, size_t match_count, yanet_error **err
 ) {
-	struct cp_config *cp_config = ADDR_OF(&dp_config->cp_config);
-	cp_config_lock(cp_config);
-
-	struct cp_config_gen *cp_config_gen =
-		ADDR_OF(&cp_config->cp_config_gen);
-	uint64_t worker_count = dp_config->worker_count;
-
-	// Find matching counter storages in each worker's registry.
-	//
-	// Every worker registry is built by the same ectx traversal, so the
-	// tag-set match order is identical across workers: for match index i,
-	// worker_matches[w][i] holds the same tag-set for every worker w.
-	struct cp_counter_storage ***worker_matches =
-		calloc(worker_count, sizeof(*worker_matches));
-	if (worker_matches == NULL) {
-		yanet_error_add(err, "malloc failed");
-		cp_config_unlock(cp_config);
-		return NULL;
-	}
-
-	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
-		struct config_gen_ectx *ectx =
-			cp_config_gen_worker_ectx(cp_config_gen, worker_idx);
-		if (ectx == NULL) {
-			worker_matches[worker_idx] = NULL;
-			continue;
-		}
-		worker_matches[worker_idx] =
-			cp_config_counter_storage_registry_find(
-				ADDR_OF(&ectx->counter_storage_registry),
-				tags,
-				tag_count,
-				err
-			);
-		if (worker_matches[worker_idx] == NULL) {
-			goto err_matches;
-		}
-	}
-
-	// Use worker 0's matches as the reference. When worker 0 has no ectx
-	// (e.g. the initial config gen before any install), return an empty
-	// list.
-	struct cp_counter_storage **matches0 =
-		worker_count > 0 ? worker_matches[0] : NULL;
-
-	size_t match_count = 0;
-	if (matches0 != NULL) {
-		for (size_t i = 0; matches0[i] != NULL; ++i) {
-			struct counter_storage *storage =
-				ADDR_OF(&matches0[i]->storage);
-			match_count += counter_registry_match_count(
-				ADDR_OF(&storage->registry), query, query_count
-			);
-		}
-	}
-
 	size_t list_size = sizeof(struct counter_handle_list) +
 			   sizeof(struct counter_handle) * match_count;
 	struct counter_handle_list *list =
 		(struct counter_handle_list *)malloc(list_size);
 	if (list == NULL) {
 		yanet_error_add(err, "malloc failed");
-		goto err_matches;
+		return NULL;
 	}
 	memset(list, 0, list_size);
-	list->instance_count = worker_count;
+	list->instance_count = instance_count;
 	list->count = match_count;
+	return list;
+}
+
+// Count the matches, allocate the handle list, and fill every handle's
+// name, size, generation and tags.
+//
+// Leaves every handle's value snapshot unset, which a later pass fills
+// in. On success, fills out_sources with one entry per handle, in the same
+// order as the list, for the value-copy pass to consume.
+static struct counter_handle_list *
+counter_handle_list_build_metadata(
+	const struct worker_counter_matches *matches,
+	const char *const *query,
+	size_t query_count,
+	struct matched_counter **out_sources,
+	yanet_error **err
+) {
+	// A worker set with no execution context yet (the initial generation
+	// before any install) yields an empty list.
+	if (matches->worker_count == 0 || matches->by_worker[0] == NULL) {
+		*out_sources = NULL;
+		return counter_handle_list_alloc(matches->worker_count, 0, err);
+	}
+	struct cp_counter_storage **matches0 = matches->by_worker[0];
+
+	size_t match_count = 0;
+	for (size_t i = 0; matches0[i] != NULL; ++i) {
+		struct counter_storage *storage =
+			ADDR_OF(&matches0[i]->storage);
+		match_count += counter_registry_match_count(
+			ADDR_OF(&storage->registry), query, query_count
+		);
+	}
+
+	struct counter_handle_list *list = counter_handle_list_alloc(
+		matches->worker_count, match_count, err
+	);
+	if (list == NULL) {
+		return NULL;
+	}
+
+	struct matched_counter *sources = NULL;
+	if (match_count > 0) {
+		sources = malloc(match_count * sizeof(*sources));
+		if (sources == NULL) {
+			yanet_error_add(err, "malloc failed");
+			free(list);
+			return NULL;
+		}
+	}
 
 	size_t next = 0;
-	for (size_t i = 0; matches0 != NULL && matches0[i] != NULL; ++i) {
+	for (size_t i = 0; matches0[i] != NULL; ++i) {
 		struct cp_counter_storage *cp_storage = matches0[i];
 		struct counter_storage *storage = ADDR_OF(&cp_storage->storage);
 		struct counter_registry *registry = ADDR_OF(&storage->registry);
@@ -1821,60 +1900,137 @@ yanet_get_counters_by_tags(
 			    )) {
 				continue;
 			}
-			struct counter_storage **worker_storages =
-				malloc(worker_count * sizeof(*worker_storages));
-			if (worker_storages == NULL) {
-				yanet_error_add(err, "malloc failed");
-				goto err_list;
-			}
 			if (storage_tags == NULL) {
 				storage_tags =
 					cp_counter_storage_copy_tags(cp_storage
 					);
 				if (storage_tags == NULL) {
-					free(worker_storages);
 					yanet_error_add(err, "malloc failed");
-					goto err_list;
+					free(sources);
+					yanet_counter_handle_list_free(list);
+					return NULL;
 				}
 			}
-			for (uint64_t worker_idx = 0; worker_idx < worker_count;
-			     ++worker_idx) {
-				worker_storages[worker_idx] = ADDR_OF(
-					&worker_matches[worker_idx][i]->storage
-				);
-			}
-			int fill_result = fill_counter_handle(
-				&list->counters[next++],
-				worker_storages,
-				worker_count,
-				idx,
-				storage_tags,
-				cp_storage->tag_count
-			);
-			free(worker_storages);
-			if (fill_result) {
-				yanet_error_add(err, "malloc failed");
-				goto err_list;
-			}
+			struct counter_handle *dst = &list->counters[next];
+			const struct counter *src = &counters[idx];
+			strtcpy(dst->name, src->name, sizeof(dst->name));
+			dst->size = src->size;
+			dst->gen = src->gen;
+			dst->tags = storage_tags;
+			dst->tag_count = cp_storage->tag_count;
+			sources[next] = (struct matched_counter){
+				.m_idx = i,
+				.r_idx = idx,
+			};
+			++next;
 		}
 	}
 
-	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
-		free(worker_matches[worker_idx]);
-	}
-	free(worker_matches);
-	cp_config_unlock(cp_config);
+	*out_sources = sources;
 	return list;
+}
 
-err_list:
-	yanet_counter_handle_list_free(list);
-err_matches:
-	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
-		free(worker_matches[worker_idx]);
+// Copy every matched counter's per-worker value snapshot into the list
+// built by the metadata pass.
+static int
+counter_handle_list_fill_values(
+	struct counter_handle_list *list,
+	const struct worker_counter_matches *matches,
+	const struct matched_counter *sources,
+	yanet_error **err
+) {
+	uint64_t worker_count = matches->worker_count;
+	struct counter_storage **worker_storages =
+		worker_count > 0
+			? malloc(worker_count * sizeof(*worker_storages))
+			: NULL;
+	if (worker_count > 0 && worker_storages == NULL) {
+		yanet_error_add(err, "malloc failed");
+		return -1;
 	}
-	free(worker_matches);
+
+	for (uint64_t k = 0; k < list->count; ++k) {
+		size_t m_idx = sources[k].m_idx;
+		uint64_t r_idx = sources[k].r_idx;
+		for (uint64_t w_idx = 0; w_idx < worker_count; ++w_idx) {
+			struct cp_counter_storage *cps =
+				matches->by_worker[w_idx][m_idx];
+			worker_storages[w_idx] = ADDR_OF(&cps->storage);
+		}
+		if (counter_handle_copy_values(
+			    &list->counters[k],
+			    worker_storages,
+			    worker_count,
+			    r_idx
+		    )) {
+			yanet_error_add(err, "malloc failed");
+			free(worker_storages);
+			return -1;
+		}
+	}
+	free(worker_storages);
+	return 0;
+}
+
+// Match the tag and name predicates against the active configuration generation
+// and return every matching counter's metadata and per-worker values.
+//
+// The config lock is held only long enough to acquire the generation pin
+// at the start and to drop it again at the end. The pin itself stays held
+// for the whole call: matching, allocation and the value copy all run
+// unlocked against the pinned generation, so a concurrent config update
+// can retire and replace it mid-call without disturbing this read.
+struct counter_handle_list *
+yanet_get_counters_by_tags(
+	struct dp_config *dp_config,
+	const struct counter_tag *tags,
+	size_t tag_count,
+	const char *const *query,
+	size_t query_count,
+	yanet_error **err
+) {
+	struct cp_config *cp_config = ADDR_OF(&dp_config->cp_config);
+
+	cp_config_lock(cp_config);
+	uint64_t worker_count = dp_config->worker_count;
+	struct cp_config_gen *config_gen = cp_config_gen_acquire(cp_config);
 	cp_config_unlock(cp_config);
-	return NULL;
+
+	struct worker_counter_matches matches = {
+		.by_worker = NULL,
+		.worker_count = 0,
+	};
+	struct counter_handle_list *list = NULL;
+	struct matched_counter *sources = NULL;
+
+	if (worker_counter_matches_collect(
+		    config_gen, worker_count, tags, tag_count, &matches, err
+	    )) {
+		goto out;
+	}
+
+	list = counter_handle_list_build_metadata(
+		&matches, query, query_count, &sources, err
+	);
+	if (list == NULL) {
+		goto out;
+	}
+
+	if (counter_handle_list_fill_values(list, &matches, sources, err)) {
+		yanet_counter_handle_list_free(list);
+		list = NULL;
+		goto out;
+	}
+
+out:
+	free(sources);
+	worker_counter_matches_free(&matches);
+
+	cp_config_lock(cp_config);
+	cp_config_gen_release(cp_config, config_gen);
+	cp_config_unlock(cp_config);
+
+	return list;
 }
 
 struct counter_handle_list *

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -90,6 +90,9 @@ cp_config_gen_new_from(
 	new_config_gen->gen = old_config_gen->gen + 1;
 	new_config_gen->config_gen_ectx_count = 0;
 	new_config_gen->config_gen_ectxs = NULL;
+	// Starts pinned by its own eventual current-published status, the
+	// same pin publish later transfers rather than adds to.
+	new_config_gen->refcnt = 1;
 
 	SET_OFFSET_OF(
 		&new_config_gen->dp_config, ADDR_OF(&old_config_gen->dp_config)
@@ -197,6 +200,15 @@ cp_config_gen_free(
 	);
 }
 
+void
+cp_config_gen_release(
+	struct cp_config *cp_config, struct cp_config_gen *config_gen
+) {
+	if (--config_gen->refcnt == 0) {
+		cp_config_gen_free(cp_config, config_gen);
+	}
+}
+
 static inline int
 cp_config_gen_install(
 	struct dp_config *dp_config,
@@ -223,7 +235,13 @@ cp_config_gen_install(
 	// pointer before its contents are fully written.
 	ATOMIC_SET_OFFSET_OF(&cp_config->cp_config_gen, new_config_gen);
 	dp_config_wait_for_gen(dp_config, new_config_gen->gen);
-	cp_config_gen_free(cp_config, old_config_gen);
+
+	// The new generation already carries the pin it was created with, so
+	// publishing it as current spends that pin rather than adding one.
+	// Dropping the old generation's own matching pin here frees it
+	// immediately, unless an unlocked reader is still pinning it too, in
+	// which case that reader's later release finishes the teardown.
+	cp_config_gen_release(cp_config, old_config_gen);
 
 	return 0;
 }
@@ -868,6 +886,10 @@ cp_config_gen_new(struct agent *agent, yanet_error **err) {
 	cp_config_gen->gen = 0;
 	cp_config_gen->config_gen_ectx_count = 0;
 	cp_config_gen->config_gen_ectxs = NULL;
+	// The bootstrap generation is installed directly by its caller
+	// rather than through the publish path, so it starts pinned by its
+	// own current-published status just like every later generation.
+	cp_config_gen->refcnt = 1;
 	SET_OFFSET_OF(
 		&cp_config_gen->dp_config, ADDR_OF(&cp_config->dp_config)
 	);

--- a/lib/controlplane/config/zone.h
+++ b/lib/controlplane/config/zone.h
@@ -57,6 +57,14 @@ struct cp_config_gen {
 	struct cp_pipeline_registry pipeline_registry;
 	struct cp_device_registry device_registry;
 	struct cp_object_registry object_registry;
+
+	// Number of holders pinning this generation alive, read and mutated
+	// only while the config lock is held.
+	//
+	// The currently published generation always counts one holder for
+	// itself, so a pin taken by an unlocked reader keeps a racing update
+	// from tearing the generation down until the pin is released too.
+	uint64_t refcnt;
 };
 
 /*
@@ -228,6 +236,29 @@ cp_config_delete_object(
 
 struct cp_config_gen *
 cp_config_gen_new(struct agent *agent, yanet_error **err);
+
+// Pin the currently published generation for use outside the config lock.
+//
+// MUST be called with the config lock held. Every acquire MUST be matched
+// by exactly one release, no matter how long the unlocked window that
+// follows runs or whether a config update replaces this generation as
+// current during that window.
+static inline struct cp_config_gen *
+cp_config_gen_acquire(struct cp_config *cp_config) {
+	struct cp_config_gen *config_gen = ADDR_OF(&cp_config->cp_config_gen);
+	config_gen->refcnt += 1;
+	return config_gen;
+}
+
+// Release a pin, freeing the generation once no pin remains.
+//
+// MUST be called with the config lock held. A generation that lost its
+// current-published status while pinned is freed here instead of at
+// publish time, once its last pin drops.
+void
+cp_config_gen_release(
+	struct cp_config *cp_config, struct cp_config_gen *config_gen
+);
 
 static inline struct cp_module *
 cp_config_gen_get_module(struct cp_config_gen *config_gen, uint64_t index) {

--- a/lib/controlplane/tests/counters_lock_test.c
+++ b/lib/controlplane/tests/counters_lock_test.c
@@ -1,0 +1,655 @@
+/*
+ * Regression tests for GH#1914: the tagged counter read must not hold the
+ * config lock across its matching, allocation and per-counter value-copy
+ * work, and the generation pin protecting that unlocked window must not
+ * let a racing config swap tear down a generation a read still touches.
+ *
+ * Installs enough pipeline counter storages that the unlocked work
+ * dominates the call, then checks lock-hold ordering, pin correctness
+ * under concurrent real config swaps, and that a pin's release never
+ * leaks a retired generation.
+ */
+
+#include "api/agent.h"
+#include "api/counter.h"
+
+#include "common/test_assert.h"
+#include "controlplane/agent/agent.h"
+#include "devices/plain/api/controlplane.h"
+#include "lib/controlplane/config/cp_pipeline.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/errors/errors.h"
+#include "logging/log.h"
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#define LOCK_TEST_CP_MEMORY (512u * 1024u * 1024u)
+#define LOCK_TEST_DP_MEMORY (16u * 1024u * 1024u)
+#define LOCK_TEST_AGENT_MEMORY (16u * 1024u * 1024u)
+#define LOCK_TEST_WORKER_COUNT 4
+#define LOCK_TEST_PIPELINE_COUNT 1000
+// Each length-0 pipeline registers 6 counters: input, output, drop,
+// input histogram, pending_input, pending_output.
+#define LOCK_TEST_COUNTERS_PER_PIPELINE 6
+// Number of separate reads the lock-hold test performs, so a poller that
+// starts watching one cycle too late still gets another chance instead of
+// failing the test outright.
+#define LOCK_TEST_READ_CYCLES 3
+
+// Poll the config try-lock at this interval while the read runs on the
+// other thread, capped by an overall deadline generous enough to absorb
+// scheduler jitter in a busy CI VM.
+#define LOCK_TEST_POLL_INTERVAL_US 100
+#define LOCK_TEST_POLL_DEADLINE_NS (15ull * 1000 * 1000 * 1000)
+
+struct reader_args {
+	struct dp_config *dp_config;
+	struct counter_handle_list *list;
+	// Cycle number of the read currently in flight.
+	//
+	// Bumped right before each read call. A companion flag stays set for
+	// the duration of that call. The main thread uses these to notice a
+	// fresh cycle starting and to poll the lock while that cycle is in
+	// progress.
+	atomic_uint cycle;
+	atomic_bool in_progress;
+	atomic_bool done;
+	atomic_bool failed;
+};
+
+static void *
+reader_thread(void *arg) {
+	struct reader_args *args = (struct reader_args *)arg;
+	struct counter_tag tags[] = {
+		{.key = "device", .value = "dev0"},
+		{.key = "kind", .value = "pipeline"},
+	};
+	for (unsigned i = 0; i < LOCK_TEST_READ_CYCLES; ++i) {
+		atomic_fetch_add_explicit(
+			&args->cycle, 1, memory_order_relaxed
+		);
+		atomic_store_explicit(
+			&args->in_progress, true, memory_order_release
+		);
+		struct counter_handle_list *list = yanet_get_counters_by_tags(
+			args->dp_config, tags, 2, NULL, -1, NULL
+		);
+		atomic_store_explicit(
+			&args->in_progress, false, memory_order_release
+		);
+		if (list == NULL) {
+			atomic_store_explicit(
+				&args->failed, true, memory_order_release
+			);
+			break;
+		}
+		if (i + 1 == LOCK_TEST_READ_CYCLES) {
+			args->list = list;
+		} else {
+			yanet_counter_handle_list_free(list);
+		}
+	}
+	atomic_store_explicit(&args->done, true, memory_order_release);
+	return NULL;
+}
+
+static int
+install_pipelines(
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	const char *name_prefix,
+	size_t count
+) {
+	yanet_error *err = NULL;
+	struct cp_pipeline_config **cfgs = calloc(count, sizeof(*cfgs));
+	TEST_ASSERT_NOT_NULL(cfgs, "failed to allocate pipeline config array");
+
+	for (size_t idx = 0; idx < count; ++idx) {
+		cfgs[idx] = calloc(1, sizeof(struct cp_pipeline_config));
+		TEST_ASSERT_NOT_NULL(
+			cfgs[idx], "failed to allocate pipeline config %zu", idx
+		);
+		snprintf(
+			cfgs[idx]->name,
+			CP_PIPELINE_NAME_LEN,
+			"%s-%zu",
+			name_prefix,
+			idx
+		);
+		cfgs[idx]->length = 0;
+	}
+
+	int rc = cp_config_update_pipelines(
+		dp_config, cp_config, count, cfgs, &err
+	);
+
+	for (size_t idx = 0; idx < count; ++idx) {
+		free(cfgs[idx]);
+	}
+	free(cfgs);
+
+	TEST_ASSERT_SUCCESS(
+		rc,
+		"update_pipelines failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	return TEST_SUCCESS;
+}
+
+// Install a device with every pipeline named using the given prefix and
+// index.
+//
+// Each pipeline is wired as an equal-weight input, so a counter registry
+// lookup for that device under the pipeline kind tag matches one storage
+// per pipeline, per worker. Reinstalling the same pipeline set always
+// allocates a fresh pipeline object and counter registry per name, so it
+// genuinely retires the previous generation's matched storages.
+static int
+install_device(
+	struct agent *agent,
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	const char *device_name,
+	const char *pipeline_prefix,
+	size_t pipeline_count
+) {
+	yanet_error *err = NULL;
+	struct cp_device_plain_config *cfg = cp_device_plain_config_new(
+		device_name, pipeline_count, 0, &err
+	);
+	TEST_ASSERT_NOT_NULL(
+		cfg,
+		"device config new failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	char name[CP_PIPELINE_NAME_LEN];
+	for (size_t idx = 0; idx < pipeline_count; ++idx) {
+		snprintf(name, sizeof(name), "%s-%zu", pipeline_prefix, idx);
+		int rc = cp_device_plain_config_set_input_pipeline(
+			cfg, idx, name, 1
+		);
+		TEST_ASSERT_EQUAL(
+			rc, 0, "set_input_pipeline failed at index %zu", idx
+		);
+	}
+
+	struct cp_device *dev = cp_device_plain_new(agent, cfg, &err);
+	cp_device_plain_config_free(cfg);
+	TEST_ASSERT_NOT_NULL(
+		dev,
+		"device new failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct cp_device *devs[] = {dev};
+	int rc = cp_config_update_devices(dp_config, cp_config, 1, devs, &err);
+	TEST_ASSERT_SUCCESS(
+		rc,
+		"update_devices failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	return TEST_SUCCESS;
+}
+
+// Install a pipeline set and a device wired to it under the same name
+// prefix, the pairing every test below needs to give a counter registry
+// lookup something to match.
+static int
+install_counter_surface(
+	struct agent *agent,
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	const char *device_name,
+	const char *pipeline_prefix,
+	size_t pipeline_count
+) {
+	TEST_ASSERT_SUCCESS(
+		install_pipelines(
+			dp_config, cp_config, pipeline_prefix, pipeline_count
+		),
+		"failed to install pipelines for %s",
+		pipeline_prefix
+	);
+	TEST_ASSERT_SUCCESS(
+		install_device(
+			agent,
+			dp_config,
+			cp_config,
+			device_name,
+			pipeline_prefix,
+			pipeline_count
+		),
+		"failed to install device %s",
+		device_name
+	);
+	return TEST_SUCCESS;
+}
+
+static uint64_t
+now_ns(void) {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+
+// Verifies that a large tagged counter read releases the config lock long
+// before it returns, instead of holding it across matching, allocation
+// and the whole per-counter value-copy pass.
+static int
+test_lock_released_during_value_copy(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent =
+		agent_attach(shm, 0, "cnt-1914", LOCK_TEST_AGENT_MEMORY, &err);
+	TEST_ASSERT_NOT_NULL(
+		agent,
+		"agent_attach failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct dp_config *dp_config = agent_dp_config(agent);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	TEST_ASSERT_SUCCESS(
+		install_counter_surface(
+			agent,
+			dp_config,
+			cp_config,
+			"dev0",
+			"lock-pipe",
+			LOCK_TEST_PIPELINE_COUNT
+		),
+		"failed to install the lock-test counter surface"
+	);
+
+	struct reader_args args = {
+		.dp_config = dp_config,
+	};
+
+	pthread_t reader;
+	int rc = pthread_create(&reader, NULL, reader_thread, &args);
+	TEST_ASSERT_EQUAL(rc, 0, "pthread_create failed");
+
+	bool witnessed = false;
+	unsigned seen_cycle = 0;
+	uint64_t deadline = now_ns() + LOCK_TEST_POLL_DEADLINE_NS;
+
+	while (!witnessed && now_ns() < deadline) {
+		unsigned cycle = 0;
+		bool started = false;
+		while (now_ns() < deadline) {
+			cycle = atomic_load_explicit(
+				&args.cycle, memory_order_acquire
+			);
+			if (cycle != seen_cycle &&
+			    atomic_load_explicit(
+				    &args.in_progress, memory_order_acquire
+			    )) {
+				started = true;
+				break;
+			}
+			if (atomic_load_explicit(
+				    &args.done, memory_order_acquire
+			    )) {
+				break;
+			}
+			usleep(LOCK_TEST_POLL_INTERVAL_US);
+		}
+		if (!started) {
+			break;
+		}
+		seen_cycle = cycle;
+
+		// Poll the try-lock while this read cycle stays in progress.
+		// A success observed before the flag drops demonstrates the
+		// lock was not held for the whole call. A hold reintroduced
+		// across the whole call instead makes every attempt fail
+		// until the flag drops, which this loop then reports as not
+		// witnessed for the cycle.
+		while (now_ns() < deadline &&
+		       atomic_load_explicit(
+			       &args.in_progress, memory_order_acquire
+		       )) {
+			if (cp_config_try_lock(cp_config)) {
+				bool still_in_progress = atomic_load_explicit(
+					&args.in_progress, memory_order_acquire
+				);
+				cp_config_unlock(cp_config);
+				if (still_in_progress) {
+					witnessed = true;
+				}
+				break;
+			}
+			usleep(LOCK_TEST_POLL_INTERVAL_US);
+		}
+	}
+
+	pthread_join(reader, NULL);
+
+	TEST_ASSERT(
+		!atomic_load_explicit(&args.failed, memory_order_acquire),
+		"reader thread reported a failure"
+	);
+	TEST_ASSERT(
+		witnessed,
+		"never witnessed a lock success while a read stayed in "
+		"progress across %d read cycles",
+		LOCK_TEST_READ_CYCLES
+	);
+
+	TEST_ASSERT_NOT_NULL(args.list, "yanet_get_counters_by_tags failed");
+	TEST_ASSERT_EQUAL(
+		args.list->count,
+		(uint64_t)LOCK_TEST_PIPELINE_COUNT *
+			LOCK_TEST_COUNTERS_PER_PIPELINE,
+		"unexpected matched counter count"
+	);
+	yanet_counter_handle_list_free(args.list);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+#define RACE_TEST_PIPELINE_COUNT 80
+#define RACE_TEST_READ_CYCLES 40
+#define RACE_TEST_WRITE_SAFETY_DEADLINE_NS (30ull * 1000 * 1000 * 1000)
+
+// Shared state for the racing-swap regression test: a writer thread keeps
+// genuinely retiring "race-pipe-*" storages (a fresh pipeline object per
+// reinstall) while a reader thread concurrently reads them, exercising a
+// pin's release against a generation a racing update has already retired.
+struct race_state {
+	struct dp_config *dp_config;
+	struct cp_config *cp_config;
+	atomic_bool stop;
+	atomic_bool reader_failed;
+	atomic_bool writer_failed;
+	uint64_t reader_iterations;
+	uint64_t writer_iterations;
+};
+
+static void *
+race_reader_thread(void *arg) {
+	struct race_state *state = (struct race_state *)arg;
+	struct counter_tag tags[] = {
+		{.key = "device", .value = "race-dev0"},
+		{.key = "kind", .value = "pipeline"},
+	};
+	// Every generation carries the full "race-pipe-*" set, so the match
+	// count is deterministic even while the writer is swapping storages.
+	uint64_t expected_matches = (uint64_t)RACE_TEST_PIPELINE_COUNT *
+				    LOCK_TEST_COUNTERS_PER_PIPELINE;
+	for (uint64_t i = 0; i < RACE_TEST_READ_CYCLES; ++i) {
+		struct counter_handle_list *list = yanet_get_counters_by_tags(
+			state->dp_config, tags, 2, NULL, -1, NULL
+		);
+		if (list == NULL || list->count != expected_matches) {
+			if (list != NULL) {
+				yanet_counter_handle_list_free(list);
+			}
+			atomic_store_explicit(
+				&state->reader_failed,
+				true,
+				memory_order_release
+			);
+			break;
+		}
+		yanet_counter_handle_list_free(list);
+		state->reader_iterations = i + 1;
+	}
+	atomic_store_explicit(&state->stop, true, memory_order_release);
+	return NULL;
+}
+
+static void *
+race_writer_thread(void *arg) {
+	struct race_state *state = (struct race_state *)arg;
+	uint64_t deadline = now_ns() + RACE_TEST_WRITE_SAFETY_DEADLINE_NS;
+	while (!atomic_load_explicit(&state->stop, memory_order_acquire) &&
+	       now_ns() < deadline) {
+		if (install_pipelines(
+			    state->dp_config,
+			    state->cp_config,
+			    "race-pipe",
+			    RACE_TEST_PIPELINE_COUNT
+		    ) != TEST_SUCCESS) {
+			atomic_store_explicit(
+				&state->writer_failed,
+				true,
+				memory_order_release
+			);
+			break;
+		}
+		state->writer_iterations += 1;
+	}
+	return NULL;
+}
+
+// Verifies that concurrent reads survive a racing config swap that
+// genuinely retires the matched storages: each reinstall below allocates a
+// fresh pipeline object and counter registry, so a release that still read
+// through a retired generation would use-after-free under the address
+// sanitizer.
+static int
+test_racing_swap_no_uaf(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent =
+		agent_attach(shm, 0, "cnt-race", LOCK_TEST_AGENT_MEMORY, &err);
+	TEST_ASSERT_NOT_NULL(
+		agent,
+		"agent_attach failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct dp_config *dp_config = agent_dp_config(agent);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	TEST_ASSERT_SUCCESS(
+		install_counter_surface(
+			agent,
+			dp_config,
+			cp_config,
+			"race-dev0",
+			"race-pipe",
+			RACE_TEST_PIPELINE_COUNT
+		),
+		"failed to install the race-test counter surface"
+	);
+
+	struct race_state state = {
+		.dp_config = dp_config,
+		.cp_config = cp_config,
+	};
+
+	pthread_t writer;
+	int rc = pthread_create(&writer, NULL, race_writer_thread, &state);
+	TEST_ASSERT_EQUAL(rc, 0, "pthread_create(writer) failed");
+
+	pthread_t reader;
+	rc = pthread_create(&reader, NULL, race_reader_thread, &state);
+	if (rc != 0) {
+		// Stop and reap the writer before failing out, so it does not
+		// keep writing into this stack frame and installing pipelines
+		// into an arena the caller is about to tear down.
+		atomic_store_explicit(&state.stop, true, memory_order_release);
+		pthread_join(writer, NULL);
+		TEST_ASSERT_EQUAL(rc, 0, "pthread_create(reader) failed");
+	}
+
+	pthread_join(reader, NULL);
+	pthread_join(writer, NULL);
+
+	TEST_ASSERT(
+		!atomic_load_explicit(
+			&state.reader_failed, memory_order_acquire
+		),
+		"reader thread reported a failure"
+	);
+	TEST_ASSERT(
+		!atomic_load_explicit(
+			&state.writer_failed, memory_order_acquire
+		),
+		"writer thread reported a failure"
+	);
+	TEST_ASSERT(
+		state.writer_iterations > 0,
+		"writer never completed a single racing pipeline reinstall"
+	);
+	TEST_ASSERT(
+		state.reader_iterations > 0,
+		"reader never completed a single racing counter read"
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+// A tight budget so a leaked generation exhausts it quickly.
+//
+// Not merely a leaked handle list: a leaked generation alone must run the
+// budget out within a small, deterministic number of cycles, rather than
+// only near the end of a long run. Confirmed against a build with the
+// release path reverted to a no-op: each unreleased generation costs
+// roughly 47 KB against the 8 MB arena, so the swap failure lands about a
+// fifth of the way through the cycle budget. A correct release keeps only
+// one generation live and completes every cycle.
+#define LEAK_TEST_CP_MEMORY (8u * 1024u * 1024u)
+#define LEAK_TEST_DP_MEMORY (2u * 1024u * 1024u)
+#define LEAK_TEST_AGENT_MEMORY (512u * 1024u)
+#define LEAK_TEST_WORKER_COUNT 2
+#define LEAK_TEST_PIPELINE_COUNT 1
+#define LEAK_TEST_CYCLES 500
+
+// Verifies that repeated read-then-swap cycles do not leak configuration
+// generations.
+//
+// Generations live in the shared-memory allocator, invisible to a heap
+// sanitizer, so a leak is instead caught by exhausting a budget
+// deliberately too small to hold more than a handful of them.
+static int
+test_repeated_swap_no_generation_leak(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent =
+		agent_attach(shm, 0, "cnt-leak", LEAK_TEST_AGENT_MEMORY, &err);
+	TEST_ASSERT_NOT_NULL(
+		agent,
+		"agent_attach failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct dp_config *dp_config = agent_dp_config(agent);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	TEST_ASSERT_SUCCESS(
+		install_counter_surface(
+			agent,
+			dp_config,
+			cp_config,
+			"leak-dev0",
+			"leak-pipe",
+			LEAK_TEST_PIPELINE_COUNT
+		),
+		"failed to install the leak-test counter surface"
+	);
+
+	struct counter_tag tags[] = {
+		{.key = "device", .value = "leak-dev0"},
+		{.key = "kind", .value = "pipeline"},
+	};
+
+	for (unsigned i = 0; i < LEAK_TEST_CYCLES; ++i) {
+		struct counter_handle_list *list = yanet_get_counters_by_tags(
+			dp_config, tags, 2, NULL, -1, NULL
+		);
+		TEST_ASSERT_NOT_NULL(
+			list, "read failed unexpectedly at cycle %u", i
+		);
+		yanet_counter_handle_list_free(list);
+
+		TEST_ASSERT_SUCCESS(
+			install_pipelines(
+				dp_config,
+				cp_config,
+				"leak-pipe",
+				LEAK_TEST_PIPELINE_COUNT
+			),
+			"swap failed at cycle %u",
+			i
+		);
+	}
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+// Runs a test function against a fresh harness instance, so one test's
+// generation swaps only ever rebuild its own pipeline set instead of also
+// re-walking another test's much larger one.
+static int
+run_with_harness(
+	const struct dataplane_ut_config *cfg,
+	int (*test_fn)(struct yanet_shm *)
+) {
+	struct dataplane_ut *ut = dataplane_ut_new(cfg);
+	if (ut == NULL) {
+		fprintf(stderr, "dataplane_ut_new failed\n");
+		return 1;
+	}
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	if (shm == NULL) {
+		fprintf(stderr, "dataplane_ut_shm returned NULL\n");
+		dataplane_ut_free(ut);
+		return 1;
+	}
+	int res = test_fn(shm);
+	dataplane_ut_free(ut);
+	return (res == TEST_SUCCESS) ? 0 : 1;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	const char *port_names[] = {"01:00.0"};
+	const char *devs_to_load[] = {"plain"};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = LOCK_TEST_CP_MEMORY,
+		.dp_memory = LOCK_TEST_DP_MEMORY,
+		.worker_count = LOCK_TEST_WORKER_COUNT,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = NULL,
+		.module_count = 0,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+	};
+
+	int rc = run_with_harness(&cfg, test_lock_released_during_value_copy);
+	if (rc != 0) {
+		return rc;
+	}
+
+	rc = run_with_harness(&cfg, test_racing_swap_no_uaf);
+	if (rc != 0) {
+		return rc;
+	}
+
+	struct dataplane_ut_config leak_cfg = cfg;
+	leak_cfg.cp_memory = LEAK_TEST_CP_MEMORY;
+	leak_cfg.dp_memory = LEAK_TEST_DP_MEMORY;
+	leak_cfg.worker_count = LEAK_TEST_WORKER_COUNT;
+
+	return run_with_harness(
+		&leak_cfg, test_repeated_swap_no_generation_leak
+	);
+}

--- a/lib/controlplane/tests/meson.build
+++ b/lib/controlplane/tests/meson.build
@@ -20,6 +20,36 @@ counters_test = executable(
 
 test('counters_uaf', counters_test, suite: ['lib'])
 
+counters_lock_thread_dep = dependency('threads')
+
+counters_lock_test = executable(
+  'counters_lock_test',
+  ['counters_lock_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_device_plain',
+    '-Wl,--export-dynamic-symbol=new_device_plain',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_dev_plain_api,
+    libdpdk_dep,
+    counters_lock_thread_dep,
+  ],
+  link_with: [lib_dev_plain_dp],
+  include_directories: yanet_rootdir,
+)
+
+test(
+  'counters_lock',
+  counters_lock_test,
+  suite: ['lib'],
+  timeout: 90,
+)
+
 loaded_counts_test = executable(
   'loaded_counts_test',
   ['loaded_counts_test.c'],


### PR DESCRIPTION
- Adds a reference count to configuration generations: the tagged counter read pins the active generation under a brief lock hold, runs matching, allocation and value copies entirely unlocked against the pinned generation, and drops the pin under another brief hold — zero allocations happen under the shared-memory config lock.
- A racing config update retires the replaced generation through the same release path once the last reader lets go, so a reader may perform the deferred teardown that the update path performs today.
- Decomposes the read into separate matching, metadata and value-copy passes, sharing one value-copy helper with the dataplane-owned worker and port counter paths.
- Adds regression tests covering the lock hold during a large read, a racing generation swap under the address sanitizer, and generation leaks across repeated swaps.
- The new field is appended at the end of the generation structure, so a running dataplane keeps reading existing offsets unchanged; control-plane processes should restart together on upgrade.
- A process killed inside the unlocked window now leaks one pinned generation instead of poisoning the lock for every other process, a strictly smaller failure than the previous dead-holder hang.
- Supersedes #1940, which stays open as the fallback approach.

Closes #1914.