### PR TITLE
test(route): drop a dead module-config cleanup

### DIFF
--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -1157,7 +1157,6 @@ func TestUpdateFIB_ShadowedNexthopCounterExcludedFromMetrics(t *testing.T) {
 		}),
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() { _, _ = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "test"}) })
 
 	wirePipeline(t, agent, "port0", "test")
 


### PR DESCRIPTION
A route functional test registers a cleanup that deletes its module config, then wires the module into a pipeline. The wiring helper registers no cleanup of its own, so the module is still referenced by a live chain when the delete runs, and the backend correctly refuses to free it rather than leave the chain dangling. The error was discarded, so the call freed nothing and reported nothing.

- Remove the cleanup. Verified by running the same delete against a wired and an unwired module: it succeeds on the unwired one and fails on the wired one, which is the only case this test ever reached, so removing it changes no observable state.
- The per-test harness teardown already releases the config and the whole shared-memory segment, and nothing after the deleted line depends on the config having been removed.

This was the last instance of the shape in the package; the two others were removed in #2077, where the mechanism was first established.