### PR TITLE
fix(route-mpls): avoid zero-length VLAs on an empty poll tick

### DIFF
--- a/modules/route-mpls/dataplane/dataplane.c
+++ b/modules/route-mpls/dataplane/dataplane.c
@@ -42,12 +42,22 @@ route_mpls_handle_packets(
 		cp_module
 	);
 
-	struct packet *ip4_packets[packet_front_input_count(packet_front)];
-	uint32_t ip4_result[packet_front_input_count(packet_front)];
+	// The worker's per-tick force-poll can reach this handler with an empty
+	// front, and the arrays below would then be declared with zero length,
+	// which is undefined behavior. The early return is only safe because
+	// nothing in this handler runs after its final packet loop — any code
+	// added after that loop must run before the return.
+	uint64_t count = packet_front_input_count(packet_front);
+	if (count == 0) {
+		return;
+	}
+
+	struct packet *ip4_packets[count];
+	uint32_t ip4_result[count];
 	uint64_t ip4_idx = 0;
 
-	struct packet *ip6_packets[packet_front_input_count(packet_front)];
-	uint32_t ip6_result[packet_front_input_count(packet_front)];
+	struct packet *ip6_packets[count];
+	uint32_t ip6_result[count];
 	uint64_t ip6_idx = 0;
 
 	for (struct packet *packet = packet_list_first(&packet_front->input);


### PR DESCRIPTION
The worker force-polls every module in a non-empty chain once per tick regardless of input, so a handler's per-round input count is legitimately zero in normal steady state rather than as an edge case. Sizing the handler's four local variable-length arrays directly by that count declared them with zero length on every such tick, which C leaves undefined.

The handler now reads the count once, returns early when it is zero, and sizes the arrays by that local. This is the shape already merged for the mirror and forward modules. The comment states the invariant the guard rests on as well as the reason for it: the early return is sound only because nothing runs after the handler's final packet loop, so trailing work added later must run before the guard. That claim was checked against the function rather than the diff, and the per-tick bookkeeping lives in the caller, which already guards its own histogram on a non-zero packet count.

One limitation is worth stating plainly rather than leaving to be discovered. Unlike its two siblings, this fix is not backed by an execution measurement. A sanitizer sweep of the base emitted zero reports from this module — not because it is clean, but because nothing executes it: the module is absent from the link list the in-process test harness uses, it has no test or fuzzing directory, and its only vehicle is the virtual-machine functional suite, which runs uninstrumented. So this change is verified by inspection and by being byte-for-byte the same guard as the two modules where the reports did appear and then disappeared. Giving the module a real in-process vehicle is tracked as #2059.

While reading this handler for that check, a separate pre-existing defect surfaced: on an invalid filter verdict the packet has already been popped from the input list and is then skipped without being forwarded or dropped, so it is neither. That is filed as #2061 and is deliberately not addressed here.

Part of #2055.