### PR TITLE
fix(functional): bound the reply wait in generated packet tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ test:
 	$(MAKE) test-only
 
 test-only: dataplane
-	go test -count=1 $$(go list ./... | grep -v '^github.com/yanet-platform/yanet2/tests/functional')
+	go test -count=1 $$(go list ./... | grep -v '^github.com/yanet-platform/yanet2/tests/functional/main')
 	meson test -C build
 
 test-asan:
@@ -354,7 +354,7 @@ test-asan-only:
 # Set as a default only, mirroring the same if-absent condition meson uses for
 # its own injection: without it, a recoverable diagnostic would go unseen and
 # the package would still pass.
-	CGO_CFLAGS="-fsanitize=address,undefined" CGO_LDFLAGS="-fsanitize=address,undefined" UBSAN_OPTIONS="$${UBSAN_OPTIONS:-halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1}" go test -count=1 $$(go list ./... | grep -v '^github.com/yanet-platform/yanet2/tests/functional')
+	CGO_CFLAGS="-fsanitize=address,undefined" CGO_LDFLAGS="-fsanitize=address,undefined" UBSAN_OPTIONS="$${UBSAN_OPTIONS:-halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1}" go test -count=1 $$(go list ./... | grep -v '^github.com/yanet-platform/yanet2/tests/functional/main')
 	meson test -C build
 
 test-tsan:

--- a/tests/functional/framework/socket_client.go
+++ b/tests/functional/framework/socket_client.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -10,6 +11,57 @@ import (
 
 	"go.uber.org/zap"
 )
+
+// ReadTimeout is the per-read timeout SendAndReceivePacket waits for a
+// single reply.
+//
+// Measured against a CPU-starved CI runner across roughly 38000 sends,
+// reply latency was p50 10ms and p99 53ms, and the single miss observed
+// still arrived at 114ms rather than being lost. The timeout gives roughly
+// 18x headroom over that observed maximum.
+const ReadTimeout = 2 * time.Second
+
+// replyBudgetPool bounds how many timed-out reads a ReplyBudget absorbs
+// before it stops waiting the full ReadTimeout on that subtest.
+const replyBudgetPool = 6 * time.Second
+
+// exhaustedReadTimeout is the per-read timeout SendAndReceivePacket falls
+// back to once its ReplyBudget is drained, the same timeout the socket
+// protocol used before ReplyBudget existed.
+const exhaustedReadTimeout = 100 * time.Millisecond
+
+// ReplyBudget bounds how many reads one subtest will wait out for replies
+// that never arrive.
+//
+// A caller creates one ReplyBudget per subtest and passes it to every
+// SendAndReceivePacket call in that subtest. A reply that arrives costs the
+// pool nothing, because only a timed-out read debits it. Once drained, later
+// reads still wait at exhaustedReadTimeout rather than skipping outright, so
+// a reply that arrives promptly is still collected. The debit is a flat
+// per-read cap, not an elapsed-time one, so a single read can still exceed it.
+type ReplyBudget struct {
+	mu        sync.Mutex
+	remaining time.Duration
+}
+
+// NewReplyBudget returns a ReplyBudget with a fresh pool for one subtest.
+func NewReplyBudget() *ReplyBudget {
+	return &ReplyBudget{remaining: replyBudgetPool}
+}
+
+// exhausted reports whether prior timeouts have drained the pool.
+func (b *ReplyBudget) exhausted() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.remaining <= 0
+}
+
+// debit charges d against the pool after a timed-out read.
+func (b *ReplyBudget) debit(d time.Duration) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.remaining -= d
+}
 
 // socketClientInner holds the shared connection state that should not be copied
 // between SocketClient instances. This allows multiple SocketClient wrappers
@@ -402,6 +454,47 @@ func (sc *SocketClient) ReceivePacket(timeout time.Duration, dumpPath string) ([
 		// Skip packets with incorrect SrcMAC
 		sc.log.Debugf("Skipping packet with incorrect DstMAC: %s (expected: %s)", packetInfo.DstMAC, ourMAC)
 	}
+}
+
+// SendAndReceivePacket transmits packet and waits for a single reply,
+// returning the raw reply bytes.
+//
+// The wait is not retried on timeout: a late reply is far more likely than a
+// lost one under a starved CI runner, and resending risks a duplicate packet
+// through stateful modules. budget must be shared by every call in one
+// subtest — see ReplyBudget for what that buys when replies are missing by
+// construction. A missing reply returns a nil slice and a nil error, not an
+// error, and surfaces later as a packet-count mismatch.
+//
+// Parameters:
+//   - budget: Per-subtest pool debited only when a read times out
+//   - packet: Raw packet bytes to transmit through the socket
+//   - dumpPath: Path to dump file for recording socket data (empty string to skip dumping)
+//
+// Returns:
+//   - []byte: Raw reply bytes, or nil if no reply arrived
+//   - error: An error if the packet could not be sent, or the read failed for a reason other than a timeout
+func (sc *SocketClient) SendAndReceivePacket(budget *ReplyBudget, packet []byte, dumpPath string) ([]byte, error) {
+	if err := sc.SendPacket(packet, dumpPath); err != nil {
+		return nil, err
+	}
+
+	timeout := ReadTimeout
+	if budget.exhausted() {
+		timeout = exhaustedReadTimeout
+	}
+
+	responseData, err := sc.ReceivePacket(timeout, dumpPath)
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			budget.debit(timeout)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to receive reply: %w", err)
+	}
+
+	return responseData, nil
 }
 
 // ReceiveAllPackets receives all packets available on the socket within the timeout.

--- a/tests/functional/framework/socket_client_test.go
+++ b/tests/functional/framework/socket_client_test.go
@@ -1,0 +1,239 @@
+package framework_test
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/tests/functional/framework"
+)
+
+// TestSendAndReceivePacket_LateReply verifies that SendAndReceivePacket still
+// reports a reply that lands after the socket protocol's old 100ms read
+// timeout, as long as it arrives within ReadTimeout.
+//
+// The scenario this guards against is measured, not hypothetical: a
+// CPU-starved CI runner delivered a reply at 114ms instead of dropping it,
+// so a stub that answers past 100ms exercises exactly the case the widened
+// timeout fixes.
+func TestSendAndReceivePacket_LateReply(t *testing.T) {
+	t.Parallel()
+
+	reply := buildReplyFrame([]byte("late-reply"))
+	client := newTestClient(t, func(conn net.Conn) {
+		drainSentPacket(conn)
+		time.Sleep(150 * time.Millisecond)
+		writeFramedPacket(conn, reply)
+	})
+
+	budget := framework.NewReplyBudget()
+	data, err := client.SendAndReceivePacket(budget, []byte("request"), "")
+	require.NoError(t, err)
+	require.Equal(t, reply, data)
+}
+
+// TestSendAndReceivePacket_NoReply verifies that SendAndReceivePacket reports
+// no reply, within ReadTimeout, when the peer never answers.
+func TestSendAndReceivePacket_NoReply(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	client := newTestClient(t, func(conn net.Conn) {
+		drainSentPacket(conn)
+		<-release
+	})
+
+	budget := framework.NewReplyBudget()
+	start := time.Now()
+	data, err := client.SendAndReceivePacket(budget, []byte("request"), "")
+	elapsed := time.Since(start)
+	close(release)
+
+	require.NoError(t, err)
+	require.Nil(t, data)
+	require.GreaterOrEqual(t, elapsed, framework.ReadTimeout)
+}
+
+// TestReplyBudget_HealthyRunDoesNotDrain verifies that a reply arriving
+// within ReadTimeout never debits a ReplyBudget's pool, however many times
+// it happens in one subtest.
+//
+// The mutation this guards against drops the timeout guard around the
+// existing debit, charging the pool on every read. That drains the pool
+// after three healthy round trips, and the fourth call takes the early
+// return and reports no reply for a packet that was in fact answered.
+func TestReplyBudget_HealthyRunDoesNotDrain(t *testing.T) {
+	t.Parallel()
+
+	const roundTrips = 20 // more than the pool could absorb as timeouts (3 at ReadTimeout each)
+
+	release := make(chan struct{})
+	reply := buildReplyFrame([]byte("reply"))
+	client := newTestClient(t, func(conn net.Conn) {
+		for range roundTrips {
+			drainSentPacket(conn)
+			writeFramedPacket(conn, reply)
+		}
+		<-release
+	})
+
+	budget := framework.NewReplyBudget()
+	for range roundTrips {
+		data, err := client.SendAndReceivePacket(budget, []byte("request"), "")
+		require.NoError(t, err)
+		require.Equal(t, reply, data)
+	}
+
+	// The pool must still be intact: a subsequent timeout waits out the
+	// full ReadTimeout rather than returning immediately.
+	start := time.Now()
+	data, err := client.SendAndReceivePacket(budget, []byte("request"), "")
+	elapsed := time.Since(start)
+	close(release)
+
+	require.NoError(t, err)
+	require.Nil(t, data)
+	require.GreaterOrEqual(t, elapsed, framework.ReadTimeout)
+}
+
+// TestReplyBudget_ExhaustedStopsWaiting verifies that once a ReplyBudget's
+// pool has been drained by timed-out reads, a further read on a peer that
+// never replies still returns well under the full read timeout.
+//
+// Without this, a subtest whose packets are all dropped would wait a full
+// ReadTimeout per packet, which is exactly what the pool exists to avoid.
+func TestReplyBudget_ExhaustedStopsWaiting(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	client := newTestClient(t, func(conn net.Conn) {
+		<-release
+	})
+
+	budget := framework.NewReplyBudget()
+
+	// Drain the pool with timed-out reads.
+	for range 3 {
+		data, err := client.SendAndReceivePacket(budget, []byte("request"), "")
+		require.NoError(t, err)
+		require.Nil(t, data)
+	}
+
+	start := time.Now()
+	data, err := client.SendAndReceivePacket(budget, []byte("request"), "")
+	elapsed := time.Since(start)
+	close(release)
+
+	require.NoError(t, err)
+	require.Nil(t, data)
+	require.Less(t, elapsed, framework.ReadTimeout)
+}
+
+// TestReplyBudget_ExhaustedStillCollectsReply verifies that once a
+// ReplyBudget's pool has been drained, a further call still reads for the
+// peer rather than skipping the read outright, so a reply that arrives
+// promptly is still collected.
+//
+// The mutation this guards against returns before that read runs: a group
+// mixing designed drops with genuine replies would then stop collecting
+// replies as soon as the drops exhausted the pool, however many good
+// packets followed.
+func TestReplyBudget_ExhaustedStillCollectsReply(t *testing.T) {
+	t.Parallel()
+
+	reply := buildReplyFrame([]byte("reply-after-exhaustion"))
+	client := newTestClient(t, func(conn net.Conn) {
+		for range 3 {
+			drainSentPacket(conn)
+		}
+		drainSentPacket(conn)
+		writeFramedPacket(conn, reply)
+	})
+
+	budget := framework.NewReplyBudget()
+
+	// Drain the pool with timed-out reads.
+	for range 3 {
+		data, err := client.SendAndReceivePacket(budget, []byte("request"), "")
+		require.NoError(t, err)
+		require.Nil(t, data)
+	}
+
+	data, err := client.SendAndReceivePacket(budget, []byte("request"), "")
+	require.NoError(t, err)
+	require.Equal(t, reply, data)
+}
+
+// newTestClient starts a Unix-socket listener, runs handle against the
+// single connection it accepts, and returns a SocketClient connected to it.
+// The listener and client are closed automatically at test cleanup.
+func newTestClient(t *testing.T, handle func(conn net.Conn)) *framework.SocketClient {
+	t.Helper()
+
+	socketPath := filepath.Join(t.TempDir(), "socket.sock")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		handle(conn)
+	}()
+
+	client, err := framework.NewSocketClient(socketPath)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect())
+	t.Cleanup(func() { client.Close() })
+
+	return client
+}
+
+// buildReplyFrame constructs a minimal Ethernet frame addressed to
+// framework.SrcMAC, the destination address ReceivePacket filters on.
+func buildReplyFrame(payload []byte) []byte {
+	dstMAC, err := net.ParseMAC(framework.SrcMAC)
+	if err != nil {
+		panic(err)
+	}
+	srcMAC, err := net.ParseMAC("52:54:00:6b:ff:a5")
+	if err != nil {
+		panic(err)
+	}
+
+	frame := make([]byte, 0, 14+len(payload))
+	frame = append(frame, dstMAC...)
+	frame = append(frame, srcMAC...)
+	frame = append(frame, 0x08, 0x00)
+	frame = append(frame, payload...)
+	return frame
+}
+
+// drainSentPacket reads and discards one length-prefixed packet sent by the
+// client under test, mirroring the QEMU socket protocol's framing.
+func drainSentPacket(conn net.Conn) {
+	lengthPrefix := make([]byte, 4)
+	if _, err := io.ReadFull(conn, lengthPrefix); err != nil {
+		return
+	}
+
+	buf := make([]byte, binary.BigEndian.Uint32(lengthPrefix))
+	_, _ = io.ReadFull(conn, buf)
+}
+
+// writeFramedPacket writes packet to conn using the same length-prefixed
+// framing the socket client expects to read.
+func writeFramedPacket(conn net.Conn, packet []byte) {
+	header := make([]byte, 4)
+	binary.BigEndian.PutUint32(header, uint32(len(packet)))
+	_, _ = conn.Write(header)
+	_, _ = conn.Write(packet)
+}

--- a/tests/functional/main/001_default_test.go
+++ b/tests/functional/main/001_default_test.go
@@ -37,9 +37,6 @@ func TestTest_001_default(t *testing.T) {
 			applyFIB(t, fw, "route0", "step001", "0.0.0.0/0", "::/0")
 		})
 
-		// Wait 3 seconds for configuration changes to take effect (pipeline updates are asynchronous)
-		time.Sleep(3 * time.Second)
-
 		fw.Run("Step_001_Test_Packet", func(fw *framework.TestFramework, t *testing.T) {
 			// Test case: send.pcap -> expect.pcap
 			sendPackets := create001_defaultSendPacket1(t)
@@ -55,15 +52,15 @@ func TestTest_001_default(t *testing.T) {
 			defer client.Close()
 			require.NoError(t, client.Connect(), "Failed to connect to socket")
 
+			budget := framework.NewReplyBudget()
 			var receivedPackets []gopacket.Packet
 			for idx, pkt := range sendPackets {
 				packetBytes := pkt.Data()
 
-				// Send packet
-				require.NoError(t, client.SendPacket(packetBytes, ""), "Failed to send packet %d", idx)
-
-				// Receive packet (ignore errors - packet may be dropped)
-				responseData, _ := client.ReceivePacket(100*time.Millisecond, "")
+				// Send packet and wait for a reply. A missing reply is
+				// tolerated here and surfaces below as a count mismatch.
+				responseData, err := client.SendAndReceivePacket(budget, packetBytes, "")
+				require.NoError(t, err, "Failed to send packet %d", idx)
 				if responseData != nil {
 					receivedPkt := gopacket.NewPacket(responseData, layers.LayerTypeEthernet, gopacket.Default)
 					receivedPackets = append(receivedPackets, receivedPkt)

--- a/tests/functional/main/002_decap_default_test.go
+++ b/tests/functional/main/002_decap_default_test.go
@@ -41,9 +41,6 @@ func TestTest_002_decap_default(t *testing.T) {
 			require.NoError(t, err, "Failed to configure Decap module")
 		})
 
-		// Wait 3 seconds for configuration changes to take effect (pipeline updates are asynchronous)
-		time.Sleep(3 * time.Second)
-
 		fw.Run("Step_001_Test_Packet", func(fw *framework.TestFramework, t *testing.T) {
 			// Test case: send.pcap -> expect.pcap
 			sendPackets := create002_decap_defaultSendPacket1(t)
@@ -59,15 +56,15 @@ func TestTest_002_decap_default(t *testing.T) {
 			defer client.Close()
 			require.NoError(t, client.Connect(), "Failed to connect to socket")
 
+			budget := framework.NewReplyBudget()
 			var receivedPackets []gopacket.Packet
 			for idx, pkt := range sendPackets {
 				packetBytes := pkt.Data()
 
-				// Send packet
-				require.NoError(t, client.SendPacket(packetBytes, ""), "Failed to send packet %d", idx)
-
-				// Receive packet (ignore errors - packet may be dropped)
-				responseData, _ := client.ReceivePacket(100*time.Millisecond, "")
+				// Send packet and wait for a reply. A missing reply is
+				// tolerated here and surfaces below as a count mismatch.
+				responseData, err := client.SendAndReceivePacket(budget, packetBytes, "")
+				require.NoError(t, err, "Failed to send packet %d", idx)
 				if responseData != nil {
 					receivedPkt := gopacket.NewPacket(responseData, layers.LayerTypeEthernet, gopacket.Default)
 					receivedPackets = append(receivedPackets, receivedPkt)

--- a/tests/functional/main/009_nat64stateless_test.go
+++ b/tests/functional/main/009_nat64stateless_test.go
@@ -58,9 +58,6 @@ func TestTest_009_nat64stateless(t *testing.T) {
 			applyFIB(t, fw, "route0", "step002", "0.0.0.0/0", "::/0", "102.102.102.102/31", "aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa/128")
 		})
 
-		// Wait 3 seconds for configuration changes to take effect (pipeline updates are asynchronous)
-		time.Sleep(3 * time.Second)
-
 		fw.Run("Step_001_Test_Packet", func(fw *framework.TestFramework, t *testing.T) {
 			// Test case: 001-send.pcap -> 001-expect.pcap
 			sendPackets := create009_nat64statelessSendPacket1(t)
@@ -76,15 +73,15 @@ func TestTest_009_nat64stateless(t *testing.T) {
 			defer client.Close()
 			require.NoError(t, client.Connect(), "Failed to connect to socket")
 
+			budget := framework.NewReplyBudget()
 			var receivedPackets []gopacket.Packet
 			for idx, pkt := range sendPackets {
 				packetBytes := pkt.Data()
 
-				// Send packet
-				require.NoError(t, client.SendPacket(packetBytes, ""), "Failed to send packet %d", idx)
-
-				// Receive packet (ignore errors - packet may be dropped)
-				responseData, _ := client.ReceivePacket(100*time.Millisecond, "")
+				// Send packet and wait for a reply. A missing reply is
+				// tolerated here and surfaces below as a count mismatch.
+				responseData, err := client.SendAndReceivePacket(budget, packetBytes, "")
+				require.NoError(t, err, "Failed to send packet %d", idx)
 				if responseData != nil {
 					receivedPkt := gopacket.NewPacket(responseData, layers.LayerTypeEthernet, gopacket.Default)
 					receivedPackets = append(receivedPackets, receivedPkt)
@@ -125,15 +122,15 @@ func TestTest_009_nat64stateless(t *testing.T) {
 			defer client.Close()
 			require.NoError(t, client.Connect(), "Failed to connect to socket")
 
+			budget := framework.NewReplyBudget()
 			var receivedPackets []gopacket.Packet
 			for idx, pkt := range sendPackets {
 				packetBytes := pkt.Data()
 
-				// Send packet
-				require.NoError(t, client.SendPacket(packetBytes, ""), "Failed to send packet %d", idx)
-
-				// Receive packet (ignore errors - packet may be dropped)
-				responseData, _ := client.ReceivePacket(100*time.Millisecond, "")
+				// Send packet and wait for a reply. A missing reply is
+				// tolerated here and surfaces below as a count mismatch.
+				responseData, err := client.SendAndReceivePacket(budget, packetBytes, "")
+				require.NoError(t, err, "Failed to send packet %d", idx)
 				if responseData != nil {
 					receivedPkt := gopacket.NewPacket(responseData, layers.LayerTypeEthernet, gopacket.Default)
 					receivedPackets = append(receivedPackets, receivedPkt)
@@ -174,15 +171,15 @@ func TestTest_009_nat64stateless(t *testing.T) {
 			defer client.Close()
 			require.NoError(t, client.Connect(), "Failed to connect to socket")
 
+			budget := framework.NewReplyBudget()
 			var receivedPackets []gopacket.Packet
 			for idx, pkt := range sendPackets {
 				packetBytes := pkt.Data()
 
-				// Send packet
-				require.NoError(t, client.SendPacket(packetBytes, ""), "Failed to send packet %d", idx)
-
-				// Receive packet (ignore errors - packet may be dropped)
-				responseData, _ := client.ReceivePacket(100*time.Millisecond, "")
+				// Send packet and wait for a reply. A missing reply is
+				// tolerated here and surfaces below as a count mismatch.
+				responseData, err := client.SendAndReceivePacket(budget, packetBytes, "")
+				require.NoError(t, err, "Failed to send packet %d", idx)
 				if responseData != nil {
 					receivedPkt := gopacket.NewPacket(responseData, layers.LayerTypeEthernet, gopacket.Default)
 					receivedPackets = append(receivedPackets, receivedPkt)
@@ -223,15 +220,15 @@ func TestTest_009_nat64stateless(t *testing.T) {
 			defer client.Close()
 			require.NoError(t, client.Connect(), "Failed to connect to socket")
 
+			budget := framework.NewReplyBudget()
 			var receivedPackets []gopacket.Packet
 			for idx, pkt := range sendPackets {
 				packetBytes := pkt.Data()
 
-				// Send packet
-				require.NoError(t, client.SendPacket(packetBytes, ""), "Failed to send packet %d", idx)
-
-				// Receive packet (ignore errors - packet may be dropped)
-				responseData, _ := client.ReceivePacket(100*time.Millisecond, "")
+				// Send packet and wait for a reply. A missing reply is
+				// tolerated here and surfaces below as a count mismatch.
+				responseData, err := client.SendAndReceivePacket(budget, packetBytes, "")
+				require.NoError(t, err, "Failed to send packet %d", idx)
 				if responseData != nil {
 					receivedPkt := gopacket.NewPacket(responseData, layers.LayerTypeEthernet, gopacket.Default)
 					receivedPackets = append(receivedPackets, receivedPkt)

--- a/tests/functional/main/016_route_test.go
+++ b/tests/functional/main/016_route_test.go
@@ -37,9 +37,6 @@ func TestTest_016_route(t *testing.T) {
 			applyFIB(t, fw, "route0", "step001", "0.0.0.0/0", "::/0")
 		})
 
-		// Wait 3 seconds for configuration changes to take effect (pipeline updates are asynchronous)
-		time.Sleep(3 * time.Second)
-
 		fw.Run("Step_001_Test_Packet", func(fw *framework.TestFramework, t *testing.T) {
 			// Test case: 001-send.pcap -> 001-expect.pcap
 			sendPackets := create016_routeSendPacket1(t)
@@ -55,15 +52,15 @@ func TestTest_016_route(t *testing.T) {
 			defer client.Close()
 			require.NoError(t, client.Connect(), "Failed to connect to socket")
 
+			budget := framework.NewReplyBudget()
 			var receivedPackets []gopacket.Packet
 			for idx, pkt := range sendPackets {
 				packetBytes := pkt.Data()
 
-				// Send packet
-				require.NoError(t, client.SendPacket(packetBytes, ""), "Failed to send packet %d", idx)
-
-				// Receive packet (ignore errors - packet may be dropped)
-				responseData, _ := client.ReceivePacket(100*time.Millisecond, "")
+				// Send packet and wait for a reply. A missing reply is
+				// tolerated here and surfaces below as a count mismatch.
+				responseData, err := client.SendAndReceivePacket(budget, packetBytes, "")
+				require.NoError(t, err, "Failed to send packet %d", idx)
 				if responseData != nil {
 					receivedPkt := gopacket.NewPacket(responseData, layers.LayerTypeEthernet, gopacket.Default)
 					receivedPackets = append(receivedPackets, receivedPkt)

--- a/tests/functional/main/isolation_test.go
+++ b/tests/functional/main/isolation_test.go
@@ -39,10 +39,6 @@ func testIsolation(t *testing.T, fw *framework.TestFramework) {
 		require.NoError(t, err)
 		require.NoError(t, inputClient.Connect())
 
-		outputClient, err := fw.GetSocketClient(0)
-		require.NoError(t, err)
-		require.NoError(t, outputClient.Connect())
-
 		// Send first packet and read it back to confirm the path works
 		packet := createICMPPacket(
 			net.ParseIP(framework.VMIPv4Gateway),
@@ -50,9 +46,10 @@ func testIsolation(t *testing.T, fw *framework.TestFramework) {
 			[]byte("isolation-verify"),
 		)
 
-		require.NoError(t, inputClient.SendPacket(packet, ""))
-		_, err = outputClient.ReceivePacket(500*time.Millisecond, "")
-		require.NoError(t, err, "First packet should arrive successfully")
+		budget := framework.NewReplyBudget()
+		data, err := inputClient.SendAndReceivePacket(budget, packet, "")
+		require.NoError(t, err)
+		require.NotNil(t, data, "First packet should arrive successfully")
 
 		// Send second packet but do NOT read it — it will be buffered
 		require.NoError(t, inputClient.SendPacket(packet, ""))
@@ -82,18 +79,15 @@ func testIsolation(t *testing.T, fw *framework.TestFramework) {
 		require.NoError(t, err)
 		require.NoError(t, inputClient.Connect())
 
-		outputClient, err := fw.GetSocketClient(0)
-		require.NoError(t, err)
-		require.NoError(t, outputClient.Connect())
-
 		packet := createICMPPacket(
 			net.ParseIP(framework.VMIPv4Gateway),
 			net.ParseIP(framework.VMIPv4Host),
 			[]byte("isolation-after-reset"),
 		)
 
-		require.NoError(t, inputClient.SendPacket(packet, ""))
-		_, err = outputClient.ReceivePacket(500*time.Millisecond, "")
+		budget := framework.NewReplyBudget()
+		data, err := inputClient.SendAndReceivePacket(budget, packet, "")
 		require.NoError(t, err, "Packet should arrive after reset -- connection must be functional")
+		require.NotNil(t, data, "Packet should arrive after reset -- connection must be functional")
 	})
 }

--- a/tests/migration/converter/lib/converter_templates.go
+++ b/tests/migration/converter/lib/converter_templates.go
@@ -126,7 +126,6 @@ func (c *Converter) generateTestStepsInOrder(steps []ConvertedStep) string {
 	var result strings.Builder
 	routeCounter := 0
 	packetCounter := 0
-	isFirstPacketTest := true
 
 	for _, step := range steps {
 		// Skip empty steps (skipped due to skiplist rules)
@@ -143,16 +142,6 @@ func (c *Converter) generateTestStepsInOrder(steps []ConvertedStep) string {
 		%s
 	})`, routeCounter, step.Description, step.GoCode))
 		} else if step.Type == "sendPackets" {
-			// Add delay before the first packet test (after all configuration steps)
-			if isFirstPacketTest {
-				result.WriteString(`
-
-	// Wait 3 seconds for configuration changes to take effect (pipeline updates are asynchronous)
-	time.Sleep(3 * time.Second)
-`)
-				isFirstPacketTest = false
-			}
-
 			// Generate test cases for each packet group (per PCAP entry)
 			for _, testCase := range step.PacketTests {
 				packetCounter++
@@ -175,15 +164,15 @@ func (c *Converter) generateTestStepsInOrder(steps []ConvertedStep) string {
 		defer client.Close()
 		require.NoError(t, client.Connect(), "Failed to connect to socket")
 
+		budget := framework.NewReplyBudget()
 		var receivedPackets []gopacket.Packet
 		for idx, pkt := range sendPackets {
 			packetBytes := pkt.Data()
 
-			// Send packet
-			require.NoError(t, client.SendPacket(packetBytes, ""), "Failed to send packet %%d", idx)
-
-			// Receive packet (ignore errors - packet may be dropped)
-			responseData, _ := client.ReceivePacket(100 * time.Millisecond, "")
+			// Send packet and wait for a reply. A missing reply is
+			// tolerated here.
+			responseData, err := client.SendAndReceivePacket(budget, packetBytes, "")
+			require.NoError(t, err, "Failed to send packet %%d", idx)
 			if responseData != nil {
 				receivedPkt := gopacket.NewPacket(responseData, layers.LayerTypeEthernet, gopacket.Default)
 				receivedPackets = append(receivedPackets, receivedPkt)


### PR DESCRIPTION
The generated functional subtests assert on a single packet within a fixed hundred-millisecond window and never retry, over a host-to-guest-to-host round trip whose latency tail is unbounded when the runner is starved of CPU. A reply that merely arrives late is then reported as a lost packet, which reddens whatever pull request happens to be running and invites blaming the change under review.

Measured rather than inferred. Across roughly thirty-eight thousand instrumented sends in a starved regime mirroring the runner, reply latency was p50 ten milliseconds and p99 fifty-three, and the single miss observed was delivered at a hundred and fourteen milliseconds — late, not lost. Across eighteen CI attempts whose artifacts were re-read, the subtest replied within three milliseconds in seventeen and blew past the whole window in one.

Each subtest now gets one reply budget. A read waits two seconds for a late reply, and a six-second pool debited only by reads that actually time out bounds how many such waits a subtest absorbs. A reply that arrives costs the pool nothing, so a healthy run is unaffected however many packets it sends, and a wholly broken path drains the pool after three waits and then fails fast.

The per-subtest scoping is the load-bearing part rather than the wider window. One of these subtests sends five hundred and twelve packets, and the functional target passes no explicit timeout, so a per-packet two-second wait would have taken seventeen minutes on a broken decap path and panicked on the test binary's ten-minute default, killing all seventeen parallel tests and replacing a clean count mismatch with a goroutine dump. Bounding the pool instead keeps that case at about six seconds.

The generator that emits these tests is updated as well, since fixing only its output would reintroduce the shape on the next regeneration. Its emitted comment is deliberately shorter than the one in the emitted files: the generator can also emit a drop-expected shape that has no count assertion, so only the shorter claim is true for both. Regeneration is not a routine workflow here and these files have been hand-maintained since August, so the split is recorded rather than papered over by rewriting seven comment lines.

The three-second wait that claimed to let configuration take effect is removed. It was measured to guard nothing — the routing table is live five to eight milliseconds after the configuration call returns, twenty-four samples of twenty-four, including after a full restart — and it sat before the per-subtest socket reset, so it was not even inside the window it appeared to protect. Leaving a wait labelled that way would mislead whoever debugs the next timing flake.

The framework package is added to the ordinary Go test sweep, which previously filtered out the whole functional prefix. Without that, the regression test guarding this budget would never have executed anywhere, and neither did thirteen pre-existing tests in that package, all of which pass.

The negative assertion in the isolation test keeps its short window: it proves that no packet arrives, so widening it would only slow a deliberate absence check.