### PR TITLE
fix(dataplane): guard teardown against never-started workers and devices

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -190,10 +190,19 @@ dataplane_create_devices(
 	struct dataplane_device_config *device_configs
 ) {
 
-	dataplane->device_count = device_count;
+	dataplane->device_count = 0;
+
 	dataplane->devices = (struct dataplane_device *)malloc(
-		sizeof(struct dataplane_device) * dataplane->device_count
+		sizeof(struct dataplane_device) * device_count
 	);
+	if (dataplane->devices == NULL) {
+		LOG(ERROR, "failed to allocate 'devices'");
+		return -1;
+	}
+	memset(dataplane->devices,
+	       0,
+	       sizeof(struct dataplane_device) * device_count);
+	dataplane->device_count = device_count;
 
 	/*
 	 * Scan device list for yanet_ring devices. Such device consists of

--- a/dataplane/device.c
+++ b/dataplane/device.c
@@ -2,6 +2,7 @@
 #include "dataplane.h"
 
 #include <pthread.h>
+#include <string.h>
 
 #include "common/strutils.h"
 #include "dpdk.h"
@@ -129,6 +130,9 @@ dataplane_device_init(
 		errno = ENOMEM;
 		return -1;
 	}
+	memset(device->workers,
+	       0,
+	       sizeof(struct dataplane_worker) * config->worker_count);
 
 	for (device->worker_count = 0;
 	     device->worker_count < config->worker_count;

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -400,6 +400,8 @@ dataplane_worker_init(
 	    config->instance_id,
 	    device->port_id);
 
+	worker->thread_started = false;
+
 	if (config->instance_id >= dataplane->instance_count) {
 		LOG(ERROR,
 		    "worker core=%u references instance=%u but only %u "
@@ -626,10 +628,17 @@ dataplane_worker_start(struct dataplane_worker *worker) {
 		return -1;
 	}
 
+	worker->thread_started = true;
+
 	return 0;
 }
 
 void
 dataplane_worker_stop(struct dataplane_worker *worker) {
+	if (!worker->thread_started) {
+		return;
+	}
+
 	pthread_join(worker->thread_id, NULL);
+	worker->thread_started = false;
 }

--- a/dataplane/worker.h
+++ b/dataplane/worker.h
@@ -2,6 +2,7 @@
 
 #include <pthread.h>
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "config.h"
@@ -69,6 +70,8 @@ struct dataplane_worker {
 	struct dp_worker *dp_worker;
 
 	pthread_t thread_id;
+	// Gates the join: false unless a thread was created and not yet reaped.
+	bool thread_started;
 
 	// FIXME port_id and device_id could be inherited from device
 	uint16_t port_id;


### PR DESCRIPTION
Worker teardown now tracks whether a thread was actually created and skips the join when it was not, so a worker whose thread creation failed can no longer be joined on an uninitialized handle.

- The worker and device arrays are zeroed at allocation, so a slot that was never initialized presents an empty, skippable state instead of heap garbage.
- The device array allocation is now checked for failure, and the device count is published only once the array is valid. Previously the count was set before an unchecked allocation, so a failure there left a full count over garbage memory.
- The safety was previously non-local, holding only because teardown has a single call site that is unreachable after a failed start. Adding cleanup on the failed-start path, or a signal handler that stops the dataplane, would have silently turned it into a join on a garbage handle.
- The device-array half reaches past the issue's literal checkbox, but it is the same defect class in the sibling allocation the issue cites as the source of the uninitialized memory, and it is reached by the very scenario the issue names as motivation.
- This removes the undefined behaviour, not the blocking wait. Stopping a successfully started dataplane still blocks, because the worker loop never returns and no shutdown signal exists.

Closes #1945.