### PR TITLE
ci(sanitizer): fail the Go half of the sanitizer job on a UBSan diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,10 @@ test-asan-only:
 		meson configure -Dbuildtype=debug -Doptimization=0 -Dfuzzing=disabled -Db_sanitize=address,undefined $(EXTRA_MODULES_FLAG) build; \
 	fi
 	meson compile -C build
-	CGO_CFLAGS="-fsanitize=address,undefined" CGO_LDFLAGS="-fsanitize=address,undefined" go test -count=1 $$(go list ./... | grep -v '^github.com/yanet-platform/yanet2/tests/functional')
+# Set as a default only, mirroring the same if-absent condition meson uses for
+# its own injection: without it, a recoverable diagnostic would go unseen and
+# the package would still pass.
+	CGO_CFLAGS="-fsanitize=address,undefined" CGO_LDFLAGS="-fsanitize=address,undefined" UBSAN_OPTIONS="$${UBSAN_OPTIONS:-halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1}" go test -count=1 $$(go list ./... | grep -v '^github.com/yanet-platform/yanet2/tests/functional')
 	meson test -C build
 
 test-tsan:


### PR DESCRIPTION
A sanitizer diagnostic did not reliably fail the sanitizer job, but the gap was narrower than it looked and worth stating precisely, because it decided the shape of the fix.

Meson injects fatal sanitizer options into every test it runs unless that test overrides them, so the C half of this job already failed on a diagnostic — measured at 67 of 68 tests, the exception being one deliberate opt-out. The Go runner set none of them. An address-sanitizer error there still aborted and failed the package, so that half was never silent. What was silent is a recoverable undefined-behaviour diagnostic: it left the package reporting success, and without verbose output its text was discarded rather than merely unread. That is where fifty-three zero-length-array reports sat on a green main until #2055.

The Go invocation now carries the same option string meson injects, verified byte-identical against meson's own source rather than transcribed, so both halves of one job run one policy instead of two.

## Why fatal rather than scanning output

The issue proposed capturing every package's output and scanning it for sanitizer markers. Making the diagnostic fatal is preferred for three reasons. A failing package has its output printed by the test runner already, so visibility arrives with severity rather than needing its own mechanism. There is no marker list to keep in sync with the sanitizers' message formats. And it is what the C half already does, so the two halves stop diverging.

The one thing a scan could have covered that fatality cannot is a class that prints without killing. Enumerated, there is no such class here: recoverable undefined behaviour is the case being fixed, address errors already fail, and leaks never report at all under the Go runner, so there would have been nothing to scan for them either.

## Evidence

The Go half is clean at the base commit: zero diagnostics across the sweep, 71 packages passing, and enabling the gate changes no verdict. Instrumentation was proven present rather than inferred, so the silence is real silence.

For the second acceptance criterion, a reintroduction was verified rather than assumed. A pre-fix object from the #2055 class was rebuilt and placed into the real link path: ungated it printed six reports while its package still passed, and gated the same package failed.

## What this deliberately does not cover

Leaks remain a C-half capability only. The Go runtime exits through a raw system call, so the leak check registered at exit never runs — no flag changes that, and neither approach to this issue would have. Go code itself is never instrumented; only C reached through cgo is, which is roughly two thirds of the tested packages.

The nat64 unit test keeps its opt-out, so the C half retains exactly one hole. Removing it means fixing twenty diagnostics and a leak in that test harness, which is separable work tracked in #2071 rather than folded in here.

## Cost to expect

Any future undefined behaviour in C reachable from a Go test now fails CI, including third-party code after a submodule bump. That exposure is largely already present, since the C half applies this same policy to the same objects. When it does bite, the remedy is a targeted suppression entry or disabling the specific check for the offending translation unit — not removing the gate.

Closes #2056.