### PR TITLE
chore(agents): prefer Go regression tests

### DIFF
--- a/.agents/skills/review-change/SKILL.md
+++ b/.agents/skills/review-change/SKILL.md
@@ -74,6 +74,8 @@ Use small read-only or isolated probes for material claims. Examples include che
 
 Review tests and benchmarks as production logic: prove that their data reaches the claimed path, assertions distinguish broken behavior, and sampling covers the stated domain. Then run the smallest relevant builds, tests, linters, and formatters from `AGENTS.md`.
 
+For new permanent behavioral or regression coverage of C, CGO, dataplane, or controlplane behavior, require a Go test and prefer `dataplane_ut` when it can exercise the behavior faithfully, even when the implementation fix is in C. Adding a new case to an existing C test is new coverage, not maintenance. Allow a permanent C test only when the test itself requires direct ASan or TSan instrumentation and Go cannot exercise the behavior faithfully, with that sanitizer-specific reason stated. A C fuzz target may supplement but never replace the required permanent behavioral or regression test. Unrelated fuzz-only work, diagnostic or scratch code under `.arch/bughunter/`, and Rust or TypeScript tests remain outside this rule. Bug-hunter scratch reproducers may use any language.
+
 Keep verification failures separate from code-review findings. A green command does not cancel a semantic defect, and a command that was not run is `NOT RUN`, not implicitly passing.
 
 ## Reconcile external findings

--- a/.rulesync/subagents/architect.md
+++ b/.rulesync/subagents/architect.md
@@ -35,6 +35,10 @@ You are the lead architect for the YANET2 project — a high-performance softwar
 4. **Define execution order**: For cross-layer changes, specify the sequence (typically: C API → Go controlplane → Rust CLI → Web UI).
 5. **Identify risks**: Flag shared memory changes, cross-module dependencies, build system impacts.
 
+### Permanent behavioral-test routing
+
+New permanent behavioral or regression tests for C, CGO, dataplane, or controlplane behavior are written in Go, even when the implementation fix is in C. Route them to `coder-go`, using the suitable Go package and `dataplane_ut` when it can exercise the behavior faithfully. A permanent C test is allowed only when the test itself must run under direct ASan or TSan instrumentation and the behavior cannot be exercised faithfully through Go. The brief must state that sanitizer-specific reason. For an in-scope defect or behavior, a C fuzz target may provide additional coverage but never substitutes for the required permanent behavioral or regression test. Use Go unless the direct-ASan/TSan-and-Go-infeasible C exception is explicitly justified. Unrelated fuzz-only tasks remain outside this routing. Maintenance-only edits to existing C tests that add no new behavioral or regression coverage and bug-hunter scratch reproducers remain allowed, and this policy does not redirect Rust CLI or TypeScript UI tests.
+
 ## Project Architecture
 
 See `AGENTS.md` — Architecture, Data Flow, Module Structure, Devices. Key integration files to remember when delegating: `controlplane/yncp/director.go` (module registration hub), `controlplane/yncp/cfg.go` (module config fields), `modules/meson.build` (subdir declarations), root `Cargo.toml` (Rust workspace members).
@@ -49,13 +53,13 @@ Quickly gathers concrete repository facts: definitions, callers, tests, registra
 
 ### `coder-c` — C/DPDK/Meson Specialist
 
-Writes code for: dataplane packet processing, C API layer, shared memory structures, meson build files, fuzzing targets, C tests.
+Writes code for: dataplane packet processing, C API layer, shared memory structures, meson build files, fuzzing targets, maintenance-only edits to existing C tests that add no new behavioral or regression coverage, or permanent C tests where direct ASan/TSan instrumentation is necessary and Go cannot exercise the behavior faithfully.
 **Use when**: task involves `dataplane/`, `modules/*/dataplane/`, `modules/*/api/`, `lib/`, `common/*.h`, `filter/`, `meson.build` files.
 
 ### `coder-go` — Go/Proto/CGO Specialist
 
-Writes code for: Go control plane services, CGO/FFI bindings, protobuf definitions, Go tests.
-**Use when**: task involves `modules/*/controlplane/`, `modules/*/internal/ffi/`, `modules/*/bindings/go/`, `controlplane/`, `common/go/`, `*.proto` files.
+Writes code for: Go control plane services, CGO/FFI bindings, protobuf definitions, all Go and `*_test.go` files except bug-hunter diagnostic/scratch reproducers under `.arch/bughunter/`, and permanent behavioral/regression tests for C, CGO, dataplane, or controlplane behavior.
+**Use when**: task involves any Go or `*_test.go` file outside bug-hunter diagnostic/scratch reproducers under `.arch/bughunter/`, including `bindings/go/`, `modules/*/controlplane/`, `modules/*/internal/ffi/`, `modules/*/bindings/go/`, `devices/*/controlplane/`, `tests/`, `modules/*/tests/`, `controlplane/`, `common/go/`, or `*.proto` files.
 
 ### `coder-rust` — Rust CLI Specialist
 

--- a/.rulesync/subagents/bug-hunter.md
+++ b/.rulesync/subagents/bug-hunter.md
@@ -83,6 +83,8 @@ To reproduce a bug you often need to *run something new*. Do it without touching
    - **Rust**: a tiny crate with a path dependency on the target crate.
 3. **If the proper repro is a permanent in-tree harness** (a new fuzz target or a new unit test), do NOT add it. Describe it precisely as a **"suggested regression test"** in your report; the architect has a coder author it.
 
+For a suggested permanent behavioral or regression test covering C, CGO, dataplane, or controlplane behavior, recommend a Go test in the suitable package and prefer `dataplane_ut` when it can exercise the behavior faithfully, even when the fix is in C. Recommend a permanent C test only when the test itself must run under direct ASan or TSan instrumentation and Go cannot exercise the behavior faithfully, and state that sanitizer-specific reason. Scratch reproducers under `.arch/bughunter/` remain free to use the language and harness needed to confirm the defect. For an in-scope defect or behavior, a C fuzz target may provide additional coverage but never substitutes for the required permanent behavioral or regression test. Use Go unless the direct-ASan/TSan-and-Go-infeasible C exception is explicitly justified. Unrelated fuzz-only tasks remain outside this routing. Maintenance-only edits to existing C tests that add no new behavioral or regression coverage remain allowed.
+
 ## Invocation Protocol
 
 The architect invokes you with a **mode** and a **payload**.

--- a/.rulesync/subagents/coder-c.md
+++ b/.rulesync/subagents/coder-c.md
@@ -5,7 +5,10 @@ name: coder-c
 description: >-
   Use this agent when the task involves writing or modifying C code in the
   YANET2 dataplane, module packet handlers, C API layers (shared memory FFI),
-  Meson build files, fuzzing targets, or C-level tests. Covers dataplane/,
+  Meson build files, fuzzing targets, maintenance-only edits to existing C tests
+  that add no new behavioral or regression coverage, or permanent C tests where
+  direct ASan/TSan instrumentation is necessary and Go cannot exercise the
+  behavior faithfully. Covers dataplane/,
   modules/*/dataplane/, modules/*/api/, lib/, common/*.h, filter/,
   modules/*/fuzzing/, modules/*/tests/, and meson.build files.
 claudecode:
@@ -33,10 +36,17 @@ You own these directories and file types:
 - `common/*.h` — Common C headers (lpm, radix, rcu, memory, ttlmap)
 - `filter/` — Packet filter compiler and classifiers
 - `modules/*/fuzzing/` — LibFuzzer targets
-- `modules/*/tests/` — C dataplane tests
+- `modules/*/tests/` — maintenance-only edits to existing C dataplane tests
+  that add no new behavioral or regression coverage, or permanent C tests where
+  direct ASan/TSan instrumentation is necessary and Go cannot exercise the
+  behavior faithfully
 - All `meson.build` files across the project
 
 You do NOT touch: Go files, Rust files, TypeScript files, protobuf files. If a task requires changes to those, state what changes are needed and defer to the appropriate specialist.
+
+## Permanent Test Routing
+
+New permanent behavioral or regression tests for C, CGO, dataplane, or controlplane behavior belong in Go, even when the implementation fix is in C. Defer authoring to `coder-go`, which should use the suitable Go package and `dataplane_ut` when it can exercise the behavior faithfully. A permanent C test is allowed only when the test itself must run under direct ASan or TSan instrumentation and the behavior cannot be exercised faithfully through Go. The brief must state that sanitizer-specific reason. For an in-scope defect or behavior, a C fuzz target may provide additional coverage but never substitutes for the required permanent behavioral or regression test. Use Go unless the direct-ASan/TSan-and-Go-infeasible C exception is explicitly justified. Unrelated fuzz-only tasks remain outside this routing. Maintenance-only edits to existing C tests that add no new behavioral or regression coverage and bug-hunter scratch reproducers remain allowed.
 
 ## Canonical Module Dataplane Structure
 

--- a/.rulesync/subagents/coder-go.md
+++ b/.rulesync/subagents/coder-go.md
@@ -5,8 +5,11 @@ name: coder-go
 description: >-
   Use this agent when working on Go code in the YANET2 control plane: module
   gRPC services, CGO/FFI bindings, protobuf definitions, gateway code, shared Go
-  libraries, Go tests. Covers modules/*/controlplane/, modules/*/bindings/go/,
-  controlplane/, common/go/, operators/, and *.proto files.
+  libraries, all Go and *_test.go files across the repository except bug-hunter
+  diagnostic/scratch reproducers under .arch/bughunter/, including permanent behavior/regression
+  tests for C, CGO, dataplane, and controlplane paths. Covers bindings/go/,
+  modules/*/controlplane/, modules/*/bindings/go/, devices/*/controlplane/,
+  tests/, modules/*/tests/, controlplane/, common/go/, operators/, and *.proto files.
 claudecode:
   model: sonnet
   tools: >-
@@ -28,13 +31,24 @@ You own these directories:
 - `modules/*/controlplane/` — Module gRPC services
 - `modules/*/internal/ffi/` — CGO bindings (newer modules)
 - `modules/*/bindings/go/` — Safe Go bindings via generated wrappers (newest pattern)
+- `bindings/go/` — Root-level Go CGO bindings
+- `devices/*/controlplane/` — Device control-plane packages
 - `controlplane/` — Gateway server, director, common FFI
 - `common/go/` — Shared Go libraries (metrics, xgrpc, logging, dataplane, etc.)
 - `operators/` — External operators (bird-adapter, pipeline, decap, forward, route)
+- `tests/` — Go tests in the mixed-language root test tree
+- `modules/*/tests/` — Go tests in mixed-language module test trees
+- All Go and `*_test.go` files across the repository, including mixed-language test roots above, except bug-hunter diagnostic/scratch reproducers under `.arch/bughunter/`
 - All `*.proto` files (in `modules/*/controlplane/*pb/`, `controlplane/ynpb/`, `common/*pb/`)
 - `go.mod`, `go.sum`
 
 You do NOT touch: C files, Rust files, TypeScript files, `meson.build` files (except protobuf-related meson.build in `*pb/` directories).
+
+Bug-hunter owns diagnostic and scratch reproducers under `.arch/bughunter/`, regardless of language.
+
+## Permanent Test Ownership
+
+Own new permanent behavioral or regression tests for C, CGO, dataplane, or controlplane behavior. Write these tests in the suitable Go package, even when the implementation fix is in C, and prefer `dataplane_ut` when it can exercise the behavior faithfully. A permanent C test is an exception only when the test itself must run under direct ASan or TSan instrumentation and Go cannot exercise the behavior faithfully. Require the brief to state that sanitizer-specific reason. For an in-scope defect or behavior, a C fuzz target may provide additional coverage but never substitutes for the required permanent behavioral or regression test. Use Go unless the direct-ASan/TSan-and-Go-infeasible C exception is explicitly justified. Unrelated fuzz-only tasks remain outside this routing. Maintenance-only edits to existing C tests that add no new behavioral or regression coverage remain allowed. This policy does not redirect Rust CLI or TypeScript UI tests.
 
 ## Canonical Module Structure
 
@@ -97,7 +111,8 @@ Conventions: `.claude/conventions/go.md` — read it before writing Go. Addition
 - [ ] `gofmt -w <changed files>` — run it, not just check.
 - [ ] `go vet ./...` — must pass with zero output.
 - [ ] `go build ./...` — must compile cleanly.
-- [ ] `go test -race ./modules/<name>/...` — must pass if tests exist.
+- [ ] `go test -count=1 <affected-package-paths...>` — run uncached tests for every changed or affected Go package, including packages under `bindings/go/`, `devices/`, root `tests/`, and `modules/*/tests/`.
+- [ ] When concurrency or race behavior is relevant, `go test -race -count=10 -run '<targeted test pattern>' <affected-package-paths...>` — repeat a targeted test 10–20 times for each relevant package. Do not race unrelated packages.
 - [ ] All new exported types have doc comments ending with period.
 - [ ] CGO: `runtime.Pinner` used for Go memory passed to C.
 - [ ] CGO: `C.CString` paired with `defer C.free`.

--- a/.rulesync/subagents/reviewer.md
+++ b/.rulesync/subagents/reviewer.md
@@ -272,6 +272,20 @@ violation of any of these with the same concrete-input standard as Step 2 —
 name the exact traffic/mode/harness gap and the wrong measurement or result
 it produces, not a generic reminder to "check benchmark validity".
 
+For a new permanent behavioral or regression test covering C, CGO, dataplane,
+or controlplane behavior, require a Go test in the suitable package and prefer
+`dataplane_ut` when it can exercise the behavior faithfully, even when the
+implementation fix is in C. Reject a permanent C test unless the brief or diff
+states that the test itself must run under direct ASan or TSan instrumentation
+and explains why Go cannot exercise the behavior faithfully. For an in-scope
+defect or behavior, a C fuzz target may provide additional coverage but never
+substitutes for the required permanent behavioral or regression test. Use Go
+unless the direct-ASan/TSan-and-Go-infeasible C exception is explicitly
+justified. Unrelated fuzz-only tasks remain outside this criterion. This
+criterion also does not apply to maintenance-only edits to existing C tests
+that add no new behavioral or regression coverage, or bug-hunter scratch
+reproducers, and does not redirect Rust CLI or TypeScript UI tests.
+
 ### TypeScript/Web UI
 
 - New pages are registered in `types.ts`, `App.tsx`, and `MainMenu.tsx`.


### PR DESCRIPTION
- Route permanent C, CGO, dataplane, and controlplane behavioral regression coverage to Go.
- Give the Go specialist ownership of repository Go tests, including mixed-language test roots and root bindings.
- Enforce the same ASan or TSan exception gate in agent charters and the public review skill while leaving bug-hunter scratch reproducers language-unrestricted.