### PR TITLE
fix(gateway,functional): eliminate the close-then-bind race in ephemeral port reservation

### DIFF
--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -82,6 +82,7 @@ type gatewayOptions struct {
 	Services []serviceEntry
 	Log      *zap.Logger
 	LogLevel *zap.AtomicLevel
+	Listener net.Listener
 }
 
 func newGatewayOptions() *gatewayOptions {
@@ -121,6 +122,18 @@ func WithAtomicLogLevel(level *zap.AtomicLevel) GatewayOption {
 	}
 }
 
+// WithListener hands the Gateway an already-open listener to serve instead
+// of binding cfg.Server.Endpoint itself.
+//
+// Run serves this listener directly and never calls net.Listen. The server
+// closes it when it stops, and closing it again is a harmless net.ErrClosed
+// — close it yourself only if Run never runs.
+func WithListener(listener net.Listener) GatewayOption {
+	return func(o *gatewayOptions) {
+		o.Listener = listener
+	}
+}
+
 // Gateway is the Gateway API to YANET modules.
 //
 // It is a gRPC server that acts as a proxy for each YANET module's
@@ -135,6 +148,7 @@ func WithAtomicLogLevel(level *zap.AtomicLevel) GatewayOption {
 type Gateway struct {
 	cfg              *Config
 	server           *grpc.Server
+	listener         net.Listener
 	services         []Service
 	serviceRunners   []*ServiceRunner
 	registry         *BackendRegistry
@@ -150,6 +164,15 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	}
 	log := opts.Log
 	registry := NewBackendRegistry()
+
+	// endpoint is what the gateway's own loopback dial, TLS SNI host, and
+	// out-of-process service registration target. It follows the injected
+	// listener's real address when one is supplied, and cfg.Server.Endpoint
+	// otherwise, without ever mutating cfg, which the caller owns.
+	endpoint := cfg.Server.Endpoint
+	if opts.Listener != nil {
+		endpoint = opts.Listener.Addr().String()
+	}
 
 	authManager, err := auth.NewManager(&cfg.Auth, auth.WithLog(log))
 	if err != nil {
@@ -319,12 +342,12 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	//
 	// Out-of-process module backends (from the Register RPC) each get their
 	// own connection via RegisterBackend in the registration loop.
-	creds, err := TransportCredentials(cfg.Server.TLS, cfg.Server.Endpoint)
+	creds, err := TransportCredentials(cfg.Server.TLS, endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build loopback TLS credentials: %w", err)
 	}
 
-	loopback, err := dialBackend(cfg.Server.Endpoint, creds)
+	loopback, err := dialBackend(endpoint, creds)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create loopback backend for gateway-hosted services: %w", err)
 	}
@@ -361,7 +384,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 			}
 		} else {
 			// Out-of-process: wrap in a ServiceRunner.
-			runner := NewServiceRunner(entry.service, cfg.Server.Endpoint, cfg.Server.TLS, WithServiceRunnerLog(log))
+			runner := NewServiceRunner(entry.service, endpoint, cfg.Server.TLS, WithServiceRunnerLog(log))
 			serviceRunners = append(serviceRunners, runner)
 		}
 
@@ -371,6 +394,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	return &Gateway{
 		cfg:              cfg,
 		server:           server,
+		listener:         opts.Listener,
 		services:         services,
 		serviceRunners:   serviceRunners,
 		registry:         registry,
@@ -406,9 +430,13 @@ func (m *Gateway) Close() error {
 func (m *Gateway) Run(ctx context.Context) error {
 	m.log.Info("starting gRPC gateway")
 
-	listener, err := net.Listen("tcp", m.cfg.Server.Endpoint)
-	if err != nil {
-		return fmt.Errorf("failed to initialize gRPC listener: %w", err)
+	listener := m.listener
+	if listener == nil {
+		var err error
+		listener, err = net.Listen("tcp", m.cfg.Server.Endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to initialize gRPC listener: %w", err)
+		}
 	}
 
 	m.log.Info("exposing gRPC gateway", zap.Stringer("addr", listener.Addr()))

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -73,18 +74,22 @@ func TestNewGateway_DeclaredKindsWired(t *testing.T) {
 	require.Equal(t, BackendKindInProcess, kinds["test.InProcessService"], "WithService must yield in-process kind")
 }
 
-// freeTCPAddr reserves and immediately releases an ephemeral TCP port so a
-// server that binds it later gets a concrete, otherwise-unused endpoint.
-func freeTCPAddr(t *testing.T) string {
+// NewTestListener opens an ephemeral loopback TCP listener for a test to
+// pass into WithListener or hold open to occupy a port, registering a
+// cleanup that closes it.
+//
+// It hands back the open listener rather than closing it and returning a
+// bare address, which would let another process grab that port first — the
+// TOCTOU this helper avoids. Cleanup tolerates an already-closed listener.
+func NewTestListener(t *testing.T) net.Listener {
 	t.Helper()
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	addr := listener.Addr().String()
-	require.NoError(t, listener.Close())
+	t.Cleanup(func() { _ = listener.Close() })
 
-	return addr
+	return listener
 }
 
 // blockingReadinessService is a fake Service whose Watch handler blocks on
@@ -159,9 +164,9 @@ func TestGateway_Run_ShutsDownWithOpenStream(t *testing.T) {
 	t.Parallel()
 
 	cfg := DefaultConfig()
-	cfg.Server.Endpoint = freeTCPAddr(t)
+	listener := NewTestListener(t)
 
-	gw, err := NewGateway(cfg, WithLog(zap.NewNop()))
+	gw, err := NewGateway(cfg, WithLog(zap.NewNop()), WithListener(listener))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = gw.Close() })
 
@@ -172,7 +177,7 @@ func TestGateway_Run_ShutsDownWithOpenStream(t *testing.T) {
 		return gw.Run(ctx)
 	})
 
-	conn, err := grpc.NewClient(cfg.Server.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 
@@ -202,9 +207,9 @@ func TestGateway_Run_DrainsReadinessOnShutdown(t *testing.T) {
 	t.Parallel()
 
 	cfg := DefaultConfig()
-	cfg.Server.Endpoint = freeTCPAddr(t)
+	listener := NewTestListener(t)
 
-	gw, err := NewGateway(cfg, WithLog(zap.NewNop()))
+	gw, err := NewGateway(cfg, WithLog(zap.NewNop()), WithListener(listener))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = gw.Close() })
 
@@ -223,7 +228,7 @@ func TestGateway_Run_DrainsReadinessOnShutdown(t *testing.T) {
 		return resp.GetScopes()[0].GetState() == readinesspb.State_STATE_READY
 	}, 5*time.Second, 50*time.Millisecond, "gateway did not become ready")
 
-	conn, err := grpc.NewClient(cfg.Server.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 
@@ -278,6 +283,26 @@ func TestGateway_Run_DrainsReadinessOnShutdown(t *testing.T) {
 	require.Equal(t, "SHUTTING_DOWN", scope.GetReasons()[0].GetCode())
 }
 
+// TestGateway_Run_BindsOwnListenerWhenNoneInjected verifies that Run falls
+// back to binding cfg.Server.Endpoint itself when constructed without
+// WithListener, by pointing the endpoint at an address a held-open
+// NewTestListener keeps occupied for the whole test, so the bind
+// deterministically fails rather than racing another process for the port.
+func TestGateway_Run_BindsOwnListenerWhenNoneInjected(t *testing.T) {
+	t.Parallel()
+
+	occupied := NewTestListener(t)
+
+	cfg := DefaultConfig()
+	cfg.Server.Endpoint = occupied.Addr().String()
+
+	gw, err := NewGateway(cfg, WithLog(zap.NewNop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
+
+	require.ErrorContains(t, gw.Run(t.Context()), "failed to initialize gRPC listener")
+}
+
 // TestGateway_Director_RegistryMissCarriesReasonTrailer verifies that a
 // NotFound for a service the registry has no backend for keeps the exact
 // "unknown service" message and also carries the errorReasonMetadataKey
@@ -289,9 +314,9 @@ func TestGateway_Director_RegistryMissCarriesReasonTrailer(t *testing.T) {
 	t.Parallel()
 
 	cfg := DefaultConfig()
-	cfg.Server.Endpoint = freeTCPAddr(t)
+	listener := NewTestListener(t)
 
-	gw, err := NewGateway(cfg, WithLog(zap.NewNop()))
+	gw, err := NewGateway(cfg, WithLog(zap.NewNop()), WithListener(listener))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = gw.Close() })
 
@@ -302,7 +327,7 @@ func TestGateway_Director_RegistryMissCarriesReasonTrailer(t *testing.T) {
 		return gw.Run(ctx)
 	})
 
-	conn, err := grpc.NewClient(cfg.Server.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 
@@ -367,7 +392,7 @@ func TestServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
 		_ = gatewayGroup.Wait()
 	})
 
-	backendAddr := freeTCPAddr(t)
+	backendAddr := filepath.Join(t.TempDir(), "runner.sock")
 	runner := NewServiceRunner(
 		&blockingReadinessService{endpoint: backendAddr},
 		gatewayListener.Addr().String(),
@@ -387,7 +412,7 @@ func TestServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
 		t.Fatal("service runner did not become ready")
 	}
 
-	conn, err := grpc.NewClient(backendAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient("unix://"+backendAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 

--- a/controlplane/gateway/proxy_context_test.go
+++ b/controlplane/gateway/proxy_context_test.go
@@ -103,9 +103,9 @@ func startCancelProbeGateway(t *testing.T) (gatewayAddr string, entered chan str
 	t.Helper()
 
 	cfg := gateway.DefaultConfig()
-	cfg.Server.Endpoint = reserveTCPAddr(t)
+	listener := gateway.NewTestListener(t)
 
-	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()))
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()), gateway.WithListener(listener))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = gw.Close() })
 
@@ -123,7 +123,7 @@ func startCancelProbeGateway(t *testing.T) (gatewayAddr string, entered chan str
 	// unblocks instead of deadlocking the run-group wait.
 	backendAddr, entered, results := newCancelProbeServer(t)
 
-	registerConn, err := grpc.NewClient(cfg.Server.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	registerConn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = registerConn.Close() })
 
@@ -138,7 +138,7 @@ func startCancelProbeGateway(t *testing.T) (gatewayAddr string, entered chan str
 		return regErr == nil
 	}, 5*time.Second, 50*time.Millisecond, "failed to register the fake module backend with the gateway")
 
-	return cfg.Server.Endpoint, entered, results
+	return listener.Addr().String(), entered, results
 }
 
 // TestGateway_ProxiedRPC_ClientCancelPropagatesToBackendCtx verifies that

--- a/controlplane/gateway/registration_loop_test.go
+++ b/controlplane/gateway/registration_loop_test.go
@@ -2,7 +2,6 @@ package gateway_test
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
@@ -17,20 +16,6 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/gateway"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
-
-// reserveTCPAddr reserves and immediately releases an ephemeral TCP port so a
-// server that binds it later gets a concrete, otherwise-unused endpoint.
-func reserveTCPAddr(t *testing.T) string {
-	t.Helper()
-
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-
-	addr := listener.Addr().String()
-	require.NoError(t, listener.Close())
-
-	return addr
-}
 
 // findRegisteredService looks up a service by name in a ListServices
 // response, returning the entry and whether it was found.
@@ -55,11 +40,11 @@ func TestGateway_RegistrationLoop_SurvivesSweepsThatEvictOneShot(t *testing.T) {
 	t.Parallel()
 
 	cfg := gateway.DefaultConfig()
-	cfg.Server.Endpoint = reserveTCPAddr(t)
+	listener := gateway.NewTestListener(t)
 	cfg.Registry.TTL = xcfg.MustNonZero(time.Second)
 	cfg.Registry.SweepInterval = xcfg.MustNonZero(25 * time.Millisecond)
 
-	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()))
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()), gateway.WithListener(listener))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = gw.Close() })
 
@@ -74,7 +59,7 @@ func TestGateway_RegistrationLoop_SurvivesSweepsThatEvictOneShot(t *testing.T) {
 		return gw.Run(wgContext)
 	})
 
-	connection, err := grpc.NewClient(cfg.Server.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	connection, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = connection.Close() })
 
@@ -87,14 +72,18 @@ func TestGateway_RegistrationLoop_SurvivesSweepsThatEvictOneShot(t *testing.T) {
 
 	loopedServiceName := "test.LoopedService"
 	oneShotServiceName := "test.OneShotService"
-	loopedBackendAddr := reserveTCPAddr(t)
-	oneShotBackendAddr := reserveTCPAddr(t)
+	// These are registry keys only: registration records the address
+	// without ever connecting to it, and nothing in this test calls a
+	// method that would dial either one. TEST-NET-1 (RFC 5737) addresses
+	// stand in as self-evidently unreachable values.
+	loopedBackendAddr := "192.0.2.1:0"
+	oneShotBackendAddr := "192.0.2.2:0"
 
 	constantBackOff := func() backoff.BackOff {
 		return backoff.NewConstantBackOff(10 * time.Millisecond)
 	}
 
-	oneShotRegistrar, err := gateway.NewGatewayRegistrar(cfg.Server.Endpoint, nil,
+	oneShotRegistrar, err := gateway.NewGatewayRegistrar(listener.Addr().String(), nil,
 		gateway.WithBackOff(constantBackOff),
 		gateway.WithMaxElapsedTime(time.Second),
 	)
@@ -103,7 +92,7 @@ func TestGateway_RegistrationLoop_SurvivesSweepsThatEvictOneShot(t *testing.T) {
 
 	require.NoError(t, oneShotRegistrar.RegisterServices(t.Context(), []string{oneShotServiceName}, oneShotBackendAddr))
 
-	loopedRegistrar, err := gateway.NewGatewayRegistrar(cfg.Server.Endpoint, nil,
+	loopedRegistrar, err := gateway.NewGatewayRegistrar(listener.Addr().String(), nil,
 		gateway.WithBackOff(constantBackOff),
 		gateway.WithMaxElapsedTime(time.Second),
 	)

--- a/tests/functional/framework/qemu.go
+++ b/tests/functional/framework/qemu.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -275,20 +276,10 @@ func (q *QEMUManager) Start() (bool, error) {
 		args = append(args, "-loadvm", templateSnapshot)
 	}
 
-	// Network interface configuration. SSH forwarding is added in
-	// keep-alive mode for manual debugging.
-	netdev := "user,id=net0"
-	if ShouldKeepVMAlive() {
-		// Get a random free port for SSH forwarding to support multiple VMs
-		var err error
-		q.sshPort, err = getFreePort()
-		if err != nil {
-			return false, fmt.Errorf("failed to get free port for SSH forwarding: %w", err)
-		}
-		q.log.Infof("Keep VM alive mode enabled: SSH port forwarding 127.0.0.1:%d -> VM:22", q.sshPort)
-		netdev += fmt.Sprintf(",hostfwd=tcp:127.0.0.1:%d-:22", q.sshPort)
-	}
-	args = append(args, "-netdev", netdev)
+	// Network interface configuration. SSH forwarding, when enabled, is
+	// added over the monitor once the monitor and serial consoles are
+	// connected, instead of baked into this netdev.
+	args = append(args, "-netdev", "user,id=net0")
 
 	args = append(args,
 		"-device", "virtio-net-pci,netdev=net0,mac=AA:BB:CC:DD:CA:B0",
@@ -437,7 +428,68 @@ func (q *QEMUManager) Start() (bool, error) {
 
 	go q.readSerial()
 
+	// The monitor gives no reply until a client has also connected to the
+	// serial socket, so the forward is added only now that both consoles
+	// are wired up.
+	if ShouldKeepVMAlive() {
+		q.addSSHHostForward()
+	}
+
 	return fromSnapshot, nil
+}
+
+// addSSHHostForward asks the QEMU monitor to add a hostfwd rule for SSH,
+// leaving port 0 for the kernel to assign. QEMU binds and holds that port
+// itself, so no other process can race for it the way it could with a port
+// picked ahead of time on the host.
+//
+// A failed hostfwd_add is local to the monitor command and never takes the
+// VM down, so failure here only logs a warning: YANET_KEEP_VM_ALIVE exists
+// to leave a VM for a human to inspect, and killing that VM because a
+// debug convenience could not get a port would defeat its purpose.
+func (q *QEMUManager) addSSHHostForward() {
+	resp, err := q.SendMonitorCommand("hostfwd_add net0 tcp:127.0.0.1:0-:22")
+	if err != nil {
+		q.log.Warnf("Keep VM alive mode: hostfwd_add failed: %v; SSH access will be unavailable", err)
+		return
+	}
+	if resp != "" {
+		q.log.Warnf("Keep VM alive mode: hostfwd_add returned an error: %s; SSH access will be unavailable", resp)
+		return
+	}
+
+	info, err := q.SendMonitorCommand("info usernet")
+	if err != nil {
+		q.log.Warnf("Keep VM alive mode: info usernet failed: %v; SSH access will be unavailable", err)
+		return
+	}
+	port, err := parseUsernetSSHPort(info)
+	if err != nil {
+		q.log.Warnf("Keep VM alive mode: could not determine the forwarded SSH port: %v; SSH access will be unavailable", err)
+		return
+	}
+
+	q.sshPort = port
+	q.log.Infof("Keep VM alive mode enabled: SSH port forwarding 127.0.0.1:%d -> VM:22", q.sshPort)
+}
+
+// parseUsernetSSHPort extracts the host-side port of the guest-port-22
+// hostfwd row from "info usernet" output, tolerating other forwards being
+// listed alongside it. Row format:
+//
+//	Protocol[State]    FD  Source Address  Port   Dest. Address  Port RecvQ SendQ
+//	TCP[HOST_FORWARD]  12       127.0.0.1 43007       10.0.2.15    22     0     0
+func parseUsernetSSHPort(output string) (int, error) {
+	for line := range strings.SplitSeq(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 6 || !strings.HasPrefix(fields[0], "TCP[") || fields[5] != "22" {
+			continue
+		}
+		if port, err := strconv.Atoi(fields[3]); err == nil {
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no SSH (guest port 22) host forward found in %q", output)
 }
 
 // Stop performs graceful termination of the QEMU virtual machine and comprehensive
@@ -489,7 +541,9 @@ func (q *QEMUManager) Stop() error {
 		}
 		q.log.Infof("Serial console socket: %s", q.SerialPath)
 		q.log.Infof("To connect: socat - UNIX-CONNECT:%s", q.SerialPath)
-		q.log.Infof("SSH: ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@localhost -p %d", q.sshPort)
+		if q.sshPort != 0 {
+			q.log.Infof("SSH: ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@localhost -p %d", q.sshPort)
+		}
 	} else {
 		alreadyExited := false
 		if q.processExit != nil {
@@ -710,18 +764,16 @@ func (q *QEMUManager) readUntilMonitorPrompt() (string, error) {
 			raw.Write(buf[:n])
 			// Strip readline escape sequences before checking for the prompt.
 			cleaned := stripMonitorEscapes(raw.String())
-			// The cleaned output contains:
-			//   "(qemu) <echoed-command>\n<output>\n(qemu) "
-			// We need the SECOND "(qemu)" prompt (end of response), not the
-			// first one which is just the command echo prefix.
-			// Count prompt occurrences: we need at least 2.
+			// One prompt, at the end, is the normal shape — e.g. the banner read
+			// in connectToMonitor, itself exactly one prompt. Two prompts appear
+			// when connectToMonitor's banner drain times out: the queued banner
+			// prompt survives into the next command's reply. Wait for either
+			// shape.
 			count := strings.Count(cleaned, "(qemu)")
 			if count >= 2 {
 				break
 			}
-			// Fallback: single prompt means no readline echo (e.g. banner drain).
 			if count == 1 && strings.HasSuffix(strings.TrimRight(cleaned, " \n"), "(qemu)") {
-				// Only one prompt and it is at the end -- we're done.
 				break
 			}
 		}
@@ -730,25 +782,28 @@ func (q *QEMUManager) readUntilMonitorPrompt() (string, error) {
 		}
 	}
 
-	// Extract content between first and last "(qemu)" prompt.
 	cleaned := stripMonitorEscapes(raw.String())
 	first := strings.Index(cleaned, "(qemu)")
 	last := strings.LastIndex(cleaned, "(qemu)")
 	if first >= 0 && last > first {
-		// Content between prompts = command echo + newline + actual output.
-		between := cleaned[first+len("(qemu)") : last]
-		// Strip the echoed command (first line) to get only the actual output.
-		lines := strings.SplitN(strings.TrimLeft(between, " \r\n"), "\n", 2)
-		if len(lines) > 1 {
-			return strings.TrimSpace(lines[1]), nil
-		}
-		return "", nil
+		// Two prompts: content is between them, command echo + output.
+		return stripEchoLine(cleaned[first+len("(qemu)") : last]), nil
 	}
 	if first >= 0 {
-		result := cleaned[first+len("(qemu)"):]
-		return strings.TrimSpace(result), nil
+		// One prompt, at the end: content is what precedes it.
+		return stripEchoLine(cleaned[:first]), nil
 	}
 	return strings.TrimSpace(cleaned), nil
+}
+
+// stripEchoLine drops the first line of s, the readline echo of the typed
+// command, and returns the remaining trimmed output.
+func stripEchoLine(s string) string {
+	lines := strings.SplitN(strings.TrimLeft(s, " \r\n"), "\n", 2)
+	if len(lines) > 1 {
+		return strings.TrimSpace(lines[1])
+	}
+	return ""
 }
 
 // connectToSerial connects to QEMU serial console via unix socket
@@ -1194,21 +1249,6 @@ func isKVMEnabled() bool {
 		return true
 	}
 	return false
-}
-
-// getFreePort asks the kernel for a free open port that is ready to use.
-func getFreePort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return 0, err
-	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
 // checkForExistingVM checks if there's already a running QEMU process with the given VM name.


### PR DESCRIPTION
Three test helpers picked a free port by listening on a loopback address, recording it, closing the listener and returning the bare address. Anything else on the machine, including a sibling parallel test, could take that port before the real server bound it. It surfaced once as an intermittent bind failure in a gateway registration test that passed on rerun.

The gateway now accepts an already-open listener and serves it directly, deriving its own endpoint from that listener rather than binding one itself. Tests hand over a port they never release, so the window is gone rather than narrowed. The two duplicated gateway helpers are replaced by a single shared one.

The service-runner test moves to a unix socket, which needs no port at all and covers a production code path the TCP variant did not. Two addresses in the registration-loop test turned out to be registry keys that nothing ever dials, so they stop reserving a port and use documentation-range addresses instead.

The functional-test framework no longer picks the SSH forwarding port on the host. It lets the kernel assign one and has QEMU bind and hold it, added over the monitor once both consoles are connected instead of baked into the command line. A forwarding failure can therefore no longer take the VM down, and the reservation helper is deleted rather than documented.

Reading the assigned port back required correcting how monitor replies are extracted: a reply carries a single prompt at the end, and the old code returned the text after it, which was always empty. That also restores the snapshot commands' ability to detect an error, which had been silently disabled.

The gateway's own bind path keeps a test, since every other gateway test now injects a listener.

Closes #1942.
