### PR TITLE
fix(dataplane): pin every segment of a chained mbuf on the worker tx pipe

### DIFF
--- a/bindings/go/dataplane_ut/tx_pipe.go
+++ b/bindings/go/dataplane_ut/tx_pipe.go
@@ -92,3 +92,39 @@ type TxPipeMbuf struct {
 func (m *TxPipeMbuf) Complete() {
 	C.dataplane_ut_tx_pipe_complete(m.ptr)
 }
+
+// Segment returns the segment at chain position idx below m (0 is m
+// itself), or nil past the end of the chain.
+func (m *TxPipeMbuf) Segment(idx int) *TxPipeMbuf {
+	ptr := C.dataplane_ut_tx_pipe_segment(m.ptr, C.size_t(idx))
+	if ptr == nil {
+		return nil
+	}
+
+	return &TxPipeMbuf{ptr: ptr}
+}
+
+// Refcnt reads the segment's current DPDK refcount.
+func (m *TxPipeMbuf) Refcnt() uint16 {
+	return uint16(C.dataplane_ut_tx_pipe_segment_refcnt(m.ptr))
+}
+
+// AddRefcnt adds delta to the segment's refcount directly, bypassing the
+// pipe.
+//
+// A positive delta manufactures the mismatch Push rejects, a matching
+// negative delta restores uniformity so the chain can be reused through the
+// normal push/drain path.
+func (m *TxPipeMbuf) AddRefcnt(delta int16) {
+	C.dataplane_ut_tx_pipe_segment_refcnt_add(m.ptr, C.int16_t(delta))
+}
+
+// CompleteSegment releases exactly this segment's consumer-side reference,
+// where Complete releases a whole chain at once.
+//
+// Release each segment exactly once, through this method or Complete but
+// never both, and never twice on the same segment — either mistake
+// double-frees it.
+func (m *TxPipeMbuf) CompleteSegment() {
+	C.dataplane_ut_tx_pipe_complete_segment(m.ptr)
+}

--- a/lib/dataplane/worker/tx_pipe.c
+++ b/lib/dataplane/worker/tx_pipe.c
@@ -1,5 +1,6 @@
 #include "tx_pipe.h"
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -16,8 +17,26 @@ worker_connection_push_cb(void **item, size_t count, void *data) {
 	struct worker_tx_pipe *tx_pipe = push_ctx->tx_pipe;
 
 	if (count > 0) {
-		uint32_t ref_cnt =
-			rte_mbuf_refcnt_update(push_ctx->mbuf, 1) - 1;
+		// Every segment must share one ref_cnt, the baseline
+		// worker_pending_mbuf_ready checks each segment against: one
+		// above it never sinks back down and wedges the pipe, one
+		// below it already reads as reclaimable while still in flight.
+		// Walked by hand rather than rte_pktmbuf_refcnt_update,
+		// which pins every segment blind with no unwind on mismatch.
+		uint64_t ref_cnt = rte_mbuf_refcnt_read(push_ctx->mbuf);
+		struct rte_mbuf *seg = push_ctx->mbuf;
+		do {
+			if (rte_mbuf_refcnt_read(seg) != ref_cnt) {
+				for (struct rte_mbuf *pinned = push_ctx->mbuf;
+				     pinned != seg;
+				     pinned = pinned->next) {
+					rte_mbuf_refcnt_update(pinned, -1);
+				}
+				return 0;
+			}
+			rte_mbuf_refcnt_update(seg, 1);
+		} while ((seg = seg->next) != NULL);
+
 		memcpy(item, &push_ctx->mbuf, sizeof(struct rte_mbuf *));
 
 		uint32_t ofs = tx_pipe->pending_stop & tx_pipe->pending_mask;
@@ -88,20 +107,45 @@ worker_tx_pipe_push(struct worker_tx_pipe *tx_pipe, struct rte_mbuf *mbuf) {
 	return 0;
 }
 
+// True once every segment has sunk back to ref_cnt: the consumer freed
+// the whole chain, only the producer's pin remains.
+//
+// Safe mid-decrement — a segment's next pointer clears only once its
+// own pin drops, never while still above baseline.
+static bool
+worker_pending_mbuf_ready(struct rte_mbuf *mbuf, uint64_t ref_cnt) {
+	do {
+		// Acquire load, not relaxed + fence: a bare fence with no
+		// preceding acquire load is invisible to TSan. Pairs with
+		// the consumer's release decrement — DPDK has no
+		// acquire-ordered refcnt accessor.
+		if (rte_atomic_load_explicit(
+			    &mbuf->refcnt, rte_memory_order_acquire
+		    ) > ref_cnt) {
+			return false;
+		}
+	} while ((mbuf = mbuf->next) != NULL);
+
+	return true;
+}
+
 void
 worker_tx_pipe_reclaim(struct worker_tx_pipe *tx_pipe) {
 	// Reclaim consumed pipe slots (producer free phase).
 	data_pipe_item_free(&tx_pipe->pipe, worker_connection_free_cb, NULL);
 
-	// Release mbufs whose consumer-side NIC tx has completed. A single
-	// pipe feeds one rx worker and one NIC tx queue, so completion is
-	// FIFO: drain from the head and stop at the first mbuf still held.
+	// Release mbufs whose consumer-side NIC tx has completed on every
+	// segment. A single pipe feeds one rx worker and one NIC tx queue,
+	// so completion is FIFO: drain from the head and stop at the first
+	// mbuf still held.
 	while (tx_pipe->pending_start < tx_pipe->pending_stop) {
 		uint32_t ofs = tx_pipe->pending_start & tx_pipe->pending_mask;
 		struct worker_pending_mbuf *pending =
 			tx_pipe->pending_mbufs + ofs;
 
-		if (rte_mbuf_refcnt_read(pending->mbuf) > pending->ref_cnt) {
+		if (!worker_pending_mbuf_ready(
+			    pending->mbuf, pending->ref_cnt
+		    )) {
 			break;
 		}
 

--- a/lib/dataplane/worker/tx_pipe.h
+++ b/lib/dataplane/worker/tx_pipe.h
@@ -19,10 +19,10 @@ struct worker_pending_mbuf {
 
 // A data pipe to another worker paired with its own deferred-free ring.
 //
-// The producer holds an extra reference on each mbuf pushed into pipe
-// and records it in pending_mbufs. The reference is released once the
-// consumer's NIC tx completes. Per-pipe completion is FIFO, so the ring
-// is drained head-first.
+// The producer pins every segment, recording their shared pre-pin
+// refcount as the baseline reclaim checks each segment against — so
+// segments must already agree on one refcount. FIFO completion drains
+// the ring head-first as each segment's NIC tx finishes.
 struct worker_tx_pipe {
 	struct data_pipe pipe;
 	struct worker_pending_mbuf *pending_mbufs;
@@ -43,7 +43,9 @@ worker_tx_pipe_fini(struct worker_tx_pipe *tx_pipe);
 
 // Push mbuf onto the pipe for the consumer to transmit.
 //
-// Returns 0 on success, -1 if the pipe or its deferred-free ring is full.
+// Returns 0 on success, -1 if the pipe or its deferred-free ring is
+// full, or if the chain's segments don't share one refcount to record
+// as the reclaim baseline.
 int
 worker_tx_pipe_push(struct worker_tx_pipe *tx_pipe, struct rte_mbuf *mbuf);
 

--- a/lib/dataplane_ut/tx_pipe.c
+++ b/lib/dataplane_ut/tx_pipe.c
@@ -118,6 +118,32 @@ dataplane_ut_tx_pipe_complete(struct rte_mbuf *mbuf) {
 	rte_pktmbuf_free(mbuf);
 }
 
+struct rte_mbuf *
+dataplane_ut_tx_pipe_segment(struct rte_mbuf *mbuf, size_t idx) {
+	while (mbuf != NULL && idx > 0) {
+		mbuf = mbuf->next;
+		--idx;
+	}
+	return mbuf;
+}
+
+uint16_t
+dataplane_ut_tx_pipe_segment_refcnt(struct rte_mbuf *segment) {
+	return rte_mbuf_refcnt_read(segment);
+}
+
+void
+dataplane_ut_tx_pipe_segment_refcnt_add(
+	struct rte_mbuf *segment, int16_t delta
+) {
+	rte_mbuf_refcnt_update(segment, delta);
+}
+
+void
+dataplane_ut_tx_pipe_complete_segment(struct rte_mbuf *segment) {
+	rte_pktmbuf_free_seg(segment);
+}
+
 void
 dataplane_ut_tx_pipe_reclaim(struct dataplane_ut_tx_pipe *fixture) {
 	worker_tx_pipe_reclaim(&fixture->tx_pipe);

--- a/lib/dataplane_ut/tx_pipe.h
+++ b/lib/dataplane_ut/tx_pipe.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdint.h>
 
 struct dataplane_ut_tx_pipe;
 struct rte_mbuf;
@@ -45,6 +46,35 @@ dataplane_ut_tx_pipe_drain(struct dataplane_ut_tx_pipe *fixture, size_t accept);
 // would once DMA finishes.
 void
 dataplane_ut_tx_pipe_complete(struct rte_mbuf *mbuf);
+
+// Return the mbuf idx segments below mbuf (0 is mbuf itself), or NULL
+// past the end of the chain.
+struct rte_mbuf *
+dataplane_ut_tx_pipe_segment(struct rte_mbuf *mbuf, size_t idx);
+
+// Read one segment's current DPDK refcount, e.g. to check a rejected
+// push restored it to its pre-push value.
+uint16_t
+dataplane_ut_tx_pipe_segment_refcnt(struct rte_mbuf *segment);
+
+// Add delta to one segment's refcount directly, bypassing the pipe.
+//
+// A positive delta manufactures the mismatched-refcount chain that
+// dataplane_ut_tx_pipe_push rejects. A matching negative delta restores
+// uniformity so the chain can drain through the normal path afterward.
+void
+dataplane_ut_tx_pipe_segment_refcnt_add(
+	struct rte_mbuf *segment, int16_t delta
+);
+
+// Release exactly one segment's consumer-side reference — the
+// per-segment counterpart to dataplane_ut_tx_pipe_complete.
+//
+// Every segment must be released exactly once, via this call or
+// dataplane_ut_tx_pipe_complete but never both: mixing them, or
+// calling either twice on one segment, double-frees it.
+void
+dataplane_ut_tx_pipe_complete_segment(struct rte_mbuf *segment);
 
 // Reclaim the fixture's pending ring via worker_tx_pipe_reclaim.
 void

--- a/tests/worker/tx_pipe_test.go
+++ b/tests/worker/tx_pipe_test.go
@@ -3,9 +3,7 @@
 // lib/dataplane_ut/tx_pipe.h fixture.
 //
 // A pass confirms the drain/reclaim cycle returns every mbuf to its pool
-// exactly once. Coverage is confined to single-segment mbufs: the producer
-// pins only the head segment of a chained mbuf, so a multi-segment chain's
-// tail segments would be freed twice on reclaim.
+// exactly once, across chain shapes and segment-release orders.
 package worker_test
 
 import (
@@ -134,4 +132,159 @@ func TestReclaimFreesPipeSlotsForReuse(t *testing.T) {
 	fixture.Drain(1)
 	freed.Complete()
 	fixture.Reclaim()
+}
+
+// TestPushRejectedMultiSegmentReclaimReturnsMbufToPool verifies that a
+// multi-segment mbuf a Drain call rejects outright returns every segment to
+// the pool exactly once via Reclaim.
+func TestPushRejectedMultiSegmentReclaimReturnsMbufToPool(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	const segCount = 3
+	mbuf, err := fixture.AllocMbuf(segCount)
+	require.NoError(t, err)
+	require.Equal(t, segCount, fixture.Outstanding())
+
+	require.NoError(t, fixture.Push(mbuf))
+
+	fixture.Drain(0)
+	fixture.Reclaim()
+
+	require.Equal(t, 0, fixture.Outstanding())
+}
+
+// TestPushAcceptedMultiSegmentCompleteReclaimReturnsMbufToPool verifies that
+// a multi-segment mbuf accepted by Drain returns every segment to the pool
+// exactly once, after Complete and Reclaim run.
+func TestPushAcceptedMultiSegmentCompleteReclaimReturnsMbufToPool(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	const segCount = 3
+	mbuf, err := fixture.AllocMbuf(segCount)
+	require.NoError(t, err)
+
+	require.NoError(t, fixture.Push(mbuf))
+
+	fixture.Drain(1)
+	require.Equal(t, segCount, fixture.Outstanding(), "an accepted chain must survive drain until NIC completion")
+
+	mbuf.Complete()
+	fixture.Reclaim()
+
+	require.Equal(t, 0, fixture.Outstanding())
+}
+
+// TestReclaimIsOrderIndependentAcrossSegmentReleaseOrder verifies that
+// reclaim waits for every segment of a drained chain to be released before
+// freeing any of them, in any release order.
+//
+// It releases head-first, the order that defeats a readiness check which
+// inspects only the head instead of the whole chain.
+func TestReclaimIsOrderIndependentAcrossSegmentReleaseOrder(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	const segCount = 3
+	mbuf, err := fixture.AllocMbuf(segCount)
+	require.NoError(t, err)
+
+	require.NoError(t, fixture.Push(mbuf))
+	fixture.Drain(1)
+
+	segments := make([]*dataplaneut.TxPipeMbuf, segCount)
+	for idx := range segments {
+		segments[idx] = mbuf.Segment(idx)
+		require.NotNil(t, segments[idx])
+	}
+
+	for released := 1; released <= segCount; released++ {
+		segments[released-1].CompleteSegment()
+		fixture.Reclaim()
+
+		if released < segCount {
+			require.Equal(t, segCount, fixture.Outstanding(),
+				"no segment may return to the pool until every segment of the chain is released")
+			continue
+		}
+
+		require.Equal(t, 0, fixture.Outstanding(),
+			"every segment must be back in the pool exactly once the last one is released")
+	}
+}
+
+// pushNonUniformChain builds a segCount-segment chain, bumps the refcount
+// of the segment at mismatchIdx (>= 1) so it disagrees with the head,
+// pushes it expecting rejection, and returns the segments with their
+// pre-push refcounts.
+func pushNonUniformChain(t *testing.T, fixture *dataplaneut.TxPipeFixture, segCount, mismatchIdx int) ([]*dataplaneut.TxPipeMbuf, []uint16) {
+	t.Helper()
+
+	mbuf, err := fixture.AllocMbuf(segCount)
+	require.NoError(t, err)
+
+	segments := make([]*dataplaneut.TxPipeMbuf, segCount)
+	for idx := range segments {
+		segments[idx] = mbuf.Segment(idx)
+		require.NotNil(t, segments[idx])
+	}
+
+	segments[mismatchIdx].AddRefcnt(1)
+
+	before := make([]uint16, segCount)
+	for idx, segment := range segments {
+		before[idx] = segment.Refcnt()
+	}
+
+	require.Error(t, fixture.Push(segments[0]), "push must reject a chain whose segments do not all share the head's refcount")
+
+	return segments, before
+}
+
+// TestPushRejectsMismatchOnFirstTailSegment verifies that a mismatch on the
+// first tail segment leaves every segment's refcount unchanged, and that
+// the pipe still accepts a push afterward.
+func TestPushRejectsMismatchOnFirstTailSegment(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	segments, before := pushNonUniformChain(t, fixture, 3, 1)
+	for idx, segment := range segments {
+		require.Equal(t, before[idx], segment.Refcnt(),
+			"segment %d refcount must be unchanged by the rejected push and its unwind", idx)
+	}
+
+	// Restore uniformity and confirm the pipe isn't wedged.
+	segments[1].AddRefcnt(-1)
+	require.NoError(t, fixture.Push(segments[0]))
+	fixture.Drain(1)
+	segments[0].Complete()
+	fixture.Reclaim()
+
+	require.Equal(t, 0, fixture.Outstanding(),
+		"the recovered chain must be back in the pool exactly once")
+}
+
+// TestPushRejectsMismatchOnLaterTailSegment verifies that a mismatch on a
+// later tail segment also leaves every segment's refcount unchanged and the
+// pipe still usable afterward.
+//
+// By this point Push has already pinned two segments, so this is the case
+// that catches an unwind collapsed to a single decrement — the first-tail
+// case passes vacuously, since it only had the head pinned.
+func TestPushRejectsMismatchOnLaterTailSegment(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	segments, before := pushNonUniformChain(t, fixture, 3, 2)
+	for idx, segment := range segments {
+		require.Equal(t, before[idx], segment.Refcnt(),
+			"segment %d refcount must be unchanged by the rejected push and its unwind", idx)
+	}
+
+	// Restore uniformity and confirm the pipe isn't wedged.
+	segments[2].AddRefcnt(-1)
+	require.NoError(t, fixture.Push(segments[0]))
+	fixture.Drain(1)
+	segments[0].Complete()
+	fixture.Reclaim()
+
+	require.Equal(t, 0, fixture.Outstanding(),
+		"the recovered chain must be back in the pool exactly once")
 }


### PR DESCRIPTION
The producer pinned only the head segment of a chained mbuf before handing it to another worker's tx queue, but both the producer and the consumer free the whole chain, so every tail segment of a multi-segment packet went back to the mempool twice.

- Pin every segment of the chain on push and record the pre-pin refcount as the baseline each one must fall back to, so the producer performs the real free only once the consumer has finished with the whole chain.
- Reject a chain whose segments do not share that baseline at the push site, unwinding the segments already pinned, through the existing backpressure path. Reclaim compares every segment against one recorded value, so a segment above it never sinks back and wedges the pipe, while one below it already qualifies and would be freed mid-flight.
- Read each segment's refcount on the reclaim walk with an acquire load that pairs with the consumer's release decrement, rather than a relaxed read plus a trailing fence, which has no acquire load to pair with and stays invisible to a happens-before checker.
- Keep the per-worker rx mempool single-producer-put, byte-identical to main. The consumer only ever decrements a pin on an mbuf it did not allocate, and the mempool put always happens on the owning worker.
- Extend the test fixture to reach, weigh and release one segment of a queued chain independently, and add tests over the real pipe for multi-segment reject and accept, release-order independence, and the push guard.

This is an alternative to the ownership-transfer approach, which fixes the same defect by moving the mbuf to the consumer and dropping the single-producer-put flag. The argument offered for relaxing the flag was that a whole-chain pin still races the consumer. That was tested and does not hold for a readiness check requiring every segment at its baseline: observing all of them decremented implies the consumer completed every decrement, so reclaim is independent of the order segments are released in. An exhaustive sweep of chains of one to five segments across every release permutation and every reclaim interleaving, plus roughly 6.6 M segments of two-thread stress, produced no cross-core mempool put, against a control on the unfixed code that fails immediately.

On lab-vla-fw3 at saturation the two approaches are indistinguishable, both from each other and from main, which is expected because the difference sits well under that rig's noise floor. The relevant asymmetry is that relaxing the flag adds cost to every packet's free, while the cross-worker path it optimises carries about one packet in ninety thousand on a production-shaped configuration.

The extraction of the tx pipe into its own unit, which this branch previously carried, merged separately in #2037, so what remains here is the behavioural change alone.

Closes #1718.
