### PR TITLE
fix(xcfg): marshal configuration wrappers to JSON as the value they wrap

### DIFF
--- a/common/go/xcfg/nonempty.go
+++ b/common/go/xcfg/nonempty.go
@@ -1,6 +1,7 @@
 package xcfg
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
@@ -56,6 +57,14 @@ func (m NonEmptyString) String() string {
 // MarshalYAML implements yaml.Marshaler.
 func (m NonEmptyString) MarshalYAML() (any, error) {
 	return m.v, nil
+}
+
+// MarshalJSON implements json.Marshaler.
+//
+// Without it, config dumps reach a reflect-based JSON encoder that finds
+// no exported field and renders any value as "{}".
+func (m NonEmptyString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.v)
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler, rejecting empty strings.

--- a/common/go/xcfg/nonempty_test.go
+++ b/common/go/xcfg/nonempty_test.go
@@ -1,6 +1,7 @@
 package xcfg
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -69,6 +70,16 @@ func Test_NonEmptyString_NullYAMLCaughtByValidate(t *testing.T) {
 	// Validate() catches this instead.
 	require.NoError(t, yaml.Unmarshal([]byte("v:"), &out))
 	require.Error(t, out.V.Validate())
+}
+
+func Test_NonEmptyString_MarshalJSON(t *testing.T) {
+	type doc struct {
+		V NonEmptyString `json:"v"`
+	}
+
+	buf, err := json.Marshal(doc{V: MustNonEmptyString("hello")})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"v":"hello"}`, string(buf))
 }
 
 func Test_NonEmptyString_YAMLRoundTrip(t *testing.T) {

--- a/common/go/xcfg/nonzero.go
+++ b/common/go/xcfg/nonzero.go
@@ -1,6 +1,7 @@
 package xcfg
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
@@ -59,6 +60,14 @@ func (m NonZero[T]) Validate() error {
 // MarshalYAML implements yaml.Marshaler for round-trip serialization.
 func (m NonZero[T]) MarshalYAML() (any, error) {
 	return m.v, nil
+}
+
+// MarshalJSON implements json.Marshaler.
+//
+// Without it, config dumps reach a reflect-based JSON encoder that finds
+// no exported field and renders any value as "{}".
+func (m NonZero[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.v)
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler, rejecting zero values.

--- a/common/go/xcfg/nonzero_test.go
+++ b/common/go/xcfg/nonzero_test.go
@@ -1,6 +1,7 @@
 package xcfg
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -65,6 +66,16 @@ func Test_NonZero_NullYAMLCaughtByValidate(t *testing.T) {
 	}
 	require.NoError(t, yaml.Unmarshal([]byte("v:"), &out))
 	require.Error(t, out.V.Validate())
+}
+
+func Test_NonZero_MarshalJSON(t *testing.T) {
+	type doc struct {
+		V NonZero[int] `json:"v"`
+	}
+
+	buf, err := json.Marshal(doc{V: MustNonZero(42)})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"v":42}`, string(buf))
 }
 
 func Test_NonZero_YAMLRoundTrip(t *testing.T) {

--- a/common/go/xcfg/optional.go
+++ b/common/go/xcfg/optional.go
@@ -40,10 +40,8 @@ func (m Optional[T]) MarshalYAML() (any, error) {
 
 // MarshalJSON implements json.Marshaler.
 //
-// Without it, zap.Any's reflect-based encoding sees only the unexported
-// field and renders every Optional the same regardless of presence. This
-// delegates to the wrapped pointer so an absent value logs as null and a
-// present one logs as the value it wraps.
+// Without it, config dumps reach a reflect-based JSON encoder that finds
+// no exported field and renders any value as "{}".
 func (m Optional[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.v)
 }

--- a/common/go/xcfg/required.go
+++ b/common/go/xcfg/required.go
@@ -46,9 +46,8 @@ func (m Required[T]) MarshalYAML() (any, error) {
 
 // MarshalJSON implements json.Marshaler.
 //
-// Without it, zap.Any's reflect-based encoding sees only the unexported
-// fields and renders every Required the same regardless of its value. This
-// delegates to the wrapped value so it logs the same as an unwrapped T.
+// Without it, config dumps reach a reflect-based JSON encoder that finds
+// no exported field and renders any value as "{}".
 func (m Required[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.v)
 }


### PR DESCRIPTION
The control plane and the operators log their parsed configuration through a reflect-based JSON encoder. The wrapper types that carry a configured string or number keep it in an unexported field and had no JSON marshaler of their own, so the encoder found nothing to serialise and rendered each one as an empty object. An operator reading that line to confirm what was parsed saw no memory paths, endpoints, gateway endpoints or memory requirements at all — a control plane configured entirely correctly logged the same line as one configured wrong.

Each wrapper now serialises as the value it wraps, matching what it already did for YAML. The same startup line that read `{"cert_file":{},"ttl":{}}` now reads `{"cert_file":"/etc/yanet2/tls/cert.pem","ttl":300000000000}`.

Two sibling wrappers gained the same marshaler recently, and their rationale had two problems. It named a logging helper this package does not depend on, and the failure it described does not occur on the path it named: that helper renders a wrapper passed to it directly through the value's own text form, so the empty object only appears when the wrapper is nested inside a configuration struct. All four wrappers now carry one accurate rationale.

Closes #1959.