### PR TITLE
fix(forward): avoid zero-length VLAs on an empty poll tick

### DIFF
--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -33,16 +33,26 @@ forward_handle_packets(
 		cp_module
 	);
 
-	struct packet *vlan_packets[packet_front_input_count(packet_front)];
-	uint32_t vlan_result[packet_front_input_count(packet_front)];
+	// A force-polled tick can hand this module an empty front, and sizing
+	// the arrays below directly by that count would then declare them with
+	// zero length, which is undefined behavior. The early return is only
+	// safe because nothing runs after this handler's final packet loop —
+	// any code added after that loop must run before the return.
+	uint64_t count = packet_front_input_count(packet_front);
+	if (count == 0) {
+		return;
+	}
+
+	struct packet *vlan_packets[count];
+	uint32_t vlan_result[count];
 	uint64_t vlan_idx = 0;
 
-	struct packet *ip4_packets[packet_front_input_count(packet_front)];
-	uint32_t ip4_result[packet_front_input_count(packet_front)];
+	struct packet *ip4_packets[count];
+	uint32_t ip4_result[count];
 	uint64_t ip4_idx = 0;
 
-	struct packet *ip6_packets[packet_front_input_count(packet_front)];
-	uint32_t ip6_result[packet_front_input_count(packet_front)];
+	struct packet *ip6_packets[count];
+	uint32_t ip6_result[count];
 	uint64_t ip6_idx = 0;
 
 	for (struct packet *packet = packet_list_first(&packet_front->input);


### PR DESCRIPTION
The worker force-polls every module in a non-empty chain once per tick regardless of input, so a handler's per-round input count is legitimately zero in normal steady state rather than as an edge case. Sizing the handler's six local variable-length arrays directly by that count declared them with zero length on every such tick, which C leaves undefined.

The handler now reads the count once, returns early when it is zero, and sizes the arrays by that local. This is the fix already merged for the mirror module, applied unchanged. Returning early skips nothing: this handler does no work after its packet loop, and the counters read before the guard are pointer lookups with no side effects. The per-tick bookkeeping belongs to the caller, which already guards its own histogram on a non-zero packet count.

Measured rather than inferred. A sanitizer build of the base emitted six variable-length-array-bound reports from this handler, reached with an empty front from seven independent test packages. The same build of this change emits none, with the instrumentation confirmed still compiled in so that the silence is real.

No new test accompanies this change, deliberately. Those seven packages already reach this handler with an empty front, so a forward-owned empty-round test would duplicate an existing vehicle rather than add coverage.

The fuzz build was not run locally, because the local target wipes and rebuilds the whole tree while this change alters no signature or symbol. The fuzz workflow is nightly rather than pull-request triggered, so it was dispatched manually against this branch instead.

Part of #2055.