### PR TITLE
fix(acl,fwstate): hold the firewall-state config whose maps are borrowed

### DIFF
--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -364,6 +364,21 @@ cp_module_release(struct cp_module *cp_module) {
 	}
 }
 
+void
+cp_module_acquire(struct cp_module *cp_module) {
+	struct agent *agent = ADDR_OF(&cp_module->agent);
+	struct cp_config *cp_config =
+		(agent != NULL) ? ADDR_OF(&agent->cp_config) : NULL;
+
+	if (cp_config != NULL) {
+		cp_config_lock(cp_config);
+	}
+	registry_item_ref(&cp_module->config_item);
+	if (cp_config != NULL) {
+		cp_config_unlock(cp_config);
+	}
+}
+
 static void
 cp_module_drain_parked(
 	struct agent *agent,

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -217,6 +217,19 @@ cp_module_registry_item_free_cb(struct registry_item *item, void *data);
 void
 cp_module_release(struct cp_module *cp_module);
 
+// Take an external reference on a module configuration, matched later by
+// cp_module_release, so it outlives its own construction lifetime.
+//
+// The caller must already hold a live reference — acquiring on a
+// zero-count configuration does not unpark it, so the next drain of that
+// type destroys it under the new holder.
+//
+// Takes the module's own agent's configuration lock itself. Must not
+// already be held: it is a non-reentrant cross-process spinlock, and
+// nesting it hangs the instance.
+void
+cp_module_acquire(struct cp_module *cp_module);
+
 struct cp_module_registry {
 	struct memory_context *memory_context;
 	struct registry registry;

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 14
+#define YANET_MODULE_ABI_VERSION 15
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/modules/acl/api/controlplane.c
+++ b/modules/acl/api/controlplane.c
@@ -99,8 +99,14 @@ acl_module_config_destroy(struct cp_module *cp_module) {
 
 	cp_module_fini(cp_module);
 
-	// Note: We don't destroy fwstate_cfg maps here because they're owned by
-	// the fwstate module. We only stored offsets to them.
+	// fwstate_cfg's maps are not freed here: they are owned by the
+	// fwstate module, and this config only ever stored offsets into
+	// them plus a reference on their owner, dropped below.
+	struct cp_module *fwstate_owner = ADDR_OF(&config->fwstate_owner);
+	if (fwstate_owner != NULL) {
+		cp_module_release(fwstate_owner);
+	}
+
 	memory_bfree(
 		&agent->memory_context,
 		cp_module,
@@ -154,6 +160,7 @@ acl_module_config_init(
 
 	// Initialize fwstate_cfg with NULL pointers
 	memset(&config->fwstate_cfg, 0, sizeof(struct fwstate_config));
+	SET_OFFSET_OF(&config->fwstate_owner, NULL);
 
 	// Register module-level counters
 	struct {
@@ -884,6 +891,16 @@ acl_module_config_set_fwstate_config(
 	EQUATE_OFFSET(
 		&config->fwstate_cfg.fw6state, &fwstate_config->cfg.fw6state
 	);
+
+	// Take the new hold before dropping any old one, so relinking to the
+	// same owner never passes through a transient zero refcount.
+	cp_module_acquire(fwstate_cp_module);
+
+	struct cp_module *prev_owner = ADDR_OF(&config->fwstate_owner);
+	if (prev_owner != NULL) {
+		cp_module_release(prev_owner);
+	}
+	SET_OFFSET_OF(&config->fwstate_owner, fwstate_cp_module);
 }
 
 void
@@ -908,6 +925,20 @@ acl_module_config_transfer_fwstate_config(
 		&new_config->fwstate_cfg.fw6state,
 		&old_config->fwstate_cfg.fw6state
 	);
+
+	// Give the receiving config its own hold on the same owner the
+	// source config holds, read from the source rather than assumed, so
+	// both configs keep the owner alive until each releases its own hold.
+	struct cp_module *owner = ADDR_OF(&old_config->fwstate_owner);
+	if (owner != NULL) {
+		cp_module_acquire(owner);
+	}
+
+	struct cp_module *prev_owner = ADDR_OF(&new_config->fwstate_owner);
+	if (prev_owner != NULL) {
+		cp_module_release(prev_owner);
+	}
+	SET_OFFSET_OF(&new_config->fwstate_owner, owner);
 }
 
 void

--- a/modules/acl/dataplane/config.h
+++ b/modules/acl/dataplane/config.h
@@ -36,6 +36,12 @@ struct acl_module_config {
 
 	struct fwstate_config fwstate_cfg;
 
+	// The fwstate module config that fwstate_cfg's maps were copied from,
+	// held with its own reference via cp_module_acquire/cp_module_release
+	// so the maps outlive a deleted fwstate configuration that this ACL
+	// configuration still points into. NULL when never linked.
+	struct cp_module *fwstate_owner;
+
 	// Metrics
 	uint64_t compilation_time_ns;
 	uint64_t filter_rule_count_ip4;

--- a/modules/acl/tests/functional/acl_fwstate_ownership_test.go
+++ b/modules/acl/tests/functional/acl_fwstate_ownership_test.go
@@ -1,0 +1,132 @@
+package acl_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
+	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
+)
+
+// agentRootMemoryNode returns the named agent's own root memory-context
+// node from its live dataplane snapshot.
+//
+// A cp_module's outer struct and everything it owns directly, of any
+// module type sharing this agent, is freed against this root context, so
+// its free count advances once and only once per config actually torn
+// down, regardless of which module type triggered the teardown.
+func agentRootMemoryNode(t *testing.T, agent *ffi.Agent, name string) ffi.AgentMemoryNode {
+	t.Helper()
+
+	for _, agentInfo := range agent.DPConfig().Agents() {
+		if agentInfo.Name != name {
+			continue
+		}
+		require.Lenf(t, agentInfo.Instances, 1, "agent %q: expected exactly one live instance", name)
+
+		for _, node := range agentInfo.Instances[0].MemoryTree {
+			if node.ParentIdx == math.MaxUint32 {
+				return node
+			}
+		}
+		t.Fatalf("agent %q: no root memory-context node in its snapshot", name)
+	}
+
+	t.Fatalf("agent %q not found in dataplane config", name)
+	return ffi.AgentMemoryNode{}
+}
+
+// TestACL_FWStateOwnership_DeleteFWStateDoesNotFreeLinkedMaps is a
+// regression test for issue #2003.
+//
+// Linking an ACL config to a fwstate config copies offsets into maps the
+// fwstate config owns, plus a hold on that fwstate config. Only the last
+// linked ACL config's own teardown may release the hold and free the maps.
+//
+// Each measurement is driven through a construction of the drained type, the
+// only call that destroys a parked entry: a release alone only parks, so
+// measuring right after one would show the delay, not the ownership.
+func TestACL_FWStateOwnership_DeleteFWStateDoesNotFreeLinkedMaps(t *testing.T) {
+	agent, backend := setupACLFWStateHarness(t)
+
+	fwCfg, err := cfwstate.NewModuleConfig(agent, "fw0")
+	require.NoError(t, err)
+	require.NoError(t, fwCfg.CreateMaps(cfwstate.MapConfig{
+		IndexSize:        1024,
+		ExtraBucketCount: 64,
+	}, 1))
+	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{fwCfg.AsFFIModule()}))
+
+	handle, err := backend.NewModule("acl0")
+	require.NoError(t, err)
+	rules := []cacl.AclRule{
+		allow4Rule(
+			filter.IPNets{filter.UnspecifiedIPv4},
+			filter.IPNets{filter.UnspecifiedIPv4},
+			udpProto,
+		),
+	}
+	require.NoError(t, handle.UpdateRules(rules))
+	handle.SetFwStateConfig(fwCfg.AsFFIModule())
+	require.NoError(t, backend.UpdateModule(handle))
+
+	beforeFWStateDelete := agentRootMemoryNode(t, agent, "acl")
+
+	// Release fw0's own creator and publish references. ACL's own hold,
+	// taken by SetFwStateConfig, is the only thing left standing between
+	// fw0 and its teardown.
+	fwCfg.Free()
+	require.NoError(t, agent.DeleteModuleConfig("fwstate", "fw0"))
+
+	// Construct another fwstate config: the only call that would drain
+	// and destroy a parked fwstate entry. If ACL's hold were missing,
+	// fw0 would already be parked by now and would be destroyed right
+	// here, out from under the still-linked acl0.
+	other, err := cfwstate.NewModuleConfig(agent, "fw1")
+	require.NoError(t, err)
+	t.Cleanup(other.Free)
+
+	afterFWStateDelete := agentRootMemoryNode(t, agent, "acl")
+	require.Equalf(
+		t, beforeFWStateDelete.BFreeCount, afterFWStateDelete.BFreeCount,
+		"deleting the linked fwstate config, plus a fwstate construction "+
+			"able to drain it, must not free its maps while the linked "+
+			"ACL config is still alive",
+	)
+
+	// Tear down the linked ACL config itself, then construct another ACL
+	// config to drain and destroy it, which runs acl0's own destructor
+	// and drops its hold on fw0.
+	handle.Free()
+	require.NoError(t, backend.DeleteModule("acl0"))
+
+	other2, err := backend.NewModule("acl1")
+	require.NoError(t, err)
+	t.Cleanup(other2.Free)
+
+	// Snapshot here, not before: acl0's own config block has already been
+	// freed against the root context by the drain above, which would mask
+	// the assertion below regardless of fw0's own fate. fw0 itself is
+	// still only parked. A successful fwstate construction only allocates
+	// against the root context, and its device link reallocates against
+	// its own child context, so any further rise from here is
+	// attributable solely to fw0 actually being reclaimed.
+	beforeFWStateDrain := agentRootMemoryNode(t, agent, "acl")
+
+	// Construct one more fwstate config to drain and destroy fw0, now
+	// that nothing holds a reference on it.
+	other3, err := cfwstate.NewModuleConfig(agent, "fw2")
+	require.NoError(t, err)
+	t.Cleanup(other3.Free)
+
+	afterACLTeardown := agentRootMemoryNode(t, agent, "acl")
+	require.Greaterf(
+		t, afterACLTeardown.BFreeCount, beforeFWStateDrain.BFreeCount,
+		"tearing down the last linked ACL config must let fw0's maps be "+
+			"reclaimed",
+	)
+}


### PR DESCRIPTION
Linking an access-control configuration to a firewall-state one copies the latter's configuration structure into the former, and that copy carries offsets to the state maps the firewall-state side owns and allocates. The copy took no reference of any kind.

Deleting the firewall-state configuration then destroyed it and freed those maps while access-control configurations still pointed at them and the dataplane still read through the offsets. Linking and then deleting is reachable from the command line, so this was a live use-after-free on the packet path.

Note the asymmetry that makes it specific to deletion. Every supersede path detaches the maps before releasing, because they migrate to the successor — deletion has no successor and frees unconditionally, which is correct in isolation and wrong while someone else still points at them.

Closes #2003.

## The fix

The access-control configuration now remembers **which** firewall-state module owns the maps it copied, and holds a reference on it through the reference count that #1998 made the single source of truth for a module configuration's lifetime.

Linking acquires and releases any previous hold, so linking twice neither leaks nor double-counts. Transferring between two access-control configurations gives the receiver its own hold, read from the configuration it copies from. The access-control teardown releases.

Deleting the firewall-state configuration therefore drops its generation references and its creator's, but a linked access-control configuration keeps the count above zero: nothing is destroyed and the maps stay. They are reclaimed once the last referencing access-control configuration is itself torn down.

An acquire entry point mirrors the existing release, taking the configuration lock the same way. Its documentation states both preconditions whose violation is silent and fatal — that the caller must already hold a live reference, and that the lock must not already be held, since it is a non-reentrant cross-process spinlock and nesting it hangs the instance.

## Why not refuse the deletion instead

Refusing to delete while links exist is unsound. The service knows the link set only at the moment of linking, so that knowledge lives in process memory while the link itself lives in shared memory. A control-plane restart loses the former and keeps the latter, and the next deletion frees the maps again. Reconstructing the set would mean scanning other modules' configurations.

## Layout

The access-control configuration structure grew by one pointer and the module ABI version is raised. That version is compared only when a module is loaded as an external shared object, so it does not enforce the agreement between a separately built control plane and dataplane — that gap is filed as #2004 and is not addressed here.

## Test

The regression test links, deletes the firewall-state configuration, and asserts its maps survived; then tears down the access-control side and asserts they are reclaimed. Both halves were proven by mutation. The second needed a third measurement point: its first form compared across a window that also contained the access-control configuration's own block free, so it passed even with the release removed — a permanent shared-memory leak would have shipped green.
