### PR TITLE
fix(controlplane,nat64): route C log statements through the control-plane logger

### DIFF
--- a/common/go/logging/clog/clog.go
+++ b/common/go/logging/clog/clog.go
@@ -1,0 +1,133 @@
+// Package clog routes lib/logging's C LOG() output through a zap.Logger and
+// pushes zap's configured level into the C library's cheap level gate.
+//
+// zap remains the authority: the C gate is only a prefilter that skips
+// formatting and the cgo transition for lines zap would drop anyway, so it
+// must never end up stricter than zap's own level.
+package clog
+
+/*
+#cgo CFLAGS: -I../../../.. -I../../../../build
+#cgo LDFLAGS: -L../../../../build/lib/logging/ -llogging
+
+#include "sink.h"
+*/
+import "C"
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// currentLogger is the destination for C log lines.
+//
+// The C sink callback may run concurrently with Attach, so it is always
+// read atomically and a nil value is a silent no-op rather than a panic.
+var currentLogger atomic.Pointer[zap.Logger]
+
+// setLevelMu serializes SetLevel against itself.
+//
+// SetLevel walks the C gate's levels in two loops, enabling one range and
+// disabling the rest. Without this lock, two overlapping calls (gRPC serves
+// UpdateLevel concurrently) could interleave those loops and leave the gate
+// representing neither requested level. Level changes are rare and
+// human-driven, so a mutex is cheap enough and needs no C-side change.
+var setLevelMu sync.Mutex
+
+// Attach makes log the destination for the C library's LOG() calls.
+//
+// It installs a process-global C sink pointer through a plain,
+// unsynchronized store, so callers must install it exactly once during
+// bootstrap, before any C code can log and before that pointer can be read
+// concurrently. Production relies on this: it calls Attach once at startup,
+// ahead of the gateway serving requests.
+func Attach(log *zap.Logger) {
+	currentLogger.Store(log)
+	C.clog_install_sink()
+}
+
+// SetLevel pushes level into the C library's gate.
+//
+// It enables the mapped minimum through ERROR before disabling everything
+// below it, so no level that should stay enabled is ever momentarily off.
+// Concurrent calls are serialized against each other, so two overlapping
+// updates cannot interleave into a gate state matching neither.
+func SetLevel(level zapcore.Level) {
+	setLevelMu.Lock()
+	defer setLevelMu.Unlock()
+
+	minLevel := cMinLevel(level)
+
+	for lid := minLevel; lid <= C.ERROR; lid++ {
+		C.log_enable_id(C.enum_log_id(lid))
+	}
+	for lid := minLevel - 1; lid >= C.int(C.TRACE); lid-- {
+		C.log_disable_id(C.enum_log_id(lid))
+	}
+}
+
+// cMinLevel maps a zap level to the lowest C log_id that must stay enabled
+// for that level.
+func cMinLevel(level zapcore.Level) C.int {
+	switch level {
+	case zapcore.DebugLevel:
+		return C.TRACE
+	case zapcore.InfoLevel:
+		return C.INFO
+	case zapcore.WarnLevel:
+		return C.WARN
+	default:
+		// Error and anything more severe collapse onto the C library's
+		// most severe level.
+		return C.ERROR
+	}
+}
+
+// zapLevel maps a C log_id to the zap level a line routed through the sink
+// is reported at.
+func zapLevel(level C.enum_log_id) zapcore.Level {
+	switch level {
+	case C.TRACE, C.DEBUG:
+		return zapcore.DebugLevel
+	case C.INFO:
+		return zapcore.InfoLevel
+	case C.WARN:
+		return zapcore.WarnLevel
+	default:
+		return zapcore.ErrorLevel
+	}
+}
+
+// clogSink is installed as the C sink and receives the bare formatted
+// message plus the C source location for every enabled LOG() call.
+//
+// It bypasses Logger.Log, which cannot override the caller, and instead
+// checks and writes the entry directly through the logger's core so the C
+// file and line land in the caller column next to Go call sites.
+//
+//export clogSink
+func clogSink(level C.enum_log_id, file *C.char, line C.int, msg *C.char, ctx unsafe.Pointer) {
+	log := currentLogger.Load()
+	if log == nil {
+		return
+	}
+
+	entry := zapcore.Entry{
+		Level:   zapLevel(level),
+		Time:    time.Now(),
+		Message: C.GoString(msg),
+		Caller: zapcore.EntryCaller{
+			Defined: true,
+			File:    C.GoString(file),
+			Line:    int(line),
+		},
+	}
+	if ce := log.Core().Check(entry, nil); ce != nil {
+		ce.Write()
+	}
+}

--- a/common/go/logging/clog/sink.c
+++ b/common/go/logging/clog/sink.c
@@ -1,0 +1,21 @@
+#include "sink.h"
+
+// Cgo cannot declare const parameters on an exported Go function, so the
+// exported callback's type differs from the log_sink_fn typedef.
+// This wrapper restores the qualifiers before calling it — casting the
+// function pointer instead would be undefined behavior.
+static void
+clog_sink_trampoline(
+	enum log_id level,
+	const char *file,
+	int line,
+	const char *msg,
+	void *ctx
+) {
+	clogSink(level, (char *)file, line, (char *)msg, ctx);
+}
+
+void
+clog_install_sink(void) {
+	log_set_sink(clog_sink_trampoline, NULL);
+}

--- a/common/go/logging/clog/sink.h
+++ b/common/go/logging/clog/sink.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "lib/logging/log.h"
+
+// clogSink is defined in clog.go and exported to C via cgo.
+extern void
+clogSink(enum log_id level, char *file, int line, char *msg, void *ctx);
+
+void
+clog_install_sink(void);

--- a/controlplane/builtin/logging.go
+++ b/controlplane/builtin/logging.go
@@ -18,15 +18,17 @@ import (
 type Logging struct {
 	ynpb.UnimplementedLoggingServer
 
-	atom *zap.AtomicLevel
-	log  *zap.Logger
+	atom     *zap.AtomicLevel
+	observer func(zapcore.Level)
+	log      *zap.Logger
 }
 
 // LoggingOption configures the Logging constructor.
 type LoggingOption func(*loggingOptions)
 
 type loggingOptions struct {
-	Log *zap.Logger
+	Observer func(zapcore.Level)
+	Log      *zap.Logger
 }
 
 func newLoggingOptions() *loggingOptions {
@@ -42,6 +44,17 @@ func WithLoggingLog(log *zap.Logger) LoggingOption {
 	}
 }
 
+// WithLoggingLevelObserver registers a function called with the new level
+// every time UpdateLevel changes it, in addition to the atomic Go level.
+//
+// This is how a runtime level change also reaches lib/logging's C gate,
+// without this package importing the cgo-based clog package.
+func WithLoggingLevelObserver(observer func(zapcore.Level)) LoggingOption {
+	return func(o *loggingOptions) {
+		o.Observer = observer
+	}
+}
+
 // NewLogging creates a new Logging service.
 func NewLogging(level *zap.AtomicLevel, options ...LoggingOption) *Logging {
 	opts := newLoggingOptions()
@@ -50,8 +63,9 @@ func NewLogging(level *zap.AtomicLevel, options ...LoggingOption) *Logging {
 	}
 
 	return &Logging{
-		atom: level,
-		log:  opts.Log,
+		atom:     level,
+		observer: opts.Observer,
+		log:      opts.Log,
 	}
 }
 
@@ -83,7 +97,23 @@ func (m *Logging) UpdateLevel(
 		return nil, fmt.Errorf("failed to convert logging level: %w", err)
 	}
 
-	m.atom.SetLevel(level)
+	// The observer drives an external gate that must never be stricter
+	// than zap, even momentarily, or a line it drops never reaches zap
+	// to be re-filtered. zapcore.Level orders from most to least verbose,
+	// so widening the level (a numerically smaller value) applies the
+	// observer before the atomic level. Narrowing keeps the old order,
+	// since a temporarily loose gate only costs some extra formatting.
+	if level < m.atom.Level() {
+		if m.observer != nil {
+			m.observer(level)
+		}
+		m.atom.SetLevel(level)
+	} else {
+		m.atom.SetLevel(level)
+		if m.observer != nil {
+			m.observer(level)
+		}
+	}
 	m.log.Info("updated log level", zap.Stringer("level", level))
 
 	return &ynpb.UpdateLevelResponse{}, nil

--- a/controlplane/cmd/yncp-director/main.go
+++ b/controlplane/cmd/yncp-director/main.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/yanet-platform/yanet2/common/go/logging"
+	"github.com/yanet-platform/yanet2/common/go/logging/clog"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 	"github.com/yanet-platform/yanet2/common/go/xcmd"
 	"github.com/yanet-platform/yanet2/controlplane/yncp"
@@ -64,7 +65,14 @@ func run(cmd Cmd) error {
 	}
 	defer log.Sync()
 
-	director, err := yncp.NewDirector(cfg, yncp.WithLog(log), yncp.WithAtomicLogLevel(&atomicLevel))
+	clog.Attach(log)
+	clog.SetLevel(atomicLevel.Level())
+
+	director, err := yncp.NewDirector(cfg,
+		yncp.WithLog(log),
+		yncp.WithAtomicLogLevel(&atomicLevel),
+		yncp.WithLogLevelObserver(clog.SetLevel),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create director: %w", err)
 	}

--- a/controlplane/yncp/director.go
+++ b/controlplane/yncp/director.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/yanet-platform/yanet2/common/go/xbackoff"
 	"github.com/yanet-platform/yanet2/controlplane/builtin"
@@ -20,8 +21,9 @@ import (
 const dataplaneReadyTimeout = 60 * time.Second
 
 type options struct {
-	Log      *zap.Logger
-	LogLevel *zap.AtomicLevel
+	Log              *zap.Logger
+	LogLevel         *zap.AtomicLevel
+	LogLevelObserver func(zapcore.Level)
 }
 
 func newOptions() *options {
@@ -48,6 +50,17 @@ func WithLog(log *zap.Logger) DirectorOption {
 func WithAtomicLogLevel(level *zap.AtomicLevel) DirectorOption {
 	return func(o *options) {
 		o.LogLevel = level
+	}
+}
+
+// WithLogLevelObserver registers a function called with the new level every
+// time the logging RPC changes it, alongside the atomic Go level.
+//
+// This is how the director drives lib/logging's C gate from a runtime
+// level change without this package depending on cgo itself.
+func WithLogLevelObserver(observer func(zapcore.Level)) DirectorOption {
+	return func(o *options) {
+		o.LogLevelObserver = observer
 	}
 }
 
@@ -113,7 +126,10 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 
 	gatewayOptions := []gateway.GatewayOption{
 		gateway.WithBuiltinService(
-			builtin.NewLogging(opts.LogLevel, builtin.WithLoggingLog(log)),
+			builtin.NewLogging(opts.LogLevel,
+				builtin.WithLoggingLog(log),
+				builtin.WithLoggingLevelObserver(opts.LogLevelObserver),
+			),
 		),
 		gateway.WithBuiltinService(
 			builtin.NewInspect(cfg.Gateway.InstanceID, shm),

--- a/lib/logging/log.c
+++ b/lib/logging/log.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <strings.h>
@@ -8,6 +9,10 @@
 #include "log.h"
 
 static const char *__log_color_reset = LOG_RESET; // NOLINT
+
+static log_sink_fn __log_sink = NULL;	  // NOLINT
+static void *__log_sink_ctx = NULL;	  // NOLINT
+static __thread int __log_sink_depth = 0; // NOLINT
 
 struct logger {
 	uint8_t enable;
@@ -59,9 +64,14 @@ log_color_reset(void) {
 	return __log_color_reset;
 }
 
+// The control plane can flip a level at runtime while a worker thread
+// concurrently reads it through LOG(), so every access to loggers[].enable
+// goes through a relaxed atomic: nothing else is ordered against the gate,
+// a momentarily stale read is by design, and relaxed still compiles to a
+// plain load on the architectures this runs on.
 inline uint8_t
 log_enabled(enum log_id lid) {
-	return loggers[lid].enable;
+	return __atomic_load_n(&loggers[lid].enable, __ATOMIC_RELAXED);
 }
 
 /**
@@ -70,19 +80,19 @@ log_enabled(enum log_id lid) {
  */
 inline void
 log_enable_id(enum log_id lid) {
-	loggers[lid].enable = 1;
+	__atomic_store_n(&loggers[lid].enable, 1, __ATOMIC_RELAXED);
 }
 
 inline void
 log_disable_id(enum log_id lid) {
-	loggers[lid].enable = 0;
+	__atomic_store_n(&loggers[lid].enable, 0, __ATOMIC_RELAXED);
 }
 
 inline void
 log_reset(void) {
 	for (uint64_t idx = 0; idx < sizeof(loggers) / sizeof(struct logger);
 	     idx++) {
-		loggers[idx].enable = 0;
+		__atomic_store_n(&loggers[idx].enable, 0, __ATOMIC_RELAXED);
 	}
 }
 
@@ -92,7 +102,9 @@ log_enable_name(const char *log_name) {
 	for (uint64_t idx = 0; idx < sizeof(loggers) / sizeof(struct logger);
 	     idx++) {
 		if (strcasecmp(loggers[idx].name, log_name) == 0) {
-			loggers[idx].enable = 1;
+			__atomic_store_n(
+				&loggers[idx].enable, 1, __ATOMIC_RELAXED
+			);
 			lid = (enum log_id)idx;
 			break;
 		}
@@ -113,21 +125,66 @@ log_enable_name(const char *log_name) {
 	// enable leveled logs
 	switch (lid) {
 	case TRACE:
-		loggers[TRACE].enable = 1;
+		__atomic_store_n(&loggers[TRACE].enable, 1, __ATOMIC_RELAXED);
 		// fallthrough
 	case DEBUG:
-		loggers[DEBUG].enable = 1;
+		__atomic_store_n(&loggers[DEBUG].enable, 1, __ATOMIC_RELAXED);
 		// fallthrough
 	case INFO:
-		loggers[INFO].enable = 1;
+		__atomic_store_n(&loggers[INFO].enable, 1, __ATOMIC_RELAXED);
 		// fallthrough
 	case WARN:
-		loggers[WARN].enable = 1;
+		__atomic_store_n(&loggers[WARN].enable, 1, __ATOMIC_RELAXED);
 		// fallthrough
 	case ERROR:
-		loggers[ERROR].enable = 1;
+		__atomic_store_n(&loggers[ERROR].enable, 1, __ATOMIC_RELAXED);
 		// fallthrough
 	default:
 		break;
 	}
+}
+
+void
+log_set_sink(log_sink_fn sink, void *ctx) {
+	__log_sink = sink;
+	__log_sink_ctx = ctx;
+}
+
+void
+log_write(enum log_id level, const char *file, int line, const char *fmt, ...) {
+	va_list args;
+	va_start(args, fmt);
+
+	log_sink_fn sink = __log_sink;
+	void *sink_ctx = __log_sink_ctx;
+
+	// A sink calling back into LOG() on the same thread would otherwise
+	// recurse forever, so a reentrant call falls back to the stderr path
+	// below instead of the sink.
+	if (sink != NULL && __log_sink_depth == 0) {
+		char msg[1024];
+		vsnprintf(msg, sizeof(msg), fmt, args);
+		va_end(args);
+
+		__log_sink_depth++;
+		sink(level, file, line, msg, sink_ctx);
+		__log_sink_depth--;
+		return;
+	}
+
+	// Locking the stream keeps the three calls below atomic, so a
+	// concurrent stderr writer cannot split the prefix from the message.
+	flockfile(stderr);
+	fprintf(stderr,
+		"%s [%s%-5s%s][%s:%d]: ",
+		log_fmt_timestamp(),
+		log_color(level),
+		log_name(level),
+		log_color_reset(),
+		file,
+		line);
+	vfprintf(stderr, fmt, args);
+	fputc('\n', stderr);
+	funlockfile(stderr);
+	va_end(args);
 }

--- a/lib/logging/log.h
+++ b/lib/logging/log.h
@@ -3,7 +3,17 @@
 #include <stdint.h>
 #include <stdio.h>
 
+// The meson-generated header is absent for cgo compilation of Go packages
+// reaching this file, which runs without a configured build directory.
+// Only ENABLE_TRACE_LOG is consumed below, so its absence just leaves trace
+// logging disabled, matching a default meson configuration.
+#if defined(__has_include)
+#if __has_include("yanet_build_config.h")
 #include "yanet_build_config.h"
+#endif
+#else
+#include "yanet_build_config.h"
+#endif
 
 #define LOG_RED "\x1b[31m"
 #define LOG_GREEN "\x1b[32m"
@@ -35,15 +45,13 @@ enum log_id { TRACE, DEBUG, INFO, WARN, ERROR, LOG_ID_MAX }; // NOLINT
 #define LOG(log_level, fmt_, ...)                                              \
 	do {                                                                   \
 		if (log_enabled(log_level)) {                                  \
-			fprintf(stderr,                                        \
-				"%s [%s%-5s%s][%s:%d]: " fmt_ "\n",            \
-				log_fmt_timestamp(),                           \
-				log_color(log_level),                          \
-				log_name(log_level),                           \
-				log_color_reset(),                             \
+			log_write(                                             \
+				log_level,                                     \
 				__FILE_NAME__,                                 \
 				__LINE__,                                      \
-				##__VA_ARGS__);                                \
+				fmt_,                                          \
+				##__VA_ARGS__                                  \
+			);                                                     \
 		}                                                              \
 	} while (0)
 
@@ -61,6 +69,25 @@ enum log_id { TRACE, DEBUG, INFO, WARN, ERROR, LOG_ID_MAX }; // NOLINT
 #define LOG_TRACE(...) (void)(0)
 #define LOG_TRACEX(...) (void)(0)
 #endif // ENABLE_TRACE_LOG
+
+// Sink hook: receives the bare formatted message, no timestamp, level name
+// or color, so a process embedding this library can route log lines through
+// its own logger instead of stderr. The message is truncated beyond 1024
+// bytes, unlike the unbounded stderr path.
+typedef void (*log_sink_fn)(
+	enum log_id level,
+	const char *file,
+	int line,
+	const char *msg,
+	void *ctx
+);
+
+void
+log_set_sink(log_sink_fn sink, void *ctx);
+
+void
+log_write(enum log_id level, const char *file, int line, const char *fmt, ...)
+	__attribute__((format(printf, 4, 5)));
 
 const char *
 log_fmt_timestamp(void);

--- a/modules/nat64/api/nat64cp.c
+++ b/modules/nat64/api/nat64cp.c
@@ -61,8 +61,6 @@ error_init:
 
 void
 nat64_module_config_free(struct cp_module *cp_module) {
-	LOG(DEBUG, "Starting cleanup of NAT64 module '%s'", cp_module->name);
-
 	struct nat64_module_config *config =
 		container_of(cp_module, struct nat64_module_config, cp_module);
 
@@ -75,17 +73,11 @@ nat64_module_config_free(struct cp_module *cp_module) {
 
 	cp_module_fini(cp_module);
 
-	LOG(DEBUG,
-	    "Freeing main config structure: size=%zu bytes, address=%p",
-	    sizeof(struct nat64_module_config),
-	    (void *)config);
 	memory_bfree(
 		&agent->memory_context,
 		config,
 		sizeof(struct nat64_module_config)
 	);
-
-	LOG(DEBUG, "Completed cleanup of NAT64 module config");
 }
 
 int
@@ -93,32 +85,24 @@ nat64_module_config_data_init(
 	struct nat64_module_config *config,
 	struct memory_context *memory_context
 ) {
-	LOG(DEBUG, "Starting nat64_module_config_data_init");
-
 	// Initialize LPM structures
-	LOG(DEBUG, "Initializing v4_to_v6 LPM");
 	if (lpm_init(&config->mappings.v4_to_v6, memory_context, "v4_to_v6")) {
 		LOG(ERROR, "Failed to initialize v4_to_v6 LPM");
 		goto error_lpm_v4;
 	}
-	LOG(DEBUG, "v4_to_v6 LPM initialized successfully");
 
-	LOG(DEBUG, "Initializing v6_to_v4 LPM");
 	if (lpm_init(&config->mappings.v6_to_v4, memory_context, "v6_to_v4")) {
 		LOG(ERROR, "Failed to initialize v6_to_v4 LPM");
 		goto error_lpm_v6;
 	}
-	LOG(DEBUG, "v6_to_v4 LPM initialized successfully");
 
 	// Initialize v6 prefixes LPM
-	LOG(DEBUG, "Initializing v6_prefixes LPM");
 	if (lpm_init(
 		    &config->prefixes.v6_prefixes, memory_context, "v6_prefixes"
 	    )) {
 		LOG(ERROR, "Failed to initialize v6_prefixes LPM");
 		goto error_lpm_prefixes;
 	}
-	LOG(DEBUG, "v6_prefixes LPM initialized successfully");
 
 	// Initialize other fields
 	config->mappings.count = 0;
@@ -148,35 +132,16 @@ nat64_module_config_data_destroy(
 	struct nat64_module_config *config,
 	struct memory_context *memory_context
 ) {
-	LOG(DEBUG,
-	    "Freeing v4_to_v6 LPM table at %p",
-	    (void *)&config->mappings.v4_to_v6);
 	lpm_free(&config->mappings.v4_to_v6);
-
-	LOG(DEBUG,
-	    "Freeing v6_to_v4 LPM table at %p",
-	    (void *)&config->mappings.v6_to_v4);
 	lpm_free(&config->mappings.v6_to_v4);
-
-	LOG(DEBUG,
-	    "Freeing v6_prefixes LPM table at %p",
-	    (void *)&config->prefixes.v6_prefixes);
 	lpm_free(&config->prefixes.v6_prefixes);
 
 	if (config->mappings.list) {
 		struct ip4to6 *mapping_list = ADDR_OF(&config->mappings.list);
 		size_t mappings_size =
 			sizeof(struct ip4to6) * config->mappings.count;
-		LOG(DEBUG,
-		    "Freeing mappings list: count=%zu, size=%zu bytes, "
-		    "address=%p",
-		    config->mappings.count,
-		    mappings_size,
-		    (void *)mapping_list);
 
 		memory_bfree(memory_context, mapping_list, mappings_size);
-	} else {
-		LOG(DEBUG, "No mappings list to free");
 	}
 
 	if (config->prefixes.prefixes) {
@@ -184,16 +149,8 @@ nat64_module_config_data_destroy(
 			sizeof(struct nat64_prefix) * config->prefixes.count;
 		struct nat64_prefix *prefixes =
 			ADDR_OF(&config->prefixes.prefixes);
-		LOG(DEBUG,
-		    "Freeing prefixes array: count=%zu, size=%zu bytes, "
-		    "address=%p",
-		    config->prefixes.count,
-		    prefixes_size,
-		    (void *)prefixes);
 
 		memory_bfree(memory_context, prefixes, prefixes_size);
-	} else {
-		LOG(DEBUG, "No prefixes array to free");
 	}
 }
 
@@ -311,7 +268,7 @@ nat64_module_config_add_prefix(
 
 	LOG(DEBUG,
 	    "Added prefix "
-	    "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x\n",
+	    "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
 	    prefix[0],
 	    prefix[1],
 	    prefix[2],

--- a/tests/common/rcu_bench.c
+++ b/tests/common/rcu_bench.c
@@ -151,7 +151,7 @@ benchmark_multiworker_throughput(size_t num_workers) {
 	LOG(INFO, "  Total updates: %zu", num_updates);
 	LOG(INFO, "  Update throughput: %.2f ops/sec", updates_per_sec);
 	LOG(INFO, "  Avg update latency: %.2f µs", avg_update_latency_us);
-	LOG(INFO, "");
+	LOG(INFO, "%s", "");
 }
 
 // Benchmark 2: Contention and Fairness
@@ -266,7 +266,7 @@ benchmark_contention(void) {
 	    (double)max_time / 1000.0,
 	    avg_time / 1000.0);
 	LOG(INFO, "  Fairness index: %.3f (1.0 = perfect)", fairness);
-	LOG(INFO, "");
+	LOG(INFO, "%s", "");
 }
 
 // Benchmark 3: Latency Distribution
@@ -331,7 +331,7 @@ benchmark_latency_distribution(void) {
 	LOG(INFO, "  P95 latency: %lu µs", p95);
 	LOG(INFO, "  P99 latency: %lu µs", p99);
 	LOG(INFO, "  Max latency: %lu µs", max_lat);
-	LOG(INFO, "");
+	LOG(INFO, "%s", "");
 }
 
 // Benchmark 4: Reader/Writer Thread Interaction
@@ -523,7 +523,7 @@ benchmark_reader_writer_interaction(size_t num_readers) {
 	    avg_update_lat,
 	    max_update_lat);
 	LOG(INFO, "  Read/Update ratio: %.2f:1", (double)reads / updates);
-	LOG(INFO, "");
+	LOG(INFO, "%s", "");
 }
 
 // Main Benchmark Runner
@@ -534,7 +534,7 @@ main(void) {
 
 	LOG(INFO, "=== RCU Performance Benchmark Suite ===");
 	LOG(INFO, "BENCH_WORKERS: %d", BENCH_WORKERS);
-	LOG(INFO, "");
+	LOG(INFO, "%s", "");
 
 	const size_t arena_size = 1 << 20;
 	void *arena = malloc(arena_size);


### PR DESCRIPTION
The C logging library never emitted anything in the control-plane process. Every level defaults to disabled and only the dataplane binary ever enabled one, so every C log statement reachable through cgo was dead: the built control-plane binary links the library and calls it zero times.

Give the library a pluggable sink. With none installed it formats to stderr exactly as before, byte for byte, so the dataplane is unaffected. The line is now written while holding the stream lock, which also closes a pre-existing race where two threads could interleave inside a single line and fight over the shared timestamp buffer.

Add a cgo subpackage that installs that sink and routes C lines into the control plane's own logger, overriding the caller field so a C line renders in the same column as a Go one. It is deliberately a subpackage rather than part of the shared logging package, because five pure-Go operators import that package and must not acquire a cgo dependency.

Drive the C level gate from the configured logger both at startup and from the runtime level RPC, so changing the level moves both halves at once. The Go logger stays the authority; the C gate is only a prefilter that skips formatting and a cgo transition for lines that would be dropped anyway.

Prune seventeen of the twenty-one debug statements on the nat64 control-plane path, keeping the four that record a configuration fact and dropping those that only narrate control flow or print an allocation address. The shipped default configuration selects the debug level, so these would otherwise have started printing on every deployment. One kept statement also lost a trailing newline that was adding a blank line after every such record.

Two premises of the issue turned out to be wrong, and this change reflects the corrected picture. The twenty-seven statements in the dataplane configuration library that the issue asked to audit are not reachable from the control plane at all, which executes only eight functions from there, all in a file carrying no log statements. The statements that actually become live belong to the nat64 and ACL modules, and they run outside the configuration lock.

The wedged-worker diagnostic stays out of scope. It belongs inside the generation wait, which runs while the configuration lock is held, and nothing may log under that lock. It remains part of #1676.

Closes #1892.