### PR TITLE
test(route): pin the forwarding bench's counter arms to real dataplane paths

### DIFF
--- a/modules/route/tests/functional/route_bench_test.go
+++ b/modules/route/tests/functional/route_bench_test.go
@@ -37,23 +37,42 @@ var routeForwardShapes = []routeForwardShape{
 	{name: "spread", spread: true},
 }
 
+// routeForwardCounterMode names one of the two RouteService configurations
+// that BenchmarkRouteForward and TestRoute_NexthopCounterArms both build
+// their arms from.
+type routeForwardCounterMode struct {
+	name string
+	// disabled selects the operator opt-out over the shipped default.
+	disabled bool
+}
+
+var routeForwardCounterModes = []routeForwardCounterMode{
+	{name: "uncounted", disabled: true},
+	{name: "counted"},
+}
+
+// serviceOptions returns the RouteServiceOption set that puts a service
+// into this counter mode.
+func (m routeForwardCounterMode) serviceOptions() []route.RouteServiceOption {
+	if m.disabled {
+		return []route.RouteServiceOption{route.WithNexthopCountersDisabled()}
+	}
+	return nil
+}
+
 // BenchmarkRouteForward measures IPv4 forwarding in both counter modes.
 //
-// The counted arm routes the FIB through RouteService.UpdateFIB with empty
-// counter names, so the service materialises the default per-nexthop
-// counter and the dataplane takes its counted arm (the shipped default).
-// The uncounted arm builds the service with the disable option, so empty
-// counters stay empty and the dataplane takes its uncounted arm.
+// See routeForwardCounterModes for what distinguishes the two arms.
 //
 // The payload-resetting bench runner is required: the route module
 // decrements TTL in place, so without it every round past the initial TTL
 // would measure the drop path instead of forwarding.
 func BenchmarkRouteForward(b *testing.B) {
-	for _, counterMode := range []string{"uncounted", "counted"} {
-		b.Run("counter="+counterMode, func(b *testing.B) {
+	for _, mode := range routeForwardCounterModes {
+		b.Run("counter="+mode.name, func(b *testing.B) {
 			for _, shape := range routeForwardShapes {
 				b.Run(shape.name, func(b *testing.B) {
-					runRouteForwardBench(b, shape, counterMode)
+					runRouteForwardBench(b, shape, mode)
 				})
 			}
 		})
@@ -65,16 +84,12 @@ func BenchmarkRouteForward(b *testing.B) {
 //
 // Setup is excluded from timing: only h.Bench is measured, so the service
 // path's extra setup work does not skew results.
-func runRouteForwardBench(b *testing.B, shape routeForwardShape, counterMode string) {
+func runRouteForwardBench(b *testing.B, shape routeForwardShape, mode routeForwardCounterMode) {
 	b.Helper()
 
 	h, agent, backend := setupRouteHarness(b, "port0")
 
-	var serviceOpts []route.RouteServiceOption
-	if counterMode == "uncounted" {
-		serviceOpts = append(serviceOpts, route.WithNexthopCountersDisabled())
-	}
-	service := route.NewRouteService(backend, serviceOpts...)
+	service := route.NewRouteService(backend, mode.serviceOptions()...)
 
 	entries := buildRouteForwardFIB(shape)
 	_, err := service.UpdateFIB(b.Context(), &routepb.UpdateFIBRequest{
@@ -82,9 +97,6 @@ func runRouteForwardBench(b *testing.B, shape routeForwardShape, counterMode str
 		Entries:    toFIBEntries(b, entries),
 	})
 	require.NoError(b, err)
-	b.Cleanup(func() {
-		_, _ = service.DeleteConfig(b.Context(), &routepb.DeleteConfigRequest{Name: "bench"})
-	})
 
 	// Route config must exist before the pipeline resolves chain references.
 	wirePipeline(b, agent, "port0", "bench")
@@ -95,8 +107,7 @@ func runRouteForwardBench(b *testing.B, shape routeForwardShape, counterMode str
 
 // buildRouteForwardFIB assembles the FIB entries for a bench shape.
 //
-// Nexthop counters are left empty in both modes. The counted service fills
-// the default name per nexthop. The uncounted service leaves it empty.
+// Nexthop counters are left empty in both modes.
 func buildRouteForwardFIB(shape routeForwardShape) []FIBEntry {
 	if shape.spread {
 		entries := make([]FIBEntry, 32)

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -1,8 +1,10 @@
 package route_test
 
 import (
+	"encoding/hex"
 	"net"
 	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -1165,4 +1167,165 @@ func TestUpdateFIB_ShadowedNexthopCounterExcludedFromMetrics(t *testing.T) {
 	names := nexthopCounterLabels(all)
 	require.NotContains(t, names, "nexthop_shadowed", "a fully shadowed nexthop must not be scraped")
 	require.Contains(t, names, "nexthop_surviving")
+}
+
+// nexthopCounterPrefix mirrors the unexported prefix constant in service.go
+// without depending on it, so the generated-name check and the disabled
+// arm's "no per-nexthop counter registered" check cannot drift apart.
+const nexthopCounterPrefix = "nexthop_"
+
+// nexthopCounterNames computes the per-nexthop counter names a counted arm
+// must materialize for fib, deduplicated since several nexthops can share
+// a (device, DstMAC) pair.
+//
+// A renamed materializer in service.go still gets caught by a name mismatch.
+func nexthopCounterNames(fib []FIBEntry) []string {
+	seen := map[string]bool{}
+	names := make([]string, 0)
+	for _, entry := range fib {
+		for _, nexthop := range entry.Nexthops {
+			name := nexthopCounterPrefix + nexthop.Device + "_" + hex.EncodeToString(nexthop.DstMAC)
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// applyRouteForwardArm pushes fib through service.UpdateFIB under module
+// name "arms" and wires the pipeline topology on top of it.
+//
+// Shared by both counter arms so their only difference is the service's
+// nexthop-counter option.
+func applyRouteForwardArm(
+	t *testing.T,
+	service *route.RouteService,
+	agent *ffi.Agent,
+	fib []FIBEntry,
+) {
+	t.Helper()
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "arms",
+		Entries:    toFIBEntries(t, fib),
+	})
+	require.NoError(t, err)
+
+	wirePipeline(t, agent, "port0", "arms")
+}
+
+// requireCounterModesDistinct guards the table this test derives its own
+// expectations from: it fails if modes collapses to one kind instead of
+// covering both.
+//
+// The test's assertions branch on the same mode.disabled field the service
+// wiring branches on, so a table with only counted rows or only disabled
+// rows would pass every sub-test while asserting nothing about the arm the
+// row name claims to be.
+func requireCounterModesDistinct(t *testing.T, modes []routeForwardCounterMode) {
+	t.Helper()
+
+	var haveCounted, haveDisabled bool
+	for _, mode := range modes {
+		if mode.disabled {
+			haveDisabled = true
+		} else {
+			haveCounted = true
+		}
+	}
+	require.True(t, haveCounted, "the counter axis must keep a counted mode")
+	require.True(t, haveDisabled, "the counter axis must keep a disabled mode")
+}
+
+// TestRoute_NexthopCounterArms verifies that BenchmarkRouteForward's two
+// counter modes exercise genuinely distinct dataplane paths.
+//
+// It ranges over routeForwardCounterModes, the same table the benchmark
+// builds its arms from: the counted mode must materialize and increment a
+// per-nexthop counter for every packet forwarded, and the disabled mode
+// must never register one.
+func TestRoute_NexthopCounterArms(t *testing.T) {
+	requireCounterModesDistinct(t, routeForwardCounterModes)
+	require.NotEmpty(t, routeForwardShapes, "the shape table must keep at least one shape")
+
+	path := dataplaneut.CounterPath{
+		Device: "port0", Pipeline: "arms", Function: "arms",
+		Chain: "arms_chain", ModuleType: "route", ModuleName: "arms",
+	}
+
+	for _, shape := range routeForwardShapes {
+		t.Run(shape.name, func(t *testing.T) {
+			fib := buildRouteForwardFIB(shape)
+			names := nexthopCounterNames(fib)
+			require.NotEmpty(t, names, "shape must materialize at least one nexthop counter name")
+
+			for _, mode := range routeForwardCounterModes {
+				t.Run(mode.name, func(t *testing.T) {
+					h, agent, backend := setupRouteHarness(t, "port0")
+					service := route.NewRouteService(backend, mode.serviceOptions()...)
+					applyRouteForwardArm(t, service, agent, fib)
+
+					packets := buildRouteForwardPackets(t)
+					result, err := h.HandlePackets(packets...)
+					require.NoError(t, err)
+					require.Len(t, result.Output, len(packets), "all packets must be forwarded")
+					require.Empty(t, result.Drop)
+
+					if mode.disabled {
+						// Unfiltered on purpose: a filtered query would only
+						// prove the *expected* names are absent, not that no
+						// per-nexthop counter exists under any name.
+						for _, counter := range dataplaneut.RuleCounters(t, h, path, nil) {
+							require.False(t, strings.HasPrefix(counter.Name, nexthopCounterPrefix),
+								"disabled arm must register no per-nexthop counter, found %q", counter.Name)
+						}
+						return
+					}
+
+					// Positive control for the disabled arm's unfiltered
+					// query above: asserts the unfiltered result is a
+					// superset of names, so a nil sentinel that degraded to a
+					// filter excluding per-nexthop counters fails here.
+					unfiltered := dataplaneut.RuleCounters(t, h, path, nil)
+					unfilteredNames := make(map[string]bool, len(unfiltered))
+					for _, counter := range unfiltered {
+						unfilteredNames[counter.Name] = true
+					}
+					for _, name := range names {
+						require.True(t, unfilteredNames[name],
+							"unfiltered query must include per-nexthop counter %q", name)
+					}
+
+					counters := dataplaneut.RuleCounters(t, h, path, names)
+
+					var wantBytes uint64
+					for _, packet := range packets {
+						wantBytes += uint64(len(packet.Data()))
+					}
+
+					byName := map[string][]uint64{}
+					for _, counter := range counters {
+						require.NotEmpty(t, counter.Values)
+						_, dup := byName[counter.Name]
+						require.False(t, dup, "counter name %q must not repeat in the query result", counter.Name)
+						byName[counter.Name] = counter.Values[0]
+					}
+
+					var gotPackets, gotBytes uint64
+					for _, name := range names {
+						values, ok := byName[name]
+						require.True(t, ok, "materialized counter %q must be registered", name)
+						require.GreaterOrEqual(t, len(values), 2, "counter %q must have at least two values (packets, bytes)", name)
+						gotPackets += values[0]
+						gotBytes += values[1]
+					}
+					require.Equal(t, uint64(len(packets)), gotPackets, "per-nexthop counters must sum to every forwarded packet")
+					require.Equal(t, wantBytes, gotBytes, "per-nexthop counters must sum to every forwarded byte")
+				})
+			}
+		})
+	}
 }


### PR DESCRIPTION
The forwarding benchmark measures a counted arm, the shipped default where the control plane materialises a per-nexthop counter, against an uncounted arm, the operator opt-out. Nothing guaranteed the two arms differ on the packet path, so a flipped default, a broken materialiser, or a dataplane that stopped honouring the counter would have collapsed them into one measurement while the benchmark still reported no regression — the defect class of #1765, one level up. Benchmarks never run in CI, so the standing guard belongs in a test.

- Give the benchmark one definition of its counter axis and build both arms from it, replacing the mode-string comparison the arms' meaning previously hung on.
- Add a functional test that drives real packets through each mode of that same table: the counted mode must register every materialised nexthop counter and account for every forwarded packet and byte, the opt-out must register none under any name, and both must forward every packet so the opt-out cannot pass against a broken dataplane.
- Guard both tables the test derives its work from, since it takes its expectations from the same field the service wiring branches on and would otherwise pass against a mode table that had gone one-sided or a shape table that had gone empty.
- Pin the unfiltered counter query with a positive control in the counted arm, asserting it returns a superset of the expected names, so the opt-out's silence is evidence rather than an assumption. Fail loudly on a repeated counter name instead of undercounting the sums.
- Drop the benchmark's module-config cleanup, which could never succeed. The module is wired into a live chain by the time it fires, so the backend correctly refuses to free it, the error was discarded and nothing was reclaimed. Verified by comparing the same delete against a wired and an unwired module. The per-iteration harness teardown already releases the whole segment, so removing it changes no observable state, and the new test registers no such cleanup of its own.
- Trim two benchmark doc comments that restated semantics now stated once beside the mode they describe, which also brings the benchmark's own doc back inside the comment budget.

The historical rerun that acceptance criterion #3 of #1765 asked for was performed, and it is what closes the issue. The post-#1987 benchmark was backported onto both named commits and measured there, interleaved across commits, twenty repetitions per arm, in release builds configured identically.

- On the commit predating the counter the two arms are the same code and read −0.23% geomean at p ≥ 0.606, with exactly zero instruction difference per packet. That run is the harness noise floor.
- On the commit that follows the counter the counted arm is 6.20%, 7.61% and 6.55% slower across the three shapes at p = 0.000, roughly three to six times the floor.
- Across the two commits the counted arm moved 7.99% geomean while the uncounted control did not move at all, and the unit-test dataplane harness is byte-identical between them, so the absolute comparison is sound. The benchmark would have caught the regression.

Assumptions taken along the way, since the issue's own framing turned out to be wrong on one point.

- The benchmark file exists at both named commits as the same blob, so #1987 rewrote it rather than adding it and the backport was feasible rather than blocked.
- Today's figure was read at current main rather than at the commit #1987 merged on, because the route counter path was reworked a day earlier. The cost is still present there at 6.41% geomean, and its per-packet instruction cost rose from 8.00 to 11.28, which is recorded on #1764.
- The cross-commit comparison was confined to the pair the criterion names, because the harness itself changed by current main and that pair's absolute numbers would not be comparable.
- A checked-in throughput baseline was rejected as the standing check, since a wall-clock number is machine-specific and would be a flake source on shared runners.

Closes #1991.