### PR TITLE
refactor(dataplane): make packet_front input the stage entry point

### DIFF
--- a/lib/dataplane/module/packet_front.h
+++ b/lib/dataplane/module/packet_front.h
@@ -3,21 +3,13 @@
 #include "lib/dataplane/packet/packet.h"
 
 /*
- * The structure enumerated packets processed by pipeline modules.
- * Each module reads a packet from an input list and then writes result to
- * an output list or drop list.
+ * Packets processed by a pipeline stage. A module reads incoming packets
+ * from the input list and writes results to the output or drop list.
  *
- * Before module invocation input and output exchange packets so ouptut of
- * one module connects with input of the following.
- *
- * RX and TX are considered as separated stages of packet processing working
- * before and after pipeline processing.
- *
- * The count/byte counters for the input, output, drop and pending lists
- * live here rather than on the packet lists themselves: they reflect the
- * role a list plays in the front. The input counters are a snapshot taken
- * when output is switched into input; output, drop and pending counters
- * accumulate as packets are emitted.
+ * input is the stage entry list and output the emission list. The entry
+ * push (packet_front_input) sets the input counters directly — the only
+ * switch is the inter-module handoff turning module N's output into
+ * module N+1's input.
  */
 struct packet_front {
 	struct packet_list pending_input;
@@ -126,6 +118,13 @@ packet_front_pending_output(
 }
 
 static inline void
+packet_front_input(struct packet_front *packet_front, struct packet *packet) {
+	packet_list_add(&packet_front->input, packet);
+	packet_front->input_count += 1;
+	packet_front->input_bytes += packet->data_len;
+}
+
+static inline void
 packet_front_output(struct packet_front *packet_front, struct packet *packet) {
 	packet_list_add(&packet_front->output, packet);
 	packet_front->output_count += 1;
@@ -139,6 +138,8 @@ packet_front_drop(struct packet_front *packet_front, struct packet *packet) {
 	packet_front->drop_bytes += packet->data_len;
 }
 
+// Inter-module handoff: move output into input for the next module. Stage
+// entry is by packet_front_input, not a switch.
 static inline void
 packet_front_switch(struct packet_front *packet_front) {
 	packet_list_concat(&packet_front->input, &packet_front->output);
@@ -162,15 +163,29 @@ packet_front_pass(struct packet_front *packet_front) {
 // Move the whole output list of src into dst, transferring the output
 // counters.
 //
-// Used by the single-chain and single-pipeline fast paths that schedule a
-// front on a fresh packet_front; dst->output is empty on entry, so its first
-// packet_front_switch reads the transferred counters.
+// Used by the single-pipeline fast path that schedules a front on a fresh
+// packet_front for a stage that reads output.
 static inline void
 packet_front_take_output(struct packet_front *dst, struct packet_front *src) {
 	packet_list_concat(&dst->output, &src->output);
 
 	dst->output_count = src->output_count;
 	dst->output_bytes = src->output_bytes;
+	src->output_count = 0;
+	src->output_bytes = 0;
+}
+
+// Move src's output list into dst's input, copying src's output counters to
+// dst's input counters.
+//
+// Used by the single-chain fast path that schedules a front on a fresh
+// packet_front so module 0 reads input directly without a prior switch.
+static inline void
+packet_front_take_input(struct packet_front *dst, struct packet_front *src) {
+	packet_list_concat(&dst->input, &src->output);
+
+	dst->input_count = src->output_count;
+	dst->input_bytes = src->output_bytes;
 	src->output_count = 0;
 	src->output_bytes = 0;
 }
@@ -201,11 +216,6 @@ packet_front_drop_pending_input(struct packet_front *packet_front) {
 	packet_front->drop_bytes += packet_front->pending_input_bytes;
 	packet_front->pending_input_count = 0;
 	packet_front->pending_input_bytes = 0;
-}
-
-static inline struct packet_list *
-packet_front_input(struct packet_front *packet_front) {
-	return &packet_front->input;
 }
 
 static inline uint64_t

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -136,12 +136,21 @@ chain_ectx_process(
 	struct chain_ectx *chain_ectx,
 	struct packet_front *packet_front
 ) {
+	// A chain with no modules is a wire: pass input through to output so
+	// the caller's merge carries the packets onward.
+	if (chain_ectx->length == 0) {
+		packet_front_pass(packet_front);
+		return;
+	}
+
 	uint64_t input_size = packet_front_input_count(packet_front);
 
 	uint64_t tsc_start = rte_rdtsc();
 
 	for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
-		packet_front_switch(packet_front);
+		if (idx > 0) {
+			packet_front_switch(packet_front);
+		}
 
 		struct module_ectx *module_ectx =
 			ADDR_OF(&chain_ectx->modules[idx].module_ectx);
@@ -188,7 +197,7 @@ function_ectx_run_single_chain(
 	struct chain_ectx *chain_ectx = ADDR_OF(chains);
 
 	struct packet_front *schedule = &chain_ectx->schedule;
-	packet_front_take_output(schedule, packet_front);
+	packet_front_take_input(schedule, packet_front);
 
 	chain_ectx_process(dp_worker, chain_ectx, schedule);
 
@@ -211,7 +220,7 @@ function_ectx_run_chains(
 
 		struct chain_ectx *chain_ectx =
 			ADDR_OF(function_ectx->chain_map + map_idx);
-		packet_front_output(&chain_ectx->schedule, packet);
+		packet_front_input(&chain_ectx->schedule, packet);
 
 		packet = packet_list_pop(&packet_front->output);
 	}
@@ -466,8 +475,6 @@ device_ectx_process_entry(
 	struct device_entry_ectx *entry_ectx,
 	struct packet_front *packet_front
 ) {
-	packet_front_switch(packet_front);
-
 	counter_add_packets_bytes(
 		ADDR_OF_NONNULL(&entry_ectx->counter_packet_rx),
 		packet_front_input_count(packet_front),

--- a/lib/dataplane/worker/pipeline_round.c
+++ b/lib/dataplane/worker/pipeline_round.c
@@ -47,7 +47,7 @@ worker_pipeline_round(
 				packet_front_drop(packet_front, packet);
 				continue;
 			}
-			packet_front_output(
+			packet_front_input(
 				&ADDR_OF(&device_ectx->input_pipelines)
 					 ->schedule,
 				packet
@@ -65,7 +65,7 @@ worker_pipeline_round(
 				packet_front_drop(packet_front, packet);
 				continue;
 			}
-			packet_front_output(
+			packet_front_input(
 				&ADDR_OF(&device_ectx->output_pipelines)
 					 ->schedule,
 				packet
@@ -90,7 +90,7 @@ worker_pipeline_round(
 					 ->schedule;
 
 			if (!force_poll &&
-			    packet_list_first(&schedule->output) == NULL) {
+			    packet_list_first(&schedule->input) == NULL) {
 				continue;
 			}
 
@@ -123,7 +123,7 @@ worker_pipeline_round(
 					 ->schedule;
 
 			if (!force_poll &&
-			    packet_list_first(&schedule->output) == NULL) {
+			    packet_list_first(&schedule->input) == NULL) {
 				continue;
 			}
 

--- a/lib/fuzzing/fuzzing.h
+++ b/lib/fuzzing/fuzzing.h
@@ -156,13 +156,12 @@ fuzzing_process_packet(
 	packet->mbuf = mbuf;
 
 	// Create packet front and hand the packet to input the way the
-	// pipeline does: emit to output, then switch it into input so the
-	// input counters modules read for VLA sizing are populated.
+	// pipeline does: push it directly to input so the input counters
+	// modules read for VLA sizing are populated.
 	struct packet_front pf;
 	packet_front_init(&pf);
 	packet->data_len = packet_data_len(packet);
-	packet_front_output(&pf, packet);
-	packet_front_switch(&pf);
+	packet_front_input(&pf, packet);
 
 	// Parse packet
 	if (parse_packet(packet)) {


### PR DESCRIPTION
- Makes the input list the real entry point of a packet front stage, so packets no longer land in output only to be switched into input before the first consumer runs.
- Removes the initial output-to-input switch at the device entry and before the first chain module; schedules are primed directly into input, leaving output strictly for genuine emission and in-round rescheduling.
- Moves the worker demux and the device-entry work-check onto input alongside the priming change, so non-force-poll iterations still detect staged packets.
- Fixes a latent metric bug where the per-module latency histogram was keyed on a batch size that was always zero, captured before the in-loop switch populated it.
- Layout-neutral: no struct field changes and no module ABI version bump.
- Conceptually complementary to #1988, which removes the pending indirection between devices; the two touch overlapping files for orthogonal concerns and this branch will need a rebase once #1988 lands.
