### PR TITLE
refactor(devices): park unreferenced devices on owning agents

### DIFF
--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -77,6 +77,16 @@ func (m ShmDeviceConfig) AsRawPtr() unsafe.Pointer {
 	return unsafe.Pointer(m.ptr)
 }
 
+// Release drops the construction reference the C constructor took.
+//
+// When this is the last reference, the device parks on its agent until the
+// next construction of the same device type reclaims it.
+func (m ShmDeviceConfig) Release() {
+	if m.ptr != nil {
+		C.cp_device_release(m.ptr)
+	}
+}
+
 type Agent struct {
 	name string
 	ptr  *C.struct_agent
@@ -192,6 +202,16 @@ func (m *Agent) UpdatePipeline(pipelineConfig PipelineConfig) error {
 
 func (m *Agent) UpdatePlainDevices(devices []DeviceConfig) error {
 	configs := make([]ShmDeviceConfig, 0, len(devices))
+
+	// This helper owns the construction references of every device it
+	// creates, so drop them once the update resolves: on success the live
+	// generation holds the only remaining reference, and on failure the
+	// release parks each device for the next construction to reclaim.
+	defer func() {
+		for idx := range configs {
+			configs[idx].Release()
+		}
+	}()
 
 	for idx := range devices {
 		device := &devices[idx]

--- a/devices/plain/api/controlplane.c
+++ b/devices/plain/api/controlplane.c
@@ -10,12 +10,29 @@
 
 #include "lib/errors/errors.h"
 
+// Destroy a plain device: base teardown, then the wrapper allocation.
+static void
+cp_device_plain_destroy(struct cp_device *cp_device) {
+	struct agent *agent = ADDR_OF(&cp_device->agent);
+	cp_device_fini(cp_device);
+	memory_bfree(
+		&agent->memory_context,
+		cp_device,
+		sizeof(struct cp_device_plain)
+	);
+}
+
 struct cp_device *
 cp_device_plain_new(
 	struct agent *agent,
 	const struct cp_device_plain_config *config,
 	yanet_error **err
 ) {
+	// Reclaim this type's parked entries before the wrapper allocation:
+	// a parked instance can be most of the arena, so reclaiming it first
+	// can be the difference between success and failure under pressure.
+	cp_device_drain_parked(agent, "plain", cp_device_plain_destroy);
+
 	struct cp_device_plain *cp_device_plain =
 		(struct cp_device_plain *)memory_balloc(
 			&agent->memory_context, sizeof(struct cp_device_plain)
@@ -46,13 +63,7 @@ cp_device_plain_new(
 
 void
 cp_device_plain_free(struct cp_device *cp_device) {
-	struct agent *agent = ADDR_OF(&cp_device->agent);
-	cp_device_fini(cp_device);
-	memory_bfree(
-		&agent->memory_context,
-		cp_device,
-		sizeof(struct cp_device_plain)
-	);
+	cp_device_release(cp_device);
 }
 
 struct cp_device_plain_config *

--- a/devices/plain/api/controlplane.h
+++ b/devices/plain/api/controlplane.h
@@ -19,6 +19,10 @@ cp_device_plain_new(
 	yanet_error **err
 );
 
+// Drop the creator's construction reference.
+//
+// Parks the device on its agent when this is the last reference, leaving
+// destruction to the next plain-device construction's reclaim.
 void
 cp_device_plain_free(struct cp_device *cp_device);
 

--- a/devices/plain/controlplane/ffi.go
+++ b/devices/plain/controlplane/ffi.go
@@ -90,11 +90,11 @@ func (m *DeviceConfig) AsFFIDevice() ffi.ShmDeviceConfig {
 	return m.ptr
 }
 
-// Free releases the underlying shared-memory device allocation.
+// Free drops the underlying device's construction reference.
 //
-// Safe to call multiple times: subsequent calls are no-ops. Call it only after
-// the device has been superseded by a newer generation installed via
-// UpdateDevices, so no live config generation references it anymore.
+// Safe to call multiple times: subsequent calls are no-ops. When this is the
+// last reference, the device parks on the agent until the next plain-device
+// construction reclaims it.
 func (m *DeviceConfig) Free() {
 	if ptr := m.asRawPtr(); ptr != nil {
 		C.cp_device_plain_free(ptr)

--- a/devices/plain/controlplane/service.go
+++ b/devices/plain/controlplane/service.go
@@ -50,11 +50,10 @@ func (m *DevicePlainService) UpdateDevice(
 		return nil, fmt.Errorf("failed to update device: %w", err)
 	}
 
-	// UpdateDevices publishes the new generation and waits for the dataplane
-	// to drop the old one, so the superseded device is no longer referenced
-	// and can be freed explicitly. This mirrors how the ACL control plane
-	// reclaims superseded module configs, instead of relying on a type-blind
-	// drain of the agent's unused list.
+	// Free only drops the superseded handle's construction reference: the
+	// device parks on the agent, and the next plain-device construction
+	// reclaims it. This mirrors how the module control planes retire
+	// superseded configs.
 	if old, ok := m.configs[name]; ok {
 		old.Free()
 	}

--- a/devices/plain/controlplane/service_test.go
+++ b/devices/plain/controlplane/service_test.go
@@ -16,9 +16,10 @@ import (
 // UpdateDevice calls do not leak shared-memory arena space.
 //
 // Each update after the first supersedes the previous generation's device;
-// the service frees that handle explicitly once the new generation is
-// installed, so free bytes must settle after the first update instead of
-// decreasing indefinitely.
+// freeing that handle parks it on the agent, and the next update's
+// construction reclaims the parked entry. Exactly one parked device's worth
+// of space stays held between updates, so free bytes must settle after the
+// first supersede instead of decreasing indefinitely.
 func TestUpdateDevice_ReclaimsSupersededDevice(t *testing.T) {
 	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
 		CPMemory:      uint64(datasize.MB * 32),
@@ -48,7 +49,10 @@ func TestUpdateDevice_ReclaimsSupersededDevice(t *testing.T) {
 		require.NoError(t, err)
 
 		freeBytes := freeBytesForAgent(t, shm, "plain")
-		if idx > 0 {
+		// The first supersede parks the old device without destroying
+		// it, so its space stays held once; every later construction
+		// reclaims the previous parked entry before parking a new one.
+		if idx > 1 {
 			require.Equalf(
 				t,
 				previousFreeBytes,
@@ -64,11 +68,12 @@ func TestUpdateDevice_ReclaimsSupersededDevice(t *testing.T) {
 }
 
 // TestUpdateDevice_ReclaimsAcrossMultipleNames verifies that tracking and
-// reclaiming superseded handles works independently per device name.
+// parking superseded handles works independently per device name.
 //
-// Two names are created and then each is updated again: every superseded
-// handle is freed by the service, so the arena settles back to the size it
-// had right before the second round of updates.
+// Two names are created and then updated for two more rounds: every
+// construction reclaims whatever the previous round parked for its own
+// name, so after the first superseding round the arena holds exactly one
+// parked device's worth of space and stops shrinking.
 func TestUpdateDevice_ReclaimsAcrossMultipleNames(t *testing.T) {
 	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
 		CPMemory:      uint64(datasize.MB * 32),
@@ -85,32 +90,36 @@ func TestUpdateDevice_ReclaimsAcrossMultipleNames(t *testing.T) {
 	t.Cleanup(func() { _ = agent.CleanUp() })
 
 	service := NewDevicePlainService(agent)
+	names := []string{"d0", "d1"}
 
-	for _, name := range []string{"d0", "d1"} {
-		_, err := service.UpdateDevice(t.Context(), &plainpb.UpdateDevicePlainRequest{
-			Name:   name,
-			Device: &commonpb.Device{},
-		})
-		require.NoError(t, err)
+	var previousFreeBytes uint64
+	for round := range 3 {
+		for _, name := range names {
+			_, err := service.UpdateDevice(t.Context(), &plainpb.UpdateDevicePlainRequest{
+				Name:   name,
+				Device: &commonpb.Device{},
+			})
+			require.NoError(t, err)
+		}
+
+		freeBytes := freeBytesForAgent(t, shm, "plain")
+		// The first superseding round parks each name's old device
+		// without destroying it, so its space stays held once; every
+		// later construction reclaims the previous parked entry
+		// before parking a new one.
+		if round > 1 {
+			require.Equalf(
+				t,
+				previousFreeBytes,
+				freeBytes,
+				"free bytes changed on round %d: %d -> %d",
+				round,
+				previousFreeBytes,
+				freeBytes,
+			)
+		}
+		previousFreeBytes = freeBytes
 	}
-
-	freeBytesBeforeSecondRound := freeBytesForAgent(t, shm, "plain")
-
-	for _, name := range []string{"d0", "d1"} {
-		_, err := service.UpdateDevice(t.Context(), &plainpb.UpdateDevicePlainRequest{
-			Name:   name,
-			Device: &commonpb.Device{},
-		})
-		require.NoError(t, err)
-	}
-
-	// Both superseded handles from the first round are freed by the second
-	// round of updates, so the arena returns to its pre-second-round size.
-	require.Equal(
-		t,
-		freeBytesBeforeSecondRound,
-		freeBytesForAgent(t, shm, "plain"),
-	)
 }
 
 // freeBytesForAgent returns the free byte count reported for the named

--- a/devices/trafgen/api/controlplane.c
+++ b/devices/trafgen/api/controlplane.c
@@ -14,12 +14,20 @@
 #include "controlplane/agent/agent.h"
 #include "dataplane/config/zone.h"
 
+static void
+cp_device_trafgen_destroy(struct cp_device *cp_device);
+
 struct cp_device *
 cp_device_trafgen_new(
 	struct agent *agent,
 	const struct cp_device_trafgen_config *config,
 	yanet_error **err
 ) {
+	// Reclaim this type's parked entries before the wrapper allocation:
+	// a parked instance can be most of the arena, so reclaiming it first
+	// can be the difference between success and failure under pressure.
+	cp_device_drain_parked(agent, "trafgen", cp_device_trafgen_destroy);
+
 	struct cp_device_trafgen *cp_device_trafgen =
 		(struct cp_device_trafgen *)memory_balloc(
 			&agent->memory_context, sizeof(struct cp_device_trafgen)
@@ -56,11 +64,10 @@ cp_device_trafgen_new(
 		);
 		if (states == NULL) {
 			yanet_error_add(err, "failed to allocate worker state");
-			cp_device_fini(&cp_device_trafgen->cp_device);
-			memory_bfree(
-				&agent->memory_context,
-				cp_device_trafgen,
-				sizeof(struct cp_device_trafgen)
+			// Construction failed before registration, so no
+			// other holder can observe this device: destroy it
+			// directly instead of parking it.
+			cp_device_trafgen_destroy(&cp_device_trafgen->cp_device
 			);
 			return NULL;
 		}
@@ -74,12 +81,17 @@ cp_device_trafgen_new(
 
 void
 cp_device_trafgen_free(struct cp_device *cp_device) {
+	cp_device_release(cp_device);
+}
+
+// Destroy a trafgen device: the subclass buffers, the base resources,
+// then the wrapper allocation.
+static void
+cp_device_trafgen_destroy(struct cp_device *cp_device) {
 	struct cp_device_trafgen *config =
 		container_of(cp_device, struct cp_device_trafgen, cp_device);
 	struct memory_context *memory_context = &cp_device->memory_context;
 
-	// Release the subclass-owned buffers before the base teardown, then the
-	// base resources, then the wrapper struct.
 	struct trafgen_worker_state *states = ADDR_OF(&config->worker_states);
 	if (states != NULL) {
 		memory_bfree(
@@ -199,8 +211,8 @@ cp_device_trafgen_set_rate(struct cp_device *cp_device, uint64_t rate_pps) {
 // Load the frames replayed by the generator.
 //
 // Called once on a freshly created device, so it only allocates. The buffers
-// live in the device's memory_context and are released by
-// cp_device_trafgen_free.
+// live in the device's memory_context and are released by the device's
+// destruction.
 int
 cp_device_trafgen_set_frames(
 	struct cp_device *cp_device,

--- a/devices/trafgen/api/controlplane.h
+++ b/devices/trafgen/api/controlplane.h
@@ -19,6 +19,10 @@ cp_device_trafgen_new(
 	yanet_error **err
 );
 
+// Drop the creator's construction reference.
+//
+// Parks the device on its agent when this is the last reference, leaving
+// destruction to the next trafgen-device construction's reclaim.
 void
 cp_device_trafgen_free(struct cp_device *cp_device);
 

--- a/devices/trafgen/bindings/go/ctrafgen/cgo.go
+++ b/devices/trafgen/bindings/go/ctrafgen/cgo.go
@@ -115,9 +115,11 @@ func (m *DeviceConfig) AsFFIDevice() ffi.ShmDeviceConfig {
 	return m.ptr
 }
 
-// Free releases the underlying C memory.
+// Free drops the underlying device's construction reference.
 //
-// Safe to call multiple times: subsequent calls are no-ops.
+// Safe to call multiple times: subsequent calls are no-ops. When this is the
+// last reference, the device parks on the agent until the next trafgen-device
+// construction reclaims it.
 func (m *DeviceConfig) Free() {
 	if ptr := m.asRawPtr(); ptr != nil {
 		C.cp_device_trafgen_free(ptr)

--- a/devices/trafgen/controlplane/service.go
+++ b/devices/trafgen/controlplane/service.go
@@ -245,11 +245,9 @@ func (m *TrafgenService) SetRate(
 // apply publishes the full device state through the backend and, on success,
 // stores the new config. The caller must hold m.mu.
 //
-// UpdateDevices publishes the new generation and waits for the dataplane to
-// drop the old one, so the superseded handle is safe to free once the new
-// config is stored. This mirrors how the ACL control plane reclaims
-// superseded module configs, instead of relying on a type-blind drain of the
-// agent's unused list.
+// The superseded handle's Free only drops its construction reference: the
+// device parks on the agent, and the next trafgen construction reclaims it.
+// This mirrors how the module control planes retire superseded configs.
 func (m *TrafgenService) apply(
 	name string,
 	packets [][]byte,

--- a/devices/vlan/api/controlplane.c
+++ b/devices/vlan/api/controlplane.c
@@ -10,12 +10,27 @@
 
 #include "lib/errors/errors.h"
 
+// Destroy a vlan device: base teardown, then the wrapper allocation.
+static void
+cp_device_vlan_destroy(struct cp_device *cp_device) {
+	struct agent *agent = ADDR_OF(&cp_device->agent);
+	cp_device_fini(cp_device);
+	memory_bfree(
+		&agent->memory_context, cp_device, sizeof(struct cp_device_vlan)
+	);
+}
+
 struct cp_device *
 cp_device_vlan_new(
 	struct agent *agent,
 	const struct cp_device_vlan_config *config,
 	yanet_error **err
 ) {
+	// Reclaim this type's parked entries before the wrapper allocation:
+	// a parked instance can be most of the arena, so reclaiming it first
+	// can be the difference between success and failure under pressure.
+	cp_device_drain_parked(agent, "vlan", cp_device_vlan_destroy);
+
 	struct cp_device_vlan *cp_device_vlan =
 		(struct cp_device_vlan *)memory_balloc(
 			&agent->memory_context, sizeof(struct cp_device_vlan)
@@ -48,11 +63,7 @@ cp_device_vlan_new(
 
 void
 cp_device_vlan_free(struct cp_device *cp_device) {
-	struct agent *agent = ADDR_OF(&cp_device->agent);
-	cp_device_fini(cp_device);
-	memory_bfree(
-		&agent->memory_context, cp_device, sizeof(struct cp_device_vlan)
-	);
+	cp_device_release(cp_device);
 }
 
 struct cp_device_vlan_config *

--- a/devices/vlan/api/controlplane.h
+++ b/devices/vlan/api/controlplane.h
@@ -20,6 +20,10 @@ cp_device_vlan_new(
 	yanet_error **err
 );
 
+// Drop the creator's construction reference.
+//
+// Parks the device on its agent when this is the last reference, leaving
+// destruction to the next vlan-device construction's reclaim.
 void
 cp_device_vlan_free(struct cp_device *cp_device);
 

--- a/devices/vlan/controlplane/ffi.go
+++ b/devices/vlan/controlplane/ffi.go
@@ -91,11 +91,11 @@ func (m *DeviceConfig) AsFFIDevice() ffi.ShmDeviceConfig {
 	return m.ptr
 }
 
-// Free releases the underlying shared-memory device allocation.
+// Free drops the underlying device's construction reference.
 //
-// Safe to call multiple times: subsequent calls are no-ops. Call it only after
-// the device has been superseded by a newer generation installed via
-// UpdateDevices, so no live config generation references it anymore.
+// Safe to call multiple times: subsequent calls are no-ops. When this is the
+// last reference, the device parks on the agent until the next vlan-device
+// construction reclaims it.
 func (m *DeviceConfig) Free() {
 	if ptr := m.asRawPtr(); ptr != nil {
 		C.cp_device_vlan_free(ptr)

--- a/devices/vlan/controlplane/service.go
+++ b/devices/vlan/controlplane/service.go
@@ -50,11 +50,10 @@ func (m *DeviceVlanService) UpdateDevice(
 		return nil, fmt.Errorf("failed to update device: %w", err)
 	}
 
-	// UpdateDevices publishes the new generation and waits for the dataplane
-	// to drop the old one, so the superseded device is no longer referenced
-	// and can be freed explicitly. This mirrors how the ACL control plane
-	// reclaims superseded module configs, instead of relying on a type-blind
-	// drain of the agent's unused list.
+	// Free only drops the superseded handle's construction reference: the
+	// device parks on the agent, and the next vlan-device construction
+	// reclaims it. This mirrors how the module control planes retire
+	// superseded configs.
 	if old, ok := m.configs[name]; ok {
 		old.Free()
 	}

--- a/devices/vlan/controlplane/service_test.go
+++ b/devices/vlan/controlplane/service_test.go
@@ -15,10 +15,11 @@ import (
 // TestUpdateDevice_DrainsUnusedDevices verifies that repeated UpdateDevice
 // calls do not leak shared-memory arena space.
 //
-// Each update after the first retires the previous generation's device onto
-// the agent's unused list. Without draining that list, the arena shrinks by
-// a fixed amount every call and eventually runs out. Free bytes must settle
-// after the first update instead of decreasing indefinitely.
+// Each update after the first supersedes the previous generation's device;
+// freeing that handle parks it on the agent, and the next update's
+// construction reclaims the parked entry. Exactly one parked device's worth
+// of space stays held between updates, so free bytes must settle after the
+// first supersede instead of decreasing indefinitely.
 func TestUpdateDevice_DrainsUnusedDevices(t *testing.T) {
 	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
 		CPMemory:      uint64(datasize.MB * 32),
@@ -49,7 +50,10 @@ func TestUpdateDevice_DrainsUnusedDevices(t *testing.T) {
 		require.NoError(t, err)
 
 		freeBytes := freeBytesForAgent(t, shm, "vlan")
-		if idx > 0 {
+		// The first supersede parks the old device without destroying
+		// it, so its space stays held once; every later construction
+		// reclaims the previous parked entry before parking a new one.
+		if idx > 1 {
 			require.Equalf(
 				t,
 				previousFreeBytes,

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -85,6 +85,15 @@ struct agent {
 	// types. Each type's construction reclaims only matching entries,
 	// leaving the rest parked for their own type's turn.
 	struct cp_module *parked_modules;
+
+	// Head of this agent's list of devices parked after their reference
+	// count reached zero.
+	//
+	// Follows the same discipline as the module list above: a device type's
+	// construction call reclaims only matching entries, so a list shared by
+	// plain and vlan devices keeps each type's entries for that type's own
+	// next construction.
+	struct cp_device *parked_devices;
 };
 
 struct dp_config *

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -347,6 +347,13 @@ cp_device_init(
 		goto err_out;
 	}
 
+	// Take the creator's reference only after construction succeeds.
+	//
+	// A failed construction leaves nothing to unbalance. This reference
+	// is never mirrored into the live-reference count: a dead creator
+	// must not hold it above zero.
+	registry_item_ref(&self->config_item);
+
 	return 0;
 
 err_out:
@@ -419,22 +426,154 @@ cp_device_registry_copy(
 	};
 
 	SET_OFFSET_OF(&new_device_registry->memory_context, memory_context);
+
+	// Mirror each copied item's new generation reference into its own
+	// agent.
+	//
+	// This keeps the per-agent live count tracking references from a
+	// live configuration generation rather than the creator's own hold,
+	// which a dead creator would otherwise never release.
+	for (uint64_t idx = 0; idx < new_device_registry->registry.capacity;
+	     ++idx) {
+		struct cp_device *device =
+			cp_device_registry_get(new_device_registry, idx);
+		if (device == NULL) {
+			continue;
+		}
+		struct agent *agent = ADDR_OF(&device->agent);
+		if (agent != NULL) {
+			agent->loaded_device_count += 1;
+		}
+	}
+
 	return 0;
 }
 
-static void
+void
 cp_device_registry_item_free_cb(struct registry_item *item, void *data) {
 	struct cp_device *device =
 		container_of(item, struct cp_device, config_item);
 	struct agent *agent = ADDR_OF(&device->agent);
-	if (agent != NULL) {
-		agent->loaded_device_count -= 1;
+	if (agent == NULL) {
+		return;
 	}
+
+	if (ADDR_OF(&device->parked_next) != NULL) {
+		return;
+	}
+
+	struct cp_device *head = ADDR_OF(&agent->parked_devices);
+	SET_OFFSET_OF(&device->parked_next, (head != NULL) ? head : device);
+	SET_OFFSET_OF(&agent->parked_devices, device);
 	(void)data;
 }
 
 void
+cp_device_release(struct cp_device *self) {
+	struct agent *agent = ADDR_OF(&self->agent);
+	struct cp_config *cp_config =
+		(agent != NULL) ? ADDR_OF(&agent->cp_config) : NULL;
+
+	if (cp_config != NULL) {
+		cp_config_lock(cp_config);
+	}
+	registry_item_unref(
+		&self->config_item, cp_device_registry_item_free_cb, NULL
+	);
+	if (cp_config != NULL) {
+		cp_config_unlock(cp_config);
+	}
+}
+
+void
+cp_device_drain_parked(
+	struct agent *agent,
+	const char *device_type,
+	cp_device_free_handler destroy
+) {
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	cp_config_lock(cp_config);
+
+	// Splice the target type's entries into a local list, leaving the
+	// rest linked in place for their own type's next call.
+	//
+	// A spliced-out tail leaves its former predecessor pointing at itself
+	// as the new end of the list, so a parked entry's link is never null.
+	struct cp_device *owned = NULL;
+	struct cp_device *prev = NULL;
+	struct cp_device *cur = ADDR_OF(&agent->parked_devices);
+
+	while (cur != NULL) {
+		struct cp_device *raw_next = ADDR_OF(&cur->parked_next);
+		struct cp_device *next = (raw_next == cur) ? NULL : raw_next;
+
+		if (!strncmp(cur->type, device_type, sizeof(cur->type))) {
+			if (prev == NULL) {
+				SET_OFFSET_OF(&agent->parked_devices, next);
+			} else {
+				SET_OFFSET_OF(
+					&prev->parked_next,
+					(next != NULL) ? next : prev
+				);
+			}
+			SET_OFFSET_OF(&cur->parked_next, owned);
+			owned = cur;
+		} else {
+			prev = cur;
+		}
+
+		cur = next;
+	}
+
+	if (owned == NULL) {
+		cp_config_unlock(cp_config);
+		return;
+	}
+
+	// Pin the agent's arena for the destroy loop below, still under the
+	// same lock the splice above ran under, so the reclaim guard can never
+	// observe the entries detached but the pin not yet set.
+	agent->parked_teardown_count += 1;
+
+	cp_config_unlock(cp_config);
+
+	while (owned != NULL) {
+		struct cp_device *next = ADDR_OF(&owned->parked_next);
+		destroy(owned);
+		owned = next;
+	}
+
+	cp_config_lock(cp_config);
+	agent->parked_teardown_count -= 1;
+	cp_config_unlock(cp_config);
+}
+
+void
 cp_device_registry_fini(struct cp_device_registry *device_registry) {
+	// Mirror each remaining item's dropped generation reference into its
+	// own agent before releasing it.
+	//
+	// The callback this teardown invokes only parks each item at zero
+	// references instead of adjusting the live count itself, so this
+	// loop mirrors the drop first. The same allocation-failure guard
+	// applies as elsewhere: a registry whose backing storage never
+	// allocated reports a nonzero capacity with nothing to walk.
+	if (ADDR_OF(&device_registry->registry.items) != NULL) {
+		for (uint64_t idx = 0; idx < device_registry->registry.capacity;
+		     ++idx) {
+			struct cp_device *device =
+				cp_device_registry_get(device_registry, idx);
+			if (device == NULL) {
+				continue;
+			}
+			struct agent *agent = ADDR_OF(&device->agent);
+			if (agent != NULL) {
+				agent->loaded_device_count -= 1;
+			}
+		}
+	}
+
 	registry_fini(
 		&device_registry->registry,
 		cp_device_registry_item_free_cb,
@@ -484,6 +623,28 @@ cp_device_registry_name_cmp(
 		container_of(item, struct cp_device, config_item);
 
 	return strncmp(device->name, (const char *)data, CP_DEVICE_NAME_LEN);
+}
+
+// Name-only lookup backing delete, whose key is the name alone.
+static struct cp_device *
+cp_device_registry_lookup_name(
+	struct cp_device_registry *device_registry, const char *name
+) {
+	uint64_t index;
+	if (registry_lookup(
+		    &device_registry->registry,
+		    cp_device_registry_name_cmp,
+		    name,
+		    &index
+	    )) {
+		return NULL;
+	}
+
+	return container_of(
+		registry_get(&device_registry->registry, index),
+		struct cp_device,
+		config_item
+	);
 }
 
 struct cp_device *
@@ -541,11 +702,6 @@ cp_device_registry_upsert(
 		return -1;
 	}
 
-	// Count the device only on its first registry reference, mirroring the
-	// 1->0 transition at which cp_device_registry_item_free_cb decrements;
-	// a re-upsert of an already-referenced instance must not double-count.
-	uint64_t refcnt_before = new_device->config_item.refcnt;
-
 	if (registry_replace(
 		    &device_registry->registry,
 		    cp_device_registry_item_cmp,
@@ -558,9 +714,21 @@ cp_device_registry_upsert(
 		return -1;
 	}
 
-	struct agent *agent = ADDR_OF(&new_device->agent);
-	if (agent != NULL && refcnt_before == 0) {
-		agent->loaded_device_count += 1;
+	// Mirror this upsert's generation-reference changes into each
+	// affected device's own agent.
+	//
+	// Gaining a reference through upsert only ever happens here, and
+	// losing one to a displacing upsert only ever happens here too, so
+	// the per-agent live count must track both in this one place.
+	struct agent *new_agent = ADDR_OF(&new_device->agent);
+	if (new_agent != NULL) {
+		new_agent->loaded_device_count += 1;
+	}
+	if (old_device != NULL) {
+		struct agent *old_agent = ADDR_OF(&old_device->agent);
+		if (old_agent != NULL) {
+			old_agent->loaded_device_count -= 1;
+		}
 	}
 
 	return 0;
@@ -570,12 +738,29 @@ int
 cp_device_registry_delete(
 	struct cp_device_registry *device_registry, const char *name
 ) {
-	return registry_replace(
-		&device_registry->registry,
-		cp_device_registry_name_cmp,
-		name,
-		NULL,
-		cp_device_registry_item_free_cb,
-		NULL
-	);
+	struct cp_device *old_device =
+		cp_device_registry_lookup_name(device_registry, name);
+
+	if (registry_replace(
+		    &device_registry->registry,
+		    cp_device_registry_name_cmp,
+		    name,
+		    NULL,
+		    cp_device_registry_item_free_cb,
+		    NULL
+	    )) {
+		return -1;
+	}
+
+	// Mirror the generation reference this delete drops into the removed
+	// device's own agent, matching the decrement upsert performs when it
+	// displaces an entry.
+	if (old_device != NULL) {
+		struct agent *old_agent = ADDR_OF(&old_device->agent);
+		if (old_agent != NULL) {
+			old_agent->loaded_device_count -= 1;
+		}
+	}
+
+	return 0;
 }

--- a/lib/controlplane/config/cp_device.h
+++ b/lib/controlplane/config/cp_device.h
@@ -13,6 +13,13 @@
 struct agent;
 struct cp_device;
 
+// Free handler for a device subclass, run when the agent reclaims a parked
+// device of that subclass's type.
+//
+// It must release the subclass's own allocations, then call cp_device_fini
+// and free the enclosing subclass allocation.
+typedef void (*cp_device_free_handler)(struct cp_device *self);
+
 struct cp_device_pipeline {
 	char name[CP_PIPELINE_NAME_LEN];
 	uint64_t weight;
@@ -46,6 +53,16 @@ struct cp_device {
 
 	struct cp_device_entry *input_pipelines;
 	struct cp_device_entry *output_pipelines;
+
+	// Link to the next device parked on the same agent's list, once this
+	// device's reference count reaches zero.
+	//
+	// Only the zero-transition handler sets it, and only a later reclaim
+	// for this device's own type reads it. It stays unset until that
+	// transition happens. The parked list's tail refers to itself
+	// instead of ending at null, so a parked entry's link is never null
+	// — which also marks that this device is already parked.
+	struct cp_device *parked_next;
 };
 
 struct dp_config;
@@ -110,6 +127,53 @@ cp_device_init(
 // Idempotent on zero-init.
 void
 cp_device_fini(struct cp_device *self);
+
+// Destroy every parked device of one type, using the caller's destructor
+// for that type.
+//
+// A different type sharing the same parked list is left in place for its
+// own next call. A parked entry already sits at reference count zero, so
+// the destructor runs directly with no further release and nothing here
+// outlives this call. A device type's construction call runs this before
+// allocating, so a recreation under memory pressure benefits from the
+// space a parked instance would free rather than failing before reaching
+// that reclaim. The caller must not hold the configuration lock.
+void
+cp_device_drain_parked(
+	struct agent *agent,
+	const char *device_type,
+	cp_device_free_handler destroy
+);
+
+// The single handler for a device reference count reaching zero, reached
+// the same way from a registry drop or an explicit release.
+//
+// Parks the device on its agent's list instead of destroying it, because
+// this generic layer does not know the device's subclass, and an agent can
+// host more than one device type at once. The device's own type-specific
+// reclaim destroys it later.
+//
+// Idempotent: once set, a parked entry's link is never null again, so a
+// duplicate transition leaves it in place instead of relinking it. Every
+// caller already holds the configuration lock, so this handler must not
+// take it itself.
+void
+cp_device_registry_item_free_cb(struct registry_item *item, void *data);
+
+// Drop the reference construction took on the caller's behalf.
+//
+// The zero-transition handler runs only when this drop is the last
+// reference, so a caller must not assume the call freed anything: a live
+// or pinned configuration generation may still hold the device. A device
+// parked here is not destroyed on the spot — the next construction call
+// for the same type reclaims it, or it is freed along with the agent's
+// arena.
+//
+// Takes the device's own agent's configuration lock itself, unlike the
+// registry-driven path to the same handler, which already runs under
+// that lock.
+void
+cp_device_release(struct cp_device *self);
 
 /*
  * Pipeline registry contains all existing devices.

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -992,8 +992,29 @@ cp_config_gen_new(struct agent *agent, yanet_error **err) {
 				"failed to upsert device '%s'",
 				device_config.name
 			);
+			// The bootstrap holds the configuration lock
+			// throughout, so drop the construction reference
+			// the lock-holding way: a plain unref, whose
+			// zero-transition parking leaves the unregistered
+			// device on the agent instead of leaking it into
+			// the arena untracked.
+			registry_item_unref(
+				&cp_device->config_item,
+				cp_device_registry_item_free_cb,
+				NULL
+			);
 			goto error;
 		}
+
+		// The bootstrap holds no creator handle beyond this
+		// registration and already holds the configuration lock, so
+		// spend the construction reference with a plain unref and
+		// leave the registry's generation reference as the only one.
+		registry_item_unref(
+			&cp_device->config_item,
+			cp_device_registry_item_free_cb,
+			NULL
+		);
 	}
 
 	return cp_config_gen;

--- a/lib/controlplane/tests/counters_lock_test.c
+++ b/lib/controlplane/tests/counters_lock_test.c
@@ -195,6 +195,9 @@ install_device(
 		"update_devices failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
+	// Drop the construction reference: the live generation holds the
+	// device from here on.
+	cp_device_plain_free(dev);
 	return TEST_SUCCESS;
 }
 

--- a/lib/controlplane/tests/counters_test.c
+++ b/lib/controlplane/tests/counters_test.c
@@ -92,6 +92,9 @@ install_device(
 		"update_devices failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
+	// Drop the construction reference: the live generation holds the
+	// device from here on.
+	cp_device_plain_free(dev);
 	return TEST_SUCCESS;
 }
 

--- a/lib/controlplane/tests/cp_object_gen_test.c
+++ b/lib/controlplane/tests/cp_object_gen_test.c
@@ -626,7 +626,11 @@ install_device_with_pipeline(
 		return -1;
 	}
 	struct cp_device *devs[] = {dev};
-	return cp_config_update_devices(dp_config, cp_config, 1, devs, err);
+	int rc = cp_config_update_devices(dp_config, cp_config, 1, devs, err);
+	// Drop the construction reference: on success the live generation
+	// holds the device, on failure it parks on the agent.
+	cp_device_plain_free(dev);
+	return rc;
 }
 
 // A forward module linked to an installed object produces a per-worker link

--- a/lib/controlplane/tests/loaded_counts_test.c
+++ b/lib/controlplane/tests/loaded_counts_test.c
@@ -9,14 +9,13 @@
  * agent's arenas and memory context, freeing the agent underneath them is a
  * use-after-free.
  *
- * The counts are maintained at registry refcount transitions: a module or
- * device gains its first reference on upsert (0->1, count++) and loses its
- * last reference in the registry free callback (1->0, count--). This test
- * drives the full update path: it puts a device into the live generation
- * (upsert), supersedes the owning agent, and checks that reclamation is
- * withheld while the count is non-zero and proceeds once the device leaves
- * the live generation, which drops the old owner's last reference via the
- * free callback.
+ * The counts follow generation references: a copy, an upsert and a delete
+ * adjust them where the reference changes hands, and the free callback only
+ * parks a device whose last reference dropped. This test drives the full
+ * update path: it puts a device into the live generation (upsert),
+ * supersedes the owning agent, and checks that reclamation is withheld while
+ * the count is non-zero and proceeds once the device leaves the live
+ * generation.
  */
 
 #include "api/agent.h"
@@ -38,10 +37,9 @@
 
 #define LOADED_COUNTS_TEST_MEMORY_LIMIT (4u * 1024u * 1024u)
 
-// Install a plain device owned by agent. The upsert refs the new device
-// (0->1, count++) and the install frees the superseded generation, dropping
-// any replaced device's last reference through the free callback, so the
-// owning agent's loaded counts track the generation that is now live.
+// Install a plain device owned by agent, mirroring the plain control
+// plane: construct, update, then drop the construction reference so the
+// live generation holds the only remaining reference.
 static int
 install_device(
 	struct agent *agent,
@@ -71,6 +69,10 @@ install_device(
 		"update_devices failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
+	// Drop the construction reference. If the update displaced this
+	// agent's own older device, that older one already parked; this
+	// device stays held by the live generation.
+	cp_device_plain_free(dev);
 	return TEST_SUCCESS;
 }
 
@@ -124,8 +126,8 @@ run_loaded_counts_test(struct yanet_shm *shm) {
 	);
 
 	// Agent B replaces dev0 with its own. Agent A's device loses its last
-	// reference when the superseded generation is freed, so the free
-	// callback drops A's loaded_device_count to zero. The device's memory
+	// reference when the superseded generation is freed, so it parks on
+	// A and A's loaded_device_count drops to zero. The device's memory
 	// remains in A's arena until A itself is reclaimed.
 	TEST_ASSERT_SUCCESS(
 		install_device(agent_b, dp_config, cp_config, "dev0"),
@@ -144,7 +146,7 @@ run_loaded_counts_test(struct yanet_shm *shm) {
 	);
 
 	// Both counts now zero: reclamation may proceed, and agent A's arena
-	// (still holding the replaced device's memory) is freed with it.
+	// (still holding the parked device's memory) is freed with it.
 	agent_free_unused_agents(agent_b);
 	TEST_ASSERT_NULL(
 		ADDR_OF(&agent_b->prev),
@@ -155,8 +157,8 @@ run_loaded_counts_test(struct yanet_shm *shm) {
 }
 
 // Regression test for re-inserting the same device instance: the loaded
-// count must track first-reference (0->1) transitions, so upserting an
-// already-referenced instance a second time must not bump the count again.
+// count follows generation references, so upserting an already-referenced
+// instance a second time must not bump the count again.
 // Before the fix the upsert incremented unconditionally, which over-counted
 // and permanently blocked reclamation of the owning agent.
 static int
@@ -182,7 +184,7 @@ run_reinsert_count_test(struct yanet_shm *shm) {
 	cp_device_plain_config_free(cfg);
 	TEST_ASSERT_NOT_NULL(dev, "device new failed");
 
-	// First install: the device gains its first reference (count 0->1).
+	// First install: the device gains a generation reference (count 0->1).
 	struct cp_device *devs[] = {dev};
 	TEST_ASSERT_SUCCESS(
 		cp_config_update_devices(dp_config, cp_config, 1, devs, &err),
@@ -195,7 +197,8 @@ run_reinsert_count_test(struct yanet_shm *shm) {
 		"device count should be one after the first install"
 	);
 
-	// Re-insert the SAME pointer: it is already referenced, so the count
+	// Re-insert the SAME pointer: the upsert's reference gain and its
+	// displacement of the instance itself must cancel out, so the count
 	// must stay one. Before the fix this bumped it to two.
 	TEST_ASSERT_SUCCESS(
 		cp_config_update_devices(dp_config, cp_config, 1, devs, &err),
@@ -207,6 +210,10 @@ run_reinsert_count_test(struct yanet_shm *shm) {
 		1,
 		"re-inserting the same device must not double-count"
 	);
+
+	// Drop the construction reference, as the control plane does after an
+	// update: the live generation keeps holding the device.
+	cp_device_plain_free(dev);
 
 	return TEST_SUCCESS;
 }

--- a/lib/controlplane/tests/meson.build
+++ b/lib/controlplane/tests/meson.build
@@ -165,3 +165,28 @@ parked_modules_test = executable(
 )
 
 test('parked_modules', parked_modules_test, suite: ['lib'])
+
+parked_devices_test = executable(
+  'parked_devices_test',
+  ['parked_devices_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_device_plain',
+    '-Wl,--export-dynamic-symbol=new_device_plain',
+    '-Wl,--undefined=new_device_vlan',
+    '-Wl,--export-dynamic-symbol=new_device_vlan',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_dev_plain_api,
+    lib_dev_vlan_api,
+    libdpdk_dep,
+  ],
+  link_with: [lib_dev_plain_dp, lib_dev_vlan_dp],
+  include_directories: yanet_rootdir,
+)
+
+test('parked_devices', parked_devices_test, suite: ['lib'])

--- a/lib/controlplane/tests/parked_devices_test.c
+++ b/lib/controlplane/tests/parked_devices_test.c
@@ -1,0 +1,329 @@
+/*
+ * Regression test for the device-parking mechanism: a construction call
+ * must reclaim only parked entries of its own type, and parking an
+ * already-parked device must not extend the list into a cycle.
+ */
+
+#include "api/agent.h"
+
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+
+#include "controlplane/agent/agent.h"
+#include "controlplane/config/cp_device.h"
+#include "controlplane/config/zone.h"
+
+#include "devices/plain/api/controlplane.h"
+#include "devices/vlan/api/controlplane.h"
+
+#include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/errors/errors.h"
+
+#include "logging/log.h"
+
+#include <stdio.h>
+
+#define PARKED_TEST_MEMORY_LIMIT (2u * 1024u * 1024u)
+
+// Reproduces a cross-type parking scenario: releasing one device type's
+// handle while another type shares the same agent.
+//
+// In production, one control plane can own plain and vlan devices through
+// a single agent. A released plain handle parks once its last reference
+// drops, and an unrelated vlan update must leave it alone. A release no
+// longer reclaims by itself, so whichever device each type releases last
+// here stays parked until a later construction of that same type reclaims
+// it.
+static int
+test_drain_parked_filters_by_type(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm,
+		0,
+		"parked-dev-drain-filter",
+		PARKED_TEST_MEMORY_LIMIT,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct cp_device_plain_config *plain_cfg0 =
+		cp_device_plain_config_new("d0", 0, 0, &err);
+	TEST_ASSERT_NOT_NULL(plain_cfg0, "cp_device_plain_config_new failed");
+	struct cp_device *plain0 = cp_device_plain_new(agent, plain_cfg0, &err);
+	cp_device_plain_config_free(plain_cfg0);
+	TEST_ASSERT_NOT_NULL(plain0, "cp_device_plain_new failed");
+
+	// Simulate a live generation holding plain0: a manual registry
+	// reference, exactly like an install would take.
+	struct cp_device_registry reg;
+	TEST_ASSERT_SUCCESS(
+		cp_device_registry_init(&agent->memory_context, &reg, &err),
+		"cp_device_registry_init failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_device_registry_upsert(&reg, "plain", "d0", plain0, &err),
+		"cp_device_registry_upsert failed"
+	);
+
+	// Release the creator's own reference, exactly as the plain control
+	// plane does on free.
+	//
+	// The generation reference above still holds plain0 alive, so
+	// nothing parks yet.
+	cp_device_plain_free(plain0);
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_devices),
+		"nothing must be parked while a generation still holds plain0"
+	);
+
+	// Retire the generation: its last reference drops and plain0 parks.
+	cp_device_registry_fini(&reg);
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_devices) == plain0,
+		"plain0 must be parked once its last reference drops"
+	);
+
+	// An unrelated vlan construction must not touch a parked plain
+	// device.
+	struct cp_device_vlan_config *vlan_cfg0 =
+		cp_device_vlan_config_new("v0", 0, 0, 100, &err);
+	TEST_ASSERT_NOT_NULL(vlan_cfg0, "cp_device_vlan_config_new failed");
+	struct cp_device *vlan0 = cp_device_vlan_new(agent, vlan_cfg0, &err);
+	cp_device_vlan_config_free(vlan_cfg0);
+	TEST_ASSERT_NOT_NULL(vlan0, "cp_device_vlan_new failed");
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_devices) == plain0,
+		"vlan's own construction must leave a parked plain device "
+		"untouched"
+	);
+
+	// A plain construction reaches its own type's parked list and
+	// destroys plain0.
+	struct cp_device_plain_config *plain_cfg1 =
+		cp_device_plain_config_new("d1", 0, 0, &err);
+	TEST_ASSERT_NOT_NULL(plain_cfg1, "cp_device_plain_config_new failed");
+	struct cp_device *plain1 = cp_device_plain_new(agent, plain_cfg1, &err);
+	cp_device_plain_config_free(plain_cfg1);
+	TEST_ASSERT_NOT_NULL(plain1, "cp_device_plain_new failed");
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_devices),
+		"plain's own construction must reclaim the parked plain device"
+	);
+
+	// Steady state: exactly one live plain and one live vlan device.
+	// Reconstructing each type below must return to this same byte count.
+	size_t checkpoint = block_allocator_free_size(&agent->block_allocator);
+
+	// Freeing the only live instance of each type parks it instead of
+	// destroying it: nothing constructs that type again yet to reclaim it.
+	cp_device_vlan_free(vlan0);
+	cp_device_plain_free(plain1);
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_devices) == plain1,
+		"the last release of each type must park it, not destroy it"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&plain1->parked_next) == vlan0,
+		"parking must chain onto the existing list head"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&vlan0->parked_next) == vlan0,
+		"the list tail stays self-referential"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)block_allocator_free_size(&agent->block_allocator),
+		(long)checkpoint,
+		"parking must not itself move memory"
+	);
+
+	// A later construction of each type reclaims what its own release
+	// left parked, exactly as plain1 reclaimed plain0 above.
+	struct cp_device_plain_config *plain_cfg2 =
+		cp_device_plain_config_new("d2", 0, 0, &err);
+	TEST_ASSERT_NOT_NULL(plain_cfg2, "cp_device_plain_config_new failed");
+	struct cp_device *plain2 = cp_device_plain_new(agent, plain_cfg2, &err);
+	cp_device_plain_config_free(plain_cfg2);
+	TEST_ASSERT_NOT_NULL(plain2, "cp_device_plain_new failed");
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_devices) == vlan0,
+		"a plain construction must reclaim only the parked plain device"
+	);
+
+	struct cp_device_vlan_config *vlan_cfg1 =
+		cp_device_vlan_config_new("v1", 0, 0, 100, &err);
+	TEST_ASSERT_NOT_NULL(vlan_cfg1, "cp_device_vlan_config_new failed");
+	struct cp_device *vlan1 = cp_device_vlan_new(agent, vlan_cfg1, &err);
+	cp_device_vlan_config_free(vlan_cfg1);
+	TEST_ASSERT_NOT_NULL(vlan1, "cp_device_vlan_new failed");
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_devices),
+		"a vlan construction must reclaim the parked vlan device"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)block_allocator_free_size(&agent->block_allocator),
+		(long)checkpoint,
+		"replacing each type's parked predecessor must return to the "
+		"same steady state"
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+// A duplicate zero-transition on an already-parked device must not link
+// it in twice.
+//
+// A single-node list can't tell: the head is already the node itself, so
+// a duplicate push is a no-op regardless. This drives it on a two-node
+// list instead: park an older device, then a newer one on top of it,
+// then re-drive the callback on the older, tail entry. Without the
+// guard that relinks the tail in front of the head, closing the two
+// nodes into a cycle a real drain call never finishes walking.
+static int
+test_park_is_idempotent(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm,
+		0,
+		"parked-dev-park-idempotent",
+		PARKED_TEST_MEMORY_LIMIT,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct cp_device_plain_config *plain_cfg_old =
+		cp_device_plain_config_new("idem-old", 0, 0, &err);
+	TEST_ASSERT_NOT_NULL(
+		plain_cfg_old, "cp_device_plain_config_new failed"
+	);
+	struct cp_device *plain_old =
+		cp_device_plain_new(agent, plain_cfg_old, &err);
+	cp_device_plain_config_free(plain_cfg_old);
+	TEST_ASSERT_NOT_NULL(plain_old, "cp_device_plain_new failed");
+	struct cp_device_plain_config *plain_cfg_new =
+		cp_device_plain_config_new("idem-new", 0, 0, &err);
+	TEST_ASSERT_NOT_NULL(
+		plain_cfg_new, "cp_device_plain_config_new failed"
+	);
+	struct cp_device *plain_new =
+		cp_device_plain_new(agent, plain_cfg_new, &err);
+	cp_device_plain_config_free(plain_cfg_new);
+	TEST_ASSERT_NOT_NULL(plain_new, "cp_device_plain_new failed");
+
+	size_t checkpoint = block_allocator_free_size(&agent->block_allocator);
+
+	// Park the older device first, then the newer one on top of it: head
+	// plain_new, tail plain_old self-referential.
+	cp_device_registry_item_free_cb(&plain_old->config_item, NULL);
+	cp_device_registry_item_free_cb(&plain_new->config_item, NULL);
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_devices) == plain_new,
+		"the second park must move the head to plain_new"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&plain_new->parked_next) == plain_old,
+		"plain_new must link onto plain_old"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&plain_old->parked_next) == plain_old,
+		"plain_old must remain the self-referential tail"
+	);
+
+	// Drive the zero-transition callback again on the tail, the same way
+	// a lost update between two racing releases once could.
+	cp_device_registry_item_free_cb(&plain_old->config_item, NULL);
+
+	// Walk from the head with a bound past the real list length: a cyclic
+	// corruption fails this assertion instead of hanging the traversal.
+	struct cp_device *seen[8];
+	size_t seen_count = 0;
+	struct cp_device *node = ADDR_OF(&agent->parked_devices);
+	while (node != NULL && seen_count < 8) {
+		seen[seen_count++] = node;
+		struct cp_device *next = ADDR_OF(&node->parked_next);
+		node = (next == node) ? NULL : next;
+	}
+	TEST_ASSERT_EQUAL(
+		(long)seen_count,
+		2L,
+		"a duplicate zero-transition must not change the list length"
+	);
+	TEST_ASSERT(
+		seen[0] == plain_new && seen[1] == plain_old,
+		"a duplicate zero-transition must not reorder the list"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&plain_old->parked_next) == plain_old,
+		"a duplicate push must leave plain_old's own link untouched"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)block_allocator_free_size(&agent->block_allocator),
+		(long)checkpoint,
+		"parking and re-parking an already-parked device must not move "
+		"memory"
+	);
+
+	// A later plain construction reclaims every parked entry of its own
+	// type, plain_old and plain_new alike.
+	struct cp_device_plain_config *plain_cfg_next =
+		cp_device_plain_config_new("idem-next", 0, 0, &err);
+	TEST_ASSERT_NOT_NULL(
+		plain_cfg_next, "cp_device_plain_config_new failed"
+	);
+	struct cp_device *plain_next =
+		cp_device_plain_new(agent, plain_cfg_next, &err);
+	cp_device_plain_config_free(plain_cfg_next);
+	TEST_ASSERT_NOT_NULL(plain_next, "cp_device_plain_new failed");
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_devices),
+		"construction must reclaim every parked device of its own type"
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	const char *port_names[] = {"01:00.0"};
+	const char *devs_to_load[] = {"plain", "vlan"};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 24,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = NULL,
+		.module_count = 0,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 2,
+	};
+
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	if (ut == NULL) {
+		fprintf(stderr, "dataplane_ut_new failed\n");
+		return 1;
+	}
+
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	if (shm == NULL) {
+		fprintf(stderr, "dataplane_ut_shm returned NULL\n");
+		dataplane_ut_free(ut);
+		return 1;
+	}
+
+	int res = test_drain_parked_filters_by_type(shm);
+	if (res == TEST_SUCCESS) {
+		res = test_park_is_idempotent(shm);
+	}
+
+	dataplane_ut_free(ut);
+
+	return (res == TEST_SUCCESS) ? 0 : 1;
+}


### PR DESCRIPTION
Device construction now takes a registry reference on creation, and the device registry parks every device whose last reference drops on its owning agent's special list instead of freeing it, mirroring the module configuration lifecycle.

- Device creation takes the creator's registry reference, released through the type's free entry point or the shared memory binding after an update resolves.
- A device leaving the live generation parks on its owning agent; the next construction of the same device type reclaims the entries it parked, so repeated updates hold at most one superseded device's worth of arena space per type instead of leaking.
- The per-agent live-device count now tracks generation references at the registry's copy, upsert, delete and teardown transitions, matching how the module count is maintained.
- The bootstrap generation drops its construction reference after registering each topology device, so only the live generation holds those devices.
- Device services keep their update flow and handle tracking, with documentation and tests updated to the parking semantics.

The new C test covers type-filtered reclamation and idempotent parking; the loaded-counts regression test pins the new accounting through the full update path.
