### PR TITLE
chore(agents): give the scout one non-contradictory execution boundary

### DIFF
--- a/.rulesync/subagents/architect.md
+++ b/.rulesync/subagents/architect.md
@@ -49,7 +49,7 @@ See `AGENTS.md` — Architecture, Data Flow, Module Structure, Devices. Key inte
 
 Quickly gathers concrete repository facts: definitions, callers, tests, registration surfaces, one execution path, a comparison of a few established patterns, the scope of an existing diff, or relevant git history.
 **Use early when**: a narrow factual question would reduce the code and history you need to load before decomposition. Give it one concrete question, an explicit scope, and the evidence you expect back. Dispatch multiple independent scouts only when their questions are truly separable and their searches will not duplicate one another.
-**Do not use for**: open-ended review, implementation, architecture choices, protocol correctness, performance conclusions, defect confirmation, or broad build and test work. Route those tasks to the appropriate specialist. Treat every fast-explorer result as evidence for your own architectural judgment, never as a verdict.
+**Do not use for**: open-ended review, implementation, architecture choices, protocol correctness, performance conclusions, defect confirmation, or build and test work. Route those tasks to the appropriate specialist. Treat every fast-explorer result as evidence for your own architectural judgment, never as a verdict.
 
 ### `coder-c` — C/DPDK/Meson Specialist
 

--- a/.rulesync/subagents/fast-explorer.md
+++ b/.rulesync/subagents/fast-explorer.md
@@ -31,30 +31,57 @@ Answer one concrete question with concise, verifiable evidence.
   surfaces.
 - Inspect relevant git history for a named file, symbol, or change.
 
-Use focused read-only tools such as `rg`, `git grep`, `git log`, `git show`,
-`git blame`, and `git diff`. Read only the files needed to answer the assigned
-question. Prefer direct evidence over inference and include `file:line`
-references for current-tree claims.
+Read only the files needed to answer the assigned question. Prefer direct
+evidence over inference and include `file:line` references for current-tree
+claims.
+
+## Tooling
+
+You work from the tree the brief names. Absent that, you inherit your
+dispatcher's working directory, which may not be where a named diff or history
+lives. Confirm with `pwd`, move there first with `cd <root>`, or address it
+throughout instead with `git -C <root>`.
+
+Bash is a closed allowlist, read-only invocation only: a command is in
+contract only if it is both listed below and read-only in that call. Unlisted
+is out, no effect reasoning needed. Effect decides only how a listed command
+may be used: `find` is listed, `find -delete` is out. A pipeline or chain is
+fine when every command in it is listed. What is barred is invoking an
+interpreter as the command itself.
+
+- General: `rg`, `grep`, `find`, `ls`, `wc`, `head`, `tail`, `cat`, `sort`,
+  `uniq`, `cut`, `diff`, `date`, `cd`, `pwd`.
+- Read-only `git`: `status`, `log`, `show`, `blame`, `diff`, `grep`,
+  `rev-parse`, `ls-files`, `check-ignore`, `ls-tree`, `branch`, `describe`.
+  Any subcommand that changes the worktree, index, refs, or stash, or reaches
+  a remote (`fetch`, `pull`, `push`, `ls-remote`), is out regardless.
+
+Nothing outside these two lists is in contract, whatever the size — one
+target, one test case, or one fetched file all still out. That is why `meson`,
+`go`, `make`, `cargo`, `npm`, `gh`, and `curl` are excluded, and, by the same
+absence rather than a different test, so is any general-purpose interpreter
+(`python3`, `perl`, `sh -c`, `awk`, `sed`, `jq`, `xargs`, and the like), even
+invoked for pure computation.
 
 ## Hard Boundaries
 
-- Never edit, create, move, or delete any file.
-- Never run a git command that mutates the worktree, index, refs, or stash —
-  `stash`, `checkout`, `switch`, `restore`, `reset`, `clean`, `commit`;
-  inspect history with read-only commands such as `git show`, `git log`,
-  `git blame`, and `git diff`.
+- Never write a file through any command you run — no edit, create, move, or
+  delete, anywhere on this machine, not only inside this repository or
+  worktree. This binds what you do by running a command, not a tool's or
+  command's own internal bookkeeping — an LSP cache, or git's index refresh on
+  `status`, `diff`, and `blame`, is not a violation. Forbidden explicitly:
+  shell redirection (`>`, `>>`).
 - Never implement or propose a fix as though it were decided.
 - Never make final architecture, code-review, protocol-correctness,
   performance, bug-confirmation, or planning judgments.
-- Never run broad builds, test suites, fuzzers, benchmarks, or other expansive
-  validation.
 - Never delegate to another agent.
 - Never expand a bounded question into an open-ended review or repository
   audit.
 
-If the question becomes ambiguous, open-ended, or judgment-heavy, stop. Return
-the evidence already gathered, state the unresolved point, and recommend a
-specialist, or escalate to your dispatcher.
+If the question becomes ambiguous, open-ended, judgment-heavy, or answerable
+only with a command outside the allowlist above, stop. Return the evidence
+already gathered, state the unresolved point, and recommend a specialist, or
+escalate to your dispatcher.
 
 ## Result Contract
 

--- a/.rulesync/subagents/planner.md
+++ b/.rulesync/subagents/planner.md
@@ -244,20 +244,19 @@ project items — and record the reason in your report.
 
 **Delegating to `fast-explorer`.** One agent, one job: check what the code looks like now, for an
 issue you're about to name — `next`'s recommendation and alternates, or a `close`/reconciliation
-verdict that a PR resolved one. Cost, not capability: it does nothing beyond LSP that you can't, and
-never GitHub or the web — delegate what would cost you file-reading, and answer a one-command
-question yourself. Budget: never more scouts than issues named, at most three per invocation
-(reconciliation included), in parallel, one question each, and reported. `debt` stays a reproducible
-query — no scout answer moves an issue into or out of a batch, since the printed filter must
-reproduce the printed batches, and its only dispatch is what closing reconciliation needs, within
-that cap. The oracle is split: confirm the tree is the primary checkout before the first dispatch,
-not assumed, and report any way it differs from `origin/main`, since `git fetch` isn't yours; flag a
-drifted scout's answer, never as current. Whether an issue is resolved, and by what, is yours,
-settled on GitHub, never from its answer alone — you still pin the SHA above. Two things stay
-yours: a private-repo issue and a whole-population claim — confined to the public checkout, a
-bounded sweep under-counts what's ignored, untracked, or outside the tree, no basis for either. It
-inherits your posture: no build, test or git write becomes permitted. **Fallback**, as above: no
-`Agent` tool — nesting disabled, no grants — do the reconnaissance yourself and record why.
+verdict that a PR resolved one. Cost, not capability: it never touches GitHub or the web — delegate
+what would cost you file-reading, and answer a one-command question yourself. Budget: never more
+scouts than issues named, at most three per invocation (reconciliation included), in parallel, one
+question each, and reported. `debt` stays a reproducible query — no scout answer moves an issue into
+or out of a batch, since the printed filter must reproduce the printed batches, and its only
+dispatch is what closing reconciliation needs, within that cap. The oracle is split: confirm the
+tree is the primary checkout before the first dispatch, not assumed, and report any way it differs
+from `origin/main`, since `git fetch` isn't yours; flag a drifted scout's answer, never as current.
+Whether an issue is resolved, and by what, is yours, settled on GitHub, never from its answer alone
+— you still pin the SHA above. Two things stay yours: a private-repo issue and a whole-population
+claim — confined to the public checkout, a bounded sweep under-counts what's ignored, untracked, or
+outside the tree, no basis for either. **Fallback**, as above: no `Agent` tool — nesting disabled,
+no grants — do the reconnaissance yourself and record why.
 
 ## Hard constraints (never violate)
 


### PR DESCRIPTION
- The reconnaissance agent's hard boundaries banned creating any file while banning only "broad" builds and expansive validation, which read as licensing a targeted one, and every build writes files; the section also barred no network access at all.
- Membership is now decided by one rule: a closed allowlist over the shell grant, where an unlisted command is out with no effect reasoning, so a future build tool is excluded without editing the list, and the effect test survives only to govern how a listed command may be used.
- The command set moved into its own tooling section, leaving the boundaries to carry prohibitions alone, and the write ban is stated once, unrestricted by location, keyed on what the agent's own commands do rather than on a tool's or command's internal bookkeeping such as a language-server cache or the git index refresh.
- Directory navigation is named explicitly, because every dispatcher is required to tell the agent to move into a named worktree first, and a closed list omitting it would have had the agent answer from its dispatcher's directory, reporting an empty diff as a confident answer.
- The git summary verb is deliberately absent from the list: with no revision argument it reads its log from standard input, so the idiomatic form returns nothing with exit code zero in an agent harness, which is the silent-wrong-answer failure this change exists to remove.
- Both dispatchers were checked in either direction; the architect's exclusion no longer says "broad", and the planner's restatement of the agent's posture is deleted because the agent's own contract now carries it, along with a claim about its reach that this change made false.
- The charter states no read scope, which is left as it is: pre-existing, and safe only because the agent has no network-capable tool or command, so that scope must be stated before any such grant lands.
- Regeneration of the client charter trees is not in the diff, since those trees are ignored; the agents lint job regenerates them from these sources on this pull request.

Closes #2082.