### PR TITLE
fix(mirror): avoid zero-length VLAs on an empty poll tick

### DIFF
--- a/modules/mirror/dataplane/dataplane.c
+++ b/modules/mirror/dataplane/dataplane.c
@@ -51,16 +51,23 @@ mirror_handle_packets(
 		cp_module
 	);
 
-	struct packet *vlan_packets[packet_front_input_count(packet_front)];
-	uint32_t vlan_result[packet_front_input_count(packet_front)];
+	// The worker force-polls every module each tick, so an empty front here
+	// is normal. Zero-sizing the arrays below is undefined behavior.
+	uint64_t count = packet_front_input_count(packet_front);
+	if (count == 0) {
+		return;
+	}
+
+	struct packet *vlan_packets[count];
+	uint32_t vlan_result[count];
 	uint64_t vlan_idx = 0;
 
-	struct packet *ip4_packets[packet_front_input_count(packet_front)];
-	uint32_t ip4_result[packet_front_input_count(packet_front)];
+	struct packet *ip4_packets[count];
+	uint32_t ip4_result[count];
 	uint64_t ip4_idx = 0;
 
-	struct packet *ip6_packets[packet_front_input_count(packet_front)];
-	uint32_t ip6_result[packet_front_input_count(packet_front)];
+	struct packet *ip6_packets[count];
+	uint32_t ip6_result[count];
 	uint64_t ip6_idx = 0;
 
 	for (struct packet *packet = packet_list_first(&packet_front->input);

--- a/modules/mirror/tests/functional/mirror_test.go
+++ b/modules/mirror/tests/functional/mirror_test.go
@@ -598,6 +598,42 @@ func TestMirror_MinAction(t *testing.T) {
 	dataplaneut.RequireModuleCounter(t, h, path, "ip4lose", 0, 0)
 }
 
+// TestMirror_EmptyRound verifies that a force-poll round with no packets at
+// all passes through mirror_handle_packets harmlessly.
+//
+// The empty round models a force-poll tick with no traffic: the worker
+// invokes mirror_handle_packets even though the input front is empty. This
+// cannot observe any sanitizer diagnostic on its own, so it only checks that
+// the round completes cleanly and leaves the module's state untouched.
+func TestMirror_EmptyRound(t *testing.T) {
+	rule := cmirror.MirrorRule{
+		Target:  "port0",
+		Mode:    cmirror.ModeNone,
+		Counter: "rule0",
+		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:   filter.IPNets{filter.MustParseIPNet("10.0.0.0/24")},
+	}
+
+	h, agent, backend := setupMirrorHarness(t, []string{"port0"})
+	applyRules(t, backend, "test", []cmirror.MirrorRule{rule})
+	wireMirrorPipeline(t, agent, "port0", "test", nil)
+
+	path := dataplaneut.CounterPath{
+		Device:     "port0",
+		Pipeline:   "test",
+		Function:   "test",
+		Chain:      "test_chain",
+		ModuleType: "mirror",
+		ModuleName: "test",
+	}
+
+	result, err := h.HandlePackets()
+	require.NoError(t, err)
+	require.Empty(t, result.Output, "empty round produces no output")
+	require.Empty(t, result.Drop, "empty round produces no drops")
+	dataplaneut.RequireModuleCounter(t, h, path, "rule0", 0, 0)
+}
+
 // TestMirrorConfigMemoryLeak verifies the block allocator returns memory once a
 // superseded mirror config generation is reclaimed.
 //


### PR DESCRIPTION
- The worker force-polls every module once per tick, so the mirror handler regularly runs with an empty input front. Its six scratch arrays were sized directly by that count, so each was declared with a zero bound, which is undefined behavior and is reported by the undefined-behavior sanitizer once per declaration.
- The input count is now read once into a local and the handler returns early when it is zero, with every array sized by that same local, so the guard is checkable by inspection instead of by re-reading six separate call sites.
- Returning early is safe because the handler has no periodic obligation. Everything past the declaration group is driven by the packet list, so an empty front leaves nothing to do and the force-poll contract loses nothing.
- Adds a functional test that drives a zero-packet force-poll round, the only one in the repository, asserting it produces no output, no drops and no counter movement. That path runs on every worker on every idle tick and had no coverage before.
- The test asserts behavior rather than sanitizer output, because nothing in the repository turns a sanitizer diagnostic into a failure today. The diagnostic was verified separately instead: under a sanitizer build the reports are gone while every instrumentation call site remains in the compiled object, so the silence is the guard firing rather than lost coverage.
- Two details of the issue's estimate turned out differently, neither changing the fix. The reports are latched per source location per process, so the cost was six lines per test binary rather than six per tick. And they never surface in a green run, because the sanitizer job runs its tests over a package list without verbose output and a passing package's output is discarded, so they appear only when a package fails or someone runs verbosely, which is exactly when that output is being read for a real finding.
- The same pattern is still live in three other modules, which is out of scope here and tracked in #2055.

Closes #2052.