### PR TITLE
ci(fuzz): stop the nightly Go fuzz loop skipping cgo packages

### DIFF
--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build and Go fuzz
     runs-on: ubuntu-24.04
+    outputs:
+      fuzz-binaries-artifact-id: ${{ steps.upload-fuzz-binaries.outputs.artifact-id }}
 
     steps:
       - name: Free up disk space on GitHub runner
@@ -55,45 +57,79 @@ jobs:
         run: |
           mkdir -p fuzz-out
           find build/tests/fuzzing/ -maxdepth 1 -type f -executable -exec cp {} fuzz-out/ \;
+          if [ -z "$(ls -A fuzz-out)" ]; then
+            echo "::error::no fuzz binaries were collected from build/tests/fuzzing/"
+            exit 1
+          fi
 
       - name: Upload fuzz binaries
+        id: upload-fuzz-binaries
         uses: actions/upload-artifact@v4
         with:
           name: fuzz-binaries
           path: fuzz-out/
           retention-days: 1
+          overwrite: true
 
       - name: Run Go fuzz tests
         id: go-fuzz
-        continue-on-error: true
+        env:
+          # The cgo test binary has to link the sanitizer runtimes the
+          # instrumented archives reference, or it fails to link entirely.
+          CGO_CFLAGS: -O2 -g -fsanitize=address,undefined
+          CGO_LDFLAGS: -O2 -g -fsanitize=address,undefined
+          # Without this, a caught sanitizer diagnostic prints but the
+          # test still passes.
+          UBSAN_OPTIONS: halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1
         run: |
+          # Listing targets executes TestMain, and this suite's TestMain
+          # boots a VM from an image never staged in this job.
+          excluded_pkg="github.com/yanet-platform/yanet2/tests/functional/main"
           packages=$(go list ./...)
+          failed_list_pkgs=""
           for pkg in $packages; do
-            fuzz_funcs=$(go test "$pkg" -list '^Fuzz' 2>/dev/null | grep '^Fuzz' || true)
+            if [ "$pkg" = "$excluded_pkg" ]; then
+              continue
+            fi
+            if ! list_out=$(go test "$pkg" -list '^Fuzz'); then
+              echo "::error::failed to list fuzz targets in $pkg"
+              failed_list_pkgs="$failed_list_pkgs $pkg"
+              continue
+            fi
+            fuzz_funcs=$(printf '%s\n' "$list_out" | grep '^Fuzz' || true)
             for func in $fuzz_funcs; do
               echo "Fuzzing $func in $pkg"
               go test "$pkg" -run '^$' -fuzz "^${func}\$" -fuzztime 10m
             done
           done
+          if [ -n "$failed_list_pkgs" ]; then
+            echo "Failed to list fuzz targets in:$failed_list_pkgs"
+            exit 1
+          fi
 
       - name: Upload Go fuzz failure testdata
         uses: actions/upload-artifact@v4
-        if: steps.go-fuzz.outcome == 'failure'
+        if: always() && steps.go-fuzz.outcome == 'failure'
         with:
           name: go-fuzz-testdata
           path: "**/testdata/fuzz/**"
           retention-days: 7
+          overwrite: true
 
   c-fuzz-test:
     name: Fuzz ${{ matrix.module }}
     runs-on: ubuntu-24.04
     needs: build
+    # The build job's conclusion tracks the Go fuzz loop, so a bare needs
+    # would skip the C fuzzers on any Go fuzz failure too. Run whenever the
+    # fuzz binaries were uploaded, even if build failed afterward.
+    if: ${{ !cancelled() && needs.build.outputs.fuzz-binaries-artifact-id != '' }}
     timeout-minutes: 15
 
     strategy:
       fail-fast: false
       matrix:
-        module: [decap, route, nat64w, dscp, fwstate]
+        module: [decap, route, nat64w, dscp, fwstate, forward, mirror]
 
     steps:
       - name: Download fuzz binaries


### PR DESCRIPTION
The nightly Go fuzz step ran with no CGO sanitizer flags against archives that the preceding build step instruments with address, undefined and coverage sanitizers, so every test binary that reaches into C failed to link.

Nothing surfaced that. The probe discarded stderr, its failure marker was filtered out by the fuzz-name match, the exit status was neutralised, and the step was allowed to fail regardless. Measured against a real fuzzing build, 39 of 135 packages were dropped without a word.

- No fuzz coverage was actually being lost, because all three existing fuzz targets live in packages that do not link the instrumented archives. The trap would have fired on the first fuzz target added to a package that touches C.
- The flags are the pair the sanitizer gate in the Makefile already uses. Pinning the compiler is deliberately avoided, since the flags alone work with the default driver, and the undefined half is required because that driver otherwise leaves those handlers unresolved. Go's own optimisation and debug defaults are restated, because setting these variables replaces them rather than appending to them.
- The sanitizer options match that same gate, so a recoverable diagnostic now fails its package instead of printing while the package still passes.
- The functional suite is excluded, because listing fuzz targets executes the suite entry point and that one boots a VM from an image never staged in this job. The exclusion names only that package rather than the whole subtree, which keeps its sibling in the sweep.
- A package whose listing fails is reported and fails the step, but only once the loop has finished, so one unlinkable package cannot cost a night of fuzzing for all the others.
- The crash-testdata upload is guarded so that it still fires now that the step is allowed to fail. Without that, ending the swallowing would have quietly stopped it uploading the one artifact that reproduces a crash.
- The C fuzz matrix no longer rides on the Go loop passing. It is gated on the fuzz binaries having been uploaded, so a Go fuzz crash no longer skips every C fuzzer, and a build that collects no binaries at all now fails instead of reporting success.
- Both artifact uploads overwrite, so re-running the build job, which can now fail for the first time, does not die on a name conflict.
- Two modules were built and shipped in the artifact every night without ever being fuzzed, and now run in the matrix. Each was first run locally for the same budget the job allows, and both completed clean.

Closes #2072.
