### PR TITLE
ci(notifications): route pr and issue alerts to dedicated telegram topics

### DIFF
--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -123,6 +123,6 @@ jobs:
         run: |
           curl -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_YANET_NOTIFICATIONS_BOT_TOKEN }}/sendMessage" \
           -d "chat_id=${{ vars.TELEGRAM_YANET_CHAT_ID }}" \
-          -d "message_thread_id=${{ vars.TELEGRAM_YANET_TOPIC_ID }}" \
+          -d "message_thread_id=${{ vars.TELEGRAM_YANET_PR_TOPIC_ID }}" \
           -d "text=$Message"
 

--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Send PR notification to topic
         run: |
           curl -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_YANET_NOTIFICATIONS_BOT_TOKEN }}/sendMessage" \
-          -d "chat_id=${{ vars.TELEGRAM_YANET_CHAT_ID }}" -d "message_thread_id=${{ vars.TELEGRAM_YANET_TOPIC_ID }}"   \
+          -d "chat_id=${{ vars.TELEGRAM_YANET_CHAT_ID }}" -d "message_thread_id=${{ vars.TELEGRAM_YANET_PR_TOPIC_ID }}"   \
           -d "text=$Message"
 
   notify_issue:
@@ -33,5 +33,5 @@ jobs:
       - name: Send issue notification to topic
         run: |
           curl -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_YANET_NOTIFICATIONS_BOT_TOKEN }}/sendMessage" \
-          -d "chat_id=${{ vars.TELEGRAM_YANET_CHAT_ID }}" -d "message_thread_id=${{ vars.TELEGRAM_YANET_TOPIC_ID }}"   \
+          -d "chat_id=${{ vars.TELEGRAM_YANET_CHAT_ID }}" -d "message_thread_id=${{ vars.TELEGRAM_YANET_ISSUES_TOPIC_ID }}"   \
           --data-urlencode "text=$Message"


### PR DESCRIPTION
- Send issue notifications to a dedicated issues topic instead of the shared one.
- Keep PR notifications and scheduled fuzz-failure alerts on their existing topic under a purpose-named variable.