### PR TITLE
refactor(gateway): enforce package encapsulation

### DIFF
--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -57,8 +57,8 @@ type ClosableService interface {
 
 // serviceEntry pairs a service with its declared backend kind.
 type serviceEntry struct {
-	service Service
-	kind    BackendKind
+	Service Service
+	Kind    BackendKind
 }
 
 // defaultPerServiceMethodLimit caps the number of distinct grpc_method label
@@ -96,14 +96,14 @@ type GatewayOption func(*gatewayOptions)
 // WithService adds an in-process module or device service to the Gateway.
 func WithService(service Service) GatewayOption {
 	return func(o *gatewayOptions) {
-		o.Services = append(o.Services, serviceEntry{service: service, kind: BackendKindInProcess})
+		o.Services = append(o.Services, serviceEntry{Service: service, Kind: BackendKindInProcess})
 	}
 }
 
 // WithBuiltinService adds a framework service that shares the gateway's own gRPC server.
 func WithBuiltinService(service Service) GatewayOption {
 	return func(o *gatewayOptions) {
-		o.Services = append(o.Services, serviceEntry{service: service, kind: BackendKindBuiltin})
+		o.Services = append(o.Services, serviceEntry{Service: service, Kind: BackendKindBuiltin})
 	}
 }
 
@@ -370,26 +370,26 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	var serviceRunners []*ServiceRunner
 
 	for _, entry := range opts.Services {
-		if entry.service.Endpoint() == "" {
+		if entry.Service.Endpoint() == "" {
 			// Shared-server service: register on the gateway's gRPC server and
 			// point every service name at the shared loopback backend using the
 			// declared kind.
-			entry.service.RegisterService(server)
+			entry.Service.RegisterService(server)
 
-			for _, name := range entry.service.ServicesNames() {
-				registry.RegisterBackend(name, loopback, entry.kind)
+			for _, name := range entry.Service.ServicesNames() {
+				registry.RegisterBackend(name, loopback, entry.Kind)
 				log.Info("registered service in registry",
 					zap.String("service", name),
-					zap.Stringer("kind", entry.kind),
+					zap.Stringer("kind", entry.Kind),
 				)
 			}
 		} else {
 			// Out-of-process: wrap in a ServiceRunner.
-			runner := NewServiceRunner(entry.service, endpoint, cfg.Server.TLS, WithServiceRunnerLog(log))
+			runner := NewServiceRunner(entry.Service, endpoint, cfg.Server.TLS, WithServiceRunnerLog(log))
 			serviceRunners = append(serviceRunners, runner)
 		}
 
-		services = append(services, entry.service)
+		services = append(services, entry.Service)
 	}
 
 	return &Gateway{
@@ -454,7 +454,7 @@ func (m *Gateway) Run(ctx context.Context) error {
 
 	for _, runner := range m.serviceRunners {
 		wg.Go(func() error {
-			m.log.Info("starting out-of-process service", zap.String("service", fmt.Sprintf("%T", runner.module)))
+			m.log.Info("starting out-of-process service", zap.String("service", runner.ServiceType()))
 			return runner.Run(ctx)
 		})
 	}

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -1,8 +1,7 @@
-package gateway
+package gateway_test
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"path/filepath"
 	"testing"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/gateway"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
@@ -51,27 +51,49 @@ func TestNewGateway_DeclaredKindsWired(t *testing.T) {
 		svcNames: []string{"test.InProcessService"},
 	}
 
-	cfg := DefaultConfig()
-	gw, err := NewGateway(cfg,
-		WithBuiltinService(builtinSvc),
-		WithService(inprocSvc),
+	cfg := gateway.DefaultConfig()
+	listener := NewTestListener(t)
+	gw, err := gateway.NewGateway(cfg, gateway.WithListener(listener),
+		gateway.WithBuiltinService(builtinSvc),
+		gateway.WithService(inprocSvc),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = gw.Close() })
 
-	entries := gw.registry.ListBackends()
-	kinds := map[string]BackendKind{}
-	for _, e := range entries {
-		kinds[e.Service()] = e.Kind()
+	ctx, cancel := context.WithCancel(t.Context())
+	var group errgroup.Group
+	group.Go(func() error { return gw.Run(ctx) })
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, group.Wait())
+	})
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := ynpb.NewGatewayClient(conn)
+	var response *ynpb.ListServicesResponse
+	require.Eventually(t, func() bool {
+		response, err = client.ListServices(t.Context(), &ynpb.ListServicesRequest{})
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond, "gateway did not become reachable")
+
+	kinds := map[string]ynpb.BackendKind{}
+	for _, entry := range response.GetServices() {
+		kinds[entry.GetBackend().GetName()] = entry.GetKind()
 	}
 
 	// Framework services registered with WithBuiltinService must be built-in.
-	require.Equal(t, BackendKindBuiltin, kinds["controlplane.ynpb.v1.Gateway"], "controlplane.ynpb.v1.Gateway must be built-in")
-	require.Equal(t, BackendKindBuiltin, kinds["controlplane.ynpb.v1.Auth"], "controlplane.ynpb.v1.Auth must be built-in")
-	require.Equal(t, BackendKindBuiltin, kinds["test.BuiltinService"], "WithBuiltinService must yield built-in kind")
+	require.Equal(t, ynpb.BackendKind_BACKEND_KIND_BUILTIN, kinds["controlplane.ynpb.v1.Gateway"], "controlplane.ynpb.v1.Gateway must be built-in")
+	require.Equal(t, ynpb.BackendKind_BACKEND_KIND_BUILTIN, kinds["controlplane.ynpb.v1.Auth"], "controlplane.ynpb.v1.Auth must be built-in")
+	require.Equal(t, ynpb.BackendKind_BACKEND_KIND_BUILTIN, kinds["test.BuiltinService"], "WithBuiltinService must yield built-in kind")
 
 	// Module/device services registered with WithService must be in-process.
-	require.Equal(t, BackendKindInProcess, kinds["test.InProcessService"], "WithService must yield in-process kind")
+	require.Equal(t, ynpb.BackendKind_BACKEND_KIND_IN_PROCESS, kinds["test.InProcessService"], "WithService must yield in-process kind")
+
+	cancel()
+	require.NoError(t, group.Wait())
 }
 
 // NewTestListener opens an ephemeral loopback TCP listener for a test to
@@ -163,10 +185,10 @@ func watchUntilOpen(
 func TestGateway_Run_ShutsDownWithOpenStream(t *testing.T) {
 	t.Parallel()
 
-	cfg := DefaultConfig()
+	cfg := gateway.DefaultConfig()
 	listener := NewTestListener(t)
 
-	gw, err := NewGateway(cfg, WithLog(zap.NewNop()), WithListener(listener))
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()), gateway.WithListener(listener))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = gw.Close() })
 
@@ -206,10 +228,10 @@ func TestGateway_Run_ShutsDownWithOpenStream(t *testing.T) {
 func TestGateway_Run_DrainsReadinessOnShutdown(t *testing.T) {
 	t.Parallel()
 
-	cfg := DefaultConfig()
+	cfg := gateway.DefaultConfig()
 	listener := NewTestListener(t)
 
-	gw, err := NewGateway(cfg, WithLog(zap.NewNop()), WithListener(listener))
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()), gateway.WithListener(listener))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = gw.Close() })
 
@@ -220,17 +242,20 @@ func TestGateway_Run_DrainsReadinessOnShutdown(t *testing.T) {
 		return gw.Run(ctx)
 	})
 
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	readinessClient := ynpb.NewReadinessServiceClient(conn)
 	require.Eventually(t, func() bool {
-		resp := gw.readinessTracker.Ready(&readinesspb.ReadyRequest{})
+		resp, readyErr := readinessClient.Ready(t.Context(), &readinesspb.ReadyRequest{})
+		if readyErr != nil {
+			return false
+		}
 		if len(resp.GetScopes()) != 1 {
 			return false
 		}
 		return resp.GetScopes()[0].GetState() == readinesspb.State_STATE_READY
 	}, 5*time.Second, 50*time.Millisecond, "gateway did not become ready")
-
-	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = conn.Close() })
 
 	watchCtx, watchCancel := context.WithCancel(t.Context())
 	t.Cleanup(watchCancel)
@@ -273,14 +298,6 @@ func TestGateway_Run_DrainsReadinessOnShutdown(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("Gateway.Run did not return within the shutdown grace period")
 	}
-
-	resp := gw.readinessTracker.Ready(&readinesspb.ReadyRequest{})
-	require.Len(t, resp.GetScopes(), 1)
-
-	scope := resp.GetScopes()[0]
-	require.Equal(t, readinesspb.State_STATE_NOT_READY, scope.GetState())
-	require.Len(t, scope.GetReasons(), 1)
-	require.Equal(t, "SHUTTING_DOWN", scope.GetReasons()[0].GetCode())
 }
 
 // TestGateway_Run_BindsOwnListenerWhenNoneInjected verifies that Run falls
@@ -293,10 +310,10 @@ func TestGateway_Run_BindsOwnListenerWhenNoneInjected(t *testing.T) {
 
 	occupied := NewTestListener(t)
 
-	cfg := DefaultConfig()
+	cfg := gateway.DefaultConfig()
 	cfg.Server.Endpoint = occupied.Addr().String()
 
-	gw, err := NewGateway(cfg, WithLog(zap.NewNop()))
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = gw.Close() })
 
@@ -313,10 +330,10 @@ func TestGateway_Run_BindsOwnListenerWhenNoneInjected(t *testing.T) {
 func TestGateway_Director_RegistryMissCarriesReasonTrailer(t *testing.T) {
 	t.Parallel()
 
-	cfg := DefaultConfig()
+	cfg := gateway.DefaultConfig()
 	listener := NewTestListener(t)
 
-	gw, err := NewGateway(cfg, WithLog(zap.NewNop()), WithListener(listener))
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()), gateway.WithListener(listener))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = gw.Close() })
 
@@ -377,7 +394,7 @@ func TestServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
 	require.NoError(t, err)
 
 	gatewayServer := grpc.NewServer()
-	ynpb.RegisterGatewayServer(gatewayServer, NewGatewayService(NewBackendRegistry()))
+	ynpb.RegisterGatewayServer(gatewayServer, gateway.NewGatewayService(gateway.NewBackendRegistry()))
 
 	var gatewayGroup errgroup.Group
 	gatewayGroup.Go(func() error {
@@ -393,7 +410,7 @@ func TestServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
 	})
 
 	backendAddr := filepath.Join(t.TempDir(), "runner.sock")
-	runner := NewServiceRunner(
+	runner := gateway.NewServiceRunner(
 		&blockingReadinessService{endpoint: backendAddr},
 		gatewayListener.Addr().String(),
 		nil,
@@ -432,178 +449,199 @@ func TestServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
 	}
 }
 
-// TestGateway_RunRegistrySweeper_PreserveModeShortCircuits verifies that
-// PreserveStaleBackends returns immediately without touching a long-stale
-// external entry.
-func TestGateway_RunRegistrySweeper_PreserveModeShortCircuits(t *testing.T) {
+// TestGateway_RunRegistrySweeper_PreserveModeKeepsStaleExternal verifies that
+// PreserveStaleBackends keeps a registered external service visible.
+func TestGateway_RunRegistrySweeper_PreserveModeKeepsStaleExternal(t *testing.T) {
 	t.Parallel()
 
-	reg := NewBackendRegistry()
-	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+	cfg := gateway.DefaultConfig()
+	cfg.Registry.PreserveStaleBackends = true
+	cfg.Registry.TTL = xcfg.MustNonZero(time.Millisecond)
+	cfg.Registry.SweepInterval = xcfg.MustNonZero(5 * time.Millisecond)
+	listener := NewTestListener(t)
 
-	entry := reg.backends["svc.Foo"]
-	entry.lastSeenAt = time.Now().UTC().Add(-24 * time.Hour)
-	reg.backends["svc.Foo"] = entry
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()), gateway.WithListener(listener))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
 
-	gw := &Gateway{
-		cfg: &Config{
-			Registry: RegistryConfig{
-				PreserveStaleBackends: true,
-				TTL:                   xcfg.MustNonZero(time.Minute),
-				SweepInterval:         xcfg.MustNonZero(time.Second),
-			},
-		},
-		registry: reg,
-		log:      zap.NewNop(),
-	}
-
-	done := make(chan error, 1)
-	go func() { done <- gw.runRegistrySweeper(t.Context()) }()
-
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("runRegistrySweeper did not return promptly in preserve mode")
-	}
-
-	require.False(t, b.Closed(), "preserved backend must not be closed")
-
-	_, ok := reg.backends["svc.Foo"]
-	require.True(t, ok, "preserved entry must remain registered")
-}
-
-// TestGateway_RunRegistrySweeper_EvictsStaleExternal verifies that a stale
-// external entry is evicted and its backend closed once the sweeper's
-// ticker fires.
-func TestGateway_RunRegistrySweeper_EvictsStaleExternal(t *testing.T) {
-	t.Parallel()
-
-	reg := NewBackendRegistry()
-	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
-
-	entry := reg.backends["svc.Foo"]
-	entry.lastSeenAt = time.Now().UTC().Add(-time.Hour)
-	reg.backends["svc.Foo"] = entry
-
-	gw := &Gateway{
-		cfg: &Config{
-			Registry: RegistryConfig{
-				TTL:           xcfg.MustNonZero(time.Millisecond),
-				SweepInterval: xcfg.MustNonZero(5 * time.Millisecond),
-			},
-		},
-		registry: reg,
-		log:      zap.NewNop(),
-	}
-
-	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
+	var group errgroup.Group
+	group.Go(func() error { return gw.Run(ctx) })
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, group.Wait())
+	})
 
-	done := make(chan error, 1)
-	go func() { done <- gw.runRegistrySweeper(ctx) }()
+	backendAddr, entered, results := newCancelProbeServer(t)
 
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	client := ynpb.NewGatewayClient(conn)
 	require.Eventually(t, func() bool {
-		return b.Closed()
-	}, time.Second, 5*time.Millisecond, "stale external backend must be evicted and closed")
+		_, err = client.ListServices(t.Context(), &ynpb.ListServicesRequest{})
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond, "gateway did not become reachable")
 
-	cancel()
+	_, err = client.Register(t.Context(), &ynpb.RegisterRequest{Backend: &ynpb.BackendDesc{
+		Name: cancelProbeServiceName, Endpoint: backendAddr,
+	}})
+	require.NoError(t, err)
 
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("runRegistrySweeper did not return after cancel")
-	}
+	time.Sleep(50 * time.Millisecond)
+	response, err := client.ListServices(t.Context(), &ynpb.ListServicesRequest{})
+	require.NoError(t, err)
+	services := response.GetServices()
+	require.True(t, hasService(services, cancelProbeServiceName), "preserved entry must remain registered")
 
-	_, ok := reg.backends["svc.Foo"]
-	require.False(t, ok, "evicted entry must be removed from the registry")
-}
-
-// TestGateway_RunRegistrySweeper_ZeroSweepIntervalFallsBack verifies that a
-// programmatic RegistryConfig with a zero SweepInterval falls back to the
-// default instead of panicking.
-//
-// A zero interval reaches time.NewTicker directly, which panics. The
-// fallback is the guard against that.
-func TestGateway_RunRegistrySweeper_ZeroSweepIntervalFallsBack(t *testing.T) {
-	t.Parallel()
-
-	reg := NewBackendRegistry()
-
-	gw := &Gateway{
-		cfg: &Config{
-			Registry: RegistryConfig{
-				TTL: xcfg.MustNonZero(time.Minute),
-			},
-		},
-		registry: reg,
-		log:      zap.NewNop(),
-	}
-
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
-
-	done := make(chan error, 1)
+	invokeCtx, invokeCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	invokeDone := make(chan error, 1)
 	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				done <- fmt.Errorf("runRegistrySweeper panicked: %v", r)
-			}
-		}()
-		done <- gw.runRegistrySweeper(ctx)
+		invokeDone <- conn.Invoke(invokeCtx, cancelProbeFullMethod, &emptypb.Empty{}, &emptypb.Empty{})
 	}()
 
 	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("runRegistrySweeper did not return after context timeout")
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("preserved backend did not receive the proxied request")
 	}
+
+	invokeCancel()
+	select {
+	case observation := <-results:
+		require.ErrorIs(t, observation.err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("preserved backend did not observe request cancellation")
+	}
+	select {
+	case invokeErr := <-invokeDone:
+		require.Equal(t, codes.Canceled, status.Code(invokeErr))
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxied request did not complete after cancellation")
+	}
+
+	cancel()
+	require.NoError(t, group.Wait())
 }
 
-// TestGateway_RunRegistrySweeper_ZeroTTLFallsBack verifies that a
-// programmatic RegistryConfig with a zero TTL falls back to the default
-// instead of evicting a live entry on the first sweep.
-//
-// The sweep interval is small and positive so a sweep genuinely runs before
-// the test's deadline. The fallback TTL must still land far enough in the
-// past to spare an entry seen moments ago, or the cutoff would land at or
-// after time.Now and wipe every live backend on the first sweep.
-func TestGateway_RunRegistrySweeper_ZeroTTLFallsBack(t *testing.T) {
+// TestGateway_RunRegistrySweeper_EvictsStaleExternal verifies that the
+// gateway removes an external service after its TTL expires.
+func TestGateway_RunRegistrySweeper_EvictsStaleExternal(t *testing.T) {
 	t.Parallel()
 
-	reg := NewBackendRegistry()
-	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+	cfg := gateway.DefaultConfig()
+	cfg.Registry.TTL = xcfg.MustNonZero(time.Millisecond)
+	cfg.Registry.SweepInterval = xcfg.MustNonZero(5 * time.Millisecond)
+	listener := NewTestListener(t)
 
-	gw := &Gateway{
-		cfg: &Config{
-			Registry: RegistryConfig{
-				SweepInterval: xcfg.MustNonZero(5 * time.Millisecond),
-			},
-		},
-		registry: reg,
-		log:      zap.NewNop(),
-	}
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()), gateway.WithListener(listener))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var group errgroup.Group
+	group.Go(func() error { return gw.Run(ctx) })
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, group.Wait())
+	})
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	client := ynpb.NewGatewayClient(conn)
+	require.Eventually(t, func() bool {
+		_, err = client.ListServices(t.Context(), &ynpb.ListServicesRequest{})
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond, "gateway did not become reachable")
+
+	_, err = client.Register(t.Context(), &ynpb.RegisterRequest{Backend: &ynpb.BackendDesc{
+		Name: "svc.Foo", Endpoint: "127.0.0.1:9000",
+	}})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		response, listErr := client.ListServices(t.Context(), &ynpb.ListServicesRequest{})
+		return listErr == nil && !hasService(response.GetServices(), "svc.Foo")
+	}, time.Second, 5*time.Millisecond, "stale external backend must be evicted")
+
+	cancel()
+	require.NoError(t, group.Wait())
+}
+
+// TestGateway_RunRegistrySweeper_ZeroSweepIntervalFallsBack verifies that a
+// zero sweep interval does not panic when Gateway.Run starts the sweeper.
+func TestGateway_RunRegistrySweeper_ZeroSweepIntervalFallsBack(t *testing.T) {
+	t.Parallel()
+
+	cfg := gateway.DefaultConfig()
+	cfg.Registry.SweepInterval = xcfg.NonZero[time.Duration]{}
+	listener := NewTestListener(t)
+
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()), gateway.WithListener(listener))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
 
 	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
+	var group errgroup.Group
+	group.Go(func() error { return gw.Run(ctx) })
 
-	done := make(chan error, 1)
-	go func() { done <- gw.runRegistrySweeper(ctx) }()
+	require.NoError(t, group.Wait())
+}
 
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("runRegistrySweeper did not return after context timeout")
+// TestGateway_RunRegistrySweeper_ZeroTTLFallsBack verifies that a zero TTL
+// does not evict a live external service on the first sweep.
+func TestGateway_RunRegistrySweeper_ZeroTTLFallsBack(t *testing.T) {
+	t.Parallel()
+
+	cfg := gateway.DefaultConfig()
+	cfg.Registry.TTL = xcfg.NonZero[time.Duration]{}
+	cfg.Registry.SweepInterval = xcfg.MustNonZero(5 * time.Millisecond)
+	listener := NewTestListener(t)
+
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()), gateway.WithListener(listener))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var group errgroup.Group
+	group.Go(func() error { return gw.Run(ctx) })
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, group.Wait())
+	})
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	client := ynpb.NewGatewayClient(conn)
+	require.Eventually(t, func() bool {
+		_, err = client.ListServices(t.Context(), &ynpb.ListServicesRequest{})
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond, "gateway did not become reachable")
+
+	_, err = client.Register(t.Context(), &ynpb.RegisterRequest{Backend: &ynpb.BackendDesc{
+		Name: "svc.Foo", Endpoint: "127.0.0.1:9000",
+	}})
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	response, err := client.ListServices(t.Context(), &ynpb.ListServicesRequest{})
+	require.NoError(t, err)
+	require.True(t, hasService(response.GetServices(), "svc.Foo"), "live entry must survive the fallback ttl")
+
+	cancel()
+	require.NoError(t, group.Wait())
+}
+
+func hasService(services []*ynpb.RegisteredBackend, name string) bool {
+	for _, service := range services {
+		if service.GetBackend().GetName() == name {
+			return true
+		}
 	}
 
-	require.False(t, b.Closed(), "live entry must survive the fallback ttl")
-
-	_, ok := reg.backends["svc.Foo"]
-	require.True(t, ok, "live entry must remain registered")
+	return false
 }

--- a/controlplane/gateway/metrics_service.go
+++ b/controlplane/gateway/metrics_service.go
@@ -43,7 +43,7 @@ func (m *MetricsService) GetMetrics(
 func metricsCollectors(server metricsCollector, entries []serviceEntry) []metricsCollector {
 	collectors := []metricsCollector{server}
 	for _, entry := range entries {
-		if collector, ok := entry.service.(metricsCollector); ok {
+		if collector, ok := entry.Service.(metricsCollector); ok {
 			collectors = append(collectors, collector)
 		}
 	}

--- a/controlplane/gateway/proxy_context_test.go
+++ b/controlplane/gateway/proxy_context_test.go
@@ -103,7 +103,7 @@ func startCancelProbeGateway(t *testing.T) (gatewayAddr string, entered chan str
 	t.Helper()
 
 	cfg := gateway.DefaultConfig()
-	listener := gateway.NewTestListener(t)
+	listener := NewTestListener(t)
 
 	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()), gateway.WithListener(listener))
 	require.NoError(t, err)

--- a/controlplane/gateway/readiness_test.go
+++ b/controlplane/gateway/readiness_test.go
@@ -1,18 +1,31 @@
-package gateway
+package gateway_test
 
 import (
+	"context"
+	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/gateway"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
+
+const testGatewayReadinessScope = "gateway"
 
 func newTestTracker() *readiness.Tracker {
 	return readiness.NewTracker(
-		[]string{gatewayReadinessScope},
+		[]string{testGatewayReadinessScope},
 		readiness.WithDrainLatch(),
 		readiness.WithLog(zap.NewNop()),
 	)
@@ -25,7 +38,7 @@ func TestReadinessTracker_InitialState(t *testing.T) {
 	require.Len(t, resp.GetScopes(), 1)
 
 	scope := resp.GetScopes()[0]
-	require.Equal(t, "gateway", scope.GetName())
+	require.Equal(t, testGatewayReadinessScope, scope.GetName())
 	require.Equal(t, readinesspb.State_STATE_UNKNOWN, scope.GetState())
 	require.Nil(t, scope.GetObservedAt())
 	require.Nil(t, scope.GetLastTransitionTime())
@@ -33,7 +46,7 @@ func TestReadinessTracker_InitialState(t *testing.T) {
 
 func TestReadinessTracker_AfterReady(t *testing.T) {
 	tracker := newTestTracker()
-	tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
+	tracker.Set(testGatewayReadinessScope, readinesspb.State_STATE_READY)
 
 	resp := tracker.Ready(&readinesspb.ReadyRequest{})
 	require.Len(t, resp.GetScopes(), 1)
@@ -47,7 +60,7 @@ func TestReadinessTracker_AfterReady(t *testing.T) {
 
 func TestReadinessTracker_AfterDrain(t *testing.T) {
 	tracker := newTestTracker()
-	tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
+	tracker.Set(testGatewayReadinessScope, readinesspb.State_STATE_READY)
 	tracker.Drain()
 
 	resp := tracker.Ready(&readinesspb.ReadyRequest{})
@@ -76,7 +89,7 @@ func TestReadinessTracker_SnapshotFilter(t *testing.T) {
 		},
 		{
 			name:        "explicit gateway filter returns gateway scope",
-			filter:      []string{"gateway"},
+			filter:      []string{testGatewayReadinessScope},
 			wantScopes:  1,
 			wantGateway: true,
 		},
@@ -90,13 +103,13 @@ func TestReadinessTracker_SnapshotFilter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tracker := newTestTracker()
-			tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
+			tracker.Set(testGatewayReadinessScope, readinesspb.State_STATE_READY)
 
 			resp := tracker.Ready(&readinesspb.ReadyRequest{Scopes: tc.filter})
 			require.Len(t, resp.GetScopes(), tc.wantScopes)
 
 			if tc.wantGateway {
-				require.Equal(t, "gateway", resp.GetScopes()[0].GetName())
+				require.Equal(t, testGatewayReadinessScope, resp.GetScopes()[0].GetName())
 			}
 		})
 	}
@@ -104,9 +117,9 @@ func TestReadinessTracker_SnapshotFilter(t *testing.T) {
 
 func TestReadinessTracker_ReadyAfterDrainIsNoop(t *testing.T) {
 	tracker := newTestTracker()
-	tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
+	tracker.Set(testGatewayReadinessScope, readinesspb.State_STATE_READY)
 	tracker.Drain()
-	tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
+	tracker.Set(testGatewayReadinessScope, readinesspb.State_STATE_READY)
 
 	resp := tracker.Ready(&readinesspb.ReadyRequest{})
 	require.Len(t, resp.GetScopes(), 1)
@@ -117,37 +130,121 @@ func TestReadinessTracker_ReadyAfterDrainIsNoop(t *testing.T) {
 	require.Equal(t, "SHUTTING_DOWN", scope.GetReasons()[0].GetCode())
 }
 
-// TestNewGateway_ReadinessTrackerLatchesDrain verifies that the gateway
-// wires its readiness tracker with the drain latch, so a late Set to ready
-// after Drain cannot undo the shutdown state, and not just that the
-// underlying tracker library supports the latch.
-func TestNewGateway_ReadinessTrackerLatchesDrain(t *testing.T) {
-	cfg := DefaultConfig()
-
-	gw, err := NewGateway(cfg, WithLog(zap.NewNop()))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = gw.Close() })
-
-	gw.readinessTracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
-	gw.readinessTracker.Drain()
-	gw.readinessTracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
-
-	resp := gw.readinessTracker.Ready(&readinesspb.ReadyRequest{})
-	require.Len(t, resp.GetScopes(), 1)
-
-	scope := resp.GetScopes()[0]
-	require.Equal(t, readinesspb.State_STATE_NOT_READY, scope.GetState())
-	require.Len(t, scope.GetReasons(), 1)
-	require.Equal(t, "SHUTTING_DOWN", scope.GetReasons()[0].GetCode())
-}
-
 func TestReadinessService_Ready(t *testing.T) {
 	tracker := newTestTracker()
-	tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
+	tracker.Set(testGatewayReadinessScope, readinesspb.State_STATE_READY)
 
-	svc := NewReadinessService(tracker)
+	svc := gateway.NewReadinessService(tracker)
 	resp, err := svc.Ready(t.Context(), &readinesspb.ReadyRequest{})
 	require.NoError(t, err)
 	require.Len(t, resp.GetScopes(), 1)
 	require.Equal(t, readinesspb.State_STATE_READY, resp.GetScopes()[0].GetState())
+}
+
+type readinessLatchService struct {
+	endpoint string
+}
+
+func (m *readinessLatchService) Name() string {
+	return "readiness-latch-service"
+}
+
+func (m *readinessLatchService) Endpoint() string {
+	return m.endpoint
+}
+
+func (m *readinessLatchService) ServicesNames() []string {
+	return []string{"test.ReadinessLatchService"}
+}
+
+func (m *readinessLatchService) RegisterService(_ *grpc.Server) {}
+
+// TestGateway_Run_ReadinessDrainLatchesLateReady verifies through the public
+// run and readiness surfaces that a late READY attempt after shutdown drain
+// cannot restore the gateway's readiness state.
+func TestGateway_Run_ReadinessDrainLatchesLateReady(t *testing.T) {
+	t.Parallel()
+
+	core, observed := observer.New(zap.InfoLevel)
+	readyLogEntered := make(chan struct{})
+	releaseReadyLog := make(chan struct{})
+	var readyLogOnce sync.Once
+	var releaseReadyLogOnce sync.Once
+	releaseReadyLogFunc := func() {
+		releaseReadyLogOnce.Do(func() { close(releaseReadyLog) })
+	}
+	t.Cleanup(releaseReadyLogFunc)
+	log := zap.New(core, zap.Hooks(func(entry zapcore.Entry) error {
+		if entry.Message == "all built-in modules ready" {
+			readyLogOnce.Do(func() { close(readyLogEntered) })
+			<-releaseReadyLog
+		}
+		return nil
+	}))
+
+	listener := NewTestListener(t)
+	service := &readinessLatchService{
+		endpoint: filepath.Join(t.TempDir(), "readiness-latch.sock"),
+	}
+	gw, err := gateway.NewGateway(
+		gateway.DefaultConfig(),
+		gateway.WithLog(log),
+		gateway.WithListener(listener),
+		gateway.WithService(service),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var group errgroup.Group
+	group.Go(func() error { return gw.Run(ctx) })
+	t.Cleanup(func() {
+		cancel()
+		releaseReadyLogFunc()
+		_ = group.Wait()
+	})
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	client := ynpb.NewGatewayClient(conn)
+	require.Eventually(t, func() bool {
+		response, listErr := client.ListServices(t.Context(), &ynpb.ListServicesRequest{})
+		if listErr != nil {
+			return false
+		}
+		for _, entry := range response.GetServices() {
+			if entry.GetBackend().GetName() == "test.ReadinessLatchService" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 50*time.Millisecond, "service runner did not register")
+
+	select {
+	case <-readyLogEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("gateway readiness publication did not reach the log hook")
+	}
+
+	watchCtx, watchCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(watchCancel)
+	stream := watchUntilOpen(t, watchCtx, ynpb.NewReadinessServiceClient(conn))
+
+	cancel()
+	response, err := stream.Recv()
+	require.NoError(t, err)
+	require.Len(t, response.GetScopes(), 1)
+	require.Equal(t, readinesspb.State_STATE_NOT_READY, response.GetScopes()[0].GetState())
+	require.Equal(t, "SHUTTING_DOWN", response.GetScopes()[0].GetReasons()[0].GetCode())
+
+	releaseReadyLogFunc()
+	watchCancel()
+	require.NoError(t, group.Wait())
+
+	transitions := observed.FilterMessage("readiness scope transitioned").All()
+	require.Len(t, transitions, 1, "late READY must not produce a post-drain transition")
+	fields := transitions[0].ContextMap()
+	require.Equal(t, readinesspb.State_STATE_NOT_READY.String(), fields["to"])
+	require.Equal(t, "SHUTTING_DOWN", fields["reason"])
 }

--- a/controlplane/gateway/registration_loop_test.go
+++ b/controlplane/gateway/registration_loop_test.go
@@ -40,7 +40,7 @@ func TestGateway_RegistrationLoop_SurvivesSweepsThatEvictOneShot(t *testing.T) {
 	t.Parallel()
 
 	cfg := gateway.DefaultConfig()
-	listener := gateway.NewTestListener(t)
+	listener := NewTestListener(t)
 	cfg.Registry.TTL = xcfg.MustNonZero(time.Second)
 	cfg.Registry.SweepInterval = xcfg.MustNonZero(25 * time.Millisecond)
 

--- a/controlplane/gateway/registry.go
+++ b/controlplane/gateway/registry.go
@@ -126,6 +126,15 @@ type BackendRegistry struct {
 	refs     map[Backend]*backendRef
 }
 
+func newBackendEntry(service string, backend Backend, kind BackendKind, lastSeenAt time.Time) BackendEntry {
+	return BackendEntry{
+		service:    service,
+		backend:    backend,
+		kind:       kind,
+		lastSeenAt: lastSeenAt,
+	}
+}
+
 // NewBackendRegistry creates a new BackendRegistry.
 func NewBackendRegistry() *BackendRegistry {
 	return &BackendRegistry{
@@ -153,7 +162,7 @@ func (m *BackendRegistry) GetBackend(service string) (proxy.Backend, func(), boo
 		return nil, func() {}, false
 	}
 
-	ref := m.refs[entry.backend]
+	ref := m.refs[entry.GetBackend()]
 	ref.Retain()
 	m.mu.RUnlock()
 
@@ -239,19 +248,17 @@ func (m *BackendRegistry) registerBackend(service string, b Backend, kind Backen
 
 	existing, ok := m.backends[service]
 	switch {
-	case ok && existing.backend.Endpoint() == b.Endpoint():
-		existing.lastSeenAt = now
-		m.backends[service] = existing
+	case ok && m.renewLocked(service, b.Endpoint(), now):
 		if _, tracked := m.refs[b]; tracked {
 			return RegistrationRenewed, nil
 		}
 		return RegistrationRenewed, b
 	case ok:
-		m.backends[service] = BackendEntry{service: service, backend: b, kind: kind, lastSeenAt: now}
+		m.backends[service] = newBackendEntry(service, b, kind, now)
 		m.retainLocked(b)
-		return RegistrationUpdated, m.releaseLocked(existing.backend)
+		return RegistrationUpdated, m.releaseLocked(existing.GetBackend())
 	default:
-		m.backends[service] = BackendEntry{service: service, backend: b, kind: kind, lastSeenAt: now}
+		m.backends[service] = newBackendEntry(service, b, kind, now)
 		m.retainLocked(b)
 		return RegistrationRegistered, nil
 	}
@@ -309,14 +316,25 @@ func (m *BackendRegistry) Renew(service, endpoint string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.renewLocked(service, endpoint, time.Now().UTC())
+}
+
+// renewLocked refreshes the matching entry and reports whether it exists.
+//
+// Must be called with m.mu held for writing.
+func (m *BackendRegistry) renewLocked(service, endpoint string, now time.Time) bool {
 	entry, ok := m.backends[service]
-	if ok && entry.backend.Endpoint() == endpoint {
-		entry.lastSeenAt = time.Now().UTC()
-		m.backends[service] = entry
-		return true
+	if !ok || entry.Endpoint() != endpoint {
+		return false
 	}
 
-	return false
+	m.backends[service] = newBackendEntry(
+		entry.Service(),
+		entry.GetBackend(),
+		entry.Kind(),
+		now,
+	)
+	return true
 }
 
 // Close closes all backend connections without holding the registry lock.
@@ -395,8 +413,7 @@ func (m *BackendRegistry) ListBackends() []BackendEntry {
 	defer m.mu.RUnlock()
 
 	services := make([]BackendEntry, 0, len(m.backends))
-	for name, entry := range m.backends {
-		entry.service = name
+	for _, entry := range m.backends {
 		services = append(services, entry)
 	}
 

--- a/controlplane/gateway/registry_test.go
+++ b/controlplane/gateway/registry_test.go
@@ -1,4 +1,4 @@
-package gateway
+package gateway_test
 
 import (
 	"context"
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/yanet-platform/yanet2/controlplane/gateway"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
@@ -66,34 +66,46 @@ func (m *fakeBackend) CloseCount() int {
 
 // Ensure fakeBackend satisfies both interfaces at compile time.
 var _ proxy.Backend = (*fakeBackend)(nil)
-var _ Backend = (*fakeBackend)(nil)
+var _ gateway.Backend = (*fakeBackend)(nil)
+
+func getBackendEntry(t *testing.T, registry *gateway.BackendRegistry, service string) *gateway.BackendEntry {
+	t.Helper()
+
+	for _, entry := range registry.ListBackends() {
+		if entry.Service() == service {
+			return &entry
+		}
+	}
+
+	t.Fatalf("backend %q is not registered", service)
+	return &gateway.BackendEntry{}
+}
 
 func TestBackendRegistry_FirstRegistration(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
 
-	status := reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+	status := reg.RegisterBackend("svc.Foo", b, gateway.BackendKindExternal)
 
-	require.Equal(t, RegistrationRegistered, status)
+	require.Equal(t, gateway.RegistrationRegistered, status)
 	require.False(t, b.Closed())
 
-	entry, ok := reg.backends["svc.Foo"]
-	require.True(t, ok)
+	entry := getBackendEntry(t, reg, "svc.Foo")
 	require.Equal(t, "127.0.0.1:9000", entry.Endpoint())
 }
 
 func TestBackendRegistry_SameEndpointRenews(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	original := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", original, BackendKindExternal)
+	reg.RegisterBackend("svc.Foo", original, gateway.BackendKindExternal)
 
 	// Re-register with a different object but the same endpoint and a claimed
 	// kind change.
 	second := &fakeBackend{endpoint: "127.0.0.1:9000"}
 
-	status := reg.RegisterBackend("svc.Foo", second, BackendKindInProcess)
+	status := reg.RegisterBackend("svc.Foo", second, gateway.BackendKindInProcess)
 
-	require.Equal(t, RegistrationRenewed, status)
+	require.Equal(t, gateway.RegistrationRenewed, status)
 
 	// The redundant new backend must be closed.
 	require.True(t, second.Closed(), "redundant backend should be closed")
@@ -101,27 +113,26 @@ func TestBackendRegistry_SameEndpointRenews(t *testing.T) {
 	// The original backend must still be open and retained.
 	require.False(t, original.Closed(), "original backend must remain open")
 
-	entry, ok := reg.backends["svc.Foo"]
-	require.True(t, ok)
-	require.Equal(t, original, entry.backend)
+	entry := getBackendEntry(t, reg, "svc.Foo")
+	require.Equal(t, original, entry.GetBackend())
 
 	// The kind claim must have no effect: it is fixed at registration.
-	require.Equal(t, BackendKindExternal, entry.Kind())
+	require.Equal(t, gateway.BackendKindExternal, entry.Kind())
 }
 
 // TestBackendRegistry_DifferentEndpointUpdates verifies that a registration
 // at a changed endpoint replaces the entry and closes the now-unreferenced
 // previous backend exactly once.
 func TestBackendRegistry_DifferentEndpointUpdates(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	prev := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", prev, BackendKindExternal)
+	reg.RegisterBackend("svc.Foo", prev, gateway.BackendKindExternal)
 
 	next := &fakeBackend{endpoint: "127.0.0.1:9001"}
 
-	status := reg.RegisterBackend("svc.Foo", next, BackendKindExternal)
+	status := reg.RegisterBackend("svc.Foo", next, gateway.BackendKindExternal)
 
-	require.Equal(t, RegistrationUpdated, status)
+	require.Equal(t, gateway.RegistrationUpdated, status)
 
 	// The previous backend must be closed exactly once.
 	require.Equal(t, 1, prev.CloseCount(), "previous backend should be closed exactly once")
@@ -129,9 +140,8 @@ func TestBackendRegistry_DifferentEndpointUpdates(t *testing.T) {
 	// The new backend must be open.
 	require.False(t, next.Closed(), "new backend must remain open")
 
-	entry, ok := reg.backends["svc.Foo"]
-	require.True(t, ok)
-	require.Equal(t, next, entry.backend)
+	entry := getBackendEntry(t, reg, "svc.Foo")
+	require.Equal(t, next, entry.GetBackend())
 	require.Equal(t, "127.0.0.1:9001", entry.Endpoint())
 }
 
@@ -142,16 +152,16 @@ func TestBackendRegistry_DifferentEndpointUpdates(t *testing.T) {
 // This guards the invariant that admitting a not-yet-known name never
 // depends on which kind is claimed for it.
 func TestBackendRegistry_FreshNameSucceedsForEveryKind(t *testing.T) {
-	kinds := []BackendKind{BackendKindBuiltin, BackendKindInProcess, BackendKindExternal}
+	kinds := []gateway.BackendKind{gateway.BackendKindBuiltin, gateway.BackendKindInProcess, gateway.BackendKindExternal}
 
 	for _, kind := range kinds {
 		t.Run(kind.String(), func(t *testing.T) {
-			reg := NewBackendRegistry()
+			reg := gateway.NewBackendRegistry()
 			b := &fakeBackend{endpoint: "127.0.0.1:9000"}
 
 			regStatus := reg.RegisterBackend("svc.Foo", b, kind)
 
-			require.Equal(t, RegistrationRegistered, regStatus)
+			require.Equal(t, gateway.RegistrationRegistered, regStatus)
 			require.False(t, b.Closed())
 		})
 	}
@@ -166,24 +176,22 @@ func TestBackendRegistry_FreshNameSucceedsForEveryKind(t *testing.T) {
 // closing it out from under the names that still use it would take down
 // every one of those services, not just the displaced name.
 func TestBackendRegistry_DisplacingOneOfSeveralSharedNamesKeepsBackendOpen(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	shared := &fakeBackend{endpoint: "127.0.0.1:8080"}
-	reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
-	reg.RegisterBackend("svc.B", shared, BackendKindBuiltin)
+	reg.RegisterBackend("svc.A", shared, gateway.BackendKindBuiltin)
+	reg.RegisterBackend("svc.B", shared, gateway.BackendKindBuiltin)
 
 	other := &fakeBackend{endpoint: "127.0.0.1:9999"}
-	status := reg.RegisterBackend("svc.A", other, BackendKindExternal)
+	status := reg.RegisterBackend("svc.A", other, gateway.BackendKindExternal)
 
-	require.Equal(t, RegistrationUpdated, status)
+	require.Equal(t, gateway.RegistrationUpdated, status)
 	require.False(t, shared.Closed(), "the shared backend must not be closed")
 
-	entryA, ok := reg.backends["svc.A"]
-	require.True(t, ok)
-	require.Equal(t, other, entryA.backend)
+	entryA := getBackendEntry(t, reg, "svc.A")
+	require.Equal(t, other, entryA.GetBackend())
 
-	entryB, ok := reg.backends["svc.B"]
-	require.True(t, ok)
-	require.Equal(t, shared, entryB.backend)
+	entryB := getBackendEntry(t, reg, "svc.B")
+	require.Equal(t, shared, entryB.GetBackend())
 }
 
 // TestBackendRegistry_DisplacingLastSharedNameClosesBackend verifies that
@@ -191,24 +199,23 @@ func TestBackendRegistry_DisplacingOneOfSeveralSharedNamesKeepsBackendOpen(t *te
 // it, exactly once, so the fix does not simply leak every displaced
 // connection.
 func TestBackendRegistry_DisplacingLastSharedNameClosesBackend(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	shared := &fakeBackend{endpoint: "127.0.0.1:8080"}
-	reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
-	reg.RegisterBackend("svc.B", shared, BackendKindBuiltin)
+	reg.RegisterBackend("svc.A", shared, gateway.BackendKindBuiltin)
+	reg.RegisterBackend("svc.B", shared, gateway.BackendKindBuiltin)
 
 	otherA := &fakeBackend{endpoint: "127.0.0.1:9998"}
-	reg.RegisterBackend("svc.A", otherA, BackendKindExternal)
+	reg.RegisterBackend("svc.A", otherA, gateway.BackendKindExternal)
 	require.False(t, shared.Closed(), "the shared backend must remain open while svc.B references it")
 
 	otherB := &fakeBackend{endpoint: "127.0.0.1:9999"}
-	status := reg.RegisterBackend("svc.B", otherB, BackendKindExternal)
+	status := reg.RegisterBackend("svc.B", otherB, gateway.BackendKindExternal)
 
-	require.Equal(t, RegistrationUpdated, status)
+	require.Equal(t, gateway.RegistrationUpdated, status)
 	require.Equal(t, 1, shared.CloseCount(), "the last-referenced backend must be closed exactly once")
 
-	entryB, ok := reg.backends["svc.B"]
-	require.True(t, ok)
-	require.Equal(t, otherB, entryB.backend)
+	entryB := getBackendEntry(t, reg, "svc.B")
+	require.Equal(t, otherB, entryB.GetBackend())
 }
 
 // TestBackendRegistry_RenewingWithASharedBackendKeepsItOpen verifies that
@@ -221,32 +228,30 @@ func TestBackendRegistry_DisplacingLastSharedNameClosesBackend(t *testing.T) {
 // svc.B, even though the renewal branch treats the passed-in backend as
 // redundant.
 func TestBackendRegistry_RenewingWithASharedBackendKeepsItOpen(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	shared := &fakeBackend{endpoint: "127.0.0.1:8080"}
-	reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
-	reg.RegisterBackend("svc.B", shared, BackendKindBuiltin)
+	reg.RegisterBackend("svc.A", shared, gateway.BackendKindBuiltin)
+	reg.RegisterBackend("svc.B", shared, gateway.BackendKindBuiltin)
 
-	status := reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
+	status := reg.RegisterBackend("svc.A", shared, gateway.BackendKindBuiltin)
 
-	require.Equal(t, RegistrationRenewed, status)
+	require.Equal(t, gateway.RegistrationRenewed, status)
 	require.False(t, shared.Closed(), "the shared backend must not be closed")
 
-	entryA, ok := reg.backends["svc.A"]
-	require.True(t, ok)
-	require.Equal(t, shared, entryA.backend)
+	entryA := getBackendEntry(t, reg, "svc.A")
+	require.Equal(t, shared, entryA.GetBackend())
 
-	entryB, ok := reg.backends["svc.B"]
-	require.True(t, ok)
-	require.Equal(t, shared, entryB.backend)
+	entryB := getBackendEntry(t, reg, "svc.B")
+	require.Equal(t, shared, entryB.GetBackend())
 }
 
 func TestBackendRegistry_Close(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	bA := &fakeBackend{endpoint: "127.0.0.1:9000"}
 	bB := &fakeBackend{endpoint: "127.0.0.1:9001"}
 
-	reg.RegisterBackend("svc.A", bA, BackendKindExternal)
-	reg.RegisterBackend("svc.B", bB, BackendKindExternal)
+	reg.RegisterBackend("svc.A", bA, gateway.BackendKindExternal)
+	reg.RegisterBackend("svc.B", bB, gateway.BackendKindExternal)
 
 	err := reg.Close()
 	require.NoError(t, err)
@@ -255,17 +260,17 @@ func TestBackendRegistry_Close(t *testing.T) {
 	require.True(t, bB.Closed(), "bB should be closed")
 
 	// Registry must be empty after Close.
-	require.Empty(t, reg.backends)
+	require.Empty(t, reg.ListBackends())
 }
 
 func TestBackendRegistry_CloseSharedBackendOnce(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	shared := &fakeBackend{endpoint: "127.0.0.1:9000"}
 
 	// Register the same backend instance under two different service names,
 	// simulating the shared loopback backend used by built-in services.
-	reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
-	reg.RegisterBackend("svc.B", shared, BackendKindBuiltin)
+	reg.RegisterBackend("svc.A", shared, gateway.BackendKindBuiltin)
+	reg.RegisterBackend("svc.B", shared, gateway.BackendKindBuiltin)
 
 	err := reg.Close()
 	require.NoError(t, err)
@@ -275,22 +280,22 @@ func TestBackendRegistry_CloseSharedBackendOnce(t *testing.T) {
 	require.Equal(t, 1, shared.CloseCount(), "shared backend must be closed exactly once")
 
 	// Registry must be empty after Close.
-	require.Empty(t, reg.backends)
+	require.Empty(t, reg.ListBackends())
 }
 
 func TestBackendRegistry_Renew(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+	reg.RegisterBackend("svc.Foo", b, gateway.BackendKindExternal)
 
-	before := reg.backends["svc.Foo"].lastSeenAt
+	before := getBackendEntry(t, reg, "svc.Foo").LastSeenAt()
 
 	// Sleep briefly so lastSeenAt can advance.
 	time.Sleep(time.Millisecond)
 
 	ok := reg.Renew("svc.Foo", "127.0.0.1:9000")
 	require.True(t, ok, "Renew should return true for matching endpoint")
-	require.True(t, reg.backends["svc.Foo"].lastSeenAt.After(before), "lastSeenAt should advance")
+	require.True(t, getBackendEntry(t, reg, "svc.Foo").LastSeenAt().After(before), "lastSeenAt should advance")
 
 	// Wrong endpoint: Renew must return false.
 	ok = reg.Renew("svc.Foo", "127.0.0.1:9999")
@@ -301,17 +306,51 @@ func TestBackendRegistry_Renew(t *testing.T) {
 	require.False(t, ok, "Renew should return false for absent service")
 }
 
+func TestBackendRegistry_LeaseReleaseIsIdempotent(t *testing.T) {
+	reg := gateway.NewBackendRegistry()
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", b, gateway.BackendKindExternal)
+
+	_, release, ok := reg.GetBackend("svc.Foo")
+	require.True(t, ok)
+
+	release()
+	release()
+	require.False(t, b.Closed(), "registry entry must keep backend open after lease release")
+	require.NoError(t, reg.Close())
+	require.Equal(t, 1, b.CloseCount(), "releasing a lease twice must close once")
+}
+
 func TestBackend_CloseIdempotent(t *testing.T) {
-	b, err := dialBackend("passthrough:x", insecure.NewCredentials())
+	registry := gateway.NewBackendRegistry()
+	service := gateway.NewGatewayService(registry)
+	_, err := service.Register(t.Context(), &ynpb.RegisterRequest{
+		Backend: &ynpb.BackendDesc{
+			Name:     "svc.Foo",
+			Endpoint: "passthrough:x",
+		},
+	})
 	require.NoError(t, err)
 
-	require.NoError(t, b.Close(), "first Close must succeed")
-	require.NoError(t, b.Close(), "second Close must be a no-op")
-	require.Equal(t, connectivity.Shutdown, b.conn.GetState(), "conn must be in Shutdown state")
+	backend := getBackendEntry(t, registry, "svc.Foo").GetBackend()
+	_, conn, err := backend.GetConnection(t.Context(), "")
+	require.NoError(t, err)
+	require.NoError(t, backend.Close(), "first Close must succeed")
+	require.NoError(t, backend.Close(), "second Close must be a no-op")
+	require.Equal(t, connectivity.Shutdown, conn.GetState(), "conn must be in Shutdown state")
+}
+
+func TestGateway_CloseIsIdempotent(t *testing.T) {
+	listener := NewTestListener(t)
+	gw, err := gateway.NewGateway(gateway.DefaultConfig(), gateway.WithListener(listener))
+	require.NoError(t, err)
+
+	require.NoError(t, gw.Close())
+	require.NoError(t, gw.Close())
 }
 
 func TestBackendRegistry_ConcurrentRace(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 
 	const goroutines = 20
 	done := make(chan struct{})
@@ -319,7 +358,7 @@ func TestBackendRegistry_ConcurrentRace(t *testing.T) {
 		go func() {
 			defer func() { done <- struct{}{} }()
 			b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-			reg.RegisterBackend("svc.Race", b, BackendKindExternal)
+			reg.RegisterBackend("svc.Race", b, gateway.BackendKindExternal)
 			reg.Renew("svc.Race", "127.0.0.1:9000")
 			if _, release, ok := reg.GetBackend("svc.Race"); ok {
 				release()
@@ -335,25 +374,25 @@ func TestBackendRegistry_ConcurrentRace(t *testing.T) {
 }
 
 func TestBackendRegistry_KindIsPreserved(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 
 	builtin := &fakeBackend{endpoint: "127.0.0.1:9000"}
 	inProc := &fakeBackend{endpoint: "127.0.0.1:9001"}
 	ext := &fakeBackend{endpoint: "127.0.0.1:9002"}
 
-	reg.RegisterBackend("svc.Builtin", builtin, BackendKindBuiltin)
-	reg.RegisterBackend("svc.InProcess", inProc, BackendKindInProcess)
-	reg.RegisterBackend("svc.External", ext, BackendKindExternal)
+	reg.RegisterBackend("svc.Builtin", builtin, gateway.BackendKindBuiltin)
+	reg.RegisterBackend("svc.InProcess", inProc, gateway.BackendKindInProcess)
+	reg.RegisterBackend("svc.External", ext, gateway.BackendKindExternal)
 
 	entries := reg.ListBackends()
-	kinds := map[string]BackendKind{}
+	kinds := map[string]gateway.BackendKind{}
 	for _, e := range entries {
 		kinds[e.Service()] = e.Kind()
 	}
 
-	require.Equal(t, BackendKindBuiltin, kinds["svc.Builtin"])
-	require.Equal(t, BackendKindInProcess, kinds["svc.InProcess"])
-	require.Equal(t, BackendKindExternal, kinds["svc.External"])
+	require.Equal(t, gateway.BackendKindBuiltin, kinds["svc.Builtin"])
+	require.Equal(t, gateway.BackendKindInProcess, kinds["svc.InProcess"])
+	require.Equal(t, gateway.BackendKindExternal, kinds["svc.External"])
 }
 
 // TestBackendRegistry_RenewKindIsImmutable verifies that Renew never changes
@@ -362,17 +401,17 @@ func TestBackendRegistry_KindIsPreserved(t *testing.T) {
 func TestBackendRegistry_RenewKindIsImmutable(t *testing.T) {
 	cases := []struct {
 		name    string
-		initial BackendKind
-		claimed BackendKind
+		initial gateway.BackendKind
+		claimed gateway.BackendKind
 	}{
-		{"same kind claimed", BackendKindExternal, BackendKindExternal},
-		{"external claims in-process", BackendKindExternal, BackendKindInProcess},
-		{"in-process claims external", BackendKindInProcess, BackendKindExternal},
+		{"same kind claimed", gateway.BackendKindExternal, gateway.BackendKindExternal},
+		{"external claims in-process", gateway.BackendKindExternal, gateway.BackendKindInProcess},
+		{"in-process claims external", gateway.BackendKindInProcess, gateway.BackendKindExternal},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			reg := NewBackendRegistry()
+			reg := gateway.NewBackendRegistry()
 			b := &fakeBackend{endpoint: "127.0.0.1:9000"}
 			reg.RegisterBackend("svc.Foo", b, tc.initial)
 
@@ -389,85 +428,61 @@ func TestBackendRegistry_RenewKindIsImmutable(t *testing.T) {
 // TestBackendRegistry_EvictStaleRemovesExternal verifies that a stale
 // external backend is removed from the registry and closed exactly once.
 func TestBackendRegistry_EvictStaleRemovesExternal(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+	reg.RegisterBackend("svc.Foo", b, gateway.BackendKindExternal)
 
-	past := time.Now().UTC().Add(-time.Hour)
-	entry := reg.backends["svc.Foo"]
-	entry.lastSeenAt = past
-	reg.backends["svc.Foo"] = entry
-
-	evicted := reg.EvictStale(time.Now().UTC())
+	evicted := reg.EvictStale(time.Now().UTC().Add(time.Hour))
 
 	require.Len(t, evicted, 1)
 	require.Equal(t, "svc.Foo", evicted[0].Service())
 	require.Equal(t, 1, b.CloseCount(), "evicted backend must be closed exactly once")
 
-	_, ok := reg.backends["svc.Foo"]
-	require.False(t, ok, "evicted entry must be removed from the registry")
+	require.Empty(t, reg.ListBackends(), "evicted entry must be removed from the registry")
 }
 
 // TestBackendRegistry_EvictStaleSparesNonExternal verifies that stale
 // builtin and in-process entries are never evicted or closed.
 //
 // This is the regression guard for the constraint that only
-// BackendKindExternal entries heartbeat: builtin and in-process entries may
-// share the gateway's loopback backend with other live services.
+// gateway.BackendKindExternal entries heartbeat. Builtin and in-process
+// entries may share the gateway's loopback backend with other live services.
 func TestBackendRegistry_EvictStaleSparesNonExternal(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	builtin := &fakeBackend{endpoint: "127.0.0.1:9000"}
 	inProc := &fakeBackend{endpoint: "127.0.0.1:9001"}
-	reg.RegisterBackend("svc.Builtin", builtin, BackendKindBuiltin)
-	reg.RegisterBackend("svc.InProcess", inProc, BackendKindInProcess)
+	reg.RegisterBackend("svc.Builtin", builtin, gateway.BackendKindBuiltin)
+	reg.RegisterBackend("svc.InProcess", inProc, gateway.BackendKindInProcess)
 
-	past := time.Now().UTC().Add(-24 * time.Hour)
-	for _, service := range []string{"svc.Builtin", "svc.InProcess"} {
-		entry := reg.backends[service]
-		entry.lastSeenAt = past
-		reg.backends[service] = entry
-	}
-
-	evicted := reg.EvictStale(time.Now().UTC())
+	evicted := reg.EvictStale(time.Now().UTC().Add(time.Hour))
 
 	require.Empty(t, evicted)
 	require.False(t, builtin.Closed(), "builtin backend must not be closed")
 	require.False(t, inProc.Closed(), "in-process backend must not be closed")
 
-	_, ok := reg.backends["svc.Builtin"]
-	require.True(t, ok, "builtin entry must remain registered")
-	_, ok = reg.backends["svc.InProcess"]
-	require.True(t, ok, "in-process entry must remain registered")
+	require.Equal(t, 2, len(reg.ListBackends()), "non-external entries must remain registered")
 }
 
 // TestBackendRegistry_EvictStaleSparesSharedBackend verifies that evicting a
 // stale external entry leaves a shared builtin backend, registered under
 // several service keys, open and its keys intact.
 func TestBackendRegistry_EvictStaleSparesSharedBackend(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	shared := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
-	reg.RegisterBackend("svc.B", shared, BackendKindBuiltin)
+	reg.RegisterBackend("svc.A", shared, gateway.BackendKindBuiltin)
+	reg.RegisterBackend("svc.B", shared, gateway.BackendKindBuiltin)
 
 	ext := &fakeBackend{endpoint: "127.0.0.1:9001"}
-	reg.RegisterBackend("svc.External", ext, BackendKindExternal)
+	reg.RegisterBackend("svc.External", ext, gateway.BackendKindExternal)
 
-	past := time.Now().UTC().Add(-time.Hour)
-	entry := reg.backends["svc.External"]
-	entry.lastSeenAt = past
-	reg.backends["svc.External"] = entry
-
-	evicted := reg.EvictStale(time.Now().UTC())
+	evicted := reg.EvictStale(time.Now().UTC().Add(time.Hour))
 
 	require.Len(t, evicted, 1)
 	require.Equal(t, "svc.External", evicted[0].Service())
 	require.True(t, ext.Closed(), "external backend must be closed")
 	require.Equal(t, 0, shared.CloseCount(), "shared backend must remain open")
 
-	_, ok := reg.backends["svc.A"]
-	require.True(t, ok, "svc.A must remain registered")
-	_, ok = reg.backends["svc.B"]
-	require.True(t, ok, "svc.B must remain registered")
+	require.Equal(t, 2, len(reg.ListBackends()), "shared builtin services must remain registered")
 }
 
 // TestBackendRegistry_LeaseSurvivesConcurrentEviction verifies that a
@@ -482,26 +497,20 @@ func TestBackendRegistry_EvictStaleSparesSharedBackend(t *testing.T) {
 func TestBackendRegistry_LeaseSurvivesConcurrentEviction(t *testing.T) {
 	t.Parallel()
 
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+	reg.RegisterBackend("svc.Foo", b, gateway.BackendKindExternal)
 
 	backend, release, ok := reg.GetBackend("svc.Foo")
 	require.True(t, ok)
 	require.NotNil(t, backend)
 
-	// Make the entry stale so a sweep evicts it while the lease above is
-	// still outstanding.
-	entry := reg.backends["svc.Foo"]
-	entry.lastSeenAt = time.Now().UTC().Add(-time.Hour)
-	reg.backends["svc.Foo"] = entry
-
-	evictedCh := make(chan []BackendEntry, 1)
+	evictedCh := make(chan []gateway.BackendEntry, 1)
 	go func() {
-		evictedCh <- reg.EvictStale(time.Now().UTC())
+		evictedCh <- reg.EvictStale(time.Now().UTC().Add(time.Hour))
 	}()
 
-	var evicted []BackendEntry
+	var evicted []gateway.BackendEntry
 	select {
 	case evicted = <-evictedCh:
 	case <-time.After(2 * time.Second):
@@ -528,28 +537,24 @@ func TestBackendRegistry_LeaseSurvivesConcurrentEviction(t *testing.T) {
 func TestBackendRegistry_ReRegisterAfterEvictionLeavesNewBackendUsable(t *testing.T) {
 	t.Parallel()
 
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	old := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", old, BackendKindExternal)
+	reg.RegisterBackend("svc.Foo", old, gateway.BackendKindExternal)
 
 	// Simulate a call that obtained the backend just before the sweeper
 	// runs.
 	_, release, ok := reg.GetBackend("svc.Foo")
 	require.True(t, ok)
 
-	entry := reg.backends["svc.Foo"]
-	entry.lastSeenAt = time.Now().UTC().Add(-time.Hour)
-	reg.backends["svc.Foo"] = entry
-
-	evicted := reg.EvictStale(time.Now().UTC())
+	evicted := reg.EvictStale(time.Now().UTC().Add(time.Hour))
 	require.Len(t, evicted, 1)
 	require.False(t, old.Closed(), "old backend must stay open while its lease is outstanding")
 
 	// A fresh registration under the same service name, using a distinct
 	// connection, lands before the old lease is released.
 	next := &fakeBackend{endpoint: "127.0.0.1:9001"}
-	status := reg.RegisterBackend("svc.Foo", next, BackendKindExternal)
-	require.Equal(t, RegistrationRegistered, status)
+	status := reg.RegisterBackend("svc.Foo", next, gateway.BackendKindExternal)
+	require.Equal(t, gateway.RegistrationRegistered, status)
 
 	nextBackend, nextRelease, ok := reg.GetBackend("svc.Foo")
 	require.True(t, ok)
@@ -569,41 +574,44 @@ func TestBackendRegistry_ReRegisterAfterEvictionLeavesNewBackendUsable(t *testin
 // registration refreshes lastSeenAt so the entry survives a sweep whose
 // cutoff would otherwise have evicted it.
 func TestBackendRegistry_RenewSavesFromEviction(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+	reg.RegisterBackend("svc.Foo", b, gateway.BackendKindExternal)
 
-	past := time.Now().UTC().Add(-time.Hour)
-	entry := reg.backends["svc.Foo"]
-	entry.lastSeenAt = past
-	reg.backends["svc.Foo"] = entry
+	before := getBackendEntry(t, reg, "svc.Foo").LastSeenAt()
+	// Sleep briefly so Renew's timestamp is distinguishable from registration.
+	time.Sleep(time.Millisecond)
 
 	ok := reg.Renew("svc.Foo", "127.0.0.1:9000")
 	require.True(t, ok)
+	renewed := getBackendEntry(t, reg, "svc.Foo").LastSeenAt()
+	require.True(t, renewed.After(before), "Renew should advance lastSeenAt")
 
-	evicted := reg.EvictStale(time.Now().UTC().Add(-time.Minute))
+	cutoff := before.Add(renewed.Sub(before) / 2)
+	require.True(t, cutoff.After(before))
+	require.True(t, cutoff.Before(renewed))
+
+	evicted := reg.EvictStale(cutoff)
 
 	require.Empty(t, evicted)
 	require.False(t, b.Closed(), "renewed backend must not be closed")
 
-	_, ok = reg.backends["svc.Foo"]
-	require.True(t, ok, "renewed entry must remain registered")
+	require.Len(t, reg.ListBackends(), 1, "renewed entry must remain registered")
 }
 
 // TestBackendRegistry_EvictStaleCutoffOlderThanAllEntriesRemovesNothing
 // verifies that a cutoff older than every entry's lastSeenAt evicts nothing.
 func TestBackendRegistry_EvictStaleCutoffOlderThanAllEntriesRemovesNothing(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+	reg.RegisterBackend("svc.Foo", b, gateway.BackendKindExternal)
 
 	evicted := reg.EvictStale(time.Now().UTC().Add(-time.Hour))
 
 	require.Empty(t, evicted)
 	require.False(t, b.Closed())
 
-	_, ok := reg.backends["svc.Foo"]
-	require.True(t, ok, "entry must remain registered")
+	require.Len(t, reg.ListBackends(), 1, "entry must remain registered")
 }
 
 // TestBackendRegistry_RenewCannotArmSweeperAgainstSharedBackend verifies
@@ -614,9 +622,9 @@ func TestBackendRegistry_EvictStaleCutoffOlderThanAllEntriesRemovesNothing(t *te
 // the sweeper would later evict and close a backend shared with every other
 // in-process service.
 func TestBackendRegistry_RenewCannotArmSweeperAgainstSharedBackend(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	shared := &fakeBackend{endpoint: "127.0.0.1:8080"}
-	reg.RegisterBackend("controlplane.ynpb.v1.Gateway", shared, BackendKindBuiltin)
+	reg.RegisterBackend("controlplane.ynpb.v1.Gateway", shared, gateway.BackendKindBuiltin)
 
 	ok := reg.Renew("controlplane.ynpb.v1.Gateway", "127.0.0.1:8080")
 	require.True(t, ok)
@@ -627,9 +635,8 @@ func TestBackendRegistry_RenewCannotArmSweeperAgainstSharedBackend(t *testing.T)
 	require.Empty(t, evicted, "a builtin entry must never be evicted, even after a spoofed renewal")
 	require.False(t, shared.Closed(), "shared backend must not be closed")
 
-	entry, ok := reg.backends["controlplane.ynpb.v1.Gateway"]
-	require.True(t, ok, "entry must remain registered")
-	require.Equal(t, BackendKindBuiltin, entry.Kind(), "entry must keep its original kind")
+	entry := getBackendEntry(t, reg, "controlplane.ynpb.v1.Gateway")
+	require.Equal(t, gateway.BackendKindBuiltin, entry.Kind(), "entry must keep its original kind")
 }
 
 // TestBackendRegistry_RenewCannotExemptExternalFromEviction verifies that
@@ -639,19 +646,14 @@ func TestBackendRegistry_RenewCannotArmSweeperAgainstSharedBackend(t *testing.T)
 // demote an external entry, a separate-process backend would become
 // permanently non-evictable the moment it stopped heartbeating.
 func TestBackendRegistry_RenewCannotExemptExternalFromEviction(t *testing.T) {
-	reg := NewBackendRegistry()
+	reg := gateway.NewBackendRegistry()
 	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+	reg.RegisterBackend("svc.Foo", b, gateway.BackendKindExternal)
 
 	ok := reg.Renew("svc.Foo", "127.0.0.1:9000")
 	require.True(t, ok)
 
-	cutoff := time.Now().UTC()
-
-	entry := reg.backends["svc.Foo"]
-	entry.lastSeenAt = cutoff.Add(-time.Hour)
-	reg.backends["svc.Foo"] = entry
-
+	cutoff := getBackendEntry(t, reg, "svc.Foo").LastSeenAt().Add(time.Nanosecond)
 	evicted := reg.EvictStale(cutoff)
 
 	require.Len(t, evicted, 1)
@@ -660,22 +662,22 @@ func TestBackendRegistry_RenewCannotExemptExternalFromEviction(t *testing.T) {
 }
 
 // TestGatewayService_RegisterKindResolution verifies that the Register RPC
-// maps in_process=true to BackendKindInProcess and in_process=false (or unset)
-// to BackendKindExternal.
+// maps in_process=true to gateway.BackendKindInProcess and in_process=false
+// (or unset) to gateway.BackendKindExternal.
 func TestGatewayService_RegisterKindResolution(t *testing.T) {
 	cases := []struct {
 		name      string
 		inProcess bool
-		wantKind  BackendKind
+		wantKind  gateway.BackendKind
 	}{
-		{"external when unset", false, BackendKindExternal},
-		{"in-process when set", true, BackendKindInProcess},
+		{"external when unset", false, gateway.BackendKindExternal},
+		{"in-process when set", true, gateway.BackendKindInProcess},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			reg := NewBackendRegistry()
-			svc := NewGatewayService(reg)
+			reg := gateway.NewBackendRegistry()
+			svc := gateway.NewGatewayService(reg)
 
 			_, err := svc.Register(t.Context(), &ynpb.RegisterRequest{
 				Backend: &ynpb.BackendDesc{
@@ -686,8 +688,7 @@ func TestGatewayService_RegisterKindResolution(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			entry, ok := reg.backends["svc.Test"]
-			require.True(t, ok)
+			entry := getBackendEntry(t, reg, "svc.Test")
 			require.Equal(t, tc.wantKind, entry.Kind())
 
 			_ = reg.Close()

--- a/controlplane/gateway/runner.go
+++ b/controlplane/gateway/runner.go
@@ -95,6 +95,11 @@ func (m *ServiceRunner) Ready() <-chan struct{} {
 	return m.ready
 }
 
+// ServiceType returns the concrete service type used in runner diagnostics.
+func (m *ServiceRunner) ServiceType() string {
+	return fmt.Sprintf("%T", m.module)
+}
+
 // Close closes the underlying service if it implements ClosableService.
 func (m *ServiceRunner) Close() error {
 	if c, ok := m.module.(ClosableService); ok {

--- a/controlplane/gateway/runner_test.go
+++ b/controlplane/gateway/runner_test.go
@@ -1,6 +1,7 @@
-package gateway
+package gateway_test
 
 import (
+	"context"
 	"net"
 	"sync"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yanet-platform/yanet2/controlplane/gateway"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
@@ -102,8 +104,8 @@ func TestServiceRunner_registerClosesGatewayClientConnection(t *testing.T) {
 	require.NoError(t, err)
 
 	trackingListener := newConnectionTrackingListener(gatewayListener)
-	backendRegistry := NewBackendRegistry()
-	gatewayService := NewGatewayService(backendRegistry)
+	backendRegistry := gateway.NewBackendRegistry()
+	gatewayService := gateway.NewGatewayService(backendRegistry)
 
 	gatewayServer := grpc.NewServer()
 	ynpb.RegisterGatewayServer(gatewayServer, gatewayService)
@@ -117,16 +119,18 @@ func TestServiceRunner_registerClosesGatewayClientConnection(t *testing.T) {
 		_ = wg.Wait()
 	})
 
-	serviceRunner := NewServiceRunner(&fakeService{}, trackingListener.Addr().String(), nil)
+	serviceRunner := gateway.NewServiceRunner(&fakeService{}, trackingListener.Addr().String(), nil)
 
-	backendAddrListener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, backendAddrListener.Close())
-	})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var runnerGroup errgroup.Group
+	runnerGroup.Go(func() error { return serviceRunner.Run(ctx) })
 
-	err = serviceRunner.register(t.Context(), backendAddrListener.Addr())
-	require.NoError(t, err)
+	select {
+	case <-serviceRunner.Ready():
+	case <-time.After(5 * time.Second):
+		t.Fatal("service runner did not become ready")
+	}
 
 	require.Eventually(t, func() bool {
 		return trackingListener.AcceptedCount() > 0
@@ -135,4 +139,7 @@ func TestServiceRunner_registerClosesGatewayClientConnection(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return trackingListener.ActiveCount() == 0
 	}, 2*time.Second, 25*time.Millisecond, "registration client connections were not closed")
+
+	cancel()
+	require.NoError(t, runnerGroup.Wait())
 }

--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -104,22 +104,6 @@ maplit:modules/pdump/controlplane/ring_test.go:TestRingBufferRunReaders:map[byte
 maplit:operators/bird-adapter/internal/mpls/routes.go:Rib.Apply:map[mplsRouteKey][]rib.Route:1  # legacy: use T{} instead of make(map...)
 maplit:operators/bird-adapter/service.go:NewAdapterService:map[string]*importHolder:1  # legacy: use T{} instead of make(map...)
 maplit:operators/route/internal/discovery/neigh/neigh.go:newOptions:map[string]string:1  # legacy: use T{} instead of make(map...)
-private:controlplane/gateway/gateway.go:Gateway.Run:runner.module:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/gateway.go:NewGateway:entry.kind:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/gateway.go:NewGateway:entry.kind:2  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/gateway.go:NewGateway:entry.service:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/gateway.go:NewGateway:entry.service:2  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/gateway.go:NewGateway:entry.service:3  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/gateway.go:NewGateway:entry.service:4  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/gateway.go:NewGateway:entry.service:5  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/metrics_service.go:metricsCollectors:entry.service:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/registry.go:BackendRegistry.GetBackend:entry.backend:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/registry.go:BackendRegistry.ListBackends:entry.service:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/registry.go:BackendRegistry.Renew:entry.backend:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/registry.go:BackendRegistry.Renew:entry.lastSeenAt:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.backend:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.backend:2  # legacy: encapsulate behind an exported method or field
-private:controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.lastSeenAt:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.checkLinkable:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.createLinkedHandles:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.swapLinkedHandles:1  # legacy: encapsulate behind an exported method or field
@@ -256,10 +240,6 @@ testpkg:common/go/xcfg/nonempty_test.go:xcfg:1  # legacy: migrate to the externa
 testpkg:common/go/xcfg/nonzero_test.go:xcfg:1  # legacy: migrate to the external test package
 testpkg:common/go/xgrpc/graceful_test.go:xgrpc:1  # legacy: migrate to the external test package
 testpkg:common/go/xnetip/netip_test.go:xnetip:1  # legacy: migrate to the external test package
-testpkg:controlplane/gateway/gateway_test.go:gateway:1  # legacy: migrate to the external test package
-testpkg:controlplane/gateway/readiness_test.go:gateway:1  # legacy: migrate to the external test package
-testpkg:controlplane/gateway/registry_test.go:gateway:1  # legacy: migrate to the external test package
-testpkg:controlplane/gateway/runner_test.go:gateway:1  # legacy: migrate to the external test package
 testpkg:controlplane/internal/xgrpc/interceptor_test.go:xgrpc:1  # legacy: migrate to the external test package
 testpkg:controlplane/internal/xgrpc/method_test.go:xgrpc:1  # legacy: migrate to the external test package
 testpkg:devices/plain/controlplane/service_test.go:plain:1  # legacy: migrate to the external test package


### PR DESCRIPTION
- Encapsulates gateway service, runner, and backend-entry access without changing registration, timestamp, ownership, or logging semantics.
- Migrates the four gateway white-box test files to the external package and preserves their lifecycle and registry contracts through public APIs.
- Adds a deterministic external regression test for the gateway drain latch; removing the latch reproduces a forbidden late return to READY.
- Removes the 16 remaining gateway private rows and four test-package rows; the two bundle rows named by the original issue were already resolved on main.

Closes #1733.