### PR TITLE
refactor(controlplane)!: remove the dead gateway_endpoint module config field

### DIFF
--- a/controlplane/bundle/cfg_test.go
+++ b/controlplane/bundle/cfg_test.go
@@ -63,7 +63,6 @@ func Test_NewBundle_ConfiguredModuleWithBadPath_FailsNamingModule(t *testing.T) 
 			MemoryPath:         xcfg.MustNonEmptyString("/nonexistent/path/for/bundle/cfg/test"),
 			MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 			Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-			GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 		}),
 	}
 

--- a/controlplane/etc/yanet/controlplane.d/default.yaml
+++ b/controlplane/etc/yanet/controlplane.d/default.yaml
@@ -14,7 +14,7 @@ gateway:
   # value but must be written down.
   instance_id: 0
   server:
-    endpoint: &gateway_endpoint "[::1]:8080"
+    endpoint: "[::1]:8080"
     http_endpoint: "[::1]:8081"
     # TLS is optional. When present both gRPC and HTTP listeners use it.
     # The certificate's SubjectAltName must include whatever host the
@@ -75,59 +75,49 @@ modules:
     memory_path: *memory_path
     memory_requirements: 16MB
     endpoint: "[::1]:0"
-    gateway_endpoint: *gateway_endpoint
   dscp:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
     endpoint: "[::1]:0"
-    gateway_endpoint: *gateway_endpoint
   forward:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
     endpoint: "[::1]:0"
-    gateway_endpoint: *gateway_endpoint
   mirror:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
     endpoint: "[::1]:0"
-    gateway_endpoint: *gateway_endpoint
   nat64:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
     endpoint: "[::1]:0"
-    gateway_endpoint: *gateway_endpoint
   pdump:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
     endpoint: "[::1]:0"
-    gateway_endpoint: *gateway_endpoint
   acl:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 8GB
     endpoint: "[::1]:0"
-    gateway_endpoint: *gateway_endpoint
   blackhole:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 4MB
     endpoint: "[::1]:0"
-    gateway_endpoint: *gateway_endpoint
 devices:
   plain:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
     endpoint: "[::1]:0"
-    gateway_endpoint: *gateway_endpoint
   vlan:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
     endpoint: "[::1]:0"
-    gateway_endpoint: *gateway_endpoint

--- a/controlplane/yncp/cfg_test.go
+++ b/controlplane/yncp/cfg_test.go
@@ -93,7 +93,6 @@ func Test_ModuleBlock_StrayNestedKey_RejectedByKnownFields(t *testing.T) {
 		"    memory_path: /dev/hugepages/yanet\n" +
 		"    memory_requirements: 16MB\n" +
 		"    endpoint: \"[::1]:0\"\n" +
-		"    gateway_endpoint: \"[::1]:8080\"\n" +
 		"    bogus: z\n"
 	var cfg yncp.Config
 	err := xcfg.Decode([]byte(input), &cfg, xcfg.WithKnownFields())

--- a/devices/plain/controlplane/cfg.go
+++ b/devices/plain/controlplane/cfg.go
@@ -20,9 +20,6 @@ type Config struct {
 
 	// Endpoint is the gRPC endpoint address
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
-
-	// GatewayEndpoint is the address of the gateway service
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // DefaultConfig returns default configuration
@@ -31,7 +28,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }
 

--- a/devices/trafgen/controlplane/cfg.go
+++ b/devices/trafgen/controlplane/cfg.go
@@ -18,8 +18,7 @@ type Config struct {
 	// transaction.
 	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
-	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
 func DefaultConfig() *Config {
@@ -27,7 +26,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }
 

--- a/devices/vlan/controlplane/cfg.go
+++ b/devices/vlan/controlplane/cfg.go
@@ -20,9 +20,6 @@ type Config struct {
 
 	// Endpoint is the gRPC endpoint address
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
-
-	// GatewayEndpoint is the address of the gateway service
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // DefaultConfig returns default configuration
@@ -31,7 +28,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }
 

--- a/modules/acl/controlplane/cfg.go
+++ b/modules/acl/controlplane/cfg.go
@@ -17,8 +17,6 @@ type Config struct {
 	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 	// Endpoint is the gRPC endpoint address
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
-	// GatewayEndpoint is the address of the gateway service
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // DefaultConfig returns default configuration
@@ -27,7 +25,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(64 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }
 

--- a/modules/blackhole/controlplane/cfg.go
+++ b/modules/blackhole/controlplane/cfg.go
@@ -19,9 +19,6 @@ type Config struct {
 
 	// Endpoint is the gRPC address the module listens on.
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
-	// GatewayEndpoint is the gRPC address of the gateway the module
-	// registers with.
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // DefaultConfig returns default configuration.
@@ -30,7 +27,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(4 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }
 

--- a/modules/decap/controlplane/cfg.go
+++ b/modules/decap/controlplane/cfg.go
@@ -17,8 +17,7 @@ type Config struct {
 	// transaction.
 	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
-	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
 func DefaultConfig() *Config {
@@ -26,7 +25,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }
 

--- a/modules/dscp/controlplane/cfg.go
+++ b/modules/dscp/controlplane/cfg.go
@@ -17,8 +17,7 @@ type Config struct {
 	// transaction.
 	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
-	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
 func DefaultConfig() *Config {
@@ -26,7 +25,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }
 

--- a/modules/forward/controlplane/cfg.go
+++ b/modules/forward/controlplane/cfg.go
@@ -17,8 +17,7 @@ type Config struct {
 	// transaction.
 	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
-	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
 func DefaultConfig() *Config {
@@ -26,7 +25,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }
 

--- a/modules/fwstate/controlplane/cfg.go
+++ b/modules/fwstate/controlplane/cfg.go
@@ -20,9 +20,6 @@ type Config struct {
 
 	// Endpoint is the gRPC endpoint address
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
-
-	// GatewayEndpoint is the address of the gateway service
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // DefaultConfig returns default configuration
@@ -31,7 +28,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(64 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }
 

--- a/modules/mirror/controlplane/cfg.go
+++ b/modules/mirror/controlplane/cfg.go
@@ -17,8 +17,7 @@ type Config struct {
 	// transaction.
 	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
-	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
 func DefaultConfig() *Config {
@@ -26,7 +25,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }
 

--- a/modules/nat64/controlplane/cfg.go
+++ b/modules/nat64/controlplane/cfg.go
@@ -20,9 +20,6 @@ type Config struct {
 
 	// Endpoint is the gRPC endpoint address
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
-
-	// GatewayEndpoint is the address of the gateway service
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // DefaultConfig returns default configuration
@@ -31,7 +28,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }
 

--- a/modules/pdump/controlplane/cfg.go
+++ b/modules/pdump/controlplane/cfg.go
@@ -17,9 +17,8 @@ type Config struct {
 	// transaction.
 	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
-	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
-	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
-	DebugEBPF       bool                `yaml:"debug_ebpf"`
+	Endpoint  xcfg.NonEmptyString `yaml:"endpoint"`
+	DebugEBPF bool                `yaml:"debug_ebpf"`
 }
 
 func DefaultConfig() *Config {
@@ -27,7 +26,6 @@ func DefaultConfig() *Config {
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 		DebugEBPF:          false,
 	}
 }


### PR DESCRIPTION
The `gateway_endpoint` key was present in twelve of the fourteen module and device configs and was read by nothing, while `route` and `route-mpls` did not have it at all. That asymmetry is what prompted the scan.

The field lost its last reader when the built-in modules were unified behind a single gateway-owned service runner. A module whose endpoint is non-empty is now wrapped in a runner that gets its own listener but stays in-process, and the gateway hands that runner its own endpoint rather than consulting any module config. Since the shipped default endpoint is non-empty, every bundled module already takes that path and none of them could redirect their registration anywhere.

No module in this repository launches as a separate process, so the key had nothing left to point at. Removing it rather than restoring it to the two modules that lack it leaves all fourteen modules and devices symmetric with no dead configuration. The key remains meaningful for a module that owns a standalone entrypoint and drives gateway registration itself, so this removal is scoped to the bundled modules and devices here.

Breaking change. The control plane rejects unknown configuration keys, so a deployed file that still sets `gateway_endpoint` fails at startup and must have the key removed. The resulting error message is unhelpfully worded and is tracked separately in #2026.

Closes #2024.