### PR TITLE
fix(xcfg): stop double-wrapping the error from a malformed config document

### DIFF
--- a/common/go/xcfg/known_keys.go
+++ b/common/go/xcfg/known_keys.go
@@ -50,7 +50,7 @@ func CheckKnownKeys[T any](data []byte) error {
 func checkKnownKeys(data []byte, t reflect.Type) error {
 	var doc yaml.Node
 	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return fmt.Errorf("failed to parse yaml document: %w", err)
+		return err
 	}
 	if len(doc.Content) == 0 {
 		return nil

--- a/common/go/xcfg/known_keys_test.go
+++ b/common/go/xcfg/known_keys_test.go
@@ -316,3 +316,21 @@ func Test_CheckKnownKeys_OptionalCleanDocumentNotFlagged(t *testing.T) {
 	input := "sub:\n  a: x\n  b: y\n"
 	require.NoError(t, xcfg.CheckKnownKeys[optionalWrapped]([]byte(input)))
 }
+
+// Test_Decode_MalformedDocument_SameErrorBothModes asserts that a document
+// yaml.v3 itself cannot parse reports the identical error whether or not
+// WithKnownFields is set, since CheckKnownKeys must not add a wrapping
+// clause the plain decode path lacks.
+func Test_Decode_MalformedDocument_SameErrorBothModes(t *testing.T) {
+	input := "name: foo\n  bogus: bar\n"
+
+	var strict knownKeysConfig
+	errStrict := xcfg.Decode([]byte(input), &strict, xcfg.WithKnownFields())
+
+	var lenient knownKeysConfig
+	errLenient := xcfg.Decode([]byte(input), &lenient)
+
+	require.Error(t, errStrict)
+	require.Error(t, errLenient)
+	require.Equal(t, errLenient.Error(), errStrict.Error())
+}


### PR DESCRIPTION
Reordering the known-key check ahead of the strict decode in #2033 routed a parse failure through a wrapper that restated what the underlying error already said. A genuinely malformed document reported `failed to parse config file: failed to parse yaml document: yaml: line 2: ...` in strict mode, while the lenient path reported the same fault with one clause fewer. Both modes reject such a document identically, so the divergence was noise on the operator-facing surface #2033 exists to improve.

The parse error now surfaces unchanged. It already begins by naming the parser and carries the line, so the removed prefix added a clause without adding information.

The two paths were confirmed to agree exactly rather than merely similarly. The destination value never reaches the parser, which runs to completion before anything is decoded into it, so the text cannot depend on which path asked for it. That holds empirically across every parse-failure class exercised — bad indentation, unterminated quotes, tab indentation, unclosed flow collections, undefined aliases, invalid encodings, bad directives and malformed multi-document streams — all byte-identical on both paths. The accompanying test asserts that exact equality between the two modes rather than merely that both fail.

Closes #2034.