### PR TITLE
refactor(counters)!: rename the worker drops protobuf field to disposed

### DIFF
--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -445,7 +445,7 @@ struct WorkerRow {
     #[tabled(rename = "RemTX Drp")]
     remote_tx_drops: String,
     #[tabled(rename = "Disposed")]
-    drops: String,
+    disposed: String,
 }
 
 impl From<&WorkerCounter> for WorkerRow {
@@ -488,7 +488,7 @@ impl From<&WorkerCounter> for WorkerRow {
             remote_tx: format_number(w.remote_tx_packets),
             local_tx_drops: format_number(w.local_tx_drops),
             remote_tx_drops: format_number(w.remote_tx_drops),
-            drops: format_number(w.drops),
+            disposed: format_number(w.disposed),
         }
     }
 }

--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -214,7 +214,7 @@ func (m *Counters) Workers(
 			RemoteTxPackets: worker.RemoteTxPackets,
 			LocalTxDrops:    worker.LocalTxDrops,
 			RemoteTxDrops:   worker.RemoteTxDrops,
-			Drops:           worker.Drops,
+			Disposed:        worker.Disposed,
 		})
 	}
 
@@ -313,7 +313,7 @@ func workerMetrics(workers []ffi.WorkerCounter) []*commonpb.Metric {
 			commonpb.NewMetricCounter("worker_remote_tx_packets", worker.RemoteTxPackets, labels...),
 			commonpb.NewMetricCounter("worker_local_tx_drops", worker.LocalTxDrops, labels...),
 			commonpb.NewMetricCounter("worker_remote_tx_drops", worker.RemoteTxDrops, labels...),
-			commonpb.NewMetricCounter("worker_disposed", worker.Drops, labels...),
+			commonpb.NewMetricCounter("worker_disposed", worker.Disposed, labels...),
 		)
 
 		if len(worker.RxBursts) > 0 {

--- a/controlplane/ffi/worker.go
+++ b/controlplane/ffi/worker.go
@@ -28,7 +28,7 @@ type WorkerCounter struct {
 	RemoteTxPackets uint64
 	LocalTxDrops    uint64
 	RemoteTxDrops   uint64
-	Drops           uint64
+	Disposed        uint64
 }
 
 func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
@@ -55,6 +55,8 @@ func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
 	remoteTxHandle := counterByName["remote_tx"]
 	localTxDropsHandle := counterByName["local_tx_drops"]
 	remoteTxDropsHandle := counterByName["remote_tx_drops"]
+	// "drops" is the dataplane counter-registry name backing Disposed. A
+	// mismatched rename leaves dropsHandle nil, crashing the dereference below.
 	dropsHandle := counterByName["drops"]
 
 	workerCount := counters.instance_count
@@ -115,7 +117,7 @@ func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
 				workerCounterSingleValueIdx,
 				idx,
 			)),
-			Drops: uint64(C.yanet_get_counter_value(
+			Disposed: uint64(C.yanet_get_counter_value(
 				dropsHandle.values,
 				workerCounterSingleValueIdx,
 				idx,

--- a/controlplane/ynpb/v1/counters.proto
+++ b/controlplane/ynpb/v1/counters.proto
@@ -72,8 +72,12 @@ message WorkerCounter {
   uint64 local_tx_drops = 14;
   // Packets dropped because the inter-worker data pipe was full or absent.
   uint64 remote_tx_drops = 15;
-  // Total packets dropped by this worker for any reason.
-  uint64 drops = 16;
+  // Packets this worker itself freed rather than forwarded.
+  //
+  // Covers malformed input, transmit failures, and deliberate module policy
+  // drops such as an ACL deny, so nonzero alone is not a fault. Already
+  // includes every local_tx_drops and remote_tx_drops packet.
+  uint64 disposed = 16;
 }
 
 // Requests a snapshot of raw cumulative per-port extended stats counters.


### PR DESCRIPTION
Renames field 16 of the worker counter message from `drops` to `disposed`, so the wire contract matches the vocabulary operators already see. The CLI column and the exported metric were renamed earlier; the protobuf field was the last surface still saying `drops`.

The field number is unchanged, so binary wire compatibility holds. The break is deliberate and name-level only: it affects clients that read the field by name, including JSON. `buf breaking` reports `FIELD_SAME_NAME` for exactly this reason, and that break is intended.

Rewrites the field documentation. The previous text ("Total packets dropped by this worker for any reason") was accurate but silent on the two things an operator needs. The counter now documents that it counts packets a worker freed itself instead of forwarding, covering malformed input, transmit failures and deliberate module policy drops such as an ACL deny, so a nonzero value is not by itself a fault. It also documents that the value already includes every packet counted by the two sibling counters rather than partitioning against them, which is what makes subtracting both a legitimate way to get the remainder.

The naming was verified against the counter's actual behaviour before the rename: every increment of the underlying dataplane counter is paired with the same worker freeing the mbuf, and the aggregate's accounting is exact, since the drop count is only ever incremented in lockstep with appending the packet to the list that is then freed. Packets lost below the worker, such as a NIC receive-ring overflow, are not counted here at all, which is why "dropped" was the misleading half of the old name.

This is a knowing deviation from the compatibility policy in `docs/proto-compatibility.md`, which lists renaming a field among the forbidden changes for a frozen `.v1` package and prescribes deprecate-and-add or a new versioned package instead. The deviation was escalated and authorized explicitly. Both prescribed alternatives were considered and declined: deprecate-and-add would carry the same aggregate on the wire twice permanently and still require every consumer to migrate, and a `v2` package would duplicate every message and move the HTTP route for one field rename. The policy text is deliberately left unchanged. The `buf breaking` gate is being disabled for this change rather than silenced through `buf.yaml`, so the break stays visible to later changes instead of being permanently suppressed.

Assumptions recorded for the reader: the sibling counters and their CLI column headers keep their existing vocabulary, as already ratified; the metric name was already correct and is untouched; the dataplane's own counter registry name deliberately does not follow, because the dataplane addresses that counter by a hardcoded index and the name serves only as the control plane's unguarded lookup key, so renaming it would arm a control-plane crash on version skew without changing anything an operator can observe, and #1935 tracks the guard that must land first; and no new test was added, because this is a pure rename with no behavioural delta and no existing test read the field.

Closes #1934.