### PR TITLE
refactor(operator): encapsulate gRPC server options

### DIFF
--- a/common/go/operator/operator.go
+++ b/common/go/operator/operator.go
@@ -69,11 +69,11 @@ func NewOperator[T any](
 
 	if opts.GRPCServer != nil {
 		server, serviceNames = NewGRPCServer(
-			opts.GRPCServer.cfg,
-			opts.GRPCServer.services,
+			opts.GRPCServer.Config,
+			opts.GRPCServer.Services,
 			WithGRPCLog(log),
 		)
-		endpoint = opts.GRPCServer.cfg.Endpoint.Unwrap()
+		endpoint = opts.GRPCServer.Config.Endpoint.Unwrap()
 	}
 
 	reconciler := NewReconciler(

--- a/common/go/operator/options.go
+++ b/common/go/operator/options.go
@@ -10,8 +10,8 @@ import (
 )
 
 type grpcServerOption struct {
-	cfg      *GRPCServerConfig
-	services []ServiceRegistrar
+	Config   *GRPCServerConfig
+	Services []ServiceRegistrar
 }
 
 type options struct {
@@ -89,8 +89,8 @@ func WithGateways(register RegisterConfig, gateways ...GatewayConfig) Option {
 func WithGRPCServer(cfg *GRPCServerConfig, services ...ServiceRegistrar) Option {
 	return func(o *options) {
 		o.GRPCServer = &grpcServerOption{
-			cfg:      cfg,
-			services: services,
+			Config:   cfg,
+			Services: services,
 		}
 	}
 }

--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -104,9 +104,6 @@ maplit:modules/pdump/controlplane/ring_test.go:TestRingBufferRunReaders:map[byte
 maplit:operators/bird-adapter/internal/mpls/routes.go:Rib.Apply:map[mplsRouteKey][]rib.Route:1  # legacy: use T{} instead of make(map...)
 maplit:operators/bird-adapter/service.go:NewAdapterService:map[string]*importHolder:1  # legacy: use T{} instead of make(map...)
 maplit:operators/route/internal/discovery/neigh/neigh.go:newOptions:map[string]string:1  # legacy: use T{} instead of make(map...)
-private:common/go/operator/operator.go:NewOperator:opts.GRPCServer.cfg:1  # legacy: encapsulate behind an exported method or field
-private:common/go/operator/operator.go:NewOperator:opts.GRPCServer.cfg:2  # legacy: encapsulate behind an exported method or field
-private:common/go/operator/operator.go:NewOperator:opts.GRPCServer.services:1  # legacy: encapsulate behind an exported method or field
 private:controlplane/gateway/gateway.go:Gateway.Run:runner.module:1  # legacy: encapsulate behind an exported method or field
 private:controlplane/gateway/gateway.go:NewGateway:entry.kind:1  # legacy: encapsulate behind an exported method or field
 private:controlplane/gateway/gateway.go:NewGateway:entry.kind:2  # legacy: encapsulate behind an exported method or field


### PR DESCRIPTION
- Expose the shared gRPC server option carrier through exported fields.
- Remove the three corresponding encapsulation-debt ledger entries.

Closes #1737.