### PR TITLE
refactor(fwstate,acl): split the shared sync config by consumer

### DIFF
--- a/lib/fwstate/config.h
+++ b/lib/fwstate/config.h
@@ -9,9 +9,13 @@ typedef struct fwmap fwmap_t;
 #define FWSTATE_TTL48_MAX ((uint64_t)((1ULL << 48) - 1))
 
 /**
- * FWState configuration structure
- * Contains fwmap references and sync configuration
- * Maps are owned by fwstate module, referenced by ACL module
+ * FWState configuration structures.
+ *
+ * The sync parameters split by consumer: the fwstate module matches
+ * incoming sync packets, inserts state, and rewrites forwarded internal
+ * frames, so its config carries the receive-side fields. A module that
+ * synthesizes sync packets (ACL CREATE_STATE) needs only the emission
+ * addressing.
  */
 
 struct fwstate_timeouts {
@@ -23,25 +27,23 @@ struct fwstate_timeouts {
 	uint64_t default_;    // 16
 };
 
+// Receive-side sync parameters for the fwstate module: packet matching,
+// state insertion, and the internal-frame rewrite.
 struct fwstate_sync_config {
+	// Source IPv6 address stamped on forwarded internal sync frames.
 	uint8_t src_addr[16];
 
-	struct ether_addr dst_ether;
+	// Multicast destination the module matches incoming sync packets
+	// against.
 	uint8_t dst_addr_multicast[16];
 	/**
 	 * Multicast destination port in network byte order (big-endian).
 	 * Stored in BE so it can be used directly in UDP header fields
 	 * and compared with udp_hdr->dst_port without conversion.
-	 * The controlplane (converters.go ConvertPbToCSyncConfig) performs
-	 * the host-to-network conversion when populating this field.
+	 * The controlplane performs the host-to-network conversion when
+	 * populating this field.
 	 */
 	uint16_t port_multicast;
-	uint8_t dst_addr_unicast[16];
-	/**
-	 * Unicast destination port in network byte order (big-endian).
-	 * Same convention as port_multicast - converted by the controlplane.
-	 */
-	uint16_t port_unicast;
 
 	struct fwstate_timeouts timeouts;
 
@@ -54,8 +56,27 @@ struct fwstate_sync_config {
 	uint64_t sync_suppress_timeout;
 };
 
+// Emission-side sync parameters for a module that synthesizes state-sync
+// packets (ACL CREATE_STATE): the outer addressing of the frames it
+// emits. The IPv6 source is left zeroed — the fwstate module stamps its
+// own src_addr when forwarding internal frames.
+struct fwstate_sync_emit_config {
+	struct ether_addr dst_ether;
+	uint8_t dst_addr_multicast[16];
+	/**
+	 * Multicast destination port in network byte order (big-endian).
+	 * Same convention as fwstate_sync_config::port_multicast.
+	 */
+	uint16_t port_multicast;
+	uint8_t dst_addr_unicast[16];
+	/**
+	 * Unicast destination port in network byte order (big-endian).
+	 * Same convention as port_multicast - converted by the controlplane.
+	 */
+	uint16_t port_unicast;
+};
+
 struct fwstate_config {
 	fwmap_t *fw4state; // IPv4 state map
 	fwmap_t *fw6state; // IPv6 state map
-	struct fwstate_sync_config sync_config;
 };

--- a/lib/fwstate/sync.c
+++ b/lib/fwstate/sync.c
@@ -131,7 +131,7 @@ fwstate_fill_sync_frame(
 
 int
 fwstate_craft_state_sync_packet(
-	const struct fwstate_sync_config *sync_config,
+	const struct fwstate_sync_emit_config *emit_config,
 	const struct packet *packet,
 	const enum sync_packet_direction direction,
 	struct packet *sync_pkt
@@ -163,7 +163,7 @@ fwstate_craft_state_sync_packet(
 	);
 	eth_hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_VLAN);
 	struct ether_addr *ether_dst = (struct ether_addr *)&eth_hdr->dst_addr;
-	*ether_dst = sync_config->dst_ether;
+	*ether_dst = emit_config->dst_ether;
 
 	// Fill VLAN header
 	struct rte_vlan_hdr *vlan_hdr = rte_pktmbuf_mtod_offset(
@@ -184,7 +184,7 @@ fwstate_craft_state_sync_packet(
 	ipv6_hdr->hop_limits = 64;
 	// NOTE: Address will be set by the fwstate module
 	memset(ipv6_hdr->src_addr, 0, 16);
-	rte_memcpy(ipv6_hdr->dst_addr, sync_config->dst_addr_multicast, 16);
+	rte_memcpy(ipv6_hdr->dst_addr, emit_config->dst_addr_multicast, 16);
 
 	// Fill UDP header
 	struct rte_udp_hdr *udp_hdr = rte_pktmbuf_mtod_offset(
@@ -193,8 +193,8 @@ fwstate_craft_state_sync_packet(
 	// IPFW reuses the same port for both src and dst
 	// FIXME: support for unicast addrs
 	// Port values are converted to BE format in the controlplane
-	udp_hdr->src_port = sync_config->port_multicast;
-	udp_hdr->dst_port = sync_config->port_multicast;
+	udp_hdr->src_port = emit_config->port_multicast;
+	udp_hdr->dst_port = emit_config->port_multicast;
 	udp_hdr->dgram_len = rte_cpu_to_be_16(
 		sizeof(struct rte_udp_hdr) + sizeof(struct fw_state_sync_frame)
 	);

--- a/lib/fwstate/sync.h
+++ b/lib/fwstate/sync.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "config.h"
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 // Forward declarations
@@ -16,9 +18,25 @@ enum sync_packet_direction {
 };
 
 /**
+ * Report whether an emission config can produce a valid sync frame.
+ *
+ * A zeroed config (all-zero destination MAC or zero multicast port)
+ * would send the frame nowhere, so callers skip crafting instead.
+ */
+static inline bool
+fwstate_sync_emit_config_usable(const struct fwstate_sync_emit_config *config) {
+	for (size_t idx = 0; idx < sizeof(config->dst_ether.addr); ++idx) {
+		if (config->dst_ether.addr[idx] != 0) {
+			return config->port_multicast != 0;
+		}
+	}
+	return false;
+}
+
+/**
  * Craft a state synchronization packet from the given packet.
  *
- * @param sync_config The firewall state sync configuration
+ * @param emit_config The emission-side sync addressing
  * @param packet The original packet to extract 5-tuple from
  * @param direction The direction of the sync packet (INGRESS or EGRESS)
  * @param sync_pkt Pre-allocated packet to fill with sync data
@@ -26,7 +44,7 @@ enum sync_packet_direction {
  */
 int
 fwstate_craft_state_sync_packet(
-	const struct fwstate_sync_config *sync_config,
+	const struct fwstate_sync_emit_config *emit_config,
 	const struct packet *packet,
 	const enum sync_packet_direction direction,
 	struct packet *sync_pkt

--- a/modules/acl/api/controlplane.c
+++ b/modules/acl/api/controlplane.c
@@ -152,8 +152,12 @@ acl_module_config_init(
 	memset(&config->net6_share_src, 0, sizeof(config->net6_share_src));
 	memset(&config->net6_share_dst, 0, sizeof(config->net6_share_dst));
 
-	// Initialize fwstate_cfg with NULL pointers
+	// Initialize fwstate_cfg with NULL pointers and zero the emission
+	// sync config, which acl_module_config_update overwrites with the
+	// caller's config when one is given.
 	memset(&config->fwstate_cfg, 0, sizeof(struct fwstate_config));
+	memset(&config->sync_config, 0, sizeof(struct fwstate_sync_emit_config)
+	);
 
 	// Register module-level counters
 	struct {
@@ -648,6 +652,7 @@ acl_module_config_update(
 	struct cp_module *cp_module,
 	struct acl_rule *acl_rules,
 	uint32_t rule_count,
+	const struct fwstate_sync_emit_config *emit_config,
 	yanet_error **err
 ) {
 	struct acl_module_config *config =
@@ -836,6 +841,14 @@ acl_module_config_update(
 				   1000000000LL +
 			   (ts_end.tv_nsec - ts_start.tv_nsec));
 
+	// Copy the emission sync config that drives CREATE_STATE frames, or
+	// clear the one a previous update installed so a reused config emits
+	// none.
+	if (emit_config != NULL) {
+		config->sync_config = *emit_config;
+	} else {
+		memset(&config->sync_config, 0, sizeof(config->sync_config));
+	}
 	if (rule_count > 0) {
 		free(filter_rule_ptrs);
 	}
@@ -877,7 +890,8 @@ acl_module_config_set_fwstate_config(
 		fwstate_cp_module, struct fwstate_module_config, cp_module
 	);
 
-	config->fwstate_cfg.sync_config = fwstate_config->cfg.sync_config;
+	// Only the borrowed maps cross over. The emission sync config comes
+	// from acl_module_config_update.
 	EQUATE_OFFSET(
 		&config->fwstate_cfg.fw4state, &fwstate_config->cfg.fw4state
 	);
@@ -898,8 +912,6 @@ acl_module_config_transfer_fwstate_config(
 		old_cp_module, struct acl_module_config, cp_module
 	);
 
-	new_config->fwstate_cfg.sync_config =
-		old_config->fwstate_cfg.sync_config;
 	EQUATE_OFFSET(
 		&new_config->fwstate_cfg.fw4state,
 		&old_config->fwstate_cfg.fw4state

--- a/modules/acl/api/controlplane.h
+++ b/modules/acl/api/controlplane.h
@@ -19,6 +19,7 @@ enum acl_rule_action_kind {
 
 struct agent;
 struct cp_module;
+struct fwstate_sync_emit_config;
 
 struct cp_module *
 acl_module_config_init(
@@ -55,11 +56,17 @@ struct acl_rule {
 	enum filter_ip_fragment fragment;
 };
 
+// Compile rules into the ACL config and set the emission-side sync
+// parameters.
+//
+// emit_config is copied by value when non-NULL and drives the CREATE_STATE
+// sync frames.
 int
 acl_module_config_update(
 	struct cp_module *cp_module,
 	struct acl_rule *rules,
 	uint32_t rule_count,
+	const struct fwstate_sync_emit_config *emit_config,
 	yanet_error **err
 );
 

--- a/modules/acl/bindings/go/cacl/safe.go
+++ b/modules/acl/bindings/go/cacl/safe.go
@@ -1,9 +1,11 @@
 package cacl
 
 //#include "modules/acl/api/controlplane.h"
+//#include "lib/fwstate/config.h"
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"unsafe"
@@ -11,6 +13,7 @@ import (
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	cfwstate "github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 )
 
 // Action kind constants mirror the C ACL_RULE_ACTION_KIND_* enum values.
@@ -60,9 +63,12 @@ type AclConfigInfo struct {
 	FilterRuleCountVlan    uint64
 }
 
-// UpdateRules compiles the given rules into C structures and pushes them into
+// UpdateRules compiles the given rules into C structures, attaches the
+// optional emission-side sync configuration, and pushes the config into
 // shared memory.
-func (m *ModuleConfig) UpdateRules(rules []AclRule) error {
+//
+// Pass nil emitConfig for a ruleset that emits no sync packets.
+func (m *ModuleConfig) UpdateRules(rules []AclRule, emitConfig *cfwstate.SyncEmitConfig) error {
 	pinner := &runtime.Pinner{}
 	defer pinner.Unpin()
 
@@ -76,11 +82,21 @@ func (m *ModuleConfig) UpdateRules(rules []AclRule) error {
 		cRulesPtr = &cRules[0]
 	}
 
+	var cEmitPtr unsafe.Pointer
+	if emitConfig != nil {
+		cEmitPtr = cfwstate.NewCEmitSyncConfig(*emitConfig)
+		if cEmitPtr == nil {
+			return errors.New("failed to allocate ACL sync emission config")
+		}
+		defer cfwstate.FreeCEmitSyncConfig(cEmitPtr)
+	}
+
 	var cErr *C.yanet_error
 	rc := C.acl_module_config_update(
 		m.asRawPtr(),
 		cRulesPtr,
 		C.uint32_t(len(cRules)),
+		(*C.struct_fwstate_sync_emit_config)(cEmitPtr),
 		&cErr,
 	)
 	if rc != 0 {

--- a/modules/acl/cli/build.rs
+++ b/modules/acl/cli/build.rs
@@ -20,6 +20,10 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             ".modules.acl.controlplane.aclpb.v1.ShowConfigResponse",
             "#[derive(serde::Serialize)]",
         )
+        .message_attribute(
+            ".modules.acl.controlplane.aclpb.v1.SyncConfig",
+            "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default)]",
+        )
         .field_attribute(
             ".modules.acl.controlplane.aclpb.v1.Action.kind",
             "#[serde(with = \"crate::action_kind\")]",

--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -33,6 +33,24 @@ pub struct UpdateCmd {
     /// Path to the ruleset YAML file
     #[arg(required = true, long = "rules", value_name = "PATH")]
     pub rules: PathBuf,
+    /// Destination MAC address of emitted state-sync frames
+    /// (e.g., "00:11:22:33:44:55")
+    #[arg(long)]
+    pub dst_ether: Option<String>,
+    /// Multicast IPv6 destination of emitted state-sync frames
+    /// (e.g., "ff02::1")
+    #[arg(long)]
+    pub dst_addr_multicast: Option<String>,
+    /// Multicast port of emitted state-sync frames
+    #[arg(long)]
+    pub port_multicast: Option<u32>,
+    /// Unicast IPv6 destination of emitted state-sync frames
+    /// (e.g., "2001:db8::2")
+    #[arg(long)]
+    pub dst_addr_unicast: Option<String>,
+    /// Unicast port of emitted state-sync frames
+    #[arg(long)]
+    pub port_unicast: Option<u32>,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -1,3 +1,4 @@
+use core::net::Ipv6Addr;
 use std::{collections::HashMap, fs::File, path::Path};
 
 use aclpb::{
@@ -258,6 +259,8 @@ fn print_metrics_table(metrics: &[Metric]) {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ACLConfig {
     rules: Vec<aclpb::Rule>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sync_config: Option<aclpb::SyncConfig>,
 }
 
 impl ACLConfig {
@@ -270,6 +273,22 @@ impl ACLConfig {
 
         Ok(config)
     }
+}
+
+/// Display view of an ACL config returned by the show command.
+///
+/// `sync_config` is omitted when absent.
+#[derive(Debug, Serialize)]
+struct ShowConfig {
+    rules: Vec<aclpb::Rule>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sync_config: Option<aclpb::SyncConfig>,
+}
+
+/// Parse an IPv6 address string into the proto message.
+fn parse_ipv6(s: &str) -> Result<commonpb::IpAddress, String> {
+    let addr: Ipv6Addr = s.parse().map_err(|err: core::net::AddrParseError| err.to_string())?;
+    Ok(commonpb::IpAddress { addr: addr.octets().to_vec() })
 }
 
 /// ACL module CLI.
@@ -359,10 +378,13 @@ impl ACLService {
         output::data(
             || &response,
             || {
-                let config = ACLConfig { rules: response.rules.clone() };
+                let display = ShowConfig {
+                    rules: response.rules.clone(),
+                    sync_config: response.sync_config.clone(),
+                };
                 print!(
                     "{}",
-                    serde_yaml::to_string(&config).expect("ACL config YAML serialization must not fail")
+                    serde_yaml::to_string(&display).expect("ACL config YAML serialization must not fail")
                 );
 
                 if response.rules.is_empty() {
@@ -391,6 +413,53 @@ impl ACLService {
         Ok(())
     }
 
+    /// Merge the emission sync config from the YAML file and the flags.
+    ///
+    /// The YAML section is the base; every flag that was passed overrides
+    /// its field. A config with neither source carries no sync config.
+    fn merge_sync_config(
+        &self,
+        base: Option<aclpb::SyncConfig>,
+        cmd: &UpdateCmd,
+    ) -> Result<Option<aclpb::SyncConfig>, String> {
+        let mut sync = match base {
+            Some(base) => base,
+            None => {
+                let no_flags = cmd.dst_ether.is_none()
+                    && cmd.dst_addr_multicast.is_none()
+                    && cmd.port_multicast.is_none()
+                    && cmd.dst_addr_unicast.is_none()
+                    && cmd.port_unicast.is_none();
+                if no_flags {
+                    return Ok(None);
+                }
+                aclpb::SyncConfig::default()
+            }
+        };
+
+        if let Some(ref dst_ether) = cmd.dst_ether {
+            sync.dst_ether = Some(
+                dst_ether
+                    .parse()
+                    .map_err(|err: Box<dyn core::error::Error>| err.to_string())?,
+            );
+        }
+        if let Some(ref dst_addr_multicast) = cmd.dst_addr_multicast {
+            sync.dst_addr_multicast = Some(parse_ipv6(dst_addr_multicast)?);
+        }
+        if let Some(port_multicast) = cmd.port_multicast {
+            sync.port_multicast = port_multicast;
+        }
+        if let Some(ref dst_addr_unicast) = cmd.dst_addr_unicast {
+            sync.dst_addr_unicast = Some(parse_ipv6(dst_addr_unicast)?);
+        }
+        if let Some(port_unicast) = cmd.port_unicast {
+            sync.port_unicast = port_unicast;
+        }
+
+        Ok(Some(sync))
+    }
+
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
         let config = ACLConfig::load(&cmd.rules).map_err(|err| {
             self.service.invalid(
@@ -399,9 +468,14 @@ impl ACLService {
             )
         })?;
         let rule_count = config.rules.len();
+        let sync_config = self
+            .merge_sync_config(config.sync_config, &cmd)
+            .map_err(|err| self.service.invalid("update", err))?;
+
         let request = UpdateConfigRequest {
             name: cmd.config_name.clone(),
             rules: config.rules,
+            sync_config,
         };
         log::trace!("UpdateConfigRequest: {request:?}");
         let response = self

--- a/modules/acl/controlplane/acl_adapter.go
+++ b/modules/acl/controlplane/acl_adapter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
+	cfwstate "github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 	fwstate "github.com/yanet-platform/yanet2/modules/fwstate/controlplane"
 )
 
@@ -193,15 +194,18 @@ func (m *ACLService) swapLinkedHandles(newHandles map[string]ModuleHandle, entri
 		entry := entries[name]
 
 		var rules []*aclpb.Rule
+		var syncConfig *aclpb.SyncConfig
 		if entry.published != nil {
 			oldHandles[name] = entry.published.acl
 			rules = entry.published.rules
+			syncConfig = entry.Published().SyncConfig()
 		}
 
 		entry.published = &aclConfig{
 			rules:       rules,
 			acl:         newHandle,
 			fwstateName: fwstateConfigName,
+			syncConfig:  syncConfig,
 		}
 	}
 	m.publishMetricsSnapshotLocked()
@@ -265,7 +269,13 @@ func (m *ACLService) createLinkedHandles(
 			return nil, fmt.Errorf("failed to convert rules for ACL config %q: %w", name, err)
 		}
 
-		if err := handle.UpdateRules(rules); err != nil {
+		var emitCfg *cfwstate.SyncEmitConfig
+		if stored := entry.Published().SyncConfig(); stored != nil {
+			emit := stored.ToC()
+			emitCfg = &emit
+		}
+
+		if err := handle.UpdateRules(rules, emitCfg); err != nil {
 			handle.Free()
 			for _, h := range newHandles {
 				h.Free()

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -4,6 +4,8 @@ package modules.acl.controlplane.aclpb.v1;
 
 import "common/filterpb/v1/filter.proto";
 import "common/commonpb/v1/metric.proto";
+import "common/commonpb/v1/ipaddr.proto";
+import "common/commonpb/v1/macaddr.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1;aclpb";
 
@@ -29,6 +31,12 @@ service MetricsService {
 message UpdateConfigRequest {
   string name = 1;
   repeated Rule rules = 2;
+  // sync_config carries the emission-side synchronization parameters the
+  // ACL dataplane uses for CREATE_STATE sync packets.
+  //
+  // Required when any rule uses ACTION_KIND_CREATE_STATE; otherwise
+  // optional.
+  SyncConfig sync_config = 3;
 }
 
 message UpdateConfigResponse {}
@@ -39,6 +47,9 @@ message ShowConfigResponse {
   string name = 1;
   repeated Rule rules = 2;
   string fwstate_name = 3;
+  // sync_config is the emission-side synchronization parameters this ACL
+  // config uses, absent when the config carries none.
+  SyncConfig sync_config = 4;
 }
 
 message Rule {
@@ -79,3 +90,15 @@ message DeleteConfigResponse { bool deleted = 1; }
 message ListConfigsRequest {}
 
 message ListConfigsResponse { repeated string configs = 1; }
+
+// SyncConfig carries the emission-side state-sync addressing: the outer
+// header fields of the sync frames a CREATE_STATE action synthesizes.
+// The receive-side parameters (timeouts, suppression) belong to the
+// fwstate module's own configuration.
+message SyncConfig {
+  common.commonpb.v1.MACAddress dst_ether = 1;          // Destination MAC address;
+  common.commonpb.v1.IPAddress dst_addr_multicast = 2; // Multicast IPv6 address;
+  uint32 port_multicast = 3;                            // Multicast port;
+  common.commonpb.v1.IPAddress dst_addr_unicast = 4;   // Unicast IPv6 address;
+  uint32 port_unicast = 5;                              // Unicast port;
+}

--- a/modules/acl/controlplane/aclpb/v1/convert.go
+++ b/modules/acl/controlplane/aclpb/v1/convert.go
@@ -6,7 +6,26 @@ import (
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
 	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
+	cfwstate "github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 )
+
+// ToC converts the proto SyncConfig to the [cfwstate.SyncEmitConfig]
+// value the C API consumes.
+func (m *SyncConfig) ToC() cfwstate.SyncEmitConfig {
+	if m == nil {
+		return cfwstate.SyncEmitConfig{}
+	}
+	var cfg cfwstate.SyncEmitConfig
+	if dstEther := m.GetDstEther(); dstEther != nil {
+		eui := dstEther.EUI48()
+		copy(cfg.DstEther[:], eui[:])
+	}
+	copy(cfg.DstAddrMulticast[:], m.GetDstAddrMulticast().GetAddr())
+	cfg.PortMulticast = uint16(m.GetPortMulticast())
+	copy(cfg.DstAddrUnicast[:], m.GetDstAddrUnicast().GetAddr())
+	cfg.PortUnicast = uint16(m.GetPortUnicast())
+	return cfg
+}
 
 // ToActions converts proto actions into backend cacl.AclAction values.
 //

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -2,6 +2,7 @@ package acl
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"sort"
 	"sync"
@@ -19,6 +20,7 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
 	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
+	cfwstate "github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 )
 
 // ModuleHandle is a handle to an ACL module configuration written to
@@ -27,7 +29,7 @@ import (
 type ModuleHandle interface {
 	Free()
 	AsFFIModule() ffi.ModuleConfig
-	UpdateRules(rules []cacl.AclRule) error
+	UpdateRules(rules []cacl.AclRule, emitConfig *cfwstate.SyncEmitConfig) error
 	SetFwStateConfig(fw ffi.ModuleConfig)
 	TransferFwStateConfig(old ffi.ModuleConfig)
 	GetInfo() *cacl.AclConfigInfo
@@ -83,6 +85,7 @@ type aclConfig struct {
 	rules       []*aclpb.Rule
 	acl         ModuleHandle
 	fwstateName string
+	syncConfig  *aclpb.SyncConfig
 }
 
 // Rules returns the rules held by the config.
@@ -98,6 +101,12 @@ func (m *aclConfig) Handle() ModuleHandle {
 // FwStateName returns the linked fwstate config name.
 func (m *aclConfig) FwStateName() string {
 	return m.fwstateName
+}
+
+// SyncConfig returns the stored emission-side sync configuration, or nil
+// when the config carries none.
+func (m *aclConfig) SyncConfig() *aclpb.SyncConfig {
+	return m.syncConfig
 }
 
 // Free releases the module handle held by the config.
@@ -466,6 +475,82 @@ func rulesEqual(a, b []*aclpb.Rule) bool {
 	return true
 }
 
+// rulesNeedCreateState reports whether any rule uses CREATE_STATE, the
+// action that synthesizes state-sync packets and therefore requires the
+// emission-side sync config. CHECK_STATE-only rulesets read state and
+// carry no sync config.
+func rulesNeedCreateState(rules []*aclpb.Rule) bool {
+	for _, rule := range rules {
+		for _, action := range rule.GetActions() {
+			if action.GetKind() == aclpb.ActionKind_ACTION_KIND_CREATE_STATE {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// syncConfigsEqual reports whether two sync configs are equal. Both nil
+// compares equal; one nil and one non-nil does not.
+func syncConfigsEqual(a, b *aclpb.SyncConfig) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return proto.Equal(a, b)
+}
+
+// validateSyncConfig rejects an emission sync config that could not
+// produce valid sync frames: a missing destination MAC, a missing
+// multicast destination pair (the only destination the craft path
+// uses), or out-of-range ports.
+func validateSyncConfig(cfg *aclpb.SyncConfig) error {
+	if portMulticast := cfg.GetPortMulticast(); portMulticast > maxSyncPort {
+		return fmt.Errorf("port_multicast %d exceeds maximum allowed value %d", portMulticast, maxSyncPort)
+	}
+	if portUnicast := cfg.GetPortUnicast(); portUnicast > maxSyncPort {
+		return fmt.Errorf("port_unicast %d exceeds maximum allowed value %d", portUnicast, maxSyncPort)
+	}
+
+	var missing []string
+
+	if dstEther := cfg.GetDstEther(); dstEther == nil {
+		missing = append(missing, "dst_ether")
+	} else {
+		eui := dstEther.EUI48()
+		if isAllZeroBytes(eui[:]) {
+			missing = append(missing, "dst_ether")
+		}
+	}
+
+	if len(cfg.GetDstAddrMulticast().GetAddr()) != 16 || isAllZeroBytes(cfg.GetDstAddrMulticast().GetAddr()) {
+		missing = append(missing, "dst_addr_multicast")
+	}
+	if cfg.GetPortMulticast() == 0 {
+		missing = append(missing, "port_multicast")
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required sync config fields: %v", missing)
+	}
+	return nil
+}
+
+// maxSyncPort is the highest value accepted for the sync config ports,
+// matching the width of the C-side uint16 port field.
+const maxSyncPort uint32 = 65535
+
+func isAllZeroBytes(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func (m *ACLService) UpdateConfig(
 	ctx context.Context,
 	req *aclpb.UpdateConfigRequest,
@@ -485,7 +570,22 @@ func (m *ACLService) UpdateConfig(
 	err := m.withEntry(name, func(entry *configEntry) error {
 		oldConfig := entry.Published()
 
-		if oldConfig != nil && rulesEqual(oldConfig.Rules(), req.Rules) {
+		syncConfig := req.GetSyncConfig()
+
+		if rulesNeedCreateState(req.Rules) {
+			if syncConfig == nil {
+				return status.Error(codes.InvalidArgument,
+					"sync_config is required when any rule uses ACTION_KIND_CREATE_STATE")
+			}
+		}
+		if syncConfig != nil {
+			if err := validateSyncConfig(syncConfig); err != nil {
+				return status.Errorf(codes.InvalidArgument, "invalid sync config: %v", err)
+			}
+		}
+
+		if oldConfig != nil && rulesEqual(oldConfig.Rules(), req.Rules) &&
+			syncConfigsEqual(oldConfig.SyncConfig(), syncConfig) {
 			resp = &aclpb.UpdateConfigResponse{}
 			return nil
 		}
@@ -500,7 +600,13 @@ func (m *ACLService) UpdateConfig(
 			return status.Errorf(codes.Internal, "failed to create module config: %v", err)
 		}
 
-		if err := handle.UpdateRules(rules); err != nil {
+		var emitCfg *cfwstate.SyncEmitConfig
+		if syncConfig != nil {
+			emit := syncConfig.ToC()
+			emitCfg = &emit
+		}
+
+		if err := handle.UpdateRules(rules, emitCfg); err != nil {
 			handle.Free()
 			return status.Errorf(codes.Internal, "failed to update module config: %v", err)
 		}
@@ -520,11 +626,17 @@ func (m *ACLService) UpdateConfig(
 			return status.Errorf(codes.Internal, "failed to update module: %v", err)
 		}
 
+		var storedSync *aclpb.SyncConfig
+		if syncConfig != nil {
+			storedSync = proto.Clone(syncConfig).(*aclpb.SyncConfig)
+		}
+
 		m.mu.Lock()
 		entry.Publish(&aclConfig{
 			rules:       req.Rules,
 			acl:         handle,
 			fwstateName: fwstateName,
+			syncConfig:  storedSync,
 		})
 		m.publishMetricsSnapshotLocked()
 		m.mu.Unlock()
@@ -568,6 +680,7 @@ func (m *ACLService) ShowConfig(
 		Name:        name,
 		Rules:       config.Rules(),
 		FwstateName: config.FwStateName(),
+		SyncConfig:  config.SyncConfig(),
 	}
 
 	return response, nil

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -52,6 +52,7 @@ type fakeHandle struct {
 	mu          sync.Mutex
 	name        string
 	rules       []cacl.AclRule
+	emitConfig  *cfwstate.SyncEmitConfig
 	freeCount   int
 	transferred bool
 }
@@ -92,12 +93,22 @@ func (m *fakeHandle) AsFFIModule() ffi.ModuleConfig {
 	return ffi.ModuleConfig{}
 }
 
-func (m *fakeHandle) UpdateRules(rules []cacl.AclRule) error {
+func (m *fakeHandle) UpdateRules(rules []cacl.AclRule, emitConfig *cfwstate.SyncEmitConfig) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	m.rules = rules
+	m.emitConfig = emitConfig
 	return nil
+}
+
+// EmitConfig returns the emit config passed to the last UpdateRules call,
+// so a test can assert a relink carried the stored sync config over.
+func (m *fakeHandle) EmitConfig() *cfwstate.SyncEmitConfig {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.emitConfig
 }
 
 func (m *fakeHandle) SetFwStateConfig(_ ffi.ModuleConfig) {}
@@ -252,7 +263,7 @@ func newMetricsSnapshotHarness(testingTB testing.TB) (*dataplaneut.Harness, *ffi
 		moduleConfig, moduleErr := cacl.NewModuleConfig(agent, name)
 		require.NoError(testingTB, moduleErr)
 		testingTB.Cleanup(moduleConfig.Free)
-		require.NoError(testingTB, moduleConfig.UpdateRules(nil))
+		require.NoError(testingTB, moduleConfig.UpdateRules(nil, nil))
 		moduleConfigs = append(moduleConfigs, moduleConfig.AsFFIModule())
 	}
 	require.NoError(testingTB, agent.UpdateModules(moduleConfigs))
@@ -476,14 +487,13 @@ type compileBlockingHandle struct {
 	name    string
 }
 
-func (m *compileBlockingHandle) UpdateRules(rules []cacl.AclRule) error {
+func (m *compileBlockingHandle) UpdateRules(rules []cacl.AclRule, emitConfig *cfwstate.SyncEmitConfig) error {
 	block := m.backend.recordEntry(m.name)
 	if block != nil {
 		close(block.entered)
 		<-block.release
 	}
-
-	return m.ModuleHandle.UpdateRules(rules)
+	return m.ModuleHandle.UpdateRules(rules, emitConfig)
 }
 
 func newTestService(b acl.Backend) *acl.ACLService {
@@ -613,6 +623,202 @@ func TestUpdateConfig_Idempotency(t *testing.T) {
 	publishAfter := b.PublishCalls()
 
 	assert.Equal(t, publishBefore, publishAfter, "second call with identical rules must not publish")
+}
+
+// validTestSyncConfig returns a sync config that passes validation.
+func validTestSyncConfig() *aclpb.SyncConfig {
+	return &aclpb.SyncConfig{
+		DstEther:         &commonpb.MACAddress{Addr: 0x333300000001},
+		DstAddrMulticast: &commonpb.IPAddress{Addr: []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
+		PortMulticast:    9999,
+	}
+}
+
+// TestUpdateConfig_IdempotencyCountsSyncConfig verifies that the
+// idempotence short-circuit compares the sync config, not only the rules.
+// The ruleset only reads state, so a config with no sync section stays
+// legal and dropping the section is observable as a publish.
+func TestUpdateConfig_IdempotencyCountsSyncConfig(t *testing.T) {
+	b := newFakeBackend()
+	svc := newTestService(b)
+
+	rules := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_CHECK_STATE}}}}
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:       "acl0",
+		Rules:      rules,
+		SyncConfig: validTestSyncConfig(),
+	})
+	require.NoError(t, err)
+	publishBefore := b.PublishCalls()
+
+	_, err = svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:       "acl0",
+		Rules:      rules,
+		SyncConfig: validTestSyncConfig(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, publishBefore, b.PublishCalls(), "identical sync config must not publish")
+
+	altered := validTestSyncConfig()
+	altered.PortMulticast = 1000
+	_, err = svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:       "acl0",
+		Rules:      rules,
+		SyncConfig: altered,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, publishBefore+1, b.PublishCalls(), "a changed sync config must publish")
+
+	_, err = svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:  "acl0",
+		Rules: rules,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, publishBefore+2, b.PublishCalls(), "dropping the sync config must publish")
+}
+
+// TestUpdateConfig_CheckStateOnlyRulesNeedNoSyncConfig verifies that a
+// ruleset which only reads state carries no sync config requirement.
+func TestUpdateConfig_CheckStateOnlyRulesNeedNoSyncConfig(t *testing.T) {
+	b := newFakeBackend()
+	svc := newTestService(b)
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name: "acl0",
+		Rules: []*aclpb.Rule{
+			{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_CHECK_STATE}}},
+		},
+	})
+	require.NoError(t, err)
+}
+
+// TestUpdateConfig_RequiresSyncConfigForCreateState verifies that a ruleset
+// using CREATE_STATE is rejected without a sync config and accepted with one.
+func TestUpdateConfig_RequiresSyncConfigForCreateState(t *testing.T) {
+	b := newFakeBackend()
+	svc := newTestService(b)
+
+	rules := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_CREATE_STATE}}}}
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{Name: "acl0", Rules: rules})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "sync_config is required")
+
+	_, err = svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:       "acl0",
+		Rules:      rules,
+		SyncConfig: validTestSyncConfig(),
+	})
+	require.NoError(t, err)
+}
+
+// TestUpdateConfig_RejectsInvalidSyncConfig verifies that a supplied sync
+// config is validated even when no rule requires one.
+func TestUpdateConfig_RejectsInvalidSyncConfig(t *testing.T) {
+	b := newFakeBackend()
+	svc := newTestService(b)
+
+	cfg := validTestSyncConfig()
+	cfg.PortUnicast = 65536
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:       "acl0",
+		Rules:      []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}},
+		SyncConfig: cfg,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "port_unicast")
+}
+
+// TestUpdateConfig_ValidatesSyncConfig covers the sync config validation
+// through the update RPC: every field the craft path requires, and the
+// 16-bit port bounds.
+func TestUpdateConfig_ValidatesSyncConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*aclpb.SyncConfig)
+		wantErr string
+	}{
+		{
+			name:   "valid config passes",
+			mutate: func(*aclpb.SyncConfig) {},
+		},
+		{
+			name: "valid config with unicast destination passes",
+			mutate: func(c *aclpb.SyncConfig) {
+				c.DstAddrUnicast = &commonpb.IPAddress{Addr: []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}}
+				c.PortUnicast = 1000
+			},
+		},
+		{
+			name:    "missing dst_ether",
+			mutate:  func(c *aclpb.SyncConfig) { c.DstEther = nil },
+			wantErr: "dst_ether",
+		},
+		{
+			name:    "all-zero dst_ether",
+			mutate:  func(c *aclpb.SyncConfig) { c.DstEther = &commonpb.MACAddress{} },
+			wantErr: "dst_ether",
+		},
+		{
+			name:    "missing multicast address",
+			mutate:  func(c *aclpb.SyncConfig) { c.DstAddrMulticast = nil },
+			wantErr: "dst_addr_multicast",
+		},
+		{
+			name:    "short multicast address",
+			mutate:  func(c *aclpb.SyncConfig) { c.DstAddrMulticast = &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4}} },
+			wantErr: "dst_addr_multicast",
+		},
+		{
+			name:    "all-zero multicast address",
+			mutate:  func(c *aclpb.SyncConfig) { c.DstAddrMulticast = &commonpb.IPAddress{} },
+			wantErr: "dst_addr_multicast",
+		},
+		{
+			name:    "zero multicast port",
+			mutate:  func(c *aclpb.SyncConfig) { c.PortMulticast = 0 },
+			wantErr: "port_multicast",
+		},
+		{
+			name:    "multicast port over 16 bits",
+			mutate:  func(c *aclpb.SyncConfig) { c.PortMulticast = 65536 },
+			wantErr: "port_multicast",
+		},
+		{
+			name:    "unicast port over 16 bits",
+			mutate:  func(c *aclpb.SyncConfig) { c.PortUnicast = 65536 },
+			wantErr: "port_unicast",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newFakeBackend()
+			svc := newTestService(b)
+
+			cfg := validTestSyncConfig()
+			tc.mutate(cfg)
+
+			resp, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+				Name: "acl0",
+				Rules: []*aclpb.Rule{
+					{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_CREATE_STATE}}},
+				},
+				SyncConfig: cfg,
+			})
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+			assert.Contains(t, err.Error(), tc.wantErr)
+			assert.Nil(t, resp)
+		})
+	}
 }
 
 // TestUpdateConfig_ErrorPropagation verifies that a backend failure from
@@ -1384,6 +1590,45 @@ func TestRelinkConfigs_ConcurrentWithUpdateOfSharedName(t *testing.T) {
 		require.NoError(t, err)
 	}
 	assertAllHandlesFreed(t, backend)
+}
+
+// TestRelinkConfigs_PreservesSyncConfig verifies that relinking a name to a
+// fwstate config keeps the stored sync config both in the service state and
+// on the refreshed handle, so CREATE_STATE keeps emitting after a relink.
+func TestRelinkConfigs_PreservesSyncConfig(t *testing.T) {
+	backend := newFakeBackend()
+	svc := newTestService(backend)
+	adapter := acl.NewACLAdapter(svc)
+
+	fwstateConfig := &fwstate.FwStateConfig{ModuleConfig: &cfwstate.ModuleConfig{}}
+	publish := func(_ []ffi.ModuleConfig) error { return nil }
+
+	syncCfg := validTestSyncConfig()
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name: "a",
+		Rules: []*aclpb.Rule{
+			{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_CREATE_STATE}}},
+		},
+		SyncConfig: syncCfg,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, adapter.RelinkConfigs(fwstateConfig, publish))
+
+	resp, err := svc.ShowConfig(t.Context(), &aclpb.ShowConfigRequest{Name: "a"})
+	require.NoError(t, err)
+	require.NotNil(t, resp.SyncConfig, "a relink must keep the stored sync config")
+	assert.True(t, proto.Equal(syncCfg, resp.SyncConfig))
+
+	var refreshed *fakeHandle
+	for _, handle := range backend.CreatedHandles() {
+		if handle.Name() == "a" && handle.FreeCount() == 0 {
+			require.Nil(t, refreshed, "only one a handle may remain owned after relinking")
+			refreshed = handle
+		}
+	}
+	require.NotNil(t, refreshed, "RelinkConfigs must leave a refreshed a handle owned")
+	require.NotNil(t, refreshed.EmitConfig(), "the refreshed handle must receive the stored emit config")
 }
 
 // TestACLAdapterLinkConfigs_UnknownName verifies that LinkConfigs with an

--- a/modules/acl/dataplane/config.h
+++ b/modules/acl/dataplane/config.h
@@ -34,8 +34,11 @@ struct acl_module_config {
 	uint64_t target_count;
 	struct acl_target *targets;
 
+	// Fwstate module maps borrowed for state lookups.
 	struct fwstate_config fwstate_cfg;
 
+	// Emission-side sync parameters for CREATE_STATE frames.
+	struct fwstate_sync_emit_config sync_config;
 	// Metrics
 	uint64_t compilation_time_ns;
 	uint64_t filter_rule_count_ip4;

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -155,7 +155,7 @@ acl_handle_packets(
 		net6_share_dir_is_built(&acl_config->net6_share_src);
 
 	struct fwstate_config *fwstate_config = &acl_config->fwstate_cfg;
-	struct fwstate_sync_config *sync_config = &fwstate_config->sync_config;
+	struct fwstate_sync_emit_config *sync_config = &acl_config->sync_config;
 	fwmap_t *fw4state = ADDR_OF(&fwstate_config->fw4state);
 	fwmap_t *fw6state = ADDR_OF(&fwstate_config->fw6state);
 
@@ -561,7 +561,8 @@ acl_handle_packets(
 			pass_cnt[0] += 1;
 			packet_front_output(packet_front, packet);
 
-			if (push_sync_packet != SYNC_NONE) {
+			if (push_sync_packet != SYNC_NONE &&
+			    fwstate_sync_emit_config_usable(sync_config)) {
 				create_cnt[0] += 1;
 
 				// Allocate a new packet for the sync frame

--- a/modules/acl/tests/functional/acl_bench_dataset_test.go
+++ b/modules/acl/tests/functional/acl_bench_dataset_test.go
@@ -696,7 +696,7 @@ func datasetBenchSetup(b *testing.B) *datasetBenchState {
 			datasetBenchErr = err
 			return
 		}
-		if datasetBenchErr = handle.UpdateRules(rules); datasetBenchErr != nil {
+		if datasetBenchErr = handle.UpdateRules(rules, nil); datasetBenchErr != nil {
 			return
 		}
 		if datasetBenchErr = backend.UpdateModule(handle); datasetBenchErr != nil {
@@ -850,7 +850,7 @@ func datasetTopoBenchSetup(b *testing.B) *datasetBenchState {
 			topoBenchErr = err
 			return
 		}
-		if topoBenchErr = handle.UpdateRules(rules); topoBenchErr != nil {
+		if topoBenchErr = handle.UpdateRules(rules, nil); topoBenchErr != nil {
 			return
 		}
 		if topoBenchErr = backend.UpdateModule(handle); topoBenchErr != nil {

--- a/modules/acl/tests/functional/acl_sync_config_test.go
+++ b/modules/acl/tests/functional/acl_sync_config_test.go
@@ -1,0 +1,116 @@
+package acl_test
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	"github.com/yanet-platform/yanet2/common/go/xerror"
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
+	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
+)
+
+// syncEmitConfig builds an emission config that passes the usable check and
+// addresses the crafted sync frames to a link-local multicast destination.
+func syncEmitConfig() *cfwstate.SyncEmitConfig {
+	multicast := netip.MustParseAddr("ff02::1").As16()
+	cfg := &cfwstate.SyncEmitConfig{
+		DstEther:      [6]byte{0x33, 0x33, 0x00, 0x00, 0x00, 0x01},
+		PortMulticast: 9999,
+	}
+	copy(cfg.DstAddrMulticast[:], multicast[:])
+	return cfg
+}
+
+// syncStatePacket builds the TCP packet the CREATE_STATE rule matches.
+func syncStatePacket(t *testing.T) gopacket.Packet {
+	t.Helper()
+
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip4 := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolTCP,
+		SrcIP:    net.ParseIP("192.0.2.1"),
+		DstIP:    net.ParseIP("10.0.0.1"),
+	}
+	tcp := layers.TCP{
+		SrcPort: 12345,
+		DstPort: 80,
+		SYN:     true,
+	}
+	require.NoError(t, tcp.SetNetworkLayerForChecksum(&ip4))
+	return xpacket.LayersToPacket(t, &eth, &ip4, &tcp)
+}
+
+// TestACL_UpdateRules_EmitConfigDrivesSyncFrames verifies the positive
+// emission path: a ruleset that creates state and carries a usable emit
+// config synthesizes one state-sync frame per matched packet.
+func TestACL_UpdateRules_EmitConfigDrivesSyncFrames(t *testing.T) {
+	// CREATE_STATE is non-terminal: the packet passes and the module
+	// synthesizes a state-sync frame when the emit config is usable.
+	rule := allow4Rule(
+		filter.IPNets{filter.UnspecifiedIPv4},
+		filter.IPNets{filter.UnspecifiedIPv4},
+		tcpProto,
+	)
+	rule.Actions = []cacl.AclAction{{Kind: cacl.ActionCreateState}, {Kind: cacl.ActionAllow}}
+
+	h, agent, backend := setupACLHarness(t, []string{"port0"})
+
+	handle, err := backend.NewModule("sync-emit")
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+
+	require.NoError(t, handle.UpdateRules([]cacl.AclRule{rule}, syncEmitConfig()))
+	require.NoError(t, backend.UpdateModule(handle))
+	wireACLPipeline(t, agent, "port0", "sync-emit")
+
+	result, err := h.HandlePackets(syncStatePacket(t))
+	require.NoError(t, err)
+	require.Len(t, result.Output, 2, "a usable emit config must add a state-sync frame to the output")
+}
+
+// TestACL_UpdateRules_NilEmitConfigClearsPreviousSyncConfig verifies the
+// nil contract of the exported binding: a later UpdateRules with a nil emit
+// config clears the previously installed one on the same handle, so the
+// published config emits no state-sync frames instead of crafting them to
+// the stale destination.
+func TestACL_UpdateRules_NilEmitConfigClearsPreviousSyncConfig(t *testing.T) {
+	rule := allow4Rule(
+		filter.IPNets{filter.UnspecifiedIPv4},
+		filter.IPNets{filter.UnspecifiedIPv4},
+		tcpProto,
+	)
+	rule.Actions = []cacl.AclAction{{Kind: cacl.ActionCreateState}, {Kind: cacl.ActionAllow}}
+
+	// The same handle compiles the rules twice, and the second compile
+	// allocates fresh filter tables in the module arena next to the
+	// first, so the harness carries a larger agent arena (the sizes the
+	// net6-share tests proved under ASan).
+	h, agent, backend := setupACLHarnessSized(t, []string{"port0"}, 192*datasize.MB, 48*datasize.MB)
+
+	handle, err := backend.NewModule("sync-emit")
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+
+	require.NoError(t, handle.UpdateRules([]cacl.AclRule{rule}, syncEmitConfig()))
+	require.NoError(t, handle.UpdateRules([]cacl.AclRule{rule}, nil))
+	require.NoError(t, backend.UpdateModule(handle))
+	wireACLPipeline(t, agent, "port0", "sync-emit")
+
+	result, err := h.HandlePackets(syncStatePacket(t))
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "a nil emit config must clear the previously installed one")
+}

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -116,7 +116,7 @@ func applyACLRules(
 	require.NoError(tb, err)
 	tb.Cleanup(handle.Free)
 
-	require.NoError(tb, handle.UpdateRules(rules))
+	require.NoError(tb, handle.UpdateRules(rules, nil))
 	require.NoError(tb, backend.UpdateModule(handle))
 	return handle
 }
@@ -1733,7 +1733,7 @@ func TestACL_RejectsNonContiguousIPv4Mask(t *testing.T) {
 		),
 	}
 
-	err = handle.UpdateRules(rules)
+	err = handle.UpdateRules(rules, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "non-contiguous")
 }
@@ -1760,7 +1760,7 @@ func TestACL_RejectsNonBiContiguousIPv6Mask(t *testing.T) {
 		),
 	}
 
-	err = handle.UpdateRules(rules)
+	err = handle.UpdateRules(rules, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "bi-contiguous")
 }

--- a/modules/acl/web/draftReducer.ts
+++ b/modules/acl/web/draftReducer.ts
@@ -1,4 +1,4 @@
-import type { Rule } from '@yanet/core/api/acl';
+import type { Rule, SyncConfig } from '@yanet/core/api/acl';
 
 /** Monotonically increasing counter for generating stable tmp- ids. */
 let tmpIdCounter = 0;
@@ -10,6 +10,11 @@ const serverIds = (rules: Rule[]): string[] => rules.map((_, idx) => `srv-${idx}
 export interface AclDraftState {
     server: Record<string, Rule[]>;
     serverFwStateName: Record<string, string>;
+    /**
+     * Emission sync config currently stored on the server, per config name.
+     * The web layer carries it along on save instead of editing it.
+     */
+    serverSyncConfig: Record<string, SyncConfig | undefined>;
     draft: Record<string, Rule[]>;
     /**
      * Stable row ids parallel to draft[configName].
@@ -27,6 +32,7 @@ export interface AclDraftState {
 export const initialAclDraftState: AclDraftState = {
     server: {},
     serverFwStateName: {},
+    serverSyncConfig: {},
     draft: {},
     draftIds: {},
     serverConfigs: [],
@@ -36,7 +42,7 @@ export const initialAclDraftState: AclDraftState = {
 };
 
 export type AclDraftAction =
-    | { type: 'LOAD_ALL_CONFIGS'; configs: Array<{ name: string; rules: Rule[]; fwstateName: string }> }
+    | { type: 'LOAD_ALL_CONFIGS'; configs: Array<{ name: string; rules: Rule[]; fwstateName: string; syncConfig?: SyncConfig }> }
     | { type: 'ADD_RULE'; configName: string; rule: Rule }
     | { type: 'UPDATE_RULE_AT_INDEX'; configName: string; index: number; rule: Rule }
     | { type: 'REMOVE_RULES'; configName: string; indices: number[] }
@@ -54,15 +60,17 @@ export const aclDraftReducer = (
         case 'LOAD_ALL_CONFIGS': {
             const newServer: Record<string, Rule[]> = { ...state.server };
             const newServerFwStateName: Record<string, string> = { ...state.serverFwStateName };
+            const newServerSyncConfig: Record<string, SyncConfig | undefined> = { ...state.serverSyncConfig };
             const newDraft: Record<string, Rule[]> = { ...state.draft };
             const newDraftIds: Record<string, string[]> = { ...state.draftIds };
             const serverConfigs: string[] = [];
             // Use reference equality to detect whether the user has local edits:
             // if draft[name] === server[name] the config was never mutated locally,
             // so it is safe to fast-forward to the new server snapshot.
-            for (const { name, rules, fwstateName } of action.configs) {
+            for (const { name, rules, fwstateName, syncConfig } of action.configs) {
                 newServer[name] = rules;
                 newServerFwStateName[name] = fwstateName;
+                newServerSyncConfig[name] = syncConfig;
                 if (state.draft[name] === state.server[name]) {
                     newDraft[name] = rules;
                     newDraftIds[name] = serverIds(rules);
@@ -81,6 +89,7 @@ export const aclDraftReducer = (
                 ...state,
                 server: newServer,
                 serverFwStateName: newServerFwStateName,
+                serverSyncConfig: newServerSyncConfig,
                 draft: newDraft,
                 draftIds: newDraftIds,
                 serverConfigs,
@@ -228,12 +237,14 @@ export const aclDraftReducer = (
                 // gone from the server.
                 const { [action.configName]: _s, ...serverRest } = state.server;
                 const { [action.configName]: _f, ...fwStateNameRest } = state.serverFwStateName;
+                const { [action.configName]: _sc, ...syncConfigRest } = state.serverSyncConfig;
                 const { [action.configName]: _d, ...draftRest } = state.draft;
                 const { [action.configName]: _di, ...draftIdsRest } = state.draftIds;
                 return {
                     ...state,
                     server: serverRest,
                     serverFwStateName: fwStateNameRest,
+                    serverSyncConfig: syncConfigRest,
                     draft: draftRest,
                     draftIds: draftIdsRest,
                     serverConfigs: state.serverConfigs.filter(n => n !== action.configName),

--- a/modules/acl/web/useAclDraft.ts
+++ b/modules/acl/web/useAclDraft.ts
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useReducer, useState } from 'react';
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import { API, inventoryConfigNames, loadKnownConfigs, unionConfigNames } from '@yanet/core/api';
 import { useConfigListCache } from '@yanet/core/hooks';
 import { toaster, compareNatural, warnConfigsUnknown } from '@yanet/core/utils';
-import type { Rule } from '@yanet/core/api/acl';
+import type { Rule, SyncConfig } from '@yanet/core/api/acl';
 import {
     aclDraftReducer,
     initialAclDraftState,
@@ -13,9 +13,6 @@ import { useConfigPersistence, type ConfigPersistenceDispatch } from '@yanet/cor
 const EMPTY_RULES: Rule[] = [];
 const EMPTY_IDS: string[] = [];
 const EMPTY_FWSTATE_NAME = '';
-
-const aclUpdateConfig = (name: string, rules: Rule[]): Promise<unknown> =>
-    API.acl.updateConfig({ name, rules });
 
 const aclDeleteConfig = (name: string): Promise<unknown> =>
     API.acl.deleteConfig({ name });
@@ -51,6 +48,15 @@ export const useAclDraft = (): UseAclDraftResult => {
     const [loadFailed, setLoadFailed] = useState(false);
     const { write: writeCache } = useConfigListCache('acl');
 
+    // Latest stored sync config per name, read by the identity-stable save
+    // wrapper below so a web save keeps the config's emission settings
+    // instead of dropping them.
+    const serverSyncConfigRef = useRef<Record<string, SyncConfig | undefined>>({});
+    serverSyncConfigRef.current = state.serverSyncConfig;
+
+    const aclUpdateConfig = useCallback((name: string, rules: Rule[]): Promise<unknown> =>
+        API.acl.updateConfig({ name, rules, sync_config: serverSyncConfigRef.current[name] }), []);
+
     const dispatchDraft = useCallback((action: AclDraftAction): void => {
         rawDispatch(action);
     }, []);
@@ -66,9 +72,14 @@ export const useAclDraft = (): UseAclDraftResult => {
 
             const configs = await loadKnownConfigs(
                 names,
-                async (name): Promise<{ name: string; rules: Rule[]; fwstateName: string }> => {
+                async (name): Promise<{ name: string; rules: Rule[]; fwstateName: string; syncConfig?: SyncConfig }> => {
                     const resp = await API.acl.showConfig({ name });
-                    return { name, rules: resp.rules ?? [], fwstateName: resp.fwstate_name ?? '' };
+                    return {
+                        name,
+                        rules: resp.rules ?? [],
+                        fwstateName: resp.fwstate_name ?? '',
+                        syncConfig: resp.sync_config,
+                    };
                 },
                 { onDropped: warnConfigsUnknown('acl-configs-unknown', 'ACL') },
             );

--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -39,14 +39,14 @@ fwstate_config_fini(struct fwstate_config *config, struct agent *agent) {
 
 // Set default timeout values for fwstate configuration
 static void
-fwstate_config_set_defaults(struct fwstate_config *config) {
-	memset(config, 0, sizeof(struct fwstate_config));
-	config->sync_config.timeouts.tcp_syn_ack = FW_STATE_DEFAULT_TIMEOUT;
-	config->sync_config.timeouts.tcp_syn = FW_STATE_DEFAULT_TIMEOUT;
-	config->sync_config.timeouts.tcp_fin = FW_STATE_DEFAULT_TIMEOUT;
-	config->sync_config.timeouts.tcp = FW_STATE_DEFAULT_TIMEOUT;
-	config->sync_config.timeouts.udp = 30e9;      // 30 seconds
-	config->sync_config.timeouts.default_ = 16e9; // 16 seconds
+fwstate_config_set_defaults(struct fwstate_sync_config *config) {
+	memset(config, 0, sizeof(struct fwstate_sync_config));
+	config->timeouts.tcp_syn_ack = FW_STATE_DEFAULT_TIMEOUT;
+	config->timeouts.tcp_syn = FW_STATE_DEFAULT_TIMEOUT;
+	config->timeouts.tcp_fin = FW_STATE_DEFAULT_TIMEOUT;
+	config->timeouts.tcp = FW_STATE_DEFAULT_TIMEOUT;
+	config->timeouts.udp = 30e9;	  // 30 seconds
+	config->timeouts.default_ = 16e9; // 16 seconds
 }
 
 static void
@@ -82,7 +82,10 @@ fwstate_module_config_new(
 		);
 		return NULL;
 	}
-	fwstate_config_set_defaults(&config->cfg);
+	// balloc does not zero, and the map create path reads the raw map
+	// pointers to reject double creation, so both halves start zeroed.
+	memset(&config->cfg, 0, sizeof(struct fwstate_config));
+	fwstate_config_set_defaults(&config->sync_config);
 
 	// Register module-level counters.
 	// size=2 counters hold [packets, bytes]; size=1 counters hold
@@ -167,7 +170,7 @@ fwstate_module_config_propogate(
 		old_cp_module, struct fwstate_module_config, cp_module
 	);
 
-	new->cfg = old->cfg; // copy sync config
+	new->sync_config = old->sync_config;
 	EQUATE_OFFSET(&new->cfg.fw4state, &old->cfg.fw4state);
 	EQUATE_OFFSET(&new->cfg.fw6state, &old->cfg.fw6state);
 }
@@ -320,7 +323,7 @@ fwstate_module_config_set_sync_config(
 	struct fwstate_module_config *config = container_of(
 		cp_module, struct fwstate_module_config, cp_module
 	);
-	config->cfg.sync_config = *sync_config;
+	config->sync_config = *sync_config;
 }
 
 struct fwmap_stats
@@ -350,7 +353,7 @@ fwstate_config_get_sync_config(const struct cp_module *cp_module) {
 		cp_module, struct fwstate_module_config, cp_module
 	);
 
-	return config->cfg.sync_config;
+	return config->sync_config;
 }
 
 // Structure to hold outdated layers from both IPv4 and IPv6 maps

--- a/modules/fwstate/bindings/go/cfwstate/safe.go
+++ b/modules/fwstate/bindings/go/cfwstate/safe.go
@@ -24,14 +24,12 @@ type MapConfig struct {
 	ExtraBucketCount uint32
 }
 
-// SyncConfig stores fwstate synchronization settings for C API calls.
+// SyncConfig stores the receive-side fwstate synchronization settings
+// the fwstate module consumes: packet matching, timeouts, suppression.
 type SyncConfig struct {
 	SrcAddr             [16]byte
-	DstEther            [6]byte
 	DstAddrMulticast    [16]byte
-	DstAddrUnicast      [16]byte
 	PortMulticast       uint16
-	PortUnicast         uint16
 	TcpSynAck           uint64
 	TcpSyn              uint64
 	TcpFin              uint64
@@ -41,14 +39,21 @@ type SyncConfig struct {
 	SyncSuppressTimeout uint64
 }
 
+// SyncEmitConfig stores the emission-side sync addressing a module
+// synthesizing state-sync packets (ACL CREATE_STATE) needs.
+type SyncEmitConfig struct {
+	DstEther         [6]byte
+	DstAddrMulticast [16]byte
+	PortMulticast    uint16
+	DstAddrUnicast   [16]byte
+	PortUnicast      uint16
+}
+
 func newSyncConfigFromC(cCfg *C.struct_fwstate_sync_config) SyncConfig {
 	var syncCfg SyncConfig
 	copy(syncCfg.SrcAddr[:], unsafe.Slice((*byte)(unsafe.Pointer(&cCfg.src_addr[0])), 16))
-	copy(syncCfg.DstEther[:], unsafe.Slice((*byte)(unsafe.Pointer(&cCfg.dst_ether)), 6))
 	copy(syncCfg.DstAddrMulticast[:], unsafe.Slice((*byte)(unsafe.Pointer(&cCfg.dst_addr_multicast[0])), 16))
-	copy(syncCfg.DstAddrUnicast[:], unsafe.Slice((*byte)(unsafe.Pointer(&cCfg.dst_addr_unicast[0])), 16))
 	syncCfg.PortMulticast = uint16(ntohs(uint16(cCfg.port_multicast)))
-	syncCfg.PortUnicast = uint16(ntohs(uint16(cCfg.port_unicast)))
 	syncCfg.TcpSynAck = uint64(cCfg.timeouts.tcp_syn_ack)
 	syncCfg.TcpSyn = uint64(cCfg.timeouts.tcp_syn)
 	syncCfg.TcpFin = uint64(cCfg.timeouts.tcp_fin)
@@ -62,11 +67,8 @@ func newSyncConfigFromC(cCfg *C.struct_fwstate_sync_config) SyncConfig {
 func (m SyncConfig) toC() C.struct_fwstate_sync_config {
 	var cSyncConfig C.struct_fwstate_sync_config
 	copy(unsafe.Slice((*byte)(unsafe.Pointer(&cSyncConfig.src_addr[0])), 16), m.SrcAddr[:])
-	copy(unsafe.Slice((*byte)(unsafe.Pointer(&cSyncConfig.dst_ether)), 6), m.DstEther[:])
 	copy(unsafe.Slice((*byte)(unsafe.Pointer(&cSyncConfig.dst_addr_multicast[0])), 16), m.DstAddrMulticast[:])
-	copy(unsafe.Slice((*byte)(unsafe.Pointer(&cSyncConfig.dst_addr_unicast[0])), 16), m.DstAddrUnicast[:])
 	cSyncConfig.port_multicast = C.uint16_t(htons(uint16(m.PortMulticast)))
-	cSyncConfig.port_unicast = C.uint16_t(htons(uint16(m.PortUnicast)))
 	cSyncConfig.timeouts.tcp_syn_ack = C.uint64_t(m.TcpSynAck)
 	cSyncConfig.timeouts.tcp_syn = C.uint64_t(m.TcpSyn)
 	cSyncConfig.timeouts.tcp_fin = C.uint64_t(m.TcpFin)
@@ -76,6 +78,42 @@ func (m SyncConfig) toC() C.struct_fwstate_sync_config {
 	cSyncConfig.sync_suppress_timeout = C.uint64_t(m.SyncSuppressTimeout)
 
 	return cSyncConfig
+}
+
+func (m SyncEmitConfig) toC() C.struct_fwstate_sync_emit_config {
+	var cEmitConfig C.struct_fwstate_sync_emit_config
+	copy(unsafe.Slice((*byte)(unsafe.Pointer(&cEmitConfig.dst_ether)), 6), m.DstEther[:])
+	copy(unsafe.Slice((*byte)(unsafe.Pointer(&cEmitConfig.dst_addr_multicast[0])), 16), m.DstAddrMulticast[:])
+	cEmitConfig.port_multicast = C.uint16_t(htons(uint16(m.PortMulticast)))
+	copy(unsafe.Slice((*byte)(unsafe.Pointer(&cEmitConfig.dst_addr_unicast[0])), 16), m.DstAddrUnicast[:])
+	cEmitConfig.port_unicast = C.uint16_t(htons(uint16(m.PortUnicast)))
+
+	return cEmitConfig
+}
+
+// NewCEmitSyncConfig allocates a C-side copy of the emission sync
+// configuration that other modules' bindings can pass to their C APIs.
+//
+// The caller owns the returned pointer and must release it with
+// [FreeCEmitSyncConfig] once the C side no longer references it. Returns
+// nil on allocation failure.
+func NewCEmitSyncConfig(emit SyncEmitConfig) unsafe.Pointer {
+	cEmitConfig := emit.toC()
+	ptr := C.calloc(1, C.sizeof_struct_fwstate_sync_emit_config)
+	if ptr == nil {
+		return nil
+	}
+	*(*C.struct_fwstate_sync_emit_config)(ptr) = cEmitConfig
+	return ptr
+}
+
+// FreeCEmitSyncConfig releases a pointer previously returned by
+// [NewCEmitSyncConfig]. Safe to call with nil.
+func FreeCEmitSyncConfig(ptr unsafe.Pointer) {
+	if ptr == nil {
+		return
+	}
+	C.free(ptr)
 }
 
 // StateKey stores a cursor key with address bytes as plain Go data.

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -81,10 +81,6 @@ pub struct UpdateCmd {
     #[arg(long)]
     pub src_addr: Option<String>,
 
-    /// Destination MAC address (e.g., "00:11:22:33:44:55")
-    #[arg(long)]
-    pub dst_ether: Option<String>,
-
     /// Multicast IPv6 address (e.g., "ff02::1")
     #[arg(long)]
     pub dst_addr_multicast: Option<String>,
@@ -92,14 +88,6 @@ pub struct UpdateCmd {
     /// Multicast port
     #[arg(long)]
     pub port_multicast: Option<u32>,
-
-    /// Unicast IPv6 address (e.g., "2001:db8::2")
-    #[arg(long)]
-    pub dst_addr_unicast: Option<String>,
-
-    /// Unicast port
-    #[arg(long)]
-    pub port_unicast: Option<u32>,
 
     /// TCP SYN-ACK timeout (e.g., "60s", "5m", "1h")
     #[arg(long, value_parser = parse_duration)]

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use args::{DeleteCmd, DirectionArg, EntriesCmd, Family, LinkCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
-use commonpb::pb::{GetMetricsRequest, IpAddress, MacAddress, Metric as ProtoMetric};
+use commonpb::pb::{GetMetricsRequest, IpAddress, Metric as ProtoMetric};
 use fwstatepb::{
     DeleteConfigRequest, Direction, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest, ListEntriesRequest,
     ShowConfigRequest, UpdateConfigRequest, fw_state_service_client::FwStateServiceClient,
@@ -141,7 +141,7 @@ impl FWStateService {
                     output::empty_with_hint(
                         format_args!("No FWState configurations found."),
                         format_args!(
-                            "create one with 'yanet-cli-fwstate update --name <name> --src-addr <addr> --dst-ether <mac> --dst-addr-unicast <addr> --port-unicast <port>'"
+                            "create one with 'yanet-cli-fwstate update --name <name> --src-addr <addr> --dst-addr-multicast <addr> --port-multicast <port>'"
                         ),
                     );
                     return;
@@ -226,13 +226,6 @@ impl FWStateService {
             sync_config.src_addr = Some(parse_ipv6(src_addr).map_err(|err| self.service.invalid("update", err))?);
         }
 
-        if let Some(ref dst_ether) = cmd.dst_ether {
-            let mac = dst_ether
-                .parse::<MacAddress>()
-                .map_err(|err| self.service.invalid("update", err.to_string()))?;
-            sync_config.dst_ether = Some(mac);
-        }
-
         if let Some(ref dst_addr_multicast) = cmd.dst_addr_multicast {
             sync_config.dst_addr_multicast =
                 Some(parse_ipv6(dst_addr_multicast).map_err(|err| self.service.invalid("update", err))?);
@@ -240,15 +233,6 @@ impl FWStateService {
 
         if let Some(port_multicast) = cmd.port_multicast {
             sync_config.port_multicast = port_multicast;
-        }
-
-        if let Some(ref dst_addr_unicast) = cmd.dst_addr_unicast {
-            sync_config.dst_addr_unicast =
-                Some(parse_ipv6(dst_addr_unicast).map_err(|err| self.service.invalid("update", err))?);
-        }
-
-        if let Some(port_unicast) = cmd.port_unicast {
-            sync_config.port_unicast = port_unicast;
         }
 
         // Convert timeouts from Duration to nanoseconds if provided

--- a/modules/fwstate/controlplane/delete_test.go
+++ b/modules/fwstate/controlplane/delete_test.go
@@ -91,7 +91,7 @@ func newACLDeleteTestConfig(
 	config, err := cacl.NewModuleConfig(agent, name)
 	require.NoError(testingTB, err)
 	testingTB.Cleanup(config.Free)
-	require.NoError(testingTB, config.UpdateRules(nil))
+	require.NoError(testingTB, config.UpdateRules(nil, nil))
 
 	return config
 }
@@ -140,7 +140,6 @@ func validDeleteTestUpdateRequest(name string) *fwstatepb.UpdateConfigRequest {
 		Name: name,
 		SyncConfig: &fwstatepb.SyncConfig{
 			SrcAddr:          &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
-			DstEther:         commonpb.NewMACAddressEUI48([6]byte{1, 2, 3, 4, 5, 6}),
 			DstAddrMulticast: &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
 			PortMulticast:    9999,
 		},

--- a/modules/fwstate/controlplane/fwstatepb/v1/convert.go
+++ b/modules/fwstate/controlplane/fwstatepb/v1/convert.go
@@ -30,15 +30,8 @@ func (m *SyncConfig) ToC() cfwstate.SyncConfig {
 	var cfg cfwstate.SyncConfig
 	src := m.GetSrcAddr().GetAddr()
 	copy(cfg.SrcAddr[:], src)
-	dstEther := m.GetDstEther()
-	if dstEther != nil {
-		eui := dstEther.EUI48()
-		copy(cfg.DstEther[:], eui[:])
-	}
 	copy(cfg.DstAddrMulticast[:], m.GetDstAddrMulticast().GetAddr())
-	copy(cfg.DstAddrUnicast[:], m.GetDstAddrUnicast().GetAddr())
 	cfg.PortMulticast = uint16(m.GetPortMulticast())
-	cfg.PortUnicast = uint16(m.GetPortUnicast())
 	cfg.TcpSynAck = m.GetTcpSynAck()
 	cfg.TcpSyn = m.GetTcpSyn()
 	cfg.TcpFin = m.GetTcpFin()
@@ -55,25 +48,15 @@ func (m *SyncConfig) ToCWithDefaults(current cfwstate.SyncConfig) cfwstate.SyncC
 		return cfg
 	}
 	pbPortMulticast := m.GetPortMulticast()
-	pbPortUnicast := m.GetPortUnicast()
 
 	if len(m.GetSrcAddr().GetAddr()) == 0 {
 		cfg.SrcAddr = current.SrcAddr
 	}
-	if m.GetDstEther() == nil {
-		cfg.DstEther = current.DstEther
-	}
 	if len(m.GetDstAddrMulticast().GetAddr()) == 0 {
 		cfg.DstAddrMulticast = current.DstAddrMulticast
 	}
-	if len(m.GetDstAddrUnicast().GetAddr()) == 0 {
-		cfg.DstAddrUnicast = current.DstAddrUnicast
-	}
 	if pbPortMulticast == 0 {
 		cfg.PortMulticast = current.PortMulticast
-	}
-	if pbPortUnicast == 0 {
-		cfg.PortUnicast = current.PortUnicast
 	}
 	if cfg.TcpSynAck == 0 {
 		cfg.TcpSynAck = current.TcpSynAck
@@ -106,11 +89,8 @@ func (m *SyncConfig) ToCWithDefaults(current cfwstate.SyncConfig) cfwstate.SyncC
 func FromCSyncConfig(cfg cfwstate.SyncConfig) *SyncConfig {
 	return &SyncConfig{
 		SrcAddr:             &commonpb.IPAddress{Addr: append([]byte(nil), cfg.SrcAddr[:]...)},
-		DstEther:            commonpb.NewMACAddressEUI48(cfg.DstEther),
 		DstAddrMulticast:    &commonpb.IPAddress{Addr: append([]byte(nil), cfg.DstAddrMulticast[:]...)},
 		PortMulticast:       uint32(cfg.PortMulticast),
-		DstAddrUnicast:      &commonpb.IPAddress{Addr: append([]byte(nil), cfg.DstAddrUnicast[:]...)},
-		PortUnicast:         uint32(cfg.PortUnicast),
 		TcpSynAck:           cfg.TcpSynAck,
 		TcpSyn:              cfg.TcpSyn,
 		TcpFin:              cfg.TcpFin,

--- a/modules/fwstate/controlplane/fwstatepb/v1/convert_test.go
+++ b/modules/fwstate/controlplane/fwstatepb/v1/convert_test.go
@@ -8,52 +8,33 @@ import (
 	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 )
 
-// TestPortsRoundTrip verifies that port_unicast and port_multicast survive
-// the Pb->C->Pb round-trip with correct LE<->BE byte-order conversion.
+// TestPortsRoundTrip verifies that port_multicast survives the Pb->C->Pb
+// round-trip with correct LE<->BE byte-order conversion.
 func TestPortsRoundTrip(t *testing.T) {
 	const portMulticast uint32 = 4789
-	const portUnicast uint32 = 9999
 
 	pb := &SyncConfig{
 		SrcAddr:          &commonpb.IPAddress{Addr: make([]byte, 16)},
-		DstEther:         commonpb.NewMACAddressEUI48([6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
 		DstAddrMulticast: &commonpb.IPAddress{Addr: make([]byte, 16)},
-		DstAddrUnicast:   &commonpb.IPAddress{Addr: make([]byte, 16)},
 		PortMulticast:    portMulticast,
-		PortUnicast:      portUnicast,
 	}
 
 	cCfg := pb.ToC()
 	got := FromCSyncConfig(cCfg)
 
 	require.Equal(t, portMulticast, got.PortMulticast)
-	require.Equal(t, portUnicast, got.PortUnicast)
-	require.Equal(t, pb.DstEther.GetAddr(), got.DstEther.GetAddr())
 }
 
 func TestSyncConfig_ToCWithDefaults(t *testing.T) {
 	t.Run("omitted", func(t *testing.T) {
 		current := cfwstate.SyncConfig{
-			DstEther: [6]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+			SrcAddr: [16]byte{1},
 		}
 		pb := &SyncConfig{}
 
 		cfg := pb.ToCWithDefaults(current)
 
-		require.Equal(t, current.DstEther, cfg.DstEther)
-	})
-
-	t.Run("explicit_zero", func(t *testing.T) {
-		current := cfwstate.SyncConfig{
-			DstEther: [6]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
-		}
-		pb := &SyncConfig{
-			DstEther: &commonpb.MACAddress{},
-		}
-
-		cfg := pb.ToCWithDefaults(current)
-
-		require.Equal(t, [6]byte{}, cfg.DstEther)
+		require.Equal(t, current.SrcAddr, cfg.SrcAddr)
 	})
 }
 

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
@@ -138,13 +138,22 @@ message MapConfig {
 }
 
 // Firewall state synchronization configuration
+// SyncConfig carries the receive-side fwstate synchronization parameters:
+// incoming-packet matching, connection timeouts, and the suppression
+// window. The emission addressing for modules that synthesize sync
+// packets lives with the ACL module's own configuration.
 message SyncConfig {
-  common.commonpb.v1.IPAddress src_addr = 1;           // IPv6 source address;
-  common.commonpb.v1.MACAddress dst_ether = 2;         // Destination MAC address;
-  common.commonpb.v1.IPAddress dst_addr_multicast = 3; // Multicast IPv6 address;
+  common.commonpb.v1.IPAddress src_addr = 1;           // IPv6 source address stamped on forwarded internal frames;
+  // Deprecated: the emission-side destination MAC moved to the ACL
+  // module's SyncConfig; fwstate ignores this field.
+  common.commonpb.v1.MACAddress dst_ether = 2 [deprecated = true];
+  common.commonpb.v1.IPAddress dst_addr_multicast = 3; // Multicast IPv6 address matched on incoming sync packets;
   uint32 port_multicast = 4;                           // Multicast port;
-  common.commonpb.v1.IPAddress dst_addr_unicast = 5;   // Unicast IPv6 address;
-  uint32 port_unicast = 6;                             // Unicast port;
+  // Deprecated: the emission-side unicast destination moved to the ACL
+  // module's SyncConfig; fwstate ignores this field.
+  common.commonpb.v1.IPAddress dst_addr_unicast = 5 [deprecated = true];
+  // Deprecated: see dst_addr_unicast.
+  uint32 port_unicast = 6 [deprecated = true];         // Unused;
 
   // Connection timeouts
   uint64 tcp_syn_ack = 7; // TCP SYN-ACK timeout in nanoseconds;
@@ -158,7 +167,7 @@ message SyncConfig {
   // whose new expiry lands within this window of the current one is discarded
   // (the fwmap record is left untouched), debouncing refreshes for busy
   // sessions. Every entry TTL is inflated by this value so the effective
-  // keep-alive never drops below the configured timeout. Zero disables it.
+  // keep-alive never falls below the configured timeout. Zero disables it.
   //
   // Optional so that clients unaware of the field (an older web form) can omit
   // it and keep the current window, while an explicit zero disables it.

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -85,8 +85,8 @@ const (
 	// service state lock.
 	maxListEntriesBatchSize uint32 = 10000
 
-	// maxSyncPort is the highest value accepted for port_multicast and
-	// port_unicast, matching the width of the C-side uint16 port field.
+	// maxSyncPort is the highest value accepted for port_multicast,
+	// matching the width of the C-side uint16 port field.
 	maxSyncPort uint32 = 65535
 )
 
@@ -711,14 +711,11 @@ func (m *FWStateService) readConfigEntries(
 // C-side uint16 port field.
 //
 // A zero port means "unset / keep current" and is allowed here. The
-// required-destination-pair check in validateSyncConfig rejects a request
-// that leaves both destinations unset.
+// required-destination check in validateSyncConfig rejects a request
+// that leaves the multicast destination unset.
 func validateSyncPorts(cfg *fwstatepb.SyncConfig) error {
 	if portMulticast := cfg.GetPortMulticast(); portMulticast > maxSyncPort {
 		return status.Errorf(codes.InvalidArgument, "port_multicast %d exceeds maximum allowed value %d", portMulticast, maxSyncPort)
-	}
-	if portUnicast := cfg.GetPortUnicast(); portUnicast > maxSyncPort {
-		return status.Errorf(codes.InvalidArgument, "port_unicast %d exceeds maximum allowed value %d", portUnicast, maxSyncPort)
 	}
 	return nil
 }
@@ -732,23 +729,13 @@ func validateSyncConfig(cfg *fwstatepb.SyncConfig) error {
 		missing = append(missing, "src_addr")
 	}
 
-	// Check dst_ether (6 bytes for MAC)
-	dstEther := cfg.GetDstEther()
-	if dstEther == nil {
-		missing = append(missing, "dst_ether")
-	} else {
-		eui := dstEther.EUI48()
-		if isAllZeroBytes(eui[:]) {
-			missing = append(missing, "dst_ether")
-		}
+	// The module matches incoming sync packets against the multicast
+	// destination, so both the address and the port are required.
+	if len(cfg.GetDstAddrMulticast().GetAddr()) != 16 || isAllZeroBytes(cfg.GetDstAddrMulticast().GetAddr()) {
+		missing = append(missing, "dst_addr_multicast")
 	}
-
-	// Check that at least one destination pair is configured
-	hasMulticast := len(cfg.GetDstAddrMulticast().GetAddr()) == 16 && !isAllZeroBytes(cfg.GetDstAddrMulticast().GetAddr()) && cfg.PortMulticast != 0
-	hasUnicast := len(cfg.GetDstAddrUnicast().GetAddr()) == 16 && !isAllZeroBytes(cfg.GetDstAddrUnicast().GetAddr()) && cfg.PortUnicast != 0
-
-	if !hasMulticast && !hasUnicast {
-		missing = append(missing, "dst_addr_multicast+port_multicast or dst_addr_unicast+port_unicast")
+	if cfg.GetPortMulticast() == 0 {
+		missing = append(missing, "port_multicast")
 	}
 
 	if len(missing) > 0 {

--- a/modules/fwstate/controlplane/service_test.go
+++ b/modules/fwstate/controlplane/service_test.go
@@ -59,37 +59,21 @@ func TestValidateSyncPorts(t *testing.T) {
 	cases := []struct {
 		name          string
 		portMulticast uint32
-		portUnicast   uint32
 		wantErr       bool
 	}{
 		{
-			name:          "both zero",
+			name:          "zero",
 			portMulticast: 0,
-			portUnicast:   0,
 			wantErr:       false,
 		},
 		{
 			name:          "boundary value",
 			portMulticast: 65535,
-			portUnicast:   65535,
 			wantErr:       false,
 		},
 		{
-			name:          "multicast port just above boundary",
+			name:          "just above boundary",
 			portMulticast: 65536,
-			portUnicast:   0,
-			wantErr:       true,
-		},
-		{
-			name:          "unicast port far above boundary",
-			portMulticast: 0,
-			portUnicast:   70000,
-			wantErr:       true,
-		},
-		{
-			name:          "one valid one out of range",
-			portMulticast: 1,
-			portUnicast:   70000,
 			wantErr:       true,
 		},
 	}
@@ -98,7 +82,6 @@ func TestValidateSyncPorts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := &fwstatepb.SyncConfig{
 				PortMulticast: tc.portMulticast,
-				PortUnicast:   tc.portUnicast,
 			}
 
 			err := validateSyncPorts(cfg)
@@ -113,38 +96,35 @@ func TestValidateSyncPorts(t *testing.T) {
 	}
 }
 
-// TestValidateSyncConfigDstEther checks that dst_ether validation
-// distinguishes between absent and explicitly-zero MAC values.
-func TestValidateSyncConfigDstEther(t *testing.T) {
+// TestValidateSyncConfigMulticastRequired checks that the multicast
+// destination pair is validated as required.
+func TestValidateSyncConfigMulticastRequired(t *testing.T) {
 	newConfig := func() *fwstatepb.SyncConfig {
 		return &fwstatepb.SyncConfig{
-			SrcAddr:          &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
-			DstAddrMulticast: &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
-			PortMulticast:    1,
+			SrcAddr:       &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
+			PortMulticast: 1,
 		}
 	}
 
-	t.Run("missing", func(t *testing.T) {
-		cfg := newConfig()
-		cfg.DstEther = nil
-
-		err := validateSyncConfig(cfg)
+	t.Run("missing multicast address", func(t *testing.T) {
+		err := validateSyncConfig(newConfig())
 		require.Error(t, err)
-		require.True(t, strings.Contains(err.Error(), "dst_ether"))
+		require.True(t, strings.Contains(err.Error(), "dst_addr_multicast"))
 	})
 
-	t.Run("zero", func(t *testing.T) {
+	t.Run("zero multicast port", func(t *testing.T) {
 		cfg := newConfig()
-		cfg.DstEther = &commonpb.MACAddress{}
+		cfg.DstAddrMulticast = &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}}
+		cfg.PortMulticast = 0
 
 		err := validateSyncConfig(cfg)
 		require.Error(t, err)
-		require.True(t, strings.Contains(err.Error(), "dst_ether"))
+		require.True(t, strings.Contains(err.Error(), "port_multicast"))
 	})
 
 	t.Run("valid", func(t *testing.T) {
 		cfg := newConfig()
-		cfg.DstEther = commonpb.NewMACAddressEUI48([6]byte{1, 2, 3, 4, 5, 6})
+		cfg.DstAddrMulticast = &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}}
 
 		err := validateSyncConfig(cfg)
 		require.NoError(t, err)

--- a/modules/fwstate/dataplane/config.h
+++ b/modules/fwstate/dataplane/config.h
@@ -11,6 +11,11 @@ struct fwstate_module_config {
 
 	struct fwstate_config cfg;
 
+	// Receive-side sync parameters: packet matching, timeouts, and
+	// suppression. Split from the maps so the struct mirrors what the
+	// module consumes.
+	struct fwstate_sync_config sync_config;
+
 	// Module-level counters, registered by fwstate_module_config_new.
 	// Each counter_id is resolved per-worker via counter_get_address().
 	// size=2 counters hold [packets, bytes]; size=1 counters hold

--- a/modules/fwstate/dataplane/dataplane.c
+++ b/modules/fwstate/dataplane/dataplane.c
@@ -453,7 +453,7 @@ fwstate_handle_packets(
 		// packet before pushing to packet_front->output
 
 		if (!is_fw_state_sync_packet(
-			    packet, &fwstate_config->sync_config
+			    packet, &fwstate_module->sync_config
 		    )) {
 			// Not a sync packet, pass through
 			passthrough_cnt[0] += 1;
@@ -522,7 +522,7 @@ fwstate_handle_packets(
 					sync_frame,
 					is_external,
 					now,
-					&fwstate_config->sync_config,
+					&fwstate_module->sync_config,
 					sync_v4_inserted_cnt,
 					sync_v4_insert_failed_cnt,
 					sync_v4_suppressed_cnt
@@ -535,7 +535,7 @@ fwstate_handle_packets(
 					sync_frame,
 					is_external,
 					now,
-					&fwstate_config->sync_config,
+					&fwstate_module->sync_config,
 					sync_v6_inserted_cnt,
 					sync_v6_insert_failed_cnt,
 					sync_v6_suppressed_cnt
@@ -555,7 +555,7 @@ fwstate_handle_packets(
 		} else if (any_applied) {
 			rte_memcpy(
 				ipv6_hdr->src_addr,
-				fwstate_config->sync_config.src_addr,
+				fwstate_module->sync_config.src_addr,
 				16
 			);
 			struct rte_udp_hdr *udp_hdr = rte_pktmbuf_mtod_offset(

--- a/modules/fwstate/fuzzing/fwstate.c
+++ b/modules/fwstate/fuzzing/fwstate.c
@@ -171,21 +171,21 @@ fwstate_test_config(struct cp_module **cp_module) {
 	uint8_t multicast_addr[16] = {
 		0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01
 	};
-	memcpy(config->cfg.sync_config.dst_addr_multicast, multicast_addr, 16);
-	config->cfg.sync_config.port_multicast = rte_cpu_to_be_16(9999);
+	memcpy(config->sync_config.dst_addr_multicast, multicast_addr, 16);
+	config->sync_config.port_multicast = rte_cpu_to_be_16(9999);
 
 	// Set imeouts
-	config->cfg.sync_config.timeouts.tcp_syn_ack = 120000000000ULL;
-	config->cfg.sync_config.timeouts.tcp_syn = 120000000000ULL;
-	config->cfg.sync_config.timeouts.tcp_fin = 120000000000ULL;
-	config->cfg.sync_config.timeouts.tcp = 120000000000ULL;
-	config->cfg.sync_config.timeouts.udp = 30000000000ULL;
-	config->cfg.sync_config.timeouts.default_ = 16000000000ULL;
+	config->sync_config.timeouts.tcp_syn_ack = 120000000000ULL;
+	config->sync_config.timeouts.tcp_syn = 120000000000ULL;
+	config->sync_config.timeouts.tcp_fin = 120000000000ULL;
+	config->sync_config.timeouts.tcp = 120000000000ULL;
+	config->sync_config.timeouts.udp = 30000000000ULL;
+	config->sync_config.timeouts.default_ = 16000000000ULL;
 
 	// Exercise the suppression path under fuzzing: a fixed window means
 	// repeated frames for the same 5-tuple probe the fwmap without a write
 	// lock and may be discarded, covering the new code path.
-	config->cfg.sync_config.sync_suppress_timeout = 8000000000ULL;
+	config->sync_config.sync_suppress_timeout = 8000000000ULL;
 
 	*cp_module = (struct cp_module *)config;
 	return 0;

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -75,17 +75,17 @@ func fwstateModuleConfig(memCtx testutils.MemoryContext) (*C.struct_cp_module, *
 	// Multicast IPv6 address: ff02::1
 	multicastAddr := [16]C.uint8_t{0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
 	for i := range 16 {
-		m.cfg.sync_config.dst_addr_multicast[i] = multicastAddr[i]
+		m.sync_config.dst_addr_multicast[i] = multicastAddr[i]
 	}
-	m.cfg.sync_config.port_multicast = C.uint16_t(0x0f27) // 9999 in network byte order
+	m.sync_config.port_multicast = C.uint16_t(0x0f27) // 9999 in network byte order
 
 	// Set timeouts (in nanoseconds)
-	m.cfg.sync_config.timeouts.tcp_syn_ack = C.uint64_t(120e9)
-	m.cfg.sync_config.timeouts.tcp_syn = C.uint64_t(120e9)
-	m.cfg.sync_config.timeouts.tcp_fin = C.uint64_t(120e9)
-	m.cfg.sync_config.timeouts.tcp = C.uint64_t(120e9)
-	m.cfg.sync_config.timeouts.udp = C.uint64_t(30e9)
-	m.cfg.sync_config.timeouts.default_ = C.uint64_t(16e9)
+	m.sync_config.timeouts.tcp_syn_ack = C.uint64_t(120e9)
+	m.sync_config.timeouts.tcp_syn = C.uint64_t(120e9)
+	m.sync_config.timeouts.tcp_fin = C.uint64_t(120e9)
+	m.sync_config.timeouts.tcp = C.uint64_t(120e9)
+	m.sync_config.timeouts.udp = C.uint64_t(30e9)
+	m.sync_config.timeouts.default_ = C.uint64_t(16e9)
 
 	// Link the counter registry and spawn a per-worker counter storage once,
 	// so counter values accumulate across fwstateHandlePackets calls.
@@ -107,7 +107,7 @@ func fwstateCounterStorageFree(storage *C.struct_counter_storage) {
 // module config produced by fwstateModuleConfig. Zero disables suppression.
 func SetSyncSuppressTimeout(cpModule *C.struct_cp_module, ns uint64) {
 	m := (*C.struct_fwstate_module_config)(unsafe.Pointer(cpModule))
-	m.cfg.sync_config.sync_suppress_timeout = C.uint64_t(ns)
+	m.sync_config.sync_suppress_timeout = C.uint64_t(ns)
 }
 
 // SetSyncTCPTimeouts overrides the TCP established (tcp) and teardown
@@ -115,8 +115,8 @@ func SetSyncSuppressTimeout(cpModule *C.struct_cp_module, ns uint64) {
 // shorter-TTL state transition.
 func SetSyncTCPTimeouts(cpModule *C.struct_cp_module, tcp, tcpFin uint64) {
 	m := (*C.struct_fwstate_module_config)(unsafe.Pointer(cpModule))
-	m.cfg.sync_config.timeouts.tcp = C.uint64_t(tcp)
-	m.cfg.sync_config.timeouts.tcp_fin = C.uint64_t(tcpFin)
+	m.sync_config.timeouts.tcp = C.uint64_t(tcp)
+	m.sync_config.timeouts.tcp_fin = C.uint64_t(tcpFin)
 }
 
 func fwstateHandlePackets(cpModule *C.struct_cp_module, storage *C.struct_counter_storage, packets ...gopacket.Packet) (*dataplane.PacketFrontPayload, error) {

--- a/modules/fwstate/web/FWStatePage.tsx
+++ b/modules/fwstate/web/FWStatePage.tsx
@@ -19,7 +19,6 @@ import { API, ApiError, inventoryConfigNames, loadKnownConfigs, unionConfigNames
 import { Direction, type FwStateEntry, type ListEntriesRequest, type MapStats } from '@yanet/core/api/fwstate';
 import { ConfirmDialog, ConfigTabStrip, PageLayout, PageLoader, EmptyPagePlaceholder } from '@yanet/core/components';
 import { ipAddressToString, isValidIPAddress, parseIPToBytes, stringToIPAddress, type IPAddressWire } from '@yanet/core/utils/netip';
-import { parseMACToBytes } from '@yanet/core/utils/mac';
 import { formatBytes, toaster, compareNatural, warnConfigsUnknown } from '@yanet/core/utils';
 import { AddConfigModal, DeleteConfigModal, CommandPaletteHeader } from '@yanet/core/components';
 import { SaveIcon, TrashIcon } from '@yanet/core/components/draft';
@@ -31,12 +30,8 @@ interface DraftConfig {
     mapIndexSize: number;
     mapExtraBucketCount: number;
     srcAddr: string;
-    dstEther: string;
     dstAddrMulticast: string;
     portMulticast: number;
-    dstAddrUnicast: string;
-    portUnicast: number;
-    syncMode: 'multicast' | 'unicast' | 'both';
     tcpSynAck: string;
     tcpSyn: string;
     tcpFin: string;
@@ -70,8 +65,6 @@ const STATES_TABLE_LOAD_THRESHOLD = 60;
 const STATES_TABLE_MAX_BATCH_SIZE = 10000;
 const BACKWARD_RESET_CURSOR = Number.MAX_SAFE_INTEGER;
 const STATES_CURSORBAR_HEIGHT = 41;
-
-const zeroIPv6AddressWire = (): IPAddressWire => ({ addr: '::' });
 
 const formatDurationNsAsSeconds = (value: number): string => {
     if (!Number.isFinite(value) || value <= 0) return '';
@@ -114,32 +107,14 @@ const isValidNonzeroIPv6Address = (value: string): boolean => {
     return isValidIPv6Address(value) && !isZeroIPv6Address(value);
 };
 
-const isValidNonzeroMAC = (value: string): boolean => {
-    const parsed = parseMACToBytes(value);
-    return Boolean(parsed && parsed.some((byte) => byte !== 0));
-};
-
 const toDraftConfig = (config: Awaited<ReturnType<typeof API.fwstate.showConfig>> | null, isLocalOnly: boolean): DraftConfig => {
     const sync = config?.sync_config;
-    const multicastAddress = ipAddressToString(sync?.dst_addr_multicast as IPAddressWire | undefined).trim();
-    const unicastAddress = ipAddressToString(sync?.dst_addr_unicast as IPAddressWire | undefined).trim();
-    const multicastPresent = isValidNonzeroIPv6Address(multicastAddress) && (sync?.port_multicast ?? 0) !== 0;
-    const unicastPresent = isValidNonzeroIPv6Address(unicastAddress) && (sync?.port_unicast ?? 0) !== 0;
-    const syncMode: DraftConfig['syncMode'] = multicastPresent && unicastPresent
-        ? 'both'
-        : unicastPresent
-            ? 'unicast'
-            : 'multicast';
     return {
         mapIndexSize: config?.map_config?.index_size ?? 1_048_576,
         mapExtraBucketCount: config?.map_config?.extra_bucket_count ?? 1_024,
         srcAddr: ipAddressToString(sync?.src_addr as IPAddressWire | undefined),
-        dstEther: sync?.dst_ether?.addr ?? '',
         dstAddrMulticast: ipAddressToString(sync?.dst_addr_multicast as IPAddressWire | undefined),
         portMulticast: sync?.port_multicast ?? 0,
-        dstAddrUnicast: ipAddressToString(sync?.dst_addr_unicast as IPAddressWire | undefined),
-        portUnicast: sync?.port_unicast ?? 0,
-        syncMode,
         tcpSynAck: formatDurationNsAsSeconds(sync?.tcp_syn_ack ?? DEFAULT_NS.tcpSynAck),
         tcpSyn: formatDurationNsAsSeconds(sync?.tcp_syn ?? DEFAULT_NS.tcpSyn),
         tcpFin: formatDurationNsAsSeconds(sync?.tcp_fin ?? DEFAULT_NS.tcpFin),
@@ -1329,15 +1304,10 @@ const FWStatePage: React.FC = () => {
     const validateCurrent = (): boolean => {
         if (!current) return false;
         const durationFields = [current.tcpSynAck, current.tcpSyn, current.tcpFin, current.tcp, current.udp, current.defaultTimeout];
-        const useMulticast = current.syncMode === 'multicast' || current.syncMode === 'both';
-        const useUnicast = current.syncMode === 'unicast' || current.syncMode === 'both';
         if (current.mapIndexSize < 0 || current.mapExtraBucketCount < 0) return false;
-        if (useMulticast && (current.portMulticast < 0 || current.portMulticast > 65535)) return false;
-        if (useUnicast && (current.portUnicast < 0 || current.portUnicast > 65535)) return false;
+        if (current.portMulticast < 0 || current.portMulticast > 65535) return false;
         if (!isValidNonzeroIPv6Address(current.srcAddr)) return false;
-        if (useMulticast && (!isValidNonzeroIPv6Address(current.dstAddrMulticast) || current.portMulticast === 0)) return false;
-        if (useUnicast && (!isValidNonzeroIPv6Address(current.dstAddrUnicast) || current.portUnicast === 0)) return false;
-        if (!isValidNonzeroMAC(current.dstEther)) return false;
+        if (!isValidNonzeroIPv6Address(current.dstAddrMulticast) || current.portMulticast === 0) return false;
         if (durationFields.some((value) => parseDurationToNs(value) === null)) return false;
         return true;
     };
@@ -1353,15 +1323,10 @@ const FWStatePage: React.FC = () => {
             return;
         }
         const requestName = currentName;
-        const useMulticast = current.syncMode === 'multicast' || current.syncMode === 'both';
-        const useUnicast = current.syncMode === 'unicast' || current.syncMode === 'both';
         const syncConfig = {
             src_addr: stringToIPAddress(current.srcAddr),
-            dst_ether: { addr: current.dstEther },
-            dst_addr_multicast: useMulticast ? stringToIPAddress(current.dstAddrMulticast) : zeroIPv6AddressWire(),
-            port_multicast: useMulticast ? current.portMulticast : 0,
-            dst_addr_unicast: useUnicast ? stringToIPAddress(current.dstAddrUnicast) : zeroIPv6AddressWire(),
-            port_unicast: useUnicast ? current.portUnicast : 0,
+            dst_addr_multicast: stringToIPAddress(current.dstAddrMulticast),
+            port_multicast: current.portMulticast,
             tcp_syn_ack: parseDurationToNs(current.tcpSynAck) ?? undefined,
             tcp_syn: parseDurationToNs(current.tcpSyn) ?? undefined,
             tcp_fin: parseDurationToNs(current.tcpFin) ?? undefined,
@@ -1615,12 +1580,8 @@ const FWStatePage: React.FC = () => {
     }
 
     const configurationTab = current && (() => {
-        const useMulticast = current.syncMode === 'multicast' || current.syncMode === 'both';
-        const useUnicast = current.syncMode === 'unicast' || current.syncMode === 'both';
-        const multicastAddrError = !useMulticast ? undefined : !isValidNonzeroIPv6Address(current.dstAddrMulticast) ? 'Non-zero IPv6 required' : undefined;
-        const multicastPortError = !useMulticast ? undefined : current.portMulticast === 0 ? 'Port required' : current.portMulticast < 0 || current.portMulticast > 65535 ? '0..65535' : undefined;
-        const unicastAddrError = !useUnicast ? undefined : !isValidNonzeroIPv6Address(current.dstAddrUnicast) ? 'Non-zero IPv6 required' : undefined;
-        const unicastPortError = !useUnicast ? undefined : current.portUnicast === 0 ? 'Port required' : current.portUnicast < 0 || current.portUnicast > 65535 ? '0..65535' : undefined;
+        const multicastAddrError = !isValidNonzeroIPv6Address(current.dstAddrMulticast) ? 'Non-zero IPv6 required' : undefined;
+        const multicastPortError = current.portMulticast === 0 ? 'Port required' : current.portMulticast < 0 || current.portMulticast > 65535 ? '0..65535' : undefined;
 
         return (
             <div className="fwstate-config-panel">
@@ -1650,56 +1611,21 @@ const FWStatePage: React.FC = () => {
                                 <Text variant="caption-2" color="secondary">Sync source address</Text>
                                 <TextInput value={current.srcAddr} onUpdate={(srcAddr) => updateCurrent({ srcAddr })} error={!isValidNonzeroIPv6Address(current.srcAddr) ? 'Non-zero IPv6 required' : undefined} placeholder="2001:db8::1" />
                             </label>
-                            <label className="fwstate-field fwstate-sync-grid__mac">
-                                <Text variant="caption-2" color="secondary">Destination MAC</Text>
-                                <TextInput value={current.dstEther} onUpdate={(dstEther) => updateCurrent({ dstEther })} error={!isValidNonzeroMAC(current.dstEther) ? 'Non-zero MAC required' : undefined} placeholder="aa:bb:cc:dd:ee:ff" />
-                            </label>
-                            <label className="fwstate-field fwstate-sync-grid__mode">
-                                <Text variant="caption-2" color="secondary">Endpoint mode</Text>
-                                <Select
-                                    value={[current.syncMode]}
-                                    options={[
-                                        { value: 'multicast', content: 'Multicast' },
-                                        { value: 'unicast', content: 'Unicast' },
-                                        { value: 'both', content: 'Both' },
-                                    ]}
-                                    onUpdate={(value) => updateCurrent({ syncMode: (value[0] as DraftConfig['syncMode']) || 'multicast' })}
-                                />
-                            </label>
-                            {useMulticast && (
-                                <div className="fwstate-sync-grid__endpoint">
-                                    <div className="fwstate-field">
-                                        <Text variant="caption-2" color="secondary">Multicast endpoint</Text>
-                                        <div className="fwstate-endpoint-row">
-                                            <label className="fwstate-field">
-                                                <Text variant="caption-2" color="secondary">Address</Text>
-                                                <TextInput value={current.dstAddrMulticast} onUpdate={(dstAddrMulticast) => updateCurrent({ dstAddrMulticast })} error={multicastAddrError} placeholder="ff02::1" />
-                                            </label>
-                                            <label className="fwstate-field">
-                                                <Text variant="caption-2" color="secondary">Port</Text>
-                                                <TextInput type="number" value={String(current.portMulticast)} onUpdate={(v) => updateCurrent({ portMulticast: Number(v) })} error={multicastPortError} placeholder="2000" />
-                                            </label>
-                                        </div>
+                            <div className="fwstate-sync-grid__endpoint">
+                                <div className="fwstate-field">
+                                    <Text variant="caption-2" color="secondary">Multicast endpoint</Text>
+                                    <div className="fwstate-endpoint-row">
+                                        <label className="fwstate-field">
+                                            <Text variant="caption-2" color="secondary">Address</Text>
+                                            <TextInput value={current.dstAddrMulticast} onUpdate={(dstAddrMulticast) => updateCurrent({ dstAddrMulticast })} error={multicastAddrError} placeholder="ff02::1" />
+                                        </label>
+                                        <label className="fwstate-field">
+                                            <Text variant="caption-2" color="secondary">Port</Text>
+                                            <TextInput type="number" value={String(current.portMulticast)} onUpdate={(v) => updateCurrent({ portMulticast: Number(v) })} error={multicastPortError} placeholder="2000" />
+                                        </label>
                                     </div>
                                 </div>
-                            )}
-                            {useUnicast && (
-                                <div className="fwstate-sync-grid__endpoint">
-                                    <div className="fwstate-field">
-                                        <Text variant="caption-2" color="secondary">Unicast endpoint</Text>
-                                        <div className="fwstate-endpoint-row">
-                                            <label className="fwstate-field">
-                                                <Text variant="caption-2" color="secondary">Address</Text>
-                                                <TextInput value={current.dstAddrUnicast} onUpdate={(dstAddrUnicast) => updateCurrent({ dstAddrUnicast })} error={unicastAddrError} placeholder="2001:db8::2" />
-                                            </label>
-                                            <label className="fwstate-field">
-                                                <Text variant="caption-2" color="secondary">Port</Text>
-                                                <TextInput type="number" value={String(current.portUnicast)} onUpdate={(v) => updateCurrent({ portUnicast: Number(v) })} error={unicastPortError} placeholder="2000" />
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div>
-                            )}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/tests/functional/main/fwstate_test.go
+++ b/tests/functional/main/fwstate_test.go
@@ -121,7 +121,6 @@ func testFWStateListEntries(t *testing.T, fw *framework.TestFramework) {
 				" --index-size 1024" +
 				" --extra-bucket-count 64" +
 				" --src-addr 2001:db8::100" +
-				" --dst-ether 33:33:00:00:00:01" +
 				" --dst-addr-multicast ff02::1" +
 				" --port-multicast 9999" +
 				" --tcp 120s --tcp-syn 60s --tcp-syn-ack 60s --tcp-fin 60s" +
@@ -482,7 +481,6 @@ func testFWStateUDPEndianness(t *testing.T, fw *framework.TestFramework) {
 				" --index-size 1024" +
 				" --extra-bucket-count 64" +
 				" --src-addr 2001:db8::100" +
-				" --dst-ether 33:33:00:00:00:01" +
 				" --dst-addr-multicast ff02::1" +
 				" --port-multicast 9999" +
 				" --tcp 120s --tcp-syn 60s --tcp-syn-ack 60s --tcp-fin 60s" +
@@ -728,7 +726,6 @@ func testFWStateExternalSyncFrame(t *testing.T, fw *framework.TestFramework) {
 				" --index-size 1024" +
 				" --extra-bucket-count 64" +
 				" --src-addr 2001:db8::100" +
-				" --dst-ether 33:33:00:00:00:01" +
 				" --dst-addr-multicast ff02::1" +
 				" --port-multicast 9999" +
 				" --tcp 120s --tcp-syn 60s --tcp-syn-ack 60s --tcp-fin 60s" +

--- a/tests/functional/testdata/acl+fwstate.yaml
+++ b/tests/functional/testdata/acl+fwstate.yaml
@@ -9,6 +9,13 @@
 #   Rule 5: CreateState for TCP from 2001:db8:1::/48 -> 2001:db8:2::/48 port 80.
 #   Rule 6: CheckState for return TCP traffic (2001:db8:2::/48 -> 2001:db8:1::/48).
 
+# Emission parameters for the state-sync frames the CREATE_STATE rules
+# synthesize.
+sync_config:
+  dst_ether: "33:33:00:00:00:01"
+  dst_addr_multicast: "ff02::1"
+  port_multicast: 9999
+
 rules:
   # === IPv4 ===
 

--- a/tests/functional/testdata/acl-mbuf-leak.yaml
+++ b/tests/functional/testdata/acl-mbuf-leak.yaml
@@ -1,3 +1,10 @@
+# Emission parameters for the state-sync frames the CREATE_STATE rule
+# synthesizes.
+sync_config:
+  dst_ether: "33:33:00:00:00:01"
+  dst_addr_multicast: "ff02::1"
+  port_multicast: 9999
+
 rules:
   - actions:
       - kind: ACTION_KIND_PASS

--- a/tests/fwstate/sync_endian_test.c
+++ b/tests/fwstate/sync_endian_test.c
@@ -34,7 +34,7 @@
 #define TEST_DST_PORT 80
 
 // Dummy sync config (only used for packet construction, not for port logic)
-static struct fwstate_sync_config test_sync_config;
+static struct fwstate_sync_emit_config test_sync_config;
 static struct rte_mempool *test_pool;
 
 static void

--- a/tests/pipeline/dispatch_test.go
+++ b/tests/pipeline/dispatch_test.go
@@ -127,7 +127,7 @@ func publishMatchAllACL(t *testing.T, backend acl.Backend, name string, action u
 		},
 		Fragment: filter.FragmentAny,
 	}
-	require.NoError(t, handle.UpdateRules([]cacl.AclRule{rule}))
+	require.NoError(t, handle.UpdateRules([]cacl.AclRule{rule}, nil))
 	require.NoError(t, backend.UpdateModule(handle))
 }
 

--- a/web/src/core/api/acl.ts
+++ b/web/src/core/api/acl.ts
@@ -1,7 +1,10 @@
 import { createService, type CallOptions } from './client';
 
 // Types matching aclpb/acl.proto and filterpb/filter.proto exactly.
-// No Action.counter, no keep_state, no MapConfig, no SyncConfig, no DUMP kind.
+// No Action.counter, no keep_state, no MapConfig, no DUMP kind.
+
+import type { MACAddress } from './neighbours';
+import type { IPAddressWire } from '../utils/netip';
 
 import type { IPNet, VlanRange, Device, ListConfigsResponse } from './shared';
 export type { IPNet, VlanRange, Device, ListConfigsResponse };
@@ -55,15 +58,25 @@ export interface ShowConfigRequest {
     name?: string;
 }
 
+export interface SyncConfig {
+    dst_ether?: MACAddress;
+    dst_addr_multicast?: IPAddressWire;
+    port_multicast?: number;
+    dst_addr_unicast?: IPAddressWire;
+    port_unicast?: number;
+}
+
 export interface ShowConfigResponse {
     name?: string;
     rules?: Rule[];
     fwstate_name?: string;
+    sync_config?: SyncConfig;
 }
 
 export interface UpdateConfigRequest {
     name?: string;
     rules?: Rule[];
+    sync_config?: SyncConfig;
 }
 
 export interface UpdateConfigResponse {}

--- a/web/src/core/api/fwstate.ts
+++ b/web/src/core/api/fwstate.ts
@@ -1,5 +1,4 @@
 import { createService, createStreamingService, type CallOptions, type StreamCallbacks } from './client';
-import type { MACAddress } from './neighbours';
 import type { IPAddressWire } from '../utils/netip';
 
 export interface MapConfig {
@@ -9,11 +8,8 @@ export interface MapConfig {
 
 export interface SyncConfig {
     src_addr?: IPAddressWire;
-    dst_ether?: MACAddress;
     dst_addr_multicast?: IPAddressWire;
     port_multicast?: number;
-    dst_addr_unicast?: IPAddressWire;
-    port_unicast?: number;
     tcp_syn_ack?: number;
     tcp_syn?: number;
     tcp_fin?: number;


### PR DESCRIPTION
- Split the single fwstate sync configuration into two structures: the fwstate module keeps the receive-side parameters (frame matching, timeouts, suppression, internal-frame rewrite), and the ACL module carries its own emission-side addressing.
- The ACL update RPC gains the emission sync configuration, required for rulesets that create state; the state-check refresh path skips crafting when no usable configuration is set instead of emitting to a zero destination.
- The fwstate RPC drops the emission-only fields, and both CLIs and the fwstate web form move to their own half of the configuration.
- The ACL CLI round-trips the sync configuration through YAML and command-line flags.
- Fixed a latent defect where relinking a config to a new fwstate module handle dropped the stored sync configuration, silently stopping CREATE_STATE sync emission after a relink; added regression and validation coverage.
- Extracted from #2041 as a prerequisite refactor; that PR will be restacked on top of this one.