### PR TITLE
fix(controlplane): key device registry by type and name

### DIFF
--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -454,8 +454,30 @@ cp_device_registry_get(
 	return container_of(item, struct cp_device, config_item);
 }
 
+struct cp_device_cmp_data {
+	const char *type;
+	const char *name;
+};
+
 static int
 cp_device_registry_item_cmp(
+	const struct registry_item *item, const void *data
+) {
+	const struct cp_device *device =
+		container_of(item, struct cp_device, config_item);
+	const struct cp_device_cmp_data *cmp_data =
+		(const struct cp_device_cmp_data *)data;
+
+	int cmp = strncmp(device->name, cmp_data->name, sizeof(device->name));
+	if (cmp) {
+		return cmp;
+	}
+
+	return strncmp(device->type, cmp_data->type, sizeof(device->type));
+}
+
+static int
+cp_device_registry_name_cmp(
 	const struct registry_item *item, const void *data
 ) {
 	const struct cp_device *device =
@@ -466,13 +488,19 @@ cp_device_registry_item_cmp(
 
 struct cp_device *
 cp_device_registry_lookup(
-	struct cp_device_registry *device_registry, const char *name
+	struct cp_device_registry *device_registry,
+	const char *type,
+	const char *name
 ) {
+	struct cp_device_cmp_data cmp_data = {
+		.type = type,
+		.name = name,
+	};
 	uint64_t index;
 	if (registry_lookup(
 		    &device_registry->registry,
 		    cp_device_registry_item_cmp,
-		    name,
+		    &cmp_data,
 		    &index
 	    )) {
 		return NULL;
@@ -488,12 +516,17 @@ cp_device_registry_lookup(
 int
 cp_device_registry_upsert(
 	struct cp_device_registry *device_registry,
+	const char *type,
 	const char *name,
 	struct cp_device *new_device,
 	yanet_error **err
 ) {
+	struct cp_device_cmp_data cmp_data = {
+		.type = type,
+		.name = name,
+	};
 	struct cp_device *old_device =
-		cp_device_registry_lookup(device_registry, name);
+		cp_device_registry_lookup(device_registry, type, name);
 
 	if (counter_registry_link(
 		    &new_device->counter_registry,
@@ -516,7 +549,7 @@ cp_device_registry_upsert(
 	if (registry_replace(
 		    &device_registry->registry,
 		    cp_device_registry_item_cmp,
-		    name,
+		    &cmp_data,
 		    &new_device->config_item,
 		    cp_device_registry_item_free_cb,
 		    NULL
@@ -539,7 +572,7 @@ cp_device_registry_delete(
 ) {
 	return registry_replace(
 		&device_registry->registry,
-		cp_device_registry_item_cmp,
+		cp_device_registry_name_cmp,
 		name,
 		NULL,
 		cp_device_registry_item_free_cb,

--- a/lib/controlplane/config/cp_device.h
+++ b/lib/controlplane/config/cp_device.h
@@ -148,12 +148,15 @@ cp_device_registry_get(
 
 struct cp_device *
 cp_device_registry_lookup(
-	struct cp_device_registry *device_registry, const char *name
+	struct cp_device_registry *device_registry,
+	const char *type,
+	const char *name
 );
 
 int
 cp_device_registry_upsert(
 	struct cp_device_registry *device_registry,
+	const char *type,
 	const char *name,
 	struct cp_device *device,
 	yanet_error **err

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -677,6 +677,7 @@ cp_config_update_devices(
 	for (uint64_t idx = 0; idx < device_count; ++idx) {
 		if (cp_device_registry_upsert(
 			    &new_config_gen->device_registry,
+			    devices[idx]->type,
 			    devices[idx]->name,
 			    devices[idx],
 			    err
@@ -981,6 +982,7 @@ cp_config_gen_new(struct agent *agent, yanet_error **err) {
 		}
 		if (cp_device_registry_upsert(
 			    &cp_config_gen->device_registry,
+			    device_config.type,
 			    device_config.name,
 			    cp_device,
 			    err

--- a/tests/controlplane/functional/device_registry_test.go
+++ b/tests/controlplane/functional/device_registry_test.go
@@ -1,0 +1,53 @@
+package functional_test
+
+import (
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	plain "github.com/yanet-platform/yanet2/devices/plain/controlplane"
+	vlan "github.com/yanet-platform/yanet2/devices/vlan/controlplane"
+)
+
+func TestDeviceRegistryRejectsSameNameAcrossTypes(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		Devices:       []string{"d0"},
+		DevicesToLoad: []string{"plain", "vlan"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	const agentName = "device-registry-type-key"
+	agent, err := shm.AgentAttach(agentName, 0, datasize.MB*4)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	devicesBefore := shm.DPConfig(0).Devices()
+	require.Len(t, devicesBefore, 1)
+	require.Equal(t, "plain", devicesBefore[0].Type)
+	require.Equal(t, "d0", devicesBefore[0].Name)
+	plainConfig, err := plain.NewDeviceConfig(agent, "d0", &commonpb.Device{})
+	require.NoError(t, err)
+	vlanConfig, err := vlan.NewDeviceConfig(agent, "d0", &commonpb.Device{}, 100)
+	require.NoError(t, err)
+
+	updateErr := agent.UpdateDevices([]ffi.ShmDeviceConfig{
+		plainConfig.AsFFIDevice(),
+		vlanConfig.AsFFIDevice(),
+	})
+	if updateErr != nil {
+		plainConfig.Free()
+		vlanConfig.Free()
+	}
+	require.Error(t, updateErr)
+
+	require.Equal(t, devicesBefore, shm.DPConfig(0).Devices())
+}


### PR DESCRIPTION
- Key device replacement by both type and name so invalid cross-type collisions reach validation instead of silently evicting one entry.
- Preserve the existing name-only deletion, module-linkage, and counter-tag contracts because duplicate names remain invalid and are never published.
- Cover rejected collisions in `tests/controlplane/functional` through the Go shared-memory/CGO path with real plain and VLAN configurations, and verify that the published device snapshot stays unchanged.

Closes #1726.