### PR TITLE
chore(deps): update netip to 0.3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,9 +1233,9 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "netip"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513b83d6285ebc6b4519a89263bb0bd789e4d2d279f1f99e59034d3138b6f74f"
+checksum = "d2d1ae2988edc6b837fa9c5103d83aa495d5b8a5b423e17f3fbd2beea67b9d74"
 
 [[package]]
 name = "no-std-net"


### PR DESCRIPTION
Picks up the two additive changes in the dependency's latest patch release.

The overflow error returned by its address-and-prefix conversions is now re-exported and implements the standard error trait, so callers can name it and propagate it instead of only unwrapping or stringifying it.

Networks can also now be built from an address and a prefix length for both address families, including into the contiguous wrapper, which previously had no constructor other than parsing a string. A follow-up change uses that to decode the shared contiguous network message without a format-and-reparse round trip.

Lockfile only — the existing version requirements already admitted this release.
