### PR TITLE
fix(acl): avoid zero-length VLAs on an empty poll tick

### DIFF
--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -204,30 +204,39 @@ acl_handle_packets(
 	 * For the second option we have to split v4 and v6 processing.
 	 */
 
-	struct packet *vlan_packets[packet_front_input_count(packet_front)];
-	uint32_t vlan_result[packet_front_input_count(packet_front)];
+	// A force-polled tick can reach this handler with an empty front, and
+	// zero-sizing every variable-length array declared below is undefined
+	// behavior. The early return is only safe because everything below is
+	// per-packet — trailing work added later must go above the guard.
+	uint64_t count = packet_front_input_count(packet_front);
+	if (count == 0) {
+		return;
+	}
+
+	struct packet *vlan_packets[count];
+	uint32_t vlan_result[count];
 	uint64_t vlan_idx = 0;
 
-	struct packet *ip4_packets[packet_front_input_count(packet_front)];
-	uint32_t ip4_result[packet_front_input_count(packet_front)];
+	struct packet *ip4_packets[count];
+	uint32_t ip4_result[count];
 	uint64_t ip4_idx = 0;
 
-	struct packet *ip4_port_packets[packet_front_input_count(packet_front)];
-	uint32_t ip4_port_result[packet_front_input_count(packet_front)];
+	struct packet *ip4_port_packets[count];
+	uint32_t ip4_port_result[count];
 	uint64_t ip4_port_idx = 0;
 
-	struct packet *ip6_packets[packet_front_input_count(packet_front)];
-	uint32_t ip6_result[packet_front_input_count(packet_front)];
+	struct packet *ip6_packets[count];
+	uint32_t ip6_result[count];
 	uint64_t ip6_idx = 0;
 
-	struct packet *ip6_port_packets[packet_front_input_count(packet_front)];
-	uint32_t ip6_port_result[packet_front_input_count(packet_front)];
+	struct packet *ip6_port_packets[count];
+	uint32_t ip6_port_result[count];
 	uint64_t ip6_port_idx = 0;
 
 	// Position of each ip6_port batch packet within the ip6 batch, filled
 	// only on the shared-classification path where every ip6_port packet
 	// is by construction also an ip6 packet.
-	uint32_t ip6_port_pos[packet_front_input_count(packet_front)];
+	uint32_t ip6_port_pos[count];
 
 	for (struct packet *packet = packet_list_first(&packet_front->input);
 	     packet != NULL;
@@ -287,17 +296,14 @@ acl_handle_packets(
 	);
 
 	if (net6_share) {
-		const uint32_t batch_count =
-			packet_front_input_count(packet_front);
-
 		struct net6_share_dir *share_src = &acl_config->net6_share_src;
 		struct net6_share_dir *share_dst = &acl_config->net6_share_dst;
 
 		// Classify each v6 address half once on the union tries.
-		uint32_t src_hi[batch_count];
-		uint32_t src_lo[batch_count];
-		uint32_t dst_hi[batch_count];
-		uint32_t dst_lo[batch_count];
+		uint32_t src_hi[count];
+		uint32_t src_lo[count];
+		uint32_t dst_hi[count];
+		uint32_t dst_lo[count];
 
 		for (uint64_t idx = 0; idx < ip6_idx; ++idx) {
 			struct rte_mbuf *mbuf =
@@ -338,8 +344,8 @@ acl_handle_packets(
 		struct net6_classifier *ip6_dst_cls = (struct net6_classifier *)
 			ADDR_OF(&acl_config->filter_ip6.v[ip6_dst_leaf].data);
 
-		uint32_t ip6_src_slots[batch_count];
-		uint32_t ip6_dst_slots[batch_count];
+		uint32_t ip6_src_slots[count];
+		uint32_t ip6_dst_slots[count];
 
 		for (uint64_t idx = 0; idx < ip6_idx; ++idx) {
 			ip6_src_slots[idx] = value_table_get(
@@ -371,8 +377,8 @@ acl_handle_packets(
 					 .data
 			);
 
-		uint32_t ip6_port_src_slots[batch_count];
-		uint32_t ip6_port_dst_slots[batch_count];
+		uint32_t ip6_port_src_slots[count];
+		uint32_t ip6_port_dst_slots[count];
 
 		for (uint64_t idx = 0; idx < ip6_port_idx; ++idx) {
 			uint32_t pos = ip6_port_pos[idx];

--- a/modules/acl/tests/functional/acl_net6_share_test.go
+++ b/modules/acl/tests/functional/acl_net6_share_test.go
@@ -462,3 +462,93 @@ func TestACL_Net6Share_VerdictParity_ScaleHeavy(t *testing.T) {
 	)
 	runNet6ShareVerdictParity(t, 40000, 4096, scaleCPMemory, scaleAgentMemory)
 }
+
+// TestACL_Net6Share_EmptyRoundForcePoll runs one force-polled empty round.
+//
+// It builds the shared net6 trie, then calls acl_handle_packets with an
+// empty input front. No Go-visible assertion can observe the zero-length-
+// VLA defect this accompanies: it is undefined behavior the handler never
+// indexes. This is the only test in acl's own suite that reaches an empty
+// front, and, under a sanitizer build, the only one that extends that
+// reach to the shared-classification arrays.
+func TestACL_Net6Share_EmptyRoundForcePoll(t *testing.T) {
+	const (
+		emptyRoundCPMemory    = 192 * datasize.MB
+		emptyRoundAgentMemory = 48 * datasize.MB
+	)
+
+	_, present := os.LookupEnv(net6ShareDisableEnv)
+	require.False(
+		t, present,
+		"%s is present in the ambient environment (acl_module_init_net6_share "+
+			"keys off getenv() != NULL, not the value); this test would compile "+
+			"the unshared path and cover none of the shared-classification arrays",
+		net6ShareDisableEnv,
+	)
+
+	harness, agent, backend := setupACLHarnessSized(t, []string{"port0"}, emptyRoundCPMemory, emptyRoundAgentMemory)
+	handle := applyACLRules(t, backend, "test", net6ShareEdgeCaseRules())
+	wireACLPipeline(t, agent, "port0", "test")
+
+	info := handle.GetInfo()
+	require.True(
+		t,
+		info.FilterRuleCountIp6 > 0 && info.FilterRuleCountIp6Port > 0,
+		"ruleset has filter_rule_count_ip6=%d filter_rule_count_ip6_port=%d; "+
+			"acl_module_init_net6_share returns without building the shared "+
+			"trie when either is zero, so this test would exercise only the "+
+			"unshared main-body arrays",
+		info.FilterRuleCountIp6, info.FilterRuleCountIp6Port,
+	)
+
+	result, err := harness.HandlePackets()
+	require.NoError(t, err)
+	require.Empty(t, result.Output, "empty round must not produce output")
+	require.Empty(t, result.Drop, "empty round must not produce drops")
+
+	path := aclCounterPath("port0", "test")
+	counters := harness.SharedMemory().DPConfig(0).ModuleCounters(
+		path.Device, path.Pipeline, path.Function, path.Chain,
+		path.ModuleType, path.ModuleName, nil,
+	)
+	for name, values := range dataplaneut.ValueCounters(counters) {
+		for _, value := range values {
+			require.Zero(
+				t, value,
+				"counter %q holds %d after an empty round; today every acl "+
+					"counter stays at zero with no packet input, so this "+
+					"failing means behavior changed and is worth checking, "+
+					"not necessarily a defect",
+				name, value,
+			)
+		}
+	}
+
+	// Positive control: proves the wiring is live and that this rule set
+	// really does route through filter_ip6_port on the shared-classification
+	// path, and that the guard above did not break that non-empty path. It
+	// says nothing about the empty round itself, which this test cannot
+	// observe for the reason given above.
+	ethernetLayer := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv6,
+	}
+	ipv6Layer := layers.IPv6{
+		Version:    6,
+		HopLimit:   64,
+		NextHeader: layers.IPProtocolTCP,
+		SrcIP:      net.ParseIP("2001:db8:5::1"),
+		DstIP:      net.ParseIP("2001:db8:9::1000:1"),
+	}
+	tcpLayer := layers.TCP{SrcPort: 12345, DstPort: 8000, SYN: true}
+	require.NoError(t, tcpLayer.SetNetworkLayerForChecksum(&ipv6Layer))
+	packet := xpacket.LayersToPacket(t, &ethernetLayer, &ipv6Layer, &tcpLayer)
+	packetSize := uint64(len(packet.Data()))
+
+	result, err = harness.HandlePackets(packet)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "deep_lo_a packet must be allowed through")
+	require.Empty(t, result.Drop)
+	dataplaneut.RequireModuleCounter(t, harness, path, "deep_lo_a", 1, packetSize)
+}


### PR DESCRIPTION
The worker force-polls every module in a non-empty chain once per tick regardless of input, so a handler's per-round input count is legitimately zero in normal steady state rather than as an edge case. Sizing the handler's local variable-length arrays directly by that count declared them with zero length on every such tick, which C leaves undefined.

This module needed more care than its siblings. It has nineteen such arrays, not the eleven visible in the obvious block: eight more sit further down on the shared-classification path, sized by a second local that re-reads the same count. A guard placed at the first declaration would have left those eight undefined, and nothing in the repository would have noticed. The guard therefore sits above every declaration, so one return dominates all nineteen.

Measured rather than inferred. A sanitizer build of the base emitted eleven variable-length-array-bound reports from this handler; the same build of this change emits none, with the instrumentation confirmed still compiled in so that the silence is real. The eight on the shared-classification path emitted nothing anywhere, because reaching them needs the shared trie built and an empty front at the same time and no test supplied both.

That is what the new test is for. It compiles a ruleset that builds the shared trie, asserts the trie really was built rather than trusting the ruleset to have done it, and then runs one force-polled round with no packets. Before it, this module's own suite never reached its handler with an empty front — the only vehicle in the repository was a pipeline test nobody would associate with this module. Run against the pre-fix handler the new test lights all nineteen sites, including the eight, so it is a real vehicle and not a decoration.

It cannot assert the defect directly, and its doc comment says so rather than implying otherwise. A zero-length array here is undefined behaviour the handler never indexes, and on an empty round every module counter takes a zero delta while the per-module latency histogram is skipped entirely. What the test asserts instead is the reject path's one observable postcondition, that the module's whole counter vector is untouched — which also pins the caller's own guard against timing an empty round. Its value is reach: under a sanitizer build it is what turns a regression into a diagnostic. It is not a gate, because nothing here converts a sanitizer diagnostic into a failure — that gap is #2056.

With this the defect class is closed. The defining search for an array sized directly by the input-count call now returns nothing across the module, device, library and dataplane trees, mirror having been fixed in #2057, forward in #2062 and route-mpls in #2065.

Closes #2055.