### PR TITLE
fix(dataplane): reject invalid numeric config values

### DIFF
--- a/dataplane/config.c
+++ b/dataplane/config.c
@@ -1,9 +1,72 @@
 #include "config.h"
 
+#include <ctype.h>
+#include <errno.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <yaml.h>
 
 #include "common/strutils.h"
+
+static void
+print_scalar(const char *value, size_t length) {
+	fputc('\'', stderr);
+	for (size_t idx = 0; idx < length; ++idx) {
+		unsigned char character = (unsigned char)value[idx];
+		switch (character) {
+		case '\\':
+			fputs("\\\\", stderr);
+			break;
+		case '\'':
+			fputs("\\'", stderr);
+			break;
+		case '\0':
+			fputs("\\0", stderr);
+			break;
+		default:
+			if (isprint(character)) {
+				fputc(character, stderr);
+			} else {
+				fprintf(stderr, "\\x%02x", character);
+			}
+			break;
+		}
+	}
+	fputc('\'', stderr);
+}
+
+static int
+parse_unsigned(
+	const char *field,
+	const char *value,
+	size_t length,
+	uint64_t max,
+	uint64_t *result
+) {
+	char *end = NULL;
+	const char *first = value;
+	while (isspace((unsigned char)*first)) {
+		++first;
+	}
+
+	errno = 0;
+	uintmax_t parsed = strtoumax(value, &end, 10);
+
+	if (*first == '-' || value == end || end != value + length ||
+	    errno == ERANGE || parsed > max) {
+		fprintf(stderr, "invalid %s value ", field);
+		print_scalar(value, length);
+		fprintf(stderr,
+			" (length %zu): expected an unsigned integer in range "
+			"0..%" PRIu64 "\n",
+			length,
+			max);
+		return -1;
+	}
+
+	*result = (uint64_t)parsed;
+	return 0;
+}
 
 static int
 resolve_connections(struct dataplane_config *config) {
@@ -91,6 +154,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 
 	yaml_parser_t parser;
 	yaml_event_t event;
+	int event_live = 0;
 	if (!yaml_parser_initialize(&parser)) {
 		return -1;
 	}
@@ -112,9 +176,13 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 	struct dataplane_connection_config *connection = NULL;
 
 	char *start = NULL;
-	char *end = NULL;
+	size_t scalar_length = 0;
+	uint64_t value = 0;
 
-	yaml_parser_parse(&parser, &event);
+	if (!yaml_parser_parse(&parser, &event)) {
+		goto error;
+	}
+	event_live = 1;
 	while (event.type != YAML_STREAM_END_EVENT) {
 
 		switch (event.type) {
@@ -134,7 +202,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 
 		case YAML_SCALAR_EVENT:
 			start = (char *)event.data.scalar.value;
-			end = start + event.data.scalar.length;
+			scalar_length = event.data.scalar.length;
 
 			switch (state) {
 			case state_dataplane_storage:
@@ -144,9 +212,13 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 				state = state_dataplane;
 				break;
 			case state_dataplane_dpdk_memory:
-				dataplane->dpdk_memory =
-					strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "dataplane.dpdk_memory",
+					    start,
+					    scalar_length,
+					    UINT64_MAX,
+					    &dataplane->dpdk_memory
+				    ) != 0) {
 					goto error;
 				}
 				state = state_dataplane;
@@ -183,22 +255,38 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 
 			// handle new instance
 			case state_instance_numa_id:
-				instance->numa_idx = strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "instances.numa_id",
+					    start,
+					    scalar_length,
+					    UINT16_MAX,
+					    &value
+				    ) != 0) {
 					goto error;
 				}
+				instance->numa_idx = (uint16_t)value;
 				state = state_instance;
 				break;
 			case state_instance_dp_memory:
-				instance->dp_memory = strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "instances.dp_memory",
+					    start,
+					    scalar_length,
+					    UINT64_MAX,
+					    &instance->dp_memory
+				    ) != 0) {
 					goto error;
 				}
 				state = state_instance;
 				break;
 			case state_instance_cp_memory:
-				instance->cp_memory = strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "instances.cp_memory",
+					    start,
+					    scalar_length,
+					    UINT64_MAX,
+					    &instance->cp_memory
+				    ) != 0) {
 					goto error;
 				}
 				state = state_instance;
@@ -223,24 +311,39 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 				state = state_device;
 				break;
 			case state_device_mtu:
-				device->mtu = strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "devices.mtu",
+					    start,
+					    scalar_length,
+					    UINT32_MAX,
+					    &value
+				    ) != 0) {
 					goto error;
 				}
+				device->mtu = (uint32_t)value;
 				state = state_device;
 				break;
 			case state_device_max_lro_packet_size:
-				device->max_lro_packet_size =
-					strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "devices.max_lro_packet_size",
+					    start,
+					    scalar_length,
+					    UINT64_MAX,
+					    &device->max_lro_packet_size
+				    ) != 0) {
 					goto error;
 				}
 
 				state = state_device;
 				break;
 			case state_device_rss_hash:
-				device->rss_hash = strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "devices.rss_hash",
+					    start,
+					    scalar_length,
+					    UINT64_MAX,
+					    &device->rss_hash
+				    ) != 0) {
 					goto error;
 				}
 
@@ -248,42 +351,72 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 				break;
 
 			case state_worker_core_id:
-				worker->core_id = strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "workers.core_id",
+					    start,
+					    scalar_length,
+					    UINT16_MAX,
+					    &value
+				    ) != 0) {
 					goto error;
 				}
+				worker->core_id = (uint16_t)value;
 
 				state = state_worker;
 				break;
 			case state_worker_instance_id:
-				worker->instance_id = strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "workers.instance_id",
+					    start,
+					    scalar_length,
+					    UINT16_MAX,
+					    &value
+				    ) != 0) {
 					goto error;
 				}
+				worker->instance_id = (uint16_t)value;
 
 				state = state_worker;
 				break;
 			case state_worker_rx_queue_len:
-				worker->rx_queue_len = strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "workers.rx_queue_len",
+					    start,
+					    scalar_length,
+					    UINT16_MAX,
+					    &value
+				    ) != 0) {
 					goto error;
 				}
+				worker->rx_queue_len = (uint16_t)value;
 
 				state = state_worker;
 				break;
 			case state_worker_tx_queue_len:
-				worker->tx_queue_len = strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "workers.tx_queue_len",
+					    start,
+					    scalar_length,
+					    UINT16_MAX,
+					    &value
+				    ) != 0) {
 					goto error;
 				}
+				worker->tx_queue_len = (uint16_t)value;
 
 				state = state_worker;
 				break;
 			case state_worker_num_mbufs:
-				worker->num_mbufs = strtol(start, &end, 10);
-				if (*end != '\0') {
+				if (parse_unsigned(
+					    "workers.num_mbufs",
+					    start,
+					    scalar_length,
+					    UINT32_MAX,
+					    &value
+				    ) != 0) {
 					goto error;
 				}
+				worker->num_mbufs = (uint32_t)value;
 
 				state = state_worker;
 				break;
@@ -561,9 +694,14 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 		}
 
 		yaml_event_delete(&event);
-		yaml_parser_parse(&parser, &event);
+		event_live = 0;
+		if (!yaml_parser_parse(&parser, &event)) {
+			goto error;
+		}
+		event_live = 1;
 	}
 	yaml_event_delete(&event);
+	event_live = 0;
 
 	if (resolve_connections(dataplane) != 0) {
 		goto error;
@@ -576,6 +714,9 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 	return 0;
 
 error:
+	if (event_live) {
+		yaml_event_delete(&event);
+	}
 	dataplane_config_free(dataplane);
 
 err_alloc_config:

--- a/dataplane/unittest/config/main.c
+++ b/dataplane/unittest/config/main.c
@@ -16,6 +16,126 @@ check_instance(
 	assert(config->cp_memory == cp_memory);
 }
 
+static int
+parse_yaml(const char *yaml, struct dataplane_config **config) {
+	FILE *f = fmemopen((void *)yaml, strlen(yaml), "r");
+	assert(f != NULL);
+
+	int rc = dataplane_config_init(f, config);
+	fclose(f);
+	return rc;
+}
+
+struct numeric_field {
+	const char *yaml_format;
+	const char *overflow;
+};
+
+static void
+test_numeric_field_rejects_invalid_values(const struct numeric_field *field) {
+	const char *invalid_values[] = {
+		"-1", "\" -1\"", "\"1\\0junk\"", field->overflow, "not-a-number"
+	};
+	char yaml[512];
+
+	for (size_t value_idx = 0;
+	     value_idx < sizeof(invalid_values) / sizeof(invalid_values[0]);
+	     ++value_idx) {
+		int length = snprintf(
+			yaml,
+			sizeof(yaml),
+			field->yaml_format,
+			invalid_values[value_idx]
+		);
+		assert(length >= 0 && (size_t)length < sizeof(yaml));
+
+		struct dataplane_config *config = NULL;
+		int rc = parse_yaml(yaml, &config);
+		assert(rc == -1);
+		assert(config == NULL);
+	}
+}
+
+static void
+test_numeric_field_maximum_values(void) {
+	const char yaml[] = "dataplane:\n"
+			    "  dpdk_memory: 18446744073709551615\n"
+			    "  instances:\n"
+			    "    - numa_id: 65535\n"
+			    "      dp_memory: 18446744073709551615\n"
+			    "      cp_memory: 18446744073709551615\n"
+			    "  devices:\n"
+			    "    - mtu: 4294967295\n"
+			    "      max_lro_packet_size: 18446744073709551615\n"
+			    "      rss_hash: 18446744073709551615\n"
+			    "      workers:\n"
+			    "        - core_id: 65535\n"
+			    "          instance_id: 65535\n"
+			    "          rx_queue_len: 65535\n"
+			    "          tx_queue_len: 65535\n"
+			    "          num_mbufs: 4294967295\n";
+
+	struct dataplane_config *config = NULL;
+	int rc = parse_yaml(yaml, &config);
+	assert(rc == 0);
+
+	assert(config->dpdk_memory == UINT64_MAX);
+	assert(config->instance_count == 1);
+	assert(config->instances[0].numa_idx == UINT16_MAX);
+	assert(config->instances[0].dp_memory == UINT64_MAX);
+	assert(config->instances[0].cp_memory == UINT64_MAX);
+	assert(config->device_count == 1);
+	assert(config->devices[0].mtu == UINT32_MAX);
+	assert(config->devices[0].max_lro_packet_size == UINT64_MAX);
+	assert(config->devices[0].rss_hash == UINT64_MAX);
+	assert(config->devices[0].worker_count == 1);
+	assert(config->devices[0].workers[0].core_id == UINT16_MAX);
+	assert(config->devices[0].workers[0].instance_id == UINT16_MAX);
+	assert(config->devices[0].workers[0].rx_queue_len == UINT16_MAX);
+	assert(config->devices[0].workers[0].tx_queue_len == UINT16_MAX);
+	assert(config->devices[0].workers[0].num_mbufs == UINT32_MAX);
+
+	dataplane_config_free(config);
+}
+
+static void
+test_numeric_field_ranges(void) {
+	const struct numeric_field fields[] = {
+		{"dataplane:\n  dpdk_memory: %s\n", "18446744073709551616"},
+		{"dataplane:\n  instances:\n    - numa_id: %s\n", "65536"},
+		{"dataplane:\n  instances:\n    - dp_memory: %s\n",
+		 "18446744073709551616"},
+		{"dataplane:\n  instances:\n    - cp_memory: %s\n",
+		 "18446744073709551616"},
+		{"dataplane:\n  devices:\n    - mtu: %s\n", "4294967296"},
+		{"dataplane:\n  devices:\n    - max_lro_packet_size: %s\n",
+		 "18446744073709551616"},
+		{"dataplane:\n  devices:\n    - rss_hash: %s\n",
+		 "18446744073709551616"},
+		{"dataplane:\n  devices:\n    - workers:\n        - core_id: "
+		 "%s\n",
+		 "65536"},
+		{"dataplane:\n  devices:\n    - workers:\n        - "
+		 "instance_id: %s\n",
+		 "65536"},
+		{"dataplane:\n  devices:\n    - workers:\n        - "
+		 "rx_queue_len: %s\n",
+		 "65536"},
+		{"dataplane:\n  devices:\n    - workers:\n        - "
+		 "tx_queue_len: %s\n",
+		 "65536"},
+		{"dataplane:\n  devices:\n    - workers:\n        - num_mbufs: "
+		 "%s\n",
+		 "4294967296"},
+	};
+
+	for (size_t field_idx = 0;
+	     field_idx < sizeof(fields) / sizeof(fields[0]);
+	     ++field_idx) {
+		test_numeric_field_rejects_invalid_values(fields + field_idx);
+	}
+}
+
 static void
 test_resolve_connections_unknown_device(void) {
 	const char yaml[] = "dataplane:\n"
@@ -108,6 +228,8 @@ main(int argc, char **argv) {
 	(void)argv;
 
 	test_valid_config();
+	test_numeric_field_maximum_values();
+	test_numeric_field_ranges();
 	test_resolve_connections_unknown_device();
 	test_resolve_connections_duplicate_device();
 	test_resolve_connections_empty_device_name();


### PR DESCRIPTION
- Validate every unsigned dataplane configuration field against its declared width before assignment.
- Reject negative, malformed, and overflowing values with field-specific diagnostics.
- Add boundary and invalid-input coverage for all numeric fields.

Closes #1943.