### PR TITLE
refactor(dataplane): route packets straight to device entry schedules

### DIFF
--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -50,6 +50,7 @@
 #include "lib/dataplane/pipeline/pipeline.h"
 #include "lib/dataplane/time/clock.h"
 
+#include "lib/controlplane/config/econtext.h"
 #include "lib/controlplane/config/zone.h"
 #include "lib/dataplane/worker/counters.h"
 #include "lib/dataplane/worker/pipeline_round.h"
@@ -64,7 +65,7 @@
 
 static void
 worker_read(
-	struct dataplane_worker *worker, struct packet_front *packet_front
+	struct dataplane_worker *worker, struct config_gen_ectx *config_gen_ectx
 ) {
 	struct worker_read_ctx *ctx = &worker->read_ctx;
 	struct rte_mbuf *mbufs[ctx->read_size];
@@ -93,7 +94,28 @@ worker_read(
 			*(worker->dp_worker->drop_count) += 1;
 			continue;
 		}
-		packet_front_pending_input(packet_front, packet);
+
+		// With no active config there is no device schedule to route
+		// into, so free the mbuf and account it as a drop rather than
+		// letting pre-config traffic accumulate in the NIC RX ring.
+		if (config_gen_ectx == NULL) {
+			rte_pktmbuf_free(mbufs[idx]);
+			*(worker->dp_worker->drop_count) += 1;
+			continue;
+		}
+
+		struct device_ectx *device_ectx = config_gen_ectx_get_device(
+			config_gen_ectx, packet->tx_device_id
+		);
+		if (device_ectx == NULL) {
+			rte_pktmbuf_free(mbufs[idx]);
+			*(worker->dp_worker->drop_count) += 1;
+			continue;
+		}
+		packet_front_input(
+			&ADDR_OF(&device_ectx->input_pipelines)->schedule,
+			packet
+		);
 	}
 }
 
@@ -335,27 +357,24 @@ worker_loop_round(struct dataplane_worker *worker) {
 	struct cp_config_gen *cp_config_gen = round.cp_config_gen;
 	struct config_gen_ectx *config_gen_ectx = round.config_gen_ectx;
 
-	// No configuration has been installed yet (startup). Drain the NIC
-	// RX ring into a throwaway stack front so packets that arrived
-	// before the first configuration do not accumulate and get
-	// processed stale once a configuration appears.
+	// No configuration has been installed yet (startup). worker_read frees
+	// the RX mbufs itself when handed a NULL config_gen_ectx, so pre-config
+	// traffic does not accumulate and get processed stale once a
+	// configuration appears. worker_write still runs to drain remote rx
+	// pipes and reclaim tx pipes.
 	if (config_gen_ectx == NULL) {
+		worker_read(worker, NULL);
+
 		struct packet_front packet_front;
 		packet_front_init(&packet_front);
 
-		worker_read(worker, &packet_front);
 		worker_write(worker, &packet_front);
-
-		packet_front_drop_pending_input(&packet_front);
-
-		*(worker->dp_worker->drop_count) += packet_front.drop_count;
-		dataplane_drop_packets(worker->dataplane, &packet_front.drop);
 		return;
 	}
 
 	struct packet_front *packet_front = &config_gen_ectx->packet_front;
 
-	worker_read(worker, packet_front);
+	worker_read(worker, config_gen_ectx);
 
 	worker_pipeline_round(
 		worker->dp_worker, cp_config_gen, config_gen_ectx, packet_front

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -27,6 +27,66 @@ config_gen_ectx_get_object(
 	return ADDR_OF(objects + index);
 }
 
+// Route a packet to its target device's input entry, counting it as
+// pending_input on the originating schedule.
+//
+// The packet lands on the target device entry's schedule input so the next
+// round picks it up. When the target device is absent from this generation
+// the packet is dropped on the originating schedule instead of being
+// stranded. packet->tx_device_id must already name the destination.
+static inline void
+module_ectx_route_input(
+	struct module_ectx *module_ectx,
+	struct packet_front *packet_front,
+	struct packet *packet
+) {
+	packet_front->pending_input_count += 1;
+	packet_front->pending_input_bytes += packet->data_len;
+
+	struct config_gen_ectx *config_gen_ectx =
+		ADDR_OF(&module_ectx->config_gen_ectx);
+	struct device_ectx *device_ectx = config_gen_ectx_get_device(
+		config_gen_ectx, packet->tx_device_id
+	);
+	if (device_ectx == NULL) {
+		packet_front_drop(packet_front, packet);
+		return;
+	}
+	packet_front_input(
+		&ADDR_OF(&device_ectx->input_pipelines)->schedule, packet
+	);
+}
+
+// Route a packet to its target device's output entry, counting it as
+// pending_output on the originating schedule.
+//
+// Symmetric to module_ectx_route_input: the packet is placed on the target
+// device's output-pipelines schedule, or dropped on the originating schedule
+// when the device is gone. packet->tx_device_id must already name the
+// destination.
+static inline void
+module_ectx_route_output(
+	struct module_ectx *module_ectx,
+	struct packet_front *packet_front,
+	struct packet *packet
+) {
+	packet_front->pending_output_count += 1;
+	packet_front->pending_output_bytes += packet->data_len;
+
+	struct config_gen_ectx *config_gen_ectx =
+		ADDR_OF(&module_ectx->config_gen_ectx);
+	struct device_ectx *device_ectx = config_gen_ectx_get_device(
+		config_gen_ectx, packet->tx_device_id
+	);
+	if (device_ectx == NULL) {
+		packet_front_drop(packet_front, packet);
+		return;
+	}
+	packet_front_input(
+		&ADDR_OF(&device_ectx->output_pipelines)->schedule, packet
+	);
+}
+
 // Build one execution context per worker.
 //
 // Returns an array of worker_count offset pointers, each a config_gen_ectx

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -32,7 +32,7 @@ _Static_assert(
 	"struct packet size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct packet_front) == 160,
+	sizeof(struct packet_front) == 128,
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
@@ -44,7 +44,7 @@ _Static_assert(
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct config_gen_ectx) == 208,
+	sizeof(struct config_gen_ectx) == 176,
 	"struct config_gen_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 13
+#define YANET_MODULE_ABI_VERSION 14
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/module/packet_front.h
+++ b/lib/dataplane/module/packet_front.h
@@ -12,9 +12,6 @@
  * module N+1's input.
  */
 struct packet_front {
-	struct packet_list pending_input;
-	struct packet_list pending_output;
-
 	struct packet_list input;
 	struct packet_list output;
 	struct packet_list drop;
@@ -37,8 +34,6 @@ struct packet_front {
 
 static inline void
 packet_front_init(struct packet_front *packet_front) {
-	packet_list_init(&packet_front->pending_input);
-	packet_list_init(&packet_front->pending_output);
 	packet_list_init(&packet_front->input);
 	packet_list_init(&packet_front->output);
 	packet_list_init(&packet_front->drop);
@@ -57,8 +52,8 @@ packet_front_init(struct packet_front *packet_front) {
 
 // Resets a fully-drained front to a clean reusable state.
 //
-// Only valid on a front whose input, output and pending lists have already
-// been drained to empty by a completed worker round. Resets the spent drop
+// Only valid on a front whose input and output lists have already been
+// drained to empty by a completed worker round. Resets the spent drop
 // list (its mbufs were already freed by the caller, so only the head needs
 // resetting) and the stale pending/drop accumulator counters, so the front
 // can be handed to the next round without a full packet_front_init.
@@ -74,18 +69,19 @@ packet_front_recycle(struct packet_front *packet_front) {
 	packet_front->pending_output_bytes = 0;
 }
 
-// Move the whole output, drop and pending lists from src into dst, transferring
-// the counters, and leave src empty.
+// Move the whole output and drop lists from src into dst, transferring the
+// counters, and leave src empty.
 //
-// Zeroing src lets a scratch front be reused across rounds without a separate
-// per-round reset: merge moves every packet and counter out, so nothing stale
-// survives into the next round.
+// Pending packets are routed straight to their target device's schedule, so
+// src never holds pending lists; only the pending tallies are folded into
+// dst so per-level accounting still attributes them to the right entry.
+// Zeroing src lets a scratch front be reused across rounds without a
+// separate per-round reset: merge moves every packet and counter out, so
+// nothing stale survives into the next round.
 static inline void
 packet_front_merge(struct packet_front *dst, struct packet_front *src) {
 	packet_list_concat(&dst->output, &src->output);
 	packet_list_concat(&dst->drop, &src->drop);
-	packet_list_concat(&dst->pending_input, &src->pending_input);
-	packet_list_concat(&dst->pending_output, &src->pending_output);
 
 	dst->pending_input_count += src->pending_input_count;
 	dst->pending_input_bytes += src->pending_input_bytes;
@@ -97,24 +93,6 @@ packet_front_merge(struct packet_front *dst, struct packet_front *src) {
 	dst->drop_bytes += src->drop_bytes;
 
 	packet_front_init(src);
-}
-
-static inline void
-packet_front_pending_input(
-	struct packet_front *packet_front, struct packet *packet
-) {
-	packet_list_add(&packet_front->pending_input, packet);
-	packet_front->pending_input_count += 1;
-	packet_front->pending_input_bytes += packet->data_len;
-}
-
-static inline void
-packet_front_pending_output(
-	struct packet_front *packet_front, struct packet *packet
-) {
-	packet_list_add(&packet_front->pending_output, packet);
-	packet_front->pending_output_count += 1;
-	packet_front->pending_output_bytes += packet->data_len;
 }
 
 static inline void
@@ -201,21 +179,6 @@ packet_front_drop_output(struct packet_front *packet_front) {
 	packet_front->drop_bytes += packet_front->output_bytes;
 	packet_front->output_count = 0;
 	packet_front->output_bytes = 0;
-}
-
-// Move the whole pending_input list into the drop list, transferring the
-// counters.
-//
-// Used by drain paths that discard all pending input (e.g. when no
-// pipeline is configured).
-static inline void
-packet_front_drop_pending_input(struct packet_front *packet_front) {
-	packet_list_concat(&packet_front->drop, &packet_front->pending_input);
-
-	packet_front->drop_count += packet_front->pending_input_count;
-	packet_front->drop_bytes += packet_front->pending_input_bytes;
-	packet_front->pending_input_count = 0;
-	packet_front->pending_input_bytes = 0;
 }
 
 static inline uint64_t

--- a/lib/dataplane/worker/pipeline_round.c
+++ b/lib/dataplane/worker/pipeline_round.c
@@ -14,8 +14,9 @@ worker_pipeline_round(
 	struct config_gen_ectx *config_gen_ectx,
 	struct packet_front *packet_front
 ) {
-	uint64_t device_count =
-		cp_config_gen->device_registry.registry.capacity;
+	(void)cp_config_gen;
+
+	uint64_t device_count = config_gen_ectx->device_count;
 
 	/*
 	 * Force a full traversal on the first iteration.
@@ -23,57 +24,40 @@ worker_pipeline_round(
 	 * Every device, and through it every pipeline, function, chain and
 	 * module, runs once per tick even when no packets arrived, so periodic
 	 * work has a chance to make progress. Later iterations only revisit
-	 * entities that received recirculated packets.
+	 * devices whose input or output entry received packets, whether
+	 * straight from RX or routed in by a module.
 	 */
 	int force_poll = 1;
 
 	while (1) {
-		struct packet *packet;
-
-		int empty = 1;
-
-		// Demux pending traffic into each target device's per-entry
-		// schedule front. A packet whose target device is absent from
-		// this generation (out of range or not configured) cannot be
-		// delivered, so it is dropped rather than stranded.
-		while ((packet = packet_list_pop(&packet_front->pending_input)
-		       ) != NULL) {
-			empty = 0;
-			struct device_ectx *device_ectx =
-				config_gen_ectx_get_device(
-					config_gen_ectx, packet->tx_device_id
-				);
-			if (device_ectx == NULL) {
-				packet_front_drop(packet_front, packet);
-				continue;
+		if (!force_poll) {
+			int has_work = 0;
+			for (uint64_t idx = 0; idx < device_count; ++idx) {
+				struct device_ectx *device_ectx =
+					config_gen_ectx_get_device(
+						config_gen_ectx, idx
+					);
+				if (device_ectx == NULL) {
+					continue;
+				}
+				if (packet_list_first(
+					    &ADDR_OF(&device_ectx
+							      ->input_pipelines)
+						     ->schedule.input
+				    ) != NULL ||
+				    packet_list_first(
+					    &ADDR_OF(&device_ectx
+							      ->output_pipelines
+					    )
+						     ->schedule.input
+				    ) != NULL) {
+					has_work = 1;
+					break;
+				}
 			}
-			packet_front_input(
-				&ADDR_OF(&device_ectx->input_pipelines)
-					 ->schedule,
-				packet
-			);
-		}
-
-		while ((packet = packet_list_pop(&packet_front->pending_output)
-		       ) != NULL) {
-			empty = 0;
-			struct device_ectx *device_ectx =
-				config_gen_ectx_get_device(
-					config_gen_ectx, packet->tx_device_id
-				);
-			if (device_ectx == NULL) {
-				packet_front_drop(packet_front, packet);
-				continue;
+			if (!has_work) {
+				break;
 			}
-			packet_front_input(
-				&ADDR_OF(&device_ectx->output_pipelines)
-					 ->schedule,
-				packet
-			);
-		}
-
-		if (empty && !force_poll) {
-			break;
 		}
 
 		for (uint64_t idx = 0; idx < device_count; ++idx) {
@@ -101,8 +85,8 @@ worker_pipeline_round(
 			/*
 			 * Input entry point processing has no packet
 			 * transmission allowed so drop the whole output.
-			 * The only chance for a packet to be survived is
-			 * being scheduled into pending input/output queues.
+			 * The only chance for a packet to survive is being
+			 * routed into a device entry by a module.
 			 */
 			packet_front_drop_output(schedule);
 

--- a/lib/dataplane/worker/pipeline_round.h
+++ b/lib/dataplane/worker/pipeline_round.h
@@ -5,17 +5,17 @@ struct cp_config_gen;
 struct config_gen_ectx;
 struct packet_front;
 
-// Drain pending_input and pending_output through the device pipeline.
+// Drain the device entry schedules through the pipeline.
 //
 // The caller has already snapshotted cp_config_gen and ensured a non-NULL
 // config_gen_ectx, set dp_worker->current_time, incremented the worker
-// iteration counter, and populated packet_front->pending_input or
-// pending_output with packets ready for pipeline processing.
+// iteration counter, and placed RX packets (and any module-routed
+// recirculation) directly onto the target device entry schedules.
 // config_gen_ectx must be non-NULL.
 //
 // On return, packet_front->output holds packets that should be written
 // out (or onward), packet_front->drop holds packets the pipeline rejected,
-// and both pending_input and pending_output are empty.
+// and every device entry schedule is left empty.
 void
 worker_pipeline_round(
 	struct dp_worker *dp_worker,

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -14,6 +14,7 @@
 #include "common/memory_address.h"
 #include "common/strutils.h"
 #include "lib/controlplane/agent/agent.h"
+#include "lib/controlplane/config/econtext.h"
 #include "lib/controlplane/config/zone.h"
 #include "lib/counters/counters.h"
 #include "lib/dataplane/config/agent.h"
@@ -473,19 +474,13 @@ dataplane_ut_run(
 		// must still get a well-formed result (output/drop initialized)
 		// and input must end up drained, so packets are neither leaked
 		// nor re-added to a non-empty list by dataplane_ut_run_rounds.
-		struct packet_front packet_front;
-		packet_front_init(&packet_front);
-
-		struct packet *packet;
-		while ((packet = packet_list_pop(input)) != NULL) {
-			packet_front_pending_input(&packet_front, packet);
-		}
-
 		packet_list_init(&result->output);
 		packet_list_init(&result->drop);
 
-		packet_front_drop_pending_input(&packet_front);
-		packet_list_concat(&result->drop, &packet_front.drop);
+		struct packet *packet;
+		while ((packet = packet_list_pop(input)) != NULL) {
+			packet_list_add(&result->drop, packet);
+		}
 		return;
 	}
 
@@ -503,19 +498,33 @@ dataplane_ut_run(
 	struct packet_front packet_front;
 	packet_front_init(&packet_front);
 
-	struct packet *packet;
-	while ((packet = packet_list_pop(input)) != NULL) {
-		packet_front_pending_input(&packet_front, packet);
-	}
-
 	packet_list_init(&result->output);
 	packet_list_init(&result->drop);
 
 	if (config_gen_ectx == NULL) {
 		// No active pipeline: drop everything.
-		packet_front_drop_pending_input(&packet_front);
-		packet_list_concat(&result->drop, &packet_front.drop);
+		struct packet *packet;
+		while ((packet = packet_list_pop(input)) != NULL) {
+			packet_list_add(&result->drop, packet);
+		}
 		return;
+	}
+
+	// Feed input straight onto each packet's target device input entry,
+	// the same way worker_read deposits RX into the pipeline.
+	struct packet *packet;
+	while ((packet = packet_list_pop(input)) != NULL) {
+		struct device_ectx *device_ectx = config_gen_ectx_get_device(
+			config_gen_ectx, packet->tx_device_id
+		);
+		if (device_ectx == NULL) {
+			packet_front_drop(&packet_front, packet);
+			continue;
+		}
+		packet_front_input(
+			&ADDR_OF(&device_ectx->input_pipelines)->schedule,
+			packet
+		);
 	}
 
 	worker_pipeline_round(

--- a/lib/fuzzing/fuzzing.h
+++ b/lib/fuzzing/fuzzing.h
@@ -201,16 +201,5 @@ fuzzing_process_packet(
 		rte_pktmbuf_free(cleanup_mbuf);
 	}
 
-	// Clean up pending packets
-	while ((cleanup_packet = packet_list_pop(&pf.pending_input)) != NULL) {
-		struct rte_mbuf *cleanup_mbuf = packet_to_mbuf(cleanup_packet);
-		rte_pktmbuf_free(cleanup_mbuf);
-	}
-
-	while ((cleanup_packet = packet_list_pop(&pf.pending_output)) != NULL) {
-		struct rte_mbuf *cleanup_mbuf = packet_to_mbuf(cleanup_packet);
-		rte_pktmbuf_free(cleanup_mbuf);
-	}
-
 	return 0;
 }

--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -134,13 +134,13 @@ forward_handle_packets(
 
 			if (target->mode == FORWARD_MODE_IN) {
 				packet->tx_device_id = device_id;
-				packet_front_pending_input(
-					packet_front, packet
+				module_ectx_route_input(
+					module_ectx, packet_front, packet
 				);
 			} else if (target->mode == FORWARD_MODE_OUT) {
 				packet->tx_device_id = device_id;
-				packet_front_pending_output(
-					packet_front, packet
+				module_ectx_route_output(
+					module_ectx, packet_front, packet
 				);
 			} else {
 				packet_front_output(packet_front, packet);

--- a/modules/mirror/dataplane/dataplane.c
+++ b/modules/mirror/dataplane/dataplane.c
@@ -5,6 +5,8 @@
 
 #include <filter/query.h>
 
+#include "controlplane/config/econtext.h"
+
 #include "lib/dataplane/config/zone.h"
 #include "lib/dataplane/module/module.h"
 #include "lib/dataplane/module/packet_front.h"
@@ -23,8 +25,9 @@ static void
 mirror_clone(
 	struct dp_worker *worker,
 	struct packet *packet,
+	struct module_ectx *module_ectx,
 	struct packet_front *packet_front,
-	void (*add)(struct packet_front *, struct packet *),
+	void (*route)(struct module_ectx *, struct packet_front *, struct packet *),
 	uint16_t device_id
 ) {
 	struct packet *clone = worker_clone_packet(worker, packet);
@@ -33,7 +36,7 @@ mirror_clone(
 	}
 
 	clone->tx_device_id = device_id;
-	add(packet_front, clone);
+	route(module_ectx, packet_front, clone);
 }
 
 static void
@@ -147,16 +150,18 @@ mirror_handle_packets(
 					mirror_clone(
 						dp_worker,
 						packet,
+						module_ectx,
 						packet_front,
-						packet_front_pending_input,
+						module_ectx_route_input,
 						device_id
 					);
 				} else if (target->mode == MIRROR_MODE_OUT) {
 					mirror_clone(
 						dp_worker,
 						packet,
+						module_ectx,
 						packet_front,
-						packet_front_pending_output,
+						module_ectx_route_output,
 						device_id
 					);
 				}

--- a/modules/nat64/tests/unittest/nat64_test.c
+++ b/modules/nat64/tests/unittest/nat64_test.c
@@ -5127,8 +5127,6 @@ test_nat64_icmp_embedded_overflow(void) {
 	packet_list_cleanup(&pf.input);
 	packet_list_cleanup(&pf.output);
 	packet_list_cleanup(&pf.drop);
-	packet_list_cleanup(&pf.pending_input);
-	packet_list_cleanup(&pf.pending_output);
 
 	return TEST_SUCCESS;
 }
@@ -5762,9 +5760,6 @@ test_nat64_icmp_v4tov6_valid_error_translates(void) {
 		test_params.module_config.stats.malformed_packets
 	);
 
-	packet_list_cleanup(&test_params.packet_front.pending_input);
-	packet_list_cleanup(&test_params.packet_front.pending_output);
-
 	return TEST_SUCCESS;
 }
 
@@ -5873,8 +5868,6 @@ test_nat64_icmp_v4tov6_fuzz_crash_regression(void) {
 	packet_list_cleanup(&pf.input);
 	packet_list_cleanup(&pf.output);
 	packet_list_cleanup(&pf.drop);
-	packet_list_cleanup(&pf.pending_input);
-	packet_list_cleanup(&pf.pending_output);
 
 	return TEST_SUCCESS;
 }

--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -7,6 +7,8 @@
 #include "common/memory.h"
 #include "lib/logging/log.h"
 
+#include "controlplane/config/econtext.h"
+
 #include "dataplane/config/zone.h"
 
 #include "dataplane/module/module.h"
@@ -242,7 +244,7 @@ route_handle_packets(
 				module_ectx, route->counter_id, packet
 			);
 		}
-		packet_front_pending_output(packet_front, packet);
+		module_ectx_route_output(module_ectx, packet_front, packet);
 	}
 }
 


### PR DESCRIPTION
- Drops the pending input/output lists from the packet front, so a packet a module routes to another device lands straight on that device's entry schedule instead of being collected and demultiplexed on the next round.
- Adds device-entry routing helpers that preserve per-level packet accounting while placing packets directly on the target device, dropping them on the originating schedule when the device is gone from this generation.
- Worker read now deposits RX onto the target device input schedule and frees pre-configuration traffic itself, and the pipeline round polls device entry schedules directly rather than draining pending lists.
- Updates the forward, mirror, and route modules plus the unit-test and fuzz harnesses, and bumps the module ABI version for the struct layout change.
