### PR TITLE
feat(dataplane): warn at startup when running a non-production build

### DIFF
--- a/common/buildinfo.h
+++ b/common/buildinfo.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <stdbool.h>
+
+#include "asan.h"
+
+// Reports whether this translation unit was compiled as a production build:
+// optimizations enabled and AddressSanitizer disabled.
+//
+// The answer reflects the compile flags of whichever translation unit
+// includes this header, so it is only meaningful from a meson-built C
+// source and must never be evaluated from a cgo preamble, which compiles
+// with its own, independent flags.
+static inline bool
+build_is_optimized(void) {
+#if defined(HAVE_ASAN)
+	return false;
+#elif defined(__OPTIMIZE__)
+	return true;
+#else
+	return false;
+#endif
+}

--- a/dataplane/main.c
+++ b/dataplane/main.c
@@ -3,6 +3,7 @@
 
 #include <rte_version.h>
 
+#include "common/buildinfo.h"
 #include "config.h"
 #include "dataplane.h"
 #include "logging/log.h"
@@ -80,6 +81,12 @@ main(int argc, char **argv) {
 
 	// This function initializes and enables logging
 	log_enable_name("debug");
+
+	if (!build_is_optimized()) {
+		LOG(WARN,
+		    "running a non-production build (optimizations off or "
+		    "sanitizers on): throughput will be far below production");
+	}
 
 	struct dataplane_config *config;
 	FILE *config_file = fopen(config_path, "r");

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "common/buildinfo.h"
 #include "common/memory.h"
 #include "common/memory_address.h"
 #include "common/strutils.h"
@@ -637,18 +638,5 @@ dataplane_ut_run_rounds(
 
 int
 dataplane_ut_build_optimized(void) {
-#if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-	return 0;
-#endif
-#endif
-#if defined(__SANITIZE_ADDRESS__)
-	return 0;
-#else
-#if defined(__OPTIMIZE__)
-	return 1;
-#else
-	return 0;
-#endif
-#endif
+	return build_is_optimized();
 }


### PR DESCRIPTION
- The dataplane now warns at startup when it is running a build with optimizations disabled or AddressSanitizer enabled, so an accidentally deployed development build is visible in the log without anyone having to ask for version output.
- The warning is emitted as soon as logging is first enabled, so it survives a later configuration failure and no configured log level can suppress it.
- The check that the benchmark harness has always applied to itself moves into a shared header, and the harness becomes a thin adapter over it, so both callers answer from one rule. Benchmark warning behaviour is unchanged.
- The shared header is header-only rather than a new build-system library. The tracking issue originally specified a library, out of a concern that a shared inline check would report the wrong toolchain's flags. That hazard is a property of where the check is called rather than of the header itself, and both callers are compiled by the main build system, so the harness keeps answering through its existing compiled symbol, the language bindings link exactly as before, and no build files change.
- The check deliberately keeps its existing semantics: optimizations off, or AddressSanitizer on. ThreadSanitizer, UndefinedBehaviorSanitizer and a configure-time build-system flag were each considered and left out, so no existing benchmark changes behaviour. Every sanitizer build this repository's own targets produce also disables optimizations, so those builds still warn.
- No automated test is added. The check is a pure function of compile flags with no runtime input, so an assertion written alongside it only restates the macros it is testing, and one written on the Go side would fail spuriously against a locally configured debug build, because no in-process source of truth for the build configuration is reachable from there. Both directions of the check, and the warning actually reaching standard error, were confirmed by execution instead.

Closes #1750.