### PR TITLE
chore(agents): let the architect redirect a running subagent

### DIFF
--- a/.rulesync/subagents/architect.md
+++ b/.rulesync/subagents/architect.md
@@ -15,7 +15,7 @@ claudecode:
     networking-expert, reviewer, bug-hunter, performance-engineer, planner),
     AskUserQuestion, ExitPlanMode, Bash, Write, Read, WebFetch, WebSearch, LSP,
     Glob, Grep, Skill, TaskList, TaskCreate, TaskGet, TaskUpdate, TaskStop,
-    mcp__github
+    SendMessage, mcp__github
   color: purple
   memory: project
   effort: xhigh


### PR DESCRIPTION
Correcting a subagent mid-run meant stopping it and briefing a replacement from scratch, which discards the work already done and pays for a second full run. The architect now holds the tool that carries a correction to the agent still holding the context.

- The grant is one entry in the architect's tool list and changes no prose, no other agent, and no other frontmatter key.
- No specialist receives it, so corrections continue to flow only from the architect downwards, and the rules that make it the sole party talking to the bug hunter and the performance engineer are untouched.
- The tool list is a folded YAML scalar, so the entry was placed outside the parenthesised sublist that enumerates subagent types rather than tools, and the resolved value was checked after the edit.

Two things this does not do, recorded so the grant is not mistaken for something larger:

- It takes effect only in a new session. Agent definitions are snapshotted at session start, so a run already under way keeps the pre-grant tool list.
- It removes no existing discipline. Spawning a second agent while the first still runs remains the hazard it always was, and stopping an agent outright remains the right answer when the correction is a design reversal rather than an addition.