### PR TITLE
fix(forward): allow concurrent metrics reads

### DIFF
--- a/modules/forward/controlplane/metrics.go
+++ b/modules/forward/controlplane/metrics.go
@@ -56,8 +56,8 @@ func (m *ForwardService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metri
 // per-module counter such as "rx" — leaves that config with nothing to
 // read.
 func (m *ForwardService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*commonpb.Metric, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	result := make([]*commonpb.Metric, 0)
 	for configName, config := range m.configs {

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -48,7 +48,7 @@ func (m *forwardConfig) Free() {
 type ForwardService struct {
 	forwardpb.UnimplementedForwardServiceServer
 
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	backend Backend
 	configs map[string]forwardConfig
 }
@@ -63,8 +63,8 @@ func NewForwardService(backend Backend) *ForwardService {
 func (m *ForwardService) ListConfigs(
 	ctx context.Context, request *forwardpb.ListConfigsRequest,
 ) (*forwardpb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	configs := make([]string, 0, len(m.configs))
 	for name := range m.configs {
@@ -84,8 +84,8 @@ func (m *ForwardService) ShowConfig(ctx context.Context, req *forwardpb.ShowConf
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	config, ok := m.configs[req.Name]
 

--- a/modules/forward/controlplane/service_test.go
+++ b/modules/forward/controlplane/service_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
@@ -34,6 +36,18 @@ func (m *mockBackend) DeleteModule(name string) error {
 }
 
 func (m *mockBackend) ModuleCounters(name string, counterNames []string) []forward.CounterView {
+	return nil
+}
+
+type blockingMetricsBackend struct {
+	mockBackend
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (m *blockingMetricsBackend) ModuleCounters(name string, counterNames []string) []forward.CounterView {
+	m.entered <- struct{}{}
+	<-m.release
 	return nil
 }
 
@@ -303,6 +317,62 @@ func TestMetricsExactTagNeverReadsForeignCounter(t *testing.T) {
 		require.NotContains(t, metric.GetName(), "forward_rule")
 	}
 	require.Empty(t, backend.queries, "rx is not one of the config's own rule counters, so ModuleCounters must never be called")
+}
+
+// TestConcurrentMetricsReads verifies that concurrent metrics reads both reach
+// the dataplane counter backend without serializing behind the service lock.
+func TestConcurrentMetricsReads(t *testing.T) {
+	backend := &blockingMetricsBackend{
+		entered: make(chan struct{}, 2),
+		release: make(chan struct{}),
+	}
+	service := forward.NewForwardService(backend)
+
+	var group errgroup.Group
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(backend.release)
+		})
+	}
+	defer func() {
+		release()
+		require.NoError(t, group.Wait())
+	}()
+
+	_, err := service.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*forwardpb.Rule{
+			{Action: &forwardpb.Action{Target: "device0", Counter: "to_device0"}},
+		},
+	})
+	require.NoError(t, err)
+
+	group.Go(func() error {
+		_, err := service.Metrics()
+		return err
+	})
+
+	waitForEntry := func() {
+		timer := time.NewTimer(time.Second)
+		defer timer.Stop()
+
+		select {
+		case <-backend.entered:
+		case <-timer.C:
+			t.Fatal("timed out waiting for metrics reader")
+		}
+	}
+	waitForEntry()
+
+	group.Go(func() error {
+		_, err := service.Metrics()
+		return err
+	})
+	waitForEntry()
+
+	release()
+	require.NoError(t, group.Wait())
 }
 
 // Run with: go test -race


### PR DESCRIPTION
- Lets read-only forward service operations share the config lock while preserving exclusive configuration mutation and module lifetime protection.
- Adds deterministic race-safe regression coverage proving concurrent metrics reads both reach the dataplane counter backend.
- Assumes backend counter snapshots are safe in parallel because each call pins its own configuration generation and returns call-owned copies.
- Keeps the read lock across counter snapshots so configuration replacement or deletion cannot release module state mid-read.

Closes #1922.