### PR TITLE
refactor(dataplane): extract the worker tx pipe into its own unit

### DIFF
--- a/bindings/go/dataplane_ut/tx_pipe.go
+++ b/bindings/go/dataplane_ut/tx_pipe.go
@@ -1,0 +1,94 @@
+package dataplaneut
+
+/*
+#include "lib/dataplane_ut/tx_pipe.h"
+*/
+import "C"
+
+import (
+	"fmt"
+)
+
+// TxPipeFixture is a handle to a lib/dataplane_ut/tx_pipe.h fixture.
+//
+// One worker_tx_pipe is paired with a mock mempool, exercised directly
+// without spinning up a full Harness.
+type TxPipeFixture struct {
+	ptr *C.struct_dataplane_ut_tx_pipe
+}
+
+// NewTxPipeFixture constructs a fixture.
+// Free must be called when the test is done.
+func NewTxPipeFixture() (*TxPipeFixture, error) {
+	ptr := C.dataplane_ut_tx_pipe_new()
+	if ptr == nil {
+		return nil, fmt.Errorf("failed to create tx pipe fixture: dataplane_ut_tx_pipe_new returned NULL")
+	}
+
+	return &TxPipeFixture{ptr: ptr}, nil
+}
+
+// Free tears down the fixture. Nil-safe.
+func (m *TxPipeFixture) Free() {
+	C.dataplane_ut_tx_pipe_free(m.ptr)
+	m.ptr = nil
+}
+
+// AllocMbuf allocates a chained mbuf of segCount segments from the
+// fixture's mock pool.
+//
+// segCount must be at least 1.
+func (m *TxPipeFixture) AllocMbuf(segCount int) (*TxPipeMbuf, error) {
+	ptr := C.dataplane_ut_tx_pipe_alloc_mbuf(m.ptr, C.size_t(segCount))
+	if ptr == nil {
+		return nil, fmt.Errorf("failed to allocate a %d-segment mbuf: pool exhausted", segCount)
+	}
+
+	return &TxPipeMbuf{ptr: ptr}, nil
+}
+
+// Push pushes mbuf onto the fixture's pipe for a later Drain to transmit.
+//
+// Returns an error if the pipe or its deferred-free ring is full.
+func (m *TxPipeFixture) Push(mbuf *TxPipeMbuf) error {
+	if C.dataplane_ut_tx_pipe_push(m.ptr, mbuf.ptr) != 0 {
+		return fmt.Errorf("tx pipe push failed: pipe or deferred-free ring full")
+	}
+
+	return nil
+}
+
+// Drain pops the fixture's pipe, handing at most accept mbufs of each popped
+// burst to a stub transmit and freeing whatever it did not accept — the same
+// rejected-tail path a short real NIC tx_burst would take.
+func (m *TxPipeFixture) Drain(accept int) {
+	C.dataplane_ut_tx_pipe_drain(m.ptr, C.size_t(accept))
+}
+
+// Reclaim reclaims the fixture's pending ring: consumed pipe slots plus any
+// mbufs whose simulated NIC tx has completed.
+func (m *TxPipeFixture) Reclaim() {
+	C.dataplane_ut_tx_pipe_reclaim(m.ptr)
+}
+
+// Outstanding returns the number of mock-pool objects currently allocated
+// (dequeued but not yet returned).
+func (m *TxPipeFixture) Outstanding() int {
+	return int(C.dataplane_ut_tx_pipe_outstanding(m.ptr))
+}
+
+// TxPipeMbuf is a handle to a chained mbuf allocated by
+// TxPipeFixture.AllocMbuf.
+type TxPipeMbuf struct {
+	ptr *C.struct_rte_mbuf
+}
+
+// Complete simulates the NIC completing transmission of an mbuf a prior
+// Drain accepted, releasing it exactly as a real driver's tx-descriptor
+// reclaim would once DMA finishes.
+//
+// Must be called at most once per mbuf, and only for an mbuf a Drain call
+// accepted rather than rejected.
+func (m *TxPipeMbuf) Complete() {
+	C.dataplane_ut_tx_pipe_complete(m.ptr)
+}

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -82,22 +82,9 @@ dataplane_worker_connect(
 	}
 
 	struct worker_tx_pipe *tx_pipe = tx_conn->pipes + tx_conn->count;
-	if (data_pipe_init(&tx_pipe->pipe, WORKER_TX_PIPE_SIZE)) {
+	if (worker_tx_pipe_init(tx_pipe)) {
 		return -1;
 	}
-
-	uint32_t pending_capacity =
-		1u << (WORKER_TX_PIPE_SIZE + WORKER_TX_PIPE_PENDING_SHIFT);
-	tx_pipe->pending_mbufs = (struct worker_pending_mbuf *)malloc(
-		sizeof(struct worker_pending_mbuf) * pending_capacity
-	);
-	if (tx_pipe->pending_mbufs == NULL) {
-		data_pipe_fini(&tx_pipe->pipe);
-		return -1;
-	}
-	tx_pipe->pending_mask = pending_capacity - 1;
-	tx_pipe->pending_start = 0;
-	tx_pipe->pending_stop = 0;
 
 	++tx_conn->count;
 

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -55,8 +55,8 @@
 #include "lib/dataplane/worker/counters.h"
 #include "lib/dataplane/worker/pipeline_round.h"
 #include "lib/dataplane/worker/round.h"
+#include "lib/dataplane/worker/tx_pipe.h"
 
-#include "common/data_pipe.h"
 #include "logging/log.h"
 
 #include <rte_ethdev.h>
@@ -119,40 +119,16 @@ worker_read(
 	}
 }
 
-struct worker_push_ctx {
-	struct worker_tx_pipe *tx_pipe;
-	struct rte_mbuf *mbuf;
-};
-
 static size_t
-worker_connection_push_cb(void **item, size_t count, void *data) {
-	struct worker_push_ctx *push_ctx = (struct worker_push_ctx *)data;
-	struct worker_tx_pipe *tx_pipe = push_ctx->tx_pipe;
-
-	if (count > 0) {
-		uint32_t ref_cnt =
-			rte_mbuf_refcnt_update(push_ctx->mbuf, 1) - 1;
-		memcpy(item, &push_ctx->mbuf, sizeof(struct rte_mbuf *));
-
-		uint32_t ofs = tx_pipe->pending_stop & tx_pipe->pending_mask;
-		tx_pipe->pending_mbufs[ofs].mbuf = push_ctx->mbuf;
-		tx_pipe->pending_mbufs[ofs].ref_cnt = ref_cnt;
-		++tx_pipe->pending_stop;
-
-		return 1;
-	}
-	return 0;
-}
-
-static size_t
-worker_rx_pipe_pop_cb(void **item, size_t count, void *data) {
+worker_tx_transmit_cb(struct rte_mbuf **mbufs, size_t count, void *data) {
 	struct dataplane_worker *worker = (struct dataplane_worker *)data;
-	struct rte_mbuf **mbufs = (struct rte_mbuf **)item;
 
 	(*worker->dp_worker->remote_rx_count) += count;
 
+	uint16_t burst_count =
+		count > UINT16_MAX ? UINT16_MAX : (uint16_t)count;
 	size_t written = rte_eth_tx_burst(
-		worker->port_id, worker->queue_id, mbufs, count
+		worker->port_id, worker->queue_id, mbufs, burst_count
 	);
 	*(worker->dp_worker->tx_count) += written;
 
@@ -162,19 +138,7 @@ worker_rx_pipe_pop_cb(void **item, size_t count, void *data) {
 		*(worker->dp_worker->drop_count) += dropped;
 	}
 
-	for (size_t idx = written; idx < count; ++idx) {
-		rte_pktmbuf_free(mbufs[idx]);
-	}
-
-	return count;
-}
-
-static size_t
-worker_connection_free_cb(void **item, size_t count, void *data) {
-	(void)item;
-	(void)data;
-
-	return count;
+	return written;
 }
 
 /*
@@ -193,46 +157,7 @@ worker_send_to_port(struct dataplane_worker *worker, struct packet *packet) {
 	struct worker_tx_pipe *tx_pipe =
 		tx_conn->pipes + packet->hash % tx_conn->count;
 
-	// Backpressure: drop when this pipe's pending ring is full.
-	if (tx_pipe->pending_stop - tx_pipe->pending_start >
-	    tx_pipe->pending_mask) {
-		return -1;
-	}
-
-	struct worker_push_ctx push_ctx = {
-		.tx_pipe = tx_pipe,
-		.mbuf = packet_to_mbuf(packet),
-	};
-
-	if (data_pipe_item_push(
-		    &tx_pipe->pipe, worker_connection_push_cb, &push_ctx
-	    ) != 1) {
-		return -1;
-	}
-
-	return 0;
-}
-
-static void
-worker_tx_pipe_reclaim(struct worker_tx_pipe *tx_pipe) {
-	// Reclaim consumed pipe slots (producer free phase).
-	data_pipe_item_free(&tx_pipe->pipe, worker_connection_free_cb, NULL);
-
-	// Release mbufs whose consumer-side NIC tx has completed. A single
-	// pipe feeds one rx worker and one NIC tx queue, so completion is
-	// FIFO: drain from the head and stop at the first mbuf still held.
-	while (tx_pipe->pending_start < tx_pipe->pending_stop) {
-		uint32_t ofs = tx_pipe->pending_start & tx_pipe->pending_mask;
-		struct worker_pending_mbuf *pending =
-			tx_pipe->pending_mbufs + ofs;
-
-		if (rte_mbuf_refcnt_read(pending->mbuf) > pending->ref_cnt) {
-			break;
-		}
-
-		rte_pktmbuf_free(pending->mbuf);
-		++tx_pipe->pending_start;
-	}
+	return worker_tx_pipe_push(tx_pipe, packet_to_mbuf(packet));
 }
 
 static void
@@ -331,8 +256,8 @@ worker_write(
 
 	// Read incoming mbufs from remote workers and write them to device
 	for (uint32_t pipe_idx = 0; pipe_idx < ctx->rx_pipe_count; ++pipe_idx) {
-		data_pipe_item_pop(
-			ctx->rx_pipes + pipe_idx, worker_rx_pipe_pop_cb, worker
+		worker_tx_pipe_drain(
+			ctx->rx_pipes + pipe_idx, worker_tx_transmit_cb, worker
 		);
 	}
 

--- a/dataplane/worker.h
+++ b/dataplane/worker.h
@@ -9,40 +9,15 @@
 
 #include "common/data_pipe.h"
 #include "lib/dataplane/packet/packet.h"
+#include "lib/dataplane/worker/tx_pipe.h"
 
 struct dataplane;
 struct dataplane_instance;
 
 struct dp_worker;
 
-// log2 of the per-connection SPSC data pipe capacity.
-#define WORKER_TX_PIPE_SIZE 10
-// The per-pipe deferred-free ring holds 2^(WORKER_TX_PIPE_SIZE + this)
-// mbufs, sized above the pipe capacity to absorb consumer-side NIC tx
-// backlog before backpressure drops further packets.
-#define WORKER_TX_PIPE_PENDING_SHIFT 2
-
 struct worker_read_ctx {
 	uint16_t read_size;
-};
-
-struct worker_pending_mbuf {
-	struct rte_mbuf *mbuf;
-	uint64_t ref_cnt;
-};
-
-// A data pipe to another worker paired with its own deferred-free ring.
-//
-// The producer holds an extra reference on each mbuf pushed into `pipe`
-// and records it in `pending_mbufs`; the reference is released once the
-// consumer's NIC tx completes. Per-pipe completion is FIFO, so the ring
-// is drained head-first.
-struct worker_tx_pipe {
-	struct data_pipe pipe;
-	struct worker_pending_mbuf *pending_mbufs;
-	uint32_t pending_mask;
-	uint64_t pending_start;
-	uint64_t pending_stop;
 };
 
 struct worker_tx_connection {

--- a/lib/dataplane/worker/meson.build
+++ b/lib/dataplane/worker/meson.build
@@ -14,6 +14,7 @@ sources = files(
   'pipeline_round.c',
   'worker.c',
   'counters.c',
+  'tx_pipe.c',
 )
 
 lib_worker_dp = static_library(

--- a/lib/dataplane/worker/tx_pipe.c
+++ b/lib/dataplane/worker/tx_pipe.c
@@ -1,0 +1,147 @@
+#include "tx_pipe.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <rte_mbuf.h>
+
+struct worker_push_ctx {
+	struct worker_tx_pipe *tx_pipe;
+	struct rte_mbuf *mbuf;
+};
+
+static size_t
+worker_connection_push_cb(void **item, size_t count, void *data) {
+	struct worker_push_ctx *push_ctx = (struct worker_push_ctx *)data;
+	struct worker_tx_pipe *tx_pipe = push_ctx->tx_pipe;
+
+	if (count > 0) {
+		uint32_t ref_cnt =
+			rte_mbuf_refcnt_update(push_ctx->mbuf, 1) - 1;
+		memcpy(item, &push_ctx->mbuf, sizeof(struct rte_mbuf *));
+
+		uint32_t ofs = tx_pipe->pending_stop & tx_pipe->pending_mask;
+		tx_pipe->pending_mbufs[ofs].mbuf = push_ctx->mbuf;
+		tx_pipe->pending_mbufs[ofs].ref_cnt = ref_cnt;
+		++tx_pipe->pending_stop;
+
+		return 1;
+	}
+	return 0;
+}
+
+static size_t
+worker_connection_free_cb(void **item, size_t count, void *data) {
+	(void)item;
+	(void)data;
+
+	return count;
+}
+
+int
+worker_tx_pipe_init(struct worker_tx_pipe *tx_pipe) {
+	if (data_pipe_init(&tx_pipe->pipe, WORKER_TX_PIPE_SIZE)) {
+		return -1;
+	}
+
+	uint32_t pending_capacity =
+		1u << (WORKER_TX_PIPE_SIZE + WORKER_TX_PIPE_PENDING_SHIFT);
+	tx_pipe->pending_mbufs = (struct worker_pending_mbuf *)malloc(
+		sizeof(struct worker_pending_mbuf) * pending_capacity
+	);
+	if (tx_pipe->pending_mbufs == NULL) {
+		data_pipe_fini(&tx_pipe->pipe);
+		return -1;
+	}
+	tx_pipe->pending_mask = pending_capacity - 1;
+	tx_pipe->pending_start = 0;
+	tx_pipe->pending_stop = 0;
+
+	return 0;
+}
+
+void
+worker_tx_pipe_fini(struct worker_tx_pipe *tx_pipe) {
+	free(tx_pipe->pending_mbufs);
+	data_pipe_fini(&tx_pipe->pipe);
+}
+
+int
+worker_tx_pipe_push(struct worker_tx_pipe *tx_pipe, struct rte_mbuf *mbuf) {
+	// Backpressure: drop when this pipe's pending ring is full.
+	if (tx_pipe->pending_stop - tx_pipe->pending_start >
+	    tx_pipe->pending_mask) {
+		return -1;
+	}
+
+	struct worker_push_ctx push_ctx = {
+		.tx_pipe = tx_pipe,
+		.mbuf = mbuf,
+	};
+
+	if (data_pipe_item_push(
+		    &tx_pipe->pipe, worker_connection_push_cb, &push_ctx
+	    ) != 1) {
+		return -1;
+	}
+
+	return 0;
+}
+
+void
+worker_tx_pipe_reclaim(struct worker_tx_pipe *tx_pipe) {
+	// Reclaim consumed pipe slots (producer free phase).
+	data_pipe_item_free(&tx_pipe->pipe, worker_connection_free_cb, NULL);
+
+	// Release mbufs whose consumer-side NIC tx has completed. A single
+	// pipe feeds one rx worker and one NIC tx queue, so completion is
+	// FIFO: drain from the head and stop at the first mbuf still held.
+	while (tx_pipe->pending_start < tx_pipe->pending_stop) {
+		uint32_t ofs = tx_pipe->pending_start & tx_pipe->pending_mask;
+		struct worker_pending_mbuf *pending =
+			tx_pipe->pending_mbufs + ofs;
+
+		if (rte_mbuf_refcnt_read(pending->mbuf) > pending->ref_cnt) {
+			break;
+		}
+
+		rte_pktmbuf_free(pending->mbuf);
+		++tx_pipe->pending_start;
+	}
+}
+
+struct worker_tx_pipe_drain_ctx {
+	worker_tx_pipe_transmit_func transmit_func;
+	void *transmit_func_data;
+};
+
+static size_t
+worker_tx_pipe_drain_cb(void **item, size_t count, void *data) {
+	struct worker_tx_pipe_drain_ctx *drain_ctx =
+		(struct worker_tx_pipe_drain_ctx *)data;
+	struct rte_mbuf **mbufs = (struct rte_mbuf **)item;
+
+	size_t written = drain_ctx->transmit_func(
+		mbufs, count, drain_ctx->transmit_func_data
+	);
+
+	for (size_t idx = written; idx < count; ++idx) {
+		rte_pktmbuf_free(mbufs[idx]);
+	}
+
+	return count;
+}
+
+void
+worker_tx_pipe_drain(
+	struct data_pipe *rx_pipe,
+	worker_tx_pipe_transmit_func transmit_func,
+	void *transmit_func_data
+) {
+	struct worker_tx_pipe_drain_ctx drain_ctx = {
+		.transmit_func = transmit_func,
+		.transmit_func_data = transmit_func_data,
+	};
+
+	data_pipe_item_pop(rx_pipe, worker_tx_pipe_drain_cb, &drain_ctx);
+}

--- a/lib/dataplane/worker/tx_pipe.h
+++ b/lib/dataplane/worker/tx_pipe.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/data_pipe.h"
+
+// log2 of the per-connection SPSC data pipe capacity.
+#define WORKER_TX_PIPE_SIZE 10
+// The per-pipe deferred-free ring holds 2^(WORKER_TX_PIPE_SIZE + this)
+// mbufs, sized above the pipe capacity to absorb consumer-side NIC tx
+// backlog before backpressure drops further packets.
+#define WORKER_TX_PIPE_PENDING_SHIFT 2
+
+struct worker_pending_mbuf {
+	struct rte_mbuf *mbuf;
+	uint64_t ref_cnt;
+};
+
+// A data pipe to another worker paired with its own deferred-free ring.
+//
+// The producer holds an extra reference on each mbuf pushed into pipe
+// and records it in pending_mbufs. The reference is released once the
+// consumer's NIC tx completes. Per-pipe completion is FIFO, so the ring
+// is drained head-first.
+struct worker_tx_pipe {
+	struct data_pipe pipe;
+	struct worker_pending_mbuf *pending_mbufs;
+	uint32_t pending_mask;
+	uint64_t pending_start;
+	uint64_t pending_stop;
+};
+
+// Initialize the pipe and its deferred-free ring.
+//
+// Returns 0 on success, -1 on error.
+int
+worker_tx_pipe_init(struct worker_tx_pipe *tx_pipe);
+
+// Release resources allocated by worker_tx_pipe_init().
+void
+worker_tx_pipe_fini(struct worker_tx_pipe *tx_pipe);
+
+// Push mbuf onto the pipe for the consumer to transmit.
+//
+// Returns 0 on success, -1 if the pipe or its deferred-free ring is full.
+int
+worker_tx_pipe_push(struct worker_tx_pipe *tx_pipe, struct rte_mbuf *mbuf);
+
+// Reclaim consumed pipe slots and release mbufs whose consumer-side NIC tx
+// has completed.
+void
+worker_tx_pipe_reclaim(struct worker_tx_pipe *tx_pipe);
+
+// Caller-supplied transmit callback for worker_tx_pipe_drain().
+//
+// Must attempt to transmit the given mbufs and return how many were
+// actually accepted. The drain frees the rest.
+typedef size_t (*worker_tx_pipe_transmit_func)(
+	struct rte_mbuf **mbufs, size_t count, void *data
+);
+
+// Drain a consumer-side rx pipe, handing popped mbufs to transmit_func and
+// freeing whatever it did not accept.
+void
+worker_tx_pipe_drain(
+	struct data_pipe *rx_pipe,
+	worker_tx_pipe_transmit_func transmit_func,
+	void *transmit_func_data
+);

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -411,9 +411,7 @@ dataplane_ut_free(struct dataplane_ut *ut) {
 	}
 
 	if (ut->mempool != NULL) {
-		// Do NOT call rte_mempool_free — the test pool is not a real
-		// DPDK pool and has no backing memory to tear down that way.
-		free(ut->mempool);
+		test_mempool_free(ut->mempool);
 		ut->mempool = NULL;
 	}
 

--- a/lib/dataplane_ut/mempool.h
+++ b/lib/dataplane_ut/mempool.h
@@ -26,6 +26,7 @@ test_pool_enqueue(struct rte_mempool *mp, void *const *obj_table, unsigned n) {
 	for (unsigned idx = 0; idx < n; idx++) {
 		free((char *)obj_table[idx] - mp->header_size);
 	}
+	*(size_t *)mp->pool_data -= n;
 
 	return 0;
 }
@@ -51,6 +52,8 @@ test_pool_dequeue(struct rte_mempool *mp, void **obj_table, unsigned n) {
 
 		rte_pktmbuf_init(mp, NULL, obj_table[idx], 0);
 	}
+	*(size_t *)mp->pool_data += n;
+
 	return 0;
 }
 
@@ -69,14 +72,19 @@ static const struct rte_mempool_ops test_pool_ops = {
 	.get_count = test_pool_get_count,
 };
 
-struct rte_mempool *
+static inline struct rte_mempool *
 test_mempool_create(void) {
 	rte_mempool_ops_table.num_ops = 0;
 	rte_mempool_register_ops(&test_pool_ops);
 
+	// The outstanding-object counter lives right after the private data,
+	// inside this same allocation, so every caller's plain free(mp) stays
+	// correct instead of leaking a separately-allocated counter.
 	size_t private_data_size = sizeof(struct rte_pktmbuf_pool_private);
 	struct rte_mempool *mp =
-		calloc(1, sizeof(struct rte_mempool) + private_data_size);
+		calloc(1,
+		       sizeof(struct rte_mempool) + private_data_size +
+			       sizeof(size_t));
 	mp->flags |= RTE_MEMPOOL_F_POOL_CREATED;
 	mp->socket_id = 0;
 	mp->cache_size = 0;
@@ -86,6 +94,22 @@ test_mempool_create(void) {
 		mp->header_size += 64 - (mp->header_size % 64);
 	}
 	mp->private_data_size = private_data_size;
+	mp->pool_data =
+		(char *)mp + sizeof(struct rte_mempool) + private_data_size;
 	rte_pktmbuf_pool_init(mp, NULL);
 	return mp;
+}
+
+// Release resources allocated by test_mempool_create().
+static inline void
+test_mempool_free(struct rte_mempool *mp) {
+	// Do NOT call rte_mempool_free — the test pool is not a real DPDK
+	// pool and has no backing memory to tear down that way.
+	free(mp);
+}
+
+// Number of mock-pool objects currently dequeued but not yet enqueued back.
+static inline size_t
+test_mempool_outstanding(const struct rte_mempool *mp) {
+	return *(const size_t *)mp->pool_data;
 }

--- a/lib/dataplane_ut/meson.build
+++ b/lib/dataplane_ut/meson.build
@@ -12,6 +12,7 @@ dependencies = [
 
 sources = files(
   'dataplane_ut.c',
+  'tx_pipe.c',
 )
 
 lib_dataplane_ut = static_library(

--- a/lib/dataplane_ut/tx_pipe.c
+++ b/lib/dataplane_ut/tx_pipe.c
@@ -1,0 +1,129 @@
+#include "tx_pipe.h"
+
+#include <stdlib.h>
+
+#include <rte_mbuf.h>
+
+#include "lib/dataplane/worker/tx_pipe.h"
+#include "lib/dataplane_ut/mempool.h"
+
+struct dataplane_ut_tx_pipe {
+	struct worker_tx_pipe tx_pipe;
+	struct rte_mempool *mempool;
+};
+
+struct dataplane_ut_tx_pipe *
+dataplane_ut_tx_pipe_new(void) {
+	struct dataplane_ut_tx_pipe *fixture =
+		(struct dataplane_ut_tx_pipe *)malloc(sizeof(*fixture));
+	if (fixture == NULL) {
+		return NULL;
+	}
+
+	fixture->mempool = test_mempool_create();
+	if (fixture->mempool == NULL) {
+		free(fixture);
+		return NULL;
+	}
+
+	if (worker_tx_pipe_init(&fixture->tx_pipe)) {
+		test_mempool_free(fixture->mempool);
+		free(fixture);
+		return NULL;
+	}
+
+	return fixture;
+}
+
+void
+dataplane_ut_tx_pipe_free(struct dataplane_ut_tx_pipe *fixture) {
+	if (fixture == NULL) {
+		return;
+	}
+
+	worker_tx_pipe_fini(&fixture->tx_pipe);
+	test_mempool_free(fixture->mempool);
+	free(fixture);
+}
+
+struct rte_mbuf *
+dataplane_ut_tx_pipe_alloc_mbuf(
+	struct dataplane_ut_tx_pipe *fixture, size_t seg_count
+) {
+	if (seg_count == 0) {
+		return NULL;
+	}
+
+	struct rte_mbuf *head = NULL;
+	struct rte_mbuf *tail = NULL;
+
+	for (size_t idx = 0; idx < seg_count; ++idx) {
+		struct rte_mbuf *seg = rte_pktmbuf_alloc(fixture->mempool);
+		if (seg == NULL) {
+			if (head != NULL) {
+				rte_pktmbuf_free(head);
+			}
+			return NULL;
+		}
+
+		if (head == NULL) {
+			head = seg;
+		} else {
+			tail->next = seg;
+		}
+		tail = seg;
+	}
+
+	head->nb_segs = (uint16_t)seg_count;
+	head->pkt_len = 0;
+
+	return head;
+}
+
+int
+dataplane_ut_tx_pipe_push(
+	struct dataplane_ut_tx_pipe *fixture, struct rte_mbuf *mbuf
+) {
+	return worker_tx_pipe_push(&fixture->tx_pipe, mbuf);
+}
+
+struct dataplane_ut_tx_pipe_transmit_ctx {
+	size_t accept;
+};
+
+static size_t
+dataplane_ut_tx_pipe_transmit_cb(
+	struct rte_mbuf **mbufs, size_t count, void *data
+) {
+	(void)mbufs;
+	struct dataplane_ut_tx_pipe_transmit_ctx *ctx =
+		(struct dataplane_ut_tx_pipe_transmit_ctx *)data;
+
+	return ctx->accept < count ? ctx->accept : count;
+}
+
+void
+dataplane_ut_tx_pipe_drain(
+	struct dataplane_ut_tx_pipe *fixture, size_t accept
+) {
+	struct dataplane_ut_tx_pipe_transmit_ctx ctx = {.accept = accept};
+
+	worker_tx_pipe_drain(
+		&fixture->tx_pipe.pipe, dataplane_ut_tx_pipe_transmit_cb, &ctx
+	);
+}
+
+void
+dataplane_ut_tx_pipe_complete(struct rte_mbuf *mbuf) {
+	rte_pktmbuf_free(mbuf);
+}
+
+void
+dataplane_ut_tx_pipe_reclaim(struct dataplane_ut_tx_pipe *fixture) {
+	worker_tx_pipe_reclaim(&fixture->tx_pipe);
+}
+
+size_t
+dataplane_ut_tx_pipe_outstanding(struct dataplane_ut_tx_pipe *fixture) {
+	return test_mempool_outstanding(fixture->mempool);
+}

--- a/lib/dataplane_ut/tx_pipe.h
+++ b/lib/dataplane_ut/tx_pipe.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <stddef.h>
+
+struct dataplane_ut_tx_pipe;
+struct rte_mbuf;
+
+// Construct a fixture owning one worker_tx_pipe and a mock mempool.
+//
+// Returns NULL on allocation failure. The caller releases it with
+// dataplane_ut_tx_pipe_free.
+struct dataplane_ut_tx_pipe *
+dataplane_ut_tx_pipe_new(void);
+
+// Tear down a fixture previously returned by dataplane_ut_tx_pipe_new.
+// NULL-safe.
+void
+dataplane_ut_tx_pipe_free(struct dataplane_ut_tx_pipe *fixture);
+
+// Allocate a chained mbuf of seg_count segments from the fixture's mock
+// pool. seg_count must be at least 1. Returns NULL on exhaustion.
+struct rte_mbuf *
+dataplane_ut_tx_pipe_alloc_mbuf(
+	struct dataplane_ut_tx_pipe *fixture, size_t seg_count
+);
+
+// Push mbuf onto the fixture's pipe via worker_tx_pipe_push.
+//
+// Returns 0 on success, -1 if the pipe or its deferred-free ring is full.
+int
+dataplane_ut_tx_pipe_push(
+	struct dataplane_ut_tx_pipe *fixture, struct rte_mbuf *mbuf
+);
+
+// Drain the fixture's pipe via worker_tx_pipe_drain, transmitting only the
+// first `accept` mbufs of each popped burst.
+//
+// The remainder is dropped by the production drain logic, exercising the
+// same rejected-tail path a short real NIC tx_burst would take.
+void
+dataplane_ut_tx_pipe_drain(struct dataplane_ut_tx_pipe *fixture, size_t accept);
+
+// Simulate the NIC completing transmission of an mbuf a prior drain
+// accepted, releasing it exactly as a real driver's tx-descriptor reclaim
+// would once DMA finishes.
+void
+dataplane_ut_tx_pipe_complete(struct rte_mbuf *mbuf);
+
+// Reclaim the fixture's pending ring via worker_tx_pipe_reclaim.
+void
+dataplane_ut_tx_pipe_reclaim(struct dataplane_ut_tx_pipe *fixture);
+
+// Number of mock-pool objects currently allocated (dequeued but not yet
+// returned).
+size_t
+dataplane_ut_tx_pipe_outstanding(struct dataplane_ut_tx_pipe *fixture);

--- a/tests/worker/tx_pipe_test.go
+++ b/tests/worker/tx_pipe_test.go
@@ -1,0 +1,137 @@
+// Package worker_test holds regression tests for the tx-pipe unit in
+// lib/dataplane/worker/tx_pipe.c, reached through the
+// lib/dataplane_ut/tx_pipe.h fixture.
+//
+// A pass confirms the drain/reclaim cycle returns every mbuf to its pool
+// exactly once. Coverage is confined to single-segment mbufs: the producer
+// pins only the head segment of a chained mbuf, so a multi-segment chain's
+// tail segments would be freed twice on reclaim.
+package worker_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+)
+
+// newTxPipeFixture constructs a fixture and registers its teardown.
+func newTxPipeFixture(t *testing.T) *dataplaneut.TxPipeFixture {
+	t.Helper()
+
+	fixture, err := dataplaneut.NewTxPipeFixture()
+	require.NoError(t, err)
+	t.Cleanup(fixture.Free)
+
+	return fixture
+}
+
+// TestPushRejectedReclaimReturnsMbufToPool verifies that a single-segment
+// mbuf a Drain call rejects outright (accept=0) is fully released once
+// Reclaim runs: the drain frees it as an untransmitted tail, and reclaim's
+// own FIFO pass over the deferred-free ring observes the drop and does not
+// double free it.
+func TestPushRejectedReclaimReturnsMbufToPool(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	mbuf, err := fixture.AllocMbuf(1)
+	require.NoError(t, err)
+	require.Equal(t, 1, fixture.Outstanding())
+
+	require.NoError(t, fixture.Push(mbuf))
+
+	fixture.Drain(0)
+	fixture.Reclaim()
+
+	require.Equal(t, 0, fixture.Outstanding())
+}
+
+// TestPushAcceptedCompleteReclaimReturnsMbufToPool verifies the accepted
+// path: a Drain call that transmits the mbuf (accept=1) leaves it alive
+// until a simulated NIC completion, and only then does Reclaim release it.
+func TestPushAcceptedCompleteReclaimReturnsMbufToPool(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	mbuf, err := fixture.AllocMbuf(1)
+	require.NoError(t, err)
+
+	require.NoError(t, fixture.Push(mbuf))
+
+	fixture.Drain(1)
+	require.Equal(t, 1, fixture.Outstanding(), "an accepted mbuf must survive drain until NIC completion")
+
+	mbuf.Complete()
+	fixture.Reclaim()
+
+	require.Equal(t, 0, fixture.Outstanding())
+}
+
+// TestDrainPartialAcceptWithinBurst verifies that when one Drain call pops a
+// burst of several pushed mbufs but a stub transmit accepts only a prefix,
+// the accepted prefix survives for later completion while the rejected
+// remainder is freed immediately — and that a single Reclaim afterwards
+// balances both outcomes across the whole burst.
+func TestDrainPartialAcceptWithinBurst(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	const burstSize = 3
+	mbufs := make([]*dataplaneut.TxPipeMbuf, burstSize)
+	for idx := range mbufs {
+		mbuf, err := fixture.AllocMbuf(1)
+		require.NoError(t, err)
+		require.NoError(t, fixture.Push(mbuf))
+		mbufs[idx] = mbuf
+	}
+	require.Equal(t, burstSize, fixture.Outstanding())
+
+	fixture.Drain(1)
+	// A rejected mbuf only loses its push-time pin here. The deferred-free
+	// ring is FIFO, so releasing it back to the pool waits for Reclaim to
+	// walk past the still-outstanding accepted head entry ahead of it.
+	require.Equal(t, burstSize, fixture.Outstanding())
+
+	mbufs[0].Complete()
+	fixture.Reclaim()
+
+	require.Equal(t, 0, fixture.Outstanding())
+}
+
+// TestReclaimFreesPipeSlotsForReuse verifies that filling the pipe to
+// capacity blocks further pushes, and that draining, completing, and
+// reclaiming every outstanding mbuf frees its slots so the pipe accepts
+// pushes again.
+func TestReclaimFreesPipeSlotsForReuse(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	var mbufs []*dataplaneut.TxPipeMbuf
+	for {
+		mbuf, err := fixture.AllocMbuf(1)
+		require.NoError(t, err)
+
+		if err := fixture.Push(mbuf); err != nil {
+			// mbuf was allocated to probe fullness and never pushed,
+			// so it holds no extra pin — Complete releases it back
+			// to the pool exactly like a plain single-owner free.
+			mbuf.Complete()
+			break
+		}
+		mbufs = append(mbufs, mbuf)
+	}
+	require.NotEmpty(t, mbufs, "the pipe must accept at least one push before filling up")
+
+	fixture.Drain(len(mbufs))
+	for _, mbuf := range mbufs {
+		mbuf.Complete()
+	}
+	fixture.Reclaim()
+	require.Equal(t, 0, fixture.Outstanding())
+
+	freed, err := fixture.AllocMbuf(1)
+	require.NoError(t, err)
+	require.NoError(t, fixture.Push(freed), "a push after reclaim should find a free pipe slot")
+
+	fixture.Drain(1)
+	freed.Complete()
+	fixture.Reclaim()
+}


### PR DESCRIPTION
The cross-worker tx pipe lived inline in the worker: its structure and capacity macros in the worker header, its push, reclaim and drain paths as static callbacks in the worker source, and its initialization open-coded inside the dataplane's worker-connect routine. None of it could be reached from a test, so the pipe's mbuf accounting went entirely uncovered.

- Move the pipe into its own unit, and give the drain a caller-supplied transmit callback so it no longer depends on the worker structure while the worker keeps its own counter bookkeeping.
- Add a test fixture pairing one pipe with a mock mempool that counts live objects, plus bindings and tests asserting the pool balances exactly across push, drain, partial-accept and reclaim, and that reclaiming frees pipe slots for reuse.

Mbuf ownership, the reference the producer holds and the reclaim conditions are carried over unchanged, so this is behaviour-preserving. Every relocated block was verified token-identical to its original modulo whitespace, the one exception being the push path taking the mbuf as a parameter rather than deriving it from a packet.

Two consequences of that deliberate inertness are worth stating. Coverage is confined to single-segment mbufs, because the pin this code carries covers only the head segment and a chained mbuf's tail segments are freed twice on reclaim — that is issue #1718, fixed separately in #2031, which now rebases onto this. And the drain clamps the burst it hands to the transmit callback, where the previous code narrowed a size_t into a uint16_t parameter, which is unreachable at the current pipe capacity.

The mock mempool's new outstanding-object counter lives inside the pool's own allocation rather than beside it, so the call sites that release the pool with a plain free stay correct under a leak sanitizer.
