### PR TITLE
feat(counters): add config counter registry to cp_module

### DIFF
--- a/lib/controlplane/config/cp_counter.c
+++ b/lib/controlplane/config/cp_counter.c
@@ -511,6 +511,54 @@ cp_config_counter_storage_registry_insert_module(
 }
 
 struct counter_storage *
+cp_config_counter_storage_registry_lookup_module_config(
+	struct cp_config_counter_storage_registry *registry,
+	const char *device_name,
+	const char *pipeline_name,
+	const char *function_name,
+	const char *chain_name,
+	const char *module_type,
+	const char *module_name
+) {
+	struct counter_tag tags[] = {
+		{.key = "device", .value = device_name},
+		{.key = "pipeline", .value = pipeline_name},
+		{.key = "function", .value = function_name},
+		{.key = "chain", .value = chain_name},
+		{.key = "module_type", .value = module_type},
+		{.key = "module_name", .value = module_name},
+		{.key = "kind", .value = "config"}
+	};
+	return get_one(registry, tags, 7);
+}
+
+int
+cp_config_counter_storage_registry_insert_module_config(
+	struct cp_config_counter_storage_registry *registry,
+	const char *device_name,
+	const char *pipeline_name,
+	const char *function_name,
+	const char *chain_name,
+	const char *module_type,
+	const char *module_name,
+	struct counter_storage *counter_storage,
+	yanet_error **err
+) {
+	struct counter_tag tags[] = {
+		{.key = "device", .value = device_name},
+		{.key = "pipeline", .value = pipeline_name},
+		{.key = "function", .value = function_name},
+		{.key = "chain", .value = chain_name},
+		{.key = "module_type", .value = module_type},
+		{.key = "module_name", .value = module_name},
+		{.key = "kind", .value = "config"},
+	};
+	return cp_config_counter_storage_registry_insert(
+		registry, tags, 7, counter_storage, err
+	);
+}
+
+struct counter_storage *
 cp_config_counter_storage_registry_lookup_object(
 	struct cp_config_counter_storage_registry *registry,
 	const char *object_type,

--- a/lib/controlplane/config/cp_counter.h
+++ b/lib/controlplane/config/cp_counter.h
@@ -151,6 +151,30 @@ cp_config_counter_storage_registry_insert_module(
 );
 
 struct counter_storage *
+cp_config_counter_storage_registry_lookup_module_config(
+	struct cp_config_counter_storage_registry *registry,
+	const char *device_name,
+	const char *pipeline_name,
+	const char *function_name,
+	const char *chain_name,
+	const char *module_type,
+	const char *module_name
+);
+
+int
+cp_config_counter_storage_registry_insert_module_config(
+	struct cp_config_counter_storage_registry *registry,
+	const char *device_name,
+	const char *pipeline_name,
+	const char *function_name,
+	const char *chain_name,
+	const char *module_type,
+	const char *module_name,
+	struct counter_storage *counter_storage,
+	yanet_error **err
+);
+
+struct counter_storage *
 cp_config_counter_storage_registry_lookup_object(
 	struct cp_config_counter_storage_registry *registry,
 	const char *object_type,

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -118,6 +118,21 @@ cp_module_init(
 		goto fail;
 	}
 
+	if (counter_registry_init(
+		    &cp_module->config_counter_registry,
+		    &cp_module->memory_context,
+		    0
+	    )) {
+		yanet_error_add(
+			err,
+			"failed to initialize config counter registry for "
+			"module '%s:%s'",
+			module_type,
+			module_name
+		);
+		goto fail;
+	}
+
 	cp_module->rx_counter_id = counter_registry_register(
 		&cp_module->counter_registry, "rx", 2, err
 	);
@@ -208,6 +223,7 @@ fail:
 void
 cp_module_fini(struct cp_module *cp_module) {
 	counter_registry_fini(&cp_module->counter_registry);
+	counter_registry_fini(&cp_module->config_counter_registry);
 
 	struct cp_module_device *devices = ADDR_OF(&cp_module->devices);
 	if (devices != NULL) {
@@ -611,11 +627,24 @@ cp_module_registry_upsert(
 	struct cp_module *old_module =
 		cp_module_registry_lookup(module_registry, type, name);
 
-	counter_registry_link(
-		&new_module->counter_registry,
-		(old_module != NULL) ? &old_module->counter_registry : NULL,
-		err
-	);
+	if (counter_registry_link(
+		    &new_module->counter_registry,
+		    (old_module != NULL) ? &old_module->counter_registry : NULL,
+		    err
+	    )) {
+		yanet_error_add(err, "failed to link counter registry");
+		return -1;
+	}
+
+	if (counter_registry_link(
+		    &new_module->config_counter_registry,
+		    (old_module != NULL) ? &old_module->config_counter_registry
+					 : NULL,
+		    err
+	    )) {
+		yanet_error_add(err, "failed to link config counter registry");
+		return -1;
+	}
 
 	if (registry_replace(
 		    &module_registry->registry,

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -61,6 +61,11 @@ struct cp_module {
 	// Counters declared inside module data
 	struct counter_registry counter_registry;
 
+	// Counters declared from user-supplied configuration (per-rule,
+	// per-route, etc.). Expanded into a separate storage tagged
+	// kind=config on config-gen installation.
+	struct counter_registry config_counter_registry;
+
 	// Rx packet/byte counter (size 2: [packets, bytes])
 	uint64_t rx_counter_id;
 	// Tx packet/byte counter (size 2: [packets, bytes])

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -19,6 +19,12 @@ module_ectx_free(
 		counter_storage_free(counter_storage);
 	}
 
+	struct counter_storage *config_counter_storage =
+		ADDR_OF(&module_ectx->config_counter_storage);
+	if (config_counter_storage != NULL) {
+		counter_storage_free(config_counter_storage);
+	}
+
 	uint64_t *cm_index = ADDR_OF(&module_ectx->cm_index);
 	if (cm_index != NULL) {
 		memory_bfree(
@@ -195,6 +201,62 @@ module_ectx_create(
 	}
 
 	SET_OFFSET_OF(&module_ectx->counter_storage, counter_storage);
+
+	struct counter_storage *old_config_counter_storage = NULL;
+	if (old_ectx != NULL) {
+		old_config_counter_storage =
+			cp_config_counter_storage_registry_lookup_module_config(
+				ADDR_OF(&old_ectx->counter_storage_registry),
+				cp_device->name,
+				cp_pipeline->name,
+				cp_function->name,
+				cp_chain->name,
+				cp_module->type,
+				cp_module->name
+			);
+	}
+
+	struct counter_storage *config_counter_storage = counter_storage_spawn(
+		&cp_config->counter_storage_memory_context,
+		old_config_counter_storage,
+		&cp_module->config_counter_registry
+	);
+	if (config_counter_storage == NULL) {
+		yanet_error_add(
+			err,
+			"failed to spawn config counter storage for module "
+			"'%s:%s'",
+			cp_module->type,
+			cp_module->name
+		);
+		goto error;
+	}
+
+	if (cp_config_counter_storage_registry_insert_module_config(
+		    ADDR_OF(&config_gen_ectx->counter_storage_registry),
+		    cp_device->name,
+		    cp_pipeline->name,
+		    cp_function->name,
+		    cp_chain->name,
+		    cp_module->type,
+		    cp_module->name,
+		    config_counter_storage,
+		    err
+	    )) {
+		yanet_error_add(
+			err,
+			"failed to insert config counter storage for module "
+			"'%s:%s'",
+			cp_module->type,
+			cp_module->name
+		);
+		counter_storage_free(config_counter_storage);
+		goto error;
+	}
+
+	SET_OFFSET_OF(
+		&module_ectx->config_counter_storage, config_counter_storage
+	);
 
 	if (cp_module->object_count > 0) {
 		struct memory_context *counter_storage_memory_context =

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -36,11 +36,11 @@ _Static_assert(
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct cp_module) == 576,
+	sizeof(struct cp_module) == 696,
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct module_ectx) == 168,
+	sizeof(struct module_ectx) == 176,
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 14
+#define YANET_MODULE_ABI_VERSION 15
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -36,6 +36,7 @@ struct module_ectx {
 	struct counter_value_handle *perf_counters[MODULE_ECTX_PERF_COUNTERS];
 
 	struct counter_storage *counter_storage;
+	struct counter_storage *config_counter_storage;
 	struct config_gen_ectx *config_gen_ectx;
 
 	uint64_t mc_index_size;


### PR DESCRIPTION
Split module counters into two registries: the existing `counter_registry` for predefined counters (rx, tx, drop, pending, histograms, module-static) and a new `config_counter_registry` for user-supplied config-defined counters (per-rule, per-route, per-nexthop).

- Add `config_counter_registry` field to `struct cp_module`, initialized and finalized alongside the existing registry, with offset continuity preserved across generations via `counter_registry_link`.
- Add `config_counter_storage` to `struct module_ectx`, spawned from the config registry and tagged `kind=config` in the tag-indexed storage registry on config-gen installation.
- Add `cp_config_counter_storage_registry_insert/lookup_module_config` for the new storage kind.
- Bump `YANET_MODULE_ABI_VERSION` 14 to 15.

Modules can now migrate their config-defined counter registrations (ACL per-rule, route per-route, etc.) from `counter_registry` to `config_counter_registry` in follow-up changes.