### PR TITLE
chore(agents): support OpenCode charter generation

### DIFF
--- a/.claude/conventions/c.md
+++ b/.claude/conventions/c.md
@@ -3,7 +3,7 @@
 Loaded on demand by the agent writing or reviewing C; this is the single source for these rules.
 
 - Always use braces for `if`/`else`/`for`/`while`, even single-line bodies. `clang-format` (`InsertBraces: true`) inserts them automatically, but it silently skips some cases, among them a body inside a macro definition, a body split from its condition by a preprocessor directive, and an empty `;` body.
-- Format with `clang-format`.
+- Format with `clang-format`, restricted to the exact `.c`/`.h` paths you changed. Never pass a `.go` or `meson.build` path (alone or batched with C files) — clang-format has no concept of Go or meson grammar and silently mangles it with no warning (breaks `:=`, `for range`, `key:` syntax). Format Go separately with `gofmt`.
 - **Functions with more than six parameters are a code smell.** Split them or use a designated-initializer config struct; omnibus initialisers are untestable.
 - **Multi-segment mbufs**: `rte_pktmbuf_data_len()` is head-only. Whole-packet work walks `mbuf->next`/uses `rte_pktmbuf_pkt_len()`, or rejects chained packets.
 - **Zero config limits mean unset/no clamp.** Never use the sentinel in min/subtraction arithmetic; clamp accepted degenerate values below internal header deltas.

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -3,7 +3,7 @@
 # Warns after a pull if the primary checkout's generated agent charters
 # could not be verified against .rulesync/subagents/.
 #
-# .claude/agents/ and .codex/agents/ are generated from
+# .claude/agents/, .codex/agents/, and .opencode/agents/ are generated from
 # .rulesync/subagents/ by 'make ai/agents' and are not tracked in git.
 # No-op in a linked worktree: core.hooksPath is shared across every
 # worktree, but only the primary checkout has git-dir == git-common-dir.
@@ -15,7 +15,7 @@ if [ "$git_dir" != "$common_dir" ]; then
 fi
 
 if ! make lint/agents >/dev/null; then
-	echo "agent charters could not be verified; run 'make ai/agents' to regenerate .claude/agents/ and .codex/agents/, or inspect the error above" >&2
+	echo "agent charters could not be verified; run 'make ai/agents' to regenerate .claude/agents/, .codex/agents/, and .opencode/agents/, or inspect the error above" >&2
 fi
 
 exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ deploy/packages/
 
 # Generated from .rulesync/subagents/*.md by 'make ai/agents'.
 .claude/agents
+.opencode/
 
 # Ignore skills by default.
 #

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,2 +1,3 @@
 .claude/agents/
 .codex/agents/
+.opencode/agents/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ git submodule update --init   # DPDK submodule
 meson setup build             # configure C/DPDK build
 
 # AI agent tooling (not needed to build YANET; requires Node/npm)
-make ai/agents                # generate .claude/agents/ and .codex/agents/ (regenerate after any pull touching .rulesync/)
+make ai/agents                # generate .claude/agents/, .codex/agents/, and .opencode/agents/ (regenerate after any pull touching .rulesync/)
 
 # Build everything
 make all                      # builds dataplane + CLI
@@ -182,7 +182,7 @@ Active modules: `route, acl, balancer2, blackhole, forward, decap, nat64, fwstat
 
 Meson orchestrates C/DPDK builds and Go binary compilation (via `custom_target` with `go build`). Rust is built separately via Cargo. DPDK is a Meson subproject in `subprojects/dpdk/`. Sanitizer flags are propagated to CGO automatically when using `-Db_sanitize`.
 
-Agent charters are authored once at `.rulesync/subagents/*.md` — `make ai/agents` generates the `.claude/agents/` and `.codex/agents/` trees both clients read. Public skills are authored once under `.agents/skills/<name>/`, which Codex reads directly, and the Claude Code tree mirrors them by symlink (`.claude/skills/<name>` → `../../.agents/skills/<name>`).
+Agent charters are authored once at `.rulesync/subagents/*.md` — `make ai/agents` generates the `.claude/agents/`, `.codex/agents/`, and `.opencode/agents/` trees all three clients read. Public skills are authored once under `.agents/skills/<name>/`, which Codex reads directly, and the Claude Code tree mirrors them by symlink (`.claude/skills/<name>` → `../../.agents/skills/<name>`).
 
 ## Coding Conventions
 
@@ -232,7 +232,7 @@ Web UI lives in `web/` (the shell), but per-module pages are **co-located with t
 - **Seed a fresh worktree before launching anyone into it**, because it holds only tracked files. Symlink the client memory tree and local settings. The build directory is always called `build`, so every existing `meson compile -C build` recipe stays correct, but which of two things it is depends on what the task's gates do with it. A gate that only links against the archives already in it, or ignores it entirely, may borrow the primary `build` by symlink, seeding the generated `*.pb.go` beside it — `go build`, `go test`, `cargo`, `npm` and a lint-only target such as `make lint/comments` all qualify. A gate that PRODUCES or CONSUMES `build` needs the worktree's own real one instead: `make test`, `make dataplane`, `make fuzz` and `make test-asan` drive meson at it, and `make test-functional` mounts it into the VM without meson at all. Through the symlink each of those exercises the primary checkout's artifacts rather than yours, so the gate goes green on stale ones while ninja rewrites the archives every other worktree links against, and `meson setup --reconfigure`/`--wipe` retargets the developer's shared directory at your worktree. Building its own costs more than the tree: `meson setup build` initialises the empty `subprojects/dpdk` and `subprojects/libpcap` itself, but a linked worktree does not share the superproject's submodule objects, so git clones them from the remote (network required) into `.git/worktrees/<name>/modules/` — budget roughly 255 MB on top of the build, and put such a worktree on a volume with room. A web gate needs `npm ci` from the worktree root. A gitignored tree, such as a private module, cannot be worktree-isolated at all — work it at the primary checkout with absolute paths.
 - **Before a command that produces or consumes `build`, check whether it is a real directory and report a seeding gap if it is a symlink** — a borrowed link makes the gate exercise the primary checkout's artifacts instead of yours.
 - **If your memory tree is missing from the worktree, write through the primary checkout's absolute path** rather than creating a second copy that dies with the worktree.
-- **Never symlink `.claude/agents/` or `.codex/agents/` into a worktree.** `make ai/agents` writes every generated file through the symlink before it notices and refuses, and neither tree is git-tracked — the damage to the primary's real tree is neither prevented, detected, nor recoverable. `.worktreeinclude` gives a tool-created worktree its own copy instead, but nothing ever refreshes it: `.githooks/post-merge` no-ops outside the primary checkout, and the old tracked scheme's propagation through merge or rebase is gone. Charter generation (`make ai/agents`) runs only at the primary checkout, after merge.
+- **Never symlink `.claude/agents/`, `.codex/agents/`, or `.opencode/agents/` into a worktree.** `make ai/agents` writes every generated file through the symlink before it notices and refuses, and none of these trees are git-tracked — the damage to the primary's real tree is neither prevented, detected, nor recoverable. `.worktreeinclude` gives a tool-created worktree its own copy instead, but nothing ever refreshes it: `.githooks/post-merge` no-ops outside the primary checkout, and the old tracked scheme's propagation through merge or rebase is gone. Charter generation (`make ai/agents`) runs only at the primary checkout, after merge.
 
 ### Commits & PRs
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CARGO ?= cargo
 RULESYNC ?= npx --yes rulesync@16.8.0
-RULESYNC_GENERATE_ARGS := generate --targets claudecode,codexcli --features subagents
+RULESYNC_GENERATE_ARGS := generate --targets claudecode,codexcli,opencode --features subagents
 
 # Compile database consumed by lint/clang-syntax.
 COMPILE_DB ?= build/compile_commands.json
@@ -225,7 +225,7 @@ lint-commit:
 	lint/commit/commitlint_test.sh
 	lint/commit/commitlint.sh --range origin/main..HEAD
 
-# Generate .claude/agents/*.md and .codex/agents/*.toml from the tracked
+# Generate .claude/agents/*.md, .codex/agents/*.toml, and .opencode/agents/*.md from the tracked
 # source of truth, .rulesync/subagents/*.md.
 #
 # Refuses when the source roster is empty: rulesync's delete:true wipes
@@ -245,7 +245,7 @@ ai/agents:
 		fi
 	$(RULESYNC) $(RULESYNC_GENERATE_ARGS)
 
-# Reports whether .claude/agents/ and .codex/agents/ have drifted from
+# Reports whether .claude/agents/, .codex/agents/, and .opencode/agents/ have drifted from
 # .rulesync/subagents/*.md, without writing to the filesystem.
 #
 # Run by .githooks/post-merge after a pull to warn about stale charters.

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://github.com/dyoshikawa/rulesync/releases/download/v16.8.0/config-schema.json",
-  "targets": ["claudecode", "codexcli"],
+  "targets": ["claudecode", "codexcli", "opencode"],
   "features": ["subagents"],
   "delete": true
 }


### PR DESCRIPTION
- Generate shared agent charters for OpenCode alongside Claude Code and Codex.
- Keep local worktree seeding, drift diagnostics, and direct Rulesync configuration aligned across all clients.
- Restrict automated C formatting guidance to changed C headers and sources.