### PR TITLE
refactor(controlplane): let a parked module carry its own teardown

### DIFF
--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 
 #include <fcntl.h>
+#include <signal.h>
 #include <unistd.h>
 
 #include <errno.h>
@@ -2318,6 +2319,22 @@ yanet_counter_handle_list_free(struct counter_handle_list *counters) {
 	free(counters);
 }
 
+// Whether the process recorded as pid is confirmed gone.
+//
+// Scoped narrowly to the parked-teardown pin below: it decides only
+// whether an already-set pin still means anything, never whether an agent
+// may be reclaimed on its own — a superseded agent's owning process is very
+// often still the live one doing the superseding, and gating reclaim on
+// that generally would leak an arena on every such update. Bias toward
+// "alive": kill() reports ESRCH only when the pid is unambiguously unused,
+// so a reused pid is misread as live, leaving one arena unreclaimed exactly
+// as it is today, rather than risking a false "dead" that frees memory a
+// running destructor is still walking.
+static bool
+agent_owner_process_is_dead(pid_t pid) {
+	return pid > 0 && kill(pid, 0) == -1 && errno == ESRCH;
+}
+
 // Unlocked body shared by agent_free_unused_agents and the agent_attach call
 // site, which already holds cp_config_lock itself.
 //
@@ -2337,10 +2354,14 @@ agent_free_unused_agents_locked(struct agent *agent) {
 	while (ADDR_OF(&agent->prev) != NULL) {
 		struct agent *prev_agent = ADDR_OF(&agent->prev);
 
+		bool teardown_pin_blocks =
+			prev_agent->parked_teardown_count != 0 &&
+			!agent_owner_process_is_dead(prev_agent->pid);
+
 		if (prev_agent->loaded_module_count == 0 &&
 		    prev_agent->loaded_device_count == 0 &&
 		    prev_agent->loaded_object_count == 0 &&
-		    prev_agent->parked_teardown_count == 0) {
+		    !teardown_pin_blocks) {
 			SET_OFFSET_OF(&agent->prev, ADDR_OF(&prev_agent->prev));
 			agent_cleanup(prev_agent);
 			continue;

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -64,9 +64,10 @@ struct agent {
 	// a nonzero count as a live reference, because those destructors
 	// still touch this agent's arena even though the generation counts
 	// above already read zero for them. A process that dies mid-teardown
-	// leaves this above zero forever, leaking that one superseded arena
-	// rather than risking a destructor running against memory that has
-	// already been freed.
+	// would otherwise leave this above zero forever, leaking that one
+	// superseded arena — the reclaim guard instead ignores this pin once
+	// pid is confirmed no longer running, rather than risking a
+	// destructor running against memory that has already been freed.
 	uint64_t parked_teardown_count;
 	struct agent *prev;
 	char name[80];
@@ -79,11 +80,11 @@ struct agent {
 	// Head of this agent's list of modules parked after their reference
 	// count reached zero.
 	//
-	// Parked entries await destruction until the next construction call
-	// for their module type reclaims them. A control plane can reuse one
-	// agent across more than one service, so this list may mix module
-	// types. Each type's construction reclaims only matching entries,
-	// leaving the rest parked for their own type's turn.
+	// Parked entries await destruction until the next construction call on
+	// this agent drains the whole list, invoking each entry's own stored
+	// teardown regardless of its module type. A control plane can reuse one
+	// agent across more than one service, so this list may mix types, but
+	// nothing needs to match them anymore.
 	struct cp_module *parked_modules;
 };
 

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -11,24 +11,23 @@
 #include "controlplane/config/zone.h"
 
 #include <stdio.h>
+#include <unistd.h>
 
-// Destroy every parked module of one type, using the caller's destructor
-// for that type.
+// Destroy every module parked on the agent, using each entry's own stored
+// destructor.
 //
-// A different type sharing the same parked list is left in place for its
-// own next call. A parked entry already sits at reference count zero, so
-// the destructor runs directly with no further release and nothing here
-// outlives this call. Matching entries are detached under the
-// configuration lock and destroyed outside it, because a type's teardown
-// can run tens of milliseconds and must not hold a lock every update
-// needs. While outside the lock, a teardown is marked in flight so the
-// arena cannot be reclaimed out from under an entry still being destroyed.
+// A parked entry already sits at reference count zero, so its destructor
+// runs directly with no further release. The whole list is detached under
+// the configuration lock and destroyed outside it, since a teardown can
+// run tens of milliseconds and must not hold a lock every update needs.
+// While outside the lock, the batch is marked in flight so the arena
+// cannot be reclaimed out from under it.
+//
+// A stored destructor is a code address, valid only inside the process
+// that wrote it. This cannot fire today, since it only ever runs against
+// the caller's own just-attached agent — it guards a future drain instead.
 static void
-cp_module_drain_parked(
-	struct agent *agent,
-	const char *module_type,
-	cp_module_free_handler destroy
-);
+cp_module_drain_parked(struct agent *agent);
 
 static int
 cp_module_build_perf_counters(struct cp_module *cp_module, yanet_error **err) {
@@ -71,8 +70,7 @@ cp_module_init(
 ) {
 	memset(cp_module, 0, sizeof(struct cp_module));
 
-	// Reclaim this type's parked entries before anything else here
-	// allocates.
+	// Reclaim every parked entry before anything else here allocates.
 	//
 	// The caller's own wrapper allocation already happened, but a parked
 	// instance can be most of the arena for a large type, so reclaiming
@@ -80,7 +78,7 @@ cp_module_init(
 	// pressure. Construction has not registered or parked this instance
 	// anywhere yet, so the walk below cannot observe it — only earlier
 	// instances left behind by a previous release.
-	cp_module_drain_parked(agent, module_type, destroy);
+	cp_module_drain_parked(agent);
 
 	struct dp_config *dp_config = ADDR_OF(&agent->dp_config);
 
@@ -97,6 +95,7 @@ cp_module_init(
 
 	strtcpy(cp_module->type, module_type, sizeof(cp_module->type));
 	strtcpy(cp_module->name, module_name, sizeof(cp_module->name));
+	cp_module->destroy = destroy;
 	memory_context_init_from(
 		&cp_module->memory_context, &agent->memory_context, module_name
 	);
@@ -380,61 +379,35 @@ cp_module_acquire(struct cp_module *cp_module) {
 }
 
 static void
-cp_module_drain_parked(
-	struct agent *agent,
-	const char *module_type,
-	cp_module_free_handler destroy
-) {
+cp_module_drain_parked(struct agent *agent) {
+	if (agent->pid != getpid()) {
+		return;
+	}
+
 	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
 
 	cp_config_lock(cp_config);
 
-	// Splice the target type's entries into a local list, leaving the
-	// rest linked in place for their own type's next call.
-	//
-	// A spliced-out tail leaves its former predecessor pointing at itself
-	// as the new end of the list, so a parked entry's link is never null.
-	struct cp_module *owned = NULL;
-	struct cp_module *prev = NULL;
-	struct cp_module *cur = ADDR_OF(&agent->parked_modules);
-
-	while (cur != NULL) {
-		struct cp_module *raw_next = ADDR_OF(&cur->parked_next);
-		struct cp_module *next = (raw_next == cur) ? NULL : raw_next;
-
-		if (!strncmp(cur->type, module_type, sizeof(cur->type))) {
-			if (prev == NULL) {
-				SET_OFFSET_OF(&agent->parked_modules, next);
-			} else {
-				SET_OFFSET_OF(
-					&prev->parked_next,
-					(next != NULL) ? next : prev
-				);
-			}
-			SET_OFFSET_OF(&cur->parked_next, owned);
-			owned = cur;
-		} else {
-			prev = cur;
-		}
-
-		cur = next;
-	}
-
+	struct cp_module *owned = ADDR_OF(&agent->parked_modules);
 	if (owned == NULL) {
 		cp_config_unlock(cp_config);
 		return;
 	}
+	SET_OFFSET_OF(&agent->parked_modules, NULL);
 
 	// Pin the agent's arena for the destroy loop below, still under the
-	// same lock the splice above ran under, so the reclaim guard can never
-	// observe the entries detached but the pin not yet set.
+	// same lock the take above ran under, so the reclaim guard can never
+	// observe the list cleared but the pin not yet set.
 	agent->parked_teardown_count += 1;
 
 	cp_config_unlock(cp_config);
 
 	while (owned != NULL) {
-		struct cp_module *next = ADDR_OF(&owned->parked_next);
-		destroy(owned);
+		// A self-referential link marks the list's tail.
+		struct cp_module *raw_next = ADDR_OF(&owned->parked_next);
+		struct cp_module *next = (raw_next == owned) ? NULL : raw_next;
+
+		owned->destroy(owned);
 		owned = next;
 	}
 

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -98,12 +98,23 @@ struct cp_module {
 	// Link to the next module parked on the same agent's list, once this
 	// module's reference count reaches zero.
 	//
-	// Only the zero-transition handler sets it, and only a later reclaim
-	// for this module's own type reads it. It stays unset until that
-	// transition happens. The parked list's tail refers to itself
-	// instead of ending at null, so a parked entry's link is never null
-	// — which also marks that this module is already parked.
+	// Only the zero-transition handler sets it, and only a later drain
+	// reads it. It stays unset until that transition happens. The parked
+	// list's tail refers to itself instead of ending at null, so a
+	// parked entry's link is never null — which also marks that this
+	// module is already parked.
 	struct cp_module *parked_next;
+
+	// Teardown for this module's own configuration data, set once at
+	// construction and never reassigned.
+	//
+	// A drain reads this directly off each parked entry instead of
+	// being told a type to match, so it can reclaim the whole list in
+	// one pass regardless of how many types share the agent. This is a
+	// plain code pointer, not a shared-memory offset: valid only inside
+	// the process that set it, which is why a drain must confirm the
+	// agent's owning process before calling it.
+	cp_module_free_handler destroy;
 };
 
 /**
@@ -152,18 +163,18 @@ cp_module_link_object(
  * Initialize a module configuration structure.
  *
  * Sets up counters and associates the module with the given agent. Before
- * any of that allocates, this reclaims whatever the agent parked for this
- * type since the last such call, using the destructor supplied here, so a
- * recreation under memory pressure benefits from the space a parked
- * instance would free rather than failing before reaching that reclaim.
- * The destructor is used only for this call and never stored. A different
- * type sharing the same agent is left for its own next call to collect.
+ * any of that allocates, this drains everything the agent has parked since
+ * the last such call, using each entry's own stored destructor, so a
+ * recreation under memory pressure benefits from the space parked instances
+ * would free rather than failing before reaching that reclaim. The
+ * destructor passed here is stored on this new configuration for its own
+ * eventual parking, not used to reclaim anything today.
  *
  * @param cp_module Pointer to the module configuration to initialize
  * @param agent Pointer to the controlplane agent owning this module
  * @param module_type Type identifier for the module
  * @param module_name Name identifier for the module
- * @param destroy Destructor for a parked module of this same type
+ * @param destroy Destructor for this module's own configuration data
  * @param err Error output parameter
  * @return 0 on success, negative error code on failure
  */
@@ -191,9 +202,9 @@ cp_module_fini(struct cp_module *cp_module);
 // the same way from a registry drop or an explicit release.
 //
 // Parks the module on its agent's list instead of destroying it, because
-// this generic layer does not know the module's type, and an agent can
-// host more than one type at once — as when acl and fwstate share one.
-// The module's own type-specific reclaim destroys it later.
+// this generic layer does not know how to tear down a module's own
+// configuration data. The module's own stored destructor destroys it
+// later, when the agent's next construction call drains the list.
 //
 // Idempotent: once set, a parked entry's link is never null again, so a
 // duplicate transition leaves it in place instead of relinking it. Every
@@ -207,9 +218,8 @@ cp_module_registry_item_free_cb(struct registry_item *item, void *data);
 // The zero-transition handler runs only when this drop is the last
 // reference, so a caller must not assume the call freed anything: a live
 // or pinned configuration generation may still hold the module. A module
-// parked here is not destroyed on the spot — the next construction call
-// for the same type reclaims it, or it is freed along with the agent's
-// arena.
+// parked here is not destroyed on the spot — the agent's next construction
+// call of any type drains it, or it is freed along with the agent's arena.
 //
 // Takes the module's own agent's configuration lock itself, unlike the
 // registry-driven path to the same handler, which already runs under

--- a/lib/controlplane/tests/meson.build
+++ b/lib/controlplane/tests/meson.build
@@ -157,7 +157,6 @@ parked_modules_test = executable(
     lib_logging_dep,
     lib_errors_dep,
     lib_decap_cp_dep,
-    lib_forward_cp_dep,
     libdpdk_dep,
   ],
   link_with: [lib_decap_dp, lib_forward_dp],

--- a/lib/controlplane/tests/parked_modules_test.c
+++ b/lib/controlplane/tests/parked_modules_test.c
@@ -1,11 +1,13 @@
 /*
  * Regression test for the module-parking mechanism: a construction call
- * must reclaim only parked entries of its own type, and parking an
- * already-parked module must not extend the list into a cycle.
+ * drains every parked entry on the agent through each entry's own stored
+ * teardown, and parking an already-parked module must not extend the list
+ * into a cycle.
  */
 
 #include "api/agent.h"
 
+#include "common/container_of.h"
 #include "common/memory.h"
 #include "common/memory_block.h"
 #include "common/test_assert.h"
@@ -15,135 +17,246 @@
 #include "controlplane/config/zone.h"
 
 #include "modules/decap/api/controlplane.h"
-#include "modules/forward/api/controlplane.h"
 
 #include "lib/dataplane_ut/dataplane_ut.h"
 #include "lib/errors/errors.h"
 
 #include "logging/log.h"
 
+#include <errno.h>
+#include <signal.h>
+#include <stdbool.h>
 #include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
-#define PARKED_TEST_MEMORY_LIMIT (2u * 1024u * 1024u)
+#define PARKED_TEST_MEMORY_LIMIT (1024u * 1024u)
 
-// Reproduces a real cross-service parking scenario: releasing one
-// service's module while another service shares the same agent.
+// Frees any error a failed call above just set, before the TEST_ASSERT_*
+// macro below returns on that same failure. Every call in this file that
+// takes `&err` is expected to succeed, so this is a no-op on the ordinary
+// path; it only fires on a genuine assertion failure, so that failure's
+// real signal is not buried under an unrelated leak report.
+static void
+free_err_on_failure(bool failed, yanet_error **err) {
+	if (failed) {
+		yanet_error_free(*err);
+		*err = NULL;
+	}
+}
+
+// A minimal cp_module wrapper standing in for a real module's own config
+// struct, used to drive distinguishable teardowns without depending on any
+// real module's internal layout.
+struct fake_module_config {
+	struct cp_module cp_module;
+	int id;
+};
+
+#define FAKE_DESTROY_LOG_CAP 8
+
+static int fake_destroy_a_ids[FAKE_DESTROY_LOG_CAP];
+static size_t fake_destroy_a_count;
+static int fake_destroy_b_ids[FAKE_DESTROY_LOG_CAP];
+static size_t fake_destroy_b_count;
+
+static void
+fake_module_config_destroy_common(
+	struct cp_module *cp_module, int *ids, size_t *count
+) {
+	struct fake_module_config *fake =
+		container_of(cp_module, struct fake_module_config, cp_module);
+	struct agent *agent = ADDR_OF(&cp_module->agent);
+
+	if (*count < FAKE_DESTROY_LOG_CAP) {
+		ids[(*count)++] = fake->id;
+	}
+
+	cp_module_fini(cp_module);
+	memory_bfree(&agent->memory_context, fake, sizeof(*fake));
+}
+
+static void
+fake_module_config_destroy_a(struct cp_module *cp_module) {
+	fake_module_config_destroy_common(
+		cp_module, fake_destroy_a_ids, &fake_destroy_a_count
+	);
+}
+
+static void
+fake_module_config_destroy_b(struct cp_module *cp_module) {
+	fake_module_config_destroy_common(
+		cp_module, fake_destroy_b_ids, &fake_destroy_b_count
+	);
+}
+
+static struct cp_module *
+fake_module_config_new(
+	struct agent *agent,
+	const char *module_type,
+	const char *module_name,
+	int id,
+	cp_module_free_handler destroy,
+	yanet_error **err
+) {
+	struct fake_module_config *fake =
+		(struct fake_module_config *)memory_balloc(
+			&agent->memory_context,
+			sizeof(struct fake_module_config)
+		);
+	if (fake == NULL) {
+		return NULL;
+	}
+
+	if (cp_module_init(
+		    &fake->cp_module,
+		    agent,
+		    module_type,
+		    module_name,
+		    destroy,
+		    err
+	    )) {
+		memory_bfree(&agent->memory_context, fake, sizeof(*fake));
+		return NULL;
+	}
+	fake->id = id;
+
+	return &fake->cp_module;
+}
+
+// A drain reclaims every parked entry regardless of type, each through its
+// own stored teardown rather than a teardown belonging to some other entry.
 //
-// In production, acl and fwstate share one agent. A released fwstate
-// handle parks once its last reference drops, and an unrelated acl update
-// must leave it alone. Decap and forward stand in for fwstate and acl
-// here, since both link into every test harness. A release no longer
-// reclaims by itself, so whichever module each type releases last here
-// stays parked until a later construction of that same type reclaims it.
+// Parks a decap-typed and a forward-typed fake module, both under one
+// agent, then triggers the drain with a decap construction — the type one
+// of the two parked entries shares, and the other does not. Recording each
+// teardown's own log lets the assertions tell "both entries destroyed, each
+// by its own handler" apart from "one handler destroyed everything", which
+// a bare list-emptied check cannot.
+//
+// Parking is driven the way production drives it: a manual registry stands
+// in for a live configuration generation holding both fakes, and only
+// retiring that generation — not the creator's own release beforehand —
+// drops each to zero references and parks it.
 static int
-test_drain_parked_filters_by_type(struct yanet_shm *shm) {
+test_drain_reclaims_every_type_via_own_teardown(struct yanet_shm *shm) {
 	yanet_error *err = NULL;
 
 	struct agent *agent = agent_attach(
-		shm, 0, "parked-drain-filter", PARKED_TEST_MEMORY_LIMIT, &err
+		shm,
+		0,
+		"parked-drain-every-type",
+		PARKED_TEST_MEMORY_LIMIT,
+		&err
 	);
+	free_err_on_failure(agent == NULL, &err);
 	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
 
-	struct cp_module *decap0 = decap_module_config_new(agent, "d0", &err);
-	TEST_ASSERT_NOT_NULL(decap0, "decap_module_config_new failed");
+	fake_destroy_a_count = 0;
+	fake_destroy_b_count = 0;
 
-	// Simulate a live generation holding decap0: a manual registry
+	struct cp_module *decap_fake = fake_module_config_new(
+		agent,
+		"decap",
+		"fake-decap",
+		1,
+		fake_module_config_destroy_a,
+		&err
+	);
+	free_err_on_failure(decap_fake == NULL, &err);
+	TEST_ASSERT_NOT_NULL(decap_fake, "fake_module_config_new failed");
+
+	struct cp_module *forward_fake = fake_module_config_new(
+		agent,
+		"forward",
+		"fake-forward",
+		2,
+		fake_module_config_destroy_b,
+		&err
+	);
+	free_err_on_failure(forward_fake == NULL, &err);
+	TEST_ASSERT_NOT_NULL(forward_fake, "fake_module_config_new failed");
+
+	// Simulate a live generation holding both fakes: a manual registry
 	// reference, exactly like an install would take.
 	struct cp_module_registry reg;
-	TEST_ASSERT_SUCCESS(
-		cp_module_registry_init(&agent->memory_context, &reg, &err),
-		"cp_module_registry_init failed"
+	int reg_init_rc =
+		cp_module_registry_init(&agent->memory_context, &reg, &err);
+	free_err_on_failure(reg_init_rc != TEST_SUCCESS, &err);
+	TEST_ASSERT_SUCCESS(reg_init_rc, "cp_module_registry_init failed");
+	int decap_upsert_rc = cp_module_registry_upsert(
+		&reg, "decap", "fake-decap", decap_fake, &err
 	);
+	free_err_on_failure(decap_upsert_rc != TEST_SUCCESS, &err);
 	TEST_ASSERT_SUCCESS(
-		cp_module_registry_upsert(&reg, "decap", "d0", decap0, &err),
-		"cp_module_registry_upsert failed"
+		decap_upsert_rc, "cp_module_registry_upsert failed"
+	);
+	int forward_upsert_rc = cp_module_registry_upsert(
+		&reg, "forward", "fake-forward", forward_fake, &err
+	);
+	free_err_on_failure(forward_upsert_rc != TEST_SUCCESS, &err);
+	TEST_ASSERT_SUCCESS(
+		forward_upsert_rc, "cp_module_registry_upsert failed"
 	);
 
-	// Release the creator's own reference, exactly as decap's control
-	// plane does on free.
+	// Release each creator's own reference, exactly as a module's real
+	// public free does.
 	//
-	// The generation reference above still holds decap0 alive, so
+	// The generation reference above still holds both fakes alive, so
 	// nothing parks yet.
-	decap_module_config_free(decap0);
+	cp_module_release(decap_fake);
+	cp_module_release(forward_fake);
 	TEST_ASSERT_NULL(
 		ADDR_OF(&agent->parked_modules),
-		"nothing must be parked while a generation still holds decap0"
+		"nothing must be parked while a generation still holds the "
+		"configuration"
 	);
 
-	// Retire the generation: its last reference drops and decap0 parks.
+	// Retire the generation: its last reference on each fake drops and
+	// both park.
 	cp_module_registry_fini(&reg);
-	TEST_ASSERT(
-		ADDR_OF(&agent->parked_modules) == decap0,
-		"decap0 must be parked once its last reference drops"
+	TEST_ASSERT_NOT_NULL(
+		ADDR_OF(&agent->parked_modules),
+		"both fakes must be parked once their generation retires"
 	);
 
-	// An unrelated forward construction must not touch a parked decap
-	// module.
-	struct cp_module *forward0 =
-		forward_module_config_init(agent, "f0", &err);
-	TEST_ASSERT_NOT_NULL(forward0, "forward_module_config_init failed");
-	TEST_ASSERT(
-		ADDR_OF(&agent->parked_modules) == decap0,
-		"forward's own construction must leave a parked decap module "
-		"untouched"
+	// Trigger the drain via a decap construction, which shares only the
+	// first fake's type.
+	struct cp_module *trigger = fake_module_config_new(
+		agent,
+		"decap",
+		"fake-trigger",
+		3,
+		fake_module_config_destroy_a,
+		&err
 	);
+	free_err_on_failure(trigger == NULL, &err);
+	TEST_ASSERT_NOT_NULL(trigger, "fake_module_config_new failed");
 
-	// A decap construction reaches its own type's parked list and
-	// destroys decap0.
-	struct cp_module *decap1 = decap_module_config_new(agent, "d1", &err);
-	TEST_ASSERT_NOT_NULL(decap1, "decap_module_config_new failed");
 	TEST_ASSERT_NULL(
 		ADDR_OF(&agent->parked_modules),
-		"decap's own construction must reclaim the parked decap module"
-	);
-
-	// Steady state: exactly one live decap and one live forward module.
-	// Reconstructing each type below must return to this same byte count.
-	size_t checkpoint = block_allocator_free_size(&agent->block_allocator);
-
-	// Freeing the only live instance of each type parks it instead of
-	// destroying it: nothing constructs that type again yet to reclaim it.
-	forward_module_config_free(forward0);
-	decap_module_config_free(decap1);
-	TEST_ASSERT(
-		ADDR_OF(&agent->parked_modules) == decap1,
-		"the last release of each type must park it, not destroy it"
-	);
-	TEST_ASSERT(
-		ADDR_OF(&decap1->parked_next) == forward0,
-		"parking must chain onto the existing list head"
-	);
-	TEST_ASSERT(
-		ADDR_OF(&forward0->parked_next) == forward0,
-		"the list tail stays self-referential"
+		"a construction of either parked type must drain the whole list"
 	);
 	TEST_ASSERT_EQUAL(
-		(long)block_allocator_free_size(&agent->block_allocator),
-		(long)checkpoint,
-		"parking must not itself move memory"
-	);
-
-	// A later construction of each type reclaims what its own release
-	// left parked, exactly as decap1 reclaimed decap0 above.
-	struct cp_module *decap2 = decap_module_config_new(agent, "d2", &err);
-	TEST_ASSERT_NOT_NULL(decap2, "decap_module_config_new failed");
-	TEST_ASSERT(
-		ADDR_OF(&agent->parked_modules) == forward0,
-		"a decap construction must reclaim only the parked decap module"
-	);
-
-	struct cp_module *forward1 =
-		forward_module_config_init(agent, "f1", &err);
-	TEST_ASSERT_NOT_NULL(forward1, "forward_module_config_init failed");
-	TEST_ASSERT_NULL(
-		ADDR_OF(&agent->parked_modules),
-		"a forward construction must reclaim the parked forward module"
+		(long)fake_destroy_a_count,
+		1L,
+		"the decap fake's own teardown must have run exactly once"
 	);
 	TEST_ASSERT_EQUAL(
-		(long)block_allocator_free_size(&agent->block_allocator),
-		(long)checkpoint,
-		"replacing each type's parked predecessor must return to the "
-		"same steady state"
+		(long)fake_destroy_b_count,
+		1L,
+		"the forward fake's own teardown must have run exactly once"
+	);
+	TEST_ASSERT(
+		fake_destroy_a_ids[0] == 1,
+		"the decap fake's own teardown must have destroyed the decap "
+		"fake"
+	);
+	TEST_ASSERT(
+		fake_destroy_b_ids[0] == 2,
+		"the forward fake's own teardown must have destroyed the "
+		"forward "
+		"fake"
 	);
 
 	agent_detach(agent);
@@ -166,21 +279,27 @@ test_park_is_idempotent(struct yanet_shm *shm) {
 	struct agent *agent = agent_attach(
 		shm, 0, "parked-park-idempotent", PARKED_TEST_MEMORY_LIMIT, &err
 	);
+	free_err_on_failure(agent == NULL, &err);
 	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
 
 	struct cp_module *decap_old =
 		decap_module_config_new(agent, "idem-old", &err);
+	free_err_on_failure(decap_old == NULL, &err);
 	TEST_ASSERT_NOT_NULL(decap_old, "decap_module_config_new failed");
 	struct cp_module *decap_new =
 		decap_module_config_new(agent, "idem-new", &err);
+	free_err_on_failure(decap_new == NULL, &err);
 	TEST_ASSERT_NOT_NULL(decap_new, "decap_module_config_new failed");
 
 	size_t checkpoint = block_allocator_free_size(&agent->block_allocator);
 
 	// Park the older module first, then the newer one on top of it: head
-	// decap_new, tail decap_old self-referential.
-	cp_module_registry_item_free_cb(&decap_old->config_item, NULL);
-	cp_module_registry_item_free_cb(&decap_new->config_item, NULL);
+	// decap_new, tail decap_old self-referential. Each is freed through
+	// the real public free a decap control plane calls, dropping the
+	// creator's only reference straight to zero — the module's real
+	// public free parks rather than destroys.
+	decap_module_config_free(decap_old);
+	decap_module_config_free(decap_new);
 	TEST_ASSERT(
 		ADDR_OF(&agent->parked_modules) == decap_new,
 		"the second park must move the head to decap_new"
@@ -228,17 +347,99 @@ test_park_is_idempotent(struct yanet_shm *shm) {
 		"memory"
 	);
 
-	// A later decap construction reclaims every parked entry of its own
-	// type, decap_old and decap_new alike.
+	// A later decap construction reclaims every parked entry, decap_old
+	// and decap_new alike.
 	struct cp_module *decap_next =
 		decap_module_config_new(agent, "idem-next", &err);
+	free_err_on_failure(decap_next == NULL, &err);
 	TEST_ASSERT_NOT_NULL(decap_next, "decap_module_config_new failed");
 	TEST_ASSERT_NULL(
 		ADDR_OF(&agent->parked_modules),
-		"construction must reclaim every parked module of its own type"
+		"construction must reclaim every parked module"
 	);
 
 	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+// Whether the process identified by pid is confirmed to no longer exist.
+static int
+process_is_dead(pid_t pid) {
+	return pid > 0 && kill(pid, 0) == -1 && errno == ESRCH;
+}
+
+// The reclaim guard ignores a parked-teardown pin once its owning process
+// is confirmed dead, but still honours one owned by a running process.
+//
+// Neither agent here ever actually parks a real module: the guard's
+// decision depends only on the pin count and the recorded pid, so setting
+// those fields directly is enough to drive it. Reuses agent_attach's own
+// internal reclaim pass — every attach under a name already in use retires
+// its predecessor the same way a real update would.
+static int
+test_pin_staleness_governs_reclaim(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	// A pid guaranteed to no longer exist: fork a child, let it exit
+	// immediately, and reap it so its pid cannot still be running.
+	pid_t dead_pid = fork();
+	TEST_ASSERT(dead_pid >= 0, "fork failed");
+	if (dead_pid == 0) {
+		_exit(0);
+	}
+	int wstatus = 0;
+	TEST_ASSERT(
+		waitpid(dead_pid, &wstatus, 0) == dead_pid, "waitpid failed"
+	);
+	TEST_ASSERT(
+		process_is_dead(dead_pid),
+		"the reaped child's pid must read as dead before the test "
+		"proceeds"
+	);
+
+	struct agent *dead_owner_v1 = agent_attach(
+		shm, 0, "parked-pin-dead-owner", PARKED_TEST_MEMORY_LIMIT, &err
+	);
+	free_err_on_failure(dead_owner_v1 == NULL, &err);
+	TEST_ASSERT_NOT_NULL(dead_owner_v1, "agent_attach failed");
+	dead_owner_v1->pid = dead_pid;
+	dead_owner_v1->parked_teardown_count = 1;
+
+	struct agent *dead_owner_v2 = agent_attach(
+		shm, 0, "parked-pin-dead-owner", PARKED_TEST_MEMORY_LIMIT, &err
+	);
+	free_err_on_failure(dead_owner_v2 == NULL, &err);
+	TEST_ASSERT_NOT_NULL(dead_owner_v2, "agent_attach failed");
+	TEST_ASSERT_NULL(
+		ADDR_OF(&dead_owner_v2->prev),
+		"a pin whose owning process is confirmed dead must not block "
+		"reclaim"
+	);
+
+	struct agent *live_owner_v1 = agent_attach(
+		shm, 0, "parked-pin-live-owner", PARKED_TEST_MEMORY_LIMIT, &err
+	);
+	free_err_on_failure(live_owner_v1 == NULL, &err);
+	TEST_ASSERT_NOT_NULL(live_owner_v1, "agent_attach failed");
+	live_owner_v1->pid = getpid();
+	live_owner_v1->parked_teardown_count = 1;
+
+	struct agent *live_owner_v2 = agent_attach(
+		shm, 0, "parked-pin-live-owner", PARKED_TEST_MEMORY_LIMIT, &err
+	);
+	free_err_on_failure(live_owner_v2 == NULL, &err);
+	TEST_ASSERT_NOT_NULL(live_owner_v2, "agent_attach failed");
+	TEST_ASSERT(
+		ADDR_OF(&live_owner_v2->prev) == live_owner_v1,
+		"a pin whose owning process is still running must block reclaim"
+	);
+
+	// Clear the fabricated pin so nothing downstream mistakes this agent
+	// for one with a real teardown still in flight.
+	live_owner_v1->parked_teardown_count = 0;
+
+	agent_detach(dead_owner_v2);
+	agent_detach(live_owner_v2);
 	return TEST_SUCCESS;
 }
 
@@ -249,7 +450,7 @@ main(void) {
 	const char *mods_to_load[] = {"decap", "forward"};
 
 	struct dataplane_ut_config cfg = {
-		.cp_memory = 1u << 24,
+		.cp_memory = 1u << 26,
 		.dp_memory = 1u << 20,
 		.worker_count = 1,
 		.modules = mods_to_load,
@@ -269,9 +470,12 @@ main(void) {
 		return 1;
 	}
 
-	int res = test_drain_parked_filters_by_type(shm);
+	int res = test_drain_reclaims_every_type_via_own_teardown(shm);
 	if (res == TEST_SUCCESS) {
 		res = test_park_is_idempotent(shm);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_pin_staleness_governs_reclaim(shm);
 	}
 
 	dataplane_ut_free(ut);

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -36,7 +36,7 @@ _Static_assert(
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct cp_module) == 576,
+	sizeof(struct cp_module) == 584,
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 15
+#define YANET_MODULE_ABI_VERSION 16
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/modules/acl/tests/functional/acl_fwstate_agent_test.go
+++ b/modules/acl/tests/functional/acl_fwstate_agent_test.go
@@ -1,6 +1,7 @@
 package acl_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,33 +41,78 @@ func setupACLFWStateHarness(tb testing.TB) (*ffi.Agent, acl.Backend) {
 	return agent, backend
 }
 
-// TestACL_FWStateAgentSharing_ParkedModuleSurvivesUnrelatedDrain reproduces
-// production agent sharing where fwstate parks during an ACL drain.
+// aclSharedAgentRootMemoryNode returns the shared "acl" agent's own root
+// memory-context node.
+//
+// A parked entry's own stored teardown frees its outer struct directly
+// against this root context, so BFreeCount/BFreeSize advance once and only
+// once per real teardown, unlike the live-module count, which never
+// observes a park.
+func aclSharedAgentRootMemoryNode(t *testing.T, agent *ffi.Agent) ffi.AgentMemoryNode {
+	t.Helper()
+
+	const agentName = "acl"
+	for _, agentInfo := range agent.DPConfig().Agents() {
+		if agentInfo.Name != agentName {
+			continue
+		}
+		require.Lenf(t, agentInfo.Instances, 1, "agent %q: expected exactly one live instance", agentName)
+
+		for _, node := range agentInfo.Instances[0].MemoryTree {
+			if node.ParentIdx == math.MaxUint32 {
+				return node
+			}
+		}
+		t.Fatalf("agent %q: no root memory-context node in its snapshot", agentName)
+	}
+
+	t.Fatalf("agent %q not found in dataplane config", agentName)
+	return ffi.AgentMemoryNode{}
+}
+
+// TestACL_FWStateAgentSharing_UnrelatedUpdateReclaimsParkedModule pins the
+// type-agnostic drain contract: constructing an access-control module on
+// the shared agent reclaims a parked firewall-state entry through that
+// entry's own stored teardown, not just entries of the constructing type.
 //
 // The acl module attaches one agent and hands it to both the ACL and
-// fwstate services. The sequence mirrors the fwstate service's own release
-// path, followed by a delete that retires the generation still pinning it,
-// parking the module before the ACL update runs. A drain call must stay
-// scoped to its own module type: destroying the parked fwstate module with
-// the wrong destructor would corrupt the arena during the filter
-// compiler's teardown.
-func TestACL_FWStateAgentSharing_ParkedModuleSurvivesUnrelatedDrain(t *testing.T) {
+// fwstate services, so this is the only place in the tree where a drain
+// actually crosses module types. fw0 is built with real maps, then
+// detached before release the way the fwstate service detaches a
+// superseded config's maps: leaving them attached instead would trip the
+// separate, already-filed map-ownership gap (#2003), which this test is
+// not about. A release alone must not run fw0's teardown; only the later
+// ACL construction, sharing the agent but not fw0's type, does.
+func TestACL_FWStateAgentSharing_UnrelatedUpdateReclaimsParkedModule(t *testing.T) {
 	agent, backend := setupACLFWStateHarness(t)
 
 	fwCfg, err := cfwstate.NewModuleConfig(agent, "fw0")
 	require.NoError(t, err)
+	require.NoError(t, fwCfg.CreateMaps(cfwstate.MapConfig{
+		IndexSize:        1024,
+		ExtraBucketCount: 64,
+	}, 1))
 	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{fwCfg.AsFFIModule()}))
 
-	// Release the creator's reference while the published generation
-	// still holds fw0: it must not park yet.
+	// Detach fw0's maps before releasing it, mirroring the fwstate
+	// service's own supersede path, then release the creator's reference
+	// while the published generation still holds fw0: it must not park
+	// yet.
+	fwCfg.DetachMaps()
 	fwCfg.Free()
 
 	// Retiring the generation that still references fw0 is what actually
 	// parks it.
 	require.NoError(t, agent.DeleteModuleConfig("fwstate", "fw0"))
 
-	// An ACL update on the shared agent must not touch the parked fwstate
-	// module: its own drain call is filtered to the acl type.
+	afterPark := aclSharedAgentRootMemoryNode(t, agent)
+	require.Equalf(
+		t, uint64(0), afterPark.BFreeCount,
+		"parking fw0 must not itself run its teardown",
+	)
+
+	// An ACL construction on the shared agent is the only call able to
+	// reach fw0 next: it shares the agent but not fw0's module type.
 	rules := []cacl.AclRule{
 		allow4Rule(
 			filter.IPNets{filter.UnspecifiedIPv4},
@@ -76,4 +122,15 @@ func TestACL_FWStateAgentSharing_ParkedModuleSurvivesUnrelatedDrain(t *testing.T
 	}
 	handle := applyACLRules(t, backend, "acl0", rules)
 	require.NotNil(t, handle)
+
+	afterACLUpdate := aclSharedAgentRootMemoryNode(t, agent)
+	require.Equalf(
+		t, afterPark.BFreeCount+1, afterACLUpdate.BFreeCount,
+		"the ACL construction must drain fw0 through its own stored teardown",
+	)
+	require.Greaterf(
+		t, afterACLUpdate.BFreeSize, afterPark.BFreeSize,
+		"fw0's teardown must have reclaimed its own bytes, not merely "+
+			"emptied the parked list",
+	)
 }

--- a/modules/fwstate/tests/dataplane/harness.c
+++ b/modules/fwstate/tests/dataplane/harness.c
@@ -2,6 +2,7 @@
 
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 // Allocate and initialize a stand-in agent for a test that needs the real
 // structure behind it, not just a bare memory context, such as one that
@@ -22,6 +23,11 @@ fwstate_test_agent_new(struct memory_context *parent, const char *name) {
 
 	memset(agent, 0, sizeof(struct agent));
 	memory_context_init_from(&agent->memory_context, parent, name);
+
+	// Matches production agent_attach, which stamps the attaching
+	// process's own pid: the parked-entry drain refuses to run a stored
+	// teardown against any other pid.
+	agent->pid = getpid();
 
 	return agent;
 }
@@ -123,41 +129,26 @@ cp_module_release(struct cp_module *cp_module) {
 
 // Reproduces the production parked-entry reclaim, folded into
 // construction below the same way the real implementation folds it in.
+//
+// Drains every parked entry through its own stored destructor rather than
+// matching a type, mirroring lib/controlplane/config/cp_module.c.
 static void
-cp_module_drain_parked(
-	struct agent *agent,
-	const char *module_type,
-	cp_module_free_handler destroy
-) {
-	struct cp_module *owned = NULL;
-	struct cp_module *prev = NULL;
-	struct cp_module *cur = ADDR_OF(&agent->parked_modules);
-
-	while (cur != NULL) {
-		struct cp_module *raw_next = ADDR_OF(&cur->parked_next);
-		struct cp_module *next = (raw_next == cur) ? NULL : raw_next;
-
-		if (!strncmp(cur->type, module_type, sizeof(cur->type))) {
-			if (prev == NULL) {
-				SET_OFFSET_OF(&agent->parked_modules, next);
-			} else {
-				SET_OFFSET_OF(
-					&prev->parked_next,
-					(next != NULL) ? next : prev
-				);
-			}
-			SET_OFFSET_OF(&cur->parked_next, owned);
-			owned = cur;
-		} else {
-			prev = cur;
-		}
-
-		cur = next;
+cp_module_drain_parked(struct agent *agent) {
+	if (agent->pid != getpid()) {
+		return;
 	}
 
+	struct cp_module *owned = ADDR_OF(&agent->parked_modules);
+	if (owned == NULL) {
+		return;
+	}
+	SET_OFFSET_OF(&agent->parked_modules, NULL);
+
 	while (owned != NULL) {
-		struct cp_module *next = ADDR_OF(&owned->parked_next);
-		destroy(owned);
+		struct cp_module *raw_next = ADDR_OF(&owned->parked_next);
+		struct cp_module *next = (raw_next == owned) ? NULL : raw_next;
+
+		owned->destroy(owned);
 		owned = next;
 	}
 }
@@ -177,9 +168,9 @@ cp_module_init(
 	// lib/controlplane/config/cp_module.c:13-74)
 	memset(cp_module, 0, sizeof(struct cp_module));
 
-	// Reclaim this type's parked entries first, the same as production
-	// does, before this construction allocates anything of its own.
-	cp_module_drain_parked(agent, module_type, destroy);
+	// Reclaim every parked entry first, the same as production does,
+	// before this construction allocates anything of its own.
+	cp_module_drain_parked(agent);
 
 	// We don't have dp_config in tests, so skip dp_module_idx lookup
 	cp_module->dp_module_idx = 0;
@@ -187,6 +178,7 @@ cp_module_init(
 	// Copy module type and name
 	strncpy(cp_module->type, module_type, sizeof(cp_module->type) - 1);
 	strncpy(cp_module->name, module_name, sizeof(cp_module->name) - 1);
+	cp_module->destroy = destroy;
 
 	// Initialize memory context from agent
 	memory_context_init_from(


### PR DESCRIPTION
Stacked on #1998; the diff against `main` will not read correctly until that merges. This branch will be rebased then, and its base is expected to move to the map-ownership fix, which lands first.

In #1998 a released module configuration parks on a list owned by its agent, and only a construction of its **own type** reclaims it, because only that caller knows which teardown to apply. Two costs follow from that matching. The drain has to remove entries from the middle of a mixed list, which is the most delicate code in that change — a reviewer had to hand-trace four orderings of head, middle, tail and sole-node splices. And an entry whose type is never constructed again stays parked until the process exits, which is exactly the shape of a delete-only workload.

Storing the teardown in the entry removes the reason for both. The drain takes the whole list, clears the head, and calls each entry's own handler, so any construction on that agent reclaims everything. The type filter, the predecessor tracking, the tail relinking and the string comparison all go, along with the question of whether a truncated type could match the wrong module.

## The cost this introduces, and what pays for it

A stored handler is a code address living in shared memory, in a segment the dataplane maps. It is valid only inside the process that wrote it.

Nothing calls a stale one today: the drain runs only against the agent the caller just attached, and a superseded agent's arena is freed wholesale rather than walked. But that safety was an invariant nothing in the code stated, and the most natural future change — draining a superseded agent before reclaiming its arena — would violate it by jumping into a dead process's address space. The drain now refuses to run against an agent owned by another process, so the invariant is checked rather than promised.

## The teardown pin stays

Removing it was the original intent here and it was wrong. The window it guards — entries detached from the list while destructors run unlocked — does not require two processes fighting over one agent name, which the documented precondition forbids. It also opens when the **same** process attaches that name again, and the built-in function and pipeline services attach per request, so one goroutine can supersede an agent another is mid-drain on. That is ordinary behaviour, not a violated contract.

What does change is the pin's one bad property. A process dying inside a teardown used to leave the count above zero forever, so that arena was never reclaimed again. Liveness of the recorded owner now decides whether an existing pin still means anything — scoped to that question only, deliberately not a general precondition for reclaiming, since a superseded agent's owner is very often the same live process and gating reclamation on it would leak an arena per request.

## Shared memory layout

The module configuration structure grew by the stored handler, so the tripwire literal moves and the module ABI version is raised. Picking this up requires `go clean -cache`, removing stale standalone binaries, and wiping `/dev/hugepages/yanet*` along with cached functional-test images.

## Tests

The test that pinned the old contract asserted a parked entry survives an unrelated module's drain, and after this change it still passed — its firewall-state configuration never created maps, so nothing observable happened either way. It is inverted to assert the new contract and given real maps, and it fails on its own reclamation assertion when a type comparison is put back.

The drain test now pins that each entry is destroyed by **its own** handler rather than that the list emptied, which a single wrong handler applied to everything would also achieve. Both it and the pin-staleness test were re-proven by mutation after being reworked to park through the real registry rather than by calling the zero-reference handler directly, which had been fabricating a state the code forbids.
