### PR TITLE
fix(bird-adapter): keep startup import config optional

### DIFF
--- a/operators/bird-adapter/cmd/yanet-bird-adapter/README.md
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/README.md
@@ -55,9 +55,11 @@ bird:
   source_v6: "::1"
 ```
 
-The `bird` block is applied automatically at startup. Set `name: ""` to
-disable it — a bare `name:` (YAML null) does not, since it leaves the
-shipped default in place. There is no separate bootstrap step.
+The `bird` block is applied automatically at startup when present. Older
+configuration files may omit the block — the server then starts bare and
+expects the client subcommand to configure it later. Set `name: ""` to
+disable a present block — a bare `name:` (YAML null) does not, since it leaves
+the shipped default in place. There is no separate bootstrap step.
 
 ### Reconfigure at Runtime
 

--- a/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
@@ -61,7 +61,7 @@ type ServerConfig struct {
 	// gateway that proxies it.
 	RouteOperatorEndpoint string `yaml:"route_operator_endpoint"`
 	// BIRD configures the BIRD import applied at startup.
-	BIRD BIRDConfig `yaml:"bird"`
+	BIRD xcfg.Optional[BIRDConfig] `yaml:"bird"`
 }
 
 func (m *ServerConfig) Default() {
@@ -76,15 +76,6 @@ func DefaultServerConfig() *ServerConfig {
 		},
 		ListenAddr:            "localhost:50051",
 		RouteOperatorEndpoint: "[::1]:8080",
-		BIRD: BIRDConfig{
-			Name: "route0",
-			Sockets: []string{
-				"/var/run/bird/yanet-master4.sock",
-				"/var/run/bird/yanet-master6.sock",
-			},
-			SourceV4: netip.MustParseAddr("127.0.0.1"),
-			SourceV6: netip.MustParseAddr("::1"),
-		},
 	}
 }
 
@@ -98,6 +89,18 @@ type BIRDConfig struct {
 	Sockets  []string   `yaml:"sockets"`
 	SourceV4 netip.Addr `yaml:"source_v4"`
 	SourceV6 netip.Addr `yaml:"source_v6"`
+}
+
+func (m *BIRDConfig) Default() {
+	*m = BIRDConfig{
+		Name: "route0",
+		Sockets: []string{
+			"/var/run/bird/yanet-master4.sock",
+			"/var/run/bird/yanet-master6.sock",
+		},
+		SourceV4: netip.MustParseAddr("127.0.0.1"),
+		SourceV6: netip.MustParseAddr("::1"),
+	}
 }
 
 // Validate checks that the config is structurally sound.
@@ -160,11 +163,13 @@ func runServer() error {
 		return nil
 	})
 
-	// Apply the configured startup BIRD import.
-	wg.Go(func() error {
-		runStartupImport(ctx, log, adapterService, cfg.BIRD, cfg.Logging.Level.String())
-		return nil
-	})
+	if startupConfig := cfg.BIRD.Unwrap(); startupConfig != nil {
+		// Apply the configured startup BIRD import.
+		wg.Go(func() error {
+			runStartupImport(ctx, log, adapterService, *startupConfig, cfg.Logging.Level.String())
+			return nil
+		})
+	}
 
 	// Wait for interrupt signal
 	wg.Go(func() error {

--- a/operators/bird-adapter/cmd/yanet-bird-adapter/server_test.go
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/server_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"net/netip"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,13 +16,70 @@ import (
 //
 // With strict parsing enabled a stale or renamed key in the shipped YAML
 // would break every fresh install, so this test loads the conffile through
-// xcfg.WithKnownFields() and requires it to decode to exactly
-// DefaultServerConfig(). That also catches the Go defaults silently
-// drifting away from the shipped conffile.
+// xcfg.WithKnownFields() and requires it to decode to the server defaults plus
+// its explicitly present BIRD block. That also catches the Go defaults
+// silently drifting away from the shipped conffile.
 func Test_ShippedDefaultConfig_MatchesServerConfig(t *testing.T) {
 	cfg, err := xcfg.LoadConfig[ServerConfig]("../../etc/yanet/bird-adapter-default.yaml", xcfg.WithKnownFields())
 	require.NoError(t, err)
-	require.Equal(t, DefaultServerConfig(), cfg)
+
+	expected := DefaultServerConfig()
+	expectedBIRD := BIRDConfig{}
+	expectedBIRD.Default()
+	expected.BIRD = xcfg.NewOptional(expectedBIRD)
+	require.Equal(t, expected, cfg)
+}
+
+// Test_LoadConfig_BIRDBlockSemantics covers absent and present startup BIRD
+// configuration, including nested defaults and explicit disabling.
+func Test_LoadConfig_BIRDBlockSemantics(t *testing.T) {
+	defaultBIRD := BIRDConfig{}
+	defaultBIRD.Default()
+	partialBIRD := defaultBIRD
+	partialBIRD.Name = "route1"
+	emptyNameBIRD := defaultBIRD
+	emptyNameBIRD.Name = ""
+
+	tests := []struct {
+		name     string
+		config   []byte
+		wantBIRD *BIRDConfig
+	}{
+		{
+			name: "old-style config without bird block",
+			config: []byte(`logging:
+  level: info
+listen_addr: "localhost:50051"
+route_operator_endpoint: "[::1]:8080"
+`),
+		},
+		{
+			name:     "present block gets nested defaults",
+			config:   []byte("bird:\n  name: route1\n"),
+			wantBIRD: &partialBIRD,
+		},
+		{
+			name:     "empty name disables import",
+			config:   []byte("bird:\n  name: \"\"\n"),
+			wantBIRD: &emptyNameBIRD,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "server.yaml")
+			require.NoError(t, os.WriteFile(configPath, tc.config, 0o600))
+
+			cfg, err := xcfg.LoadConfig[ServerConfig](configPath, xcfg.WithKnownFields())
+			require.NoError(t, err)
+			if tc.wantBIRD == nil {
+				require.Nil(t, cfg.BIRD.Unwrap())
+				return
+			}
+
+			require.Equal(t, tc.wantBIRD, cfg.BIRD.Unwrap())
+		})
+	}
 }
 
 // Test_BIRDConfig_Validate asserts that an empty name disables the startup


### PR DESCRIPTION
- Restores compatibility for configurations that omit the BIRD startup section.
- Keeps explicit startup imports, nested defaults, and strict validation intact.
- Covers omitted, partial, and disabled configurations with regression tests.