### PR TITLE
feat(fwstate): filter listed state entries by address family

### DIFF
--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -138,22 +138,46 @@ pub enum DirectionArg {
     Backward,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Family {
+    /// fw4state map
+    Ipv4,
+    /// fw6state map
+    Ipv6,
+}
+
+impl Family {
+    /// Renders the family as the request's `is_ipv6` map selector.
+    pub fn is_ipv6(self) -> bool {
+        matches!(self, Self::Ipv6)
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 pub struct EntriesCmd {
     /// FWState config name
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 
-    /// List IPv4 map entries
+    /// Address families to list, in the given order
     ///
-    /// Omit both flags, or pass both, to list IPv4 then IPv6.
-    #[arg(long, short = '4')]
+    /// Repeatable and comma-separated. Omit every family argument to list
+    /// IPv4 then IPv6.
+    #[arg(
+        long = "family",
+        short = 'f',
+        value_name = "FAMILY",
+        value_enum,
+        value_delimiter = ','
+    )]
+    pub families: Vec<Family>,
+
+    /// Shorthand for --family ipv4
+    #[arg(long, short = '4', conflicts_with = "families")]
     pub ipv4: bool,
 
-    /// List IPv6 map entries
-    ///
-    /// Omit both flags, or pass both, to list IPv4 then IPv6.
-    #[arg(long, short = '6')]
+    /// Shorthand for --family ipv6
+    #[arg(long, short = '6', conflicts_with = "families")]
     pub ipv6: bool,
 
     /// Layer index to iterate (0 = active layer)
@@ -190,12 +214,27 @@ pub struct EntriesCmd {
 }
 
 impl EntriesCmd {
-    /// Returns which maps to list: `false` is IPv4, `true` is IPv6.
-    pub fn ipv6_maps(&self) -> &'static [bool] {
+    /// Returns the maps to list, in listing order.
+    ///
+    /// A repeated family collapses onto its first occurrence, so `--family
+    /// ipv4,ipv4` reads one map rather than dumping it twice. The shorthand
+    /// flags conflict with `--family`, so only one of the two sources is
+    /// ever populated.
+    pub fn families(&self) -> Vec<Family> {
+        if !self.families.is_empty() {
+            let mut families = Vec::with_capacity(self.families.len());
+            for family in self.families.iter().copied() {
+                if !families.contains(&family) {
+                    families.push(family);
+                }
+            }
+            return families;
+        }
+
         match (self.ipv4, self.ipv6) {
-            (true, false) => &[false],
-            (false, true) => &[true],
-            _ => &[false, true],
+            (true, false) => vec![Family::Ipv4],
+            (false, true) => vec![Family::Ipv6],
+            _ => vec![Family::Ipv4, Family::Ipv6],
         }
     }
 }
@@ -240,16 +279,32 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ipv6_maps_from_flags() {
-        let cases: [(&[&str], &[bool]); 4] = [
-            (&["entries", "--name", "x"], &[false, true]),
-            (&["entries", "--name", "x", "--ipv4"], &[false]),
-            (&["entries", "--name", "x", "--ipv6"], &[true]),
-            (&["entries", "--name", "x", "--ipv4", "--ipv6"], &[false, true]),
+    fn families_from_args() {
+        let both = &[Family::Ipv4, Family::Ipv6][..];
+        let cases: [(&[&str], &[Family]); 8] = [
+            (&["entries", "--name", "x"], both),
+            (&["entries", "--name", "x", "--ipv4"], &[Family::Ipv4]),
+            (&["entries", "--name", "x", "--ipv6"], &[Family::Ipv6]),
+            (&["entries", "--name", "x", "--ipv4", "--ipv6"], both),
+            (&["entries", "--name", "x", "--family", "ipv6"], &[Family::Ipv6]),
+            (&["entries", "--name", "x", "-f", "ipv4,ipv6"], both),
+            // The listing follows the requested order, and a repeat reads
+            // the map once rather than dumping it twice.
+            (
+                &["entries", "--name", "x", "-f", "ipv6", "-f", "ipv4"],
+                &[Family::Ipv6, Family::Ipv4],
+            ),
+            (&["entries", "--name", "x", "-f", "ipv4,ipv4"], &[Family::Ipv4]),
         ];
         for (args, want) in cases {
             let cmd = EntriesCmd::try_parse_from(args).unwrap();
-            assert_eq!(want, cmd.ipv6_maps(), "{args:?}");
+            assert_eq!(want, cmd.families(), "{args:?}");
         }
+    }
+
+    #[test]
+    fn shorthand_conflicts_with_family() {
+        let args = ["entries", "--name", "x", "--family", "ipv6", "--ipv4"];
+        assert!(EntriesCmd::try_parse_from(args).is_err());
     }
 }

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -144,7 +144,15 @@ pub struct EntriesCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 
-    /// Use IPv6 map instead of IPv4
+    /// List IPv4 map entries
+    ///
+    /// Omit both flags, or pass both, to list IPv4 then IPv6.
+    #[arg(long, short = '4')]
+    pub ipv4: bool,
+
+    /// List IPv6 map entries
+    ///
+    /// Omit both flags, or pass both, to list IPv4 then IPv6.
     #[arg(long, short = '6')]
     pub ipv6: bool,
 
@@ -161,16 +169,35 @@ pub struct EntriesCmd {
     pub batch: u32,
 
     /// Total number of entries to return (0 = unlimited)
+    ///
+    /// This limit is shared across both maps when listing both families.
     #[arg(long, default_value = "0")]
     pub count: u32,
 
     /// Iteration direction
+    ///
+    /// When listing both families, this flag is applied to each map separately.
     #[arg(long, default_value = "forward")]
     pub direction: DirectionArg,
 
     /// Starting cursor position (0 = beginning)
+    ///
+    /// When listing both families, this flag is applied to each map separately.
+    /// The second pass starts from this index again, not where the first map
+    /// stopped.
     #[arg(long, default_value = "0")]
     pub index: u32,
+}
+
+impl EntriesCmd {
+    /// Returns which maps to list: `false` is IPv4, `true` is IPv6.
+    pub fn ipv6_maps(&self) -> &'static [bool] {
+        match (self.ipv4, self.ipv6) {
+            (true, false) => &[false],
+            (false, true) => &[true],
+            _ => &[false, true],
+        }
+    }
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -206,4 +233,23 @@ pub struct MetricsCmd {
     /// Show only metrics matching this category
     #[arg(long, short, value_enum)]
     pub name: Option<MetricName>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipv6_maps_from_flags() {
+        let cases: [(&[&str], &[bool]); 4] = [
+            (&["entries", "--name", "x"], &[false, true]),
+            (&["entries", "--name", "x", "--ipv4"], &[false]),
+            (&["entries", "--name", "x", "--ipv6"], &[true]),
+            (&["entries", "--name", "x", "--ipv4", "--ipv6"], &[false, true]),
+        ];
+        for (args, want) in cases {
+            let cmd = EntriesCmd::try_parse_from(args).unwrap();
+            assert_eq!(want, cmd.ipv6_maps(), "{args:?}");
+        }
+    }
 }

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -69,6 +69,44 @@ pub struct FWStateService {
     metrics: Service<MetricsServiceClient<LayeredChannel>>,
 }
 
+/// State an `entries` dump carries across its batches and both maps.
+struct DumpState {
+    /// Entries printed so far, which `--count` limits.
+    printed: u32,
+    /// Whether the human-readable header row is already out. Deferred until
+    /// the first entry arrives, so a zero-entry result prints no header.
+    header_printed: bool,
+    /// Config generation the last response reported.
+    generation: Option<u64>,
+}
+
+impl DumpState {
+    fn new() -> Self {
+        Self {
+            printed: 0,
+            header_printed: false,
+            generation: None,
+        }
+    }
+
+    /// Warns when a response reports a different generation than the one
+    /// before it.
+    ///
+    /// A bump means layers were relinked, so the cursor and `--layer` stop
+    /// denoting what they did when the dump began, and the remaining
+    /// entries can repeat or be missed. Rows already printed were accurate
+    /// when read, so the dump goes on and only warns.
+    fn note_generation(&mut self, generation: u64) {
+        match self.generation.replace(generation) {
+            Some(previous) if previous != generation => log::warn!(
+                "fwstate config changed mid-dump (generation {previous} -> {generation}): \
+                 entries may repeat or be missed"
+            ),
+            _ => {}
+        }
+    }
+}
+
 impl FWStateService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
         let conn = Connection::connect(connection).await?;
@@ -314,20 +352,17 @@ impl FWStateService {
         };
 
         let limit = cmd.count;
-        let mut total: u32 = 0;
-        // Deferred until the first entry actually arrives, so a zero-entry
-        // result does not print a header row over an empty table.
-        let mut header_printed = false;
+        let mut state = DumpState::new();
 
         for &is_ipv6 in cmd.ipv6_maps() {
-            if limit > 0 && total >= limit {
+            if limit > 0 && state.printed >= limit {
                 break;
             }
-            self.list_entries_map(&cmd, is_ipv6, direction, format, &mut total, &mut header_printed)
+            self.list_entries_map(&cmd, is_ipv6, direction, format, &mut state)
                 .await?;
         }
 
-        if total == 0 {
+        if state.printed == 0 {
             output::empty(format_args!(
                 "No firewall state entries found for '{}'.",
                 cmd.config_name
@@ -343,8 +378,7 @@ impl FWStateService {
         is_ipv6: bool,
         direction: Direction,
         format: CommonFormat,
-        total: &mut u32,
-        header_printed: &mut bool,
+        state: &mut DumpState,
     ) -> Result<(), Error> {
         let limit = cmd.count;
         let (tx, rx) = mpsc::channel(1);
@@ -376,19 +410,21 @@ impl FWStateService {
             .await
             .map_err(self.service.status("list entries"))?
         {
+            state.note_generation(resp.generation);
+
             for entry in &resp.entries {
-                if limit > 0 && *total >= limit {
+                if limit > 0 && state.printed >= limit {
                     break;
                 }
 
                 match format {
                     CommonFormat::Human => {
-                        if !*header_printed {
+                        if !state.header_printed {
                             println!(
                                 "{:<6} {:<48} {:<48} {:<8} {:<9} {:<7}",
                                 "IDX", "SRC", "DST", "PROTO", "FLAGS S|D", "EXPRD"
                             );
-                            *header_printed = true;
+                            state.header_printed = true;
                         }
 
                         print_entry(entry);
@@ -401,10 +437,10 @@ impl FWStateService {
                     }
                 }
 
-                *total += 1;
+                state.printed += 1;
             }
 
-            if (limit > 0 && *total >= limit) || !resp.has_more {
+            if (limit > 0 && state.printed >= limit) || !resp.has_more {
                 break;
             }
 

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -4,7 +4,7 @@ use core::{
 };
 use std::collections::HashMap;
 
-use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
+use args::{DeleteCmd, DirectionArg, EntriesCmd, Family, LinkCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
 use commonpb::pb::{GetMetricsRequest, IpAddress, MacAddress, Metric as ProtoMetric};
@@ -354,11 +354,11 @@ impl FWStateService {
         let limit = cmd.count;
         let mut state = DumpState::new();
 
-        for &is_ipv6 in cmd.ipv6_maps() {
+        for family in cmd.families() {
             if limit > 0 && state.printed >= limit {
                 break;
             }
-            self.list_entries_map(&cmd, is_ipv6, direction, format, &mut state)
+            self.list_entries_map(&cmd, family, direction, format, &mut state)
                 .await?;
         }
 
@@ -375,7 +375,7 @@ impl FWStateService {
     async fn list_entries_map(
         &mut self,
         cmd: &EntriesCmd,
-        is_ipv6: bool,
+        family: Family,
         direction: Direction,
         format: CommonFormat,
         state: &mut DumpState,
@@ -386,7 +386,7 @@ impl FWStateService {
 
         let initial_req = ListEntriesRequest {
             config_name: cmd.config_name.clone(),
-            is_ipv6,
+            is_ipv6: family.is_ipv6(),
             layer_index: cmd.layer,
             include_expired: cmd.include_expired,
             direction: direction as i32,
@@ -446,7 +446,7 @@ impl FWStateService {
 
             let next_req = ListEntriesRequest {
                 config_name: cmd.config_name.clone(),
-                is_ipv6,
+                is_ipv6: family.is_ipv6(),
                 layer_index: cmd.layer,
                 include_expired: cmd.include_expired,
                 direction: direction as i32,

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -1,4 +1,7 @@
-use core::{fmt, net::Ipv6Addr};
+use core::{
+    fmt,
+    net::{IpAddr, Ipv6Addr},
+};
 use std::collections::HashMap;
 
 use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
@@ -310,12 +313,46 @@ impl FWStateService {
             DirectionArg::Backward => Direction::Backward,
         };
 
+        let limit = cmd.count;
+        let mut total: u32 = 0;
+        // Deferred until the first entry actually arrives, so a zero-entry
+        // result does not print a header row over an empty table.
+        let mut header_printed = false;
+
+        for &is_ipv6 in cmd.ipv6_maps() {
+            if limit > 0 && total >= limit {
+                break;
+            }
+            self.list_entries_map(&cmd, is_ipv6, direction, format, &mut total, &mut header_printed)
+                .await?;
+        }
+
+        if total == 0 {
+            output::empty(format_args!(
+                "No firewall state entries found for '{}'.",
+                cmd.config_name
+            ));
+        }
+
+        Ok(())
+    }
+
+    async fn list_entries_map(
+        &mut self,
+        cmd: &EntriesCmd,
+        is_ipv6: bool,
+        direction: Direction,
+        format: CommonFormat,
+        total: &mut u32,
+        header_printed: &mut bool,
+    ) -> Result<(), Error> {
+        let limit = cmd.count;
         let (tx, rx) = mpsc::channel(1);
         let stream = ReceiverStream::new(rx);
 
         let initial_req = ListEntriesRequest {
             config_name: cmd.config_name.clone(),
-            is_ipv6: cmd.ipv6,
+            is_ipv6,
             layer_index: cmd.layer,
             include_expired: cmd.include_expired,
             direction: direction as i32,
@@ -334,30 +371,24 @@ impl FWStateService {
             .map_err(self.service.status("list entries"))?
             .into_inner();
 
-        let limit = cmd.count;
-        let mut total: u32 = 0;
-        // Deferred until the first entry actually arrives, so a zero-entry
-        // result does not print a header row over an empty table.
-        let mut header_printed = false;
-
         while let Some(resp) = response_stream
             .message()
             .await
             .map_err(self.service.status("list entries"))?
         {
             for entry in &resp.entries {
-                if limit > 0 && total >= limit {
+                if limit > 0 && *total >= limit {
                     break;
                 }
 
                 match format {
                     CommonFormat::Human => {
-                        if !header_printed {
+                        if !*header_printed {
                             println!(
-                                "{:<6} {:<45} {:<45} {:<8} {:<9} {:<7}",
+                                "{:<6} {:<48} {:<48} {:<8} {:<9} {:<7}",
                                 "IDX", "SRC", "DST", "PROTO", "FLAGS S|D", "EXPRD"
                             );
-                            header_printed = true;
+                            *header_printed = true;
                         }
 
                         print_entry(entry);
@@ -370,16 +401,16 @@ impl FWStateService {
                     }
                 }
 
-                total += 1;
+                *total += 1;
             }
 
-            if (limit > 0 && total >= limit) || !resp.has_more {
+            if (limit > 0 && *total >= limit) || !resp.has_more {
                 break;
             }
 
             let next_req = ListEntriesRequest {
                 config_name: cmd.config_name.clone(),
-                is_ipv6: cmd.ipv6,
+                is_ipv6,
                 layer_index: cmd.layer,
                 include_expired: cmd.include_expired,
                 direction: direction as i32,
@@ -389,13 +420,6 @@ impl FWStateService {
             tx.send(next_req)
                 .await
                 .map_err(|err| self.service.status("list entries")(Status::internal(format!("send error: {err}"))))?;
-        }
-
-        if total == 0 {
-            output::empty(format_args!(
-                "No firewall state entries found for '{}'.",
-                cmd.config_name
-            ));
         }
 
         Ok(())
@@ -458,8 +482,25 @@ impl FWStateService {
     }
 }
 
-fn format_addr(addr: Option<&IpAddress>) -> String {
-    addr.map(|a| a.to_string()).unwrap_or_else(|| "?".to_string())
+/// Formats an address and port as an endpoint, bracketing IPv6.
+///
+/// Without brackets the port merges into the trailing hextet: `2001:db8::2`
+/// on port 80 would read as `2001:db8::2:80`. An IPv4-mapped IPv6 address is
+/// unmapped first, and a malformed one reads as `invalid`, both as
+/// `IpAddress` renders them on its own. An absent address reads as `?`.
+fn format_endpoint(addr: Option<&IpAddress>, port: u32) -> String {
+    let Some(addr) = addr else {
+        return format!("?:{port}");
+    };
+
+    match IpAddr::try_from(addr) {
+        Ok(IpAddr::V4(v4)) => format!("{v4}:{port}"),
+        Ok(IpAddr::V6(v6)) => match v6.to_ipv4_mapped() {
+            Some(v4) => format!("{v4}:{port}"),
+            None => format!("[{v6}]:{port}"),
+        },
+        Err(..) => format!("invalid:{port}"),
+    }
 }
 
 /// Format IANA protocol number as a human-readable name.
@@ -527,24 +568,19 @@ impl fmt::Display for FwStateFlags {
 }
 
 fn print_entry(entry: &fwstatepb::FwStateEntry) {
-    let (src_addr, dst_addr, src_port, dst_port, proto) = match &entry.key {
-        Some(k) => (
-            format_addr(k.src_addr.as_ref()),
-            format_addr(k.dst_addr.as_ref()),
-            k.src_port,
-            k.dst_port,
-            k.proto,
+    let (src, dst, proto) = match &entry.key {
+        Some(key) => (
+            format_endpoint(key.src_addr.as_ref(), key.src_port),
+            format_endpoint(key.dst_addr.as_ref(), key.dst_port),
+            key.proto,
         ),
-        None => ("?".into(), "?".into(), 0, 0, 0),
+        None => (format_endpoint(None, 0), format_endpoint(None, 0), 0),
     };
 
     let flags = entry.value.as_ref().map(|v| v.flags).unwrap_or(0);
 
-    let src = format!("{}:{}", src_addr, src_port);
-    let dst = format!("{}:{}", dst_addr, dst_port);
-
     println!(
-        "{:<6} {:<45} {:<45} {:<8} {:<9} {:<7}",
+        "{:<6} {:<48} {:<48} {:<8} {:<9} {:<7}",
         entry.idx,
         src,
         dst,
@@ -774,11 +810,35 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]
     fn cmd_is_valid() {
         Cmd::command().debug_assert();
+    }
+
+    #[test]
+    fn format_endpoint_brackets_ipv6_only() {
+        let v4: IpAddress = "192.0.2.10".parse().unwrap();
+        let v6: IpAddress = "2001:db8::2".parse().unwrap();
+
+        assert_eq!("192.0.2.10:10000", format_endpoint(Some(&v4), 10000));
+        assert_eq!("[2001:db8::2]:80", format_endpoint(Some(&v6), 80));
+    }
+
+    #[test]
+    fn format_endpoint_leaves_ipv4_mapped_bare() {
+        let mapped: IpAddress = "::ffff:192.0.2.10".parse().unwrap();
+
+        assert_eq!("192.0.2.10:80", format_endpoint(Some(&mapped), 80));
+    }
+
+    #[test]
+    fn format_endpoint_renders_absent_and_malformed() {
+        let malformed = IpAddress { addr: vec![0u8; 5] };
+
+        assert_eq!("?:0", format_endpoint(None, 0));
+        assert_eq!("invalid:80", format_endpoint(Some(&malformed), 80));
     }
 }

--- a/tests/functional/main/fwstate_test.go
+++ b/tests/functional/main/fwstate_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/netip"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -26,6 +29,80 @@ var expectedEntries = []struct {
 	{"192.0.2.10:10000", "192.0.3.1:80", "TCP", "-S--|----"},
 	{"192.0.2.11:10001", "192.0.3.1:80", "TCP", "-S--|----"},
 	{"192.0.2.12:10002", "192.0.3.1:80", "TCP", "-S--|----"},
+}
+
+// expectedIPv6Sources are the IPv6 entry sources in forward listing order.
+var expectedIPv6Sources = []string{
+	"[2001:db8:1::10]:20000",
+	"[2001:db8:1::10]:20001",
+	"[2001:db8:1::10]:20002",
+}
+
+// expectedIPv4Sources returns the sources of expectedEntries in listing order.
+func expectedIPv4Sources() []string {
+	sources := make([]string, 0, len(expectedEntries))
+	for _, entry := range expectedEntries {
+		sources = append(sources, entry.src)
+	}
+	return sources
+}
+
+// decodeJSONLines decodes the CLI's newline-delimited JSON output.
+func decodeJSONLines[T any](t *testing.T, output string) []T {
+	t.Helper()
+	var decoded []T
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var item T
+		require.NoError(t, json.Unmarshal([]byte(line), &item))
+		decoded = append(decoded, item)
+	}
+	return decoded
+}
+
+// jsonEntrySources returns each listed entry's source in output order.
+func jsonEntrySources(t *testing.T, output string) []string {
+	t.Helper()
+	type sourceEntry struct {
+		Key struct {
+			SrcAddr string `json:"src_addr"`
+			SrcPort int    `json:"src_port"`
+		} `json:"key"`
+	}
+	entries := decodeJSONLines[sourceEntry](t, output)
+	sources := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		sources = append(sources, net.JoinHostPort(entry.Key.SrcAddr, strconv.Itoa(entry.Key.SrcPort)))
+	}
+	return sources
+}
+
+// listedEndpoints parses the source and destination of every row of the
+// human-formatted listing.
+//
+// ParseAddrPort rejects an IPv6 endpoint whose address is not bracketed,
+// so parsing keeps that rendering covered without pinning the column text.
+func listedEndpoints(t *testing.T, output string) (srcs, dsts []netip.AddrPort) {
+	t.Helper()
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		if _, err := strconv.Atoi(fields[0]); err != nil {
+			continue // header row
+		}
+		src, err := netip.ParseAddrPort(fields[1])
+		require.NoError(t, err, "source endpoint %q should parse", fields[1])
+		dst, err := netip.ParseAddrPort(fields[2])
+		require.NoError(t, err, "destination endpoint %q should parse", fields[2])
+		srcs = append(srcs, src)
+		dsts = append(dsts, dst)
+	}
+	return srcs, dsts
 }
 
 func TestFWStateListEntries(t *testing.T) {
@@ -90,7 +167,7 @@ func testFWStateListEntries(t *testing.T, fw *framework.TestFramework) {
 	// 4. Forward listing: verify exact entries.
 	fw.Run("Forward_listing", func(fw *framework.TestFramework, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --name fwstate0 --batch 100 --direction forward --include-expired",
+			framework.CLIFWState + " entries --name fwstate0 --ipv4 --batch 100 --direction forward --include-expired",
 		)
 		require.NoError(t, err, "list-entries forward failed")
 		t.Log("Forward listing output:\n", output)
@@ -106,7 +183,7 @@ func testFWStateListEntries(t *testing.T, fw *framework.TestFramework) {
 	// 5. Forward listing with JSON: parse and verify key fields.
 	fw.Run("Forward_listing_json", func(fw *framework.TestFramework, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --name fwstate0 --batch 100 --direction forward --include-expired --format json",
+			framework.CLIFWState + " entries --name fwstate0 --ipv4 --batch 100 --direction forward --include-expired --format json",
 		)
 		require.NoError(t, err, "list-entries forward json failed")
 		t.Log("JSON output:\n", output)
@@ -135,17 +212,7 @@ func testFWStateListEntries(t *testing.T, fw *framework.TestFramework) {
 			} `json:"value"`
 		}
 
-		var entries []jsonEntry
-		for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" {
-				continue
-			}
-			var e jsonEntry
-			require.NoError(t, json.Unmarshal([]byte(line), &e))
-			entries = append(entries, e)
-		}
-
+		entries := decodeJSONLines[jsonEntry](t, output)
 		require.Len(t, entries, 3, "should have exactly 3 JSON entries")
 
 		for i, e := range entries {
@@ -165,7 +232,7 @@ func testFWStateListEntries(t *testing.T, fw *framework.TestFramework) {
 	// 6. Backward listing from last entry: verify all entries present.
 	fw.Run("Backward_listing", func(fw *framework.TestFramework, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --name fwstate0 --batch 100 --direction backward --index 4294967295 --include-expired",
+			framework.CLIFWState + " entries --name fwstate0 --ipv4 --batch 100 --direction backward --index 4294967295 --include-expired",
 		)
 		require.NoError(t, err, "list-entries backward failed")
 		require.NotEmpty(t, output, "backward listing returned empty output")
@@ -179,7 +246,7 @@ func testFWStateListEntries(t *testing.T, fw *framework.TestFramework) {
 	// 7. Pagination: read with batch=1, verify all entries are still returned.
 	fw.Run("Pagination", func(fw *framework.TestFramework, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --name fwstate0 --batch 1 --direction forward --include-expired",
+			framework.CLIFWState + " entries --name fwstate0 --ipv4 --batch 1 --direction forward --include-expired",
 		)
 		require.NoError(t, err, "list-entries with batch=1 failed")
 		t.Log("Pagination output:\n", output)
@@ -287,11 +354,50 @@ func testFWStateListEntries(t *testing.T, fw *framework.TestFramework) {
 		require.NoError(t, err, "IPv6 list-entries forward failed")
 		t.Log("IPv6 forward listing output:\n", output)
 
-		require.Contains(t, output, "2001:db8:1::10:20000")
-		require.Contains(t, output, "2001:db8:1::10:20001")
-		require.Contains(t, output, "2001:db8:1::10:20002")
-		require.Contains(t, output, "2001:db8:2::1:80")
+		src := netip.MustParseAddr("2001:db8:1::10")
+		dst := netip.AddrPortFrom(netip.MustParseAddr("2001:db8:2::1"), 80)
+
+		srcs, dsts := listedEndpoints(t, output)
+		require.Equal(t, []netip.AddrPort{
+			netip.AddrPortFrom(src, 20000),
+			netip.AddrPortFrom(src, 20001),
+			netip.AddrPortFrom(src, 20002),
+		}, srcs)
+		require.Equal(t, []netip.AddrPort{dst, dst, dst}, dsts)
 		require.Contains(t, output, "TCP")
+	})
+
+	// Family filters: --ipv4/--ipv6 select one map. Neither or both lists IPv4 then IPv6.
+	fw.Run("Family_ipv4_only", func(fw *framework.TestFramework, t *testing.T) {
+		output, err := fw.ExecuteCommand(
+			framework.CLIFWState + " entries --name fwstate0 --ipv4 --batch 100 --direction forward --include-expired --format json",
+		)
+		require.NoError(t, err, "IPv4 list-entries failed")
+		require.Equal(t, expectedIPv4Sources(), jsonEntrySources(t, output))
+	})
+
+	fw.Run("Family_default_both", func(fw *framework.TestFramework, t *testing.T) {
+		output, err := fw.ExecuteCommand(
+			framework.CLIFWState + " entries --name fwstate0 --batch 100 --direction forward --include-expired --format json",
+		)
+		require.NoError(t, err, "default list-entries failed")
+		require.Equal(t, slices.Concat(expectedIPv4Sources(), expectedIPv6Sources), jsonEntrySources(t, output))
+	})
+
+	fw.Run("Family_both_flags", func(fw *framework.TestFramework, t *testing.T) {
+		output, err := fw.ExecuteCommand(
+			framework.CLIFWState + " entries --name fwstate0 --ipv4 --ipv6 --batch 100 --direction forward --include-expired --format json",
+		)
+		require.NoError(t, err, "list-entries with both family flags failed")
+		require.Equal(t, slices.Concat(expectedIPv4Sources(), expectedIPv6Sources), jsonEntrySources(t, output))
+	})
+
+	fw.Run("Family_count_spans_maps", func(fw *framework.TestFramework, t *testing.T) {
+		output, err := fw.ExecuteCommand(
+			framework.CLIFWState + " entries --name fwstate0 --count 4 --batch 100 --direction forward --include-expired --format json",
+		)
+		require.NoError(t, err, "list-entries with shared --count failed")
+		require.Equal(t, slices.Concat(expectedIPv4Sources(), expectedIPv6Sources[:1]), jsonEntrySources(t, output))
 	})
 
 	// 14. IPv6 CheckState: return traffic passes because forward state exists.
@@ -718,17 +824,7 @@ func testFWStateExternalSyncFrame(t *testing.T, fw *framework.TestFramework) {
 			} `json:"value"`
 		}
 
-		var entries []jsonEntry
-		for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" {
-				continue
-			}
-			var e jsonEntry
-			require.NoError(t, json.Unmarshal([]byte(line), &e))
-			entries = append(entries, e)
-		}
-
+		entries := decodeJSONLines[jsonEntry](t, output)
 		require.Len(t, entries, 1, "should have exactly 1 state entry from external sync")
 		e := entries[0]
 		require.Equal(t, "10.0.0.1", e.Key.SrcAddr, "src_addr should match sync frame")


### PR DESCRIPTION
Replace the single family switch on the entries command with a pair of independent filters. Passing neither, or both, lists IPv4 then IPv6 under a shared record limit, while the cursor and direction stay per map.

Bracket IPv6 endpoints in human-readable output and widen the address columns to fit.

*Issue: https://github.com/yanet-platform/yanet2/issues/1757*