### PR TITLE
fix(controlplane): let the configuration registry own a module config

### DIFF
--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -2320,6 +2320,14 @@ yanet_counter_handle_list_free(struct counter_handle_list *counters) {
 
 // Unlocked body shared by agent_free_unused_agents and the agent_attach call
 // site, which already holds cp_config_lock itself.
+//
+// Depends on a precondition it does not itself enforce: within one shared
+// memory instance, a live agent name has at most one process still holding
+// it. Only a reference kind that cannot outlive its owning process may gate
+// this reclaim, since nothing here can tell a dead owner from a live one
+// across a restart. A second live holder of the same name sharing that gate
+// would instead have its arena freed out from under it. Mechanically
+// proving this precondition is tracked separately as issue #2001.
 static void
 agent_free_unused_agents_locked(struct agent *agent) {
 	if (agent == NULL) {
@@ -2331,7 +2339,8 @@ agent_free_unused_agents_locked(struct agent *agent) {
 
 		if (prev_agent->loaded_module_count == 0 &&
 		    prev_agent->loaded_device_count == 0 &&
-		    prev_agent->loaded_object_count == 0) {
+		    prev_agent->loaded_object_count == 0 &&
+		    prev_agent->parked_teardown_count == 0) {
 			SET_OFFSET_OF(&agent->prev, ADDR_OF(&prev_agent->prev));
 			agent_cleanup(prev_agent);
 			continue;

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -37,19 +37,37 @@ struct agent {
 	pid_t pid;
 	uint64_t memory_limit;
 	uint64_t gen;
+	// Count of live generation references to this agent's modules.
+	//
+	// Excludes the initial reference a module construction call holds for
+	// its own creator, since a creator that dies never releases it and
+	// counting it would block reclaim forever. Every place that adds or
+	// removes such a reference keeps this count in step, so it reflects
+	// only references that can outlive the creator.
 	uint64_t loaded_module_count;
 	uint64_t loaded_device_count;
-	// cp_objects this agent owns that still hold a reference from a live
-	// generation.
+	// Count of this agent's shared objects that still hold a reference
+	// from a live generation.
 	//
-	// Mirrors loaded_module_count / loaded_device_count: incremented when
-	// an object is upserted into a generation's registry and decremented
-	// when it retires (its refcount drops to zero in
-	// cp_object_registry_item_free_cb). agent_attach /
-	// agent_free_unused_agents gate reclamation on all three counts being
-	// zero, since agent_cleanup frees the arena wholesale and cannot run
-	// per-object teardown itself.
+	// Follows the same accounting as the device count above: incremented
+	// when a reference is added and decremented when it is dropped and
+	// the object retires. Reclaiming a superseded agent waits for this
+	// and the sibling counts to reach zero, because freeing the arena is
+	// one wholesale operation with no way to tear objects down
+	// individually first.
 	uint64_t loaded_object_count;
+	// Count of this agent's parked-module teardowns currently running
+	// outside the configuration lock.
+	//
+	// Set before the lock is released to run a batch of parked
+	// destructors and cleared once they return. The reclaim guard treats
+	// a nonzero count as a live reference, because those destructors
+	// still touch this agent's arena even though the generation counts
+	// above already read zero for them. A process that dies mid-teardown
+	// leaves this above zero forever, leaking that one superseded arena
+	// rather than risking a destructor running against memory that has
+	// already been freed.
+	uint64_t parked_teardown_count;
 	struct agent *prev;
 	char name[80];
 
@@ -57,6 +75,16 @@ struct agent {
 	struct agent_arena *arenas;
 
 	struct agent_storage *storage;
+
+	// Head of this agent's list of modules parked after their reference
+	// count reached zero.
+	//
+	// Parked entries await destruction until the next construction call
+	// for their module type reclaims them. A control plane can reuse one
+	// agent across more than one service, so this list may mix module
+	// types. Each type's construction reclaims only matching entries,
+	// leaving the rest parked for their own type's turn.
+	struct cp_module *parked_modules;
 };
 
 struct dp_config *

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -12,6 +12,24 @@
 
 #include <stdio.h>
 
+// Destroy every parked module of one type, using the caller's destructor
+// for that type.
+//
+// A different type sharing the same parked list is left in place for its
+// own next call. A parked entry already sits at reference count zero, so
+// the destructor runs directly with no further release and nothing here
+// outlives this call. Matching entries are detached under the
+// configuration lock and destroyed outside it, because a type's teardown
+// can run tens of milliseconds and must not hold a lock every update
+// needs. While outside the lock, a teardown is marked in flight so the
+// arena cannot be reclaimed out from under an entry still being destroyed.
+static void
+cp_module_drain_parked(
+	struct agent *agent,
+	const char *module_type,
+	cp_module_free_handler destroy
+);
+
 static int
 cp_module_build_perf_counters(struct cp_module *cp_module, yanet_error **err) {
 	for (size_t counter_idx = 0; counter_idx < MODULE_ECTX_PERF_COUNTERS;
@@ -48,9 +66,21 @@ cp_module_init(
 	struct agent *agent,
 	const char *module_type,
 	const char *module_name,
+	cp_module_free_handler destroy,
 	yanet_error **err
 ) {
 	memset(cp_module, 0, sizeof(struct cp_module));
+
+	// Reclaim this type's parked entries before anything else here
+	// allocates.
+	//
+	// The caller's own wrapper allocation already happened, but a parked
+	// instance can be most of the arena for a large type, so reclaiming
+	// it first can be the difference between success and failure under
+	// pressure. Construction has not registered or parked this instance
+	// anywhere yet, so the walk below cannot observe it — only earlier
+	// instances left behind by a previous release.
+	cp_module_drain_parked(agent, module_type, destroy);
 
 	struct dp_config *dp_config = ADDR_OF(&agent->dp_config);
 
@@ -160,6 +190,13 @@ cp_module_init(
 	if (cp_module_link_device(cp_module, "", &any_idx, err)) {
 		goto fail;
 	}
+
+	// Take the creator's reference only after construction succeeds.
+	//
+	// A failed construction leaves nothing to unbalance. This reference
+	// is never mirrored into the live-reference count: a dead creator
+	// must not hold it above zero.
+	registry_item_ref(&cp_module->config_item);
 
 	return 0;
 
@@ -291,6 +328,106 @@ cp_module_link_object(
 	return 0;
 }
 
+void
+cp_module_registry_item_free_cb(struct registry_item *item, void *data) {
+	struct cp_module *module =
+		container_of(item, struct cp_module, config_item);
+	struct agent *agent = ADDR_OF(&module->agent);
+	if (agent == NULL) {
+		return;
+	}
+
+	if (ADDR_OF(&module->parked_next) != NULL) {
+		return;
+	}
+
+	struct cp_module *head = ADDR_OF(&agent->parked_modules);
+	SET_OFFSET_OF(&module->parked_next, (head != NULL) ? head : module);
+	SET_OFFSET_OF(&agent->parked_modules, module);
+	(void)data;
+}
+
+void
+cp_module_release(struct cp_module *cp_module) {
+	struct agent *agent = ADDR_OF(&cp_module->agent);
+	struct cp_config *cp_config =
+		(agent != NULL) ? ADDR_OF(&agent->cp_config) : NULL;
+
+	if (cp_config != NULL) {
+		cp_config_lock(cp_config);
+	}
+	registry_item_unref(
+		&cp_module->config_item, cp_module_registry_item_free_cb, NULL
+	);
+	if (cp_config != NULL) {
+		cp_config_unlock(cp_config);
+	}
+}
+
+static void
+cp_module_drain_parked(
+	struct agent *agent,
+	const char *module_type,
+	cp_module_free_handler destroy
+) {
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	cp_config_lock(cp_config);
+
+	// Splice the target type's entries into a local list, leaving the
+	// rest linked in place for their own type's next call.
+	//
+	// A spliced-out tail leaves its former predecessor pointing at itself
+	// as the new end of the list, so a parked entry's link is never null.
+	struct cp_module *owned = NULL;
+	struct cp_module *prev = NULL;
+	struct cp_module *cur = ADDR_OF(&agent->parked_modules);
+
+	while (cur != NULL) {
+		struct cp_module *raw_next = ADDR_OF(&cur->parked_next);
+		struct cp_module *next = (raw_next == cur) ? NULL : raw_next;
+
+		if (!strncmp(cur->type, module_type, sizeof(cur->type))) {
+			if (prev == NULL) {
+				SET_OFFSET_OF(&agent->parked_modules, next);
+			} else {
+				SET_OFFSET_OF(
+					&prev->parked_next,
+					(next != NULL) ? next : prev
+				);
+			}
+			SET_OFFSET_OF(&cur->parked_next, owned);
+			owned = cur;
+		} else {
+			prev = cur;
+		}
+
+		cur = next;
+	}
+
+	if (owned == NULL) {
+		cp_config_unlock(cp_config);
+		return;
+	}
+
+	// Pin the agent's arena for the destroy loop below, still under the
+	// same lock the splice above ran under, so the reclaim guard can never
+	// observe the entries detached but the pin not yet set.
+	agent->parked_teardown_count += 1;
+
+	cp_config_unlock(cp_config);
+
+	while (owned != NULL) {
+		struct cp_module *next = ADDR_OF(&owned->parked_next);
+		destroy(owned);
+		owned = next;
+	}
+
+	cp_config_lock(cp_config);
+	agent->parked_teardown_count -= 1;
+	cp_config_unlock(cp_config);
+}
+
 int
 cp_module_registry_init(
 	struct memory_context *memory_context,
@@ -323,24 +460,57 @@ cp_module_registry_copy(
 	};
 
 	SET_OFFSET_OF(&new_module_registry->memory_context, memory_context);
-	return 0;
-}
 
-static void
-cp_module_registry_item_free_cb(struct registry_item *item, void *data) {
-	struct cp_module *module =
-		container_of(item, struct cp_module, config_item);
-	struct agent *agent = ADDR_OF(&module->agent);
-	if (agent != NULL) {
-		agent->loaded_module_count -= 1;
+	// Mirror each copied item's new generation reference into its own
+	// agent.
+	//
+	// This keeps the per-agent live count tracking references from a
+	// live configuration generation rather than the creator's own hold,
+	// which a dead creator would otherwise never release.
+	for (uint64_t idx = 0; idx < new_module_registry->registry.capacity;
+	     ++idx) {
+		struct cp_module *module =
+			cp_module_registry_get(new_module_registry, idx);
+		if (module == NULL) {
+			continue;
+		}
+		struct agent *agent = ADDR_OF(&module->agent);
+		if (agent != NULL) {
+			agent->loaded_module_count += 1;
+		}
 	}
-	(void)data;
+
+	return 0;
 }
 
 void
 cp_module_registry_fini(struct cp_module_registry *module_registry) {
 	struct memory_context *memory_context =
 		ADDR_OF(&module_registry->memory_context);
+
+	// Mirror each remaining item's dropped generation reference into its
+	// own agent before releasing it.
+	//
+	// The callback this teardown invokes now only parks each item at
+	// zero references instead of adjusting the live count itself, so
+	// this loop mirrors the drop first. The same allocation-failure
+	// guard applies as elsewhere: a registry whose backing storage never
+	// allocated reports a nonzero capacity with nothing to walk.
+	if (ADDR_OF(&module_registry->registry.items) != NULL) {
+		for (uint64_t idx = 0; idx < module_registry->registry.capacity;
+		     ++idx) {
+			struct cp_module *module =
+				cp_module_registry_get(module_registry, idx);
+			if (module == NULL) {
+				continue;
+			}
+			struct agent *agent = ADDR_OF(&module->agent);
+			if (agent != NULL) {
+				agent->loaded_module_count -= 1;
+			}
+		}
+	}
+
 	registry_fini(
 		&module_registry->registry,
 		cp_module_registry_item_free_cb,
@@ -447,11 +617,6 @@ cp_module_registry_upsert(
 		err
 	);
 
-	// Count the module only on its first registry reference, mirroring the
-	// 1->0 transition at which cp_module_registry_item_free_cb decrements;
-	// a re-upsert of an already-referenced instance must not double-count.
-	uint64_t refcnt_before = new_module->config_item.refcnt;
-
 	if (registry_replace(
 		    &module_registry->registry,
 		    cp_module_registry_item_cmp,
@@ -464,9 +629,21 @@ cp_module_registry_upsert(
 		return -1;
 	}
 
-	struct agent *agent = ADDR_OF(&new_module->agent);
-	if (agent != NULL && refcnt_before == 0) {
-		agent->loaded_module_count += 1;
+	// Mirror this upsert's generation-reference changes into each
+	// affected module's own agent.
+	//
+	// Gaining a reference through upsert only ever happens here, and
+	// losing one to a displacing upsert only ever happens here too, so
+	// the per-agent live count must track both in this one place.
+	struct agent *new_agent = ADDR_OF(&new_module->agent);
+	if (new_agent != NULL) {
+		new_agent->loaded_module_count += 1;
+	}
+	if (old_module != NULL) {
+		struct agent *old_agent = ADDR_OF(&old_module->agent);
+		if (old_agent != NULL) {
+			old_agent->loaded_module_count -= 1;
+		}
 	}
 
 	return 0;
@@ -483,14 +660,31 @@ cp_module_registry_delete(
 		.name = name,
 	};
 
-	return registry_replace(
-		&module_registry->registry,
-		cp_module_registry_item_cmp,
-		&cmp_data,
-		NULL,
-		cp_module_registry_item_free_cb,
-		ADDR_OF(&module_registry->memory_context)
-	);
+	struct cp_module *old_module =
+		cp_module_registry_lookup(module_registry, type, name);
+
+	if (registry_replace(
+		    &module_registry->registry,
+		    cp_module_registry_item_cmp,
+		    &cmp_data,
+		    NULL,
+		    cp_module_registry_item_free_cb,
+		    ADDR_OF(&module_registry->memory_context)
+	    )) {
+		return -1;
+	}
+
+	// Mirror the generation reference this delete drops into the removed
+	// module's own agent, matching the decrement upsert performs when it
+	// displaces an entry.
+	if (old_module != NULL) {
+		struct agent *old_agent = ADDR_OF(&old_module->agent);
+		if (old_agent != NULL) {
+			old_agent->loaded_module_count -= 1;
+		}
+	}
+
+	return 0;
 }
 
 size_t

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "common/container_of.h"
 #include "common/memory.h"
 
 #include "counters/counters.h"
 
+#include "controlplane/agent/agent.h"
 #include "controlplane/config/defines.h"
 #include "controlplane/config/registry.h"
 
@@ -92,6 +94,16 @@ struct cp_module {
 	// resolved to per-worker object execution contexts at build time.
 	uint64_t object_count;
 	struct cp_module_object *objects;
+
+	// Link to the next module parked on the same agent's list, once this
+	// module's reference count reaches zero.
+	//
+	// Only the zero-transition handler sets it, and only a later reclaim
+	// for this module's own type reads it. It stays unset until that
+	// transition happens. The parked list's tail refers to itself
+	// instead of ending at null, so a parked entry's link is never null
+	// — which also marks that this module is already parked.
+	struct cp_module *parked_next;
 };
 
 /**
@@ -139,13 +151,19 @@ cp_module_link_object(
 /**
  * Initialize a module configuration structure.
  *
- * Sets up a new module configuration with the specified type and name,
- * initializes counters, and associates it with the given agent.
+ * Sets up counters and associates the module with the given agent. Before
+ * any of that allocates, this reclaims whatever the agent parked for this
+ * type since the last such call, using the destructor supplied here, so a
+ * recreation under memory pressure benefits from the space a parked
+ * instance would free rather than failing before reaching that reclaim.
+ * The destructor is used only for this call and never stored. A different
+ * type sharing the same agent is left for its own next call to collect.
  *
  * @param cp_module Pointer to the module configuration to initialize
  * @param agent Pointer to the controlplane agent owning this module
  * @param module_type Type identifier for the module
  * @param module_name Name identifier for the module
+ * @param destroy Destructor for a parked module of this same type
  * @param err Error output parameter
  * @return 0 on success, negative error code on failure
  */
@@ -155,6 +173,7 @@ cp_module_init(
 	struct agent *agent,
 	const char *module_type,
 	const char *module_name,
+	cp_module_free_handler destroy,
 	yanet_error **err
 );
 
@@ -167,6 +186,36 @@ cp_module_init(
  */
 void
 cp_module_fini(struct cp_module *cp_module);
+
+// The single handler for a module reference count reaching zero, reached
+// the same way from a registry drop or an explicit release.
+//
+// Parks the module on its agent's list instead of destroying it, because
+// this generic layer does not know the module's type, and an agent can
+// host more than one type at once — as when acl and fwstate share one.
+// The module's own type-specific reclaim destroys it later.
+//
+// Idempotent: once set, a parked entry's link is never null again, so a
+// duplicate transition leaves it in place instead of relinking it. Every
+// caller already holds the configuration lock, so this handler must not
+// take it itself.
+void
+cp_module_registry_item_free_cb(struct registry_item *item, void *data);
+
+// Drop the reference construction took on the caller's behalf.
+//
+// The zero-transition handler runs only when this drop is the last
+// reference, so a caller must not assume the call freed anything: a live
+// or pinned configuration generation may still hold the module. A module
+// parked here is not destroyed on the spot — the next construction call
+// for the same type reclaims it, or it is freed along with the agent's
+// arena.
+//
+// Takes the module's own agent's configuration lock itself, unlike the
+// registry-driven path to the same handler, which already runs under
+// that lock.
+void
+cp_module_release(struct cp_module *cp_module);
 
 struct cp_module_registry {
 	struct memory_context *memory_context;

--- a/lib/controlplane/tests/meson.build
+++ b/lib/controlplane/tests/meson.build
@@ -72,6 +72,28 @@ loaded_counts_test = executable(
 
 test('loaded_counts', loaded_counts_test, suite: ['lib'])
 
+module_registry_fini_guard_test = executable(
+  'module_registry_fini_guard_test',
+  ['module_registry_fini_guard_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_device_plain',
+    '-Wl,--export-dynamic-symbol=new_device_plain',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_dev_plain_api,
+    libdpdk_dep,
+  ],
+  link_with: [lib_dev_plain_dp],
+  include_directories: yanet_rootdir,
+)
+
+test('module_registry_fini_guard', module_registry_fini_guard_test, suite: ['lib'])
+
 cp_object_test = executable(
   'cp_object_test',
   ['cp_object_test.c'],
@@ -118,3 +140,28 @@ cp_object_gen_test = executable(
 )
 
 test('cp_object_gen', cp_object_gen_test, suite: ['lib'])
+
+parked_modules_test = executable(
+  'parked_modules_test',
+  ['parked_modules_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_module_decap',
+    '-Wl,--export-dynamic-symbol=new_module_decap',
+    '-Wl,--undefined=new_module_forward',
+    '-Wl,--export-dynamic-symbol=new_module_forward',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_decap_cp_dep,
+    lib_forward_cp_dep,
+    libdpdk_dep,
+  ],
+  link_with: [lib_decap_dp, lib_forward_dp],
+  include_directories: yanet_rootdir,
+)
+
+test('parked_modules', parked_modules_test, suite: ['lib'])

--- a/lib/controlplane/tests/module_registry_fini_guard_test.c
+++ b/lib/controlplane/tests/module_registry_fini_guard_test.c
@@ -1,0 +1,45 @@
+/*
+ * Regression test for a null items array reaching the live-reference
+ * mirror loop in the module registry's teardown.
+ *
+ * Registry setup records a capacity before it allocates the backing array,
+ * so a generation copy that fails partway through, for example on arena
+ * exhaustion, can leave a nonzero capacity paired with a null array.
+ * Teardown's mirror loop must skip that state exactly as the underlying
+ * registry teardown already does for the same never-allocated array.
+ */
+
+#include "common/test_assert.h"
+
+#include "controlplane/config/cp_module.h"
+
+#include <string.h>
+
+static int
+run_null_items_test(void) {
+	struct cp_module_registry registry;
+	memset(&registry, 0, sizeof(registry));
+
+	// Mirrors a capacity recorded before the backing array allocation
+	// failed: a nonzero capacity paired with a still-null array.
+	registry.registry.capacity = 8;
+
+	// Walks all eight recorded slots against a still-null backing array.
+	cp_module_registry_fini(&registry);
+
+	TEST_ASSERT_EQUAL(
+		registry.registry.capacity,
+		8,
+		"a registry with no items array must be left untouched, "
+		"exactly like registry_fini's own guard"
+	);
+
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	return (run_null_items_test() == TEST_SUCCESS) ? 0 : 1;
+}

--- a/lib/controlplane/tests/parked_modules_test.c
+++ b/lib/controlplane/tests/parked_modules_test.c
@@ -1,0 +1,280 @@
+/*
+ * Regression test for the module-parking mechanism: a construction call
+ * must reclaim only parked entries of its own type, and parking an
+ * already-parked module must not extend the list into a cycle.
+ */
+
+#include "api/agent.h"
+
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+
+#include "controlplane/agent/agent.h"
+#include "controlplane/config/cp_module.h"
+#include "controlplane/config/zone.h"
+
+#include "modules/decap/api/controlplane.h"
+#include "modules/forward/api/controlplane.h"
+
+#include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/errors/errors.h"
+
+#include "logging/log.h"
+
+#include <stdio.h>
+
+#define PARKED_TEST_MEMORY_LIMIT (2u * 1024u * 1024u)
+
+// Reproduces a real cross-service parking scenario: releasing one
+// service's module while another service shares the same agent.
+//
+// In production, acl and fwstate share one agent. A released fwstate
+// handle parks once its last reference drops, and an unrelated acl update
+// must leave it alone. Decap and forward stand in for fwstate and acl
+// here, since both link into every test harness. A release no longer
+// reclaims by itself, so whichever module each type releases last here
+// stays parked until a later construction of that same type reclaims it.
+static int
+test_drain_parked_filters_by_type(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm, 0, "parked-drain-filter", PARKED_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct cp_module *decap0 = decap_module_config_new(agent, "d0", &err);
+	TEST_ASSERT_NOT_NULL(decap0, "decap_module_config_new failed");
+
+	// Simulate a live generation holding decap0: a manual registry
+	// reference, exactly like an install would take.
+	struct cp_module_registry reg;
+	TEST_ASSERT_SUCCESS(
+		cp_module_registry_init(&agent->memory_context, &reg, &err),
+		"cp_module_registry_init failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_module_registry_upsert(&reg, "decap", "d0", decap0, &err),
+		"cp_module_registry_upsert failed"
+	);
+
+	// Release the creator's own reference, exactly as decap's control
+	// plane does on free.
+	//
+	// The generation reference above still holds decap0 alive, so
+	// nothing parks yet.
+	decap_module_config_free(decap0);
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_modules),
+		"nothing must be parked while a generation still holds decap0"
+	);
+
+	// Retire the generation: its last reference drops and decap0 parks.
+	cp_module_registry_fini(&reg);
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_modules) == decap0,
+		"decap0 must be parked once its last reference drops"
+	);
+
+	// An unrelated forward construction must not touch a parked decap
+	// module.
+	struct cp_module *forward0 =
+		forward_module_config_init(agent, "f0", &err);
+	TEST_ASSERT_NOT_NULL(forward0, "forward_module_config_init failed");
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_modules) == decap0,
+		"forward's own construction must leave a parked decap module "
+		"untouched"
+	);
+
+	// A decap construction reaches its own type's parked list and
+	// destroys decap0.
+	struct cp_module *decap1 = decap_module_config_new(agent, "d1", &err);
+	TEST_ASSERT_NOT_NULL(decap1, "decap_module_config_new failed");
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_modules),
+		"decap's own construction must reclaim the parked decap module"
+	);
+
+	// Steady state: exactly one live decap and one live forward module.
+	// Reconstructing each type below must return to this same byte count.
+	size_t checkpoint = block_allocator_free_size(&agent->block_allocator);
+
+	// Freeing the only live instance of each type parks it instead of
+	// destroying it: nothing constructs that type again yet to reclaim it.
+	forward_module_config_free(forward0);
+	decap_module_config_free(decap1);
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_modules) == decap1,
+		"the last release of each type must park it, not destroy it"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&decap1->parked_next) == forward0,
+		"parking must chain onto the existing list head"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&forward0->parked_next) == forward0,
+		"the list tail stays self-referential"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)block_allocator_free_size(&agent->block_allocator),
+		(long)checkpoint,
+		"parking must not itself move memory"
+	);
+
+	// A later construction of each type reclaims what its own release
+	// left parked, exactly as decap1 reclaimed decap0 above.
+	struct cp_module *decap2 = decap_module_config_new(agent, "d2", &err);
+	TEST_ASSERT_NOT_NULL(decap2, "decap_module_config_new failed");
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_modules) == forward0,
+		"a decap construction must reclaim only the parked decap module"
+	);
+
+	struct cp_module *forward1 =
+		forward_module_config_init(agent, "f1", &err);
+	TEST_ASSERT_NOT_NULL(forward1, "forward_module_config_init failed");
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_modules),
+		"a forward construction must reclaim the parked forward module"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)block_allocator_free_size(&agent->block_allocator),
+		(long)checkpoint,
+		"replacing each type's parked predecessor must return to the "
+		"same steady state"
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+// A duplicate zero-transition on an already-parked module must not link
+// it in twice.
+//
+// A single-node list can't tell: the head is already the node itself, so
+// a duplicate push is a no-op regardless. This drives it on a two-node
+// list instead: park an older module, then a newer one on top of it,
+// then re-drive the callback on the older, tail entry. Without the
+// guard that relinks the tail in front of the head, closing the two
+// nodes into a cycle a real drain call never finishes walking.
+static int
+test_park_is_idempotent(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm, 0, "parked-park-idempotent", PARKED_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct cp_module *decap_old =
+		decap_module_config_new(agent, "idem-old", &err);
+	TEST_ASSERT_NOT_NULL(decap_old, "decap_module_config_new failed");
+	struct cp_module *decap_new =
+		decap_module_config_new(agent, "idem-new", &err);
+	TEST_ASSERT_NOT_NULL(decap_new, "decap_module_config_new failed");
+
+	size_t checkpoint = block_allocator_free_size(&agent->block_allocator);
+
+	// Park the older module first, then the newer one on top of it: head
+	// decap_new, tail decap_old self-referential.
+	cp_module_registry_item_free_cb(&decap_old->config_item, NULL);
+	cp_module_registry_item_free_cb(&decap_new->config_item, NULL);
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_modules) == decap_new,
+		"the second park must move the head to decap_new"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&decap_new->parked_next) == decap_old,
+		"decap_new must link onto decap_old"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&decap_old->parked_next) == decap_old,
+		"decap_old must remain the self-referential tail"
+	);
+
+	// Drive the zero-transition callback again on the tail, the same way
+	// a lost update between two racing releases once could.
+	cp_module_registry_item_free_cb(&decap_old->config_item, NULL);
+
+	// Walk from the head with a bound past the real list length: a cyclic
+	// corruption fails this assertion instead of hanging the traversal.
+	struct cp_module *seen[8];
+	size_t seen_count = 0;
+	struct cp_module *node = ADDR_OF(&agent->parked_modules);
+	while (node != NULL && seen_count < 8) {
+		seen[seen_count++] = node;
+		struct cp_module *next = ADDR_OF(&node->parked_next);
+		node = (next == node) ? NULL : next;
+	}
+	TEST_ASSERT_EQUAL(
+		(long)seen_count,
+		2L,
+		"a duplicate zero-transition must not change the list length"
+	);
+	TEST_ASSERT(
+		seen[0] == decap_new && seen[1] == decap_old,
+		"a duplicate zero-transition must not reorder the list"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&decap_old->parked_next) == decap_old,
+		"a duplicate push must leave decap_old's own link untouched"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)block_allocator_free_size(&agent->block_allocator),
+		(long)checkpoint,
+		"parking and re-parking an already-parked module must not move "
+		"memory"
+	);
+
+	// A later decap construction reclaims every parked entry of its own
+	// type, decap_old and decap_new alike.
+	struct cp_module *decap_next =
+		decap_module_config_new(agent, "idem-next", &err);
+	TEST_ASSERT_NOT_NULL(decap_next, "decap_module_config_new failed");
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_modules),
+		"construction must reclaim every parked module of its own type"
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	const char *mods_to_load[] = {"decap", "forward"};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 24,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.modules = mods_to_load,
+		.module_count = 2,
+	};
+
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	if (ut == NULL) {
+		fprintf(stderr, "dataplane_ut_new failed\n");
+		return 1;
+	}
+
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	if (shm == NULL) {
+		fprintf(stderr, "dataplane_ut_shm returned NULL\n");
+		dataplane_ut_free(ut);
+		return 1;
+	}
+
+	int res = test_drain_parked_filters_by_type(shm);
+	if (res == TEST_SUCCESS) {
+		res = test_park_is_idempotent(shm);
+	}
+
+	dataplane_ut_free(ut);
+
+	return (res == TEST_SUCCESS) ? 0 : 1;
+}

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -36,7 +36,7 @@ _Static_assert(
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct cp_module) == 568,
+	sizeof(struct cp_module) == 576,
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 13
+#define YANET_MODULE_ABI_VERSION 14
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/modules/acl/api/controlplane.c
+++ b/modules/acl/api/controlplane.c
@@ -70,6 +70,44 @@ FILTER_COMPILER_DECLARE(
 #define ACL_FILTER_NET6_SRC_POS 2
 #define ACL_FILTER_NET6_DST_POS 3
 
+static void
+acl_module_config_destroy(struct cp_module *cp_module) {
+	struct acl_module_config *config =
+		container_of(cp_module, struct acl_module_config, cp_module);
+
+	memory_bfree(
+		&cp_module->memory_context,
+		ADDR_OF(&config->targets),
+		sizeof(struct acl_target) * config->target_count
+	);
+
+	filter_free(&config->filter_vlan, ACL_FILTER_VLAN_TAG);
+	filter_free(&config->filter_ip4, ACL_FILTER_IP4_TAG);
+	filter_free(&config->filter_ip4_port, ACL_FILTER_IP4_PROTO_PORT_TAG);
+	filter_free(&config->filter_ip6, ACL_FILTER_IP6_TAG);
+	filter_free(&config->filter_ip6_port, ACL_FILTER_IP6_PROTO_PORT_TAG);
+
+	filter_net6_share_dir_free(
+		&cp_module->memory_context, &config->net6_share_src
+	);
+	filter_net6_share_dir_free(
+		&cp_module->memory_context, &config->net6_share_dst
+	);
+
+	// Capture agent before fini zeroes it.
+	struct agent *agent = ADDR_OF(&cp_module->agent);
+
+	cp_module_fini(cp_module);
+
+	// Note: We don't destroy fwstate_cfg maps here because they're owned by
+	// the fwstate module. We only stored offsets to them.
+	memory_bfree(
+		&agent->memory_context,
+		cp_module,
+		sizeof(struct acl_module_config)
+	);
+}
+
 struct cp_module *
 acl_module_config_init(
 	struct agent *agent, const char *name, yanet_error **err
@@ -83,7 +121,14 @@ acl_module_config_init(
 		return NULL;
 	}
 
-	if (cp_module_init(&config->cp_module, agent, "acl", name, err)) {
+	if (cp_module_init(
+		    &config->cp_module,
+		    agent,
+		    "acl",
+		    name,
+		    acl_module_config_destroy,
+		    err
+	    )) {
 		yanet_error_add(err, "failed to init module");
 		memory_bfree(
 			&agent->memory_context,
@@ -147,7 +192,20 @@ acl_module_config_init(
 				"failed to register counter '%s'",
 				counters[i].name
 			);
-			acl_module_config_free(&config->cp_module);
+			// Frees directly instead of going through the type
+			// destructor.
+			//
+			// A failed configuration-data setup never reaches a
+			// state its own teardown could safely walk. No
+			// reference beyond the caller's own has been taken, and
+			// no registry has observed the module yet, so nothing
+			// is lost by freeing the block here.
+			cp_module_fini(&config->cp_module);
+			memory_bfree(
+				&agent->memory_context,
+				config,
+				sizeof(struct acl_module_config)
+			);
 			return NULL;
 		}
 		*counters[i].dst = id;
@@ -158,40 +216,7 @@ acl_module_config_init(
 
 void
 acl_module_config_free(struct cp_module *cp_module) {
-	struct acl_module_config *config =
-		container_of(cp_module, struct acl_module_config, cp_module);
-
-	memory_bfree(
-		&cp_module->memory_context,
-		ADDR_OF(&config->targets),
-		sizeof(struct acl_target) * config->target_count
-	);
-
-	filter_free(&config->filter_vlan, ACL_FILTER_VLAN_TAG);
-	filter_free(&config->filter_ip4, ACL_FILTER_IP4_TAG);
-	filter_free(&config->filter_ip4_port, ACL_FILTER_IP4_PROTO_PORT_TAG);
-	filter_free(&config->filter_ip6, ACL_FILTER_IP6_TAG);
-	filter_free(&config->filter_ip6_port, ACL_FILTER_IP6_PROTO_PORT_TAG);
-
-	filter_net6_share_dir_free(
-		&cp_module->memory_context, &config->net6_share_src
-	);
-	filter_net6_share_dir_free(
-		&cp_module->memory_context, &config->net6_share_dst
-	);
-
-	// Capture agent before fini zeroes it.
-	struct agent *agent = ADDR_OF(&cp_module->agent);
-
-	cp_module_fini(cp_module);
-
-	// Note: We don't destroy fwstate_cfg maps here because they're owned by
-	// the fwstate module. We only stored offsets to them.
-	memory_bfree(
-		&agent->memory_context,
-		cp_module,
-		sizeof(struct acl_module_config)
-	);
+	cp_module_release(cp_module);
 }
 
 typedef int (*acl_rule_check_func)(const struct acl_rule *acl_rule);

--- a/modules/acl/tests/functional/acl_fwstate_agent_test.go
+++ b/modules/acl/tests/functional/acl_fwstate_agent_test.go
@@ -1,0 +1,79 @@
+package acl_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
+	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
+	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
+)
+
+// setupACLFWStateHarness builds a harness with acl, forward, and fwstate
+// loaded and attaches one agent to all three, mirroring how the acl module
+// wires its own agent to the fwstate service in production.
+func setupACLFWStateHarness(tb testing.TB) (*ffi.Agent, acl.Backend) {
+	tb.Helper()
+
+	cfg := dataplaneut.Config{
+		CPMemory:      uint64(aclCPSize),
+		DPMemory:      uint64(aclDPSize),
+		WorkerCount:   1,
+		Devices:       []string{"port0"},
+		Modules:       []string{"acl", "forward", "fwstate"},
+		DevicesToLoad: []string{"plain"},
+	}
+	h, err := dataplaneut.NewHarness(cfg)
+	require.NoError(tb, err)
+	tb.Cleanup(h.Free)
+
+	shm := h.SharedMemory()
+	agent, err := shm.AgentAttach("acl", 0, aclMemSize)
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = agent.CleanUp() })
+
+	backend := acl.NewBackend(agent, uint64(aclMemSize))
+	return agent, backend
+}
+
+// TestACL_FWStateAgentSharing_ParkedModuleSurvivesUnrelatedDrain reproduces
+// production agent sharing where fwstate parks during an ACL drain.
+//
+// The acl module attaches one agent and hands it to both the ACL and
+// fwstate services. The sequence mirrors the fwstate service's own release
+// path, followed by a delete that retires the generation still pinning it,
+// parking the module before the ACL update runs. A drain call must stay
+// scoped to its own module type: destroying the parked fwstate module with
+// the wrong destructor would corrupt the arena during the filter
+// compiler's teardown.
+func TestACL_FWStateAgentSharing_ParkedModuleSurvivesUnrelatedDrain(t *testing.T) {
+	agent, backend := setupACLFWStateHarness(t)
+
+	fwCfg, err := cfwstate.NewModuleConfig(agent, "fw0")
+	require.NoError(t, err)
+	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{fwCfg.AsFFIModule()}))
+
+	// Release the creator's reference while the published generation
+	// still holds fw0: it must not park yet.
+	fwCfg.Free()
+
+	// Retiring the generation that still references fw0 is what actually
+	// parks it.
+	require.NoError(t, agent.DeleteModuleConfig("fwstate", "fw0"))
+
+	// An ACL update on the shared agent must not touch the parked fwstate
+	// module: its own drain call is filtered to the acl type.
+	rules := []cacl.AclRule{
+		allow4Rule(
+			filter.IPNets{filter.UnspecifiedIPv4},
+			filter.IPNets{filter.UnspecifiedIPv4},
+			udpProto,
+		),
+	}
+	handle := applyACLRules(t, backend, "acl0", rules)
+	require.NotNil(t, handle)
+}

--- a/modules/blackhole/api/controlplane.c
+++ b/modules/blackhole/api/controlplane.c
@@ -5,6 +5,15 @@
 
 #include "common/memory.h"
 
+static void
+blackhole_module_config_destroy(struct cp_module *config) {
+	// Capture agent before fini zeroes it.
+	struct agent *agent = ADDR_OF(&config->agent);
+
+	cp_module_fini(config);
+	memory_bfree(&agent->memory_context, config, sizeof(*config));
+}
+
 struct cp_module *
 blackhole_module_config_new(
 	struct agent *agent, const char *name, yanet_error **error
@@ -17,7 +26,14 @@ blackhole_module_config_new(
 		return NULL;
 	}
 
-	if (cp_module_init(config, agent, "blackhole", name, error)) {
+	if (cp_module_init(
+		    config,
+		    agent,
+		    "blackhole",
+		    name,
+		    blackhole_module_config_destroy,
+		    error
+	    )) {
 		yanet_error_add(error, "failed to init module");
 		memory_bfree(&agent->memory_context, config, sizeof(*config));
 		return NULL;
@@ -28,9 +44,5 @@ blackhole_module_config_new(
 
 void
 blackhole_module_config_free(struct cp_module *config) {
-	// Capture agent before fini zeroes it.
-	struct agent *agent = ADDR_OF(&config->agent);
-
-	cp_module_fini(config);
-	memory_bfree(&agent->memory_context, config, sizeof(*config));
+	cp_module_release(config);
 }

--- a/modules/decap/api/controlplane.c
+++ b/modules/decap/api/controlplane.c
@@ -12,49 +12,8 @@
 #include "controlplane/agent/agent.h"
 #include "dataplane/config/zone.h"
 
-struct cp_module *
-decap_module_config_new(
-	struct agent *agent, const char *name, yanet_error **err
-) {
-	struct decap_module_config *config =
-		(struct decap_module_config *)memory_balloc(
-			&agent->memory_context,
-			sizeof(struct decap_module_config)
-		);
-	if (config == NULL) {
-		yanet_error_add(err, "failed to allocate config");
-		return NULL;
-	}
-
-	if (cp_module_init(&config->cp_module, agent, "decap", name, err)) {
-		yanet_error_add(err, "failed to init module");
-		memory_bfree(
-			&agent->memory_context,
-			config,
-			sizeof(struct decap_module_config)
-		);
-
-		return NULL;
-	}
-
-	if (decap_module_config_data_init(
-		    config, &config->cp_module.memory_context
-	    )) {
-		yanet_error_add(err, "failed to init config data");
-		cp_module_fini(&config->cp_module);
-		memory_bfree(
-			&agent->memory_context,
-			config,
-			sizeof(struct decap_module_config)
-		);
-		return NULL;
-	}
-
-	return &config->cp_module;
-}
-
-void
-decap_module_config_free(struct cp_module *cp_module) {
+static void
+decap_module_config_destroy(struct cp_module *cp_module) {
 	struct decap_module_config *config =
 		container_of(cp_module, struct decap_module_config, cp_module);
 
@@ -69,6 +28,66 @@ decap_module_config_free(struct cp_module *cp_module) {
 		config,
 		sizeof(struct decap_module_config)
 	);
+}
+
+struct cp_module *
+decap_module_config_new(
+	struct agent *agent, const char *name, yanet_error **err
+) {
+	struct decap_module_config *config =
+		(struct decap_module_config *)memory_balloc(
+			&agent->memory_context,
+			sizeof(struct decap_module_config)
+		);
+	if (config == NULL) {
+		yanet_error_add(err, "failed to allocate config");
+		return NULL;
+	}
+
+	if (cp_module_init(
+		    &config->cp_module,
+		    agent,
+		    "decap",
+		    name,
+		    decap_module_config_destroy,
+		    err
+	    )) {
+		yanet_error_add(err, "failed to init module");
+		memory_bfree(
+			&agent->memory_context,
+			config,
+			sizeof(struct decap_module_config)
+		);
+
+		return NULL;
+	}
+
+	if (decap_module_config_data_init(
+		    config, &config->cp_module.memory_context
+	    )) {
+		yanet_error_add(err, "failed to init config data");
+		// Frees directly instead of going through the type destructor.
+		//
+		// A failed configuration-data setup never reaches a state its
+		// own teardown could safely walk. No reference beyond the
+		// caller's own has been taken, and no registry has observed
+		// the module yet, so nothing is lost by freeing the block
+		// here.
+		cp_module_fini(&config->cp_module);
+		memory_bfree(
+			&agent->memory_context,
+			config,
+			sizeof(struct decap_module_config)
+		);
+		return NULL;
+	}
+
+	return &config->cp_module;
+}
+
+void
+decap_module_config_free(struct cp_module *cp_module) {
+	cp_module_release(cp_module);
 }
 
 int

--- a/modules/decap/tests/functional/decap.go
+++ b/modules/decap/tests/functional/decap.go
@@ -1,0 +1,115 @@
+package decap_test
+
+/*
+#cgo CFLAGS: -I../../../../ -I../../../../lib
+#cgo LDFLAGS: -L../../../../build/lib/controlplane/config -lconfig_cp
+
+#include "controlplane/agent/agent.h"
+#include "controlplane/config/zone.h"
+#include "dataplane/config/zone.h"
+
+// yanet_test_pin_current_gen mirrors the pin half of the unlocked-reader
+// pattern used to read counters: lock, acquire a pin on the currently
+// published generation, unlock.
+static struct cp_config_gen *
+yanet_test_pin_current_gen(struct agent *agent) {
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	cp_config_lock(cp_config);
+	struct cp_config_gen *gen = cp_config_gen_acquire(cp_config);
+	cp_config_unlock(cp_config);
+
+	return gen;
+}
+
+// yanet_test_unpin_gen mirrors the same reader's release: lock, drop the
+// pin, unlock.
+static void
+yanet_test_unpin_gen(struct agent *agent, struct cp_config_gen *gen) {
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	cp_config_lock(cp_config);
+	cp_config_gen_release(cp_config, gen);
+	cp_config_unlock(cp_config);
+}
+
+// yanet_test_zero_worker_count clobbers the shared worker count to zero and
+// returns the value it replaced.
+//
+// The execution-context build rejects a zero worker count outright, before
+// touching the configuration arena at all, so a publish issued while this
+// is in effect fails deterministically in that stage, regardless of how
+// much arena memory happens to be free. The worker count is fixed once
+// dataplane startup fills it in, so the caller must restore it before the
+// harness does anything else that relies on it.
+static uint64_t
+yanet_test_zero_worker_count(struct agent *agent) {
+	struct dp_config *dp_config = ADDR_OF(&agent->dp_config);
+	uint64_t original = dp_config->worker_count;
+	dp_config->worker_count = 0;
+	return original;
+}
+
+// yanet_test_restore_worker_count reverses the worker-count override above.
+static void
+yanet_test_restore_worker_count(struct agent *agent, uint64_t worker_count) {
+	struct dp_config *dp_config = ADDR_OF(&agent->dp_config);
+	dp_config->worker_count = worker_count;
+}
+*/
+import "C"
+
+import "unsafe"
+
+// generationPin models an unlocked counters reader's pin on an agent's
+// currently published configuration generation.
+//
+// It is taken and dropped under the config lock exactly as a production
+// counter read does, without reading any counters itself. This lives
+// outside _test.go because cgo is not permitted there. Callers in this
+// package use it directly.
+type generationPin struct {
+	agent *C.struct_agent
+	gen   *C.struct_cp_config_gen
+}
+
+// pinCurrentGeneration pins the given agent's currently published
+// configuration generation, deferring that generation's teardown until
+// release is called.
+//
+// The pointer must be the unsafe.Pointer an *ffi.Agent exposes via
+// AsRawPtr.
+func pinCurrentGeneration(agentPtr unsafe.Pointer) *generationPin {
+	agent := (*C.struct_agent)(agentPtr)
+	return &generationPin{
+		agent: agent,
+		gen:   C.yanet_test_pin_current_gen(agent),
+	}
+}
+
+// release drops the pin taken by pinCurrentGeneration.
+//
+// Safe to call at most once: a second call would double-release the pin.
+func (m *generationPin) release() {
+	C.yanet_test_unpin_gen(m.agent, m.gen)
+}
+
+// zeroWorkerCount clobbers the shared worker count to zero.
+//
+// A publish issued while it is in effect fails deterministically inside
+// the execution-context build, independent of how much configuration
+// arena memory happens to be free. Returns the value to pass to
+// restoreWorkerCount once the publish under test has run. The pointer
+// must be the unsafe.Pointer an *ffi.Agent exposes via AsRawPtr.
+func zeroWorkerCount(agentPtr unsafe.Pointer) uint64 {
+	return uint64(C.yanet_test_zero_worker_count((*C.struct_agent)(agentPtr)))
+}
+
+// restoreWorkerCount undoes zeroWorkerCount, writing the given worker count
+// back to the shared configuration.
+//
+// The pointer must be the unsafe.Pointer an *ffi.Agent exposes via
+// AsRawPtr.
+func restoreWorkerCount(agentPtr unsafe.Pointer, workerCount uint64) {
+	C.yanet_test_restore_worker_count((*C.struct_agent)(agentPtr), C.uint64_t(workerCount))
+}

--- a/modules/decap/tests/functional/failed_publish_test.go
+++ b/modules/decap/tests/functional/failed_publish_test.go
@@ -1,0 +1,132 @@
+package decap_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/decap/bindings/go/cdecap"
+)
+
+// Memory sizes for the failed-publish regression harness.
+const (
+	failedPublishCPSize    = 32 * datasize.MB
+	failedPublishDPSize    = 4 * datasize.MB
+	failedPublishAgentSize = 2 * datasize.MB
+)
+
+// TestFailedPublish_LeavesCallersModuleIntact guards a failed publish after
+// upsert, keeping the creator's own reference usable afterward.
+//
+// Only a construction of decap's type drains the park list, never a
+// release. A final construction after every intervening call proves both
+// releases actually parked their configs, rather than one of them having
+// leaked outside the park list.
+func TestFailedPublish_LeavesCallersModuleIntact(t *testing.T) {
+	h, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(failedPublishCPSize),
+		DPMemory:      uint64(failedPublishDPSize),
+		WorkerCount:   1,
+		Devices:       []string{"port0"},
+		Modules:       []string{"decap"},
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	shm := h.SharedMemory()
+	const agentName = "cpml-failed-publish"
+
+	agent, err := shm.AgentAttach(agentName, 0, failedPublishAgentSize)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	beforeCreate := agentRootMemoryNode(t, shm, agentName)
+
+	mod, err := cdecap.NewModuleConfig(agent, "decap0")
+	require.NoError(t, err)
+	require.NoError(t, mod.PrefixAdd(netip.MustParsePrefix("2001:db8::/32")))
+
+	afterCreate := agentRootMemoryNode(t, shm, agentName)
+	require.Equalf(
+		t, beforeCreate.BAllocCount+1, afterCreate.BAllocCount,
+		"module creation must allocate its config struct on the agent's root context",
+	)
+
+	// Zeroing the worker count fails the execution-context build
+	// deterministically, in the exact phase this test targets.
+	//
+	// A byte-target arena starve instead lands in a different phase under a
+	// sanitizer build, where every allocation carries red zones: the arena
+	// runs out earlier, during the candidate generation's registry copy,
+	// before the module is ever upserted into it.
+	originalWorkerCount := zeroWorkerCount(agent.AsRawPtr())
+
+	err = agent.UpdateModules([]ffi.ModuleConfig{mod.AsFFIModule()})
+	restoreWorkerCount(agent.AsRawPtr(), originalWorkerCount)
+	require.Error(
+		t, err,
+		"a zero worker count must fail the execution-context build",
+	)
+	require.ErrorContains(t, err, "execution context")
+
+	afterFailedPublish := agentRootMemoryNode(t, shm, agentName)
+	require.Equalf(
+		t, afterCreate.BFreeCount, afterFailedPublish.BFreeCount,
+		"a failed publish must not destroy the module while the creator's own reference is still held",
+	)
+
+	// Create an unrelated config: creation is the only call that drains
+	// the park list.
+	//
+	// This checkpoint proves the tracked module's creator reference kept
+	// it out of that list rather than merely arriving late.
+	other, err := cdecap.NewModuleConfig(agent, "decap1")
+	require.NoError(t, err)
+
+	afterUnrelatedCreate := agentRootMemoryNode(t, shm, agentName)
+	require.Equalf(
+		t, afterFailedPublish.BFreeCount, afterUnrelatedCreate.BFreeCount,
+		"creating the unrelated config must not destroy anything by itself",
+	)
+
+	other.Free()
+
+	afterUnrelatedFree := agentRootMemoryNode(t, shm, agentName)
+	require.Equalf(
+		t, afterUnrelatedCreate.BFreeCount, afterUnrelatedFree.BFreeCount,
+		"releasing the unrelated config must park it, not destroy it immediately",
+	)
+
+	// The module must still be a valid, uncorrupted config, not merely an
+	// untouched reference count: exercise it the same way a caller that
+	// goes on using it would.
+	require.NoError(
+		t, mod.PrefixAdd(netip.MustParsePrefix("2001:db9::/32")),
+		"the caller must still be able to use the module after the failed publish",
+	)
+
+	mod.Free()
+
+	afterModFree := agentRootMemoryNode(t, shm, agentName)
+	require.Equalf(
+		t, afterUnrelatedFree.BFreeCount, afterModFree.BFreeCount,
+		"the caller's own release must park mod, not destroy it immediately",
+	)
+
+	// Construct decap's type once more: the only trigger that drains the
+	// park list, which now holds both the unrelated config and the tracked
+	// module.
+	_, err = cdecap.NewModuleConfig(agent, "decap2")
+	require.NoError(t, err)
+
+	afterDrain := agentRootMemoryNode(t, shm, agentName)
+	require.Equalf(
+		t, afterModFree.BFreeCount+2, afterDrain.BFreeCount,
+		"decap's next construction must drain both the unrelated config and mod",
+	)
+}

--- a/modules/decap/tests/functional/module_lifetime_test.go
+++ b/modules/decap/tests/functional/module_lifetime_test.go
@@ -1,0 +1,209 @@
+package decap_test
+
+import (
+	"math"
+	"net/netip"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	decap "github.com/yanet-platform/yanet2/modules/decap/controlplane"
+)
+
+// newLifetimeHarness starts a minimal single-worker decap harness, matching
+// the restart-leak suite's own setup, for module-configuration lifetime
+// tests that never process a packet.
+func newLifetimeHarness(t *testing.T) *dataplaneut.Harness {
+	t.Helper()
+
+	h, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 16),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		Devices:       []string{"port0"},
+		Modules:       []string{"decap"},
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	return h
+}
+
+// agentRootMemoryNode returns the named agent's own root memory-context
+// node.
+//
+// A module's outer structure is always allocated and freed directly against
+// this root context, so its free count advances once and only once per
+// module actually torn down. The live generation-reference count is not
+// used here: it moves whether or not a teardown ran, so it cannot
+// distinguish a real destroy from a skipped one.
+func agentRootMemoryNode(t *testing.T, shm *ffi.SharedMemory, name string) ffi.AgentMemoryNode {
+	t.Helper()
+
+	for _, agentInfo := range shm.DPConfig(0).Agents() {
+		if agentInfo.Name != name {
+			continue
+		}
+		require.Lenf(t, agentInfo.Instances, 1, "agent %q: expected exactly one live instance", name)
+
+		for _, node := range agentInfo.Instances[0].MemoryTree {
+			if node.ParentIdx == math.MaxUint32 {
+				return node
+			}
+		}
+		t.Fatalf("agent %q: no root memory-context node in its snapshot", name)
+	}
+
+	t.Fatalf("agent %q not found in dataplane config", name)
+	return ffi.AgentMemoryNode{}
+}
+
+// TestModuleLifetime_LiveGeneration_ReleaseDoesNotDestroy verifies that
+// releasing a module's creator handle does not tear it down while the
+// currently published generation still references it.
+//
+// A regression that frees unconditionally on release would advance the
+// agent's root context free count by one right after release, even though
+// nothing has yet superseded the generation this module is published in.
+func TestModuleLifetime_LiveGeneration_ReleaseDoesNotDestroy(t *testing.T) {
+	h := newLifetimeHarness(t)
+	shm := h.SharedMemory()
+
+	agent, err := shm.AgentAttach("cpml-live", 0, datasize.MB*1)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	handle, err := decap.NewBackend(agent).UpdateModule(
+		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")},
+	)
+	require.NoError(t, err)
+
+	before := agentRootMemoryNode(t, shm, "cpml-live")
+
+	handle.Free()
+
+	after := agentRootMemoryNode(t, shm, "cpml-live")
+	require.Equalf(
+		t, before.BFreeCount, after.BFreeCount,
+		"creator release destroyed the module while the live generation still referenced it",
+	)
+}
+
+// TestModuleLifetime_Superseded_DestroyedOnNextOwnAPICall guards a superseded
+// module's destroy timing.
+//
+// Publishing "decap0" a second time parks the first module, but only the next
+// construction of decap's type drains that park list and destroys it, never a
+// release by itself.
+func TestModuleLifetime_Superseded_DestroyedOnNextOwnAPICall(t *testing.T) {
+	h := newLifetimeHarness(t)
+	shm := h.SharedMemory()
+
+	agent, err := shm.AgentAttach("cpml-supersede", 0, datasize.MB*1)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	backend := decap.NewBackend(agent)
+
+	first, err := backend.UpdateModule(
+		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")},
+	)
+	require.NoError(t, err)
+	first.Free()
+
+	mid := agentRootMemoryNode(t, shm, "cpml-supersede")
+
+	second, err := backend.UpdateModule(
+		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:db9::/32")},
+	)
+	require.NoError(t, err)
+
+	afterPublish := agentRootMemoryNode(t, shm, "cpml-supersede")
+	require.Equalf(
+		t, mid.BFreeCount, afterPublish.BFreeCount,
+		"the superseded module was destroyed before decap's own API drained it",
+	)
+
+	second.Free()
+
+	afterSecondRelease := agentRootMemoryNode(t, shm, "cpml-supersede")
+	require.Equalf(
+		t, mid.BFreeCount, afterSecondRelease.BFreeCount,
+		"releasing the live generation's own creator handle destroyed the parked module by itself",
+	)
+
+	_, err = backend.UpdateModule(
+		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:dba::/32")},
+	)
+	require.NoError(t, err)
+
+	afterThirdCreate := agentRootMemoryNode(t, shm, "cpml-supersede")
+	require.Equalf(
+		t, mid.BFreeCount+1, afterThirdCreate.BFreeCount,
+		"the superseded module was not destroyed once decap's own API constructed again",
+	)
+}
+
+// TestModuleLifetime_PinnedGeneration_DefersDestruction guards deferred
+// destruction under a pinned reader generation.
+//
+// An unlocked counters reader's pin on a superseded generation defers that
+// module's destruction until the pin drops, and destruction then still needs
+// decap's own API to run before it happens, exactly once.
+func TestModuleLifetime_PinnedGeneration_DefersDestruction(t *testing.T) {
+	h := newLifetimeHarness(t)
+	shm := h.SharedMemory()
+
+	agent, err := shm.AgentAttach("cpml-pinned", 0, datasize.MB*1)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	backend := decap.NewBackend(agent)
+
+	first, err := backend.UpdateModule(
+		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")},
+	)
+	require.NoError(t, err)
+	first.Free()
+
+	// Pin the generation that publishes the first module before superseding
+	// it, the same way an unlocked counters reader would.
+	pin := pinCurrentGeneration(agent.AsRawPtr())
+
+	mid := agentRootMemoryNode(t, shm, "cpml-pinned")
+
+	second, err := backend.UpdateModule(
+		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:db9::/32")},
+	)
+	require.NoError(t, err)
+	second.Free()
+
+	afterSecond := agentRootMemoryNode(t, shm, "cpml-pinned")
+	require.Equalf(
+		t, mid.BFreeCount, afterSecond.BFreeCount,
+		"the pinned generation's module was destroyed while the pin was still held",
+	)
+
+	pin.release()
+
+	afterUnpin := agentRootMemoryNode(t, shm, "cpml-pinned")
+	require.Equalf(
+		t, mid.BFreeCount, afterUnpin.BFreeCount,
+		"dropping the pin destroyed the module directly, without decap's own API draining it",
+	)
+
+	_, err = backend.UpdateModule(
+		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:dba::/32")},
+	)
+	require.NoError(t, err)
+
+	afterThird := agentRootMemoryNode(t, shm, "cpml-pinned")
+	require.Equalf(
+		t, mid.BFreeCount+1, afterThird.BFreeCount,
+		"the module was not destroyed once the pin dropped and decap's own API ran again",
+	)
+}

--- a/modules/decap/tests/functional/restart_leak_test.go
+++ b/modules/decap/tests/functional/restart_leak_test.go
@@ -1,0 +1,88 @@
+package decap_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	decap "github.com/yanet-platform/yanet2/modules/decap/controlplane"
+)
+
+// TestRestart_WithoutRelease_ReclaimsSupersededAgents verifies that
+// republishing without releasing never leaks an agent arena per restart.
+//
+// Construction also takes a reference for the module's creator, and a
+// crashed creator never drops it. An earlier design mirrored that reference
+// into the agent's live-module count, so it never returned to zero and the
+// agent reclaimer withheld cleanup forever. Each round here republishes the
+// same module name and abandons the returned handle without releasing it,
+// then requires the previous generation to already be gone.
+func TestRestart_WithoutRelease_ReclaimsSupersededAgents(t *testing.T) {
+	h, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 16),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		Devices:       []string{"port0"},
+		Modules:       []string{"decap"},
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	shm := h.SharedMemory()
+	const agentName = "decap-restart"
+	const moduleName = "decap0"
+
+	var baselineFreeBytes uint64
+	for round := range 6 {
+		agent, err := shm.AgentAttach(agentName, 0, datasize.MB*1)
+		require.NoErrorf(t, err, "round %d: attach failed", round)
+
+		// The returned handle is deliberately dropped rather than released,
+		// modeling a creator that crashed before it could drop its own
+		// reference.
+		_, err = decap.NewBackend(agent).UpdateModule(
+			moduleName,
+			[]netip.Prefix{netip.MustParsePrefix("2001:db8::/32")},
+		)
+		require.NoErrorf(t, err, "round %d: publish failed", round)
+
+		instances := restartTestAgentInstances(t, shm, agentName)
+		require.Lenf(
+			t, instances, 1,
+			"round %d: %d superseded generation(s) were not reclaimed",
+			round, len(instances)-1,
+		)
+
+		if round == 0 {
+			baselineFreeBytes = instances[0].FreeBytes
+		} else {
+			require.Equalf(
+				t, baselineFreeBytes, instances[0].FreeBytes,
+				"round %d: free bytes drifted from the round-0 baseline",
+				round,
+			)
+		}
+	}
+}
+
+// restartTestAgentInstances returns the live generation list reported for
+// the named agent: one entry per not-yet-reclaimed superseded generation.
+func restartTestAgentInstances(
+	t *testing.T, shm *ffi.SharedMemory, name string,
+) []ffi.AgentInstanceInfo {
+	t.Helper()
+
+	for _, agentInfo := range shm.DPConfig(0).Agents() {
+		if agentInfo.Name == name {
+			return agentInfo.Instances
+		}
+	}
+
+	t.Fatalf("agent %q not found in dataplane config", name)
+	return nil
+}

--- a/modules/dscp/api/controlplane.c
+++ b/modules/dscp/api/controlplane.c
@@ -12,6 +12,24 @@
 #include "controlplane/agent/agent.h"
 #include "dataplane/config/zone.h"
 
+static void
+dscp_module_config_destroy(struct cp_module *cp_module) {
+	struct dscp_module_config *config =
+		container_of(cp_module, struct dscp_module_config, cp_module);
+
+	dscp_module_config_data_fini(config);
+
+	struct agent *agent = ADDR_OF(&cp_module->agent);
+
+	cp_module_fini(cp_module);
+
+	memory_bfree(
+		&agent->memory_context,
+		config,
+		sizeof(struct dscp_module_config)
+	);
+}
+
 struct cp_module *
 dscp_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
@@ -27,7 +45,14 @@ dscp_module_config_new(
 		return NULL;
 	}
 
-	if (cp_module_init(&config->cp_module, agent, "dscp", name, err)) {
+	if (cp_module_init(
+		    &config->cp_module,
+		    agent,
+		    "dscp",
+		    name,
+		    dscp_module_config_destroy,
+		    err
+	    )) {
 		yanet_error_add(err, "failed to init module");
 		memory_bfree(
 			&agent->memory_context,
@@ -42,6 +67,13 @@ dscp_module_config_new(
 		    config, &config->cp_module.memory_context
 	    )) {
 		yanet_error_add(err, "failed to init config data");
+		// Frees directly instead of going through the type destructor.
+		//
+		// A failed configuration-data setup never reaches a state its
+		// own teardown could safely walk. No reference beyond the
+		// caller's own has been taken, and no registry has observed
+		// the module yet, so nothing is lost by freeing the block
+		// here.
 		cp_module_fini(&config->cp_module);
 		memory_bfree(
 			&agent->memory_context,
@@ -56,21 +88,8 @@ dscp_module_config_new(
 
 void
 dscp_module_config_free(struct cp_module *cp_module) {
-	struct dscp_module_config *config =
-		container_of(cp_module, struct dscp_module_config, cp_module);
-
-	dscp_module_config_data_fini(config);
-
-	struct agent *agent = ADDR_OF(&cp_module->agent);
-
-	cp_module_fini(cp_module);
-
-	memory_bfree(
-		&agent->memory_context,
-		config,
-		sizeof(struct dscp_module_config)
-	);
-};
+	cp_module_release(cp_module);
+}
 
 int
 dscp_module_config_data_init(

--- a/modules/forward/api/controlplane.c
+++ b/modules/forward/api/controlplane.c
@@ -18,44 +18,8 @@ FILTER_COMPILER_DECLARE(FWD_FILTER_IP4_TAG, device, vlan, net4_src, net4_dst);
 
 FILTER_COMPILER_DECLARE(FWD_FILTER_IP6_TAG, device, vlan, net6_src, net6_dst);
 
-struct cp_module *
-forward_module_config_init(
-	struct agent *agent, const char *name, yanet_error **err
-) {
-	struct forward_module_config *config =
-		(struct forward_module_config *)memory_balloc(
-			&agent->memory_context,
-			sizeof(struct forward_module_config)
-		);
-	if (config == NULL) {
-		yanet_error_add(err, "failed to allocate config");
-		return NULL;
-	}
-
-	if (cp_module_init(&config->cp_module, agent, "forward", name, err)) {
-		yanet_error_add(err, "failed to init module");
-		memory_bfree(
-			&agent->memory_context,
-			config,
-			sizeof(struct forward_module_config)
-		);
-		return NULL;
-	}
-
-	SET_OFFSET_OF(&config->targets, NULL);
-	config->target_count = 0;
-
-	memset(&config->filter_vlan, 0, sizeof(config->filter_vlan));
-
-	memset(&config->filter_ip4, 0, sizeof(config->filter_ip4));
-
-	memset(&config->filter_ip6, 0, sizeof(config->filter_ip6));
-
-	return &config->cp_module;
-}
-
-void
-forward_module_config_free(struct cp_module *cp_module) {
+static void
+forward_module_config_destroy(struct cp_module *cp_module) {
 	struct forward_module_config *config = container_of(
 		cp_module, struct forward_module_config, cp_module
 	);
@@ -80,6 +44,54 @@ forward_module_config_free(struct cp_module *cp_module) {
 		config,
 		sizeof(struct forward_module_config)
 	);
+}
+
+struct cp_module *
+forward_module_config_init(
+	struct agent *agent, const char *name, yanet_error **err
+) {
+	struct forward_module_config *config =
+		(struct forward_module_config *)memory_balloc(
+			&agent->memory_context,
+			sizeof(struct forward_module_config)
+		);
+	if (config == NULL) {
+		yanet_error_add(err, "failed to allocate config");
+		return NULL;
+	}
+
+	if (cp_module_init(
+		    &config->cp_module,
+		    agent,
+		    "forward",
+		    name,
+		    forward_module_config_destroy,
+		    err
+	    )) {
+		yanet_error_add(err, "failed to init module");
+		memory_bfree(
+			&agent->memory_context,
+			config,
+			sizeof(struct forward_module_config)
+		);
+		return NULL;
+	}
+
+	SET_OFFSET_OF(&config->targets, NULL);
+	config->target_count = 0;
+
+	memset(&config->filter_vlan, 0, sizeof(config->filter_vlan));
+
+	memset(&config->filter_ip4, 0, sizeof(config->filter_ip4));
+
+	memset(&config->filter_ip6, 0, sizeof(config->filter_ip6));
+
+	return &config->cp_module;
+}
+
+void
+forward_module_config_free(struct cp_module *cp_module) {
+	cp_module_release(cp_module);
 }
 
 typedef int (*forward_rule_check_func)(const struct forward_rule *forward_rule);

--- a/modules/forward/fuzzing/forward.c
+++ b/modules/forward/fuzzing/forward.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "controlplane/config/cp_module.h"
 #include "dataplane/config/zone.h"
 #include "modules/forward/api/controlplane.h"
 #include "modules/forward/dataplane/config.h"
@@ -168,7 +169,17 @@ forward_test_config(struct cp_module **cp_module, yanet_error **err) {
 	return 0;
 
 fail:
-	forward_module_config_free(&config->cp_module);
+	// Frees directly against the harness arena instead of going through
+	// the public free.
+	//
+	// This module configuration was built by hand with no owning agent
+	// and never took the reference construction normally holds, so the
+	// public free's release path would decrement a reference count that
+	// starts at zero and silently wrap instead of freeing anything.
+	cp_module_fini(&config->cp_module);
+	memory_bfree(
+		&fuzz_params.mctx, config, sizeof(struct forward_module_config)
+	);
 	return -EINVAL;
 }
 

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -707,14 +707,19 @@ func TestForward_MinAction(t *testing.T) {
 	dataplaneut.RequireModuleCounter(t, h, path, "ip4lose", 0, 0)
 }
 
-// TestForwardConfigMemoryLeak verifies the block allocator returns memory to
-// the pool when an old forward config generation is freed.
+// TestForwardConfigMemoryLeak verifies the block allocator returns memory once
+// a superseded forward config generation is reclaimed.
 //
-// THE MAGIC: use 8 rules so sizeof(forward_target)*8 = 192 and
-// sizeof(forward_target*)*8 = 64 fall into different block-allocator pools
-// even with ASAN red zones (+128 bytes per allocation). With fewer rules
-// both sizes round up to the same power-of-two pool and the leak is
-// invisible to BlockAllocatorFreeSize.
+// THE MAGIC: 8 rules make sizeof(forward_target)*8 = 192 and
+// sizeof(forward_target*)*8 = 64 land in different block-allocator pools even
+// under ASAN red zones; fewer rules round both into the same pool and hide a
+// leak in either array from BlockAllocatorFreeSize.
+//
+// Releasing a handle only parks it: reclaim happens on the type's next
+// construction, not on release. Each round below publishes and releases one
+// "forward0" generation, and that construction drains the round before it, so
+// from round 1 the arena holds two generations' worth of rules and every
+// round's free byte count must match the last.
 func TestForwardConfigMemoryLeak(t *testing.T) {
 	_, agent, _ := setupForwardHarness(t, []string{"port0"})
 
@@ -727,22 +732,32 @@ func TestForwardConfigMemoryLeak(t *testing.T) {
 		}
 	}
 
-	moduleA, err := cforward.NewModuleConfig(agent, "forward0")
-	require.NoError(t, err)
-	require.NoError(t, moduleA.Update(rules))
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{moduleA.AsFFIModule()}))
+	var baseline uint64
+	for round := range 4 {
+		module, err := cforward.NewModuleConfig(agent, "forward0")
+		require.NoErrorf(t, err, "round %d: construct failed", round)
+		require.NoErrorf(t, module.Update(rules), "round %d: update failed", round)
+		require.NoErrorf(
+			t,
+			agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}),
+			"round %d: publish failed", round,
+		)
+		module.Free()
 
-	freeBefore := agent.BlockAllocatorFreeSize()
+		if round == 0 {
+			// Nothing is parked yet for this round's construction to
+			// drain, so this round's shape isn't comparable to later ones.
+			continue
+		}
 
-	moduleB, err := cforward.NewModuleConfig(agent, "forward0")
-	require.NoError(t, err)
-	t.Cleanup(moduleB.Free)
-
-	require.NoError(t, moduleB.Update(rules))
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{moduleB.AsFFIModule()}))
-
-	moduleA.Free()
-
-	freeAfter := agent.BlockAllocatorFreeSize()
-	require.Equal(t, freeBefore, freeAfter)
+		free := agent.BlockAllocatorFreeSize()
+		if round == 1 {
+			baseline = free
+		} else {
+			require.Equalf(
+				t, baseline, free,
+				"round %d: free bytes drifted from the round-1 baseline", round,
+			)
+		}
+	}
 }

--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -49,6 +49,9 @@ fwstate_config_set_defaults(struct fwstate_config *config) {
 	config->sync_config.timeouts.default_ = 16e9; // 16 seconds
 }
 
+static void
+fwstate_module_config_destroy(struct cp_module *cp_module);
+
 struct cp_module *
 fwstate_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
@@ -64,7 +67,12 @@ fwstate_module_config_new(
 	}
 
 	if (cp_module_init(
-		    &config->cp_module, agent, FWSTATE_MODULE_NAME, name, err
+		    &config->cp_module,
+		    agent,
+		    FWSTATE_MODULE_NAME,
+		    name,
+		    fwstate_module_config_destroy,
+		    err
 	    )) {
 		yanet_error_add(err, "failed to init module");
 		memory_bfree(
@@ -125,7 +133,20 @@ fwstate_module_config_new(
 				"failed to register counter '%s'",
 				counters[i].name
 			);
-			fwstate_module_config_free(&config->cp_module);
+			// Frees directly instead of going through the type
+			// destructor.
+			//
+			// A failed configuration-data setup never reaches a
+			// state its own teardown could safely walk. No
+			// reference beyond the caller's own has been taken, and
+			// no registry has observed the module yet, so nothing
+			// is lost by freeing the block here.
+			cp_module_fini(&config->cp_module);
+			memory_bfree(
+				&agent->memory_context,
+				config,
+				sizeof(struct fwstate_module_config)
+			);
 			return NULL;
 		}
 		*counters[i].dst = id;
@@ -151,8 +172,8 @@ fwstate_module_config_propogate(
 	EQUATE_OFFSET(&new->cfg.fw6state, &old->cfg.fw6state);
 }
 
-void
-fwstate_module_config_free(struct cp_module *cp_module) {
+static void
+fwstate_module_config_destroy(struct cp_module *cp_module) {
 	struct fwstate_module_config *config = container_of(
 		cp_module, struct fwstate_module_config, cp_module
 	);
@@ -169,6 +190,11 @@ fwstate_module_config_free(struct cp_module *cp_module) {
 		config,
 		sizeof(struct fwstate_module_config)
 	);
+}
+
+void
+fwstate_module_config_free(struct cp_module *cp_module) {
+	cp_module_release(cp_module);
 }
 
 void

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -31,24 +31,21 @@ import (
 // counter values accumulate. The returned storage must be freed with
 // [fwstateCounterStorageFree] (the caller owns it).
 func fwstateModuleConfig(memCtx testutils.MemoryContext) (*C.struct_cp_module, *C.struct_counter_storage) {
-	// Allocate agent in the memory context (it needs to be in the same memory space)
-	agent := (*C.struct_agent)(C.memory_balloc(
-		(*C.struct_memory_context)(memCtx.AsRawPtr()),
-		C.sizeof_struct_agent,
-	))
-	if agent == nil {
-		panic("failed to allocate agent")
-	}
-
-	// Initialize agent's memory_context (similar to dataplane.c:441-448 and mock.c:206-211)
+	// Allocate the stand-in agent through the harness constructor, which zeroes
+	// the whole structure, not just the memory context.
+	//
+	// Every module construction now walks the agent's parked-list head, and an
+	// unzeroed head reads as stale bytes rather than a valid empty list.
 	cStubAgent := C.CString("stub agent")
 	defer C.free(unsafe.Pointer(cStubAgent))
 
-	C.memory_context_init_from(
-		&agent.memory_context,
+	agent := C.fwstate_test_agent_new(
 		(*C.struct_memory_context)(memCtx.AsRawPtr()),
 		cStubAgent,
 	)
+	if agent == nil {
+		panic("failed to allocate agent")
+	}
 
 	// Use the proper API to create the module config
 	cName := C.CString("test")

--- a/modules/fwstate/tests/dataplane/harness.c
+++ b/modules/fwstate/tests/dataplane/harness.c
@@ -3,6 +3,29 @@
 #include <string.h>
 #include <time.h>
 
+// Allocate and initialize a stand-in agent for a test that needs the real
+// structure behind it, not just a bare memory context, such as one that
+// constructs a module through its own control-plane API.
+//
+// The allocator does not zero what it hands out, and the parked-module
+// reclaim this harness reproduces reads an uninitialized agent's list
+// head as a live pointer. Zeroing the whole structure, not just that one
+// field, keeps a field a later change adds starting at zero too,
+// matching what a freshly attached production agent gets.
+struct agent *
+fwstate_test_agent_new(struct memory_context *parent, const char *name) {
+	struct agent *agent =
+		(struct agent *)memory_balloc(parent, sizeof(struct agent));
+	if (agent == NULL) {
+		return NULL;
+	}
+
+	memset(agent, 0, sizeof(struct agent));
+	memory_context_init_from(&agent->memory_context, parent, name);
+
+	return agent;
+}
+
 struct counter_storage *
 fwstate_test_counter_storage_setup(struct cp_module *cp_module) {
 	struct counter_registry *registry = &cp_module->counter_registry;
@@ -66,6 +89,79 @@ clock_get_time_ns(struct tsc_clock *clock) {
 	return ts.tv_sec * (uint64_t)1e9 + ts.tv_nsec;
 }
 
+// Test doubles for the module zero-transition handler, the release entry
+// point, and the parked-list reclaim.
+//
+// The stand-in agent above has no real configuration context, so these
+// reproduce the production algorithm without the lock the real versions
+// take around it.
+void
+cp_module_registry_item_free_cb(struct registry_item *item, void *data) {
+	struct cp_module *module =
+		container_of(item, struct cp_module, config_item);
+	struct agent *agent = ADDR_OF(&module->agent);
+	if (agent == NULL) {
+		return;
+	}
+
+	if (ADDR_OF(&module->parked_next) != NULL) {
+		return;
+	}
+
+	struct cp_module *head = ADDR_OF(&agent->parked_modules);
+	SET_OFFSET_OF(&module->parked_next, (head != NULL) ? head : module);
+	SET_OFFSET_OF(&agent->parked_modules, module);
+	(void)data;
+}
+
+void
+cp_module_release(struct cp_module *cp_module) {
+	registry_item_unref(
+		&cp_module->config_item, cp_module_registry_item_free_cb, NULL
+	);
+}
+
+// Reproduces the production parked-entry reclaim, folded into
+// construction below the same way the real implementation folds it in.
+static void
+cp_module_drain_parked(
+	struct agent *agent,
+	const char *module_type,
+	cp_module_free_handler destroy
+) {
+	struct cp_module *owned = NULL;
+	struct cp_module *prev = NULL;
+	struct cp_module *cur = ADDR_OF(&agent->parked_modules);
+
+	while (cur != NULL) {
+		struct cp_module *raw_next = ADDR_OF(&cur->parked_next);
+		struct cp_module *next = (raw_next == cur) ? NULL : raw_next;
+
+		if (!strncmp(cur->type, module_type, sizeof(cur->type))) {
+			if (prev == NULL) {
+				SET_OFFSET_OF(&agent->parked_modules, next);
+			} else {
+				SET_OFFSET_OF(
+					&prev->parked_next,
+					(next != NULL) ? next : prev
+				);
+			}
+			SET_OFFSET_OF(&cur->parked_next, owned);
+			owned = cur;
+		} else {
+			prev = cur;
+		}
+
+		cur = next;
+	}
+
+	while (owned != NULL) {
+		struct cp_module *next = ADDR_OF(&owned->parked_next);
+		destroy(owned);
+		owned = next;
+	}
+}
+
 // Mock implementation of cp_module_init for tests.
 // Provides minimal initialization without requiring full dp_config.
 int
@@ -74,11 +170,16 @@ cp_module_init(
 	struct agent *agent,
 	const char *module_type,
 	const char *module_name,
+	cp_module_free_handler destroy,
 	yanet_error **err
 ) {
 	// Minimal initialization for tests (based on
 	// lib/controlplane/config/cp_module.c:13-74)
 	memset(cp_module, 0, sizeof(struct cp_module));
+
+	// Reclaim this type's parked entries first, the same as production
+	// does, before this construction allocates anything of its own.
+	cp_module_drain_parked(agent, module_type, destroy);
 
 	// We don't have dp_config in tests, so skip dp_module_idx lookup
 	cp_module->dp_module_idx = 0;

--- a/modules/fwstate/tests/dataplane/harness.h
+++ b/modules/fwstate/tests/dataplane/harness.h
@@ -23,6 +23,13 @@ fwstate_handle_packets(
 	struct packet_front *packet_front
 );
 
+// Allocate and zero-initialize a stand-in agent inside the given memory
+// context, ready to pass to a module's own control-plane constructor.
+//
+// Returns NULL on allocation failure.
+struct agent *
+fwstate_test_agent_new(struct memory_context *parent, const char *name);
+
 // Link the module's counter registry and spawn a per-worker counter storage.
 //
 // The dataplane resolves per-worker counter addresses via

--- a/modules/fwstate/tests/functional/fwstate_probe.go
+++ b/modules/fwstate/tests/functional/fwstate_probe.go
@@ -1,0 +1,85 @@
+package fwstate_test
+
+//#cgo CFLAGS: -I../../../../ -I../../../../lib
+//#cgo LDFLAGS: -L../../../../build/modules/fwstate/api -lfwstate_cp
+//#cgo LDFLAGS: -L../../../../build/lib/counters -lcounters
+//
+//#include <string.h>
+//
+//#include "lib/fwstate/fwmap.h"
+//#include "lib/fwstate/types.h"
+//#include "modules/fwstate/api/fwstate_cp.h"
+//
+// // yanet_test_fwstate_insert_ipv6 inserts one synthetic TCP state entry
+// // directly into the module's live IPv6 map, using the same insert path
+// // the dataplane's own sync-frame handler uses, but without going through
+// // a worker round: this test package never drives packet processing, so a
+// // second publish would otherwise block forever waiting for a round
+// // nothing here drives.
+// static int
+// yanet_test_fwstate_insert_ipv6(
+// 	struct cp_module *cp_module,
+// 	uint64_t now,
+// 	const uint8_t *src_addr,
+// 	const uint8_t *dst_addr,
+// 	uint16_t src_port,
+// 	uint16_t dst_port
+// ) {
+// 	fwmap_t *map = fwstate_config_resolve_map(cp_module, true, 0);
+// 	if (map == NULL) {
+// 		return -1;
+// 	}
+//
+// 	struct fw6_state_key key;
+// 	memset(&key, 0, sizeof(key));
+// 	key.hdr.proto = 6; // IPPROTO_TCP
+// 	key.hdr.src_port = src_port;
+// 	key.hdr.dst_port = dst_port;
+// 	memcpy(key.src_addr, src_addr, 16);
+// 	memcpy(key.dst_addr, dst_addr, 16);
+//
+// 	struct fw_state_value val;
+// 	memset(&val, 0, sizeof(val));
+// 	val.flags.tcp.src = FWSTATE_ACK;
+// 	val.flags.tcp.dst = FWSTATE_ACK;
+// 	val.created_at = now;
+// 	val.updated_at = now;
+// 	val.packets_forward = 1;
+//
+// 	return fwmap_put_safe(map, 0, now, (uint64_t)120e9, &key, &val);
+// }
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+// errInsertFailed reports that the underlying insert call could not
+// resolve the target map: the config has no IPv6 maps yet.
+var errInsertFailed = errors.New("fwstate: failed to resolve ipv6 map for insert")
+
+// insertFWStateIPv6Entry inserts one synthetic TCP state entry directly
+// into the given module's live IPv6 map.
+//
+// The pointer must be the unsafe.Pointer a *cfwstate.ModuleConfig exposes
+// via AsFFIModule().AsRawPtr(). The addresses must each be 16 bytes.
+func insertFWStateIPv6Entry(
+	modPtr unsafe.Pointer,
+	now uint64,
+	srcAddr, dstAddr [16]byte,
+	srcPort, dstPort uint16,
+) error {
+	rc := C.yanet_test_fwstate_insert_ipv6(
+		(*C.struct_cp_module)(modPtr),
+		C.uint64_t(now),
+		(*C.uint8_t)(&srcAddr[0]),
+		(*C.uint8_t)(&dstAddr[0]),
+		C.uint16_t(srcPort),
+		C.uint16_t(dstPort),
+	)
+	if rc < 0 {
+		return errInsertFailed
+	}
+	return nil
+}

--- a/modules/fwstate/tests/functional/map_chain_lifetime_test.go
+++ b/modules/fwstate/tests/functional/map_chain_lifetime_test.go
@@ -1,0 +1,188 @@
+package fwstate_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
+)
+
+// mapChainAgentRootMemoryNode returns the named agent's own root
+// memory-context node.
+//
+// A config's outer structure is allocated and freed directly against this
+// root context, so its free count advances once and only once per config
+// actually torn down.
+func mapChainAgentRootMemoryNode(t *testing.T, shm *ffi.SharedMemory, name string) ffi.AgentMemoryNode {
+	t.Helper()
+
+	for _, agentInfo := range shm.DPConfig(0).Agents() {
+		if agentInfo.Name != name {
+			continue
+		}
+		require.Lenf(t, agentInfo.Instances, 1, "agent %q: expected exactly one live instance", name)
+
+		for _, node := range agentInfo.Instances[0].MemoryTree {
+			if node.ParentIdx == math.MaxUint32 {
+				return node
+			}
+		}
+		t.Fatalf("agent %q: no root memory-context node in its snapshot", name)
+	}
+
+	t.Fatalf("agent %q not found in dataplane config", name)
+	return ffi.AgentMemoryNode{}
+}
+
+// newMapChainConfig builds and publishes an fwstate config under the given
+// name with sync enabled and 1024-entry maps.
+//
+// Unlike the package's shared setup helper, it returns the handle instead
+// of freeing it at test end, because this test frees each generation
+// itself, in the same order the production update path does.
+func newMapChainConfig(t *testing.T, agent *ffi.Agent, name string) *cfwstate.ModuleConfig {
+	t.Helper()
+
+	modCfg, err := cfwstate.NewModuleConfig(agent, name)
+	require.NoError(t, err)
+
+	modCfg.SetSyncConfig(cfwstate.SyncConfig{
+		DstAddrMulticast: [16]byte{
+			0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
+		},
+		PortMulticast: syncPort,
+		TcpSynAck:     uint64(120e9),
+		TcpSyn:        uint64(120e9),
+		TcpFin:        uint64(120e9),
+		Tcp:           uint64(120e9),
+		Udp:           uint64(30e9),
+		Default:       uint64(16e9),
+	})
+
+	require.NoError(t, modCfg.CreateMaps(cfwstate.MapConfig{
+		IndexSize:        1024,
+		ExtraBucketCount: 64,
+	}, 1))
+
+	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{modCfg.AsFFIModule()}))
+
+	return modCfg
+}
+
+// TestFWStateUpdate_SecondUpdateKeepsLiveMaps pins the map-chain ownership
+// contract: a state entry survives a republish under the same name.
+//
+// Republishing propagates the live map chain into the new config and detaches
+// it from the old one before releasing it. Between the publish and that
+// detach-then-free, it constructs a module of this type on an unrelated name,
+// modeling a concurrent update racing this one. The first generation still
+// holds its own creator reference at that point, so the unrelated construction
+// drains nothing of it. A release never drains by itself; only a further
+// construction after the detach-then-free drains the park list.
+func TestFWStateUpdate_SecondUpdateKeepsLiveMaps(t *testing.T) {
+	h, agent := setupFWStateHarness(t)
+	shm := h.SharedMemory()
+	const agentName = "fwstate-test"
+
+	v1 := newMapChainConfig(t, agent, "fw0")
+
+	// Insert directly into the first generation's live map rather than driving a
+	// real sync packet.
+	//
+	// This package never runs a worker round, and a second publish after one has
+	// run would otherwise block forever waiting for a round nothing here drives.
+	srcAddr := [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+	dstAddr := [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02}
+	require.NoError(t, insertFWStateIPv6Entry(
+		v1.AsFFIModule().AsRawPtr(), 1, srcAddr, dstAddr, 1234, 80,
+	))
+
+	statsBefore := v1.GetMapsStats()
+	require.Equal(
+		t, uint64(1), statsBefore.IPv6.TotalElements,
+		"one state entry must be live before the second update",
+	)
+
+	entriesBefore, _, _, err := v1.ReadForward(true, 0, 0, true, 1, 10)
+	require.NoError(t, err)
+	require.Len(t, entriesBefore, 1)
+	keyBefore := entriesBefore[0].Key
+
+	v2, err := cfwstate.NewModuleConfig(agent, "fw0")
+	require.NoError(t, err)
+	v2.PropagateConfig(v1)
+	require.NoError(t, v2.CreateMaps(cfwstate.MapConfig{
+		IndexSize:        1024,
+		ExtraBucketCount: 64,
+	}, 1))
+	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{v2.AsFFIModule()}))
+
+	afterPublish := mapChainAgentRootMemoryNode(t, shm, agentName)
+
+	// Construct a module of this type on an unrelated name, the only call that
+	// drains the park list.
+	//
+	// The construction is straddled by a checkpoint, so a premature drain of the
+	// first generation there cannot be masked by that config's own later release
+	// landing on the same count.
+	other, err := cfwstate.NewModuleConfig(agent, "fw1")
+	require.NoError(t, err)
+
+	afterUnrelatedCreate := mapChainAgentRootMemoryNode(t, shm, agentName)
+	require.Equalf(
+		t, afterPublish.BFreeCount, afterUnrelatedCreate.BFreeCount,
+		"creating the unrelated config must not destroy anything by itself",
+	)
+
+	other.Free()
+
+	afterUnrelatedFree := mapChainAgentRootMemoryNode(t, shm, agentName)
+	require.Equalf(
+		t, afterUnrelatedCreate.BFreeCount, afterUnrelatedFree.BFreeCount,
+		"releasing the unrelated config must park it, not destroy it immediately",
+	)
+
+	v1.DetachMaps()
+	v1.Free()
+	t.Cleanup(v2.Free)
+
+	afterV1Free := mapChainAgentRootMemoryNode(t, shm, agentName)
+	require.Equalf(
+		t, afterUnrelatedFree.BFreeCount, afterV1Free.BFreeCount,
+		"releasing v1 must park it, not destroy it immediately",
+	)
+
+	// Construct a module of this type once more, draining both the unrelated
+	// config and the first generation.
+	//
+	// This is the exact call that would have destroyed its map chain out from
+	// under the new generation, had the earlier detach not already run.
+	other2, err := cfwstate.NewModuleConfig(agent, "fw2")
+	require.NoError(t, err)
+	t.Cleanup(other2.Free)
+
+	afterDrain := mapChainAgentRootMemoryNode(t, shm, agentName)
+	require.Equalf(
+		t, afterV1Free.BFreeCount+2, afterDrain.BFreeCount,
+		"fwstate's next construction must drain both the unrelated config and v1",
+	)
+
+	statsAfter := v2.GetMapsStats()
+	require.Equalf(
+		t, statsBefore.IPv6.TotalElements, statsAfter.IPv6.TotalElements,
+		"the entry inserted before the second update must still be live "+
+			"in the maps the new config took over, not a fresh empty map",
+	)
+
+	entriesAfter, _, _, err := v2.ReadForward(true, 0, 0, true, 1, 10)
+	require.NoError(t, err)
+	require.Len(t, entriesAfter, 1)
+	require.Equalf(
+		t, keyBefore, entriesAfter[0].Key,
+		"the surviving entry must be the exact one inserted before the "+
+			"update, not a coincidentally-sized fresh map",
+	)
+}

--- a/modules/mirror/api/controlplane.c
+++ b/modules/mirror/api/controlplane.c
@@ -18,44 +18,8 @@ FILTER_COMPILER_DECLARE(FWD_FILTER_IP4_TAG, device, vlan, net4_src, net4_dst);
 
 FILTER_COMPILER_DECLARE(FWD_FILTER_IP6_TAG, device, vlan, net6_src, net6_dst);
 
-struct cp_module *
-mirror_module_config_init(
-	struct agent *agent, const char *name, yanet_error **err
-) {
-	struct mirror_module_config *config =
-		(struct mirror_module_config *)memory_balloc(
-			&agent->memory_context,
-			sizeof(struct mirror_module_config)
-		);
-	if (config == NULL) {
-		yanet_error_add(err, "failed to allocate config");
-		return NULL;
-	}
-
-	if (cp_module_init(&config->cp_module, agent, "mirror", name, err)) {
-		yanet_error_add(err, "failed to init module");
-		memory_bfree(
-			&agent->memory_context,
-			config,
-			sizeof(struct mirror_module_config)
-		);
-		return NULL;
-	}
-
-	SET_OFFSET_OF(&config->targets, NULL);
-	config->target_count = 0;
-
-	memset(&config->filter_vlan, 0, sizeof(config->filter_vlan));
-
-	memset(&config->filter_ip4, 0, sizeof(config->filter_ip4));
-
-	memset(&config->filter_ip6, 0, sizeof(config->filter_ip6));
-
-	return &config->cp_module;
-}
-
-void
-mirror_module_config_free(struct cp_module *cp_module) {
+static void
+mirror_module_config_destroy(struct cp_module *cp_module) {
 	struct mirror_module_config *config =
 		container_of(cp_module, struct mirror_module_config, cp_module);
 
@@ -79,6 +43,54 @@ mirror_module_config_free(struct cp_module *cp_module) {
 		config,
 		sizeof(struct mirror_module_config)
 	);
+}
+
+struct cp_module *
+mirror_module_config_init(
+	struct agent *agent, const char *name, yanet_error **err
+) {
+	struct mirror_module_config *config =
+		(struct mirror_module_config *)memory_balloc(
+			&agent->memory_context,
+			sizeof(struct mirror_module_config)
+		);
+	if (config == NULL) {
+		yanet_error_add(err, "failed to allocate config");
+		return NULL;
+	}
+
+	if (cp_module_init(
+		    &config->cp_module,
+		    agent,
+		    "mirror",
+		    name,
+		    mirror_module_config_destroy,
+		    err
+	    )) {
+		yanet_error_add(err, "failed to init module");
+		memory_bfree(
+			&agent->memory_context,
+			config,
+			sizeof(struct mirror_module_config)
+		);
+		return NULL;
+	}
+
+	SET_OFFSET_OF(&config->targets, NULL);
+	config->target_count = 0;
+
+	memset(&config->filter_vlan, 0, sizeof(config->filter_vlan));
+
+	memset(&config->filter_ip4, 0, sizeof(config->filter_ip4));
+
+	memset(&config->filter_ip6, 0, sizeof(config->filter_ip6));
+
+	return &config->cp_module;
+}
+
+void
+mirror_module_config_free(struct cp_module *cp_module) {
+	cp_module_release(cp_module);
 }
 
 typedef int (*mirror_rule_check_func)(const struct mirror_rule *mirror_rule);

--- a/modules/mirror/fuzzing/mirror.c
+++ b/modules/mirror/fuzzing/mirror.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "controlplane/config/cp_module.h"
 #include "dataplane/config/zone.h"
 #include "modules/mirror/api/controlplane.h"
 #include "modules/mirror/dataplane/config.h"
@@ -167,7 +168,17 @@ mirror_test_config(struct cp_module **cp_module, yanet_error **err) {
 	return 0;
 
 fail:
-	mirror_module_config_free(&config->cp_module);
+	// Frees directly against the harness arena instead of going through
+	// the public free.
+	//
+	// This module configuration was built by hand with no owning agent
+	// and never took the reference construction normally holds, so the
+	// public free's release path would decrement a reference count that
+	// starts at zero and silently wrap instead of freeing anything.
+	cp_module_fini(&config->cp_module);
+	memory_bfree(
+		&fuzz_params.mctx, config, sizeof(struct mirror_module_config)
+	);
 	return -EINVAL;
 }
 

--- a/modules/mirror/tests/functional/mirror_test.go
+++ b/modules/mirror/tests/functional/mirror_test.go
@@ -598,14 +598,19 @@ func TestMirror_MinAction(t *testing.T) {
 	dataplaneut.RequireModuleCounter(t, h, path, "ip4lose", 0, 0)
 }
 
-// TestMirrorConfigMemoryLeak verifies the block allocator returns memory to
-// the pool when an old mirror config generation is freed.
+// TestMirrorConfigMemoryLeak verifies the block allocator returns memory once a
+// superseded mirror config generation is reclaimed.
 //
-// THE MAGIC: use 8 rules so sizeof(mirror_target)*8 = 192 and
-// sizeof(mirror_target*)*8 = 64 fall into different block-allocator pools
-// even with ASAN red zones (+128 bytes per allocation). With fewer rules
-// both sizes round up to the same power-of-two pool and the leak is
-// invisible to BlockAllocatorFreeSize.
+// THE MAGIC: 8 rules make sizeof(mirror_target)*8 = 192 and
+// sizeof(mirror_target*)*8 = 64 land in different block-allocator pools even
+// under ASAN red zones; fewer rules round both into the same pool and hide a
+// leak in either array from BlockAllocatorFreeSize.
+//
+// Releasing a handle only parks it: reclaim happens on the type's next
+// construction, not on release. Each round below publishes and releases one
+// "mirror0" generation, and that construction drains the round before it, so
+// from round 1 the arena holds two generations' worth of rules and every
+// round's free byte count must match the last.
 func TestMirrorConfigMemoryLeak(t *testing.T) {
 	_, agent, _ := setupMirrorHarness(t, []string{"port0"})
 
@@ -618,22 +623,32 @@ func TestMirrorConfigMemoryLeak(t *testing.T) {
 		}
 	}
 
-	moduleA, err := cmirror.NewModuleConfig(agent, "mirror0")
-	require.NoError(t, err)
-	require.NoError(t, moduleA.Update(rules))
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{moduleA.AsFFIModule()}))
+	var baseline uint64
+	for round := range 4 {
+		module, err := cmirror.NewModuleConfig(agent, "mirror0")
+		require.NoErrorf(t, err, "round %d: construct failed", round)
+		require.NoErrorf(t, module.Update(rules), "round %d: update failed", round)
+		require.NoErrorf(
+			t,
+			agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}),
+			"round %d: publish failed", round,
+		)
+		module.Free()
 
-	freeBefore := agent.BlockAllocatorFreeSize()
+		if round == 0 {
+			// Nothing is parked yet for this round's construction to
+			// drain, so this round's shape isn't comparable to later ones.
+			continue
+		}
 
-	moduleB, err := cmirror.NewModuleConfig(agent, "mirror0")
-	require.NoError(t, err)
-	t.Cleanup(moduleB.Free)
-
-	require.NoError(t, moduleB.Update(rules))
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{moduleB.AsFFIModule()}))
-
-	moduleA.Free()
-
-	freeAfter := agent.BlockAllocatorFreeSize()
-	require.Equal(t, freeBefore, freeAfter)
+		free := agent.BlockAllocatorFreeSize()
+		if round == 1 {
+			baseline = free
+		} else {
+			require.Equalf(
+				t, baseline, free,
+				"round %d: free bytes drifted from the round-1 baseline", round,
+			)
+		}
+	}
 }

--- a/modules/nat64/api/nat64cp.c
+++ b/modules/nat64/api/nat64cp.c
@@ -20,47 +20,8 @@
 #include "controlplane/agent/agent.h"
 #include "dataplane/config/zone.h"
 
-struct cp_module *
-nat64_module_config_create(
-	struct agent *agent, const char *name, yanet_error **err
-) {
-	struct nat64_module_config *config =
-		(struct nat64_module_config *)memory_balloc(
-			&agent->memory_context,
-			sizeof(struct nat64_module_config)
-		);
-	if (config == NULL) {
-		yanet_error_add(err, "failed to allocate config");
-		return NULL;
-	}
-
-	if (cp_module_init(&config->cp_module, agent, "nat64", name, err)) {
-		yanet_error_add(err, "failed to init module");
-		goto error_init;
-	}
-
-	if (nat64_module_config_data_init(
-		    config, &config->cp_module.memory_context
-	    )) {
-		yanet_error_add(err, "failed to init config data");
-		goto error_data;
-	}
-
-	return &config->cp_module;
-
-error_data:
-	cp_module_fini(&config->cp_module);
-error_init:
-	memory_bfree(
-		&agent->memory_context,
-		config,
-		sizeof(struct nat64_module_config)
-	);
-	return NULL;
-}
-
-void
-nat64_module_config_free(struct cp_module *cp_module) {
+static void
+nat64_module_config_destroy(struct cp_module *cp_module) {
 	struct nat64_module_config *config =
 		container_of(cp_module, struct nat64_module_config, cp_module);
 
@@ -78,6 +39,65 @@ nat64_module_config_free(struct cp_module *cp_module) {
 		config,
 		sizeof(struct nat64_module_config)
 	);
+}
+
+struct cp_module *
+nat64_module_config_create(
+	struct agent *agent, const char *name, yanet_error **err
+) {
+	struct nat64_module_config *config =
+		(struct nat64_module_config *)memory_balloc(
+			&agent->memory_context,
+			sizeof(struct nat64_module_config)
+		);
+	if (config == NULL) {
+		yanet_error_add(err, "failed to allocate config");
+		return NULL;
+	}
+
+	if (cp_module_init(
+		    &config->cp_module,
+		    agent,
+		    "nat64",
+		    name,
+		    nat64_module_config_destroy,
+		    err
+	    )) {
+		yanet_error_add(err, "failed to init module");
+		memory_bfree(
+			&agent->memory_context,
+			config,
+			sizeof(struct nat64_module_config)
+		);
+		return NULL;
+	}
+
+	if (nat64_module_config_data_init(
+		    config, &config->cp_module.memory_context
+	    )) {
+		yanet_error_add(err, "failed to init config data");
+		// Frees directly instead of going through the type destructor.
+		//
+		// A failed configuration-data setup never reaches a state its
+		// own teardown could safely walk. No reference beyond the
+		// caller's own has been taken, and no registry has observed
+		// the module yet, so nothing is lost by freeing the block
+		// here.
+		cp_module_fini(&config->cp_module);
+		memory_bfree(
+			&agent->memory_context,
+			config,
+			sizeof(struct nat64_module_config)
+		);
+		return NULL;
+	}
+
+	return &config->cp_module;
+}
+
+void
+nat64_module_config_free(struct cp_module *cp_module) {
+	cp_module_release(cp_module);
 }
 
 int

--- a/modules/nat64/tests/dataplane/nat64.go
+++ b/modules/nat64/tests/dataplane/nat64.go
@@ -29,16 +29,49 @@ cp_module_init(
 	struct agent *agent,
 	const char *module_type,
 	const char *module_name,
+	cp_module_free_handler destroy,
 	yanet_error **err
 ) {
 	(void)cp_module, (void)agent, (void)module_type, (void)module_name,
-		(void)err;
+		(void)destroy, (void)err;
 	return -1;
 }
 
 void
 cp_module_fini(struct cp_module *cp_module) {
 	(void)cp_module;
+}
+
+// cp_module_registry_item_free_cb and cp_module_release are no longer
+// header-only, so this harness supplies its own stand-ins.
+//
+// The stub agent above has no real configuration zone, so this mock
+// reproduces the production algorithm without the config lock the real
+// implementation takes around it.
+void
+cp_module_registry_item_free_cb(struct registry_item *item, void *data) {
+	struct cp_module *module =
+		container_of(item, struct cp_module, config_item);
+	struct agent *agent = ADDR_OF(&module->agent);
+	if (agent == NULL) {
+		return;
+	}
+
+	if (ADDR_OF(&module->parked_next) != NULL) {
+		return;
+	}
+
+	struct cp_module *head = ADDR_OF(&agent->parked_modules);
+	SET_OFFSET_OF(&module->parked_next, (head != NULL) ? head : module);
+	SET_OFFSET_OF(&agent->parked_modules, module);
+	(void)data;
+}
+
+void
+cp_module_release(struct cp_module *cp_module) {
+	registry_item_unref(
+		&cp_module->config_item, cp_module_registry_item_free_cb, NULL
+	);
 }
 
 // nat64dp.c registers an RTE log type at load time and logs through the

--- a/modules/pdump/api/controlplane.c
+++ b/modules/pdump/api/controlplane.c
@@ -101,48 +101,8 @@ pdump_module_config_data_init(
 	return 0;
 }
 
-struct cp_module *
-pdump_module_config_new(
-	struct agent *agent, const char *name, yanet_error **err
-) {
-	struct pdump_module_config *config =
-		(struct pdump_module_config *)memory_balloc(
-			&agent->memory_context,
-			sizeof(struct pdump_module_config)
-		);
-	if (config == NULL) {
-		yanet_error_add(err, "failed to allocate config");
-		return NULL;
-	}
-
-	if (cp_module_init(&config->cp_module, agent, "pdump", name, err)) {
-		yanet_error_add(err, "failed to init module");
-		memory_bfree(
-			&agent->memory_context,
-			config,
-			sizeof(struct pdump_module_config)
-		);
-		return NULL;
-	}
-
-	// Initialize the module data
-	if (pdump_module_config_data_init(
-		    config, &config->cp_module.memory_context
-	    )) {
-		yanet_error_add(err, "failed to init config data");
-		memory_bfree(
-			&agent->memory_context,
-			config,
-			sizeof(struct pdump_module_config)
-		);
-		return NULL;
-	}
-
-	return &config->cp_module;
-}
-
-void
-pdump_module_config_free(struct cp_module *module) {
+static void
+pdump_module_config_destroy(struct cp_module *module) {
 	struct pdump_module_config *config =
 		container_of(module, struct pdump_module_config, cp_module);
 
@@ -187,7 +147,67 @@ pdump_module_config_free(struct cp_module *module) {
 		config,
 		sizeof(struct pdump_module_config)
 	);
-};
+}
+
+struct cp_module *
+pdump_module_config_new(
+	struct agent *agent, const char *name, yanet_error **err
+) {
+	struct pdump_module_config *config =
+		(struct pdump_module_config *)memory_balloc(
+			&agent->memory_context,
+			sizeof(struct pdump_module_config)
+		);
+	if (config == NULL) {
+		yanet_error_add(err, "failed to allocate config");
+		return NULL;
+	}
+
+	if (cp_module_init(
+		    &config->cp_module,
+		    agent,
+		    "pdump",
+		    name,
+		    pdump_module_config_destroy,
+		    err
+	    )) {
+		yanet_error_add(err, "failed to init module");
+		memory_bfree(
+			&agent->memory_context,
+			config,
+			sizeof(struct pdump_module_config)
+		);
+		return NULL;
+	}
+
+	// Initialize the module data
+	if (pdump_module_config_data_init(
+		    config, &config->cp_module.memory_context
+	    )) {
+		yanet_error_add(err, "failed to init config data");
+		// Frees directly instead of going through the type destructor.
+		//
+		// A failed configuration-data setup never reaches a state its
+		// own teardown could safely walk. No reference beyond the
+		// caller's own has been taken, and no registry has observed
+		// the module yet, so nothing is lost by freeing the block
+		// here.
+		cp_module_fini(&config->cp_module);
+		memory_bfree(
+			&agent->memory_context,
+			config,
+			sizeof(struct pdump_module_config)
+		);
+		return NULL;
+	}
+
+	return &config->cp_module;
+}
+
+void
+pdump_module_config_free(struct cp_module *module) {
+	cp_module_release(module);
+}
 
 int
 pdump_module_config_set_filter(

--- a/modules/route-mpls/api/controlplane.c
+++ b/modules/route-mpls/api/controlplane.c
@@ -13,38 +13,6 @@
 FILTER_COMPILER_DECLARE(FILTER_IP4_TAG, net4_dst);
 FILTER_COMPILER_DECLARE(FILTER_IP6_TAG, net6_dst);
 
-struct cp_module *
-route_mpls_module_config_new(
-	struct agent *agent, const char *name, yanet_error **err
-) {
-	struct module_config *config = (struct module_config *)memory_balloc(
-		&agent->memory_context, sizeof(struct module_config)
-	);
-	if (config == NULL) {
-		yanet_error_add(err, "failed to allocate config");
-		return NULL;
-	}
-
-	if (cp_module_init(
-		    &config->cp_module, agent, "route-mpls", name, err
-	    )) {
-		yanet_error_add(err, "failed to init module");
-		memory_bfree(
-			&agent->memory_context,
-			config,
-			sizeof(struct module_config)
-		);
-		return NULL;
-	}
-
-	memset(&config->filter_ip4, 0, sizeof(config->filter_ip4));
-	memset(&config->filter_ip6, 0, sizeof(config->filter_ip6));
-	config->target_count = 0;
-	SET_OFFSET_OF(&config->targets, NULL);
-
-	return &config->cp_module;
-}
-
 static inline uint64_t
 target_memory_size(uint64_t nexthop_map_size) {
 	return sizeof(struct target) + sizeof(uint64_t) * nexthop_map_size;
@@ -90,8 +58,8 @@ route_mpls_module_config_fini(struct module_config *config) {
 	SET_OFFSET_OF(&config->targets, NULL);
 }
 
-void
-route_mpls_module_config_free(struct cp_module *cp_module) {
+static void
+route_mpls_module_config_destroy(struct cp_module *cp_module) {
 	struct module_config *config =
 		container_of(cp_module, struct module_config, cp_module);
 
@@ -104,6 +72,48 @@ route_mpls_module_config_free(struct cp_module *cp_module) {
 	memory_bfree(
 		&agent->memory_context, config, sizeof(struct module_config)
 	);
+}
+
+struct cp_module *
+route_mpls_module_config_new(
+	struct agent *agent, const char *name, yanet_error **err
+) {
+	struct module_config *config = (struct module_config *)memory_balloc(
+		&agent->memory_context, sizeof(struct module_config)
+	);
+	if (config == NULL) {
+		yanet_error_add(err, "failed to allocate config");
+		return NULL;
+	}
+
+	if (cp_module_init(
+		    &config->cp_module,
+		    agent,
+		    "route-mpls",
+		    name,
+		    route_mpls_module_config_destroy,
+		    err
+	    )) {
+		yanet_error_add(err, "failed to init module");
+		memory_bfree(
+			&agent->memory_context,
+			config,
+			sizeof(struct module_config)
+		);
+		return NULL;
+	}
+
+	memset(&config->filter_ip4, 0, sizeof(config->filter_ip4));
+	memset(&config->filter_ip6, 0, sizeof(config->filter_ip6));
+	config->target_count = 0;
+	SET_OFFSET_OF(&config->targets, NULL);
+
+	return &config->cp_module;
+}
+
+void
+route_mpls_module_config_free(struct cp_module *cp_module) {
+	cp_module_release(cp_module);
 }
 
 typedef int (*route_mpls_rule_check_func)(

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -78,6 +78,9 @@ route_module_config_register_counters(
 	return 0;
 }
 
+static void
+route_module_config_destroy(struct cp_module *cp_module);
+
 struct cp_module *
 route_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
@@ -92,7 +95,14 @@ route_module_config_new(
 		return NULL;
 	}
 
-	if (cp_module_init(&config->cp_module, agent, "route", name, err)) {
+	if (cp_module_init(
+		    &config->cp_module,
+		    agent,
+		    "route",
+		    name,
+		    route_module_config_destroy,
+		    err
+	    )) {
 		yanet_error_add(err, "failed to init module");
 		memory_bfree(
 			&agent->memory_context,
@@ -106,6 +116,13 @@ route_module_config_new(
 		    config, &config->cp_module.memory_context
 	    )) {
 		yanet_error_add(err, "failed to init config data");
+		// Frees directly instead of going through the type destructor.
+		//
+		// A failed configuration-data setup never reaches a state its
+		// own teardown could safely walk. No reference beyond the
+		// caller's own has been taken, and no registry has observed
+		// the module yet, so nothing is lost by freeing the block
+		// here.
 		cp_module_fini(&config->cp_module);
 		memory_bfree(
 			&agent->memory_context,
@@ -116,7 +133,15 @@ route_module_config_new(
 	}
 
 	if (route_module_config_register_counters(config, err)) {
-		route_module_config_free(&config->cp_module);
+		// Frees directly instead of going through the public free.
+		//
+		// Registering counters is the last construction step, so
+		// configuration data is already fully set up and the type's
+		// own destructor can safely walk it. No reference beyond the
+		// caller's own has been taken and no registry has observed
+		// the module yet, so going through the public free would
+		// only park it instead of destroying it.
+		route_module_config_destroy(&config->cp_module);
 		return NULL;
 	}
 
@@ -178,8 +203,8 @@ route_module_config_data_fini(struct route_module_config *config) {
 	lpm_free(&config->lpm_v4);
 }
 
-void
-route_module_config_free(struct cp_module *cp_module) {
+static void
+route_module_config_destroy(struct cp_module *cp_module) {
 	struct route_module_config *config =
 		container_of(cp_module, struct route_module_config, cp_module);
 
@@ -194,6 +219,11 @@ route_module_config_free(struct cp_module *cp_module) {
 		config,
 		sizeof(struct route_module_config)
 	);
+}
+
+void
+route_module_config_free(struct cp_module *cp_module) {
+	cp_module_release(cp_module);
 }
 
 int

--- a/modules/route/tests/route_api_test.c
+++ b/modules/route/tests/route_api_test.c
@@ -1,15 +1,15 @@
 /*
- * Tests that route_module_config_new does not leak memory when
- * route_module_config_data_init fails due to OOM after cp_module_init
- * succeeds.
+ * Tests that construction does not leak memory when the module's own data
+ * setup fails partway through, at each of its fallible steps.
  *
- * Mechanism: agent_attach carves a private arena of exactly memory_limit
- * bytes from the cp_config allocator. All module allocations draw from
- * this arena.
+ * Attaching an agent carves a private arena of exactly the given byte
+ * limit from the shared allocator, and every allocation the module under
+ * test makes draws from that one arena.
  *
- * Leak detection: block_allocator_free_size must return to its value
- * recorded immediately after agent_attach. Any byte not freed by a
- * cleanup path stays missing from the free list.
+ * The arena's free-byte count must return to its value recorded right
+ * after attach. A byte a cleanup path leaves unfreed stays missing from
+ * that count, and a block freed twice makes the count overshoot instead,
+ * so the same check catches both a leak and a double free.
  */
 
 #include "api/agent.h"
@@ -30,6 +30,15 @@
  * but well below the 32 KB lpm_init page-chunk request.
  */
 #define ROUTE_TEST_MEMORY_LIMIT (16u * 1024u)
+
+/*
+ * 40800 bytes, found empirically: enough for construction plus one
+ * routing table's own setup, but too little for the second table to also
+ * succeed. This size reaches data setup's own error path instead of the
+ * shared type teardown, verifying that path frees the first table
+ * exactly once.
+ */
+#define ROUTE_TEST_SECOND_LPM_LIMIT (40800u)
 
 static int
 run_test(struct yanet_shm *shm) {
@@ -56,6 +65,51 @@ run_test(struct yanet_shm *shm) {
 		(long)after,
 		(long)baseline,
 		"memory leaked after failed create: baseline=%zu after=%zu",
+		baseline,
+		after
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+/*
+ * Same shape as the first test, but sized to fail at the second routing
+ * table's own setup instead of the first.
+ *
+ * This exercises the error path for a partially constructed module,
+ * verifying it frees the first table's memory exactly once rather than
+ * leaving that job to a teardown that would double free it.
+ */
+static int
+run_second_lpm_failure_test(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm,
+		0,
+		"route-test-second-lpm",
+		ROUTE_TEST_SECOND_LPM_LIMIT,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	size_t baseline = block_allocator_free_size(&agent->block_allocator);
+
+	struct cp_module *cp = route_module_config_new(agent, "probe", &err);
+	TEST_ASSERT_NULL(cp, "create unexpectedly succeeded");
+
+	const char *errmsg = (err != NULL) ? yanet_error_message(err) : "";
+	TEST_ASSERT_STR_CONTAINS(
+		errmsg, "failed to init config data", "wrong failure path"
+	);
+	yanet_error_reset(&err);
+
+	size_t after = block_allocator_free_size(&agent->block_allocator);
+	TEST_ASSERT_EQUAL(
+		(long)after,
+		(long)baseline,
+		"free list drifted after failed create: baseline=%zu after=%zu",
 		baseline,
 		after
 	);
@@ -98,6 +152,9 @@ main(void) {
 	}
 
 	int res = run_test(shm);
+	if (res == TEST_SUCCESS) {
+		res = run_second_lpm_failure_test(shm);
+	}
 	dataplane_ut_free(ut);
 
 	return (res == TEST_SUCCESS) ? 0 : 1;


### PR DESCRIPTION
A production control plane crashed three times in one day with `SIGSEGV` at address zero, always at the same instruction, during routine module configuration updates. The faulting instruction decoded to the shared-memory block allocator taking a block from a size-class pool whose free list was empty while the allocator's own bitmask claimed otherwise — corruption, not exhaustion.

A `cp_module` had two owners that did not know about each other. `struct registry_item config_item` is its first field and counts the configuration generations referencing it, and the transition to zero freed nothing, because every module service released the handle itself right after a successful publish. Those moments coincided only while a retired generation was torn down synchronously inside the publish. Once generation teardown became reference counted, an unlocked counters reader holding a pin kept a retired generation, and its pointers into the previous module, alive past that release. The corruption is immediate rather than dependent on reuse: the allocator writes its free list link into a freed block's first word, which is exactly that reference count. Downstream that produced a garbage element count in a counter storage teardown, a free whose size mapped to an out-of-range pool index, a write over the allocator's bitmask, and the crash on the next allocation.

Closes #1761.

## The model

One counter. The creator takes an ordinary reference during construction, every decrement goes through the registry item's unref, and the single transition to zero parks the module on a list hanging off its own agent, destroying nothing, because the generic layer does not know the module's type.

Reclamation happens on the next construction of that same type, which is the only caller that can supply the matching teardown. That drain is the first statement of the constructor, before any allocation, so a deleted configuration can always be recreated: whatever the parked entry holds is returned to the arena before the replacement asks for anything. The teardown is passed as an argument and never stored, so nothing in shared memory holds a pointer that could outlive the process that supplied it.

The list splice runs under the configuration lock, which every other mutation of a module's reference count already held. The teardowns themselves run outside it, because a large one costs milliseconds on a lock that has already caused a production livelock. The agent is pinned for exactly that window, and the pin is raised inside the same lock acquisition that performed the splice, so the arena reclaim guard can never observe entries detached with the pin unset.

An agent's arena is reclaimed on generation references alone. `loaded_module_count` is maintained symmetrically in the four registry wrappers that add or drop such a reference and never mirrors the creator's, so a control plane that dies without releasing anything still leaves a reclaimable arena rather than pinning one per restart.

## Two designs were rejected on the way here

- A process-local table mapping module type to destructor: rejected because it does not survive a restart, so a process cannot destroy a type it never constructed, and because lazy registration, a fixed capacity and a silent-leak branch all follow from it.
- A creator reference mirrored into the arena reclaim counters: dynamic analysis measured it leaking one agent arena per control-plane restart, without bound, because only a live process can drop a reference held in shared memory.

## Shared memory layout

`struct cp_module` gained a link field, so it grew and crosses the plugin ABI boundary. The tripwire literal is updated and `YANET_MODULE_ABI_VERSION` goes from 13 to 14. Picking this up requires `go clean -cache`, removing stale standalone binaries, and wiping `/dev/hugepages/yanet*` along with cached functional-test images.

## Known trades

- A module type that is retired and never constructed again keeps its parked configuration until the control plane restarts, where the old code freed it at once. Retention is bounded per type rather than per instance — one later construction drains every parked entry of that type — and nothing escapes the arena.
- The reclaim guard rests on a precondition it does not enforce: within one shared memory instance, a live agent name has at most one process still holding it. Attaching supersedes an existing agent of that name unconditionally, and although the owning process id is recorded, nothing reads it back, so a violation is silent. This predates the change — a constructed but unpublished module already sat in the arena with a zero generation count — and enforcing it is tracked as #2001.
- A process that dies inside a teardown leaves that one superseded arena pinned forever. A bounded leak of a single arena was chosen over the alternative of a destructor running against memory already freed.

## Worth a reviewer's attention

- A parked module's link points at itself when it is the list tail, so "already parked" is testable as a non-null link. The splice has to unwrap and reinstate that self-reference when detaching from the head, the middle or the tail. It is covered by a test that fails on list shape when the guard is removed, and it is the place a later edit will get wrong.
- One agent hosts more than one module type: the access control service attaches a single agent and hands it to the firewall state service. A survey found this is the only such sharing in the tree, and the type filter is what makes it safe.
- Failed construction never parks. Every site that fails partway now frees directly, except route, whose address lookup tries have already allocated by the time counter registration runs and which therefore calls its own destructor.
- The failed-publish test forces its failure with a structural lever rather than by exhausting the arena to a tuned byte target, and asserts which phase the failure lands in. The byte target was not portable: under a sanitizer the arena died one phase earlier, before the module was upserted, so the test passed having never entered the window it exists to check.
