### PR TITLE
feat(fwstate): add standalone v4 and v6 fwstate map objects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -257,6 +257,7 @@ add_project_arguments(yanet_project_args, language: 'c')
 subdir('common')
 subdir('lib')
 module_test_dirs = []
+subdir('objects')
 subdir('modules')
 subdir('devices')
 subdir('lib/dataplane_ut/tests')

--- a/objects/fwstate/api/fwstate_map_object.c
+++ b/objects/fwstate/api/fwstate_map_object.c
@@ -1,0 +1,377 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fwstate_map_v4_object.h"
+#include "fwstate_map_v6_object.h"
+
+#include "common/container_of.h"
+#include "common/strutils.h"
+#include "controlplane/agent/agent.h"
+#include "controlplane/config/cp_object.h"
+#include "lib/dataplane/object/object.h"
+#include "lib/fwstate/config.h"
+#include "lib/fwstate/fwtable.h"
+#include "lib/fwstate/types.h"
+
+// Shared helpers: the v4 and v6 objects share an identical
+// {cp_object, fwtable_t} layout and differ only in the fwmap_config used
+// to grow the layer chain (key size and key/copy callbacks). The helpers
+// below carry the family-agnostic machinery; each per-family function is
+// a thin wrapper that selects its key initializer.
+
+typedef void (*map_init_keys_fn)(fwmap_config_t *config);
+
+// Walk a single fwmap layer chain, freeing every layer and zeroing the
+// head offset.
+static void
+map_free_chain(fwmap_t **head_off, struct memory_context *ctx) {
+	if (*head_off == NULL) {
+		return;
+	}
+
+	fwmap_t *node = ADDR_OF(head_off);
+	while (node != NULL) {
+		fwmap_t *next = (fwmap_t *)ADDR_OF(&node->next);
+		fwmap_free(node, ctx);
+		node = next;
+	}
+	*head_off = NULL;
+}
+
+// Free one fwtable's chains (head and stale) and zero the table.
+static void
+map_free_table(fwtable_t *table, struct memory_context *ctx) {
+	fwtable_free_stale(table, ctx);
+	map_free_chain(&table->head, ctx);
+}
+
+// Populate the fwmap_config fields common to v4 and v6 (value shape,
+// hashing, sizing). The family-specific key fields are set by init_keys.
+static void
+map_init_common_config(
+	fwmap_config_t *config,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count
+) {
+	if (index_size == 0) {
+		index_size = 1024 * 1024;
+	}
+	if (extra_bucket_count == 0) {
+		extra_bucket_count = 1024;
+	}
+
+	config->value_size = sizeof(struct fw_state_value);
+	config->update_value_fn_id = FWMAP_UPDATE_VALUE_FWSTATE;
+	config->promote_value_fn_id = FWMAP_PROMOTE_VALUE_FWSTATE;
+
+	config->hash_seed = 0;
+	config->hash_fn_id = FWMAP_HASH_FNV1A;
+
+	config->worker_count = worker_count;
+	config->index_size = index_size;
+	config->extra_bucket_count = extra_bucket_count;
+	config->rand_fn_id = FWMAP_RAND_DEFAULT;
+}
+
+static void
+map_v4_init_keys(fwmap_config_t *config) {
+	config->key_size = sizeof(struct fw4_state_key);
+	config->key_equal_fn_id = FWMAP_KEY_EQUAL_FW4;
+	config->copy_key_fn_id = FWMAP_COPY_KEY_FW4;
+}
+
+static void
+map_v6_init_keys(fwmap_config_t *config) {
+	config->key_size = sizeof(struct fw6_state_key);
+	config->key_equal_fn_id = FWMAP_KEY_EQUAL_FW6;
+	config->copy_key_fn_id = FWMAP_COPY_KEY_FW6;
+}
+
+// Append one layer built with the given key initializer. Returns 0 on
+// success or -1 on error.
+static int
+map_insert_layer(
+	fwtable_t *table,
+	struct memory_context *ctx,
+	map_init_keys_fn init_keys,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count
+) {
+	if (worker_count == 0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	fwmap_config_t config;
+	map_init_common_config(
+		&config, index_size, extra_bucket_count, worker_count
+	);
+	init_keys(&config);
+
+	return fwtable_insert_layer_cp(table, &config, ctx);
+}
+
+// --- IPv4 object -------------------------------------------------------------
+
+struct fwstate_map_v4_object *
+fwstate_map_v4_object_new(struct agent *agent) {
+	return (struct fwstate_map_v4_object *)memory_balloc(
+		&agent->memory_context, sizeof(struct fwstate_map_v4_object)
+	);
+}
+
+int
+fwstate_map_v4_object_init(
+	struct fwstate_map_v4_object *self,
+	struct agent *agent,
+	const char *name,
+	yanet_error **err
+) {
+	memset(self, 0, sizeof(struct fwstate_map_v4_object));
+
+	return cp_object_init(
+		&self->cp_object, agent, FWSTATE_MAP_V4_OBJECT_TYPE, name, err
+	);
+}
+
+void
+fwstate_map_v4_object_fini(struct fwstate_map_v4_object *self) {
+	if (self == NULL) {
+		return;
+	}
+
+	struct agent *agent = ADDR_OF(&self->cp_object.agent);
+	if (agent != NULL) {
+		map_free_table(&self->table, &agent->memory_context);
+	}
+	cp_object_fini(&self->cp_object);
+}
+
+void
+fwstate_map_v4_object_free(
+	struct fwstate_map_v4_object *self, struct agent *agent
+) {
+	if (self == NULL) {
+		return;
+	}
+	memory_bfree(
+		&agent->memory_context,
+		self,
+		sizeof(struct fwstate_map_v4_object)
+	);
+}
+
+struct cp_object *
+fwstate_map_v4_object_config_new(
+	struct agent *agent, const char *name, yanet_error **err
+) {
+	struct fwstate_map_v4_object *self = fwstate_map_v4_object_new(agent);
+	if (self == NULL) {
+		yanet_error_add(
+			err, "failed to allocate fwstate-map v4 object"
+		);
+		return NULL;
+	}
+
+	if (fwstate_map_v4_object_init(self, agent, name, err)) {
+		yanet_error_add(err, "failed to init fwstate-map v4 object");
+		fwstate_map_v4_object_free(self, agent);
+		return NULL;
+	}
+
+	return &self->cp_object;
+}
+
+void
+fwstate_map_v4_object_config_free(struct cp_object *cp_object) {
+	struct fwstate_map_v4_object *self = container_of(
+		cp_object, struct fwstate_map_v4_object, cp_object
+	);
+
+	struct agent *agent = ADDR_OF(&cp_object->agent);
+
+	fwstate_map_v4_object_fini(self);
+	fwstate_map_v4_object_free(self, agent);
+}
+
+fwtable_t *
+fwstate_map_v4_object_table(const struct cp_object *cp_object) {
+	struct fwstate_map_v4_object *self = container_of(
+		cp_object, struct fwstate_map_v4_object, cp_object
+	);
+
+	return &self->table;
+}
+
+int
+fwstate_map_v4_object_insert_layer(
+	struct fwstate_map_v4_object *self,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count
+) {
+	struct agent *agent = ADDR_OF(&self->cp_object.agent);
+
+	return map_insert_layer(
+		&self->table,
+		&agent->memory_context,
+		map_v4_init_keys,
+		index_size,
+		extra_bucket_count,
+		worker_count
+	);
+}
+
+int
+fwstate_map_v4_object_trim_stale_layers(
+	struct fwstate_map_v4_object *self, uint64_t now
+) {
+	struct agent *agent = ADDR_OF(&self->cp_object.agent);
+
+	return fwtable_trim_stale_cp(&self->table, &agent->memory_context, now);
+}
+
+// --- IPv6 object -------------------------------------------------------------
+
+struct fwstate_map_v6_object *
+fwstate_map_v6_object_new(struct agent *agent) {
+	return (struct fwstate_map_v6_object *)memory_balloc(
+		&agent->memory_context, sizeof(struct fwstate_map_v6_object)
+	);
+}
+
+int
+fwstate_map_v6_object_init(
+	struct fwstate_map_v6_object *self,
+	struct agent *agent,
+	const char *name,
+	yanet_error **err
+) {
+	memset(self, 0, sizeof(struct fwstate_map_v6_object));
+
+	return cp_object_init(
+		&self->cp_object, agent, FWSTATE_MAP_V6_OBJECT_TYPE, name, err
+	);
+}
+
+void
+fwstate_map_v6_object_fini(struct fwstate_map_v6_object *self) {
+	if (self == NULL) {
+		return;
+	}
+
+	struct agent *agent = ADDR_OF(&self->cp_object.agent);
+	if (agent != NULL) {
+		map_free_table(&self->table, &agent->memory_context);
+	}
+	cp_object_fini(&self->cp_object);
+}
+
+void
+fwstate_map_v6_object_free(
+	struct fwstate_map_v6_object *self, struct agent *agent
+) {
+	if (self == NULL) {
+		return;
+	}
+	memory_bfree(
+		&agent->memory_context,
+		self,
+		sizeof(struct fwstate_map_v6_object)
+	);
+}
+
+struct cp_object *
+fwstate_map_v6_object_config_new(
+	struct agent *agent, const char *name, yanet_error **err
+) {
+	struct fwstate_map_v6_object *self = fwstate_map_v6_object_new(agent);
+	if (self == NULL) {
+		yanet_error_add(
+			err, "failed to allocate fwstate-map v6 object"
+		);
+		return NULL;
+	}
+
+	if (fwstate_map_v6_object_init(self, agent, name, err)) {
+		yanet_error_add(err, "failed to init fwstate-map v6 object");
+		fwstate_map_v6_object_free(self, agent);
+		return NULL;
+	}
+
+	return &self->cp_object;
+}
+
+void
+fwstate_map_v6_object_config_free(struct cp_object *cp_object) {
+	struct fwstate_map_v6_object *self = container_of(
+		cp_object, struct fwstate_map_v6_object, cp_object
+	);
+
+	struct agent *agent = ADDR_OF(&cp_object->agent);
+
+	fwstate_map_v6_object_fini(self);
+	fwstate_map_v6_object_free(self, agent);
+}
+
+fwtable_t *
+fwstate_map_v6_object_table(const struct cp_object *cp_object) {
+	struct fwstate_map_v6_object *self = container_of(
+		cp_object, struct fwstate_map_v6_object, cp_object
+	);
+
+	return &self->table;
+}
+
+int
+fwstate_map_v6_object_insert_layer(
+	struct fwstate_map_v6_object *self,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count
+) {
+	struct agent *agent = ADDR_OF(&self->cp_object.agent);
+
+	return map_insert_layer(
+		&self->table,
+		&agent->memory_context,
+		map_v6_init_keys,
+		index_size,
+		extra_bucket_count,
+		worker_count
+	);
+}
+
+int
+fwstate_map_v6_object_trim_stale_layers(
+	struct fwstate_map_v6_object *self, uint64_t now
+) {
+	struct agent *agent = ADDR_OF(&self->cp_object.agent);
+
+	return fwtable_trim_stale_cp(&self->table, &agent->memory_context, now);
+}
+
+// --- object factories --------------------------------------------------------
+
+struct object *
+new_object_fwstate_map_v4() {
+	struct object *object = (struct object *)malloc(sizeof(struct object));
+	if (object == NULL) {
+		return NULL;
+	}
+	strtcpy(object->name, FWSTATE_MAP_V4_OBJECT_TYPE, sizeof(object->name));
+	return object;
+}
+
+struct object *
+new_object_fwstate_map_v6() {
+	struct object *object = (struct object *)malloc(sizeof(struct object));
+	if (object == NULL) {
+		return NULL;
+	}
+	strtcpy(object->name, FWSTATE_MAP_V6_OBJECT_TYPE, sizeof(object->name));
+	return object;
+}

--- a/objects/fwstate/api/fwstate_map_v4_object.h
+++ b/objects/fwstate/api/fwstate_map_v4_object.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "controlplane/config/cp_object.h"
+
+#include "lib/errors/errors.h"
+#include "lib/fwstate/fwmap.h"
+#include "lib/fwstate/fwstate_cursor.h"
+#include "lib/fwstate/fwtable.h"
+
+#define FWSTATE_MAP_V4_OBJECT_TYPE "fwstate_map_v4"
+
+struct agent;
+struct cp_object;
+struct memory_context;
+
+// Owns a single IPv4 fwtable plus its layer chain as an independent
+// shared-memory cp_object, registered under
+// ("fwstate_map_v4", name). Module configs (fwstate, acl) reference the
+// table via cp_module_link_object and resolve it at ectx build time.
+struct fwstate_map_v4_object {
+	struct cp_object cp_object;
+
+	fwtable_t table;
+};
+
+// RAII lifecycle for struct fwstate_map_v4_object.
+//
+// new allocates ONLY the struct in the agent shared memory. init zeroes
+// the enclosing struct and calls cp_object_init; on error callers must
+// call free. fini releases field memory (free the table chain,
+// cp_object_fini) and is idempotent. free deallocates ONLY the struct and
+// is NULL-safe.
+struct fwstate_map_v4_object *
+fwstate_map_v4_object_new(struct agent *agent);
+
+int
+fwstate_map_v4_object_init(
+	struct fwstate_map_v4_object *self,
+	struct agent *agent,
+	const char *name,
+	yanet_error **err
+);
+
+void
+fwstate_map_v4_object_fini(struct fwstate_map_v4_object *self);
+
+void
+fwstate_map_v4_object_free(
+	struct fwstate_map_v4_object *self, struct agent *agent
+);
+
+// Registration convenience: allocate + init and return the cp_object
+// pointer for agent_update_objects. On failure the object is fully
+// cleaned up and NULL is returned.
+struct cp_object *
+fwstate_map_v4_object_config_new(
+	struct agent *agent, const char *name, yanet_error **err
+);
+
+// Free handler matching the cp_object destruction pattern.
+void
+fwstate_map_v4_object_config_free(struct cp_object *cp_object);
+
+// Return the address of the object's fwtable field.
+fwtable_t *
+fwstate_map_v4_object_table(const struct cp_object *cp_object);
+
+// Insert a new layer into the object's table chain.
+int
+fwstate_map_v4_object_insert_layer(
+	struct fwstate_map_v4_object *self,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count
+);
+
+// Trim stale layers from the object's table chain.
+//
+// Returns 0 on success or -1 on error. Trimmed layers are tracked in the
+// fwtable stale chain and freed on the next trim call (giving the
+// dataplane one trim cycle to quiesce), so the caller has nothing to
+// free.
+int
+fwstate_map_v4_object_trim_stale_layers(
+	struct fwstate_map_v4_object *self, uint64_t now
+);

--- a/objects/fwstate/api/fwstate_map_v6_object.h
+++ b/objects/fwstate/api/fwstate_map_v6_object.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "controlplane/config/cp_object.h"
+
+#include "lib/errors/errors.h"
+#include "lib/fwstate/fwmap.h"
+#include "lib/fwstate/fwstate_cursor.h"
+#include "lib/fwstate/fwtable.h"
+
+#define FWSTATE_MAP_V6_OBJECT_TYPE "fwstate_map_v6"
+
+struct agent;
+struct cp_object;
+struct memory_context;
+
+// Owns a single IPv6 fwtable plus its layer chain as an independent
+// shared-memory cp_object, registered under
+// ("fwstate_map_v6", name). Module configs (fwstate, acl) reference the
+// table via cp_module_link_object and resolve it at ectx build time.
+struct fwstate_map_v6_object {
+	struct cp_object cp_object;
+
+	fwtable_t table;
+};
+
+// RAII lifecycle for struct fwstate_map_v6_object.
+//
+// new allocates ONLY the struct in the agent shared memory. init zeroes
+// the enclosing struct and calls cp_object_init; on error callers must
+// call free. fini releases field memory (free the table chain,
+// cp_object_fini) and is idempotent. free deallocates ONLY the struct and
+// is NULL-safe.
+struct fwstate_map_v6_object *
+fwstate_map_v6_object_new(struct agent *agent);
+
+int
+fwstate_map_v6_object_init(
+	struct fwstate_map_v6_object *self,
+	struct agent *agent,
+	const char *name,
+	yanet_error **err
+);
+
+void
+fwstate_map_v6_object_fini(struct fwstate_map_v6_object *self);
+
+void
+fwstate_map_v6_object_free(
+	struct fwstate_map_v6_object *self, struct agent *agent
+);
+
+// Registration convenience: allocate + init and return the cp_object
+// pointer for agent_update_objects. On failure the object is fully
+// cleaned up and NULL is returned.
+struct cp_object *
+fwstate_map_v6_object_config_new(
+	struct agent *agent, const char *name, yanet_error **err
+);
+
+// Free handler matching the cp_object destruction pattern.
+void
+fwstate_map_v6_object_config_free(struct cp_object *cp_object);
+
+// Return the address of the object's fwtable field.
+fwtable_t *
+fwstate_map_v6_object_table(const struct cp_object *cp_object);
+
+// Insert a new layer into the object's table chain.
+int
+fwstate_map_v6_object_insert_layer(
+	struct fwstate_map_v6_object *self,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count
+);
+
+// Trim stale layers from the object's table chain.
+//
+// Returns 0 on success or -1 on error. Trimmed layers are tracked in the
+// fwtable stale chain and freed on the next trim call (giving the
+// dataplane one trim cycle to quiesce), so the caller has nothing to
+// free.
+int
+fwstate_map_v6_object_trim_stale_layers(
+	struct fwstate_map_v6_object *self, uint64_t now
+);

--- a/objects/fwstate/api/meson.build
+++ b/objects/fwstate/api/meson.build
@@ -1,0 +1,37 @@
+cp_dependencies = [
+  lib_common_dep,
+  lib_config_cp_dep,
+  lib_counters_dep,
+  lib_errors_dep,
+  lib_fwstate_dep,
+  libdpdk_inc_dep,
+]
+
+includes = include_directories('../../..')
+
+sources = files(
+  'fwstate_map_object.c',
+)
+
+lib_fwstate_objects = static_library(
+  'fwstate_objects',
+  sources,
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: cp_dependencies,
+  include_directories: includes,
+  install: false,
+)
+
+lib_fwstate_objects_dep = declare_dependency(
+  link_with: [lib_fwstate_objects],
+  include_directories: include_directories('.'),
+  link_args: [
+    '-Wl,--defsym',
+    '-Wl,new_object_fwstate_map_v4=new_object_fwstate_map_v4',
+    '-Wl,--export-dynamic-symbol=new_object_fwstate_map_v4',
+    '-Wl,--defsym',
+    '-Wl,new_object_fwstate_map_v6=new_object_fwstate_map_v6',
+    '-Wl,--export-dynamic-symbol=new_object_fwstate_map_v6',
+  ],
+)

--- a/objects/fwstate/bindings/go/cfwstate/cursor.go
+++ b/objects/fwstate/bindings/go/cfwstate/cursor.go
@@ -1,0 +1,76 @@
+package cfwstate
+
+//#cgo CFLAGS: -I../../../../../
+//#cgo CFLAGS: -I../../../../../lib
+//#include <stdlib.h>
+//#include "lib/fwstate/fwstate_cursor.h"
+import "C"
+
+import "unsafe"
+
+// maxCursorBatch caps the allocation made by readEntries regardless of the
+// caller-supplied count, providing a defence-in-depth limit at the binding layer.
+const maxCursorBatch uint32 = 10000
+
+// StateKey stores a cursor key with address bytes as plain Go data.
+type StateKey struct {
+	Proto   uint32
+	SrcPort uint32
+	DstPort uint32
+	SrcAddr []byte
+	DstAddr []byte
+}
+
+// StateValue stores cursor value details for a state entry.
+type StateValue struct {
+	External        bool
+	Flags           uint32
+	CreatedAt       uint64
+	UpdatedAt       uint64
+	PacketsBackward uint64
+	PacketsForward  uint64
+}
+
+// CursorEntry represents a single entry read from the cursor.
+type CursorEntry struct {
+	Key     StateKey
+	Value   StateValue
+	Idx     uint32
+	Expired bool
+}
+
+func convertCKey(ptr unsafe.Pointer, isIPv6 bool) StateKey {
+	var srcAddr []byte
+	var dstAddr []byte
+	if isIPv6 {
+		k := (*C.struct_fw6_state_key)(ptr)
+		srcAddr = C.GoBytes(unsafe.Pointer(&k.src_addr[0]), 16)
+		dstAddr = C.GoBytes(unsafe.Pointer(&k.dst_addr[0]), 16)
+	} else {
+		k := (*C.struct_fw4_state_key)(ptr)
+		srcAddr = make([]byte, 4)
+		dstAddr = make([]byte, 4)
+		*(*uint32)(unsafe.Pointer(&srcAddr[0])) = uint32(k.src_addr)
+		*(*uint32)(unsafe.Pointer(&dstAddr[0])) = uint32(k.dst_addr)
+	}
+
+	hdr := (*C.struct_fw_state_key_hdr)(ptr)
+	return StateKey{
+		Proto:   uint32(hdr.proto),
+		SrcPort: uint32(hdr.src_port),
+		DstPort: uint32(hdr.dst_port),
+		SrcAddr: srcAddr,
+		DstAddr: dstAddr,
+	}
+}
+
+func stateValueFromC(value *C.struct_fw_state_value) StateValue {
+	return StateValue{
+		External:        bool(value.external),
+		Flags:           uint32(value.flags[0]),
+		CreatedAt:       uint64(value.created_at),
+		UpdatedAt:       uint64(value.updated_at),
+		PacketsBackward: uint64(value.packets_backward),
+		PacketsForward:  uint64(value.packets_forward),
+	}
+}

--- a/objects/fwstate/bindings/go/cfwstate/map.go
+++ b/objects/fwstate/bindings/go/cfwstate/map.go
@@ -1,0 +1,437 @@
+package cfwstate
+
+//#cgo CFLAGS: -I../../../../../
+//#cgo CFLAGS: -I../../../../../lib
+//#cgo LDFLAGS: -L../../../../../build/objects/fwstate/api -lfwstate_objects
+//#cgo LDFLAGS: -L../../../../../build/lib/counters -lcounters
+//
+//#include "api/agent.h"
+//#include "common/container_of.h"
+//#include "common/numutils.h"
+//#include "lib/errors/errors.h"
+//#include "lib/fwstate/config.h"
+//#include "lib/fwstate/fwmap.h"
+//#include "lib/fwstate/fwstate_cursor.h"
+//#include "lib/fwstate/fwtable.h"
+//#include "objects/fwstate/api/fwstate_map_v4_object.h"
+//#include "objects/fwstate/api/fwstate_map_v6_object.h"
+//
+//// Per-family upcasts: cp_object is the first field of both
+//// fwstate_map_v4_object and fwstate_map_v6_object, so the cast
+//// preserves the address.
+//static inline struct fwstate_map_v4_object *
+//fwstate_map_v4_from_cp_object(struct cp_object *cp_object) {
+//	return (struct fwstate_map_v4_object *)cp_object;
+//}
+//static inline struct fwstate_map_v6_object *
+//fwstate_map_v6_from_cp_object(struct cp_object *cp_object) {
+//	return (struct fwstate_map_v6_object *)cp_object;
+//}
+//
+//// cfwstate_map_resolve_map_v4/v6 walk the object's fwtable layer chain
+//// to the requested layer index (0 = active head). The chain uses offset
+//// indirection (fwmap_t::next), so ADDR_OF dereferences each link.
+//static inline fwmap_t *
+//cfwstate_map_resolve_map_v4(
+//	struct cp_object *cp_object, uint32_t layer_index
+//) {
+//	fwtable_t *table = fwstate_map_v4_object_table(cp_object);
+//	fwmap_t *layer = ADDR_OF(&table->head);
+//	for (uint32_t i = 0; layer != NULL && i < layer_index; i++) {
+//		layer = (fwmap_t *)ADDR_OF(&layer->next);
+//	}
+//	return layer;
+//}
+//static inline fwmap_t *
+//cfwstate_map_resolve_map_v6(
+//	struct cp_object *cp_object, uint32_t layer_index
+//) {
+//	fwtable_t *table = fwstate_map_v6_object_table(cp_object);
+//	fwmap_t *layer = ADDR_OF(&table->head);
+//	for (uint32_t i = 0; layer != NULL && i < layer_index; i++) {
+//		layer = (fwmap_t *)ADDR_OF(&layer->next);
+//	}
+//	return layer;
+//}
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+// Object type strings matching the C FWSTATE_MAP_V4_OBJECT_TYPE and
+// FWSTATE_MAP_V6_OBJECT_TYPE macros.
+const (
+	// MapV4ObjectType is the registered shared-memory object type for an
+	// IPv4 fwstate-map.
+	MapV4ObjectType = C.FWSTATE_MAP_V4_OBJECT_TYPE
+	// MapV6ObjectType is the registered shared-memory object type for an
+	// IPv6 fwstate-map.
+	MapV6ObjectType = C.FWSTATE_MAP_V6_OBJECT_TYPE
+)
+
+// Kind identifies the address family of a standalone fwstate-map object.
+type Kind uint32
+
+// Kind constants select the address family passed to the per-family C
+// object constructors.
+const (
+	// KindV4 selects an IPv4 firewall-state table.
+	KindV4 Kind = 0
+	// KindV6 selects an IPv6 firewall-state table.
+	KindV6 Kind = 1
+)
+
+// String returns a human-readable representation of the kind.
+func (m Kind) String() string {
+	switch m {
+	case KindV4:
+		return "v4"
+	case KindV6:
+		return "v6"
+	default:
+		return "unknown"
+	}
+}
+
+// ObjectType returns the shared-memory object type string for this kind
+// ("fwstate_map_v4" or "fwstate_map_v6").
+func (m Kind) ObjectType() string {
+	if m == KindV6 {
+		return MapV6ObjectType
+	}
+	return MapV4ObjectType
+}
+
+// MapObjectConfig is an opaque handle to a standalone named fwstate-map
+// cp_object in shared memory.
+//
+// It wraps the cp_object pointer returned by the per-family constructor
+// (fwstate_map_v4_object_config_new or fwstate_map_v6_object_config_new).
+// The underlying struct (fwstate_map_v4_object or fwstate_map_v6_object)
+// owns a single fwtable_t for one address family. The object is
+// registered under (ObjectType(), Name()) and published via Publish.
+type MapObjectConfig struct {
+	name       string
+	kind       Kind
+	generation uint64
+	ptr        *C.struct_cp_object
+}
+
+// Generation returns the generation counter, incremented on layer insert
+// or trim.
+func (m *MapObjectConfig) Generation() uint64 {
+	return m.generation
+}
+
+// NewMapObjectConfig creates a new standalone fwstate-map object for the
+// given address family.
+//
+// The returned handle is not yet published to the dataplane; call Publish
+// to publish it. The object starts with an empty fwtable; CreateMap
+// installs the first layer.
+func NewMapObjectConfig(agent *ffi.Agent, name string, kind Kind) (*MapObjectConfig, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var cErr *C.yanet_error
+	var ptr *C.struct_cp_object
+	if kind == KindV6 {
+		ptr = C.fwstate_map_v6_object_config_new(
+			(*C.struct_agent)(agent.AsRawPtr()), cName, &cErr,
+		)
+	} else {
+		ptr = C.fwstate_map_v4_object_config_new(
+			(*C.struct_agent)(agent.AsRawPtr()), cName, &cErr,
+		)
+	}
+	if ptr == nil {
+		return nil, fmt.Errorf(
+			"failed to initialize fwstate-map object: %w",
+			cerrors.FromC(unsafe.Pointer(cErr)),
+		)
+	}
+
+	return &MapObjectConfig{
+		name: name,
+		kind: kind,
+		ptr:  ptr,
+	}, nil
+}
+
+// Name returns the map name.
+func (m *MapObjectConfig) Name() string {
+	return m.name
+}
+
+// Kind returns the address family of this map's fwtable.
+func (m *MapObjectConfig) Kind() Kind {
+	return m.kind
+}
+
+func (m *MapObjectConfig) asRawPtr() *C.struct_cp_object {
+	return m.ptr
+}
+
+// insertLayer appends one fwmap layer to the object's fwtable chain,
+// dispatching to the per-family C insert helper. fwtable_insert_layer_cp
+// works on an empty table to install the very first layer, so this single
+// entry point serves both CreateMap and InsertLayer.
+func (m *MapObjectConfig) insertLayer(
+	indexSize uint32,
+	extraBucketCount uint32,
+	workerCount uint16,
+) error {
+	var rc C.int
+	if m.kind == KindV6 {
+		rc = C.fwstate_map_v6_object_insert_layer(
+			C.fwstate_map_v6_from_cp_object(m.asRawPtr()),
+			C.uint32_t(indexSize),
+			C.uint32_t(extraBucketCount),
+			C.uint16_t(workerCount),
+		)
+	} else {
+		rc = C.fwstate_map_v4_object_insert_layer(
+			C.fwstate_map_v4_from_cp_object(m.asRawPtr()),
+			C.uint32_t(indexSize),
+			C.uint32_t(extraBucketCount),
+			C.uint16_t(workerCount),
+		)
+	}
+	if rc != 0 {
+		return fmt.Errorf(
+			"failed to insert fwstate-map layer: error code=%d", rc,
+		)
+	}
+	m.generation++
+	return nil
+}
+
+// CreateMap installs the first fwtable layer for this map's address family.
+func (m *MapObjectConfig) CreateMap(
+	indexSize uint32,
+	extraBucketCount uint32,
+	workerCount uint16,
+) error {
+	return m.insertLayer(indexSize, extraBucketCount, workerCount)
+}
+
+// InsertLayer inserts a new layer into the fwtable chain of this map.
+func (m *MapObjectConfig) InsertLayer(
+	indexSize uint32,
+	extraBucketCount uint32,
+	workerCount uint16,
+) error {
+	return m.insertLayer(indexSize, extraBucketCount, workerCount)
+}
+
+// resolveMap walks the fwtable chain to the requested layer index
+// (0 = active head) for this map's address family.
+func (m *MapObjectConfig) resolveMap(layerIndex uint32) *C.fwmap_t {
+	if m.kind == KindV6 {
+		return C.cfwstate_map_resolve_map_v6(m.asRawPtr(), C.uint32_t(layerIndex))
+	}
+	return C.cfwstate_map_resolve_map_v4(m.asRawPtr(), C.uint32_t(layerIndex))
+}
+
+// GetStats retrieves statistics for this map's fwtable.
+func (m *MapObjectConfig) GetStats() MapStats {
+	return mapStatsFromC(fwmapStatsOrZero(m.resolveMap(0)))
+}
+
+// ResolveMap resolves a specific layer's fwmap pointer.
+//
+// Returns nil if the table has no layers or layerIndex is out of range.
+func (m *MapObjectConfig) ResolveMap(layerIndex uint32) unsafe.Pointer {
+	ptr := m.resolveMap(layerIndex)
+	if ptr == nil {
+		return nil
+	}
+	return unsafe.Pointer(ptr)
+}
+
+// TrimStaleLayers trims stale layers from the fwtable chain.
+//
+// Trimmed layers are tracked in the fwtable stale chain and freed on the
+// next trim call (giving the dataplane one trim cycle to quiesce), so the
+// caller has nothing to free.
+func (m *MapObjectConfig) TrimStaleLayers(now uint64) error {
+	var rc C.int
+	if m.kind == KindV6 {
+		rc = C.fwstate_map_v6_object_trim_stale_layers(
+			C.fwstate_map_v6_from_cp_object(m.asRawPtr()),
+			C.uint64_t(now),
+		)
+	} else {
+		rc = C.fwstate_map_v4_object_trim_stale_layers(
+			C.fwstate_map_v4_from_cp_object(m.asRawPtr()),
+			C.uint64_t(now),
+		)
+	}
+	if rc != 0 {
+		return fmt.Errorf("failed to trim stale layers: error code=%d", rc)
+	}
+	m.generation++
+	return nil
+}
+
+// Free releases the underlying C memory via the fwstate-map free handler.
+//
+// Safe to call multiple times: subsequent calls are no-ops.
+func (m *MapObjectConfig) Free() {
+	if ptr := m.asRawPtr(); ptr != nil {
+		if m.kind == KindV6 {
+			C.fwstate_map_v6_object_config_free(ptr)
+		} else {
+			C.fwstate_map_v4_object_config_free(ptr)
+		}
+		m.ptr = nil
+	}
+}
+
+// Publish upserts this object into a new dataplane configuration generation
+// via agent_update_objects and blocks until every worker has advanced to it.
+//
+// This is the generation barrier used after mutating the layer chain: the
+// upsert drives cp_config_gen_install, which performs SET_OFFSET_OF on the
+// new generation followed by dp_config_wait_for_gen. Re-upserting the same
+// object pointer is safe — the registry uses reference counting, so the
+// ref/unref pair nets to zero and the object survives intact while only the
+// generation advances.
+func (m *MapObjectConfig) Publish(agent *ffi.Agent) error {
+	if m.ptr == nil {
+		return fmt.Errorf("fwstate-map object config is nil")
+	}
+
+	objects := []*C.struct_cp_object{m.ptr}
+	var cErr *C.yanet_error
+	rc := C.agent_update_objects(
+		(*C.struct_agent)(agent.AsRawPtr()),
+		C.size_t(1),
+		&objects[0],
+		&cErr,
+	)
+	if rc != 0 {
+		return fmt.Errorf(
+			"failed to update objects: %w",
+			cerrors.FromC(unsafe.Pointer(cErr)),
+		)
+	}
+	return nil
+}
+
+// DeleteMapObject removes a named object from the dataplane by type and
+// name (e.g. ("fwstate_map_v4", "default")) via agent_delete_object.
+func DeleteMapObject(agent *ffi.Agent, objectType, objectName string) error {
+	cObjectType := C.CString(objectType)
+	defer C.free(unsafe.Pointer(cObjectType))
+	cObjectName := C.CString(objectName)
+	defer C.free(unsafe.Pointer(cObjectName))
+
+	var cErr *C.yanet_error
+	rc := C.agent_delete_object(
+		(*C.struct_agent)(agent.AsRawPtr()),
+		cObjectType,
+		cObjectName,
+		&cErr,
+	)
+	if rc != 0 {
+		return fmt.Errorf(
+			"failed to delete object type %q name %q: %w",
+			objectType,
+			objectName,
+			cerrors.FromC(unsafe.Pointer(cErr)),
+		)
+	}
+	return nil
+}
+
+// ReadForward reads up to count entries in the forward direction.
+func (m *MapObjectConfig) ReadForward(
+	layerIndex uint32,
+	index int64,
+	includeExpired bool,
+	now uint64,
+	count uint32,
+) ([]CursorEntry, int64, bool, error) {
+	return m.readEntries(layerIndex, index, includeExpired, now, count, false)
+}
+
+// ReadBackward reads up to count entries in the backward direction.
+func (m *MapObjectConfig) ReadBackward(
+	layerIndex uint32,
+	index int64,
+	includeExpired bool,
+	now uint64,
+	count uint32,
+) ([]CursorEntry, int64, bool, error) {
+	return m.readEntries(layerIndex, index, includeExpired, now, count, true)
+}
+
+func (m *MapObjectConfig) readEntries(
+	layerIndex uint32,
+	index int64,
+	includeExpired bool,
+	now uint64,
+	count uint32,
+	backward bool,
+) ([]CursorEntry, int64, bool, error) {
+	fwmap := m.resolveMap(layerIndex)
+	if fwmap == nil {
+		return nil, 0, false, fmt.Errorf("failed to resolve map")
+	}
+
+	cursor := C.fwstate_cursor_t{
+		key_pos:         C.int64_t(index),
+		include_expired: C.bool(includeExpired),
+	}
+
+	if count == 0 {
+		return nil, int64(cursor.key_pos), false, nil
+	}
+	if count > maxCursorBatch {
+		count = maxCursorBatch
+	}
+
+	buf := make([]C.fwstate_cursor_entry_t, count)
+	var cEntries *C.fwstate_cursor_entry_t
+	if len(buf) > 0 {
+		cEntries = &buf[0]
+	}
+
+	var n C.uint32_t
+	if backward {
+		n = C.fwstate_cursor_read_backward(fwmap, &cursor, C.uint64_t(now), cEntries, C.uint32_t(count))
+	} else {
+		n = C.fwstate_cursor_read_forward(fwmap, &cursor, C.uint64_t(now), cEntries, C.uint32_t(count))
+	}
+
+	isIPv6 := m.kind == KindV6
+	entries := make([]CursorEntry, 0, n)
+	for idx := range n {
+		entry := buf[idx]
+		val := (*C.struct_fw_state_value)(entry.value)
+
+		entries = append(entries, CursorEntry{
+			Key:     convertCKey(entry.key, isIPv6),
+			Value:   stateValueFromC(val),
+			Idx:     uint32(entry.idx),
+			Expired: bool(entry.expired),
+		})
+	}
+
+	newIndex := int64(cursor.key_pos)
+	keyLimit := fwmap.key_cursor
+	hasMore := false
+	if backward {
+		hasMore = newIndex > -1
+	} else {
+		hasMore = newIndex < int64(keyLimit)
+	}
+
+	return entries, newIndex, hasMore, nil
+}

--- a/objects/fwstate/bindings/go/cfwstate/stats.go
+++ b/objects/fwstate/bindings/go/cfwstate/stats.go
@@ -1,0 +1,44 @@
+package cfwstate
+
+//#cgo CFLAGS: -I../../../../../
+//#cgo CFLAGS: -I../../../../../lib
+//#include "lib/fwstate/fwmap.h"
+import "C"
+
+// MapStats stores per-map statistics reported by fwstate.
+type MapStats struct {
+	IndexSize        uint32
+	ExtraBucketCount uint32
+	MaxChainLength   uint32
+	LayerCount       uint32
+	TotalElements    uint64
+	MaxDeadline      uint64
+	MemoryUsed       uint64
+}
+
+// MapsStats stores IPv4 and IPv6 fwmap statistics.
+type MapsStats struct {
+	IPv4 MapStats
+	IPv6 MapStats
+}
+
+// fwmapStatsOrZero returns stats for the given head fwmap, or zero stats
+// when head is nil (no map attached).
+func fwmapStatsOrZero(head *C.fwmap_t) C.struct_fwmap_stats {
+	if head == nil {
+		return C.struct_fwmap_stats{}
+	}
+	return C.fwmap_get_stats(head)
+}
+
+func mapStatsFromC(stats C.struct_fwmap_stats) MapStats {
+	return MapStats{
+		IndexSize:        uint32(stats.index_size),
+		ExtraBucketCount: uint32(stats.extra_bucket_count),
+		MaxChainLength:   uint32(stats.max_chain_length),
+		LayerCount:       uint32(stats.layer_count),
+		TotalElements:    uint64(stats.total_elements),
+		MaxDeadline:      uint64(stats.max_deadline),
+		MemoryUsed:       uint64(stats.memory_used),
+	}
+}

--- a/objects/fwstate/controlplane/fwstatemappb/meson.build
+++ b/objects/fwstate/controlplane/fwstatemappb/meson.build
@@ -1,0 +1,22 @@
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
+root_dir = meson.project_source_root()
+
+proto_files = [
+    join_paths(proto_dir, 'fwstatemap.proto'),
+]
+
+protoc_gen = custom_target(
+    'fwstatemap-protoc',
+    output: ['fwstatemap.pb.go', 'fwstatemap_grpc.pb.go'],
+    input: proto_files,
+    command: [
+        protoc,
+        '-I', proto_dir,
+        '-I', root_dir,
+        '--go_out=paths=source_relative:' + proto_dir,
+        '--go-grpc_out=paths=source_relative:' + proto_dir,
+        '@INPUT@',
+    ],
+    build_by_default: true,
+)
+fwstatemap_protoc_gen = protoc_gen

--- a/objects/fwstate/controlplane/fwstatemappb/v1/convert.go
+++ b/objects/fwstate/controlplane/fwstatemappb/v1/convert.go
@@ -1,0 +1,39 @@
+package fwstatemappb
+
+import (
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/objects/fwstate/bindings/go/cfwstate"
+)
+
+// FromCursorKey converts a cfwstate cursor key into its proto form.
+func FromCursorKey(key cfwstate.StateKey) *FwStateKey {
+	return &FwStateKey{
+		Proto:   key.Proto,
+		SrcPort: key.SrcPort,
+		DstPort: key.DstPort,
+		SrcAddr: &commonpb.IPAddress{Addr: append([]byte(nil), key.SrcAddr...)},
+		DstAddr: &commonpb.IPAddress{Addr: append([]byte(nil), key.DstAddr...)},
+	}
+}
+
+// FromCursorValue converts a cfwstate cursor value into its proto form.
+func FromCursorValue(value cfwstate.StateValue) *FwStateValue {
+	return &FwStateValue{
+		External:        value.External,
+		Flags:           value.Flags,
+		CreatedAt:       value.CreatedAt,
+		UpdatedAt:       value.UpdatedAt,
+		PacketsBackward: value.PacketsBackward,
+		PacketsForward:  value.PacketsForward,
+	}
+}
+
+// FromCursorEntry converts a cfwstate cursor entry into its proto form.
+func FromCursorEntry(entry cfwstate.CursorEntry) *FwStateEntry {
+	return &FwStateEntry{
+		Key:     FromCursorKey(entry.Key),
+		Value:   FromCursorValue(entry.Value),
+		Idx:     entry.Idx,
+		Expired: entry.Expired,
+	}
+}

--- a/objects/fwstate/controlplane/fwstatemappb/v1/fwstatemap.proto
+++ b/objects/fwstate/controlplane/fwstatemappb/v1/fwstatemap.proto
@@ -1,0 +1,128 @@
+syntax = "proto3";
+
+package objects.fwstate.controlplane.fwstatemappb.v1;
+
+import "common/commonpb/v1/ipaddr.proto";
+
+option go_package = "github.com/yanet-platform/yanet2/objects/fwstate/controlplane/fwstatemappb/v1;fwstatemappb";
+
+// FWStateMapService manages standalone named fwstate-map objects.
+//
+// Each fwstate-map is a pure data container holding a single fwtable for one
+// address family (v4 or v6). It has no dataplane module of its own; module
+// configs (fwstate sync, ACL) reference fwtables by name and the
+// controlplane resolves the names to concrete table addresses at publish
+// time. A consumer that needs both families references two named objects.
+service FWStateMapService {
+  // CreateMap creates a new named fwstate-map for one address family.
+  rpc CreateMap(CreateMapRequest) returns (CreateMapResponse);
+  // DeleteMap removes a named fwstate-map.
+  rpc DeleteMap(DeleteMapRequest) returns (DeleteMapResponse);
+  // ListMaps returns the names of all registered fwstate-map objects.
+  rpc ListMaps(ListMapsRequest) returns (ListMapsResponse);
+  // GetMapStats returns statistics for the single fwtable of a named
+  // fwstate-map.
+  rpc GetMapStats(GetMapStatsRequest) returns (GetMapStatsResponse);
+  // InsertLayer inserts a new layer into the fwtable chain of a named
+  // fwstate-map.
+  rpc InsertLayer(InsertLayerRequest) returns (InsertLayerResponse);
+  // Bidirectional stream for listing map entries.
+  rpc ListEntries(stream ListEntriesRequest) returns (stream ListEntriesResponse);
+}
+
+// Kind identifies the address family of a standalone fwstate-map object.
+enum Kind {
+  V4 = 0;
+  V6 = 1;
+}
+
+enum Direction {
+  FORWARD = 0;
+  BACKWARD = 1;
+}
+
+message MapStats {
+  uint32 index_size = 1;
+  uint32 extra_bucket_count = 2;
+  uint32 max_chain_length = 3;
+  uint32 layer_count = 4;
+  uint64 total_elements = 5;
+  uint64 max_deadline = 6;
+  uint64 memory_used = 7;
+  string note = 8;
+}
+
+message FwStateKey {
+  uint32 proto = 1;
+  uint32 src_port = 2;
+  uint32 dst_port = 3;
+  common.commonpb.v1.IPAddress src_addr = 4;
+  common.commonpb.v1.IPAddress dst_addr = 5;
+}
+
+message FwStateValue {
+  bool external = 1;
+  uint32 flags = 2;      // raw fw_state_flags_u byte
+  uint64 created_at = 3; // nanoseconds
+  uint64 updated_at = 4; // nanoseconds
+  uint64 packets_backward = 5;
+  uint64 packets_forward = 6;
+}
+
+message FwStateEntry {
+  FwStateKey key = 1;
+  FwStateValue value = 2;
+  uint32 idx = 3;   // Key index within the layer
+  bool expired = 4; // Whether updated_at + TTL < now
+}
+
+message CreateMapRequest {
+  string name = 1;
+  // kind selects the address family of the fwtable this map owns.
+  Kind kind = 2;
+  uint32 index_size = 3;
+  uint32 extra_bucket_count = 4;
+  uint32 worker_count = 5;
+}
+
+message CreateMapResponse {}
+
+message DeleteMapRequest { string name = 1; }
+
+message DeleteMapResponse {}
+
+message ListMapsRequest {}
+
+message ListMapsResponse { repeated string maps = 1; }
+
+message GetMapStatsRequest { string name = 1; }
+
+message GetMapStatsResponse { MapStats stats = 1; }
+
+message InsertLayerRequest {
+  string name = 1;
+  // kind is the address family of the map (redundant with the stored kind
+  // but kept for request symmetry with CreateMap).
+  Kind kind = 2;
+  uint32 index_size = 3;
+  uint32 extra_bucket_count = 4;
+  uint32 worker_count = 5;
+}
+
+message InsertLayerResponse {}
+
+message ListEntriesRequest {
+  string map_name = 1;      // Named fwstate-map to iterate
+  uint32 layer_index = 2;   // Which layer to iterate (0 = active)
+  bool include_expired = 3; // Whether to include expired entries
+  Direction direction = 4;  // Direction for this read
+  uint32 batch_size = 5;    // Number of entries to return in this batch
+  int64 index = 6;          // Cursor position from previous response (0 on first)
+}
+
+message ListEntriesResponse {
+  repeated FwStateEntry entries = 1;
+  bool has_more = 2;     // false when cursor reached the end
+  int64 index = 3;       // Updated cursor position for next request
+  uint64 generation = 4; // Config generation for consistency detection
+}

--- a/objects/fwstate/controlplane/map_service.go
+++ b/objects/fwstate/controlplane/map_service.go
@@ -1,0 +1,578 @@
+package fwstatemap
+
+// FWStateMapService.mu is the only lock in this service. Every RPC and
+// ReclaimStaleLayers acquires it for the whole operation: CreateMap and
+// InsertLayer mutate the in-memory map registry and the shared-memory
+// layer chain atomically, and ListEntries snapshots a config value under
+// it before releasing it for the cursor read. There are no collaborating
+// services to order against in this standalone objects controlplane.
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/objects/fwstate/bindings/go/cfwstate"
+	fwstatemappb "github.com/yanet-platform/yanet2/objects/fwstate/controlplane/fwstatemappb/v1"
+)
+
+// maxWorkerCount is the highest value accepted for worker_count, matching
+// the width of the C-side uint16 parameter of fwstate_map insert_layer.
+const maxWorkerCount uint32 = 65535
+
+const (
+	// DefaultListEntriesBatchSize is the batch size used when the caller
+	// sends zero in the request.
+	DefaultListEntriesBatchSize uint32 = 100
+
+	// MaxListEntriesBatchSize caps the number of entries fetched per
+	// ListEntries round-trip to prevent unbounded allocation under the
+	// service mutex.
+	MaxListEntriesBatchSize uint32 = 10000
+)
+
+// ClampBatchSize returns a batch size that is within the allowed range:
+// zero is replaced with DefaultListEntriesBatchSize, and values above
+// MaxListEntriesBatchSize are clamped to MaxListEntriesBatchSize.
+func ClampBatchSize(n uint32) uint32 {
+	if n == 0 {
+		return DefaultListEntriesBatchSize
+	}
+	if n > MaxListEntriesBatchSize {
+		return MaxListEntriesBatchSize
+	}
+	return n
+}
+
+// mapStats is the bindings-level stats shape carried across CGo.
+type mapStats = cfwstate.MapStats
+
+// MapLayerTrimmer reclaims layers whose deadline has passed.
+//
+// [cfwstate.MapObjectConfig] satisfies this interface; the seam lets unit
+// tests record trim calls without a live shared-memory handle.
+type MapLayerTrimmer interface {
+	TrimStaleLayers(now uint64) error
+}
+
+// Compile-time assertion that [cfwstate.MapObjectConfig] satisfies
+// [MapLayerTrimmer].
+var _ MapLayerTrimmer = (*cfwstate.MapObjectConfig)(nil)
+
+// MapOption configures an FWStateMapService.
+type MapOption func(*mapOptions)
+
+type mapOptions struct {
+	Metrics grpcmetrics.Factory
+	Log     *zap.Logger
+}
+
+func newMapOptions() *mapOptions {
+	return &mapOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the map service logger.
+func WithLog(log *zap.Logger) MapOption {
+	return func(o *mapOptions) {
+		o.Log = log
+	}
+}
+
+// WithMetrics enables collection of gRPC call metrics for the map
+// service using the supplied factory.
+func WithMetrics(factory grpcmetrics.Factory) MapOption {
+	return func(o *mapOptions) {
+		o.Metrics = factory
+	}
+}
+
+// NewMetricsFactory returns a [grpcmetrics.Factory] scoped to the
+// FWStateMapService.
+func NewMetricsFactory(extra ...grpcmetrics.Option) grpcmetrics.Factory {
+	opts := make([]grpcmetrics.Option, 0, len(extra)+2)
+	opts = append(opts, grpcmetrics.WithLabeler(MapLabeler))
+	opts = append(opts, grpcmetrics.WithServiceFilter(
+		func(service string) bool {
+			return service == ServiceName
+		},
+	))
+	opts = append(opts, extra...)
+	return grpcmetrics.NewFactory(opts...)
+}
+
+// MapLabeler extracts the map name from map-scoped requests for gRPC
+// metrics labeling.
+func MapLabeler(fullMethod string, req any) metrics.Labels {
+	switch r := req.(type) {
+	case *fwstatemappb.CreateMapRequest:
+		return metrics.Labels{"map": r.GetName()}
+	case *fwstatemappb.DeleteMapRequest:
+		return metrics.Labels{"map": r.GetName()}
+	case *fwstatemappb.GetMapStatsRequest:
+		return metrics.Labels{"map": r.GetName()}
+	case *fwstatemappb.InsertLayerRequest:
+		return metrics.Labels{"map": r.GetName()}
+	default:
+		return nil
+	}
+}
+
+// FWStateMap manages a standalone named fwstate-map object in shared
+// memory.
+type FWStateMap struct {
+	name   string
+	config *cfwstate.MapObjectConfig
+}
+
+// Name returns the map name.
+func (m *FWStateMap) Name() string { return m.name }
+
+// Config returns the underlying map object config handle.
+func (m *FWStateMap) Config() *cfwstate.MapObjectConfig { return m.config }
+
+// FWStateMapService implements the gRPC service for standalone named
+// fwstate-map management.
+type FWStateMapService struct {
+	fwstatemappb.UnimplementedFWStateMapServiceServer
+
+	mu      sync.Mutex
+	agent   *ffi.Agent
+	maps    map[string]*FWStateMap
+	metrics *grpcmetrics.ServerMetrics
+
+	// barrier advances the dataplane to a new config generation and waits
+	// for every worker to observe it, acting as the RCU grace period that
+	// must elapse between unlinking stale layers and freeing their memory.
+	//
+	// Defaults to republishing the map object via Publish
+	// (agent_update_objects → cp_config_gen_install → dp_config_wait_for_gen);
+	// tests override it to record barrier calls without a live agent.
+	barrier func(cfwstate.MapObjectConfig) error
+	log     *zap.Logger
+}
+
+// NewFWStateMapService creates a new FWStateMapService.
+func NewFWStateMapService(
+	agent *ffi.Agent,
+	options ...MapOption,
+) *FWStateMapService {
+	opts := newMapOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	m := &FWStateMapService{
+		agent: agent,
+		maps:  map[string]*FWStateMap{},
+		log:   opts.Log,
+	}
+	m.barrier = m.publishGeneration
+
+	if opts.Metrics != nil {
+		m.metrics = opts.Metrics(m.mapRetention)
+	}
+
+	return m
+}
+
+// publishGeneration upserts the map object into a new config generation
+// and blocks until every dataplane worker has advanced to it.
+func (m *FWStateMapService) publishGeneration(mapCP cfwstate.MapObjectConfig) error {
+	return mapCP.Publish(m.agent)
+}
+
+// UnaryServerInterceptor returns the service's gRPC metrics interceptor,
+// or nil when metrics are not configured.
+func (m *FWStateMapService) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	if m.metrics == nil {
+		return nil
+	}
+	return m.metrics.UnaryServerInterceptor()
+}
+
+func (m *FWStateMapService) mapRetention() func(metrics.MetricID) bool {
+	m.mu.Lock()
+	names := make(map[string]struct{}, len(m.maps))
+	for name := range m.maps {
+		names[name] = struct{}{}
+	}
+	m.mu.Unlock()
+
+	return func(id metrics.MetricID) bool {
+		name := id.Labels["map"]
+		if name == "" {
+			return true
+		}
+		_, ok := names[name]
+		return ok
+	}
+}
+
+// CreateMap creates a new named fwstate-map for one address family and
+// publishes it to the dataplane.
+func (m *FWStateMapService) CreateMap(
+	ctx context.Context,
+	req *fwstatemappb.CreateMapRequest,
+) (*fwstatemappb.CreateMapResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "map name is required")
+	}
+	if err := ValidateWorkerCount(req.GetWorkerCount()); err != nil {
+		return nil, err
+	}
+	kind := kindFromProto(req.GetKind())
+
+	m.log.Debug("create fwstate-map",
+		zap.String("map", name),
+		zap.String("kind", kind.String()),
+	)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.maps[name]; exists {
+		return nil, status.Errorf(codes.AlreadyExists, "fwstate-map %q already exists", name)
+	}
+
+	mapConfig, err := cfwstate.NewMapObjectConfig(m.agent, name, kind)
+	if err != nil {
+		m.log.Error("failed to create fwstate-map config",
+			zap.String("map", name), zap.Error(err))
+		return nil, status.Errorf(codes.Internal, "failed to create fwstate-map config: %v", err)
+	}
+
+	if err := mapConfig.CreateMap(
+		req.GetIndexSize(),
+		req.GetExtraBucketCount(),
+		uint16(req.GetWorkerCount()),
+	); err != nil {
+		mapConfig.Free()
+		m.log.Error("failed to create fwstate-map table",
+			zap.String("map", name), zap.Error(err))
+		return nil, status.Errorf(codes.Internal, "failed to create fwstate-map table: %v", err)
+	}
+
+	if err := mapConfig.Publish(m.agent); err != nil {
+		mapConfig.Free()
+		m.log.Error("failed to publish fwstate-map",
+			zap.String("map", name), zap.Error(err))
+		return nil, status.Errorf(codes.Internal, "failed to publish fwstate-map: %v", err)
+	}
+
+	m.maps[name] = &FWStateMap{name: name, config: mapConfig}
+
+	m.log.Info("successfully created fwstate-map",
+		zap.String("map", name),
+		zap.String("kind", kind.String()),
+	)
+	return &fwstatemappb.CreateMapResponse{}, nil
+}
+
+// DeleteMap removes a named fwstate-map.
+//
+// TODO: once module configs (fwstate sync, ACL) link these objects, refuse
+// deletion while any consumer references the map name, mirroring the
+// module-service consumer scan. For now the objects controlplane owns no
+// consumers and removes the object unconditionally when the name exists.
+func (m *FWStateMapService) DeleteMap(
+	ctx context.Context,
+	req *fwstatemappb.DeleteMapRequest,
+) (*fwstatemappb.DeleteMapResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "map name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fwMap, ok := m.maps[name]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "fwstate-map %q not found", name)
+	}
+
+	if err := cfwstate.DeleteMapObject(
+		m.agent, fwMap.Config().Kind().ObjectType(), name,
+	); err != nil {
+		m.log.Error("failed to delete fwstate-map",
+			zap.String("map", name), zap.Error(err))
+		return nil, status.Errorf(codes.Internal, "failed to delete fwstate-map: %v", err)
+	}
+
+	fwMap.Config().Free()
+	delete(m.maps, name)
+
+	m.log.Info("successfully deleted fwstate-map", zap.String("map", name))
+	return &fwstatemappb.DeleteMapResponse{}, nil
+}
+
+// ListMaps returns the names of all registered fwstate-map objects.
+func (m *FWStateMapService) ListMaps(
+	ctx context.Context,
+	req *fwstatemappb.ListMapsRequest,
+) (*fwstatemappb.ListMapsResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	response := &fwstatemappb.ListMapsResponse{
+		Maps: make([]string, 0, len(m.maps)),
+	}
+	for name := range m.maps {
+		response.Maps = append(response.Maps, name)
+	}
+	return response, nil
+}
+
+// GetMapStats returns statistics for the single fwtable of a named
+// fwstate-map.
+func (m *FWStateMapService) GetMapStats(
+	ctx context.Context,
+	req *fwstatemappb.GetMapStatsRequest,
+) (*fwstatemappb.GetMapStatsResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "map name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fwMap, ok := m.maps[name]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "fwstate-map %q not found", name)
+	}
+
+	return &fwstatemappb.GetMapStatsResponse{
+		Stats: MapStatsToProto(fwMap.Config().GetStats()),
+	}, nil
+}
+
+// InsertLayer inserts a new layer into the fwtable chain of a named
+// fwstate-map.
+//
+// After the new layer is committed in place (the table head now points at
+// the new active layer), layers whose deadline has passed are reclaimed.
+// mu stays held across the insert and the stale-layer reclamation.
+// ReclaimStaleLayers publishes its own generation barrier before freeing,
+// because the fwmap chain is shared memory walked across all generations
+// for fallback lookups and a worker can be mid-walk on a just-unlinked
+// layer.
+func (m *FWStateMapService) InsertLayer(
+	ctx context.Context,
+	req *fwstatemappb.InsertLayerRequest,
+) (*fwstatemappb.InsertLayerResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "map name is required")
+	}
+	if err := ValidateWorkerCount(req.GetWorkerCount()); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fwMap, ok := m.maps[name]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "fwstate-map %q not found", name)
+	}
+
+	if err := fwMap.Config().InsertLayer(
+		req.GetIndexSize(),
+		req.GetExtraBucketCount(),
+		uint16(req.GetWorkerCount()),
+	); err != nil {
+		m.log.Error("failed to insert fwstate-map layer",
+			zap.String("map", name), zap.Error(err))
+		return nil, status.Errorf(codes.Internal, "failed to insert layer: %v", err)
+	}
+
+	mapCP := *fwMap.Config()
+	m.ReclaimStaleLayers(fwMap.Config(), mapCP, uint64(time.Now().UnixNano()))
+
+	m.log.Info("successfully inserted fwstate-map layer", zap.String("map", name))
+	return &fwstatemappb.InsertLayerResponse{}, nil
+}
+
+// ListEntries is a bidirectional stream that reads entries from a named
+// fwstate-map's fwtable via cursor.
+func (m *FWStateMapService) ListEntries(
+	stream grpc.BidiStreamingServer[fwstatemappb.ListEntriesRequest, fwstatemappb.ListEntriesResponse],
+) error {
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		mapName := req.GetMapName()
+		if mapName == "" {
+			return status.Error(codes.InvalidArgument, "map_name is required")
+		}
+
+		count := ClampBatchSize(req.GetBatchSize())
+
+		m.mu.Lock()
+		fwMap, ok := m.maps[mapName]
+		if !ok {
+			m.mu.Unlock()
+			return status.Errorf(codes.NotFound, "fwstate-map %q not found", mapName)
+		}
+
+		mapCfg := *fwMap.Config()
+		m.mu.Unlock()
+
+		now := uint64(time.Now().UnixNano())
+		backward := req.GetDirection() == fwstatemappb.Direction_BACKWARD
+
+		var entries []cfwstate.CursorEntry
+		var newIndex int64
+		var hasMore bool
+
+		if backward {
+			entries, newIndex, hasMore, err = mapCfg.ReadBackward(
+				req.GetLayerIndex(),
+				req.GetIndex(), req.GetIncludeExpired(),
+				now, count,
+			)
+		} else {
+			entries, newIndex, hasMore, err = mapCfg.ReadForward(
+				req.GetLayerIndex(),
+				req.GetIndex(), req.GetIncludeExpired(),
+				now, count,
+			)
+		}
+
+		if err != nil {
+			return status.Errorf(codes.Internal, "cursor read failed: %v", err)
+		}
+
+		pbEntries := make([]*fwstatemappb.FwStateEntry, 0, len(entries))
+		for idx := range entries {
+			pbEntries = append(pbEntries, fwstatemappb.FromCursorEntry(entries[idx]))
+		}
+
+		resp := &fwstatemappb.ListEntriesResponse{
+			Entries:    pbEntries,
+			HasMore:    hasMore,
+			Index:      newIndex,
+			Generation: mapCfg.Generation(),
+		}
+
+		if err := stream.Send(resp); err != nil {
+			return err
+		}
+	}
+}
+
+// ReclaimStaleLayers unlinks expired layers and waits for every dataplane
+// worker to advance past the current generation.
+//
+// TrimStaleLayers atomically moves stale layers from the active chain to
+// the fwtable's stale chain so new walks skip them, but a worker already
+// mid-chain-walk can still be reading a just-unlinked layer. Publishing a
+// new generation via the barrier waits until every worker changed
+// generation, guaranteeing no in-flight walk can touch the unlinked memory.
+// The trimmed layers are then freed by the next TrimStaleLayers call,
+// giving the dataplane one trim cycle to quiesce.
+//
+// If the barrier fails the stale chain is not advanced on the next trim,
+// so the layers remain allocated for one more cycle — a rare leak, not a
+// correctness or use-after-free issue. The caller must hold mu because
+// trim mutates the shared map head chain. now is real-time nanoseconds,
+// matching the domain the dataplane stamps layer deadlines in.
+func (m *FWStateMapService) ReclaimStaleLayers(
+	trimmer MapLayerTrimmer,
+	mapCP cfwstate.MapObjectConfig,
+	now uint64,
+) {
+	if err := trimmer.TrimStaleLayers(now); err != nil {
+		m.log.Error(
+			"failed to trim stale layers; stale chain not advanced",
+			zap.Error(err),
+		)
+		return
+	}
+	if err := m.barrier(mapCP); err != nil {
+		m.log.Error(
+			"generation barrier failed after layer trim; stale chain not advanced on next trim",
+			zap.Error(err),
+		)
+		return
+	}
+}
+
+// ValidateWorkerCount rejects zero and out-of-range worker_count values.
+func ValidateWorkerCount(workerCount uint32) error {
+	if workerCount == 0 {
+		return status.Error(codes.InvalidArgument, "worker_count must be greater than zero")
+	}
+	if workerCount > maxWorkerCount {
+		return status.Errorf(codes.InvalidArgument, "worker_count %d exceeds maximum %d", workerCount, maxWorkerCount)
+	}
+	return nil
+}
+
+// MapStatsToProto converts bindings-level map stats into the proto form.
+func MapStatsToProto(stats mapStats) *fwstatemappb.MapStats {
+	return &fwstatemappb.MapStats{
+		IndexSize:        stats.IndexSize,
+		ExtraBucketCount: stats.ExtraBucketCount,
+		MaxChainLength:   stats.MaxChainLength,
+		LayerCount:       stats.LayerCount,
+		TotalElements:    stats.TotalElements,
+		MaxDeadline:      stats.MaxDeadline,
+		MemoryUsed:       stats.MemoryUsed,
+	}
+}
+
+// kindFromProto converts the proto Kind enum to the cfwstate Kind used by
+// the C API.
+func kindFromProto(kind fwstatemappb.Kind) cfwstate.Kind {
+	switch kind {
+	case fwstatemappb.Kind_V6:
+		return cfwstate.KindV6
+	default:
+		return cfwstate.KindV4
+	}
+}
+
+// NewFWStateMapServiceForTest creates an FWStateMapService without a live
+// agent, for exercising stale-layer reclamation and the in-memory map
+// registry.
+//
+// barrier may be nil when the test does not exercise stale-layer
+// reclamation. A logger is supplied via the options pattern (WithLog); it
+// defaults to a no-op logger when omitted.
+func NewFWStateMapServiceForTest(
+	barrier func(cfwstate.MapObjectConfig) error,
+	options ...MapOption,
+) *FWStateMapService {
+	opts := newMapOptions()
+	for _, option := range options {
+		option(opts)
+	}
+	m := &FWStateMapService{
+		maps: map[string]*FWStateMap{},
+		log:  opts.Log,
+	}
+	if barrier != nil {
+		m.barrier = barrier
+	}
+	return m
+}

--- a/objects/fwstate/controlplane/map_service_test.go
+++ b/objects/fwstate/controlplane/map_service_test.go
@@ -1,0 +1,300 @@
+package fwstatemap_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/common/go/metrics"
+	"github.com/yanet-platform/yanet2/objects/fwstate/bindings/go/cfwstate"
+	fwstatemap "github.com/yanet-platform/yanet2/objects/fwstate/controlplane"
+	"github.com/yanet-platform/yanet2/objects/fwstate/controlplane/fwstatemappb/v1"
+)
+
+// TestValidateWorkerCount verifies that zero, out-of-range, and valid
+// worker_count values are handled correctly.
+func TestValidateWorkerCount(t *testing.T) {
+	cases := []struct {
+		name        string
+		workerCount uint32
+		wantErr     bool
+		wantCode    codes.Code
+	}{
+		{
+			name:        "zero rejected",
+			workerCount: 0,
+			wantErr:     true,
+			wantCode:    codes.InvalidArgument,
+		},
+		{
+			name:        "valid value passes",
+			workerCount: 1,
+			wantErr:     false,
+		},
+		{
+			name:        "max uint16 passes",
+			workerCount: 65535,
+			wantErr:     false,
+		},
+		{
+			name:        "above max rejected",
+			workerCount: 65536,
+			wantErr:     true,
+			wantCode:    codes.InvalidArgument,
+		},
+		{
+			name:        "large value rejected",
+			workerCount: 1 << 20,
+			wantErr:     true,
+			wantCode:    codes.InvalidArgument,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := fwstatemap.ValidateWorkerCount(tc.workerCount)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Equal(t, tc.wantCode, status.Code(err))
+		})
+	}
+}
+
+// TestClampBatchSize verifies the default-substitution and clamping
+// behaviour of ClampBatchSize.
+func TestClampBatchSize(t *testing.T) {
+	cases := []struct {
+		name string
+		in   uint32
+		want uint32
+	}{
+		{name: "zero defaults", in: 0, want: fwstatemap.DefaultListEntriesBatchSize},
+		{name: "small passes", in: 1, want: 1},
+		{name: "mid passes", in: 500, want: 500},
+		{name: "max clamped", in: 1_000_000, want: fwstatemap.MaxListEntriesBatchSize},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, fwstatemap.ClampBatchSize(tc.in))
+		})
+	}
+}
+
+// TestMapStatsToProto verifies that MapStats are correctly converted to
+// the proto representation.
+func TestMapStatsToProto(t *testing.T) {
+	stats := cfwstate.MapStats{
+		IndexSize:        1024,
+		ExtraBucketCount: 512,
+		MaxChainLength:   4,
+		LayerCount:       2,
+		TotalElements:    1000,
+		MaxDeadline:      99999,
+		MemoryUsed:       4096,
+	}
+	pb := fwstatemap.MapStatsToProto(stats)
+	require.Equal(t, uint32(1024), pb.GetIndexSize())
+	require.Equal(t, uint32(512), pb.GetExtraBucketCount())
+	require.Equal(t, uint32(4), pb.GetMaxChainLength())
+	require.Equal(t, uint32(2), pb.GetLayerCount())
+	require.Equal(t, uint64(1000), pb.GetTotalElements())
+	require.Equal(t, uint64(99999), pb.GetMaxDeadline())
+	require.Equal(t, uint64(4096), pb.GetMemoryUsed())
+}
+
+// TestMapLabeler verifies that the gRPC metrics labeler extracts the map
+// name for the relevant request types.
+func TestMapLabeler(t *testing.T) {
+	require.Equal(t, metrics.Labels{"map": "m1"}, fwstatemap.MapLabeler("", &fwstatemappb.CreateMapRequest{Name: "m1"}))
+	require.Equal(t, metrics.Labels{"map": "m2"}, fwstatemap.MapLabeler("", &fwstatemappb.DeleteMapRequest{Name: "m2"}))
+	require.Equal(t, metrics.Labels{"map": "m3"}, fwstatemap.MapLabeler("", &fwstatemappb.GetMapStatsRequest{Name: "m3"}))
+	require.Equal(t, metrics.Labels{"map": "m4"}, fwstatemap.MapLabeler("", &fwstatemappb.InsertLayerRequest{Name: "m4"}))
+	require.Nil(t, fwstatemap.MapLabeler("", &fwstatemappb.ListMapsRequest{}))
+}
+
+// recordingTrimmer is a MapLayerTrimmer test double that records trim
+// calls so stale-layer reclamation can be asserted without a live
+// shared-memory handle.
+type recordingTrimmer struct {
+	mu       sync.Mutex
+	trimCall []uint64
+	trimErr  error
+	onTrim   func()
+}
+
+func (m *recordingTrimmer) TrimStaleLayers(now uint64) error {
+	m.mu.Lock()
+	m.trimCall = append(m.trimCall, now)
+	m.mu.Unlock()
+	if m.onTrim != nil {
+		m.onTrim()
+	}
+	return m.trimErr
+}
+
+func (m *recordingTrimmer) trimCalls() []uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]uint64(nil), m.trimCall...)
+}
+
+// recordingBarrier captures generation-barrier invocations so the RCU
+// grace period between layer trim and the next trim call can be asserted
+// without a live agent.
+type recordingBarrier struct {
+	mu    sync.Mutex
+	calls int
+	err   error
+}
+
+func (m *recordingBarrier) invoke(cfwstate.MapObjectConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	return m.err
+}
+
+func (m *recordingBarrier) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+// TestReclaimStaleLayers verifies that ReclaimStaleLayers trims stale
+// layers and runs the generation barrier on the success path.
+func TestReclaimStaleLayers(t *testing.T) {
+	trimmer := &recordingTrimmer{}
+	barrier := &recordingBarrier{}
+
+	svc := fwstatemap.NewFWStateMapServiceForTest(barrier.invoke)
+
+	svc.ReclaimStaleLayers(trimmer, cfwstate.MapObjectConfig{}, 123456)
+
+	require.Equal(t, []uint64{123456}, trimmer.trimCalls())
+	require.Equal(t, 1, barrier.count(), "generation barrier must run after trim")
+}
+
+// TestReclaimStaleLayersTrimFailureSkipsBarrier verifies that a trim
+// failure skips the generation barrier without panicking.
+func TestReclaimStaleLayersTrimFailureSkipsBarrier(t *testing.T) {
+	trimmer := &recordingTrimmer{trimErr: errors.New("trim failed")}
+	barrier := &recordingBarrier{}
+
+	svc := fwstatemap.NewFWStateMapServiceForTest(barrier.invoke)
+
+	svc.ReclaimStaleLayers(trimmer, cfwstate.MapObjectConfig{}, 0)
+
+	require.Equal(t, []uint64{0}, trimmer.trimCalls())
+	require.Equal(t, 0, barrier.count(), "barrier must not run when trim fails")
+}
+
+// TestReclaimStaleLayersBarrierRunsAfterTrim verifies that the generation
+// barrier runs only after TrimStaleLayers completes successfully.
+//
+// Regression guard for a use-after-free: the fwmap layer chain is shared
+// memory walked across all config generations for fallback lookups. A
+// worker can be mid-walk on a just-unlinked layer at the moment
+// TrimStaleLayers moves it into the stale chain. Advancing the stale chain
+// before the grace period can free memory a worker still reads. The
+// generation barrier must elapse between trim and the next reclaim.
+func TestReclaimStaleLayersBarrierRunsAfterTrim(t *testing.T) {
+	var eventsMu sync.Mutex
+	var events []string
+	record := func(event string) {
+		eventsMu.Lock()
+		events = append(events, event)
+		eventsMu.Unlock()
+	}
+
+	trimmer := &recordingTrimmer{
+		onTrim: func() { record("trim") },
+	}
+
+	svc := fwstatemap.NewFWStateMapServiceForTest(func(cfwstate.MapObjectConfig) error {
+		record("barrier")
+		return nil
+	})
+
+	svc.ReclaimStaleLayers(trimmer, cfwstate.MapObjectConfig{}, 1)
+
+	eventsMu.Lock()
+	require.Equal(
+		t,
+		[]string{"trim", "barrier"},
+		events,
+		"barrier must follow trim, never precede it",
+	)
+	eventsMu.Unlock()
+}
+
+// TestReclaimStaleLayersBarrierFailureIsLogged verifies that when the
+// generation barrier fails, ReclaimStaleLayers returns without panicking
+// and the trim is recorded as having run.
+func TestReclaimStaleLayersBarrierFailureIsLogged(t *testing.T) {
+	trimmer := &recordingTrimmer{}
+	barrier := &recordingBarrier{err: errors.New("generation barrier failed")}
+
+	svc := fwstatemap.NewFWStateMapServiceForTest(barrier.invoke)
+
+	svc.ReclaimStaleLayers(trimmer, cfwstate.MapObjectConfig{}, 1)
+
+	require.Equal(t, []uint64{1}, trimmer.trimCalls(), "trim runs unconditionally")
+	require.Equal(t, 1, barrier.count(), "barrier must run after trim")
+}
+
+// TestListMapsEmpty verifies that a fresh service reports no maps.
+func TestListMapsEmpty(t *testing.T) {
+	svc := fwstatemap.NewFWStateMapServiceForTest(nil)
+
+	resp, err := svc.ListMaps(t.Context(), &fwstatemappb.ListMapsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetMaps())
+}
+
+// TestDeleteMapNotFound verifies that deleting a missing map returns
+// NotFound without touching the agent.
+func TestDeleteMapNotFound(t *testing.T) {
+	svc := fwstatemap.NewFWStateMapServiceForTest(nil)
+
+	_, err := svc.DeleteMap(t.Context(), &fwstatemappb.DeleteMapRequest{Name: "absent"})
+	require.Error(t, err)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestDeleteMapEmptyNameRejected verifies that an empty name is rejected
+// before the agent is consulted.
+func TestDeleteMapEmptyNameRejected(t *testing.T) {
+	svc := fwstatemap.NewFWStateMapServiceForTest(nil)
+
+	_, err := svc.DeleteMap(t.Context(), &fwstatemappb.DeleteMapRequest{Name: ""})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestListMapsConcurrent verifies that concurrent ListMaps calls on a
+// fresh service do not race.
+func TestListMapsConcurrent(t *testing.T) {
+	svc := fwstatemap.NewFWStateMapServiceForTest(nil)
+
+	group := errgroup.Group{}
+	for range 50 {
+		group.Go(func() error {
+			resp, err := svc.ListMaps(t.Context(), &fwstatemappb.ListMapsRequest{})
+			if err != nil {
+				return err
+			}
+			require.Empty(t, resp.GetMaps())
+			return nil
+		})
+	}
+	require.NoError(t, group.Wait())
+}

--- a/objects/fwstate/controlplane/meson.build
+++ b/objects/fwstate/controlplane/meson.build
@@ -1,0 +1,1 @@
+subdir('fwstatemappb')

--- a/objects/fwstate/controlplane/mod.go
+++ b/objects/fwstate/controlplane/mod.go
@@ -1,0 +1,21 @@
+package fwstatemap
+
+import (
+	"google.golang.org/grpc"
+
+	fwstatemappb "github.com/yanet-platform/yanet2/objects/fwstate/controlplane/fwstatemappb/v1"
+)
+
+// ServiceName is the fully-qualified gRPC service name for the fwstate-map
+// management service, derived from the generated service descriptor.
+var ServiceName = fwstatemappb.FWStateMapService_ServiceDesc.ServiceName
+
+// ServicesNames returns the gRPC service names this controlplane serves.
+func (m *FWStateMapService) ServicesNames() []string {
+	return []string{ServiceName}
+}
+
+// Register registers the map service on the given gRPC server.
+func (m *FWStateMapService) Register(server *grpc.Server) {
+	fwstatemappb.RegisterFWStateMapServiceServer(server, m)
+}

--- a/objects/fwstate/meson.build
+++ b/objects/fwstate/meson.build
@@ -1,0 +1,4 @@
+if not dataplane_only
+  subdir('api')
+  subdir('controlplane')
+endif

--- a/objects/meson.build
+++ b/objects/meson.build
@@ -1,0 +1,1 @@
+subdir('fwstate')


### PR DESCRIPTION
- Introduces a top-level objects/ tree hosting standalone shared-memory cp_objects.
- Adds IPv4 and IPv6 fwstate map objects under objects/fwstate/api/, each owning a multi-layer fwtable registered as a named cp_object that module configs can reference and resolve at execution-context build time.
- Adds an objects-owned Go controlplane (objects/fwstate/controlplane) implementing the FWStateMapService gRPC surface: create/delete/list maps, layer insert, stats, entry streaming, and stale-layer reclamation, with self-contained CGO bindings (objects/fwstate/bindings).
- The map service is intentionally decoupled from the fwstate module's sync-config service and is not yet wired into the gateway director or the dataplane object loader; the addition is foundational and additive.