### PR TITLE
refactor(counters,acl): replace config counter registry with named module registries

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -59,7 +59,9 @@ yanet_get_chain_counters(
 	const char *chain_name
 );
 
-// Get module counters, optionally filtered by name.
+// Get module counters, optionally filtered by name. Returns the module's
+// predefined counters only; its per-rule counters live on runtime-kind
+// storages read through yanet_get_counters_by_tags.
 struct counter_handle_list *
 yanet_get_module_counters(
 	struct dp_config *dp_config,
@@ -164,8 +166,9 @@ yanet_get_counter_values(
 //
 // Recognized keys are "device", "pipeline", "function", "chain",
 // "module_type", "module_name", and "kind". The "kind" value names the
-// owner level: "device", "pipeline", "function", "chain", "module", or
-// "object".
+// owner level: "device", "pipeline", "function", "chain", "module",
+// "runtime", or "object". A "runtime" storage is module-owned and
+// additionally carries a "config" tag naming its counter registry.
 //
 // A tag is rejected with err filled and NULL returned if any of the
 // following holds: key is NULL; value is NULL; key is unrecognized;

--- a/bindings/go/dataplane_ut/testing.go
+++ b/bindings/go/dataplane_ut/testing.go
@@ -56,6 +56,64 @@ func RequireModuleCounter(
 	require.Equal(t, wantBytes, vals[1], "counter %q byte count mismatch", counterName)
 }
 
+// RuleCounters returns the per-rule counters at the given module position,
+// optionally filtered by name, read from the module's runtime-kind counter
+// storages through the tag query.
+func RuleCounters(
+	tb testing.TB,
+	h *Harness,
+	path CounterPath,
+	names []string,
+) []ffi.CounterInfo {
+	tb.Helper()
+
+	groups, err := h.SharedMemory().DPConfig(0).CountersByTags([]ffi.CounterTag{
+		{Key: "device", Value: path.Device},
+		{Key: "pipeline", Value: path.Pipeline},
+		{Key: "function", Value: path.Function},
+		{Key: "chain", Value: path.Chain},
+		{Key: "module_type", Value: path.ModuleType},
+		{Key: "module_name", Value: path.ModuleName},
+		{Key: "kind", Value: "runtime"},
+	}, names)
+	require.NoError(tb, err)
+
+	counters := make([]ffi.CounterInfo, 0)
+	for _, group := range groups {
+		counters = append(counters, group.Counters...)
+	}
+	return counters
+}
+
+// RequireRuleCounter asserts that the named per-rule counter at the given
+// path holds wantPackets and wantBytes.
+//
+// The counter is expected to be size 2: [packets, bytes]. Reads worker 0.
+func RequireRuleCounter(
+	t *testing.T,
+	h *Harness,
+	path CounterPath,
+	counterName string,
+	wantPackets, wantBytes uint64,
+) {
+	t.Helper()
+
+	counters := RuleCounters(t, h, path, []string{counterName})
+
+	byName := map[string][]uint64{}
+	for _, c := range counters {
+		if len(c.Values) > 0 {
+			byName[c.Name] = c.Values[0]
+		}
+	}
+
+	vals, ok := byName[counterName]
+	require.True(t, ok, "counter %q not found in rule counters", counterName)
+	require.GreaterOrEqual(t, len(vals), 2, "counter %q must have at least two values (packets, bytes)", counterName)
+	require.Equal(t, wantPackets, vals[0], "counter %q packet count mismatch", counterName)
+	require.Equal(t, wantBytes, vals[1], "counter %q byte count mismatch", counterName)
+}
+
 // SingleValueCounters flattens a CounterInfo slice into a map of
 // counter name -> first worker's first value.
 //

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -650,6 +650,40 @@ func (m *DPConfig) ModuleCounters(
 	return m.encodeCounters(counters)
 }
 
+// ModuleRuntimeCounters returns the module's runtime counters — those
+// expanded from its named counter registries (per-route, per-rule, etc.) —
+// optionally filtered by name.
+//
+// If counterQuery is nil or empty, returns all runtime counters.
+func (m *DPConfig) ModuleRuntimeCounters(
+	deviceName string,
+	pipelineName string,
+	functionName string,
+	chainName string,
+	moduleType string,
+	moduleName string,
+	counterQuery []string,
+) ([]CounterInfo, error) {
+	groups, err := m.CountersByTags([]CounterTag{
+		{Key: "device", Value: deviceName},
+		{Key: "pipeline", Value: pipelineName},
+		{Key: "function", Value: functionName},
+		{Key: "chain", Value: chainName},
+		{Key: "module_type", Value: moduleType},
+		{Key: "module_name", Value: moduleName},
+		{Key: "kind", Value: "runtime"},
+	}, counterQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	counters := make([]CounterInfo, 0)
+	for _, group := range groups {
+		counters = append(counters, group.Counters...)
+	}
+	return counters, nil
+}
+
 // ObjectCounters returns the counters of an object identified by its type
 // and name.
 func (m *DPConfig) ObjectCounters(

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1606,6 +1606,10 @@ yanet_get_module_counters(
 	const char *const *query,
 	size_t query_count
 ) {
+	// Select module-kind storages only; the module's runtime-kind
+	// storages hold its per-rule counters and are read through
+	// yanet_get_counters_by_tags, as are relation counters on
+	// module_object_link-kind storages sharing these six tags.
 	struct counter_tag tags[] = {
 		{.key = "device", .value = device_name},
 		{.key = "pipeline", .value = pipeline_name},
@@ -1613,9 +1617,7 @@ yanet_get_module_counters(
 		{.key = "chain", .value = chain_name},
 		{.key = "module_type", .value = module_type},
 		{.key = "module_name", .value = module_name},
-		// Select module-kind storages only; relation counters live on
-		// module_object_link-kind storages that share these six tags.
-		{.key = "kind", .value = "module"}
+		{.key = "kind", .value = "module"},
 	};
 	return yanet_get_counters_by_tags(
 		dp_config, tags, 7, query, query_count, NULL

--- a/lib/controlplane/config/cp_counter.c
+++ b/lib/controlplane/config/cp_counter.c
@@ -479,7 +479,7 @@ cp_config_counter_storage_registry_lookup_module(
 		{.key = "chain", .value = chain_name},
 		{.key = "module_type", .value = module_type},
 		{.key = "module_name", .value = module_name},
-		{.key = "kind", .value = "module"}
+		{.key = "kind", .value = "module"},
 	};
 	return get_one(registry, tags, 7);
 }
@@ -511,14 +511,15 @@ cp_config_counter_storage_registry_insert_module(
 }
 
 struct counter_storage *
-cp_config_counter_storage_registry_lookup_module_config(
+cp_config_counter_storage_registry_lookup_module_tagged(
 	struct cp_config_counter_storage_registry *registry,
 	const char *device_name,
 	const char *pipeline_name,
 	const char *function_name,
 	const char *chain_name,
 	const char *module_type,
-	const char *module_name
+	const char *module_name,
+	const char *registry_tag
 ) {
 	struct counter_tag tags[] = {
 		{.key = "device", .value = device_name},
@@ -527,13 +528,14 @@ cp_config_counter_storage_registry_lookup_module_config(
 		{.key = "chain", .value = chain_name},
 		{.key = "module_type", .value = module_type},
 		{.key = "module_name", .value = module_name},
-		{.key = "kind", .value = "config"}
+		{.key = "kind", .value = "runtime"},
+		{.key = "config", .value = registry_tag},
 	};
-	return get_one(registry, tags, 7);
+	return get_one(registry, tags, 8);
 }
 
 int
-cp_config_counter_storage_registry_insert_module_config(
+cp_config_counter_storage_registry_insert_module_tagged(
 	struct cp_config_counter_storage_registry *registry,
 	const char *device_name,
 	const char *pipeline_name,
@@ -541,6 +543,7 @@ cp_config_counter_storage_registry_insert_module_config(
 	const char *chain_name,
 	const char *module_type,
 	const char *module_name,
+	const char *registry_tag,
 	struct counter_storage *counter_storage,
 	yanet_error **err
 ) {
@@ -551,10 +554,11 @@ cp_config_counter_storage_registry_insert_module_config(
 		{.key = "chain", .value = chain_name},
 		{.key = "module_type", .value = module_type},
 		{.key = "module_name", .value = module_name},
-		{.key = "kind", .value = "config"},
+		{.key = "kind", .value = "runtime"},
+		{.key = "config", .value = registry_tag},
 	};
 	return cp_config_counter_storage_registry_insert(
-		registry, tags, 7, counter_storage, err
+		registry, tags, 8, counter_storage, err
 	);
 }
 

--- a/lib/controlplane/config/cp_counter.h
+++ b/lib/controlplane/config/cp_counter.h
@@ -151,18 +151,7 @@ cp_config_counter_storage_registry_insert_module(
 );
 
 struct counter_storage *
-cp_config_counter_storage_registry_lookup_module_config(
-	struct cp_config_counter_storage_registry *registry,
-	const char *device_name,
-	const char *pipeline_name,
-	const char *function_name,
-	const char *chain_name,
-	const char *module_type,
-	const char *module_name
-);
-
-int
-cp_config_counter_storage_registry_insert_module_config(
+cp_config_counter_storage_registry_lookup_module_tagged(
 	struct cp_config_counter_storage_registry *registry,
 	const char *device_name,
 	const char *pipeline_name,
@@ -170,6 +159,19 @@ cp_config_counter_storage_registry_insert_module_config(
 	const char *chain_name,
 	const char *module_type,
 	const char *module_name,
+	const char *registry_tag
+);
+
+int
+cp_config_counter_storage_registry_insert_module_tagged(
+	struct cp_config_counter_storage_registry *registry,
+	const char *device_name,
+	const char *pipeline_name,
+	const char *function_name,
+	const char *chain_name,
+	const char *module_type,
+	const char *module_name,
+	const char *registry_tag,
 	struct counter_storage *counter_storage,
 	yanet_error **err
 );

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -118,21 +118,6 @@ cp_module_init(
 		goto fail;
 	}
 
-	if (counter_registry_init(
-		    &cp_module->config_counter_registry,
-		    &cp_module->memory_context,
-		    0
-	    )) {
-		yanet_error_add(
-			err,
-			"failed to initialize config counter registry for "
-			"module '%s:%s'",
-			module_type,
-			module_name
-		);
-		goto fail;
-	}
-
 	cp_module->rx_counter_id = counter_registry_register(
 		&cp_module->counter_registry, "rx", 2, err
 	);
@@ -223,7 +208,24 @@ fail:
 void
 cp_module_fini(struct cp_module *cp_module) {
 	counter_registry_fini(&cp_module->counter_registry);
-	counter_registry_fini(&cp_module->config_counter_registry);
+
+	struct cp_module_counter_registry *runtime_registries =
+		ADDR_OF(&cp_module->runtime_counter_registries);
+	if (runtime_registries != NULL) {
+		for (uint64_t i = 0;
+		     i < cp_module->runtime_counter_registry_count;
+		     ++i) {
+			counter_registry_fini(&runtime_registries[i].registry);
+		}
+		memory_bfree(
+			&cp_module->memory_context,
+			runtime_registries,
+			sizeof(*runtime_registries) *
+				cp_module->runtime_counter_registry_count
+		);
+	}
+	SET_OFFSET_OF(&cp_module->runtime_counter_registries, NULL);
+	cp_module->runtime_counter_registry_count = 0;
 
 	struct cp_module_device *devices = ADDR_OF(&cp_module->devices);
 	if (devices != NULL) {
@@ -252,6 +254,78 @@ cp_module_fini(struct cp_module *cp_module) {
 	SET_OFFSET_OF(&cp_module->agent, NULL);
 
 	memory_context_fini(&cp_module->memory_context);
+}
+
+struct counter_registry *
+cp_module_counter_registry(
+	struct cp_module *cp_module,
+	const char *tag,
+	uint64_t *index_out,
+	yanet_error **err
+) {
+	struct cp_module_counter_registry *runtime_registries =
+		ADDR_OF(&cp_module->runtime_counter_registries);
+	for (uint64_t idx = 0; idx < cp_module->runtime_counter_registry_count;
+	     ++idx) {
+		if (!strncmp(
+			    runtime_registries[idx].tag, tag, COUNTER_NAME_LEN
+		    )) {
+			if (index_out != NULL) {
+				*index_out = idx;
+			}
+			return &runtime_registries[idx].registry;
+		}
+	}
+
+	uint64_t old_count = cp_module->runtime_counter_registry_count;
+	uint64_t new_count = old_count + 1;
+	struct cp_module_counter_registry *new_registries =
+		(struct cp_module_counter_registry *)memory_brealloc(
+			&cp_module->memory_context,
+			runtime_registries,
+			sizeof(*runtime_registries) * old_count,
+			sizeof(*runtime_registries) * new_count
+		);
+	if (new_registries == NULL) {
+		yanet_error_add(
+			err,
+			"failed to allocate counter registry '%s' for module "
+			"'%s:%s'",
+			tag,
+			cp_module->type,
+			cp_module->name
+		);
+		return NULL;
+	}
+
+	// realloc freed the old array, so publish the new one before any
+	// fallible step below. A failure past this point leaves the count
+	// unchanged, so the partially initialized slot sits beyond the live
+	// range and is reaped with the array at cp_module_fini.
+	SET_OFFSET_OF(&cp_module->runtime_counter_registries, new_registries);
+
+	struct cp_module_counter_registry *slot = &new_registries[old_count];
+	strtcpy(slot->tag, tag, sizeof(slot->tag));
+	if (counter_registry_init(
+		    &slot->registry, &cp_module->memory_context, 0
+	    )) {
+		yanet_error_add(
+			err,
+			"failed to initialize counter registry '%s' for module "
+			"'%s:%s'",
+			tag,
+			cp_module->type,
+			cp_module->name
+		);
+		return NULL;
+	}
+
+	cp_module->runtime_counter_registry_count = new_count;
+
+	if (index_out != NULL) {
+		*index_out = old_count;
+	}
+	return &slot->registry;
 }
 
 int
@@ -636,14 +710,44 @@ cp_module_registry_upsert(
 		return -1;
 	}
 
-	if (counter_registry_link(
-		    &new_module->config_counter_registry,
-		    (old_module != NULL) ? &old_module->config_counter_registry
-					 : NULL,
-		    err
-	    )) {
-		yanet_error_add(err, "failed to link config counter registry");
-		return -1;
+	// Link each new runtime registry against the matching-tag registry on
+	// the displaced module so per-rule counters survive a config rebuild
+	// that leaves the layout unchanged.
+	struct cp_module_counter_registry *new_runtime =
+		ADDR_OF(&new_module->runtime_counter_registries);
+	for (uint64_t idx = 0; idx < new_module->runtime_counter_registry_count;
+	     ++idx) {
+		struct counter_registry *old_registry = NULL;
+		if (old_module != NULL) {
+			struct cp_module_counter_registry *old_runtime =
+				ADDR_OF(&old_module->runtime_counter_registries
+				);
+			for (uint64_t old_idx = 0;
+			     old_idx <
+			     old_module->runtime_counter_registry_count;
+			     ++old_idx) {
+				if (!strncmp(
+					    old_runtime[old_idx].tag,
+					    new_runtime[idx].tag,
+					    COUNTER_NAME_LEN
+				    )) {
+					old_registry =
+						&old_runtime[old_idx].registry;
+					break;
+				}
+			}
+		}
+
+		if (counter_registry_link(
+			    &new_runtime[idx].registry, old_registry, err
+		    )) {
+			yanet_error_add(
+				err,
+				"failed to link counter registry '%s'",
+				new_runtime[idx].tag
+			);
+			return -1;
+		}
 	}
 
 	if (registry_replace(

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -34,6 +34,15 @@ struct cp_module_device {
 	char name[CP_DEVICE_NAME_LEN];
 };
 
+// Named counter registry for config-defined counters (per-rule, per-route,
+// etc.). Carries a module-unique tag so its per-worker storage can be
+// distinguished from other registries and from the predefined module
+// counters.
+struct cp_module_counter_registry {
+	char tag[COUNTER_NAME_LEN];
+	struct counter_registry registry;
+};
+
 // A module's declared link to a cp_object, identified by the object's
 // (type, name) pair. Resolved to a per-worker object_ectx at execution-context
 // build time, mirroring cp_module_device's name-based device linkage.
@@ -61,10 +70,12 @@ struct cp_module {
 	// Counters declared inside module data
 	struct counter_registry counter_registry;
 
-	// Counters declared from user-supplied configuration (per-rule,
-	// per-route, etc.). Expanded into a separate storage tagged
-	// kind=config on config-gen installation.
-	struct counter_registry config_counter_registry;
+	// Named counter registries for config-defined counters (per-rule,
+	// per-route, etc.). Each registry carries a module-unique tag. All
+	// registries are expanded into per-worker storages on config-gen
+	// installation.
+	uint64_t runtime_counter_registry_count;
+	struct cp_module_counter_registry *runtime_counter_registries;
 
 	// Rx packet/byte counter (size 2: [packets, bytes])
 	uint64_t rx_counter_id;
@@ -191,6 +202,19 @@ cp_module_init(
  */
 void
 cp_module_fini(struct cp_module *cp_module);
+
+// Get or create a named counter registry on the module.
+//
+// The tag must be unique within the module; on a repeat tag the existing
+// registry is returned with its index. The index is written through
+// `index_out`. Returns NULL on allocation failure.
+struct counter_registry *
+cp_module_counter_registry(
+	struct cp_module *cp_module,
+	const char *tag,
+	uint64_t *index_out,
+	yanet_error **err
+);
 
 // The single handler for a module reference count reaching zero, reached
 // the same way from a registry drop or an explicit release.

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -19,10 +19,24 @@ module_ectx_free(
 		counter_storage_free(counter_storage);
 	}
 
-	struct counter_storage *config_counter_storage =
-		ADDR_OF(&module_ectx->config_counter_storage);
-	if (config_counter_storage != NULL) {
-		counter_storage_free(config_counter_storage);
+	struct counter_storage **runtime_storages =
+		ADDR_OF(&module_ectx->runtime_counter_storages);
+	if (runtime_storages != NULL) {
+		for (uint64_t idx = 0;
+		     idx < module_ectx->runtime_counter_storage_count;
+		     ++idx) {
+			struct counter_storage *storage =
+				ADDR_OF(runtime_storages + idx);
+			if (storage != NULL) {
+				counter_storage_free(storage);
+			}
+		}
+		memory_bfree(
+			memory_context,
+			runtime_storages,
+			sizeof(struct counter_storage *) *
+				module_ectx->runtime_counter_storage_count
+		);
 	}
 
 	uint64_t *cm_index = ADDR_OF(&module_ectx->cm_index);
@@ -202,61 +216,101 @@ module_ectx_create(
 
 	SET_OFFSET_OF(&module_ectx->counter_storage, counter_storage);
 
-	struct counter_storage *old_config_counter_storage = NULL;
-	if (old_ectx != NULL) {
-		old_config_counter_storage =
-			cp_config_counter_storage_registry_lookup_module_config(
-				ADDR_OF(&old_ectx->counter_storage_registry),
-				cp_device->name,
-				cp_pipeline->name,
-				cp_function->name,
-				cp_chain->name,
+	if (cp_module->runtime_counter_registry_count > 0) {
+		struct counter_storage **runtime_storages =
+			(struct counter_storage **)memory_balloc(
+				memory_context,
+				sizeof(struct counter_storage *) *
+					cp_module
+						->runtime_counter_registry_count
+			);
+		if (runtime_storages == NULL) {
+			yanet_error_add(
+				err,
+				"failed to allocate runtime counter storages "
+				"for module '%s:%s'",
 				cp_module->type,
 				cp_module->name
 			);
-	}
-
-	struct counter_storage *config_counter_storage = counter_storage_spawn(
-		&cp_config->counter_storage_memory_context,
-		old_config_counter_storage,
-		&cp_module->config_counter_registry
-	);
-	if (config_counter_storage == NULL) {
-		yanet_error_add(
-			err,
-			"failed to spawn config counter storage for module "
-			"'%s:%s'",
-			cp_module->type,
-			cp_module->name
+			goto error;
+		}
+		memset(runtime_storages,
+		       0,
+		       sizeof(struct counter_storage *) *
+			       cp_module->runtime_counter_registry_count);
+		module_ectx->runtime_counter_storage_count =
+			cp_module->runtime_counter_registry_count;
+		SET_OFFSET_OF(
+			&module_ectx->runtime_counter_storages, runtime_storages
 		);
-		goto error;
-	}
 
-	if (cp_config_counter_storage_registry_insert_module_config(
-		    ADDR_OF(&config_gen_ectx->counter_storage_registry),
-		    cp_device->name,
-		    cp_pipeline->name,
-		    cp_function->name,
-		    cp_chain->name,
-		    cp_module->type,
-		    cp_module->name,
-		    config_counter_storage,
-		    err
-	    )) {
-		yanet_error_add(
-			err,
-			"failed to insert config counter storage for module "
-			"'%s:%s'",
-			cp_module->type,
-			cp_module->name
-		);
-		counter_storage_free(config_counter_storage);
-		goto error;
-	}
+		struct cp_module_counter_registry *runtime_registries =
+			ADDR_OF(&cp_module->runtime_counter_registries);
+		for (uint64_t idx = 0;
+		     idx < cp_module->runtime_counter_registry_count;
+		     ++idx) {
+			struct counter_storage *old_storage = NULL;
+			if (old_ectx != NULL) {
+				old_storage =
+					cp_config_counter_storage_registry_lookup_module_tagged(
+						ADDR_OF(&old_ectx->counter_storage_registry
+						),
+						cp_device->name,
+						cp_pipeline->name,
+						cp_function->name,
+						cp_chain->name,
+						cp_module->type,
+						cp_module->name,
+						runtime_registries[idx].tag
+					);
+			}
 
-	SET_OFFSET_OF(
-		&module_ectx->config_counter_storage, config_counter_storage
-	);
+			struct counter_storage *storage = counter_storage_spawn(
+				&cp_config->counter_storage_memory_context,
+				old_storage,
+				&runtime_registries[idx].registry
+			);
+			if (storage == NULL) {
+				yanet_error_add(
+					err,
+					"failed to spawn counter storage for "
+					"registry '%s' on module '%s:%s'",
+					runtime_registries[idx].tag,
+					cp_module->type,
+					cp_module->name
+				);
+				goto error;
+			}
+
+			if (cp_config_counter_storage_registry_insert_module_tagged(
+				    ADDR_OF(&config_gen_ectx
+						     ->counter_storage_registry
+				    ),
+				    cp_device->name,
+				    cp_pipeline->name,
+				    cp_function->name,
+				    cp_chain->name,
+				    cp_module->type,
+				    cp_module->name,
+				    runtime_registries[idx].tag,
+				    storage,
+				    err
+			    )) {
+				counter_storage_free(storage);
+				yanet_error_add(
+					err,
+					"failed to insert counter storage for "
+					"registry '%s' on module '%s:%s'",
+					runtime_registries[idx].tag,
+					cp_module->type,
+					cp_module->name
+				);
+				goto error;
+			}
+
+			SET_OFFSET_OF(runtime_storages + idx, storage);
+		}
+	}
 
 	if (cp_module->object_count > 0) {
 		struct memory_context *counter_storage_memory_context =

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -36,11 +36,11 @@ _Static_assert(
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct cp_module) == 696,
+	sizeof(struct cp_module) == 592,
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct module_ectx) == 176,
+	sizeof(struct module_ectx) == 184,
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 15
+#define YANET_MODULE_ABI_VERSION 16
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -36,7 +36,13 @@ struct module_ectx {
 	struct counter_value_handle *perf_counters[MODULE_ECTX_PERF_COUNTERS];
 
 	struct counter_storage *counter_storage;
-	struct counter_storage *config_counter_storage;
+
+	// Per-worker storages for the module's runtime counter registries, in
+	// parallel with cp_module.runtime_counter_registries. Offset pointer
+	// to a separately allocated array of offset pointers, one per
+	// registry.
+	uint64_t runtime_counter_storage_count;
+	struct counter_storage **runtime_counter_storages;
 	struct config_gen_ectx *config_gen_ectx;
 
 	uint64_t mc_index_size;
@@ -72,6 +78,18 @@ object_link_get_address(struct module_ectx *module_ectx, uint64_t index) {
 	struct module_object_link_ectx *links =
 		ADDR_OF(&module_ectx->object_links);
 	return links + index;
+}
+
+// Return the per-worker counter storage for the module's runtime counter
+// registry at the given index, or NULL when the index is out of range.
+static inline struct counter_storage *
+module_ectx_counter_storage(struct module_ectx *module_ectx, uint64_t index) {
+	if (index >= module_ectx->runtime_counter_storage_count) {
+		return NULL;
+	}
+	struct counter_storage **storages =
+		ADDR_OF(&module_ectx->runtime_counter_storages);
+	return ADDR_OF(storages + index);
 }
 
 static inline uint64_t

--- a/modules/acl/api/controlplane.c
+++ b/modules/acl/api/controlplane.c
@@ -687,6 +687,18 @@ acl_module_config_update(
 	SET_OFFSET_OF(&config->targets, targets);
 	config->target_count = rule_count;
 
+	// Per-rule counters live in a dedicated "rules" registry so they are
+	// separated from the module's predefined counters in the per-worker
+	// storages and the counter storage registry.
+	uint64_t rules_registry_idx;
+	struct counter_registry *rules_registry = cp_module_counter_registry(
+		cp_module, "rules", &rules_registry_idx, err
+	);
+	if (rules_registry == NULL) {
+		goto error_target;
+	}
+	config->rules_registry_idx = rules_registry_idx;
+
 	struct filter_rule *filter_rules = NULL;
 	const struct filter_rule *dummy_filter_rule_ptr = NULL;
 	const struct filter_rule **filter_rule_ptrs = &dummy_filter_rule_ptr;
@@ -741,7 +753,7 @@ acl_module_config_update(
 			counter_name = default_counter;
 		}
 		if ((targets[idx].counter_id = counter_registry_register(
-			     &cp_module->counter_registry, counter_name, 2, err
+			     rules_registry, counter_name, 2, err
 		     )) == (uint64_t)-1) {
 			goto error_target;
 		}

--- a/modules/acl/cli/build.rs
+++ b/modules/acl/cli/build.rs
@@ -21,6 +21,10 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             "#[derive(serde::Serialize)]",
         )
         .message_attribute(
+            ".modules.acl.controlplane.aclpb.v1.RuleCounter",
+            "#[derive(serde::Serialize)]",
+        )
+        .message_attribute(
             ".modules.acl.controlplane.aclpb.v1.SyncConfig",
             "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default)]",
         )

--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -16,6 +16,8 @@ pub enum ModeCmd {
     Show(ShowCmd),
     /// Show ACL metrics
     Metrics(MetricsCmd),
+    /// Show per-rule ACL counters
+    RuleCounters(RuleCountersCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -71,8 +73,6 @@ pub enum MetricName {
     Action,
     /// State-table counters: check_state, create_state, state_miss
     State,
-    /// Per-rule named counters (acl_rule_*)
-    Rule,
     /// Compiled filter rule counts per protocol
     FilterRuleCount,
     /// Compilation time and memory usage
@@ -88,7 +88,6 @@ impl MetricName {
             Self::Bytes => "bytes",
             Self::Action => "action",
             Self::State => "state",
-            Self::Rule => "rule",
             Self::FilterRuleCount => "filter_rule_count",
             Self::Compilation => "compilation",
             Self::Handler => "handler",
@@ -108,4 +107,11 @@ pub struct MetricsCmd {
     /// Show only metrics matching this category
     #[arg(long, short, value_enum)]
     pub name: Option<MetricName>,
+}
+
+#[derive(Debug, Clone, Parser, Default)]
+pub struct RuleCountersCmd {
+    /// ACL config name; omit to show rule counters of every config
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
+    pub config_name: Option<String>,
 }

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -2,10 +2,10 @@ use core::net::Ipv6Addr;
 use std::{collections::HashMap, fs::File, path::Path};
 
 use aclpb::{
-    DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
+    DeleteConfigRequest, GetRulesCountersRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     acl_service_client::AclServiceClient, metrics_service_client::MetricsServiceClient,
 };
-use args::{DeleteCmd, MetricsCmd, ModeCmd, ShowCmd, UpdateCmd};
+use args::{DeleteCmd, MetricsCmd, ModeCmd, RuleCountersCmd, ShowCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
 use serde::{Deserialize, Serialize};
@@ -153,7 +153,6 @@ fn print_metrics_table(metrics: &[Metric]) {
         println!();
 
         let std_counters: Vec<&&Metric> = counters.iter().filter(|m| m.label_value("counter").is_none()).collect();
-        let rule_counters: Vec<&&Metric> = counters.iter().filter(|m| m.label_value("counter").is_some()).collect();
 
         let mut pair_order: Vec<String> = Vec::new();
         let mut pair_map: HashMap<String, CounterPair> = HashMap::new();
@@ -193,42 +192,6 @@ fn print_metrics_table(metrics: &[Metric]) {
                         counter: p.display.clone(),
                         packets: p.packets.map(metrics::format_number).unwrap_or_else(|| "-".into()),
                         bytes: p.bytes.map(metrics::format_number).unwrap_or_else(|| "-".into()),
-                    }
-                })
-                .collect();
-            print_counter_table(rows);
-        }
-
-        if !rule_counters.is_empty() {
-            println!();
-            println!("Per-Rule Counters:");
-
-            let mut rule_order: Vec<String> = Vec::new();
-            let mut rule_map_inner: HashMap<String, (Option<u64>, Option<u64>)> = HashMap::new();
-
-            for m in &rule_counters {
-                let rule_name = m.label_value("counter").unwrap_or("unknown").to_string();
-                let val = m.value.unwrap_or(0.0) as u64;
-                if !rule_map_inner.contains_key(&rule_name) {
-                    rule_order.push(rule_name.clone());
-                    rule_map_inner.insert(rule_name.clone(), (None, None));
-                }
-                let entry = rule_map_inner.get_mut(&rule_name).unwrap();
-                if m.name.ends_with("_packets") {
-                    entry.0 = Some(val);
-                } else if m.name.ends_with("_bytes") {
-                    entry.1 = Some(val);
-                }
-            }
-
-            let rows: Vec<CounterRow> = rule_order
-                .iter()
-                .map(|name| {
-                    let (pkts, b) = rule_map_inner[name];
-                    CounterRow {
-                        counter: name.clone(),
-                        packets: pkts.map(metrics::format_number).unwrap_or_else(|| "-".into()),
-                        bytes: b.map(metrics::format_number).unwrap_or_else(|| "-".into()),
                     }
                 })
                 .collect();
@@ -495,6 +458,71 @@ impl ACLService {
         Ok(())
     }
 
+    pub async fn rule_counters(&mut self, cmd: RuleCountersCmd) -> Result<(), Error> {
+        let request = GetRulesCountersRequest {
+            name: cmd.config_name.clone().unwrap_or_default(),
+        };
+        let response = self
+            .service
+            .client()
+            .get_rules_counters(request)
+            .await
+            .map_err(self.service.status("rule-counters"))?
+            .into_inner();
+
+        output::data(
+            || &response.counters,
+            || {
+                if response.counters.is_empty() {
+                    match cmd.config_name.as_deref() {
+                        Some(name) => output::empty(format_args!("No rule counters found for '{name}'.")),
+                        None => output::empty(format_args!("No rule counters found.")),
+                    }
+                    return;
+                }
+
+                let mut location_keys: Vec<String> = Vec::new();
+                let mut location_map: HashMap<String, Vec<&aclpb::RuleCounter>> = HashMap::new();
+                for entry in &response.counters {
+                    let key = format!(
+                        "{}\0{}\0{}\0{}\0{}",
+                        entry.config, entry.device, entry.pipeline, entry.function, entry.chain,
+                    );
+                    if !location_map.contains_key(&key) {
+                        location_keys.push(key.clone());
+                    }
+                    location_map.entry(key).or_default().push(entry);
+                }
+
+                for (loc_idx, key) in location_keys.iter().enumerate() {
+                    if loc_idx > 0 {
+                        println!();
+                    }
+                    let entries = &location_map[key];
+                    let parts: Vec<&str> = key.split('\0').collect();
+                    let (cfg, device, pipeline, function, chain) = (parts[0], parts[1], parts[2], parts[3], parts[4]);
+                    println!(
+                        "ACL RULE COUNTERS  config={cfg} device={device} pipeline={pipeline} function={function} chain={chain}"
+                    );
+                    println!();
+
+                    let rows: Vec<CounterRow> = entries
+                        .iter()
+                        .map(|entry| CounterRow {
+                            counter: entry.counter.clone(),
+                            packets: metrics::format_number(entry.packets),
+                            bytes: metrics::format_number(entry.bytes),
+                        })
+                        .collect();
+                    print_counter_table(rows);
+                    println!();
+                }
+            },
+        );
+
+        Ok(())
+    }
+
     pub async fn metrics(&mut self, cmd: MetricsCmd) -> Result<(), Error> {
         let tags = cmd
             .tags
@@ -560,6 +588,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::Update(cmd) => service.update_config(cmd).await,
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
         ModeCmd::Metrics(cmd) => service.metrics(cmd).await,
+        ModeCmd::RuleCounters(cmd) => service.rule_counters(cmd).await,
     }
 }
 

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -20,6 +20,8 @@ service ACLService {
   rpc ShowConfig(ShowConfigRequest) returns (ShowConfigResponse);
   // List all ACL configurations across instances
   rpc ListConfigs(ListConfigsRequest) returns (ListConfigsResponse);
+  // Returns per-rule counters of ACL configurations
+  rpc GetRulesCounters(GetRulesCountersRequest) returns (GetRulesCountersResponse);
 }
 
 // MetricsService exposes ACL module metrics.
@@ -100,5 +102,27 @@ message SyncConfig {
   common.commonpb.v1.IPAddress dst_addr_multicast = 2; // Multicast IPv6 address;
   uint32 port_multicast = 3;                            // Multicast port;
   common.commonpb.v1.IPAddress dst_addr_unicast = 4;   // Unicast IPv6 address;
-  uint32 port_unicast = 5;                              // Unicast port;
+  uint32 port_unicast = 5;                            // Unicast port;
 }
+
+// Request for per-rule counters. An empty name returns the rule counters
+// of every configuration.
+message GetRulesCountersRequest {
+  // Optional ACL configuration name.
+  string name = 1;
+}
+
+// One per-rule counter at the module position holding it.
+message RuleCounter {
+  string config = 1;
+  string device = 2;
+  string pipeline = 3;
+  string function = 4;
+  string chain = 5;
+  // Rule counter name, as set on the rule.
+  string counter = 6;
+  uint64 packets = 7;
+  uint64 bytes = 8;
+}
+
+message GetRulesCountersResponse { repeated RuleCounter counters = 1; }

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -41,9 +41,8 @@ func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetric
 // "counter" label.
 //
 // It MUST mirror the named cases of the switch in collectDataplaneMetrics.
-// A per-rule ("counter"-labelled) metric is anything not in this set. Used
-// to derive the counter-name query so per-rule counters are not read from
-// shm when they are filtered out.
+// A per-rule counter is anything not in this set; the metrics read queries
+// only these names, so per-rule counters are never read for metrics.
 var aclStructuralCounters = []string{
 	"acl_no_match", "acl_action_allow", "acl_action_deny", "acl_action_count",
 	"acl_action_check_state", "acl_action_create_state", "acl_action_unknown",
@@ -51,11 +50,11 @@ var aclStructuralCounters = []string{
 }
 
 // Metrics returns ACL module metrics matching tags: per-pipeline packet
-// counters, per-rule counters, ACL compilation info, and gRPC call metrics.
+// counters, ACL compilation info, and gRPC call metrics.
 //
-// Counter metrics are omitted when all worker values are zero to reduce output
-// noise. A "counter" tag is pushed down into the dataplane counter read, so
-// per-rule counters excluded by tags are never read from shared memory.
+// Per-rule counters are served by GetRulesCounters, not here. Counter
+// metrics are omitted when all worker values are zero to reduce output
+// noise.
 //
 // Labels:
 //   - config:        ACL config name (all counter metrics)
@@ -63,7 +62,6 @@ var aclStructuralCounters = []string{
 //   - pipeline:      pipeline name (all counter metrics)
 //   - function:      pipeline function name (all counter metrics)
 //   - chain:         pipeline chain name (all counter metrics)
-//   - counter:       ACL rule counter name (acl_rule_packets / acl_rule_bytes only)
 //   - grpc_type:     always "unary" (gRPC metrics)
 //   - grpc_service:  fully-qualified gRPC service name (gRPC metrics)
 //   - grpc_method:   RPC name (gRPC metrics)
@@ -89,9 +87,9 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 
 	positions := dpConfig.AllModulePositions(moduleType)
 
-	names, read := metrics.Query(tags,
+	names, read := metrics.Query(
+		tags,
 		metrics.WithStructuralCounters(aclStructuralCounters),
-		metrics.WithUnknownEntryCounters(),
 	)
 
 	result := make([]*commonpb.Metric, 0)
@@ -180,15 +178,6 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 				result = append(result,
 					commonpb.NewMetricCounter("acl_sync_sent_packets", packets, baseLabels...),
 					commonpb.NewMetricCounter("acl_sync_sent_bytes", bytes, baseLabels...),
-				)
-			default:
-				ruleLabels := append(
-					baseLabels,
-					&commonpb.Label{Name: "counter", Value: counter.Name},
-				)
-				result = append(result,
-					commonpb.NewMetricCounter("acl_rule_packets", packets, ruleLabels...),
-					commonpb.NewMetricCounter("acl_rule_bytes", bytes, ruleLabels...),
 				)
 			}
 		}

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -758,3 +758,83 @@ func (m *ACLService) DeleteConfig(
 
 	return &aclpb.DeleteConfigResponse{}, nil
 }
+
+// GetRulesCounters returns the per-rule counters of the named config, or of
+// every config when the request names none.
+//
+// Counters whose packets and bytes are both zero across all workers are
+// omitted, matching the metrics read.
+func (m *ACLService) GetRulesCounters(
+	ctx context.Context,
+	req *aclpb.GetRulesCountersRequest,
+) (*aclpb.GetRulesCountersResponse, error) {
+	name := req.GetName()
+
+	if name != "" {
+		m.mu.RLock()
+		entry, ok := m.configs[name]
+		m.mu.RUnlock()
+		if !ok || entry.Published() == nil {
+			return nil, status.Errorf(codes.NotFound, "config %q not found", name)
+		}
+	}
+
+	dpConfig := m.backend.DPConfig()
+	if dpConfig == nil {
+		return &aclpb.GetRulesCountersResponse{}, nil
+	}
+
+	result := make([]*aclpb.RuleCounter, 0)
+	for pos := range dpConfig.AllModulePositions(moduleType) {
+		if name != "" && pos.ModuleName != name {
+			continue
+		}
+
+		// Runtime-kind storages expand exactly the module's per-rule
+		// registries, so this read excludes the predefined module
+		// counters (rx, tx, acl_action_*, ...) by construction.
+		groups, err := dpConfig.CountersByTags([]ffi.CounterTag{
+			{Key: "device", Value: pos.Device},
+			{Key: "pipeline", Value: pos.Pipeline},
+			{Key: "function", Value: pos.Function},
+			{Key: "chain", Value: pos.Chain},
+			{Key: "module_type", Value: moduleType},
+			{Key: "module_name", Value: pos.ModuleName},
+			{Key: "kind", Value: "runtime"},
+		}, nil)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to read rule counters of config %q: %v", pos.ModuleName, err)
+		}
+
+		for _, group := range groups {
+			for _, counter := range group.Counters {
+				var packets, bytes uint64
+				for _, workerVals := range counter.Values {
+					if len(workerVals) > 0 {
+						packets += workerVals[0]
+					}
+					if len(workerVals) > 1 {
+						bytes += workerVals[1]
+					}
+				}
+
+				if packets == 0 && bytes == 0 {
+					continue
+				}
+
+				result = append(result, &aclpb.RuleCounter{
+					Config:   pos.ModuleName,
+					Device:   pos.Device,
+					Pipeline: pos.Pipeline,
+					Function: pos.Function,
+					Chain:    pos.Chain,
+					Counter:  counter.Name,
+					Packets:  packets,
+					Bytes:    bytes,
+				})
+			}
+		}
+	}
+
+	return &aclpb.GetRulesCountersResponse{Counters: result}, nil
+}

--- a/modules/acl/dataplane/config.h
+++ b/modules/acl/dataplane/config.h
@@ -34,6 +34,11 @@ struct acl_module_config {
 	uint64_t target_count;
 	struct acl_target *targets;
 
+	// Index of the per-rule "rules" counter registry within
+	// cp_module.runtime_counter_registries. Each per-rule counter_id is
+	// resolved against this registry's per-worker storage.
+	uint64_t rules_registry_idx;
+
 	// Fwstate module maps borrowed for state lookups.
 	struct fwstate_config fwstate_cfg;
 

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -162,6 +162,10 @@ acl_handle_packets(
 	struct counter_storage *counter_storage =
 		ADDR_OF_NONNULL(&module_ectx->counter_storage);
 
+	struct counter_storage *rules_storage = module_ectx_counter_storage(
+		module_ectx, acl_config->rules_registry_idx
+	);
+
 	uint64_t *pass_cnt = counter_get_address(
 		acl_config->action_allow_counter_id, counter_storage
 	);
@@ -507,7 +511,7 @@ acl_handle_packets(
 					uint64_t *counters =
 						counter_get_address(
 							target->counter_id,
-							counter_storage
+							rules_storage
 						);
 					counters[0] += 1;
 					counters[1] += pkt_len;

--- a/modules/acl/tests/functional/acl_net6_share_test.go
+++ b/modules/acl/tests/functional/acl_net6_share_test.go
@@ -296,10 +296,7 @@ func collectNet6ShareVerdicts(
 	}
 
 	path := aclCounterPath("port0", "test")
-	counters := h.SharedMemory().DPConfig(0).ModuleCounters(
-		path.Device, path.Pipeline, path.Function, path.Chain,
-		path.ModuleType, path.ModuleName, nil,
-	)
+	counters := dataplaneut.RuleCounters(t, h, path, nil)
 
 	return net6ShareResult{
 		verdicts:     verdicts,
@@ -511,6 +508,7 @@ func TestACL_Net6Share_EmptyRoundForcePoll(t *testing.T) {
 		path.Device, path.Pipeline, path.Function, path.Chain,
 		path.ModuleType, path.ModuleName, nil,
 	)
+	counters = append(counters, dataplaneut.RuleCounters(t, harness, path, nil)...)
 	for name, values := range dataplaneut.ValueCounters(counters) {
 		for _, value := range values {
 			require.Zero(
@@ -550,5 +548,5 @@ func TestACL_Net6Share_EmptyRoundForcePoll(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Output, 1, "deep_lo_a packet must be allowed through")
 	require.Empty(t, result.Drop)
-	dataplaneut.RequireModuleCounter(t, harness, path, "deep_lo_a", 1, packetSize)
+	dataplaneut.RequireRuleCounter(t, harness, path, "deep_lo_a", 1, packetSize)
 }

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -15,6 +15,7 @@ import (
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/xerror"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -1044,7 +1045,7 @@ func TestACL_Counters(t *testing.T) {
 		}
 
 		path := aclCounterPath("port0", "test")
-		dataplaneut.RequireModuleCounter(t, h, path, "acl_http", 3, 3*pktSize)
+		dataplaneut.RequireRuleCounter(t, h, path, "acl_http", 3, 3*pktSize)
 	})
 
 	t.Run("multiple_named_counters", func(t *testing.T) {
@@ -1123,8 +1124,100 @@ func TestACL_Counters(t *testing.T) {
 		}
 
 		path := aclCounterPath("port0", "test")
-		dataplaneut.RequireModuleCounter(t, h, path, "http", 3, 3*pktSize0)
-		dataplaneut.RequireModuleCounter(t, h, path, "dns", 2, 2*pktSize1)
+		dataplaneut.RequireRuleCounter(t, h, path, "http", 3, 3*pktSize0)
+		dataplaneut.RequireRuleCounter(t, h, path, "dns", 2, 2*pktSize1)
+	})
+
+	t.Run("rules_counters_via_service", func(t *testing.T) {
+		// GetRulesCounters serves the per-rule counters of a config applied
+		// through the service, while Metrics reports no per-rule counters.
+		pbRules := []*aclpb.Rule{{
+			Actions: []*aclpb.Action{
+				{Kind: aclpb.ActionKind_ACTION_KIND_COUNT},
+				{Kind: aclpb.ActionKind_ACTION_KIND_PASS},
+			},
+			Counter: "svc_counter",
+			Devices: []*filterpb.Device{{Name: "port0"}},
+			Srcs:    []*filterpb.IPNet{{Addr: make([]byte, 4), Mask: make([]byte, 4)}},
+			Dsts:    []*filterpb.IPNet{{Addr: make([]byte, 4), Mask: make([]byte, 4)}},
+			// UDP (17) with any subtype: proto in the high byte.
+			ProtoRanges:   []*filterpb.ProtoRange{{From: 17 << 8, To: 17<<8 | 0xFF}},
+			SrcPortRanges: []*filterpb.PortRange{{From: 0, To: 65535}},
+			DstPortRanges: []*filterpb.PortRange{{From: 0, To: 65535}},
+		}}
+
+		eth := layers.Ethernet{
+			SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+			DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+			EthernetType: layers.EthernetTypeIPv4,
+		}
+		ip4 := layers.IPv4{
+			Version:  4,
+			TTL:      64,
+			Protocol: layers.IPProtocolUDP,
+			SrcIP:    net.ParseIP("192.0.2.1"),
+			DstIP:    net.ParseIP("10.0.0.1"),
+		}
+		udp := layers.UDP{SrcPort: 12345, DstPort: 80}
+		udp.SetNetworkLayerForChecksum(&ip4)
+		pkt := xpacket.LayersToPacket(t, &eth, &ip4, &udp)
+		pktSize := uint64(len(pkt.Data()))
+
+		h, agent, _ := setupACLHarness(t, []string{"port0"})
+		svc := acl.NewACLService(acl.NewBackend(agent))
+		_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+			Name:  "test",
+			Rules: pbRules,
+		})
+		require.NoError(t, err)
+		wireACLPipeline(t, agent, "port0", "test")
+
+		for range 3 {
+			result, err := h.HandlePackets(pkt)
+			require.NoError(t, err)
+			require.Len(t, result.Output, 1)
+		}
+
+		named, err := svc.GetRulesCounters(t.Context(), &aclpb.GetRulesCountersRequest{Name: "test"})
+		require.NoError(t, err)
+		require.Len(t, named.GetCounters(), 1)
+		got := named.GetCounters()[0]
+		require.Equal(t, "test", got.GetConfig())
+		require.Equal(t, "port0", got.GetDevice())
+		require.Equal(t, "test", got.GetPipeline())
+		require.Equal(t, "test", got.GetFunction())
+		require.Equal(t, "test_chain", got.GetChain())
+		require.Equal(t, "svc_counter", got.GetCounter())
+		require.Equal(t, uint64(3), got.GetPackets())
+		require.Equal(t, 3*pktSize, got.GetBytes())
+
+		all, err := svc.GetRulesCounters(t.Context(), &aclpb.GetRulesCountersRequest{})
+		require.NoError(t, err)
+		require.Len(t, all.GetCounters(), 1)
+
+		// ModuleCounters returns the predefined counters only; the
+		// rule counter is served through the runtime-kind tag query.
+		path := aclCounterPath("port0", "test")
+		moduleCounters := h.SharedMemory().DPConfig(0).ModuleCounters(
+			path.Device, path.Pipeline, path.Function, path.Chain,
+			path.ModuleType, path.ModuleName, []string{"svc_counter"},
+		)
+		require.Empty(t, moduleCounters)
+		ruleCounters := dataplaneut.RuleCounters(t, h, path, []string{"svc_counter"})
+		require.Len(t, ruleCounters, 1)
+
+		collected, err := svc.Metrics()
+		require.NoError(t, err)
+		metricNames := make(map[string]struct{}, len(collected))
+		for _, metric := range collected {
+			metricNames[metric.GetName()] = struct{}{}
+		}
+		require.NotContains(t, metricNames, "acl_rule_packets")
+		require.NotContains(t, metricNames, "acl_rule_bytes")
+		require.Contains(t, metricNames, "acl_action_allow_packets")
+
+		_, err = svc.GetRulesCounters(t.Context(), &aclpb.GetRulesCountersRequest{Name: "missing"})
+		require.Equal(t, codes.NotFound, status.Code(err))
 	})
 
 	t.Run("default_counter_name", func(t *testing.T) {
@@ -1172,7 +1265,7 @@ func TestACL_Counters(t *testing.T) {
 		}
 
 		path := aclCounterPath("port0", "test")
-		dataplaneut.RequireModuleCounter(t, h, path, "rule 0", 2, 2*pktSize)
+		dataplaneut.RequireRuleCounter(t, h, path, "rule 0", 2, 2*pktSize)
 	})
 
 	t.Run("named_counter_no_count_action", func(t *testing.T) {
@@ -1221,7 +1314,7 @@ func TestACL_Counters(t *testing.T) {
 		// The "unused" counter is registered but stays at zero because no
 		// ACTION_COUNT is present in the rule's action list.
 		path := aclCounterPath("port0", "test")
-		dataplaneut.RequireModuleCounter(t, h, path, "unused", 0, 0)
+		dataplaneut.RequireRuleCounter(t, h, path, "unused", 0, 0)
 		requireModuleCounterPackets(t, h, path, "acl_action_allow", 1)
 	})
 
@@ -1386,7 +1479,7 @@ func TestACL_NoTerminatingAction_Drop(t *testing.T) {
 	path := aclCounterPath("port0", "test")
 	requireModuleCounterPackets(t, h, path, "acl_action_non_term", 1)
 	requireModuleCounterPackets(t, h, path, "acl_action_deny", 1)
-	dataplaneut.RequireModuleCounter(t, h, path, "acl_count_only", 1, pktSize)
+	dataplaneut.RequireRuleCounter(t, h, path, "acl_count_only", 1, pktSize)
 }
 
 // TestACL_VLAN_Match asserts that a VLAN-tagged packet matches a rule whose

--- a/modules/route-mpls/api/controlplane.c
+++ b/modules/route-mpls/api/controlplane.c
@@ -255,6 +255,7 @@ route_mpls_module_init_ip6(
 static struct target *
 route_mpls_rule_target_new(
 	struct cp_module *cp_module,
+	struct counter_registry *routes_registry,
 	struct route_mpls_rule *route_mpls_rule,
 	yanet_error **err
 ) {
@@ -301,7 +302,7 @@ route_mpls_rule_target_new(
 			route_mpls_rule->nexthops + idx;
 
 		if ((nexthops[idx].counter_id = counter_registry_register(
-			     &cp_module->counter_registry,
+			     routes_registry,
 			     route_mpls_nexthop->counter,
 			     2,
 			     err
@@ -364,6 +365,16 @@ route_mpls_module_config_update(
 	struct module_config *config =
 		container_of(cp_module, struct module_config, cp_module);
 
+	// Per-nexthop counters live in a dedicated "routes" registry so they
+	// are separated from the module's predefined counters in the
+	// per-worker storages and the counter storage registry.
+	struct counter_registry *routes_registry = cp_module_counter_registry(
+		cp_module, "routes", &config->routes_registry_idx, err
+	);
+	if (routes_registry == NULL) {
+		goto error;
+	}
+
 	struct target **targets = (struct target **)memory_balloc(
 		memory_context, sizeof(struct target *) * route_mpls_rule_count
 	);
@@ -377,7 +388,7 @@ route_mpls_module_config_update(
 
 	for (uint64_t idx = 0; idx < route_mpls_rule_count; ++idx) {
 		struct target *target = route_mpls_rule_target_new(
-			cp_module, route_mpls_rules + idx, err
+			cp_module, routes_registry, route_mpls_rules + idx, err
 		);
 
 		if (target == NULL) {

--- a/modules/route-mpls/dataplane/config.h
+++ b/modules/route-mpls/dataplane/config.h
@@ -48,6 +48,11 @@ struct module_config {
 	struct target **targets;
 	uint64_t target_count;
 
+	// Index of the per-nexthop "routes" counter registry within
+	// cp_module.runtime_counter_registries. Each per-nexthop counter_id
+	// is resolved against this registry's per-worker storage.
+	uint64_t routes_registry_idx;
+
 	struct filter filter_ip4;
 	struct filter filter_ip6;
 };

--- a/modules/route-mpls/dataplane/dataplane.c
+++ b/modules/route-mpls/dataplane/dataplane.c
@@ -139,9 +139,13 @@ route_mpls_handle_packets(
 				[packet->hash % target->nexthop_map_size];
 		struct nexthop *nexthop =
 			ADDR_OF(&target->nexthops) + nexthop_idx;
+		// Per-nexthop counters live in the "routes" runtime registry,
+		// resolved through its own per-worker storage.
 		uint64_t *counters = counter_get_address(
 			nexthop->counter_id,
-			ADDR_OF_NONNULL(&module_ectx->counter_storage)
+			module_ectx_counter_storage(
+				module_ectx, module_config->routes_registry_idx
+			)
 		);
 		counters[0] += 1;
 		counters[1] += packet_data_len(packet);

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -246,11 +246,22 @@ route_module_config_add_route(
 
 	uint64_t counter_id = COUNTER_INVALID;
 	if (counter_name != NULL && counter_name[0] != '\0') {
+		// Per-route counters live in a dedicated "routes" registry so
+		// they are separated from the module's predefined counters in
+		// the per-worker storages and the counter storage registry.
+		struct counter_registry *routes_registry =
+			cp_module_counter_registry(
+				cp_module,
+				"routes",
+				&config->routes_registry_idx,
+				err
+			);
+		if (routes_registry == NULL) {
+			return -1;
+		}
+
 		counter_id = counter_registry_register(
-			&config->cp_module.counter_registry,
-			counter_name,
-			2,
-			err
+			routes_registry, counter_name, 2, err
 		);
 		if (counter_id == COUNTER_INVALID) {
 			yanet_error_add(
@@ -554,7 +565,14 @@ fib_iter_nexthop_counter_name(const struct fib_iter *it, uint64_t nexthop_idx) {
 	}
 
 	struct route_module_config *config = it->config;
-	struct counter_registry *registry = &config->cp_module.counter_registry;
+	if (config->routes_registry_idx >=
+	    config->cp_module.runtime_counter_registry_count) {
+		return "";
+	}
+	struct cp_module_counter_registry *registries =
+		ADDR_OF(&config->cp_module.runtime_counter_registries);
+	struct counter_registry *registry =
+		&registries[config->routes_registry_idx].registry;
 	if (r->counter_id < registry->count) {
 		return ADDR_OF(&registry->names)[r->counter_id].name;
 	}

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -61,6 +61,10 @@ type Backend interface {
 	// ModuleCounters reads the named counters back from every position
 	// at which the named config is installed.
 	ModuleCounters(name string, counterNames []string) []CounterView
+	// RuntimeModuleCounters reads the named runtime counters (the
+	// config's per-nexthop registry) from every position at which the
+	// named config is installed.
+	RuntimeModuleCounters(name string, counterNames []string) []CounterView
 }
 
 // backend is the real Backend implementation backed by shared memory.
@@ -158,6 +162,28 @@ func (m *backend) DeleteModule(name string) error {
 }
 
 func (m *backend) ModuleCounters(name string, counterNames []string) []CounterView {
+	return m.counters(name, counterNames, func(d, p, f, c, mt, mn string, q []string) []ffi.CounterInfo {
+		return m.agent.DPConfig().ModuleCounters(d, p, f, c, mt, mn, q)
+	})
+}
+
+func (m *backend) RuntimeModuleCounters(name string, counterNames []string) []CounterView {
+	return m.counters(name, counterNames, func(d, p, f, c, mt, mn string, q []string) []ffi.CounterInfo {
+		infos, err := m.agent.DPConfig().ModuleRuntimeCounters(d, p, f, c, mt, mn, q)
+		if err != nil {
+			return nil
+		}
+		return infos
+	})
+}
+
+// counters reads the selected counters from every position at which the
+// named config is installed, through the supplied per-position read.
+func (m *backend) counters(
+	name string,
+	counterNames []string,
+	read func(string, string, string, string, string, string, []string) []ffi.CounterInfo,
+) []CounterView {
 	dpConfig := m.agent.DPConfig()
 
 	var views []CounterView
@@ -166,7 +192,7 @@ func (m *backend) ModuleCounters(name string, counterNames []string) []CounterVi
 			continue
 		}
 
-		infos := dpConfig.ModuleCounters(
+		infos := read(
 			pos.Device,
 			pos.Pipeline,
 			pos.Function,

--- a/modules/route/controlplane/metrics.go
+++ b/modules/route/controlplane/metrics.go
@@ -102,7 +102,7 @@ func (m *RouteService) collectNexthopMetrics(tags []*commonpb.MetricTag) []*comm
 			continue
 		}
 
-		for _, counter := range m.backend.ModuleCounters(configName, names) {
+		for _, counter := range m.backend.RuntimeModuleCounters(configName, names) {
 			var packets, bytes uint64
 			for _, instance := range counter.Values {
 				if len(instance) > 0 {

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -63,9 +63,14 @@ type fakeBackend struct {
 	mu       sync.Mutex
 	handle   *fakeHandle
 	counters []route.CounterView
+	// runtimeCounters backs RuntimeModuleCounters, the per-nexthop read.
+	runtimeCounters []route.CounterView
 	// queries records the counterNames argument of every ModuleCounters
 	// call, in call order.
 	queries [][]string
+	// runtimeQueries records the counterNames argument of every
+	// RuntimeModuleCounters call, in call order.
+	runtimeQueries [][]string
 	// updateCalls records the range entries passed to UpdateModule on
 	// every call, in call order.
 	updateCalls [][]*routepb.FIBEntry
@@ -113,6 +118,14 @@ func (m *fakeBackend) ModuleCounters(name string, counterNames []string) []route
 
 	m.queries = append(m.queries, append([]string(nil), counterNames...))
 	return m.counters
+}
+
+func (m *fakeBackend) RuntimeModuleCounters(name string, counterNames []string) []route.CounterView {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.runtimeQueries = append(m.runtimeQueries, append([]string(nil), counterNames...))
+	return m.runtimeCounters
 }
 
 // newServiceWithConfig returns a service holding a single applied config
@@ -664,7 +677,7 @@ func TestUpdateFIBRejectsConflictingCounterNamesAcrossEntries(t *testing.T) {
 func TestUpdateFIBToleratesActiveNexthopCounterNamesFailure(t *testing.T) {
 	backend := newFakeBackend()
 	backend.handle = &fakeHandle{routeCount: 3, activeNamesErr: errors.New("fib_iter_new: allocation failure")}
-	backend.counters = []route.CounterView{
+	backend.runtimeCounters = []route.CounterView{
 		counterView("nexthop_my_counter", [][]uint64{{1, 100}}),
 	}
 	service := route.NewRouteService(backend)
@@ -682,7 +695,7 @@ func TestUpdateFIBToleratesActiveNexthopCounterNamesFailure(t *testing.T) {
 	all, err := service.Metrics()
 	require.NoError(t, err)
 	require.Empty(t, findMetrics(all, "route_nexthop_packets"), "the counter set must be empty until the next update")
-	for _, query := range backend.queries {
+	for _, query := range append(append([][]string(nil), backend.queries...), backend.runtimeQueries...) {
 		require.NotContains(t, query, "nexthop_my_counter", "the empty counter set must never be queried for")
 	}
 
@@ -706,7 +719,7 @@ func TestNexthopMetricsSumWorkerInstances(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	backend.counters = []route.CounterView{
+	backend.runtimeCounters = []route.CounterView{
 		counterView("nexthop_my_counter", [][]uint64{{1, 100}, {2, 200}}),
 	}
 
@@ -730,12 +743,12 @@ func TestNexthopMetricsSumWorkerInstances(t *testing.T) {
 }
 
 // TestNexthopMetricsExactTagNeverReadsForeignCounter verifies that an exact
-// "counter" tag naming a module-level counter never reaches
-// collectNexthopMetrics's dataplane read, so the structural counter can
+// "counter" tag naming anything outside a config's own reachable names never
+// reaches collectNexthopMetrics's dataplane read, so a foreign counter can
 // never resurface mislabeled under the route_nexthop_* family.
 func TestNexthopMetricsExactTagNeverReadsForeignCounter(t *testing.T) {
 	backend := newFakeBackend()
-	backend.counters = []route.CounterView{
+	backend.runtimeCounters = []route.CounterView{
 		counterView("route_forwarded_v4", [][]uint64{{7, 700}}),
 	}
 	service := route.NewRouteService(backend)
@@ -760,4 +773,5 @@ func TestNexthopMetricsExactTagNeverReadsForeignCounter(t *testing.T) {
 	// (whose exact-tag branch never matches a per-entry read) has anything
 	// left to query.
 	require.Empty(t, backend.queries)
+	require.Empty(t, backend.runtimeQueries)
 }

--- a/modules/route/dataplane/config.h
+++ b/modules/route/dataplane/config.h
@@ -69,4 +69,9 @@ struct route_module_config {
 	// A non-IP packet has no address family, so its drop counter is
 	// shared rather than kept in a per-family set.
 	uint64_t drop_non_ip_counter_id;
+
+	// Index of the per-route "routes" counter registry within
+	// cp_module.runtime_counter_registries. Each per-route counter_id is
+	// resolved against this registry's per-worker storage.
+	uint64_t routes_registry_idx;
 };

--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -34,13 +34,11 @@ enum route_drop_reason {
 
 static inline void
 route_count_packet(
-	struct module_ectx *module_ectx,
+	struct counter_storage *counter_storage,
 	uint64_t counter_id,
 	struct packet *packet
 ) {
-	uint64_t *counters = counter_get_address(
-		counter_id, ADDR_OF_NONNULL(&module_ectx->counter_storage)
-	);
+	uint64_t *counters = counter_get_address(counter_id, counter_storage);
 	counters[0] += 1;
 	counters[1] += packet_data_len(packet);
 }
@@ -160,6 +158,14 @@ route_handle_packets(
 		cp_module
 	);
 
+	struct counter_storage *counter_storage =
+		ADDR_OF_NONNULL(&module_ectx->counter_storage);
+	// Per-route counters live in the "routes" runtime registry, resolved
+	// through its own per-worker storage.
+	struct counter_storage *routes_storage = module_ectx_counter_storage(
+		module_ectx, route_config->routes_registry_idx
+	);
+
 	struct packet *packet;
 	while ((packet = packet_list_pop(&packet_front->input)) != NULL) {
 		uint32_t route_list_id = 0;
@@ -182,7 +188,7 @@ route_handle_packets(
 			counters = &route_config->counters_v6;
 		} else {
 			route_count_packet(
-				module_ectx,
+				counter_storage,
 				route_config->drop_non_ip_counter_id,
 				packet
 			);
@@ -192,7 +198,7 @@ route_handle_packets(
 
 		if (route_list_id == LPM_VALUE_INVALID) {
 			route_count_packet(
-				module_ectx,
+				counter_storage,
 				drop_reason == ROUTE_DROP_TTL_EXPIRED
 					? counters->drop_ttl_expired
 					: counters->drop_no_route,
@@ -206,7 +212,7 @@ route_handle_packets(
 			ADDR_OF(&route_config->route_lists) + route_list_id;
 		if (route_list->count == 0) {
 			route_count_packet(
-				module_ectx,
+				counter_storage,
 				counters->drop_empty_route_list,
 				packet
 			);
@@ -228,7 +234,7 @@ route_handle_packets(
 
 		if (device_id == (uint16_t)-1) {
 			route_count_packet(
-				module_ectx,
+				counter_storage,
 				counters->drop_device_unresolved,
 				packet
 			);
@@ -238,10 +244,12 @@ route_handle_packets(
 
 		route_set_packet_destination(packet, route);
 		packet->tx_device_id = device_id;
-		route_count_packet(module_ectx, counters->forwarded, packet);
+		route_count_packet(
+			counter_storage, counters->forwarded, packet
+		);
 		if (route->counter_id != COUNTER_INVALID) {
 			route_count_packet(
-				module_ectx, route->counter_id, packet
+				routes_storage, route->counter_id, packet
 			);
 		}
 		module_ectx_route_output(module_ectx, packet_front, packet);

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -1004,7 +1004,7 @@ func TestRoute_NexthopCounter(t *testing.T) {
 		Device: "port0", Pipeline: "test", Function: "test",
 		Chain: "test_chain", ModuleType: "route", ModuleName: "test",
 	}
-	dataplaneut.RequireModuleCounter(t, h, path, counterName, 1, pktSize)
+	dataplaneut.RequireRuleCounter(t, h, path, counterName, 1, pktSize)
 
 	// Close the round trip: ShowFIB's DumpFIB path must resolve the same
 	// name back out of the real C counter registry, not just accept it on


### PR DESCRIPTION
Follow-up to #2042 that generalizes the single config counter registry into a set of named per-module registries.

- A module can now hold several named runtime counter registries instead of a single config registry, created lazily via cp_module_counter_registry (get-or-create by tag).
- Each registry is tagged, gets its own per-worker storage expanded on config-gen installation, and is linked against the same-tag registry of the displaced module on config rebuild so per-rule counters survive layout-preserving updates.
- Tagged storages are addressed by kind=runtime plus a config tag naming their registry, so lookups select them explicitly instead of via an absent predicate; predefined module counters keep kind=module and yanet_get_module_counters returns only those.
- The ACL module moves its per-rule counters into a dedicated rules registry, separating them from the predefined module counters.
- ACL GetMetrics no longer returns per-rule counters; the new GetRulesCounters RPC serves them, reading exactly the runtime-kind storages through the tag query, with a matching yanet-cli-acl rule-counters subcommand.
- The route and route-mpls modules move their per-route and per-nexthop counters into a dedicated routes registry. Route metrics read them through a new ModuleRuntimeCounters query beside the unchanged module-level read, and ShowFIB resolves nexthop counter names out of the new registry.
- Module ABI version is bumped for the changed shared-memory structures.

Verified with a clean meson compile, meson test 68/68, go clean -cache plus acl/controlplane/forward/route/route-mpls/bindings Go tests (including new functional coverage for GetRulesCounters and the module/rule counter read split), cargo build/clippy/fmt/test for the CLI, and the comment, proto, and clang-format lints.