### PR TITLE
fix(common): detect optimized sanitizer builds

### DIFF
--- a/common/buildinfo.h
+++ b/common/buildinfo.h
@@ -5,7 +5,8 @@
 #include "asan.h"
 
 // Reports whether this translation unit was compiled as a production build:
-// optimizations enabled and AddressSanitizer disabled.
+// optimizations enabled and neither AddressSanitizer nor a Meson-selected
+// sanitizer enabled.
 //
 // The answer reflects the compile flags of whichever translation unit
 // includes this header, so it is only meaningful from a meson-built C
@@ -13,7 +14,7 @@
 // with its own, independent flags.
 static inline bool
 build_is_optimized(void) {
-#if defined(HAVE_ASAN)
+#if defined(HAVE_ASAN) || defined(YANET_SANITIZE)
 	return false;
 #elif defined(__OPTIMIZE__)
 	return true;

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -107,10 +107,11 @@ dataplane_ut_run(
 );
 
 // Report whether this dataplane build is suitable for benchmarking:
-// compiled with optimizations enabled and without AddressSanitizer.
+// compiled with optimizations enabled and neither AddressSanitizer nor a
+// Meson-selected sanitizer enabled.
 //
-// Benchmarks against a debug or AddressSanitizer build produce misleading
-// numbers, so the Go harness warns when this returns 0.
+// The Go harness warns when this returns 0 because the benchmark is not
+// representative for that build.
 int
 dataplane_ut_build_optimized(void);
 

--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,7 @@ yanet_cgo_cflags = []
 yanet_cgo_ldflags = []
 b_sanitize = get_option('b_sanitize')
 if b_sanitize != 'none'
+    yanet_project_args += '-DYANET_SANITIZE'
     sanitize_flags = []
     if b_sanitize.contains('address')
         sanitize_flags += 'address'


### PR DESCRIPTION
- Treats every Meson sanitizer mode as non-production even when optimization remains enabled.
- Preserves compiler-detected AddressSanitizer handling for fuzzing builds configured outside the Meson sanitizer option.
- Keeps startup and benchmark warnings sanitizer-generic because both continue to consume the same shared predicate.
- Assumes all non-`none` Meson sanitizer modes are unsuitable for production throughput measurements.
- Verified optimized unsanitized, ThreadSanitizer, and UndefinedBehaviorSanitizer code generation, release tests, fuzz builds, Clang syntax, and clean AddressSanitizer/CGO tests.

Closes #2050.