### PR TITLE
perf(counters): bulk-copy counter values per worker

### DIFF
--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1665,20 +1665,11 @@ cp_counter_storage_copy_tags(const struct cp_counter_storage *storage) {
 	return tags;
 }
 
-// Free a per-instance snapshot array as produced by fill_counter_handle.
-static void
-free_counter_values(uint64_t **values, uint64_t instance_count) {
-	if (values == NULL) {
-		return;
-	}
-	for (uint64_t i = 0; i < instance_count; ++i) {
-		free(values[i]);
-	}
-	free(values);
-}
-
 // Copy one already-described counter's per-worker value snapshot into
 // newly allocated memory, stashed behind the handle's opaque value array.
+//
+// The pointer array and every worker's value block live in one allocation:
+// the pointer array first, then each worker's values back to back.
 //
 // The caller guarantees the per-worker storages stay alive for the
 // duration of this call.
@@ -1689,19 +1680,23 @@ counter_handle_copy_values(
 	uint64_t worker_count,
 	uint64_t idx
 ) {
-	uint64_t **values = calloc(worker_count, sizeof(*values));
-	if (values == NULL) {
+	size_t ptr_array_size = worker_count * sizeof(uint64_t *);
+
+	uint8_t *base =
+		malloc(ptr_array_size +
+		       worker_count * dst->size * sizeof(uint64_t));
+	if (base == NULL) {
 		return -1;
 	}
+
+	uint64_t **values = (uint64_t **)base;
+	uint64_t *value_blocks = (uint64_t *)(base + ptr_array_size);
 	for (uint64_t w_idx = 0; w_idx < worker_count; ++w_idx) {
 		if (dst->size == 0) {
+			values[w_idx] = NULL;
 			continue;
 		}
-		values[w_idx] = malloc(dst->size * sizeof(uint64_t));
-		if (values[w_idx] == NULL) {
-			free_counter_values(values, worker_count);
-			return -1;
-		}
+		values[w_idx] = value_blocks + w_idx * dst->size;
 		struct counter_value_handle *handle =
 			counter_get_value_handle(idx, worker_storages[w_idx]);
 		memcpy(values[w_idx],
@@ -2309,10 +2304,10 @@ yanet_counter_handle_list_free(struct counter_handle_list *counters) {
 			}
 			free(handles[i].tags);
 		}
-		// Each counter owns its own per-worker snapshot array.
-		free_counter_values(
-			handles[i].values, counters->instance_count
-		);
+		// This pointer is the base of the single allocation that also
+		// holds every worker's value block, so freeing it here
+		// reclaims all of it.
+		free(handles[i].values);
 	}
 	free(counters);
 }

--- a/tests/counters/alloc_probe.go
+++ b/tests/counters/alloc_probe.go
@@ -1,0 +1,39 @@
+package counters_test
+
+//#cgo LDFLAGS: -Wl,--wrap=malloc -Wl,--wrap=calloc
+/*
+#include <stddef.h>
+
+extern void *__real_malloc(size_t size);
+extern void *__real_calloc(size_t nmemb, size_t size);
+
+static size_t alloc_count = 0;
+
+void *
+__wrap_malloc(size_t size) {
+	__atomic_fetch_add(&alloc_count, 1, __ATOMIC_RELAXED);
+	return __real_malloc(size);
+}
+
+void *
+__wrap_calloc(size_t nmemb, size_t size) {
+	__atomic_fetch_add(&alloc_count, 1, __ATOMIC_RELAXED);
+	return __real_calloc(nmemb, size);
+}
+
+size_t
+alloc_count_load(void) {
+	return __atomic_load_n(&alloc_count, __ATOMIC_RELAXED);
+}
+*/
+import "C"
+
+// allocCount returns the number of malloc/calloc calls observed so far by
+// the __wrap_malloc/__wrap_calloc probes linked into this test binary.
+//
+// This is a lower bound covering only this binary's own object files: a
+// call made inside a precompiled shared library, such as glibc's internal
+// strdup, is not linked against the wrap symbols and stays uncounted.
+func allocCount() uint64 {
+	return uint64(C.alloc_count_load())
+}

--- a/tests/counters/bulk_value_copy_test.go
+++ b/tests/counters/bulk_value_copy_test.go
@@ -1,0 +1,111 @@
+// Package counters_test holds regression tests for the counter value-copy
+// path implemented in lib/controlplane/agent/agent.c.
+package counters_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+// Memory sizes and topology for the allocation-count regression harness.
+const (
+	bulkCopyCPSize    = 32 * datasize.MB
+	bulkCopyDPSize    = 4 * datasize.MB
+	bulkCopyAgentSize = 2 * datasize.MB
+
+	// bulkCopyPipelineCount is chosen so the per-counter allocation term
+	// dominates the fixed per-call overhead: 20 empty pipelines register
+	// 6 counters each and the single device storage registers another
+	// 12, so the nil tag filter matches 132 counters across 21 storages
+	// against a fixed term of 4+workerCount+21 allocations (27 at 2
+	// workers, 33 at 8).
+	bulkCopyPipelineCount = 20
+)
+
+// bulkCopyProbe installs a device and bulkCopyPipelineCount empty pipelines
+// at the given worker count, snapshots the wrapped allocator count
+// immediately around one CountersByTags call, and returns the number of
+// allocations it performed together with the number of counters it matched.
+func bulkCopyProbe(t *testing.T, workerCount uint64) (allocs uint64, matched int) {
+	t.Helper()
+
+	cfg := dataplaneut.Config{
+		CPMemory:      uint64(bulkCopyCPSize),
+		DPMemory:      uint64(bulkCopyDPSize),
+		WorkerCount:   workerCount,
+		Devices:       []string{"port0"},
+		DevicesToLoad: []string{"plain"},
+	}
+	h, err := dataplaneut.NewHarness(cfg)
+	require.NoError(t, err)
+	defer h.Free()
+
+	agent, err := h.SharedMemory().AgentAttach(
+		"bulk-copy-probe", 0, bulkCopyAgentSize,
+	)
+	require.NoError(t, err)
+	defer func() { _ = agent.CleanUp() }()
+
+	input := make([]ffi.DevicePipelineConfig, bulkCopyPipelineCount)
+	for idx := range bulkCopyPipelineCount {
+		name := fmt.Sprintf("bulk-copy-pipeline-%d", idx)
+		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: name}))
+		input[idx] = ffi.DevicePipelineConfig{Name: name, Weight: 1}
+	}
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:  "port0",
+		Input: input,
+	}}))
+
+	dp := h.SharedMemory().DPConfig(0)
+
+	before := allocCount()
+	groups, err := dp.CountersByTags(nil, nil)
+	after := allocCount()
+	require.NoError(t, err)
+
+	for _, group := range groups {
+		matched += len(group.Counters)
+	}
+
+	return after - before, matched
+}
+
+// TestCountersByTagsAllocationsDoNotScaleWithWorkerCount pins the bulk
+// value-copy shape of counter_handle_copy_values: reading the same matched
+// counter set at a higher worker count must not multiply the allocation
+// count by that worker count, and the read overall must cost on the order
+// of one allocation per matched counter rather than one per counter per
+// worker.
+func TestCountersByTagsAllocationsDoNotScaleWithWorkerCount(t *testing.T) {
+	const (
+		lowWorkers  = 2
+		highWorkers = 8
+	)
+
+	lowAllocs, lowMatched := bulkCopyProbe(t, lowWorkers)
+	highAllocs, highMatched := bulkCopyProbe(t, highWorkers)
+
+	require.NotZero(t, lowMatched, "probe must match a non-zero counter set")
+	require.Equal(t, lowMatched, highMatched,
+		"worker count must not change the matched counter set",
+	)
+
+	matched := uint64(highMatched)
+	require.Less(t, highAllocs, lowAllocs+matched,
+		"allocation count must not scale with worker count",
+	)
+	require.Less(t, highAllocs, 2*matched,
+		"read must cost on the order of one allocation per counter",
+	)
+	require.GreaterOrEqual(t, highAllocs, matched,
+		"read must average at least one allocation per matched counter, "+
+			"or the probe stopped observing the copy",
+	)
+}


### PR DESCRIPTION
- The tagged counter read snapshotted each counter's values with one allocation per worker plus one more for the pointer array, which dominated the allocator traffic of a scrape over a large rule set.
- A single allocation per counter now holds the pointer array and every worker's values, so a counter's snapshot costs one allocation whatever the worker count.
- A new Go regression test drives the read through the shared-memory bindings at two worker counts, counting the allocations the read performs, and pins the per-counter cost with a floor that fails if the measurement ever stops observing the copy.

Closes #1916.