### PR TITLE
fix(functional): ship dataplane runtime libraries in the test guest

### DIFF
--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -1,6 +1,6 @@
 # Test configuration
 QEMU_IMAGE := yanet-test.qcow2
-BOOTED_TEMPLATE := yanet-test-booted-v2.qcow2
+BOOTED_TEMPLATE := yanet-test-booted-v3.qcow2
 
 UBUNTU_IMAGE := ubuntu-24.04-minimal-cloudimg-amd64.img
 UBUNTU_URL := https://cloud-images.ubuntu.com/minimal/releases/noble/release/$(UBUNTU_IMAGE)

--- a/tests/functional/cloud-init-user-data.yaml
+++ b/tests/functional/cloud-init-user-data.yaml
@@ -46,6 +46,13 @@ packages:
   - libnuma-dev
   - libpcap-dev
   - libyaml-dev
+  # Runtime libs the host-built yanet-dataplane loads (ldd NEEDED). Noble
+  # ships libarchive under its t64 name and hides libmlx5.so.1 inside
+  # ibverbs-providers, and one unresolvable name here fails the whole
+  # apt-get install, taking every other package on this list with it.
+  - libarchive13t64
+  - ibverbs-providers
+  - libibverbs1
   - gdb
   - kmod
   - procps

--- a/tests/functional/framework/harness.go
+++ b/tests/functional/framework/harness.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	baselineSnapshotName    = "baseline"
-	baselineTemplateVersion = "v4"
+	baselineTemplateVersion = "v5"
 )
 
 // baselineTemplatePath returns the versioned overlay path for a baseline

--- a/tests/functional/framework/harness_test.go
+++ b/tests/functional/framework/harness_test.go
@@ -16,13 +16,13 @@ func TestBaselineTemplatePath(t *testing.T) {
 			name:        "default baseline",
 			qemuImage:   "/tmp/yanet-test.qcow2",
 			baselineTag: baselineSnapshotName,
-			want:        "/tmp/yanet-test-baseline-v4.qcow2",
+			want:        "/tmp/yanet-test-baseline-v5.qcow2",
 		},
 		{
 			name:        "custom baseline",
 			qemuImage:   "/tmp/yanet-test.qcow2",
 			baselineTag: "nat64",
-			want:        "/tmp/yanet-test-nat64-v4.qcow2",
+			want:        "/tmp/yanet-test-nat64-v5.qcow2",
 		},
 	}
 
@@ -40,7 +40,7 @@ func TestBaselineTemplatePath(t *testing.T) {
 }
 
 func TestBootedTemplatePath(t *testing.T) {
-	want := "/tmp/yanet-test-booted-v2.qcow2"
+	want := "/tmp/yanet-test-booted-v3.qcow2"
 	if got := BootedImagePath("/tmp/yanet-test.qcow2"); got != want {
 		t.Errorf("BootedImagePath() = %q, want %q", got, want)
 	}

--- a/tests/functional/framework/qemu.go
+++ b/tests/functional/framework/qemu.go
@@ -145,7 +145,7 @@ const (
 	// clean boot. When a pool VM's overlay contains this snapshot, Start()
 	// restores it instantly via -loadvm instead of waiting ~44s for boot.
 	BootedSnapshotName    = "booted"
-	bootedTemplateVersion = "v2"
+	bootedTemplateVersion = "v3"
 )
 
 // OverlayHasSnapshot returns true if the given qcow2 image contains a


### PR DESCRIPTION
The host-built dataplane cannot start in the QEMU image when those libraries are missing. Bump the cached boot templates so old overlays are not reused.