### PR TITLE
fix(xcfg): report an unknown config key by path and line, not by Go type

### DIFF
--- a/common/go/xcfg/known_keys.go
+++ b/common/go/xcfg/known_keys.go
@@ -24,6 +24,13 @@ type walkableType interface {
 // mergeTag is the resolved tag yaml.v3 assigns to a "<<" merge key.
 const mergeTag = "!!merge"
 
+// unknownKey records one mapping key with no matching field, along with the
+// document line it sits on, so the reported error can point straight at it.
+type unknownKey struct {
+	Path string
+	Line int
+}
+
 // CheckKnownKeys reports every YAML mapping key in data that has no matching
 // field in T.
 //
@@ -31,8 +38,8 @@ const mergeTag = "!!merge"
 // instead of driving yaml.v3's own strict decoder, so it keeps working
 // across a field whose type implements UnmarshalYAML by re-decoding
 // through a fresh, non-strict decoder. WithKnownFields runs the same walk
-// as part of Decode. All unknown keys are collected into one error, each
-// as a dotted path rooted at the document.
+// as part of Decode. Every unknown key is collected into one error, each
+// named by its dotted path rooted at the document and the line it sits on.
 func CheckKnownKeys[T any](data []byte) error {
 	return checkKnownKeys(data, reflect.TypeFor[T]())
 }
@@ -49,12 +56,20 @@ func checkKnownKeys(data []byte, t reflect.Type) error {
 		return nil
 	}
 
-	var unknown []string
+	var unknown []unknownKey
 	walkKnownKeys(doc.Content[0], t, "", &unknown, map[*yaml.Node]bool{})
 	if len(unknown) == 0 {
 		return nil
 	}
-	return fmt.Errorf("unknown keys: %s", strings.Join(unknown, ", "))
+	if len(unknown) == 1 {
+		return fmt.Errorf("unknown key %q specified at line %d", unknown[0].Path, unknown[0].Line)
+	}
+
+	parts := make([]string, len(unknown))
+	for idx, u := range unknown {
+		parts[idx] = fmt.Sprintf("%q at line %d", u.Path, u.Line)
+	}
+	return fmt.Errorf("unknown keys specified: %s", strings.Join(parts, ", "))
 }
 
 // walkKnownKeys matches node's shape against t, appending the dotted path of
@@ -66,7 +81,7 @@ func checkKnownKeys(data []byte, t reflect.Type) error {
 // not into a node tree, and LoadConfig catches it separately, so stopping
 // silently is enough. The entry is removed on return, so a legitimate
 // anchor reused at sibling paths is still walked at each site.
-func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, unknown *[]string, visiting map[*yaml.Node]bool) {
+func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, unknown *[]unknownKey, visiting map[*yaml.Node]bool) {
 	if node == nil {
 		return
 	}
@@ -108,7 +123,7 @@ func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, unknown *[]stri
 // against, so it is skipped without reporting — for example a mapping
 // value against a plain scalar field is a shape mismatch that yaml.v3
 // itself rejects on the strict decode path.
-func walkMappingNode(node *yaml.Node, t reflect.Type, path string, unknown *[]string, visiting map[*yaml.Node]bool) {
+func walkMappingNode(node *yaml.Node, t reflect.Type, path string, unknown *[]unknownKey, visiting map[*yaml.Node]bool) {
 	switch t.Kind() {
 	case reflect.Struct:
 		fields, inlineElem := collectFields(t)
@@ -127,7 +142,7 @@ func walkMappingNode(node *yaml.Node, t reflect.Type, path string, unknown *[]st
 			case inlineElem != nil:
 				walkKnownKeys(valueNode, inlineElem, fieldPath, unknown, visiting)
 			default:
-				*unknown = append(*unknown, fieldPath)
+				*unknown = append(*unknown, unknownKey{Path: fieldPath, Line: keyNode.Line})
 			}
 		}
 	case reflect.Map:
@@ -147,7 +162,7 @@ func walkMappingNode(node *yaml.Node, t reflect.Type, path string, unknown *[]st
 // permits, though neither carries keys to check. A sequence value is
 // walked in place rather than routed through walkSequenceNode, since its
 // elements share t rather than a slice element type.
-func walkMergeValue(node *yaml.Node, t reflect.Type, path string, unknown *[]string, visiting map[*yaml.Node]bool) {
+func walkMergeValue(node *yaml.Node, t reflect.Type, path string, unknown *[]unknownKey, visiting map[*yaml.Node]bool) {
 	if node.Kind == yaml.SequenceNode {
 		for _, item := range node.Content {
 			walkKnownKeys(item, t, path, unknown, visiting)
@@ -159,7 +174,7 @@ func walkMergeValue(node *yaml.Node, t reflect.Type, path string, unknown *[]str
 
 // walkSequenceNode checks each element of a YAML sequence node against a
 // slice or array type's element type.
-func walkSequenceNode(node *yaml.Node, t reflect.Type, path string, unknown *[]string, visiting map[*yaml.Node]bool) {
+func walkSequenceNode(node *yaml.Node, t reflect.Type, path string, unknown *[]unknownKey, visiting map[*yaml.Node]bool) {
 	if t.Kind() != reflect.Slice && t.Kind() != reflect.Array {
 		return
 	}

--- a/common/go/xcfg/load.go
+++ b/common/go/xcfg/load.go
@@ -88,13 +88,16 @@ func Decode(buf []byte, dst any, options ...Option) error {
 	}
 
 	if opts.KnownFields {
-		dec := yaml.NewDecoder(bytes.NewReader(buf))
-		dec.KnownFields(true)
-		if err := dec.Decode(dst); err != nil && !errors.Is(err, io.EOF) {
+		if err := checkKnownKeys(buf, reflect.TypeOf(dst)); err != nil {
 			return err
 		}
 
-		if err := checkKnownKeys(buf, reflect.TypeOf(dst)); err != nil {
+		// checkKnownKeys runs first so an unknown key always reports through
+		// its operator-facing message rather than yaml.v3's own. This decode
+		// is what actually populates dst.
+		dec := yaml.NewDecoder(bytes.NewReader(buf))
+		dec.KnownFields(true)
+		if err := dec.Decode(dst); err != nil && !errors.Is(err, io.EOF) {
 			return err
 		}
 	} else {

--- a/common/go/xcfg/load_test.go
+++ b/common/go/xcfg/load_test.go
@@ -329,6 +329,50 @@ func Test_LoadConfig_KnownFields_ReachesCustomUnmarshalYAML(t *testing.T) {
 	require.Contains(t, err.Error(), "inner.bogus")
 }
 
+func Test_Decode_KnownFields_TopLevelUnknownReportsOurMessage(t *testing.T) {
+	// A top-level unknown key decodes into a plain field, so yaml.v3's own
+	// strict decoder can see it — it must still lose the race to our walk,
+	// which runs first and names the key and its line instead of a Go type.
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+	}
+
+	var cfg Config
+	err := Decode([]byte("name: foo\nbogus_top: true\n"), &cfg, WithKnownFields())
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "not found in type")
+	require.Contains(t, err.Error(), "bogus_top")
+	require.Contains(t, err.Error(), "specified at line 2")
+}
+
+func Test_Decode_KnownFields_ReportsRealLineNumber(t *testing.T) {
+	// The offending key sits well below line 1, so a hardcoded 0 or an
+	// off-by-one line count would fail this assertion.
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+		Path NonEmptyString `yaml:"path"`
+	}
+
+	input := "name: foo\npath: /tmp\n\n\nbogus_top: true\n"
+	var cfg Config
+	err := Decode([]byte(input), &cfg, WithKnownFields())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "specified at line 5")
+}
+
+func Test_Decode_KnownFields_MultipleUnknownKeysEachReportLine(t *testing.T) {
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+	}
+
+	input := "name: foo\nbogus_one: true\nbogus_two: true\n"
+	var cfg Config
+	err := Decode([]byte(input), &cfg, WithKnownFields())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"bogus_one" at line 2`)
+	require.Contains(t, err.Error(), `"bogus_two" at line 3`)
+}
+
 func Test_Load_LineErrorUnwrapsFromPathError(t *testing.T) {
 	// Verify that LineError from UnmarshalYAML is accessible via
 	// errors.As through the error chain, even when Decode doesn't


### PR DESCRIPTION
A stray or stale key in a control-plane configuration produced one of two unrelated errors depending only on where the key sat, and the more common one was written for a Go developer rather than for the operator editing the file.

The strict decoder ran first and reported `line 3: field bogus_top not found in type yncp.Config`. It names a type the operator cannot map to anything, it reads as though the document were missing something required when the fault is the opposite, and it stops at the first offending key. Keys inside a module or device block escaped it entirely and fell through to our own known-key walk, because the strict decoder cannot see into a type that decodes itself, which every optional config block does.

The walk now runs first, so one implementation reports every unknown key wherever it sits. A stale key now reads `unknown key "modules.decap.gateway_endpoint" specified at line 7`, and several at once are collected into one error rather than surfacing one per run. A key nested in a plain block gains its full path, `gateway.server.bogus`, where it previously reported a bare `bogus` plus a type name.

This is the error every operator upgrading past #2024 meets, since that change removed a key their deployed configuration still sets.

Decisions taken while implementing, none of which the issue fixed:

- The key is named by its dotted path rather than by the Go type the original request suggested. The path is what an operator can search for in the file, and the type is an implementation detail. Nothing outside the package parses these strings, so this breaks no consumer.
- The noun is "key" rather than "field", matching YAML vocabulary and the message this replaces.
- The strict decoder keeps its known-fields flag. The walk is a proven superset of it, so the flag can no longer report anything first, but removing it would be a behavioural change wider than this issue and it is harmless as a fail-safe.

Two follow-ups are deliberately left: the new tests sit in the package-internal test file that is already flagged for migration to an external test package, and a malformed document now reports through one extra wrapping clause in strict mode.

Closes #2026.