### PR TITLE
fix(controlplane): remove unused multi-instance attach helper

### DIFF
--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -97,28 +97,6 @@ func (m *SharedMemory) AgentAttach(
 	return &Agent{name: name, ptr: ptr}, nil
 }
 
-// AgentsAttach attaches agents to shared memory on the specified list of instances.
-func (m *SharedMemory) AgentsAttach(
-	name string,
-	instanceIndices []uint32,
-	size datasize.ByteSize,
-) ([]*Agent, error) {
-	agents := make([]*Agent, 0, len(instanceIndices))
-	for _, instanceIdx := range instanceIndices {
-		agent, err := m.AgentAttach(name, instanceIdx, size)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"failed to connect to shared memory on instance %d: %w",
-				instanceIdx,
-				err,
-			)
-		}
-
-		agents = append(agents, agent)
-	}
-	return agents, nil
-}
-
 // DPConfig represents a handle to dataplane configuration.
 type DPConfig struct {
 	ptr *C.struct_dp_config


### PR DESCRIPTION
- Remove the unused multi-instance shared-memory attachment helper instead of preserving a partial-failure leak.
- Assume no downstream source consumer relies on the exported helper; searches across the public and private repositories, the organization, and public GitHub code found only its definition.
- Preserve the single-instance attachment API used by all known callers.

Closes #2018.