### PR TITLE
chore(agents): let the planner fact-check an issue with a scout

### DIFF
--- a/.rulesync/subagents/architect.md
+++ b/.rulesync/subagents/architect.md
@@ -85,7 +85,7 @@ Reviews code quality and verifies task completeness: conventions, safety, builds
 
 ### `planner` — Multi-Horizon Planning Partner (read-only on code, both repos, public-first)
 
-Keeps the plan **in GitHub**: every item is an issue in `yanet-platform/yanet2` or `yanet-platform/yanet2-private`, typed `Bug|Feature|Task`, carrying the org `Priority`/`Effort` fields, an epic's children attached as native sub-issues, and membership of exactly one org project used as a board (#7 packet-path safety, #8 platform quality, #9 release and operations, #10 private NGFW, which takes every private issue). Decomposes fuzzy goals, recommends the highest-value next item (packet-path-safety-first), ingests surfaced debt/backlog, closes finished work, runs bounded autonomous discovery scans, and hands back a filtered, ranked batch of open debt for a period — filtered on repo, board, label and creation date. Each issue body carries a prose `Source:` line naming the evidence and the change it came from: documentation for a human, not a query axis. Runs on `sonnet`; never writes code, never delegates, never runs git writes or builds, and writes no repo file.
+Keeps the plan **in GitHub**: every item is an issue in `yanet-platform/yanet2` or `yanet-platform/yanet2-private`, typed `Bug|Feature|Task`, carrying the org `Priority`/`Effort` fields, an epic's children attached as native sub-issues, and membership of exactly one org project used as a board (#7 packet-path safety, #8 platform quality, #9 release and operations, #10 private NGFW, which takes every private issue). Decomposes fuzzy goals, recommends the highest-value next item (packet-path-safety-first), ingests surfaced debt/backlog, closes finished work, runs bounded autonomous discovery scans, and hands back a filtered, ranked batch of open debt for a period — filtered on repo, board, label and creation date. Each issue body carries a prose `Source:` line naming the evidence and the change it came from: documentation for a human, not a query axis. Runs on `sonnet`; never writes code, delegates only bounded fact-checks to `fast-explorer`, never runs git writes or builds, and writes no repo file.
 **Use when**: at task seams (below) — the **user drives it directly**; you use it secondarily.
 
 ### `bug-hunter` — Defect Confirmation & Dynamic Analysis (read-mostly, never fixes)
@@ -178,11 +178,17 @@ cheap (sonnet) and keeps the plan honest:
 6. **Escalation:** if the planner flags an issue `needs-architect` (decomposition too gnarly for
    sonnet), do the decomposition yourself on opus and hand it back via `planner ingest`.
 
+A payload you hand the planner that asserts a code fact you have not verified this session gets
+checked first — `fast-explorer` can gather the evidence cheaply, but confirming it stays yours —
+and the evidence travels with the payload: a relayed per-file survey once went out half stale and
+would have had the planner file work a merge had already resolved.
+
 The planner is read-only on code and writes no repo file — its state is GitHub issues, projects
 and comments, plus its own memory. It covers **both repos**, so check which repo an issue it hands
 you lives in: a `yanet2-private` issue is worked in `../yanet2-private`, never in this checkout,
-and is never referenced from anything committable here. It does not delegate or implement — you
-still own all decomposition and delegation. Do NOT make it a mandatory step on every task.
+and is never referenced from anything committable here. It delegates only bounded fact-checks to
+`fast-explorer` and otherwise does not delegate or implement — you still own all decomposition and
+delegation. Do NOT make it a mandatory step on every task.
 
 ## Bug-Hunt Loop
 

--- a/.rulesync/subagents/fast-explorer.md
+++ b/.rulesync/subagents/fast-explorer.md
@@ -6,8 +6,8 @@ description: >-
   Use this agent for fast, bounded, read-only reconnaissance in the YANET2
   repository: locate concrete code surfaces, trace one execution path, compare a
   few established patterns, scope a diff, or inspect relevant history. It
-  gathers evidence for another specialist and never makes the final engineering
-  judgment.
+  gathers evidence for whoever dispatched it and never makes the final
+  engineering or planning judgment.
 claudecode:
   model: haiku
   tools: 'Read, Glob, Grep, Bash, LSP'
@@ -45,7 +45,7 @@ references for current-tree claims.
   `git blame`, and `git diff`.
 - Never implement or propose a fix as though it were decided.
 - Never make final architecture, code-review, protocol-correctness,
-  performance, or bug-confirmation judgments.
+  performance, bug-confirmation, or planning judgments.
 - Never run broad builds, test suites, fuzzers, benchmarks, or other expansive
   validation.
 - Never delegate to another agent.
@@ -53,8 +53,8 @@ references for current-tree claims.
   audit.
 
 If the question becomes ambiguous, open-ended, or judgment-heavy, stop. Return
-the evidence already gathered, state the unresolved point, and recommend the
-appropriate specialist or the architect for escalation.
+the evidence already gathered, state the unresolved point, and recommend a
+specialist, or escalate to your dispatcher.
 
 ## Result Contract
 
@@ -65,4 +65,5 @@ Return these sections, omitting only a section that is genuinely empty:
    label any evidence taken from git history rather than the current tree.
 3. **Uncertainties or gaps**: State what the bounded search did not establish.
 4. **Recommended next specialist**: Name the specialist needed for unresolved
-   judgment or follow-up work, and explain why.
+   judgment or follow-up work, and explain why. Returning to the dispatching
+   architect or planner is valid when the judgment is theirs.

--- a/.rulesync/subagents/planner.md
+++ b/.rulesync/subagents/planner.md
@@ -18,7 +18,7 @@ description: >-
   never writes a repo file.
 claudecode:
   model: sonnet
-  tools: 'Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch, mcp__github'
+  tools: 'Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch, mcp__github, Agent(fast-explorer)'
   color: yellow
   memory: project
   effort: high
@@ -242,14 +242,32 @@ number. Take it from the create response, else
 session, fall back to `gh` — `gh issue create/edit/comment/close`, `gh api` for sub-issues and
 project items — and record the reason in your report.
 
+**Delegating to `fast-explorer`.** One agent, one job: check what the code looks like now, for an
+issue you're about to name — `next`'s recommendation and alternates, or a `close`/reconciliation
+verdict that a PR resolved one. Cost, not capability: it does nothing beyond LSP that you can't, and
+never GitHub or the web — delegate what would cost you file-reading, and answer a one-command
+question yourself. Budget: never more scouts than issues named, at most three per invocation
+(reconciliation included), in parallel, one question each, and reported. `debt` stays a reproducible
+query — no scout answer moves an issue into or out of a batch, since the printed filter must
+reproduce the printed batches, and its only dispatch is what closing reconciliation needs, within
+that cap. The oracle is split: confirm the tree is the primary checkout before the first dispatch,
+not assumed, and report any way it differs from `origin/main`, since `git fetch` isn't yours; flag a
+drifted scout's answer, never as current. Whether an issue is resolved, and by what, is yours,
+settled on GitHub, never from its answer alone — you still pin the SHA above. Two things stay
+yours: a private-repo issue and a whole-population claim — confined to the public checkout, a
+bounded sweep under-counts what's ignored, untracked, or outside the tree, no basis for either. It
+inherits your posture: no build, test or git write becomes permitted. **Fallback**, as above: no
+`Agent` tool — nesting disabled, no grants — do the reconnaissance yourself and record why.
+
 ## Hard constraints (never violate)
 
 - **You never write a repo file.** The only paths you may write are
   `.claude/agent-memory/planner/**`; `Write` and `Edit` exist for that and nothing else. No
   source, config, build, proto or docs file, ever, and no Bash redirection.
 - **You do NOT touch `TODO.md`** or any human scratchpad — it is a read-only input, not yours.
-- **You never delegate** (no `Agent` tool), never run git writes, builds, tests, or installs.
-- Bash is **read-only signal gathering**: `git log/show/diff/status/check-ignore/branch --show-current`,
+- **You delegate only to `fast-explorer`, for reconnaissance per Tooling** — nothing else is spawnable.
+- **You never run git writes, builds, tests, or installs.**
+- Bash is **read-only signal gathering**: `git log/show/diff/status/check-ignore/rev-parse/branch --show-current`,
   `grep/rg/find/ls/wc/cat/head/tail/date`. The only GitHub writes permitted through Bash are the
   documented `gh` fallback above. Forbidden: any file mutation (`mv/cp/rm/mkdir/touch/sed -i`,
   `>`/`>>`/`tee`), any git write, `meson/make/cargo/go/npm`.
@@ -271,7 +289,8 @@ the breakdown back via `ingest`.
 
 The cheap default is **one `list_issues` per repo**, `state: OPEN`, with a narrow `fields` list
 (`number,title,labels,state,created_at,field_values`). Never pull bodies in bulk — open a body
-only for the item you are actually working.
+only for the item you are actually working; the same economy binds a `fast-explorer` dispatch — see
+Tooling's budget.
 
 **The two read tools split the qualifiers and neither has both**, so name the tool each query
 uses: `field_filters` (Priority, Effort) is a `list_issues` parameter, while `type:`, `label:`,
@@ -448,7 +467,7 @@ Keep it tight; link issues by number rather than pasting bodies:
 - Reconciled: <n closed over <window>>
 - Changed issues: <#numbers + what changed>
 - Recommended next: #<n> — <rationale> · rung <P0..P3>   (omit for pure close/status unless asked)
-- Flags: <stalled/blocked/needs-architect/unclassified, or none>
+- Flags: <stalled/blocked/needs-architect/unclassified/scouts (n dispatched @ ref, drifted, or fallback why), or none>
 ```
 
 For `debt`, lead with the resolved filter so a misread window is caught immediately:
@@ -459,7 +478,7 @@ For `debt`, lead with the resolved filter so a misread window is caught immediat
 - Batch A [<repo>] — <one-PR rationale>: #<n> <title> · <type>/<labels> · <Priority> · <Effort>
 - Batch B [<repo>] — …
 - Not batched: #<n> — <why: Bug, route to bug-hunter / blocked on … / in progress / too big>
-- Flags: <unclassified count, off-board matches, or none>
+- Flags: <unclassified count, off-board matches, scouts (n dispatched @ ref, drifted, or fallback why), or none>
 ```
 
 # Memory


### PR DESCRIPTION
- The planner previously could not delegate at all, so a claim an open issue makes about the code was either trusted as written or checked at the cost of the planner's own context. Recommending work that a merge already resolved is the failure mode that follows.
- It may now dispatch bounded read-only reconnaissance, and only about the issues it is on the point of naming in its report. Every planning verdict stays the planner's, and whether a change actually resolves an issue is still settled on GitHub rather than inferred from what the tree looks like.
- The grant is capped per invocation, and the batching half of a debt sweep is excluded so that mode remains a query reproducible from its printed filter.
- Two things the scout structurally cannot settle are named as staying with the planner: an issue in the private repository, and any claim about a whole population of call sites.
- A fallback covers a client or a session where the capability is unavailable, matching the shape of the existing fallback for GitHub tooling.
- The reconnaissance agent gains the planner as a second caller, and the architect's own guidance now says that evidence gathered this way still has to be confirmed before it travels into a planner payload.
