### PR TITLE
refactor(controlplane): encapsulate authentication internals

### DIFF
--- a/controlplane/internal/auth/interceptor_test.go
+++ b/controlplane/internal/auth/interceptor_test.go
@@ -1,4 +1,4 @@
-package auth
+package auth_test
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
 )
 
@@ -56,17 +57,17 @@ func TestUnaryServerInterceptor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager, err := NewManager(&Config{
+			manager, err := auth.NewManager(&auth.Config{
 				Disabled: tt.disabled,
 			})
 			require.NoError(t, err)
 
-			interceptor := UnaryServerInterceptor(manager, log)
+			interceptor := auth.UnaryServerInterceptor(manager, log)
 
 			// Create context with or without token.
 			ctx := context.Background()
 			if tt.withToken {
-				md := metadata.Pairs(authMetadataKey, tt.token)
+				md := metadata.Pairs("x-yanet-authentication", tt.token)
 				ctx = metadata.NewIncomingContext(ctx, md)
 			}
 
@@ -96,12 +97,12 @@ func TestUnaryServerInterceptor(t *testing.T) {
 
 func TestStreamServerInterceptor(t *testing.T) {
 	log := zap.NewNop()
-	manager, err := NewManager(&Config{
+	manager, err := auth.NewManager(&auth.Config{
 		Disabled: true,
 	})
 	require.NoError(t, err)
 
-	interceptor := StreamServerInterceptor(manager, log)
+	interceptor := auth.StreamServerInterceptor(manager, log)
 
 	// Create context without token.
 	ctx := context.Background()
@@ -140,7 +141,7 @@ func TestExtractToken(t *testing.T) {
 	}{
 		{
 			name: "with token",
-			md:   metadata.Pairs(authMetadataKey, "test-token"),
+			md:   metadata.Pairs("x-yanet-authentication", "test-token"),
 			want: "test-token",
 		},
 		{
@@ -150,7 +151,7 @@ func TestExtractToken(t *testing.T) {
 		},
 		{
 			name: "multiple values (first wins)",
-			md:   metadata.Pairs(authMetadataKey, "token1", authMetadataKey, "token2"),
+			md:   metadata.Pairs("x-yanet-authentication", "token1", "x-yanet-authentication", "token2"),
 			want: "token1",
 		},
 	}
@@ -158,7 +159,7 @@ func TestExtractToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := metadata.NewIncomingContext(context.Background(), tt.md)
-			got := ExtractToken(ctx)
+			got := auth.ExtractToken(ctx)
 			if got != tt.want {
 				t.Errorf("extractToken() = %q, want %q", got, tt.want)
 			}
@@ -168,7 +169,7 @@ func TestExtractToken(t *testing.T) {
 	// Test without metadata in context.
 	t.Run("no metadata", func(t *testing.T) {
 		ctx := context.Background()
-		got := ExtractToken(ctx)
+		got := auth.ExtractToken(ctx)
 		if got != "" {
 			t.Errorf("extractToken() = %q, want empty", got)
 		}

--- a/controlplane/internal/auth/none/authenticator_test.go
+++ b/controlplane/internal/auth/none/authenticator_test.go
@@ -1,14 +1,15 @@
-package none
+package none_test
 
 import (
 	"context"
 	"testing"
 
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/none"
 )
 
 func TestNoneAuthenticator_IsTokenSupported(t *testing.T) {
-	auth := NewNoneAuthenticator()
+	authenticator := none.NewNoneAuthenticator()
 
 	tests := []struct {
 		name  string
@@ -29,7 +30,7 @@ func TestNoneAuthenticator_IsTokenSupported(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := auth.IsTokenSupported(tt.token); got != tt.want {
+			if got := authenticator.IsTokenSupported(tt.token); got != tt.want {
 				t.Errorf("IsTokenSupported() = %v, want %v", got, tt.want)
 			}
 		})
@@ -37,7 +38,7 @@ func TestNoneAuthenticator_IsTokenSupported(t *testing.T) {
 }
 
 func TestNoneAuthenticator_Authenticate(t *testing.T) {
-	auth := NewNoneAuthenticator()
+	authenticator := none.NewNoneAuthenticator()
 	ctx := context.Background()
 
 	tests := []struct {
@@ -57,7 +58,7 @@ func TestNoneAuthenticator_Authenticate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			requestInfo := &core.RequestInfo{FullMethod: "/test.Service/Method"}
-			authInfo, err := auth.Authenticate(ctx, tt.token, requestInfo)
+			authInfo, err := authenticator.Authenticate(ctx, tt.token, requestInfo)
 			if err != nil {
 				t.Fatalf("Authenticate() error = %v, want nil", err)
 			}

--- a/controlplane/internal/auth/sshcert/authenticator.go
+++ b/controlplane/internal/auth/sshcert/authenticator.go
@@ -30,7 +30,6 @@ type Authenticator struct {
 	caVerifier        CAVerifier
 	revocationChecker RevocationChecker
 	timeWindow        time.Duration
-	refreshInterval   time.Duration
 	stopCh            chan struct{}
 	log               *zap.Logger
 }
@@ -84,17 +83,23 @@ func NewAuthenticator(
 		o(options)
 	}
 
+	stopCh := make(chan struct{})
 	a := &Authenticator{
 		caVerifier:        caVerifier,
 		revocationChecker: revocationChecker,
 		timeWindow:        options.TimeWindow,
-		refreshInterval:   options.RefreshInterval,
 		log:               options.Log,
-		stopCh:            make(chan struct{}),
+		stopCh:            stopCh,
 	}
 
 	// Start periodic refresh.
-	go a.refreshLoop()
+	go runRefreshLoop(
+		caVerifier,
+		revocationChecker,
+		options.RefreshInterval,
+		stopCh,
+		options.Log,
+	)
 
 	return a
 }
@@ -138,7 +143,7 @@ func (m *Authenticator) Authenticate(
 		)
 	}
 
-	if err := token.checkTimestamp(time.Now(), m.timeWindow); err != nil {
+	if err := token.CheckTimestamp(time.Now(), m.timeWindow); err != nil {
 		return nil, status.Errorf(
 			codes.Unauthenticated,
 			"sshcert token expired: %v", err,
@@ -206,7 +211,7 @@ func (m *Authenticator) Authenticate(
 		)
 	}
 
-	signedData := token.canonicalSignedData()
+	signedData := token.CanonicalSignedData()
 	if err := verifySignature(signedData, token.Signature, cert); err != nil {
 		return nil, status.Errorf(
 			codes.Unauthenticated,
@@ -231,32 +236,33 @@ func (m *Authenticator) Close() {
 	close(m.stopCh)
 }
 
-// refreshLoop periodically reloads CA and KRL data.
-func (m *Authenticator) refreshLoop() {
-	ticker := time.NewTicker(m.refreshInterval)
+// runRefreshLoop periodically reloads CA and KRL data.
+func runRefreshLoop(
+	caVerifier CAVerifier,
+	revocationChecker RevocationChecker,
+	refreshInterval time.Duration,
+	stopCh <-chan struct{},
+	log *zap.Logger,
+) {
+	ticker := time.NewTicker(refreshInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-m.stopCh:
+		case <-stopCh:
 			return
 		case <-ticker.C:
-			m.doRefresh()
+			if err := caVerifier.Reload(); err != nil {
+				log.Warn("failed to refresh CA store", zap.Error(err))
+			} else {
+				log.Info("refreshed CA store")
+			}
+
+			if err := revocationChecker.Reload(); err != nil {
+				log.Warn("failed to refresh KRL", zap.Error(err))
+			} else {
+				log.Info("refreshed KRL")
+			}
 		}
-	}
-}
-
-// doRefresh reloads CA and KRL data.
-func (m *Authenticator) doRefresh() {
-	if err := m.caVerifier.Reload(); err != nil {
-		m.log.Warn("failed to refresh CA store", zap.Error(err))
-	} else {
-		m.log.Info("refreshed CA store")
-	}
-
-	if err := m.revocationChecker.Reload(); err != nil {
-		m.log.Warn("failed to refresh KRL", zap.Error(err))
-	} else {
-		m.log.Info("refreshed KRL")
 	}
 }

--- a/controlplane/internal/auth/sshcert/authenticator_test.go
+++ b/controlplane/internal/auth/sshcert/authenticator_test.go
@@ -1,4 +1,4 @@
-package sshcert
+package sshcert_test
 
 import (
 	"context"
@@ -12,27 +12,28 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshcert"
 )
 
 func TestAuthenticator_Name(t *testing.T) {
-	ca := generateCA(t)
-	store := NewCAStore([]CAEntry{
+	ca := generateTestCA(t)
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca.PublicKey()},
 	})
 
-	auth := NewAuthenticator(store, NewNopRevocationChecker())
+	auth := sshcert.NewAuthenticator(store, sshcert.NewNopRevocationChecker())
 	defer auth.Close()
 
 	assert.Equal(t, "sshcert", auth.Name())
 }
 
 func TestAuthenticator_IsTokenSupported(t *testing.T) {
-	ca := generateCA(t)
-	store := NewCAStore([]CAEntry{
+	ca := generateTestCA(t)
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca.PublicKey()},
 	})
 
-	auth := NewAuthenticator(store, NewNopRevocationChecker())
+	auth := sshcert.NewAuthenticator(store, sshcert.NewNopRevocationChecker())
 	defer auth.Close()
 
 	assert.True(t, auth.IsTokenSupported("sshcert eyJ0ZXN0Ig=="))
@@ -41,24 +42,24 @@ func TestAuthenticator_IsTokenSupported(t *testing.T) {
 }
 
 func TestAuthenticator_HappyPath(t *testing.T) {
-	ca := generateCA(t)
-	cert, userSigner := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t, ca, "alice", 1,
 		time.Now().Add(-1*time.Hour),
 		time.Now().Add(24*time.Hour),
 	)
 
-	store := NewCAStore([]CAEntry{
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca.PublicKey()},
 	})
 
-	auth := NewAuthenticator(store, NewNopRevocationChecker(),
-		WithTimeWindow(10*time.Second),
+	auth := sshcert.NewAuthenticator(store, sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(10*time.Second),
 	)
 	defer auth.Close()
 
 	now := time.Now()
-	rawToken := signCertToken(
+	rawToken := signTestCertToken(
 		t,
 		userSigner,
 		cert,
@@ -78,8 +79,8 @@ func TestAuthenticator_HappyPath(t *testing.T) {
 }
 
 func TestAuthenticator_ExpiredTimestamp(t *testing.T) {
-	ca := generateCA(t)
-	cert, userSigner := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t,
 		ca,
 		"alice",
@@ -88,18 +89,18 @@ func TestAuthenticator_ExpiredTimestamp(t *testing.T) {
 		time.Now().Add(24*time.Hour),
 	)
 
-	store := NewCAStore([]CAEntry{
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca.PublicKey()},
 	})
 
-	auth := NewAuthenticator(store, NewNopRevocationChecker(),
-		WithTimeWindow(5*time.Second),
+	auth := sshcert.NewAuthenticator(store, sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(5*time.Second),
 	)
 	defer auth.Close()
 
 	// Timestamp 1 hour ago.
 	oldTimestamp := time.Now().Add(-1 * time.Hour).UnixNano()
-	rawToken := signCertToken(
+	rawToken := signTestCertToken(
 		t, userSigner, cert,
 		"/test.Service/Method", oldTimestamp, "nonce-1",
 	)
@@ -114,8 +115,8 @@ func TestAuthenticator_ExpiredTimestamp(t *testing.T) {
 }
 
 func TestAuthenticator_MethodBindingMismatch(t *testing.T) {
-	ca := generateCA(t)
-	cert, userSigner := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t,
 		ca,
 		"alice",
@@ -124,17 +125,17 @@ func TestAuthenticator_MethodBindingMismatch(t *testing.T) {
 		time.Now().Add(24*time.Hour),
 	)
 
-	store := NewCAStore([]CAEntry{
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca.PublicKey()},
 	})
 
-	auth := NewAuthenticator(store, NewNopRevocationChecker(),
-		WithTimeWindow(10*time.Second),
+	auth := sshcert.NewAuthenticator(store, sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(10*time.Second),
 	)
 	defer auth.Close()
 
 	now := time.Now()
-	rawToken := signCertToken(
+	rawToken := signTestCertToken(
 		t, userSigner, cert,
 		"/test.Service/Method", now.UnixNano(), "nonce-1",
 	)
@@ -149,10 +150,10 @@ func TestAuthenticator_MethodBindingMismatch(t *testing.T) {
 }
 
 func TestAuthenticator_UntrustedCA(t *testing.T) {
-	ca := generateCA(t)
-	otherCA := generateCA(t)
+	ca := generateTestCA(t)
+	otherCA := generateTestCA(t)
 
-	cert, userSigner := generateUserCert(
+	cert, userSigner := generateTestUserCert(
 		t,
 		ca,
 		"alice",
@@ -162,17 +163,17 @@ func TestAuthenticator_UntrustedCA(t *testing.T) {
 	)
 
 	// Store only has otherCA.
-	store := NewCAStore([]CAEntry{
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: otherCA.PublicKey()},
 	})
 
-	auth := NewAuthenticator(store, NewNopRevocationChecker(),
-		WithTimeWindow(10*time.Second),
+	auth := sshcert.NewAuthenticator(store, sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(10*time.Second),
 	)
 	defer auth.Close()
 
 	now := time.Now()
-	rawToken := signCertToken(
+	rawToken := signTestCertToken(
 		t, userSigner, cert,
 		"/test.Service/Method", now.UnixNano(), "nonce-1",
 	)
@@ -187,8 +188,8 @@ func TestAuthenticator_UntrustedCA(t *testing.T) {
 }
 
 func TestAuthenticator_ExpiredCertificate(t *testing.T) {
-	ca := generateCA(t)
-	cert, userSigner := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t,
 		ca,
 		"alice",
@@ -197,17 +198,17 @@ func TestAuthenticator_ExpiredCertificate(t *testing.T) {
 		time.Now().Add(-24*time.Hour),
 	)
 
-	store := NewCAStore([]CAEntry{
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca.PublicKey()},
 	})
 
-	auth := NewAuthenticator(store, NewNopRevocationChecker(),
-		WithTimeWindow(10*time.Second),
+	auth := sshcert.NewAuthenticator(store, sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(10*time.Second),
 	)
 	defer auth.Close()
 
 	now := time.Now()
-	rawToken := signCertToken(
+	rawToken := signTestCertToken(
 		t, userSigner, cert,
 		"/test.Service/Method", now.UnixNano(), "nonce-1",
 	)
@@ -222,8 +223,8 @@ func TestAuthenticator_ExpiredCertificate(t *testing.T) {
 }
 
 func TestAuthenticator_RevokedCertificate(t *testing.T) {
-	ca := generateCA(t)
-	cert, userSigner := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t,
 		ca,
 		"alice",
@@ -232,22 +233,22 @@ func TestAuthenticator_RevokedCertificate(t *testing.T) {
 		time.Now().Add(24*time.Hour),
 	)
 
-	store := NewCAStore([]CAEntry{
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca.PublicKey()},
 	})
 
-	krlData := buildKRL(t, ca, []uint64{42})
+	krlData := buildTestKRL(t, ca, []uint64{42})
 	k, err := krl.ParseKRL(krlData)
 	require.NoError(t, err)
-	checker := NewKRLRevocationChecker(k)
+	checker := sshcert.NewKRLRevocationChecker(k)
 
-	auth := NewAuthenticator(store, checker,
-		WithTimeWindow(10*time.Second),
+	auth := sshcert.NewAuthenticator(store, checker,
+		sshcert.WithTimeWindow(10*time.Second),
 	)
 	defer auth.Close()
 
 	now := time.Now()
-	rawToken := signCertToken(
+	rawToken := signTestCertToken(
 		t, userSigner, cert,
 		"/test.Service/Method", now.UnixNano(), "nonce-1",
 	)
@@ -262,22 +263,22 @@ func TestAuthenticator_RevokedCertificate(t *testing.T) {
 }
 
 func TestAuthenticator_HostCertRejected(t *testing.T) {
-	ca := generateCA(t)
-	cert, userSigner := generateHostCert(t, ca, "host.example.com", 1)
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestHostCert(t, ca, "host.example.com", 1)
 
-	store := NewCAStore([]CAEntry{
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca.PublicKey()},
 	})
 
-	auth := NewAuthenticator(
+	auth := sshcert.NewAuthenticator(
 		store,
-		NewNopRevocationChecker(),
-		WithTimeWindow(10*time.Second),
+		sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(10*time.Second),
 	)
 	defer auth.Close()
 
 	now := time.Now()
-	rawToken := signCertToken(
+	rawToken := signTestCertToken(
 		t, userSigner, cert,
 		"/test.Service/Method", now.UnixNano(), "nonce-1",
 	)
@@ -292,8 +293,8 @@ func TestAuthenticator_HostCertRejected(t *testing.T) {
 }
 
 func TestAuthenticator_NopRevocationChecker(t *testing.T) {
-	ca := generateCA(t)
-	cert, userSigner := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t,
 		ca,
 		"alice",
@@ -302,18 +303,18 @@ func TestAuthenticator_NopRevocationChecker(t *testing.T) {
 		time.Now().Add(24*time.Hour),
 	)
 
-	store := NewCAStore([]CAEntry{
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca.PublicKey()},
 	})
 
 	// Nop revocation checker skips KRL check.
-	auth := NewAuthenticator(store, NewNopRevocationChecker(),
-		WithTimeWindow(10*time.Second),
+	auth := sshcert.NewAuthenticator(store, sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(10*time.Second),
 	)
 	defer auth.Close()
 
 	now := time.Now()
-	rawToken := signCertToken(
+	rawToken := signTestCertToken(
 		t, userSigner, cert,
 		"/test.Service/Method", now.UnixNano(), "nonce-1",
 	)

--- a/controlplane/internal/auth/sshcert/ca_store.go
+++ b/controlplane/internal/auth/sshcert/ca_store.go
@@ -31,23 +31,18 @@ type CAEntry struct {
 	PublicKey ssh.PublicKey
 }
 
-// caSnapshot holds an immutable set of CA entries for atomic swap.
-type caSnapshot struct {
-	entries []CAEntry
-}
-
 // CAStore stores trusted certificate authority public keys.
 type CAStore struct {
-	snapshot atomic.Pointer[caSnapshot]
+	snapshot atomic.Pointer[[]CAEntry]
 	loader   Loader
 }
 
 // NewCAStore creates a CAStore from an in-memory slice.
 func NewCAStore(entries []CAEntry) *CAStore {
-	s := &CAStore{}
-	s.snapshot.Store(&caSnapshot{entries: entries})
+	m := &CAStore{}
+	m.snapshot.Store(&entries)
 
-	return s
+	return m
 }
 
 // NewCAStoreFromLoader creates a CAStore by loading CA data from
@@ -63,22 +58,22 @@ func NewCAStoreFromLoader(loader Loader) (*CAStore, error) {
 		return nil, err
 	}
 
-	s := &CAStore{loader: loader}
-	s.snapshot.Store(&caSnapshot{entries: entries})
+	m := &CAStore{loader: loader}
+	m.snapshot.Store(&entries)
 
-	return s, nil
+	return m, nil
 }
 
 // VerifyCA cryptographically verifies that the certificate was signed by a
 // trusted CA.
 func (m *CAStore) VerifyCA(cert *ssh.Certificate) error {
-	snapshot := m.snapshot.Load()
+	entries := m.snapshot.Load()
 
 	checker := &ssh.CertChecker{
 		IsUserAuthority: func(auth ssh.PublicKey) bool {
 			authData := auth.Marshal()
 
-			for _, ca := range snapshot.entries {
+			for _, ca := range *entries {
 				if bytes.Equal(authData, ca.PublicKey.Marshal()) {
 					return true
 				}
@@ -122,7 +117,7 @@ func (m *CAStore) Reload() error {
 		return fmt.Errorf("failed to parse CA data: %w", err)
 	}
 
-	m.snapshot.Store(&caSnapshot{entries: entries})
+	m.snapshot.Store(&entries)
 
 	return nil
 }

--- a/controlplane/internal/auth/sshcert/ca_store_test.go
+++ b/controlplane/internal/auth/sshcert/ca_store_test.go
@@ -1,23 +1,116 @@
-package sshcert
+package sshcert_test
 
 import (
+	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshcert"
 )
 
+type testLoader struct {
+	data []byte
+}
+
+func (m testLoader) Source() string {
+	return "test"
+}
+
+func (m testLoader) Load() ([]byte, error) {
+	return m.data, nil
+}
+
+type mutableLoader struct {
+	mu       sync.RWMutex
+	data     []byte
+	err      error
+	nextLoad *blockedLoad
+}
+
+type blockedLoad struct {
+	data    []byte
+	started chan struct{}
+	release chan struct{}
+}
+
+func newMutableLoader(data []byte) *mutableLoader {
+	return &mutableLoader{data: append([]byte(nil), data...)}
+}
+
+func (m *mutableLoader) Source() string {
+	return "mutable"
+}
+
+func (m *mutableLoader) Load() ([]byte, error) {
+	m.mu.Lock()
+	if m.nextLoad != nil {
+		load := m.nextLoad
+		m.nextLoad = nil
+		data := append([]byte(nil), load.data...)
+		close(load.started)
+		m.mu.Unlock()
+
+		<-load.release
+		return data, nil
+	}
+
+	data := append([]byte(nil), m.data...)
+	err := m.err
+	m.mu.Unlock()
+
+	return data, err
+}
+
+func (m *mutableLoader) Set(data []byte, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.data = append([]byte(nil), data...)
+	m.err = err
+}
+
+func (m *mutableLoader) ArmNextLoad(data []byte) *blockedLoad {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.nextLoad != nil {
+		panic("mutable loader already has a blocked load")
+	}
+
+	load := &blockedLoad{
+		data:    append([]byte(nil), data...),
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m.nextLoad = load
+
+	return load
+}
+
+func authorizedKeysData(signers ...ssh.Signer) []byte {
+	var data []byte
+	for _, signer := range signers {
+		data = append(data, ssh.MarshalAuthorizedKey(signer.PublicKey())...)
+	}
+
+	return data
+}
+
 func TestCAStore_VerifyCA_Trusted(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, _ := generateTestUserCert(
 		t, ca, "alice", 1,
 		time.Now().Add(-1*time.Hour),
 		time.Now().Add(24*time.Hour),
 	)
 
-	store := NewCAStore([]CAEntry{
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca.PublicKey()},
 	})
 
@@ -26,37 +119,37 @@ func TestCAStore_VerifyCA_Trusted(t *testing.T) {
 }
 
 func TestCAStore_VerifyCA_Untrusted(t *testing.T) {
-	ca1 := generateCA(t)
-	ca2 := generateCA(t)
+	ca1 := generateTestCA(t)
+	ca2 := generateTestCA(t)
 
 	// Certificate signed by ca1.
-	cert, _ := generateUserCert(
+	cert, _ := generateTestUserCert(
 		t, ca1, "alice", 1,
 		time.Now().Add(-1*time.Hour),
 		time.Now().Add(24*time.Hour),
 	)
 
 	// Store only has ca2.
-	store := NewCAStore([]CAEntry{
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca2.PublicKey()},
 	})
 
 	err := store.VerifyCA(cert)
-	require.ErrorIs(t, err, ErrUntrustedCA)
+	require.ErrorIs(t, err, sshcert.ErrUntrustedCA)
 }
 
 func TestCAStore_VerifyCA_MultipleCAs(t *testing.T) {
-	ca1 := generateCA(t)
-	ca2 := generateCA(t)
+	ca1 := generateTestCA(t)
+	ca2 := generateTestCA(t)
 
 	// Certificate signed by ca2.
-	cert, _ := generateUserCert(
+	cert, _ := generateTestUserCert(
 		t, ca2, "alice", 1,
 		time.Now().Add(-1*time.Hour),
 		time.Now().Add(24*time.Hour),
 	)
 
-	store := NewCAStore([]CAEntry{
+	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca1.PublicKey()},
 		{PublicKey: ca2.PublicKey()},
 	})
@@ -66,22 +159,22 @@ func TestCAStore_VerifyCA_MultipleCAs(t *testing.T) {
 }
 
 func TestCAStore_VerifyCA_EmptyStore(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, _ := generateTestUserCert(
 		t, ca, "alice", 1,
 		time.Now().Add(-1*time.Hour),
 		time.Now().Add(24*time.Hour),
 	)
 
-	store := NewCAStore(nil)
+	store := sshcert.NewCAStore(nil)
 
 	err := store.VerifyCA(cert)
-	require.ErrorIs(t, err, ErrUntrustedCA)
+	require.ErrorIs(t, err, sshcert.ErrUntrustedCA)
 }
 
-func TestParseCAData(t *testing.T) {
-	ca1 := generateCA(t)
-	ca2 := generateCA(t)
+func TestCAStore_LoadAuthorizedKeys(t *testing.T) {
+	ca1 := generateTestCA(t)
+	ca2 := generateTestCA(t)
 
 	// Build authorized_keys format like cauth returns.
 	key1 := strings.TrimSpace(
@@ -92,27 +185,40 @@ func TestParseCAData(t *testing.T) {
 	)
 	data := key1 + "\n" + key2 + " secure_20211011\n"
 
-	entries, err := parseCAData([]byte(data))
+	store, err := sshcert.NewCAStoreFromLoader(testLoader{data: []byte(data)})
 	require.NoError(t, err)
-	require.Len(t, entries, 2)
+	certOne, _ := generateTestUserCert(
+		t, ca1, "alice", 1,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
+	)
+	certTwo, _ := generateTestUserCert(
+		t, ca2, "alice", 1,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
+	)
+	require.NoError(t, store.VerifyCA(certOne))
+	require.NoError(t, store.VerifyCA(certTwo))
 }
 
-func TestParseCAData_WithComments(t *testing.T) {
-	ca := generateCA(t)
+func TestCAStore_LoadAuthorizedKeys_WithComments(t *testing.T) {
+	ca := generateTestCA(t)
 
 	key := strings.TrimSpace(
 		string(ssh.MarshalAuthorizedKey(ca.PublicKey())),
 	)
 	data := "# This is a comment\n\n" + key + " my-ca\n"
 
-	entries, err := parseCAData([]byte(data))
+	store, err := sshcert.NewCAStoreFromLoader(testLoader{data: []byte(data)})
 	require.NoError(t, err)
-	require.Len(t, entries, 1)
+	cert, _ := generateTestUserCert(
+		t, ca, "alice", 1,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
+	)
+	require.NoError(t, store.VerifyCA(cert))
 }
 
 func TestParseCAData_VerifyCA(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, _ := generateTestUserCert(
 		t, ca, "alice", 1,
 		time.Now().Add(-1*time.Hour),
 		time.Now().Add(24*time.Hour),
@@ -123,10 +229,88 @@ func TestParseCAData_VerifyCA(t *testing.T) {
 	)
 	data := key + " current\n"
 
-	entries, err := parseCAData([]byte(data))
+	store, err := sshcert.NewCAStoreFromLoader(testLoader{data: []byte(data)})
 	require.NoError(t, err)
-
-	store := NewCAStore(entries)
 	err = store.VerifyCA(cert)
 	require.NoError(t, err)
+}
+
+func TestCAStore_Reload(t *testing.T) {
+	caOne := generateTestCA(t)
+	caTwo := generateTestCA(t)
+	loader := newMutableLoader(authorizedKeysData(caOne))
+
+	store, err := sshcert.NewCAStoreFromLoader(loader)
+	require.NoError(t, err)
+
+	certOne, _ := generateTestUserCert(
+		t, caOne, "alice", 1,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
+	)
+	certTwo, _ := generateTestUserCert(
+		t, caTwo, "alice", 2,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
+	)
+
+	require.NoError(t, store.VerifyCA(certOne))
+
+	loader.Set(authorizedKeysData(caTwo), nil)
+	require.NoError(t, store.Reload())
+	require.NoError(t, store.VerifyCA(certTwo))
+	require.ErrorIs(t, store.VerifyCA(certOne), sshcert.ErrUntrustedCA)
+
+	loader.Set(nil, errors.New("loader unavailable"))
+	err = store.Reload()
+	require.ErrorContains(t, err, "failed to reload CA data")
+	require.NoError(t, store.VerifyCA(certTwo))
+
+	loader.Set([]byte("not an authorized key"), nil)
+	err = store.Reload()
+	require.ErrorContains(t, err, "failed to parse CA data")
+	require.NoError(t, store.VerifyCA(certTwo))
+}
+
+func TestCAStore_ReloadConcurrentVerify(t *testing.T) {
+	sharedCA := generateTestCA(t)
+	rotatingCAOne := generateTestCA(t)
+	rotatingCATwo := generateTestCA(t)
+	loader := newMutableLoader(authorizedKeysData(sharedCA, rotatingCAOne))
+	store, err := sshcert.NewCAStoreFromLoader(loader)
+	require.NoError(t, err)
+
+	sharedCert, _ := generateTestUserCert(
+		t, sharedCA, "alice", 1,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
+	)
+	rotatingCertOne, _ := generateTestUserCert(
+		t, rotatingCAOne, "alice", 2,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
+	)
+	rotatingCertTwo, _ := generateTestUserCert(
+		t, rotatingCATwo, "alice", 3,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
+	)
+	snapshots := [][]byte{
+		authorizedKeysData(sharedCA, rotatingCAOne),
+		authorizedKeysData(sharedCA, rotatingCATwo),
+	}
+	rotatingCerts := []*ssh.Certificate{rotatingCertOne, rotatingCertTwo}
+
+	const reloadIterations = 100
+	for idx := range reloadIterations {
+		snapshotIndex := idx % len(snapshots)
+		load := loader.ArmNextLoad(snapshots[snapshotIndex])
+
+		var group errgroup.Group
+		group.Go(func() error {
+			return store.Reload()
+		})
+
+		<-load.started
+		verifyErr := store.VerifyCA(sharedCert)
+		close(load.release)
+		require.NoError(t, verifyErr)
+		require.NoError(t, group.Wait())
+		require.NoError(t, store.VerifyCA(rotatingCerts[snapshotIndex]))
+	}
 }

--- a/controlplane/internal/auth/sshcert/certificate_test.go
+++ b/controlplane/internal/auth/sshcert/certificate_test.go
@@ -1,67 +1,130 @@
-package sshcert
+package sshcert_test
 
 import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshcert"
 )
 
+func authenticateCertificate(
+	t *testing.T,
+	ca ssh.Signer,
+	cert *ssh.Certificate,
+	userSigner ssh.Signer,
+) error {
+	t.Helper()
+
+	authenticator := sshcert.NewAuthenticator(
+		sshcert.NewCAStore([]sshcert.CAEntry{{PublicKey: ca.PublicKey()}}),
+		sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(time.Minute),
+	)
+	t.Cleanup(authenticator.Close)
+
+	token := signTestCertToken(
+		t,
+		userSigner,
+		cert,
+		"/test.Service/Method",
+		time.Now().UnixNano(),
+		"nonce-1",
+	)
+	_, err := authenticator.Authenticate(
+		t.Context(),
+		token,
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
+	return err
+}
+
+func certificateToken(t *testing.T, certificate string) string {
+	t.Helper()
+
+	token := &sshcert.Token{
+		Version:     1,
+		Certificate: certificate,
+		Timestamp:   time.Now().UnixNano(),
+		Nonce:       "nonce-1",
+		Method:      "/test.Service/Method",
+		Signature:   "sig",
+	}
+	encoded, err := json.Marshal(token)
+	require.NoError(t, err)
+
+	return "sshcert " + base64.StdEncoding.EncodeToString(encoded)
+}
+
 func TestParseCertificate_Valid(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t, ca, "alice", 1,
-		time.Now().Add(-1*time.Hour),
-		time.Now().Add(24*time.Hour),
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
 	)
 
-	certB64 := encodeCert(t, cert)
-	parsed, err := parseCertificate(certB64)
-	require.NoError(t, err)
-	assert.Equal(t, cert.Serial, parsed.Serial)
+	require.NoError(t, authenticateCertificate(t, ca, cert, userSigner))
 }
 
 func TestParseCertificate_InvalidBase64(t *testing.T) {
-	_, err := parseCertificate("!!!invalid!!!")
-	require.ErrorIs(t, err, ErrInvalidCertificate)
+	ca := generateTestCA(t)
+	authenticator := sshcert.NewAuthenticator(
+		sshcert.NewCAStore([]sshcert.CAEntry{{PublicKey: ca.PublicKey()}}),
+		sshcert.NewNopRevocationChecker(),
+	)
+	t.Cleanup(authenticator.Close)
+
+	_, err := authenticator.Authenticate(
+		t.Context(),
+		certificateToken(t, "!!!invalid!!!"),
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid certificate: invalid base64")
 }
 
 func TestParseCertificate_NotACert(t *testing.T) {
-	// Encode a plain public key, not a certificate.
-	signer := generateECDSASigner(t)
-	pubKeyBytes := signer.PublicKey().Marshal()
+	signer := generateTestECDSASigner(t)
+	certificate := base64.StdEncoding.EncodeToString(signer.PublicKey().Marshal())
 
-	_, err := parseCertificate(
-		base64.StdEncoding.EncodeToString(pubKeyBytes),
+	ca := generateTestCA(t)
+	authenticator := sshcert.NewAuthenticator(
+		sshcert.NewCAStore([]sshcert.CAEntry{{PublicKey: ca.PublicKey()}}),
+		sshcert.NewNopRevocationChecker(),
 	)
-	require.ErrorIs(t, err, ErrInvalidCertificate)
+	t.Cleanup(authenticator.Close)
+
+	_, err := authenticator.Authenticate(
+		t.Context(),
+		certificateToken(t, certificate),
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid certificate: not a certificate")
 }
 
 func TestCheckKeyType_ECDSA(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t, ca, "alice", 1,
-		time.Now().Add(-1*time.Hour),
-		time.Now().Add(24*time.Hour),
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
 	)
 
-	err := checkKeyType(cert)
-	require.NoError(t, err)
+	require.NoError(t, authenticateCertificate(t, ca, cert, userSigner))
 }
 
 func TestCheckKeyType_Ed25519_Rejected(t *testing.T) {
-	ca := generateCA(t)
-
-	// Generate ed25519 user key.
-	_, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	ca := generateTestCA(t)
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
-
-	edSigner, err := ssh.NewSignerFromKey(edPriv)
+	edSigner, err := ssh.NewSignerFromKey(privateKey)
 	require.NoError(t, err)
 
 	cert := &ssh.Certificate{
@@ -70,103 +133,95 @@ func TestCheckKeyType_Ed25519_Rejected(t *testing.T) {
 		Serial:          1,
 		KeyId:           "ed25519-user",
 		ValidPrincipals: []string{"alice"},
-		ValidAfter:      uint64(time.Now().Add(-1 * time.Hour).Unix()),
-		ValidBefore:     uint64(time.Now().Add(24 * time.Hour).Unix()),
+		ValidAfter:      uint64(time.Now().Add(-time.Hour).Unix()),
+		ValidBefore:     uint64(time.Now().Add(time.Hour).Unix()),
 	}
+	require.NoError(t, cert.SignCert(rand.Reader, ca))
 
-	err = cert.SignCert(rand.Reader, ca)
-	require.NoError(t, err)
-
-	err = checkKeyType(cert)
-	require.ErrorIs(t, err, ErrUnsupportedKeyType)
+	err = authenticateCertificate(t, ca, cert, edSigner)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "certificate key type check failed: unsupported key type")
 }
 
 func TestCheckCertType_UserCert(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t, ca, "alice", 1,
-		time.Now().Add(-1*time.Hour),
-		time.Now().Add(24*time.Hour),
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
 	)
 
-	err := checkCertType(cert)
-	require.NoError(t, err)
+	require.NoError(t, authenticateCertificate(t, ca, cert, userSigner))
 }
 
 func TestCheckCertType_HostCert_Rejected(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateHostCert(t, ca, "host.example.com", 1)
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestHostCert(t, ca, "host.example.com", 1)
 
-	err := checkCertType(cert)
-	require.ErrorIs(t, err, ErrNotUserCert)
+	err := authenticateCertificate(t, ca, cert, userSigner)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "certificate type check failed: not a user certificate")
 }
 
 func TestCheckValidity_Valid(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t, ca, "alice", 1,
-		time.Now().Add(-1*time.Hour),
-		time.Now().Add(24*time.Hour),
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
 	)
 
-	err := checkValidity(cert, time.Now())
-	require.NoError(t, err)
+	require.NoError(t, authenticateCertificate(t, ca, cert, userSigner))
 }
 
 func TestCheckValidity_Expired(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t, ca, "alice", 1,
-		time.Now().Add(-48*time.Hour),
-		time.Now().Add(-24*time.Hour),
+		time.Now().Add(-48*time.Hour), time.Now().Add(-24*time.Hour),
 	)
 
-	err := checkValidity(cert, time.Now())
-	require.ErrorIs(t, err, ErrCertExpired)
+	err := authenticateCertificate(t, ca, cert, userSigner)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "certificate validity check failed: certificate expired")
 }
 
 func TestCheckValidity_NotYetValid(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t, ca, "alice", 1,
-		time.Now().Add(24*time.Hour),
-		time.Now().Add(48*time.Hour),
+		time.Now().Add(24*time.Hour), time.Now().Add(48*time.Hour),
 	)
 
-	err := checkValidity(cert, time.Now())
-	require.ErrorIs(t, err, ErrCertNotYetValid)
+	err := authenticateCertificate(t, ca, cert, userSigner)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "certificate validity check failed: certificate not yet valid")
 }
 
 func TestExtractPrincipal_Valid(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
 		t, ca, "alice", 1,
-		time.Now().Add(-1*time.Hour),
-		time.Now().Add(24*time.Hour),
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
 	)
 
-	username, err := extractPrincipal(cert)
-	require.NoError(t, err)
-	assert.Equal(t, "alice", username)
+	require.NoError(t, authenticateCertificate(t, ca, cert, userSigner))
 }
 
 func TestExtractPrincipal_Empty(t *testing.T) {
-	ca := generateCA(t)
-	signer := generateECDSASigner(t)
+	ca := generateTestCA(t)
+	signer := generateTestECDSASigner(t)
 
 	cert := &ssh.Certificate{
 		CertType:        ssh.UserCert,
 		Key:             signer.PublicKey(),
 		Serial:          1,
 		KeyId:           "empty-principals",
+		ValidAfter:      uint64(time.Now().Add(-time.Hour).Unix()),
+		ValidBefore:     uint64(time.Now().Add(time.Hour).Unix()),
 		ValidPrincipals: nil,
-		ValidAfter:      uint64(time.Now().Add(-1 * time.Hour).Unix()),
-		ValidBefore:     uint64(time.Now().Add(24 * time.Hour).Unix()),
 	}
+	require.NoError(t, cert.SignCert(rand.Reader, ca))
 
-	err := cert.SignCert(rand.Reader, ca)
-	require.NoError(t, err)
-
-	_, err = extractPrincipal(cert)
-	require.ErrorIs(t, err, ErrEmptyPrincipals)
+	err := authenticateCertificate(t, ca, cert, signer)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CA verification failed: certificate has no principals")
 }

--- a/controlplane/internal/auth/sshcert/common_test.go
+++ b/controlplane/internal/auth/sshcert/common_test.go
@@ -1,4 +1,4 @@
-package sshcert
+package sshcert_test
 
 import (
 	"crypto/ecdsa"
@@ -12,10 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/krl"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshcert"
 )
 
-// generateECDSASigner creates a new ECDSA P-256 SSH signer.
-func generateECDSASigner(t *testing.T) ssh.Signer {
+// generateTestECDSASigner creates a new ECDSA P-256 SSH signer.
+func generateTestECDSASigner(t *testing.T) ssh.Signer {
 	t.Helper()
 
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -27,15 +29,15 @@ func generateECDSASigner(t *testing.T) ssh.Signer {
 	return signer
 }
 
-// generateCA creates a new ECDSA P-256 CA signer.
-func generateCA(t *testing.T) ssh.Signer {
+// generateTestCA creates a new ECDSA P-256 CA signer.
+func generateTestCA(t *testing.T) ssh.Signer {
 	t.Helper()
 
-	return generateECDSASigner(t)
+	return generateTestECDSASigner(t)
 }
 
-// generateUserCert creates a signed SSH user certificate.
-func generateUserCert(
+// generateTestUserCert creates a signed SSH user certificate.
+func generateTestUserCert(
 	t *testing.T,
 	caSigner ssh.Signer,
 	username string,
@@ -45,7 +47,7 @@ func generateUserCert(
 ) (*ssh.Certificate, ssh.Signer) {
 	t.Helper()
 
-	userSigner := generateECDSASigner(t)
+	userSigner := generateTestECDSASigner(t)
 
 	cert := &ssh.Certificate{
 		CertType:        ssh.UserCert,
@@ -68,8 +70,8 @@ func generateUserCert(
 	return cert, userSigner
 }
 
-// generateHostCert creates a signed SSH host certificate.
-func generateHostCert(
+// generateTestHostCert creates a signed SSH host certificate.
+func generateTestHostCert(
 	t *testing.T,
 	caSigner ssh.Signer,
 	hostname string,
@@ -77,7 +79,7 @@ func generateHostCert(
 ) (*ssh.Certificate, ssh.Signer) {
 	t.Helper()
 
-	userSigner := generateECDSASigner(t)
+	userSigner := generateTestECDSASigner(t)
 
 	cert := &ssh.Certificate{
 		CertType:        ssh.HostCert,
@@ -102,8 +104,8 @@ func encodeCert(t *testing.T, cert *ssh.Certificate) string {
 	return base64.StdEncoding.EncodeToString(cert.Marshal())
 }
 
-// signCertToken creates a valid signed sshcert token for testing.
-func signCertToken(
+// signTestCertToken creates a valid signed sshcert token for testing.
+func signTestCertToken(
 	t *testing.T,
 	userSigner ssh.Signer,
 	cert *ssh.Certificate,
@@ -115,15 +117,15 @@ func signCertToken(
 
 	certB64 := encodeCert(t, cert)
 
-	token := &Token{
-		Version:     tokenVersion,
+	token := &sshcert.Token{
+		Version:     1,
 		Certificate: certB64,
 		Timestamp:   timestamp,
 		Nonce:       nonce,
 		Method:      method,
 	}
 
-	data := token.canonicalSignedData()
+	data := token.CanonicalSignedData()
 	sig, err := userSigner.Sign(rand.Reader, data)
 	require.NoError(t, err)
 
@@ -134,27 +136,12 @@ func signCertToken(
 	jsonBytes, err := json.Marshal(token)
 	require.NoError(t, err)
 
-	return tokenPrefix + base64.StdEncoding.EncodeToString(jsonBytes)
+	return "sshcert " + base64.StdEncoding.EncodeToString(jsonBytes)
 }
 
-// signData signs the given data with the signer and returns the
-// base64-encoded SSH signature.
-func signData(
-	t *testing.T,
-	signer ssh.Signer,
-	data []byte,
-) string {
-	t.Helper()
-
-	sig, err := signer.Sign(rand.Reader, data)
-	require.NoError(t, err)
-
-	return base64.StdEncoding.EncodeToString(ssh.Marshal(sig))
-}
-
-// buildKRL creates a KRL binary with the given revoked serials
+// buildTestKRL creates a KRL binary with the given revoked serials
 // for the given CA.
-func buildKRL(
+func buildTestKRL(
 	t *testing.T,
 	caSigner ssh.Signer,
 	revokedSerials []uint64,

--- a/controlplane/internal/auth/sshcert/loader_test.go
+++ b/controlplane/internal/auth/sshcert/loader_test.go
@@ -1,32 +1,50 @@
-package sshcert
+package sshcert_test
 
 import (
+	"crypto/tls"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshcert"
 )
 
 func TestNewLoader_FileAutoDetect(t *testing.T) {
-	loader := NewLoader("/etc/yanet2/auth/ca.yaml")
-	_, ok := loader.(*fileLoader)
-	assert.True(t, ok, "expected fileLoader for file path")
-	assert.Equal(t, "/etc/yanet2/auth/ca.yaml", loader.Source())
+	expectedData := []byte("file CA data content")
+	path := t.TempDir() + "/ca.pub"
+	require.NoError(t, os.WriteFile(path, expectedData, 0o600))
+
+	loader := sshcert.NewLoader(path)
+	data, err := loader.Load()
+	require.NoError(t, err)
+	assert.Equal(t, expectedData, data)
 }
 
 func TestNewLoader_HTTPAutoDetect(t *testing.T) {
-	loader := NewLoader("https://example.com/ca.yaml")
-	_, ok := loader.(*httpLoader)
-	assert.True(t, ok, "expected httpLoader for HTTP URL")
-	assert.Equal(t, "https://example.com/ca.yaml", loader.Source())
+	expectedData := []byte("HTTPS CA data content")
+	server := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(expectedData)
+		}),
+	)
+	defer server.Close()
+
+	loader := sshcert.NewLoader(server.URL + "/ca.yaml")
+	_, err := loader.Load()
+	require.Error(t, err)
+	var verificationError *tls.CertificateVerificationError
+	require.True(t, errors.As(err, &verificationError))
 }
 
 func TestNewLoader_HTTPAutoDetect_NoTLS(t *testing.T) {
-	loader := NewLoader("http://example.com/ca.yaml")
-	_, ok := loader.(*httpLoader)
-	assert.True(t, ok, "expected httpLoader for http:// URL")
+	loader := sshcert.NewLoader("http://example.com/ca.yaml")
+	assert.Equal(t, "http://example.com/ca.yaml", loader.Source())
 }
 
 func TestHTTPLoader_Success(t *testing.T) {
@@ -40,7 +58,7 @@ func TestHTTPLoader_Success(t *testing.T) {
 	)
 	defer server.Close()
 
-	loader := NewLoader(server.URL + "/ca.yaml")
+	loader := sshcert.NewLoader(server.URL + "/ca.yaml")
 	data, err := loader.Load()
 	require.NoError(t, err)
 	assert.Equal(t, expectedData, data)
@@ -54,7 +72,7 @@ func TestHTTPLoader_Non200Status(t *testing.T) {
 	)
 	defer server.Close()
 
-	loader := NewLoader(server.URL + "/missing")
+	loader := sshcert.NewLoader(server.URL + "/missing")
 	_, err := loader.Load()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected status 404")

--- a/controlplane/internal/auth/sshcert/revocation_test.go
+++ b/controlplane/internal/auth/sshcert/revocation_test.go
@@ -1,4 +1,4 @@
-package sshcert
+package sshcert_test
 
 import (
 	"testing"
@@ -6,11 +6,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/krl"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshcert"
 )
 
 func TestRevocationChecker_Revoked(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, _ := generateTestUserCert(
 		t,
 		ca,
 		"alice",
@@ -19,18 +21,18 @@ func TestRevocationChecker_Revoked(t *testing.T) {
 		time.Now().Add(24*time.Hour),
 	)
 
-	krlData := buildKRL(t, ca, []uint64{42})
+	krlData := buildTestKRL(t, ca, []uint64{42})
 	k, err := krl.ParseKRL(krlData)
 	require.NoError(t, err)
 
-	checker := NewKRLRevocationChecker(k)
+	checker := sshcert.NewKRLRevocationChecker(k)
 	err = checker.IsRevoked(cert)
-	require.ErrorIs(t, err, ErrCertRevoked)
+	require.ErrorIs(t, err, sshcert.ErrCertRevoked)
 }
 
 func TestRevocationChecker_NotRevoked(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
+	ca := generateTestCA(t)
+	cert, _ := generateTestUserCert(
 		t,
 		ca,
 		"alice",
@@ -40,11 +42,11 @@ func TestRevocationChecker_NotRevoked(t *testing.T) {
 	)
 
 	// Revoke serial 99, not 42.
-	krlData := buildKRL(t, ca, []uint64{99})
+	krlData := buildTestKRL(t, ca, []uint64{99})
 	k, err := krl.ParseKRL(krlData)
 	require.NoError(t, err)
 
-	checker := NewKRLRevocationChecker(k)
+	checker := sshcert.NewKRLRevocationChecker(k)
 	err = checker.IsRevoked(cert)
 	require.NoError(t, err)
 }

--- a/controlplane/internal/auth/sshcert/signature_test.go
+++ b/controlplane/internal/auth/sshcert/signature_test.go
@@ -1,77 +1,95 @@
-package sshcert
+package sshcert_test
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshcert"
 )
 
+func authenticateWithSignature(
+	t *testing.T,
+	ca ssh.Signer,
+	cert *ssh.Certificate,
+	signature string,
+) error {
+	t.Helper()
+
+	authenticator := sshcert.NewAuthenticator(
+		sshcert.NewCAStore([]sshcert.CAEntry{{PublicKey: ca.PublicKey()}}),
+		sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(time.Minute),
+	)
+	t.Cleanup(authenticator.Close)
+
+	token := &sshcert.Token{
+		Version:     1,
+		Certificate: base64.StdEncoding.EncodeToString(cert.Marshal()),
+		Timestamp:   time.Now().UnixNano(),
+		Nonce:       "nonce-1",
+		Method:      "/test.Service/Method",
+		Signature:   signature,
+	}
+	encoded, err := json.Marshal(token)
+	require.NoError(t, err)
+
+	_, err = authenticator.Authenticate(
+		t.Context(),
+		"sshcert "+base64.StdEncoding.EncodeToString(encoded),
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
+	return err
+}
+
 func TestVerifySignature_Valid(t *testing.T) {
-	ca := generateCA(t)
-	cert, userSigner := generateUserCert(
-		t,
-		ca,
-		"alice",
-		1,
-		time.Now().Add(-1*time.Hour),
-		time.Now().Add(24*time.Hour),
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
+		t, ca, "alice", 1,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
 	)
 
-	data := []byte("test data to sign")
-	sigB64 := signData(t, userSigner, data)
-
-	err := verifySignature(data, sigB64, cert)
-	require.NoError(t, err)
+	require.NoError(t, authenticateCertificate(t, ca, cert, userSigner))
 }
 
 func TestVerifySignature_WrongKey(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
-		t,
-		ca,
-		"alice",
-		1,
-		time.Now().Add(-1*time.Hour),
-		time.Now().Add(24*time.Hour),
+	ca := generateTestCA(t)
+	cert, _ := generateTestUserCert(
+		t, ca, "alice", 1,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
 	)
+	otherSigner := generateTestECDSASigner(t)
 
-	// Sign with a different key.
-	otherSigner := generateECDSASigner(t)
-	data := []byte("test data to sign")
-	sigB64 := signData(t, otherSigner, data)
-
-	err := verifySignature(data, sigB64, cert)
-	require.ErrorIs(t, err, ErrSignatureVerificationFailed)
+	err := authenticateCertificate(t, ca, cert, otherSigner)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "signature verification failed")
 }
 
 func TestVerifySignature_InvalidBase64(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
-		t,
-		ca,
-		"alice",
-		1,
-		time.Now().Add(-1*time.Hour),
-		time.Now().Add(24*time.Hour),
+	ca := generateTestCA(t)
+	cert, _ := generateTestUserCert(
+		t, ca, "alice", 1,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
 	)
 
-	err := verifySignature([]byte("data"), "!!!invalid!!!", cert)
+	err := authenticateWithSignature(t, ca, cert, "!!!invalid!!!")
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid base64 signature")
 }
 
 func TestVerifySignature_InvalidSSHFormat(t *testing.T) {
-	ca := generateCA(t)
-	cert, _ := generateUserCert(
-		t,
-		ca,
-		"alice",
-		1,
-		time.Now().Add(-1*time.Hour),
-		time.Now().Add(24*time.Hour),
+	ca := generateTestCA(t)
+	cert, _ := generateTestUserCert(
+		t, ca, "alice", 1,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
 	)
 
-	// Valid base64 but not an SSH signature.
-	err := verifySignature([]byte("data"), "dGVzdA==", cert)
+	err := authenticateWithSignature(t, ca, cert, "dGVzdA==")
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid SSH signature format")
 }

--- a/controlplane/internal/auth/sshcert/token.go
+++ b/controlplane/internal/auth/sshcert/token.go
@@ -55,15 +55,15 @@ func parseToken(raw string) (*Token, error) {
 		return nil, fmt.Errorf("invalid JSON payload: %w", err)
 	}
 
-	if err := token.validate(); err != nil {
+	if err := token.Validate(); err != nil {
 		return nil, err
 	}
 
 	return &token, nil
 }
 
-// validate checks token fields for correctness.
-func (m *Token) validate() error {
+// Validate checks token fields for correctness.
+func (m *Token) Validate() error {
 	if m.Version != tokenVersion {
 		return fmt.Errorf("%w: %d", ErrUnsupportedVersion, m.Version)
 	}
@@ -91,14 +91,13 @@ func (m *Token) validate() error {
 	return nil
 }
 
-// canonicalSignedData builds the canonical string that must be
-// signed.
+// CanonicalSignedData builds the canonical string that must be signed.
 //
 // Format:
 //
 //	version={version}\ncertificate={certificate}\n
 //	timestamp={timestamp}\nnonce={nonce}\nmethod={method}
-func (m *Token) canonicalSignedData() []byte {
+func (m *Token) CanonicalSignedData() []byte {
 	return fmt.Appendf(nil,
 		"version=%d\ncertificate=%s\ntimestamp=%d\nnonce=%s\nmethod=%s",
 		m.Version,
@@ -109,12 +108,9 @@ func (m *Token) canonicalSignedData() []byte {
 	)
 }
 
-// checkTimestamp verifies that the token timestamp is within the
-// allowed window relative to the current time.
-func (m *Token) checkTimestamp(
-	now time.Time,
-	window time.Duration,
-) error {
+// CheckTimestamp verifies that the token timestamp is within the allowed
+// window relative to the current time.
+func (m *Token) CheckTimestamp(now time.Time, window time.Duration) error {
 	tokenTime := time.Unix(0, m.Timestamp)
 	diff := now.Sub(tokenTime)
 

--- a/controlplane/internal/auth/sshcert/token_test.go
+++ b/controlplane/internal/auth/sshcert/token_test.go
@@ -1,4 +1,4 @@
-package sshcert
+package sshcert_test
 
 import (
 	"encoding/base64"
@@ -7,108 +7,141 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshcert"
 )
 
+func authenticateRawToken(t *testing.T, raw string) error {
+	t.Helper()
+
+	authenticator := sshcert.NewAuthenticator(
+		sshcert.NewCAStore(nil),
+		sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(time.Minute),
+	)
+	t.Cleanup(authenticator.Close)
+
+	_, err := authenticator.Authenticate(
+		t.Context(),
+		raw,
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
+	return err
+}
+
+func rawToken(t *testing.T, payload string) string {
+	t.Helper()
+
+	return "sshcert " + base64.StdEncoding.EncodeToString([]byte(payload))
+}
+
 func TestParseToken(t *testing.T) {
-	ca := generateCA(t)
-	cert, userSigner := generateUserCert(
-		t,
-		ca,
-		"alice",
-		1,
-		time.Now().Add(-1*time.Hour),
-		time.Now().Add(24*time.Hour),
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
+		t, ca, "alice", 1,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
+	)
+	raw := signTestCertToken(
+		t, userSigner, cert, "/test.Service/Method",
+		time.Now().UnixNano(), "nonce-1",
 	)
 
-	now := time.Now()
-	raw := signCertToken(
-		t,
-		userSigner,
-		cert,
-		"/test.Service/Method",
-		now.UnixNano(),
-		"nonce-1",
+	authenticator := sshcert.NewAuthenticator(
+		sshcert.NewCAStore([]sshcert.CAEntry{{PublicKey: ca.PublicKey()}}),
+		sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(time.Minute),
 	)
+	t.Cleanup(authenticator.Close)
 
-	token, err := parseToken(raw)
+	authInfo, err := authenticator.Authenticate(
+		t.Context(), raw,
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.NoError(t, err)
-	assert.Equal(t, tokenVersion, token.Version)
-	assert.NotEmpty(t, token.Certificate)
-	assert.Equal(t, "/test.Service/Method", token.Method)
-	assert.Equal(t, "nonce-1", token.Nonce)
-	assert.NotEmpty(t, token.Signature)
+	assert.Equal(t, "alice", authInfo.Username)
 }
 
 func TestParseToken_WrongPrefix(t *testing.T) {
-	_, err := parseToken("sshkey dGVzdA==")
-	require.ErrorIs(t, err, ErrInvalidTokenPrefix)
+	err := authenticateRawToken(t, "sshkey dGVzdA==")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshcert.ErrInvalidTokenPrefix.Error())
 }
 
 func TestParseToken_InvalidBase64(t *testing.T) {
-	_, err := parseToken("sshcert !!!invalid-base64!!!")
+	err := authenticateRawToken(t, "sshcert !!!invalid-base64!!!")
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid base64 encoding")
 }
 
 func TestParseToken_InvalidJSON(t *testing.T) {
-	raw := "sshcert " + base64.StdEncoding.EncodeToString(
-		[]byte("not-json"),
-	)
-	_, err := parseToken(raw)
+	err := authenticateRawToken(t, rawToken(t, "not-json"))
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid JSON payload")
 }
 
 func TestParseToken_UnsupportedVersion(t *testing.T) {
 	payload := `{"version":99,"certificate":"c","timestamp":1,"nonce":"n","method":"/m","signature":"sig"}`
-	raw := "sshcert " + base64.StdEncoding.EncodeToString(
-		[]byte(payload),
-	)
-
-	_, err := parseToken(raw)
-	require.ErrorIs(t, err, ErrUnsupportedVersion)
+	err := authenticateRawToken(t, rawToken(t, payload))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshcert.ErrUnsupportedVersion.Error())
 }
 
 func TestParseToken_EmptyCertificate(t *testing.T) {
 	payload := `{"version":1,"certificate":"","timestamp":1,"nonce":"n","method":"/m","signature":"sig"}`
-	raw := "sshcert " + base64.StdEncoding.EncodeToString(
-		[]byte(payload),
-	)
-
-	_, err := parseToken(raw)
-	require.ErrorIs(t, err, ErrEmptyCertificate)
+	err := authenticateRawToken(t, rawToken(t, payload))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshcert.ErrEmptyCertificate.Error())
 }
 
 func TestParseToken_EmptyNonce(t *testing.T) {
 	payload := `{"version":1,"certificate":"c","timestamp":1,"nonce":"","method":"/m","signature":"sig"}`
-	raw := "sshcert " + base64.StdEncoding.EncodeToString(
-		[]byte(payload),
-	)
-
-	_, err := parseToken(raw)
-	require.ErrorIs(t, err, ErrEmptyNonce)
+	err := authenticateRawToken(t, rawToken(t, payload))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshcert.ErrEmptyNonce.Error())
 }
 
 func TestParseToken_EmptyMethod(t *testing.T) {
 	payload := `{"version":1,"certificate":"c","timestamp":1,"nonce":"n","method":"","signature":"sig"}`
-	raw := "sshcert " + base64.StdEncoding.EncodeToString(
-		[]byte(payload),
-	)
-
-	_, err := parseToken(raw)
-	require.ErrorIs(t, err, ErrEmptyMethod)
+	err := authenticateRawToken(t, rawToken(t, payload))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshcert.ErrEmptyMethod.Error())
 }
 
 func TestParseToken_EmptySignature(t *testing.T) {
 	payload := `{"version":1,"certificate":"c","timestamp":1,"nonce":"n","method":"/m","signature":""}`
-	raw := "sshcert " + base64.StdEncoding.EncodeToString(
-		[]byte(payload),
+	err := authenticateRawToken(t, rawToken(t, payload))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshcert.ErrEmptySignature.Error())
+}
+
+func TestToken_CanonicalSignedDataAuthenticates(t *testing.T) {
+	ca := generateTestCA(t)
+	cert, userSigner := generateTestUserCert(
+		t, ca, "alice", 1,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour),
+	)
+	raw := signTestCertToken(
+		t, userSigner, cert, "/test.Service/Method",
+		time.Now().UnixNano(), "nonce-1",
 	)
 
-	_, err := parseToken(raw)
-	require.ErrorIs(t, err, ErrEmptySignature)
+	authenticator := sshcert.NewAuthenticator(
+		sshcert.NewCAStore([]sshcert.CAEntry{{PublicKey: ca.PublicKey()}}),
+		sshcert.NewNopRevocationChecker(),
+		sshcert.WithTimeWindow(time.Minute),
+	)
+	t.Cleanup(authenticator.Close)
+
+	_, err := authenticator.Authenticate(
+		t.Context(), raw,
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
+	require.NoError(t, err)
 }
 
 func TestToken_CanonicalSignedData(t *testing.T) {
-	token := &Token{
+	token := &sshcert.Token{
 		Version:     1,
 		Certificate: "cert-data",
 		Timestamp:   1234567890,
@@ -119,5 +152,5 @@ func TestToken_CanonicalSignedData(t *testing.T) {
 	expected := "version=1\ncertificate=cert-data\n" +
 		"timestamp=1234567890\nnonce=test-nonce\n" +
 		"method=/test.Service/Method"
-	assert.Equal(t, expected, string(token.canonicalSignedData()))
+	assert.Equal(t, expected, string(token.CanonicalSignedData()))
 }

--- a/controlplane/internal/auth/sshkey/authenticator.go
+++ b/controlplane/internal/auth/sshkey/authenticator.go
@@ -101,7 +101,7 @@ func (m *Authenticator) Authenticate(
 		)
 	}
 
-	if err := token.checkTimestamp(time.Now(), m.timeWindow); err != nil {
+	if err := token.CheckTimestamp(time.Now(), m.timeWindow); err != nil {
 		return nil, status.Errorf(
 			codes.Unauthenticated, "sshkey token expired: %v", err,
 		)
@@ -125,7 +125,7 @@ func (m *Authenticator) Authenticate(
 		)
 	}
 
-	signedData := token.canonicalSignedData()
+	signedData := token.CanonicalSignedData()
 	if err := verifySignature(signedData, token.Signature, publicKeys); err != nil {
 		return nil, status.Errorf(
 			codes.Unauthenticated, "signature verification failed: %v", err,

--- a/controlplane/internal/auth/sshkey/authenticator_test.go
+++ b/controlplane/internal/auth/sshkey/authenticator_test.go
@@ -1,4 +1,4 @@
-package sshkey
+package sshkey_test
 
 import (
 	"context"
@@ -12,18 +12,19 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshkey"
 )
 
 // setupAuthenticator creates an Authenticator with generated keys,
 // returning the authenticator and per-user signers.
-func setupAuthenticator(t *testing.T) (*Authenticator, map[string]ssh.Signer) {
+func setupAuthenticator(t *testing.T) (*sshkey.Authenticator, map[string]ssh.Signer) {
 	t.Helper()
 
-	signerAlice := generateEd25519Signer(t)
-	signerBob := generateRSASigner(t)
-	signerCharlie := generateECDSASigner(t)
+	signerAlice := generateTestEd25519Signer(t)
+	signerBob := generateTestRSASigner(t)
+	signerCharlie := generateTestECDSASigner(t)
 
-	keyStore := NewKeyStore(map[string][]KeyEntry{
+	keyStore := sshkey.NewKeyStore(map[string][]sshkey.KeyEntry{
 		"alice": {
 			{
 				PublicKey: signerAlice.PublicKey(),
@@ -44,8 +45,8 @@ func setupAuthenticator(t *testing.T) (*Authenticator, map[string]ssh.Signer) {
 		},
 	})
 
-	auth := NewAuthenticator(keyStore,
-		WithTimeWindow(5*time.Second),
+	auth := sshkey.NewAuthenticator(keyStore,
+		sshkey.WithTimeWindow(5*time.Second),
 	)
 
 	signers := map[string]ssh.Signer{
@@ -58,7 +59,7 @@ func setupAuthenticator(t *testing.T) (*Authenticator, map[string]ssh.Signer) {
 }
 
 func TestAuthenticator_IsTokenSupported(t *testing.T) {
-	auth := &Authenticator{}
+	auth := &sshkey.Authenticator{}
 
 	tests := []struct {
 		name  string
@@ -86,7 +87,7 @@ func TestAuthenticate_Ed25519(t *testing.T) {
 	method := "/test.Service/TestMethod"
 	reqInfo := &core.RequestInfo{FullMethod: method}
 
-	token := signToken(t, signers["alice"], "alice", method, now.UnixNano(), "nonce-1")
+	token := signTestToken(t, signers["alice"], "alice", method, now.UnixNano(), "nonce-1")
 
 	authInfo, err := auth.Authenticate(context.Background(), token, reqInfo)
 	require.NoError(t, err)
@@ -101,7 +102,7 @@ func TestAuthenticate_RSA(t *testing.T) {
 	method := "/test.Service/TestMethod"
 	reqInfo := &core.RequestInfo{FullMethod: method}
 
-	token := signToken(t, signers["bob"], "bob", method, now.UnixNano(), "nonce-1")
+	token := signTestToken(t, signers["bob"], "bob", method, now.UnixNano(), "nonce-1")
 
 	authInfo, err := auth.Authenticate(context.Background(), token, reqInfo)
 	require.NoError(t, err)
@@ -116,7 +117,7 @@ func TestAuthenticate_ECDSA(t *testing.T) {
 	method := "/test.Service/TestMethod"
 	reqInfo := &core.RequestInfo{FullMethod: method}
 
-	token := signToken(t, signers["charlie"], "charlie", method, now.UnixNano(), "nonce-1")
+	token := signTestToken(t, signers["charlie"], "charlie", method, now.UnixNano(), "nonce-1")
 
 	authInfo, err := auth.Authenticate(context.Background(), token, reqInfo)
 	require.NoError(t, err)
@@ -132,7 +133,7 @@ func TestAuthenticate_ExpiredTimestamp(t *testing.T) {
 	reqInfo := &core.RequestInfo{FullMethod: method}
 
 	oldTimestamp := now.Add(-10 * time.Second).UnixNano()
-	token := signToken(t, signers["alice"], "alice", method, oldTimestamp, "nonce-1")
+	token := signTestToken(t, signers["alice"], "alice", method, oldTimestamp, "nonce-1")
 
 	_, err := auth.Authenticate(context.Background(), token, reqInfo)
 	st, ok := status.FromError(err)
@@ -146,7 +147,7 @@ func TestAuthenticate_MethodBindingMismatch(t *testing.T) {
 	now := time.Now()
 	reqInfo := &core.RequestInfo{FullMethod: "/test.Service/TestMethod"}
 
-	token := signToken(
+	token := signTestToken(
 		t, signers["alice"], "alice",
 		"/other.Service/OtherMethod", now.UnixNano(), "nonce-1",
 	)
@@ -164,7 +165,7 @@ func TestAuthenticate_UnknownUser(t *testing.T) {
 	method := "/test.Service/TestMethod"
 	reqInfo := &core.RequestInfo{FullMethod: method}
 
-	token := signToken(t, signers["alice"], "unknown_user", method, now.UnixNano(), "nonce-1")
+	token := signTestToken(t, signers["alice"], "unknown_user", method, now.UnixNano(), "nonce-1")
 
 	_, err := auth.Authenticate(context.Background(), token, reqInfo)
 	requireGRPCError(t, err, codes.Unauthenticated,
@@ -180,7 +181,7 @@ func TestAuthenticate_WrongSignature(t *testing.T) {
 	reqInfo := &core.RequestInfo{FullMethod: method}
 
 	// Sign with bob's key but claim to be alice.
-	token := signToken(t, signers["bob"], "alice", method, now.UnixNano(), "nonce-1")
+	token := signTestToken(t, signers["bob"], "alice", method, now.UnixNano(), "nonce-1")
 
 	_, err := auth.Authenticate(context.Background(), token, reqInfo)
 	requireGRPCError(t, err, codes.Unauthenticated,
@@ -204,7 +205,7 @@ func TestAuthenticate_NilRequestInfo(t *testing.T) {
 	now := time.Now()
 	method := "/test.Service/TestMethod"
 
-	token := signToken(t, signers["alice"], "alice", method, now.UnixNano(), "nonce-1")
+	token := signTestToken(t, signers["alice"], "alice", method, now.UnixNano(), "nonce-1")
 
 	authInfo, err := auth.Authenticate(context.Background(), token, nil)
 	require.NoError(t, err)
@@ -217,7 +218,7 @@ func TestAuthenticate_EmptyFullMethod(t *testing.T) {
 	now := time.Now()
 	method := "/test.Service/TestMethod"
 
-	token := signToken(t, signers["alice"], "alice", method, now.UnixNano(), "nonce-1")
+	token := signTestToken(t, signers["alice"], "alice", method, now.UnixNano(), "nonce-1")
 
 	emptyReqInfo := &core.RequestInfo{}
 	authInfo, err := auth.Authenticate(context.Background(), token, emptyReqInfo)

--- a/controlplane/internal/auth/sshkey/common_test.go
+++ b/controlplane/internal/auth/sshkey/common_test.go
@@ -1,4 +1,4 @@
-package sshkey
+package sshkey_test
 
 import (
 	"crypto/ecdsa"
@@ -15,10 +15,12 @@ import (
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshkey"
 )
 
-// generateEd25519Signer creates a new Ed25519 SSH signer.
-func generateEd25519Signer(t *testing.T) ssh.Signer {
+// generateTestEd25519Signer creates a new Ed25519 SSH signer.
+func generateTestEd25519Signer(t *testing.T) ssh.Signer {
 	t.Helper()
 
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
@@ -30,8 +32,8 @@ func generateEd25519Signer(t *testing.T) ssh.Signer {
 	return signer
 }
 
-// generateRSASigner creates a new RSA SSH signer.
-func generateRSASigner(t *testing.T) ssh.Signer {
+// generateTestRSASigner creates a new RSA SSH signer.
+func generateTestRSASigner(t *testing.T) ssh.Signer {
 	t.Helper()
 
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -43,8 +45,8 @@ func generateRSASigner(t *testing.T) ssh.Signer {
 	return signer
 }
 
-// generateECDSASigner creates a new ECDSA SSH signer.
-func generateECDSASigner(t *testing.T) ssh.Signer {
+// generateTestECDSASigner creates a new ECDSA SSH signer.
+func generateTestECDSASigner(t *testing.T) ssh.Signer {
 	t.Helper()
 
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -57,7 +59,7 @@ func generateECDSASigner(t *testing.T) ssh.Signer {
 }
 
 // signToken creates a valid signed token for testing.
-func signToken(
+func signTestToken(
 	t *testing.T,
 	signer ssh.Signer,
 	username string,
@@ -67,15 +69,15 @@ func signToken(
 ) string {
 	t.Helper()
 
-	token := &Token{
-		Version:   tokenVersion,
+	token := &sshkey.Token{
+		Version:   1,
 		Username:  username,
 		Timestamp: timestamp,
 		Nonce:     nonce,
 		Method:    method,
 	}
 
-	data := token.canonicalSignedData()
+	data := token.CanonicalSignedData()
 	sig, err := signer.Sign(rand.Reader, data)
 	require.NoError(t, err)
 
@@ -84,18 +86,7 @@ func signToken(
 	jsonBytes, err := json.Marshal(token)
 	require.NoError(t, err)
 
-	return tokenPrefix + base64.StdEncoding.EncodeToString(jsonBytes)
-}
-
-// signData signs the given data with the signer and returns the
-// base64-encoded SSH signature.
-func signData(t *testing.T, signer ssh.Signer, data []byte) string {
-	t.Helper()
-
-	sig, err := signer.Sign(rand.Reader, data)
-	require.NoError(t, err)
-
-	return base64.StdEncoding.EncodeToString(ssh.Marshal(sig))
+	return "sshkey " + base64.StdEncoding.EncodeToString(jsonBytes)
 }
 
 // requireGRPCError asserts that err is a gRPC status error with the

--- a/controlplane/internal/auth/sshkey/key_store_test.go
+++ b/controlplane/internal/auth/sshkey/key_store_test.go
@@ -1,16 +1,18 @@
-package sshkey
+package sshkey_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshkey"
 )
 
 func TestKeyStore_GetKeys(t *testing.T) {
-	signer := generateEd25519Signer(t)
+	signer := generateTestEd25519Signer(t)
 
-	store := NewKeyStore(map[string][]KeyEntry{
+	store := sshkey.NewKeyStore(map[string][]sshkey.KeyEntry{
 		"alice": {
 			{
 				PublicKey: signer.PublicKey(),
@@ -24,9 +26,9 @@ func TestKeyStore_GetKeys(t *testing.T) {
 }
 
 func TestKeyStore_DisabledKeyFiltered(t *testing.T) {
-	signer := generateEd25519Signer(t)
+	signer := generateTestEd25519Signer(t)
 
-	store := NewKeyStore(map[string][]KeyEntry{
+	store := sshkey.NewKeyStore(map[string][]sshkey.KeyEntry{
 		"alice": {
 			{
 				PublicKey: signer.PublicKey(),
@@ -41,17 +43,17 @@ func TestKeyStore_DisabledKeyFiltered(t *testing.T) {
 }
 
 func TestKeyStore_UnknownUser(t *testing.T) {
-	store := NewKeyStore(map[string][]KeyEntry{})
+	store := sshkey.NewKeyStore(map[string][]sshkey.KeyEntry{})
 
 	keys := store.GetKeys("unknown")
 	assert.Nil(t, keys)
 }
 
 func TestKeyStore_MultipleKeysPerUser(t *testing.T) {
-	signer1 := generateEd25519Signer(t)
-	signer2 := generateRSASigner(t)
+	signer1 := generateTestEd25519Signer(t)
+	signer2 := generateTestRSASigner(t)
 
-	store := NewKeyStore(map[string][]KeyEntry{
+	store := sshkey.NewKeyStore(map[string][]sshkey.KeyEntry{
 		"alice": {
 			{
 				PublicKey: signer1.PublicKey(),
@@ -69,6 +71,6 @@ func TestKeyStore_MultipleKeysPerUser(t *testing.T) {
 }
 
 func TestKeyStoreFromFile_InvalidFile(t *testing.T) {
-	_, err := NewKeyStoreFromFile("/nonexistent/path.yaml")
+	_, err := sshkey.NewKeyStoreFromFile("/nonexistent/path.yaml")
 	require.Error(t, err)
 }

--- a/controlplane/internal/auth/sshkey/signature_test.go
+++ b/controlplane/internal/auth/sshkey/signature_test.go
@@ -1,81 +1,154 @@
-package sshkey
+package sshkey_test
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ssh"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshkey"
 )
 
-func TestVerifySignature_Ed25519(t *testing.T) {
-	signer := generateEd25519Signer(t)
-	data := []byte("test data to sign")
+func authenticateKeyToken(
+	t *testing.T,
+	keys map[string][]sshkey.KeyEntry,
+	rawToken string,
+) error {
+	t.Helper()
 
-	sigB64 := signData(t, signer, data)
-	require.NoError(t, verifySignature(data, sigB64, []ssh.PublicKey{signer.PublicKey()}))
+	authenticator := sshkey.NewAuthenticator(
+		sshkey.NewKeyStore(keys),
+		sshkey.WithTimeWindow(time.Minute),
+	)
+	_, err := authenticator.Authenticate(
+		t.Context(),
+		rawToken,
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
+	return err
+}
+
+func TestVerifySignature_Ed25519(t *testing.T) {
+	signer := generateTestEd25519Signer(t)
+	token := signTestToken(
+		t, signer, "alice", "/test.Service/Method",
+		time.Now().UnixNano(), "nonce-1",
+	)
+
+	err := authenticateKeyToken(t, map[string][]sshkey.KeyEntry{
+		"alice": {{PublicKey: signer.PublicKey()}},
+	}, token)
+	require.NoError(t, err)
 }
 
 func TestVerifySignature_RSA(t *testing.T) {
-	signer := generateRSASigner(t)
-	data := []byte("test data to sign")
+	signer := generateTestRSASigner(t)
+	token := signTestToken(
+		t, signer, "alice", "/test.Service/Method",
+		time.Now().UnixNano(), "nonce-1",
+	)
 
-	sigB64 := signData(t, signer, data)
-	require.NoError(t, verifySignature(data, sigB64, []ssh.PublicKey{signer.PublicKey()}))
+	err := authenticateKeyToken(t, map[string][]sshkey.KeyEntry{
+		"alice": {{PublicKey: signer.PublicKey()}},
+	}, token)
+	require.NoError(t, err)
 }
 
 func TestVerifySignature_ECDSA(t *testing.T) {
-	signer := generateECDSASigner(t)
-	data := []byte("test data to sign")
+	signer := generateTestECDSASigner(t)
+	token := signTestToken(
+		t, signer, "alice", "/test.Service/Method",
+		time.Now().UnixNano(), "nonce-1",
+	)
 
-	sigB64 := signData(t, signer, data)
-	require.NoError(t, verifySignature(data, sigB64, []ssh.PublicKey{signer.PublicKey()}))
+	err := authenticateKeyToken(t, map[string][]sshkey.KeyEntry{
+		"alice": {{PublicKey: signer.PublicKey()}},
+	}, token)
+	require.NoError(t, err)
 }
 
 func TestVerifySignature_WrongKey(t *testing.T) {
-	signerEd25519 := generateEd25519Signer(t)
-	signerRSA := generateRSASigner(t)
-	data := []byte("test data to sign")
+	signerEd25519 := generateTestEd25519Signer(t)
+	signerRSA := generateTestRSASigner(t)
+	token := signTestToken(
+		t, signerEd25519, "alice", "/test.Service/Method",
+		time.Now().UnixNano(), "nonce-1",
+	)
 
-	sigB64 := signData(t, signerEd25519, data)
-	err := verifySignature(data, sigB64, []ssh.PublicKey{signerRSA.PublicKey()})
-	require.ErrorIs(t, err, ErrSignatureVerificationFailed)
+	err := authenticateKeyToken(t, map[string][]sshkey.KeyEntry{
+		"alice": {{PublicKey: signerRSA.PublicKey()}},
+	}, token)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "signature verification failed")
 }
 
 func TestVerifySignature_MultipleKeysMatchesSecond(t *testing.T) {
-	signerEd25519 := generateEd25519Signer(t)
-	signerRSA := generateRSASigner(t)
-	data := []byte("test data to sign")
+	signerEd25519 := generateTestEd25519Signer(t)
+	signerRSA := generateTestRSASigner(t)
+	token := signTestToken(
+		t, signerRSA, "alice", "/test.Service/Method",
+		time.Now().UnixNano(), "nonce-1",
+	)
 
-	sigB64 := signData(t, signerRSA, data)
-	require.NoError(t, verifySignature(data, sigB64, []ssh.PublicKey{
-		signerEd25519.PublicKey(),
-		signerRSA.PublicKey(),
-	}))
+	err := authenticateKeyToken(t, map[string][]sshkey.KeyEntry{
+		"alice": {
+			{PublicKey: signerEd25519.PublicKey()},
+			{PublicKey: signerRSA.PublicKey()},
+		},
+	}, token)
+	require.NoError(t, err)
 }
 
 func TestVerifySignature_NoKeys(t *testing.T) {
-	signer := generateEd25519Signer(t)
-	data := []byte("test data to sign")
+	signer := generateTestEd25519Signer(t)
+	token := signTestToken(
+		t, signer, "alice", "/test.Service/Method",
+		time.Now().UnixNano(), "nonce-1",
+	)
 
-	sigB64 := signData(t, signer, data)
-	err := verifySignature(data, sigB64, []ssh.PublicKey{})
-	require.ErrorIs(t, err, ErrSignatureVerificationFailed)
+	err := authenticateKeyToken(t, map[string][]sshkey.KeyEntry{}, token)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no SSH keys found")
 }
 
 func TestVerifySignature_InvalidBase64(t *testing.T) {
-	signer := generateEd25519Signer(t)
-	data := []byte("test data to sign")
+	signer := generateTestEd25519Signer(t)
+	token := rawKeyToken(t, "alice", "!!!invalid!!!")
 
-	err := verifySignature(data, "!!!invalid!!!", []ssh.PublicKey{signer.PublicKey()})
+	err := authenticateKeyToken(t, map[string][]sshkey.KeyEntry{
+		"alice": {{PublicKey: signer.PublicKey()}},
+	}, token)
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid base64 signature")
 }
 
 func TestVerifySignature_InvalidSSHSignatureFormat(t *testing.T) {
-	signer := generateEd25519Signer(t)
-	data := []byte("test data to sign")
+	signer := generateTestEd25519Signer(t)
+	token := rawKeyToken(t, "alice", base64.StdEncoding.EncodeToString([]byte("not-a-valid-ssh-sig")))
 
-	sigB64 := base64.StdEncoding.EncodeToString([]byte("not-a-valid-ssh-sig"))
-	err := verifySignature(data, sigB64, []ssh.PublicKey{signer.PublicKey()})
+	err := authenticateKeyToken(t, map[string][]sshkey.KeyEntry{
+		"alice": {{PublicKey: signer.PublicKey()}},
+	}, token)
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid SSH signature format")
+}
+
+func rawKeyToken(t *testing.T, username, signature string) string {
+	t.Helper()
+
+	token := &sshkey.Token{
+		Version:   1,
+		Username:  username,
+		Timestamp: time.Now().UnixNano(),
+		Nonce:     "nonce-1",
+		Method:    "/test.Service/Method",
+		Signature: signature,
+	}
+	data, err := json.Marshal(token)
+	require.NoError(t, err)
+
+	return "sshkey " + base64.StdEncoding.EncodeToString(data)
 }

--- a/controlplane/internal/auth/sshkey/token.go
+++ b/controlplane/internal/auth/sshkey/token.go
@@ -54,15 +54,15 @@ func parseToken(raw string) (*Token, error) {
 		return nil, fmt.Errorf("invalid JSON payload: %w", err)
 	}
 
-	if err := token.validate(); err != nil {
+	if err := token.Validate(); err != nil {
 		return nil, err
 	}
 
 	return &token, nil
 }
 
-// validate checks token fields for correctness.
-func (m *Token) validate() error {
+// Validate checks token fields for correctness.
+func (m *Token) Validate() error {
 	if m.Version != tokenVersion {
 		return fmt.Errorf("%w: %d", ErrUnsupportedVersion, m.Version)
 	}
@@ -90,13 +90,13 @@ func (m *Token) validate() error {
 	return nil
 }
 
-// canonicalSignedData builds the canonical string that must be signed.
+// CanonicalSignedData builds the canonical string that must be signed.
 //
 // Format:
 //
 //	version={version}\nusername={username}\ntimestamp={timestamp}\n
 //	nonce={nonce}\nmethod={method}
-func (m *Token) canonicalSignedData() []byte {
+func (m *Token) CanonicalSignedData() []byte {
 	return fmt.Appendf(nil,
 		"version=%d\nusername=%s\ntimestamp=%d\nnonce=%s\nmethod=%s",
 		m.Version,
@@ -107,9 +107,9 @@ func (m *Token) canonicalSignedData() []byte {
 	)
 }
 
-// checkTimestamp verifies that the token timestamp is within the allowed
+// CheckTimestamp verifies that the token timestamp is within the allowed
 // window relative to the current time.
-func (m *Token) checkTimestamp(now time.Time, window time.Duration) error {
+func (m *Token) CheckTimestamp(now time.Time, window time.Duration) error {
 	tokenTime := time.Unix(0, m.Timestamp)
 	diff := now.Sub(tokenTime)
 

--- a/controlplane/internal/auth/sshkey/token_test.go
+++ b/controlplane/internal/auth/sshkey/token_test.go
@@ -1,4 +1,4 @@
-package sshkey
+package sshkey_test
 
 import (
 	"encoding/base64"
@@ -7,81 +7,101 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshkey"
 )
 
 func TestParseToken(t *testing.T) {
-	signer := generateEd25519Signer(t)
-	now := time.Now()
+	signer := generateTestEd25519Signer(t)
+	raw := signTestToken(
+		t, signer, "alice", "/test.Service/Method",
+		time.Now().UnixNano(), "nonce-1",
+	)
+	authenticator := sshkey.NewAuthenticator(
+		sshkey.NewKeyStore(map[string][]sshkey.KeyEntry{
+			"alice": {{PublicKey: signer.PublicKey()}},
+		}),
+	)
 
-	raw := signToken(t, signer, "alice", "/test.Service/Method", now.UnixNano(), "nonce-1")
-
-	token, err := parseToken(raw)
+	authInfo, err := authenticator.Authenticate(
+		t.Context(), raw,
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.NoError(t, err)
-	assert.Equal(t, tokenVersion, token.Version)
-	assert.Equal(t, "alice", token.Username)
-	assert.Equal(t, "/test.Service/Method", token.Method)
-	assert.Equal(t, "nonce-1", token.Nonce)
-	assert.NotEmpty(t, token.Signature)
+	assert.Equal(t, "alice", authInfo.Username)
+}
+
+func authenticateRawKeyToken(t *testing.T, raw string) error {
+	t.Helper()
+
+	authenticator := sshkey.NewAuthenticator(sshkey.NewKeyStore(map[string][]sshkey.KeyEntry{}))
+	_, err := authenticator.Authenticate(
+		t.Context(), raw,
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
+	return err
+}
+
+func rawKeyTokenPayload(payload string) string {
+	return "sshkey " + base64.StdEncoding.EncodeToString([]byte(payload))
 }
 
 func TestParseToken_WrongPrefix(t *testing.T) {
-	_, err := parseToken("basic dGVzdA==")
-	require.ErrorIs(t, err, ErrInvalidTokenPrefix)
+	err := authenticateRawKeyToken(t, "basic dGVzdA==")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshkey.ErrInvalidTokenPrefix.Error())
 }
 
 func TestParseToken_InvalidBase64(t *testing.T) {
-	_, err := parseToken("sshkey !!!invalid-base64!!!")
+	err := authenticateRawKeyToken(t, "sshkey !!!invalid-base64!!!")
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid base64 encoding")
 }
 
 func TestParseToken_InvalidJSON(t *testing.T) {
-	raw := "sshkey " + base64.StdEncoding.EncodeToString([]byte("not-json"))
-	_, err := parseToken(raw)
+	err := authenticateRawKeyToken(t, rawKeyTokenPayload("not-json"))
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid JSON payload")
 }
 
 func TestParseToken_UnsupportedVersion(t *testing.T) {
 	payload := `{"version":99,"username":"alice","timestamp":1,"nonce":"n","method":"/m","signature":"sig"}`
-	raw := "sshkey " + base64.StdEncoding.EncodeToString([]byte(payload))
-
-	_, err := parseToken(raw)
-	require.ErrorIs(t, err, ErrUnsupportedVersion)
+	err := authenticateRawKeyToken(t, rawKeyTokenPayload(payload))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshkey.ErrUnsupportedVersion.Error())
 }
 
 func TestParseToken_EmptyUsername(t *testing.T) {
 	payload := `{"version":1,"username":"","timestamp":1,"nonce":"n","method":"/m","signature":"sig"}`
-	raw := "sshkey " + base64.StdEncoding.EncodeToString([]byte(payload))
-
-	_, err := parseToken(raw)
-	require.ErrorIs(t, err, ErrEmptyUsername)
+	err := authenticateRawKeyToken(t, rawKeyTokenPayload(payload))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshkey.ErrEmptyUsername.Error())
 }
 
 func TestParseToken_EmptyNonce(t *testing.T) {
 	payload := `{"version":1,"username":"alice","timestamp":1,"nonce":"","method":"/m","signature":"sig"}`
-	raw := "sshkey " + base64.StdEncoding.EncodeToString([]byte(payload))
-
-	_, err := parseToken(raw)
-	require.ErrorIs(t, err, ErrEmptyNonce)
+	err := authenticateRawKeyToken(t, rawKeyTokenPayload(payload))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshkey.ErrEmptyNonce.Error())
 }
 
 func TestParseToken_EmptyMethod(t *testing.T) {
 	payload := `{"version":1,"username":"alice","timestamp":1,"nonce":"n","method":"","signature":"sig"}`
-	raw := "sshkey " + base64.StdEncoding.EncodeToString([]byte(payload))
-
-	_, err := parseToken(raw)
-	require.ErrorIs(t, err, ErrEmptyMethod)
+	err := authenticateRawKeyToken(t, rawKeyTokenPayload(payload))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshkey.ErrEmptyMethod.Error())
 }
 
 func TestParseToken_EmptySignature(t *testing.T) {
 	payload := `{"version":1,"username":"alice","timestamp":1,"nonce":"n","method":"/m","signature":""}`
-	raw := "sshkey " + base64.StdEncoding.EncodeToString([]byte(payload))
-
-	_, err := parseToken(raw)
-	require.ErrorIs(t, err, ErrEmptySignature)
+	err := authenticateRawKeyToken(t, rawKeyTokenPayload(payload))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), sshkey.ErrEmptySignature.Error())
 }
 
 func TestToken_CanonicalSignedData(t *testing.T) {
-	token := &Token{
+	token := &sshkey.Token{
 		Version:   1,
 		Username:  "alice",
 		Timestamp: 1234567890,
@@ -89,6 +109,7 @@ func TestToken_CanonicalSignedData(t *testing.T) {
 		Method:    "/test.Service/Method",
 	}
 
-	expected := "version=1\nusername=alice\ntimestamp=1234567890\nnonce=test-nonce\nmethod=/test.Service/Method"
-	assert.Equal(t, expected, string(token.canonicalSignedData()))
+	expected := "version=1\nusername=alice\ntimestamp=1234567890\n" +
+		"nonce=test-nonce\nmethod=/test.Service/Method"
+	assert.Equal(t, expected, string(token.CanonicalSignedData()))
 }

--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -120,16 +120,6 @@ private:controlplane/gateway/registry.go:BackendRegistry.Renew:entry.lastSeenAt:
 private:controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.backend:1  # legacy: encapsulate behind an exported method or field
 private:controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.backend:2  # legacy: encapsulate behind an exported method or field
 private:controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.lastSeenAt:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/internal/auth/sshcert/authenticator.go:Authenticator.Authenticate:token.canonicalSignedData:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/internal/auth/sshcert/authenticator.go:Authenticator.Authenticate:token.checkTimestamp:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/internal/auth/sshcert/authenticator.go:NewAuthenticator:a.refreshLoop:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/internal/auth/sshcert/ca_store.go:CAStore.VerifyCA:snapshot.entries:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/internal/auth/sshcert/ca_store.go:NewCAStore:s.snapshot:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/internal/auth/sshcert/ca_store.go:NewCAStoreFromLoader:s.snapshot:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/internal/auth/sshcert/token.go:parseToken:token.validate:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/internal/auth/sshkey/authenticator.go:Authenticator.Authenticate:token.canonicalSignedData:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/internal/auth/sshkey/authenticator.go:Authenticator.Authenticate:token.checkTimestamp:1  # legacy: encapsulate behind an exported method or field
-private:controlplane/internal/auth/sshkey/token.go:parseToken:token.validate:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.checkLinkable:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.createLinkedHandles:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.swapLinkedHandles:1  # legacy: encapsulate behind an exported method or field
@@ -270,21 +260,6 @@ testpkg:controlplane/gateway/gateway_test.go:gateway:1  # legacy: migrate to the
 testpkg:controlplane/gateway/readiness_test.go:gateway:1  # legacy: migrate to the external test package
 testpkg:controlplane/gateway/registry_test.go:gateway:1  # legacy: migrate to the external test package
 testpkg:controlplane/gateway/runner_test.go:gateway:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/interceptor_test.go:auth:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/none/authenticator_test.go:none:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshcert/authenticator_test.go:sshcert:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshcert/ca_store_test.go:sshcert:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshcert/certificate_test.go:sshcert:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshcert/common_test.go:sshcert:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshcert/loader_test.go:sshcert:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshcert/revocation_test.go:sshcert:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshcert/signature_test.go:sshcert:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshcert/token_test.go:sshcert:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshkey/authenticator_test.go:sshkey:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshkey/common_test.go:sshkey:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshkey/key_store_test.go:sshkey:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshkey/signature_test.go:sshkey:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/sshkey/token_test.go:sshkey:1  # legacy: migrate to the external test package
 testpkg:controlplane/internal/xgrpc/interceptor_test.go:xgrpc:1  # legacy: migrate to the external test package
 testpkg:controlplane/internal/xgrpc/method_test.go:xgrpc:1  # legacy: migrate to the external test package
 testpkg:devices/plain/controlplane/service_test.go:plain:1  # legacy: migrate to the external test package


### PR DESCRIPTION
- Encapsulates token operations behind read-only behavior while keeping credential-store mutation and refresh lifecycle private.
- Moves all 15 auth tests to external packages and preserves token bytes, loader routing, certificate diagnostics, CA reload, and concurrency coverage through public behavior.
- Removes exactly 25 style-ledger entries: 10 `private` and 15 `testpkg` rows.

Closes #1734.