### PR TITLE
fix(functional): disable IPv6 duplicate-address detection on kni0

### DIFF
--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -138,6 +138,17 @@ func HasBaselineSnapshot() bool {
 func (f *TestFramework) CommonConfigCommands() []string {
 	p := f.Paths
 	return []string{
+		// Duplicate address detection holds kni0's link-local address tentative, and
+		// the kernel drops packets addressed to it. The global and per-device knobs
+		// must both be below 1, since either alone leaves detection active. The
+		// default knob also covers an interface created afterward. The write precedes
+		// the link coming up, since it cannot clear an address already tentative.
+		"sysctl -w net.ipv6.conf.all.accept_dad=0 net.ipv6.conf.default.accept_dad=0 net.ipv6.conf.kni0.accept_dad=0",
+
+		// This race is timing-dependent: a link-up either falls inside the
+		// exposure window or misses it, so a green run is weak evidence it
+		// is gone.
+
 		// Configure kni0 network interface
 		"ip link set kni0 up",
 		"ip nei replace " + VMIPv6Gateway + " lladdr " + SrcMAC + " dev kni0",

--- a/tests/functional/framework/harness.go
+++ b/tests/functional/framework/harness.go
@@ -12,12 +12,12 @@ import (
 
 const (
 	baselineSnapshotName    = "baseline"
-	baselineTemplateVersion = "v5"
+	baselineTemplateVersion = "v6"
 )
 
 // baselineTemplatePath returns the versioned overlay path for a baseline
 // snapshot. Bumping the version invalidates locally cached templates when
-// their guest filesystem layout changes.
+// any captured guest state stops matching what this harness configures.
 func baselineTemplatePath(qemuImage, baselineTag string) string {
 	return SnapshotImagePath(qemuImage, baselineTag+"-"+baselineTemplateVersion)
 }

--- a/tests/functional/framework/harness_test.go
+++ b/tests/functional/framework/harness_test.go
@@ -16,13 +16,13 @@ func TestBaselineTemplatePath(t *testing.T) {
 			name:        "default baseline",
 			qemuImage:   "/tmp/yanet-test.qcow2",
 			baselineTag: baselineSnapshotName,
-			want:        "/tmp/yanet-test-baseline-v5.qcow2",
+			want:        "/tmp/yanet-test-baseline-v6.qcow2",
 		},
 		{
 			name:        "custom baseline",
 			qemuImage:   "/tmp/yanet-test.qcow2",
 			baselineTag: "nat64",
-			want:        "/tmp/yanet-test-nat64-v5.qcow2",
+			want:        "/tmp/yanet-test-nat64-v6.qcow2",
 		},
 	}
 


### PR DESCRIPTION
The ICMPv6 echo subtest sends to the autoconfigured EUI-64 link-local address of the kernel interface and waits 500 ms for a reply. Linux runs duplicate-address detection on that address when the interface comes up, and while detection is pending the address stays tentative, a state in which the kernel silently drops packets addressed to it. The IPv4 sibling subtest cannot hit this, because its address is installed explicitly and carries no such gate.

The baseline command list now clears the duplicate-address-detection knobs before bringing the interface up, removing the race instead of waiting it out. The kernel skips detection only when both the global knob and the per-device knob are below 1, so both are written, and the default knob covers an interface created after the list runs.

Measured rather than inferred. Probing from inside the configuration sequence on an unmodified tree shows the address tentative in 5 of 5 restart-path iterations, at every probe from link-up plus 0.2 seconds through plus 0.75 seconds, and clear by plus 2 seconds. With this change it is never tentative across the same 5 iterations, the write succeeds with all three knobs at zero, and the echo replies every time within the subtest's own 500 ms budget. The subtest fires about 1.75 seconds after link-up, on the trailing edge of that window. A forced cold baseline bake was exercised as well, with the forward suite passing.

Probing after the restart helper returns is a false green: that call returns about 2 seconds after link-up, by which point detection has already finished. The window is only visible from inside the command sequence.

The baseline template version is bumped, because the detection setting is guest state captured into the baked snapshot and the fast restore path never re-runs this command list. Without the bump a locally cached template keeps restoring a baseline configured without it. CI caches only the base image and never the baseline overlay, so it bakes fresh on every run and the bump costs it nothing.

Two claims from the report did not survive checking and are deliberately not recorded in the code. Re-running only the failed jobs does not reuse the same baked baseline, for the caching reason above, and the cited run produced failure, failure, then success across three attempts of one unchanged commit. A bad bake also cannot fail every restore, because the per-restore readiness heartbeat runs over IPv4 and only the one subtest reads the address that detection holds tentative. The comment records only what holds.

For anyone reading this pull request's history: the first functional run failed a routing subtest unrelated to this change, and that failure was investigated rather than waved off. The same commit was re-run and passed, so the change is constant across a red and a green attempt and cannot be the variable. That routing subtest asserts on a single packet within a fixed hundred-millisecond budget and never retries, over a round trip whose latency tail is unbounded when the runner is starved of CPU. Across roughly thirty-eight thousand instrumented sends the tail was measured directly, and the one miss that occurred was delivered at a hundred and fourteen milliseconds, late rather than lost. It is a separate test-harness robustness defect, being followed up on its own.

Closes #2063.