### PR TITLE
fix(controlplane): release shared memory when an agent fails to attach

### DIFF
--- a/controlplane/cmd/yncp-director/main.go
+++ b/controlplane/cmd/yncp-director/main.go
@@ -76,7 +76,11 @@ func run(cmd Cmd) error {
 	if err != nil {
 		return fmt.Errorf("failed to create director: %w", err)
 	}
-	defer director.Close()
+	defer func() {
+		if err := director.Close(); err != nil {
+			log.Warn("failed to close director", zap.Error(err))
+		}
+	}()
 
 	ctx := context.Background()
 	wg, ctx := errgroup.WithContext(ctx)

--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -89,8 +89,10 @@ func (m *Agent) BlockAllocatorFreeSize() uint64 {
 }
 
 func (m *Agent) Close() error {
-	_, err := C.agent_detach(m.ptr)
-	return err
+	if _, err := C.agent_detach(m.ptr); err != nil {
+		return fmt.Errorf("failed to close agent %q: %w", m.name, err)
+	}
+	return nil
 }
 
 func (m *Agent) CleanUp() error {

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -47,10 +47,13 @@ func AttachSharedMemory(path string) (*SharedMemory, error) {
 }
 
 // Detach detaches from YANET shared memory segment.
+//
+// Every agent attached to the segment must be closed before detaching,
+// because the mapping is unmapped and a later agent operation would fault.
 func (m *SharedMemory) Detach() error {
 	if m.ptr != nil {
 		if _, err := C.yanet_shm_detach(m.ptr); err != nil {
-			return err
+			return fmt.Errorf("failed to detach shared memory: %w", err)
 		}
 
 		m.ptr = nil

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -405,6 +406,8 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 
 // Close closes the gateway API.
 func (m *Gateway) Close() error {
+	var errs []error
+
 	for _, service := range m.services {
 		closer, ok := service.(ClosableService)
 		if !ok {
@@ -412,18 +415,15 @@ func (m *Gateway) Close() error {
 		}
 
 		if err := closer.Close(); err != nil {
-			m.log.Warn("failed to close service",
-				zap.String("service", fmt.Sprintf("%T", service)),
-				zap.Error(err),
-			)
+			errs = append(errs, fmt.Errorf("failed to close service %T: %w", service, err))
 		}
 	}
 
 	if err := m.registry.Close(); err != nil {
-		m.log.Warn("failed to close backend registry", zap.Error(err))
+		errs = append(errs, fmt.Errorf("failed to close backend registry: %w", err))
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // Run runs the gateway API until the specified context is canceled.

--- a/controlplane/yncp/director.go
+++ b/controlplane/yncp/director.go
@@ -95,6 +95,19 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 	waitCtx, cancel := context.WithTimeout(context.Background(), dataplaneReadyTimeout)
 	defer cancel()
 	var shm *ffi.SharedMemory
+
+	// The deferred release below covers every failure return from here to
+	// the final success, so a failure path added later does not need its
+	// own copy. shm stays nil if no attach ever succeeded.
+	releaseShm := true
+	defer func() {
+		if releaseShm && shm != nil {
+			if err := shm.Detach(); err != nil {
+				log.Warn("failed to detach shared memory", zap.Error(err))
+			}
+		}
+	}()
+
 	bo := xbackoff.New(100*time.Millisecond, xbackoff.WithMax(2*time.Second))
 	if err := bo.RunContext(waitCtx, func() error {
 		if shm == nil {
@@ -161,6 +174,8 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 		return nil, fmt.Errorf("failed to create gateway: %w", err)
 	}
 
+	releaseShm = false
+
 	return &Director{
 		cfg:     cfg,
 		shm:     shm,
@@ -171,9 +186,7 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 
 // Close closes the YANET controlplane director.
 func (m *Director) Close() error {
-	defer m.shm.Detach()
-
-	return m.gateway.Close()
+	return errors.Join(m.gateway.Close(), m.shm.Detach())
 }
 
 // Run runs the YANET controlplane director.

--- a/devices/plain/controlplane/mod.go
+++ b/devices/plain/controlplane/mod.go
@@ -1,6 +1,7 @@
 package plain
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -36,7 +37,6 @@ type DevicePlainDevice struct {
 	shm     *ffi.SharedMemory
 	agent   *ffi.Agent
 	service *DevicePlainService
-	log     *zap.Logger
 }
 
 // NewDevicePlainDevice creates a new DevicePlain device instance
@@ -60,7 +60,10 @@ func NewDevicePlainDevice(cfg *Config, options ...Option) (*DevicePlainDevice, e
 
 	agent, err := shm.AgentAttach("plain", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	plainService := NewDevicePlainService(agent)
@@ -70,7 +73,6 @@ func NewDevicePlainDevice(cfg *Config, options ...Option) (*DevicePlainDevice, e
 		shm:     shm,
 		agent:   agent,
 		service: plainService,
-		log:     log,
 	}, nil
 }
 
@@ -92,13 +94,5 @@ func (m *DevicePlainDevice) RegisterService(server *grpc.Server) {
 
 // Close closes the device and releases all resources
 func (m *DevicePlainDevice) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
-	}
-
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/devices/trafgen/controlplane/mod.go
+++ b/devices/trafgen/controlplane/mod.go
@@ -2,6 +2,7 @@
 package trafgen
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -43,7 +44,6 @@ type TrafgenDevice struct {
 	shm     *ffi.SharedMemory
 	agent   *ffi.Agent
 	service *TrafgenService
-	log     *zap.Logger
 }
 
 // NewTrafgenDevice creates a new TrafgenDevice.
@@ -67,7 +67,10 @@ func NewTrafgenDevice(cfg *Config, options ...Option) (*TrafgenDevice, error) {
 
 	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	service := NewTrafgenService(NewBackend(agent))
@@ -77,7 +80,6 @@ func NewTrafgenDevice(cfg *Config, options ...Option) (*TrafgenDevice, error) {
 		shm:     shm,
 		agent:   agent,
 		service: service,
-		log:     log,
 	}, nil
 }
 
@@ -103,13 +105,5 @@ func (m *TrafgenDevice) RegisterService(server *grpc.Server) {
 
 // Close releases shared memory resources held by the device.
 func (m *TrafgenDevice) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
-	}
-
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/devices/vlan/controlplane/mod.go
+++ b/devices/vlan/controlplane/mod.go
@@ -1,6 +1,7 @@
 package vlan
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -36,7 +37,6 @@ type DeviceVlanDevice struct {
 	shm     *ffi.SharedMemory
 	agent   *ffi.Agent
 	service *DeviceVlanService
-	log     *zap.Logger
 }
 
 // NewDeviceVlanDevice creates a new DeviceVlan device instance
@@ -60,7 +60,10 @@ func NewDeviceVlanDevice(cfg *Config, options ...Option) (*DeviceVlanDevice, err
 
 	agent, err := shm.AgentAttach("vlan", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	vlanService := NewDeviceVlanService(agent)
@@ -70,7 +73,6 @@ func NewDeviceVlanDevice(cfg *Config, options ...Option) (*DeviceVlanDevice, err
 		shm:     shm,
 		agent:   agent,
 		service: vlanService,
-		log:     log,
 	}, nil
 }
 
@@ -92,13 +94,5 @@ func (m *DeviceVlanDevice) RegisterService(server *grpc.Server) {
 
 // Close closes the device and releases all resources
 func (m *DeviceVlanDevice) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
-	}
-
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -1,6 +1,7 @@
 package acl
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -49,7 +50,6 @@ type ACLModule struct {
 	metricsService        *MetricsService
 	fwstateService        *fwstate.FWStateService
 	fwstateMetricsService *fwstate.MetricsService
-	log                   *zap.Logger
 }
 
 // NewACLModule creates a new ACL module instance.
@@ -73,7 +73,10 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 
 	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	aclService := NewACLService(
@@ -103,7 +106,6 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 		metricsService:        metricsService,
 		fwstateService:        fwstateService,
 		fwstateMetricsService: fwstateMetricsService,
-		log:                   log,
 	}, nil
 }
 
@@ -149,12 +151,5 @@ func (m *ACLModule) ACLAdapter() *ACLAdapter {
 }
 
 func (m *ACLModule) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach shared memory", zap.Error(err))
-	}
-
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/modules/blackhole/controlplane/mod.go
+++ b/modules/blackhole/controlplane/mod.go
@@ -2,6 +2,7 @@
 package blackhole
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -42,7 +43,6 @@ type BlackholeModule struct {
 	shm              *ffi.SharedMemory
 	agent            *ffi.Agent
 	blackholeService *BlackholeService
-	log              *zap.Logger
 }
 
 // NewBlackholeModule creates a new BlackholeModule.
@@ -66,7 +66,10 @@ func NewBlackholeModule(cfg *Config, options ...Option) (*BlackholeModule, error
 
 	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	blackholeService := NewBlackholeService(NewBackend(agent))
@@ -76,7 +79,6 @@ func NewBlackholeModule(cfg *Config, options ...Option) (*BlackholeModule, error
 		shm:              shm,
 		agent:            agent,
 		blackholeService: blackholeService,
-		log:              log,
 	}, nil
 }
 
@@ -102,12 +104,5 @@ func (m *BlackholeModule) RegisterService(server *grpc.Server) {
 
 // Close releases shared memory resources held by the module.
 func (m *BlackholeModule) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach shared memory", zap.Error(err))
-	}
-
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/modules/decap/controlplane/mod.go
+++ b/modules/decap/controlplane/mod.go
@@ -1,6 +1,7 @@
 package decap
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -37,7 +38,6 @@ type DecapModule struct {
 	shm          *ffi.SharedMemory
 	agent        *ffi.Agent
 	decapService *DecapService
-	log          *zap.Logger
 }
 
 func NewDecapModule(cfg *Config, options ...Option) (*DecapModule, error) {
@@ -60,7 +60,10 @@ func NewDecapModule(cfg *Config, options ...Option) (*DecapModule, error) {
 
 	agent, err := shm.AgentAttach("decap", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	decapService := NewDecapService(NewBackend(agent))
@@ -70,7 +73,6 @@ func NewDecapModule(cfg *Config, options ...Option) (*DecapModule, error) {
 		shm:          shm,
 		agent:        agent,
 		decapService: decapService,
-		log:          log,
 	}, nil
 }
 
@@ -92,13 +94,5 @@ func (m *DecapModule) RegisterService(server *grpc.Server) {
 
 // Close closes the module.
 func (m *DecapModule) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
-	}
-
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/modules/dscp/controlplane/mod.go
+++ b/modules/dscp/controlplane/mod.go
@@ -1,6 +1,7 @@
 package dscp
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -37,7 +38,6 @@ type DscpModule struct {
 	shm         *ffi.SharedMemory
 	agent       *ffi.Agent
 	dscpService *DscpService
-	log         *zap.Logger
 }
 
 func NewDSCPModule(cfg *Config, options ...Option) (*DscpModule, error) {
@@ -61,7 +61,10 @@ func NewDSCPModule(cfg *Config, options ...Option) (*DscpModule, error) {
 
 	agent, err := shm.AgentAttach("dscp", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	dscpService := NewDscpService(newBackend(agent))
@@ -71,7 +74,6 @@ func NewDSCPModule(cfg *Config, options ...Option) (*DscpModule, error) {
 		shm:         shm,
 		agent:       agent,
 		dscpService: dscpService,
-		log:         log,
 	}, nil
 }
 
@@ -93,13 +95,5 @@ func (m *DscpModule) RegisterService(server *grpc.Server) {
 
 // Close closes the module.
 func (m *DscpModule) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
-	}
-
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/modules/forward/controlplane/mod.go
+++ b/modules/forward/controlplane/mod.go
@@ -1,6 +1,7 @@
 package forward
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -44,7 +45,6 @@ type ForwardModule struct {
 	agent          *cpffi.Agent
 	forwardService *ForwardService
 	metricsService *MetricsService
-	log            *zap.Logger
 }
 
 func NewForwardModule(cfg *Config, options ...Option) (*ForwardModule, error) {
@@ -67,7 +67,10 @@ func NewForwardModule(cfg *Config, options ...Option) (*ForwardModule, error) {
 
 	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	forwardService := NewForwardService(NewBackend(agent))
@@ -79,7 +82,6 @@ func NewForwardModule(cfg *Config, options ...Option) (*ForwardModule, error) {
 		agent:          agent,
 		forwardService: forwardService,
 		metricsService: metricsService,
-		log:            log,
 	}, nil
 }
 
@@ -102,13 +104,5 @@ func (m *ForwardModule) RegisterService(server *grpc.Server) {
 
 // Close closes the module.
 func (m *ForwardModule) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
-	}
-
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/modules/mirror/controlplane/mod.go
+++ b/modules/mirror/controlplane/mod.go
@@ -1,6 +1,7 @@
 package mirror
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -42,7 +43,6 @@ type MirrorModule struct {
 	shm           *cpffi.SharedMemory
 	agent         *cpffi.Agent
 	mirrorService *MirrorService
-	log           *zap.Logger
 }
 
 func NewMirrorModule(cfg *Config, options ...Option) (*MirrorModule, error) {
@@ -65,7 +65,10 @@ func NewMirrorModule(cfg *Config, options ...Option) (*MirrorModule, error) {
 
 	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	mirrorService := NewMirrorService(NewBackend(agent))
@@ -75,7 +78,6 @@ func NewMirrorModule(cfg *Config, options ...Option) (*MirrorModule, error) {
 		shm:           shm,
 		agent:         agent,
 		mirrorService: mirrorService,
-		log:           log,
 	}, nil
 }
 
@@ -97,13 +99,5 @@ func (m *MirrorModule) RegisterService(server *grpc.Server) {
 
 // Close closes the module.
 func (m *MirrorModule) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
-	}
-
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/modules/nat64/controlplane/mod.go
+++ b/modules/nat64/controlplane/mod.go
@@ -1,6 +1,7 @@
 package nat64
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -36,7 +37,6 @@ type NAT64Module struct {
 	shm          *ffi.SharedMemory
 	agent        *ffi.Agent
 	nat64Service *NAT64Service
-	log          *zap.Logger
 }
 
 // NewNAT64Module creates a new NAT64 module instance
@@ -60,7 +60,10 @@ func NewNAT64Module(cfg *Config, options ...Option) (*NAT64Module, error) {
 
 	agent, err := shm.AgentAttach("nat64", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	nat64Service := NewNAT64Service(NewBackend(agent), WithNAT64ServiceLog(log))
@@ -70,7 +73,6 @@ func NewNAT64Module(cfg *Config, options ...Option) (*NAT64Module, error) {
 		shm:          shm,
 		agent:        agent,
 		nat64Service: nat64Service,
-		log:          log,
 	}, nil
 }
 
@@ -92,13 +94,5 @@ func (m *NAT64Module) RegisterService(server *grpc.Server) {
 
 // Close closes the module and releases all resources
 func (m *NAT64Module) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
-	}
-
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/modules/pdump/controlplane/mod.go
+++ b/modules/pdump/controlplane/mod.go
@@ -2,6 +2,7 @@ package pdump
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -68,7 +69,10 @@ func NewPdumpModule(cfg *Config, options ...Option) (*PdumpModule, error) {
 
 	agent, err := shm.AgentAttach(moduleType, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	service := NewPdumpService(agent, WithPdumpServiceLog(log))
@@ -109,13 +113,5 @@ func (m *PdumpModule) Run(ctx context.Context) error {
 
 // Close closes the module.
 func (m *PdumpModule) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
-	}
-
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/modules/route-mpls/controlplane/mod.go
+++ b/modules/route-mpls/controlplane/mod.go
@@ -1,6 +1,7 @@
 package route_mpls
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -42,7 +43,6 @@ type RouteMPLSModule struct {
 	shm     *cpffi.SharedMemory
 	agent   *cpffi.Agent
 	service *RouteMPLSService
-	log     *zap.Logger
 }
 
 // NewRouteMPLSModule creates a new RouteMPLSModule.
@@ -66,7 +66,10 @@ func NewRouteMPLSModule(cfg *Config, options ...Option) (*RouteMPLSModule, error
 
 	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	service := NewRouteMPLSService(NewBackend(agent), WithRouteMPLSServiceLog(log))
@@ -76,7 +79,6 @@ func NewRouteMPLSModule(cfg *Config, options ...Option) (*RouteMPLSModule, error
 		shm:     shm,
 		agent:   agent,
 		service: service,
-		log:     log,
 	}, nil
 }
 
@@ -104,11 +106,5 @@ func (m *RouteMPLSModule) RegisterService(server *grpc.Server) {
 
 // Close closes the module.
 func (m *RouteMPLSModule) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
-	}
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -1,6 +1,7 @@
 package route
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -48,7 +49,6 @@ type RouteModule struct {
 	agent          *cpffi.Agent
 	service        *RouteService
 	metricsService *MetricsService
-	log            *zap.Logger
 }
 
 // NewRouteModule creates a new RouteModule.
@@ -72,7 +72,10 @@ func NewRouteModule(cfg *Config, options ...Option) (*RouteModule, error) {
 
 	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
 	}
 
 	serviceOptions := []RouteServiceOption{
@@ -94,7 +97,6 @@ func NewRouteModule(cfg *Config, options ...Option) (*RouteModule, error) {
 		agent:          agent,
 		service:        service,
 		metricsService: metricsService,
-		log:            log,
 	}, nil
 }
 
@@ -135,11 +137,5 @@ func (m *RouteModule) UnaryServerInterceptors() []grpc.UnaryServerInterceptor {
 
 // Close closes the module.
 func (m *RouteModule) Close() error {
-	if err := m.agent.Close(); err != nil {
-		m.log.Warn("failed to close shared memory agent", zap.Error(err))
-	}
-	if err := m.shm.Detach(); err != nil {
-		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
-	}
-	return nil
+	return errors.Join(m.agent.Close(), m.shm.Detach())
 }


### PR DESCRIPTION
Every module and device control plane maps the dataplane's shared memory and then attaches an agent to it, but released the mapping only once both steps had succeeded, so a failed attach leaked it for the life of the process. Detaching the segment is an unmap, so nothing else reclaims it.

Their shutdown paths logged both the agent-close and the mapping-detach failure and then reported success regardless, so no caller could ever learn that cleanup had not happened.

- A cleanup failure now identifies itself where it occurs, which collapses each of the thirteen shutdown paths to a single expression and leaves the per-module logger field without a user in twelve of them.
- The gateway aggregator and the director repeated both mistakes, which would have left the newly propagated failures with no consumer at all, so they are fixed here too and the process entrypoint logs the result once.
- The director additionally leaked its own mapping on three startup failure paths, including the routine one where the dataplane does not become ready within the timeout. A single deferred release now covers every failure return, so a path added later is covered without anyone remembering to.
- The rule that an agent must be released before the mapping it lives in is stated once, on the detach operation itself, rather than repeated at each call site.

Assumptions taken while implementing this, recorded so they can be challenged:

- The scope is wider than the issue's list on two verified points. The three device control planes carry the byte-identical defect and are included. The issue lists two further modules as public, but both live in the private repository and are tracked separately.
- The built-in pipeline and function services are deliberately untouched. They attach a per-request agent onto a mapping they do not own, so they have no mapping to release.
- No test accompanies this change. The in-process dataplane test harness allocates the segment itself and exposes no path, so the attach path cannot be reached from a Go test, and driving the failure against the harness's own segment would unmap the fixture.
- A related defect found during review is deliberately left out and tracked as #2014: the module bundle abandons the services it has already constructed when a later one fails to build.

One of the four paths is only partially repaired, which the automated review caught and which is worth stating plainly. Attaching takes the mapping length from the storage file, while detaching recomputes it from fields inside the segment, and the dataplane creates and sizes that file well before it fills those fields in. The readiness backoff attaches inside exactly that window, so on the startup-timeout path the release degrades to an unmap of length zero and the mapping survives. That is not a regression, since nothing released it there before either, and the other three paths all run after readiness has been observed. The underlying asymmetry is a C defect in the attach and detach pair and is tracked as #2017, where it can get the C gates this Go-only change cannot honestly claim.

Closes #1732.