### PR TITLE
refactor(commonpb): marshal IP and MAC JSON through shared structs

### DIFF
--- a/common/commonpb/v1/ipaddr.go
+++ b/common/commonpb/v1/ipaddr.go
@@ -56,20 +56,24 @@ func (m *IPAddress) AsLogValue() any {
 	return addr.String()
 }
 
+// ipAddressJSON is the JSON wire shape shared by MarshalJSON and
+// UnmarshalJSON.
+type ipAddressJSON struct {
+	Addr string `json:"addr"`
+}
+
 // MarshalJSON serializes addr as a human-readable IP address string.
 func (m *IPAddress) MarshalJSON() ([]byte, error) {
 	addr, err := m.ToAddr()
 	if err != nil {
 		return nil, err
 	}
-	return fmt.Appendf(nil, `{"addr":"%s"}`, addr.String()), nil
+	return json.Marshal(ipAddressJSON{Addr: addr.String()})
 }
 
 // UnmarshalJSON accepts addr as an IPv4 or IPv6 address string.
 func (m *IPAddress) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		Addr string `json:"addr"`
-	}
+	var raw ipAddressJSON
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}

--- a/common/commonpb/v1/iprange.go
+++ b/common/commonpb/v1/iprange.go
@@ -86,21 +86,25 @@ func (m *IPRange) AsLogValue() any {
 	return fmt.Sprintf("[%s, %s]", start.String(), end.String())
 }
 
+// ipRangeJSON is the JSON wire shape shared by MarshalJSON and
+// UnmarshalJSON.
+type ipRangeJSON struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
 // MarshalJSON serializes the range as human-readable IP address strings.
 func (m *IPRange) MarshalJSON() ([]byte, error) {
 	start, end, err := m.ToRange()
 	if err != nil {
 		return nil, err
 	}
-	return fmt.Appendf(nil, `{"start":"%s","end":"%s"}`, start.String(), end.String()), nil
+	return json.Marshal(ipRangeJSON{Start: start.String(), End: end.String()})
 }
 
 // UnmarshalJSON accepts start and end as IPv4 or IPv6 address strings.
 func (m *IPRange) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		Start string `json:"start"`
-		End   string `json:"end"`
-	}
+	var raw ipRangeJSON
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}

--- a/common/commonpb/v1/macaddr.go
+++ b/common/commonpb/v1/macaddr.go
@@ -32,18 +32,22 @@ func (m *MACAddress) AsLogValue() any {
 	return net.HardwareAddr(eui48[:]).String()
 }
 
+// macAddressJSON is the JSON wire shape shared by MarshalJSON and
+// UnmarshalJSON.
+type macAddressJSON struct {
+	Addr string `json:"addr"`
+}
+
 // MarshalJSON serializes addr as a human-readable MAC address string.
 func (m *MACAddress) MarshalJSON() ([]byte, error) {
 	eui48 := m.EUI48()
-	return fmt.Appendf(nil, `{"addr":"%s"}`, net.HardwareAddr(eui48[:])), nil
+	return json.Marshal(macAddressJSON{Addr: net.HardwareAddr(eui48[:]).String()})
 }
 
 // UnmarshalJSON accepts addr as a MAC address string in various EUI-48
 // formats.
 func (m *MACAddress) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		Addr string `json:"addr"`
-	}
+	var raw macAddressJSON
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}


### PR DESCRIPTION
The address, range and MAC wire types each hand-built their JSON output while separately declaring an anonymous struct of the same shape for decoding, so every wire shape was written twice and the two halves could drift apart independently. They now follow the shared-struct pattern their network sibling and the histogram bucket already use: one unexported shape declared once, driving both directions through the standard encoder.

- The emitted bytes are unchanged, which the existing tests confirm unedited — they pin exact wire literals, including the key order of the two-field range shape.
- Byte-identity was additionally checked against a reimplementation of the previous hand-built output across roughly 2.5 million values, covering random and edge addresses of both families, sparse patterns that force zero-run compression, mismatched families, invalid lengths in both directions, and an exhaustive per-octet MAC sweep.
- The standard encoder escapes HTML metacharacters where the previous hand-built path did not. That cannot alter output here: the marshalled strings are produced only from addresses built out of raw bytes, which can never carry a zone suffix, so the emitted alphabet is limited to decimal digits, lowercase hex, dots and colons.
- The decode paths keep their existing assignment shapes deliberately. Dereferencing the constructor call directly is exempt from the vet check that rejects copying a lock value, and the range type assigns its fields one at a time because its error-checked construction forces an intermediate. Extracting a variable for readability in either place would fail the build.
- Encoding through the standard library costs roughly 80 nanoseconds more per value than the previous formatting, which is accepted here. These types are reached from the control-plane HTTP translation layer rather than the packet path, and that path already spends an order of magnitude more per value in reflection.

Closes #1953.