### PR TITLE
feat(common): add growable owner-scoped block allocators

### DIFF
--- a/common/memory.h
+++ b/common/memory.h
@@ -8,6 +8,18 @@
 #include "memory_block.h"
 #include "strutils.h"
 
+// The meson-generated header is absent for cgo compilation of Go packages
+// reaching this file, which runs without a configured build directory.
+// Only YANET_DEBUG is consumed below, so its absence just leaves the
+// wrong-allocator tripwire disabled, matching a release configuration.
+#if defined(__has_include)
+#if __has_include("yanet_build_config.h")
+#include "yanet_build_config.h"
+#endif
+#else
+#include "yanet_build_config.h"
+#endif
+
 struct memory_context {
 	struct block_allocator *block_allocator;
 	size_t balloc_count;
@@ -74,8 +86,9 @@ memory_context_init_from(
 	SET_OFFSET_OF(&context->parent, parent);
 	SET_OFFSET_OF(&context->first_child, NULL);
 
-	// Parent and child share the same block_allocator by construction, so
-	// its spinlock also guards this splice against concurrent siblings.
+	// The splice is a link on the parent node, so the parent's
+	// allocator lock guards it — even when the child itself goes on to
+	// allocate through a different, owner-bound allocator.
 	spinlock_lock(&allocator->lock);
 
 	// Insert at the head of the parent's child list. Capture the current
@@ -95,6 +108,38 @@ memory_context_init_from(
 // remaining children so finalising a parent before its children can never
 // leave a child pointing at freed memory. Idempotent and order-independent.
 static inline void
+memory_context_unlink_from_parent(
+	struct memory_context *self, struct memory_context *parent
+) {
+	// Walk the sibling chain and bridge over ourselves.
+	struct memory_context **cursor = &parent->first_child;
+	for (;;) {
+		struct memory_context *child = ADDR_OF(cursor);
+		if (child == NULL) {
+			break;
+		}
+		if (child == self) {
+			EQUATE_OFFSET(cursor, &self->next_sibling);
+			break;
+		}
+		cursor = &child->next_sibling;
+	}
+}
+
+// Detach any remaining children so their parent link never dangles after
+// our own storage is reused.
+static inline void
+memory_context_detach_children(struct memory_context *self) {
+	struct memory_context *child = ADDR_OF(&self->first_child);
+	while (child != NULL) {
+		struct memory_context *next = ADDR_OF(&child->next_sibling);
+		SET_OFFSET_OF(&child->parent, NULL);
+		SET_OFFSET_OF(&child->next_sibling, NULL);
+		child = next;
+	}
+}
+
+static inline void
 memory_context_fini(struct memory_context *self) {
 	// A zeroed offset reads back as NULL through ADDR_OF. A context that
 	// was already fini'd has no tree links left to touch. Return before
@@ -104,39 +149,40 @@ memory_context_fini(struct memory_context *self) {
 		return;
 	}
 
-	// Parent and child share the same block_allocator by construction, so
-	// its spinlock also guards the unlink and child-detach below against
-	// concurrent siblings.
-	spinlock_lock(&allocator->lock);
-
+	// The parent must stay alive across this call: reading self->parent
+	// unlocked relies on no concurrent fini of the parent itself, whose
+	// detach walk is what would rewrite this field.
 	struct memory_context *parent = ADDR_OF(&self->parent);
-	if (parent != NULL) {
-		// Walk the sibling chain and bridge over ourselves.
-		struct memory_context **cursor = &parent->first_child;
-		for (;;) {
-			struct memory_context *child = ADDR_OF(cursor);
-			if (child == NULL) {
-				break;
-			}
-			if (child == self) {
-				EQUATE_OFFSET(cursor, &self->next_sibling);
-				break;
-			}
-			cursor = &child->next_sibling;
+
+	if (parent == NULL) {
+		spinlock_lock(&allocator->lock);
+		memory_context_detach_children(self);
+		spinlock_unlock(&allocator->lock);
+	} else {
+		// Tree links hang off the parent node, so the unlink needs
+		// the PARENT's allocator lock. With per-owner allocators the
+		// child's own lock no longer equals it, while our child list
+		// is still guarded by our own allocator, hence two sections
+		// whenever the allocators differ. Sequential, never nested:
+		// no path takes these two locks in opposite orders.
+		struct block_allocator *parent_allocator =
+			ADDR_OF(&parent->block_allocator);
+
+		if (parent_allocator == allocator) {
+			spinlock_lock(&allocator->lock);
+			memory_context_unlink_from_parent(self, parent);
+			memory_context_detach_children(self);
+			spinlock_unlock(&allocator->lock);
+		} else {
+			spinlock_lock(&parent_allocator->lock);
+			memory_context_unlink_from_parent(self, parent);
+			spinlock_unlock(&parent_allocator->lock);
+
+			spinlock_lock(&allocator->lock);
+			memory_context_detach_children(self);
+			spinlock_unlock(&allocator->lock);
 		}
 	}
-
-	// Detach any remaining children so their parent link never dangles
-	// after our own storage is reused.
-	struct memory_context *child = ADDR_OF(&self->first_child);
-	while (child != NULL) {
-		struct memory_context *next = ADDR_OF(&child->next_sibling);
-		SET_OFFSET_OF(&child->parent, NULL);
-		SET_OFFSET_OF(&child->next_sibling, NULL);
-		child = next;
-	}
-
-	spinlock_unlock(&allocator->lock);
 
 	memset(self, 0, sizeof(*self));
 }
@@ -156,11 +202,28 @@ memory_balloc(struct memory_context *context, size_t size) {
 	return result;
 }
 
+#if defined(YANET_DEBUG)
+// Debug wrong-allocator tripwire. Declared here so memory_bfree can call
+// it ahead of the definition; struct memory_owner needs struct
+// memory_context, so the definition lives in common/memory_owner.h, which
+// this header pulls in at the very bottom.
+static inline void
+memory_owner_assert_block_owned(struct block_allocator *allocator, void *block);
+#endif
+
 static inline void
 memory_bfree(struct memory_context *context, void *block, size_t size) {
 	if (block == NULL || !size) {
 		return;
 	}
+#if defined(YANET_DEBUG)
+	// Freeing a foreign block through an owner-bound context corrupts
+	// the in-band free lists silently, so catch it while it is still
+	// cheap to name the culprit.
+	memory_owner_assert_block_owned(
+		ADDR_OF(&context->block_allocator), block
+	);
+#endif
 // Verified reproducing: gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, release
 // build flags (-O2 -g -Wall -Wextra -Werror -march=haswell -fPIC), e.g.
 // modules/acl/api/controlplane.c inlining memory_bfree into
@@ -218,3 +281,10 @@ memory_brealloc(
 	}
 	return new_data;
 }
+
+// Splits the include cycle with common/memory_owner.h: the owner struct
+// and its non-context-touching helpers sit above memory.h's needs, while
+// its grow/release helpers need struct memory_context from this header.
+// Including it here guarantees every user of memory_bfree also sees the
+// tripwire definition.
+#include "memory_owner.h"

--- a/common/memory_block.h
+++ b/common/memory_block.h
@@ -46,7 +46,20 @@ struct block_allocator_pool {
 	void *free_list;
 };
 
-typedef void *(*block_allocator_alloc_func)(size_t size, void *data);
+struct block_allocator;
+struct memory_owner;
+
+// Grows an allocator's arena supply by at least `need` bytes, returning 0
+// on success or -1 to fail the allocation. Runs with the allocator lock
+// released and may take that lock itself.
+//
+// Defined in common/memory_owner.h, which this header cannot include
+// (cycle through common/memory.h); every balloc consumer sees the
+// definition via that include chain.
+static inline int
+memory_owner_grow(
+	struct block_allocator *alloc, size_t need, struct memory_owner *owner
+);
 
 struct block_allocator {
 	struct block_allocator_pool pools[MEMORY_BLOCK_ALLOCATOR_EXP];
@@ -54,10 +67,23 @@ struct block_allocator {
 	// bitwise mask of not empty pools
 	uint32_t not_empty_mask;
 
-	// Guards the free lists above and, since every memory_context in a
-	// tree shares its root's block_allocator, the context tree splices in
-	// memory_context_init_from / memory_context_fini as well.
+	// Guards the free lists above and the memory-context tree splices
+	// in memory_context_init_from / memory_context_fini. Tree links are
+	// guarded by the allocator lock of the parent node they hang off,
+	// which is this one whenever parent and child share an allocator.
 	struct spinlock lock;
+
+	// Optional growth path for a free-list miss; a NULL offset keeps
+	// the fail-on-miss behaviour. memory_owner_init is the only
+	// installer: it binds an allocator to the owner embedding it, so
+	// grow_owner and &grow_owner->allocator are always the same pair.
+	//
+	// Never a code pointer: attached processes map the same code at
+	// different addresses under ASLR/PIE, so a stored function address
+	// would jump to garbage in another process. The owner is data and
+	// relocates through the offset; the callee is resolved by each
+	// process's own link.
+	struct memory_owner *grow_owner;
 };
 
 // FIXME: the routine must accept block sizes
@@ -72,6 +98,8 @@ block_allocator_init(struct block_allocator *allocator) {
 	}
 
 	allocator->not_empty_mask = 0;
+
+	SET_OFFSET_OF(&allocator->grow_owner, NULL);
 
 	spinlock_init(&allocator->lock);
 
@@ -178,13 +206,40 @@ block_allocator_balloc(struct block_allocator *allocator, size_t size) {
 	size_t pool_index = block_allocator_pool_index(allocator, size);
 	struct block_allocator_pool *pool = allocator->pools + pool_index;
 
-	spinlock_lock(&allocator->lock);
+	// The loop scans, grows on a miss, and rescans. A failed grow is
+	// truthful — the parent cannot fund another granule — so it ends
+	// the retries, and the closing rescan covers a competitor
+	// installing concurrently. A successful grow is retried without a
+	// bound: each one consumes parent capacity, and a competitor
+	// stealing the just-installed block is demand-driven, so a fixed
+	// attempt count would still report a false exhaustion while the
+	// parent has capacity.
+	struct memory_owner *grow_owner = ADDR_OF(&allocator->grow_owner);
+	bool exhausted = false;
 
-	uint32_t mask = allocator->not_empty_mask >> pool_index;
-	if (unlikely(mask == 0)) {
+	uint32_t mask;
+	for (;;) {
+		spinlock_lock(&allocator->lock);
+
+		mask = allocator->not_empty_mask >> pool_index;
+		if (likely(mask != 0)) {
+			break;
+		}
 		spinlock_unlock(&allocator->lock);
-		return NULL;
+
+		if (grow_owner == NULL || exhausted) {
+			return NULL;
+		}
+
+		// Grow with the lock released: growth serializes on the
+		// owner lock for its whole body and first rescans under
+		// that lock, skipping the borrow when an installed arena
+		// already covers the request.
+		if (memory_owner_grow(allocator, size, grow_owner) != 0) {
+			exhausted = true;
+		}
 	}
+
 	size_t parent_pool_index = pool_index + __builtin_ctz(mask);
 
 	while (parent_pool_index-- > pool_index) {
@@ -237,16 +292,15 @@ block_allocator_bfree(
 	spinlock_unlock(&allocator->lock);
 }
 
+// Caller holds the allocator lock.
 static inline void
-block_allocator_put_arena(
+block_allocator_put_arena_locked(
 	struct block_allocator *allocator, void *arena, size_t size
 ) {
 	uintptr_t pos = (uintptr_t)arena;
 	pos = (pos + 7) & ~(uintptr_t)0x07; // round up to 8 byte boundary
 	uintptr_t end = (uintptr_t)arena + size;
 	end = end & ~(uintptr_t)0x07; // round down to 8 byte boundary
-
-	spinlock_lock(&allocator->lock);
 
 	while (pos < end) {
 		size_t align = (size_t)1 << __builtin_ctzll(pos);
@@ -275,7 +329,14 @@ block_allocator_put_arena(
 		);
 		pos += block_size;
 	}
+}
 
+static inline void
+block_allocator_put_arena(
+	struct block_allocator *allocator, void *arena, size_t size
+) {
+	spinlock_lock(&allocator->lock);
+	block_allocator_put_arena_locked(allocator, arena, size);
 	spinlock_unlock(&allocator->lock);
 }
 

--- a/common/memory_owner.h
+++ b/common/memory_owner.h
@@ -1,0 +1,292 @@
+#pragma once
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "memory_address.h"
+#include "memory_block.h"
+#include "strutils.h"
+
+// The meson-generated header is absent for cgo compilation of Go packages
+// reaching this file, which runs without a configured build directory.
+// Only YANET_DEBUG is consumed below, so its absence just leaves the
+// wrong-allocator tripwire disabled, matching a release configuration.
+#if defined(__has_include)
+#if __has_include("yanet_build_config.h")
+#include "yanet_build_config.h"
+#endif
+#else
+#include "yanet_build_config.h"
+#endif
+
+// Defined in common/memory.h, included further down once the definitions
+// below no longer depend on it being incomplete.
+struct memory_context;
+
+// Smallest arena a memory_owner borrows from its parent context.
+#define MEMORY_OWNER_MIN_GRANULE ((size_t)64 * 1024)
+
+// One arena borrowed from the parent context and fed into the owner's
+// block allocator.
+//
+// data is a shared-memory offset pointer: assign it with SET_OFFSET_OF
+// and read it back with ADDR_OF.
+struct memory_arena {
+	void *data;
+	uint64_t size;
+};
+
+// A block_allocator that grows on demand by borrowing whole arenas from a
+// parent memory context, and returns them all on teardown.
+//
+// parent_ctx and arenas are shared-memory offset pointers.
+struct memory_owner {
+	// Must stay the first field: grow_owner points back to the owner,
+	// and the debug tripwire reaches the arenas through it.
+	struct block_allocator allocator;
+
+	struct memory_context *parent_ctx;
+
+	uint64_t arena_count;
+	uint64_t arena_capacity;
+	struct memory_arena *arenas;
+
+	char name[64];
+};
+
+// Prepares an empty owner bound to parent_ctx. The parent context must
+// outlive the owner: arenas are borrowed from it lazily and returned by
+// memory_owner_release_all.
+static inline int
+memory_owner_init(
+	struct memory_owner *owner,
+	struct memory_context *parent_ctx,
+	const char *name
+) {
+	block_allocator_init(&owner->allocator);
+	SET_OFFSET_OF(&owner->allocator.grow_owner, owner);
+
+	SET_OFFSET_OF(&owner->parent_ctx, parent_ctx);
+
+	owner->arena_count = 0;
+	owner->arena_capacity = 0;
+	SET_OFFSET_OF(&owner->arenas, NULL);
+
+	(void)strtcpy(owner->name, name, sizeof(owner->name));
+
+	return 0;
+}
+
+#if defined(YANET_DEBUG)
+// Debug tripwire for memory_bfree: a block freed through a context bound
+// to this allocator must lie inside one of the borrowed arenas. A foreign
+// block would otherwise land on the in-band free lists and corrupt them
+// silently, so abort loudly instead.
+//
+// Takes owner->allocator.lock — the lock the grow path appends under —
+// for a consistent (arenas, arena_count) pair. The interval is the true
+// parent block (arena pointer minus its red zone, grown to the
+// pool-rounded block), which is what put_arena ingested.
+static inline void
+memory_owner_assert_block_owned(
+	struct block_allocator *allocator, void *block
+) {
+	struct memory_owner *owner = ADDR_OF(&allocator->grow_owner);
+	if (owner == NULL) {
+		return;
+	}
+
+	spinlock_lock(&owner->allocator.lock);
+	struct memory_arena *arenas = ADDR_OF(&owner->arenas);
+	uint64_t arena_count = owner->arena_count;
+	uint64_t owned = 0;
+	for (uint64_t idx = 0; idx < arena_count; ++idx) {
+		uintptr_t base =
+			(uintptr_t)ADDR_OF(&arenas[idx].data) - ASAN_RED_ZONE;
+		size_t block_size = block_allocator_pool_size(
+			allocator,
+			block_allocator_pool_index(
+				allocator,
+				(size_t)arenas[idx].size + 2 * ASAN_RED_ZONE
+			)
+		);
+		if ((uintptr_t)block >= base &&
+		    (uintptr_t)block < base + block_size) {
+			owned = 1;
+			break;
+		}
+	}
+	spinlock_unlock(&owner->allocator.lock);
+
+	if (!owned) {
+		fprintf(stderr,
+			"yanet: memory_owner '%s': block %p freed through the "
+			"owner-bound context belongs to a foreign allocator\n",
+			owner->name,
+			block);
+		abort();
+	}
+}
+#endif // defined(YANET_DEBUG)
+
+// common/memory.h defines struct memory_context and the context-level
+// allocation helpers the functions below call. It includes this header
+// back at its end; the include cycle is closed on both orders because
+// everything above only needs struct memory_context as an incomplete
+// type.
+#include "memory.h"
+
+// Growth path for block_allocator_balloc: borrow one power-of-2 granule
+// of at least `need` bytes from the parent context, track it, and feed it
+// to the owner's allocator.
+static inline int
+memory_owner_grow(
+	struct block_allocator *alloc, size_t need, struct memory_owner *owner
+) {
+	// The grow binding is identity-bound: a foreign allocator would
+	// ingest the granule into the owner while the caller retries the
+	// allocator, stranding it.
+	assert(alloc == &owner->allocator);
+
+	struct memory_context *parent_ctx = ADDR_OF(&owner->parent_ctx);
+
+	// The parent block class to borrow: the requesting pool's block,
+	// floored at the minimum granule. `need` already carries the child
+	// allocator's red zones, so asking the parent for the block minus
+	// its red-zone pair lands the parent's own addition back in the
+	// same class — requesting `wanted` itself would round one pool up
+	// and double-reserve under sanitizers.
+	size_t wanted = block_allocator_pool_size(
+		alloc, block_allocator_pool_index(alloc, need)
+	);
+	if (wanted < MEMORY_OWNER_MIN_GRANULE) {
+		wanted = MEMORY_OWNER_MIN_GRANULE;
+	}
+	size_t granule = wanted - 2 * ASAN_RED_ZONE;
+
+	// A power-of-2 block freshly borrowed from the buddy parent is
+	// size-aligned, so put_arena yields exactly one whole block with
+	// zero split waste. Under ASAN the returned pointer is shifted by
+	// the red zone, so realign to the true block start and its
+	// pool-rounded size — the exact same expression when red zones are
+	// zero.
+	size_t block = block_allocator_pool_size(
+		alloc,
+		block_allocator_pool_index(alloc, granule + 2 * ASAN_RED_ZONE)
+	);
+
+	// Serialize the whole growth — borrow, track, install — on the
+	// owner lock: a competing miss whose own borrow fails then blocks
+	// here for its final rescan and cannot observe exhaustion between
+	// this granule's commitment and its installation. Nesting owner ->
+	// parent inside this lock is safe: no path takes them in the
+	// reverse order.
+	spinlock_lock(&owner->allocator.lock);
+
+	// A competitor that grew while we were missing may already have
+	// installed an arena covering this request — the caller's rescan
+	// finds it, so return without borrowing and keep surplus granules
+	// out of the parent.
+	if (alloc->not_empty_mask >> block_allocator_pool_index(alloc, need) !=
+	    0) {
+		spinlock_unlock(&owner->allocator.lock);
+		return 0;
+	}
+
+	void *arena = memory_balloc(parent_ctx, granule);
+	if (arena == NULL) {
+		spinlock_unlock(&owner->allocator.lock);
+		return -1;
+	}
+
+	if (owner->arena_count == owner->arena_capacity) {
+		uint64_t capacity = owner->arena_capacity * 2;
+		if (capacity == 0) {
+			capacity = 4;
+		}
+
+		// The array cannot go through memory_brealloc: its data
+		// fields are offsets relative to their own slot, so a memcpy
+		// to a new address silently rebases every entry. Allocate
+		// fresh and re-stamp each offset, like the agent registry
+		// rebuild does.
+		struct memory_arena *old_arenas = ADDR_OF(&owner->arenas);
+		size_t old_bytes =
+			owner->arena_capacity * sizeof(struct memory_arena);
+		struct memory_arena *arenas =
+			memory_balloc(parent_ctx, capacity * sizeof(*arenas));
+		if (arenas == NULL) {
+			memory_bfree(parent_ctx, arena, granule);
+			spinlock_unlock(&owner->allocator.lock);
+			return -1;
+		}
+		for (uint64_t idx = 0; idx < owner->arena_count; ++idx) {
+			SET_OFFSET_OF(
+				&arenas[idx].data,
+				ADDR_OF(&old_arenas[idx].data)
+			);
+			arenas[idx].size = old_arenas[idx].size;
+		}
+		if (old_arenas != NULL) {
+			memory_bfree(parent_ctx, old_arenas, old_bytes);
+		}
+
+		SET_OFFSET_OF(&owner->arenas, arenas);
+		owner->arena_capacity = capacity;
+	}
+
+	struct memory_arena *arenas = ADDR_OF(&owner->arenas);
+	SET_OFFSET_OF(&arenas[owner->arena_count].data, arena);
+	arenas[owner->arena_count].size = granule;
+	owner->arena_count++;
+
+	block_allocator_put_arena_locked(
+		&owner->allocator, (char *)arena - ASAN_RED_ZONE, block
+	);
+
+	spinlock_unlock(&owner->allocator.lock);
+
+	return 0;
+}
+
+// Returns every borrowed arena to the parent context and frees the
+// tracking array, leaving the owner ready for a fresh memory_owner_init;
+// the caller frees the owner header itself. Teardown-only: quiesce
+// allocations through the owner first.
+//
+// Quiescence is the operative guarantee — the lock only serializes the
+// walk with a grow that already holds it, and a grow paused before
+// acquiring can still append after the walk. Nested parent frees keep
+// grow's owner -> parent order. The pools need no drain — their
+// linkage lives in-band inside the released arenas.
+static inline void
+memory_owner_release_all(struct memory_owner *owner) {
+	struct memory_context *parent_ctx = ADDR_OF(&owner->parent_ctx);
+
+	spinlock_lock(&owner->allocator.lock);
+
+	struct memory_arena *arenas = ADDR_OF(&owner->arenas);
+	if (arenas != NULL) {
+		for (uint64_t idx = 0; idx < owner->arena_count; ++idx) {
+			memory_bfree(
+				parent_ctx,
+				ADDR_OF(&arenas[idx].data),
+				arenas[idx].size
+			);
+		}
+		memory_bfree(
+			parent_ctx,
+			arenas,
+			owner->arena_capacity * sizeof(struct memory_arena)
+		);
+	}
+
+	owner->arena_count = 0;
+	owner->arena_capacity = 0;
+	SET_OFFSET_OF(&owner->arenas, NULL);
+
+	spinlock_unlock(&owner->allocator.lock);
+}

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -176,9 +176,9 @@ agent_attach(
 	uint64_t arena_count =
 		(memory_limit + MEMORY_BLOCK_ALLOCATOR_MAX_SIZE - 1) /
 		MEMORY_BLOCK_ALLOCATOR_MAX_SIZE;
-	struct agent_arena *arenas = (struct agent_arena *)memory_balloc(
+	struct memory_arena *arenas = (struct memory_arena *)memory_balloc(
 		&cp_config->memory_context,
-		sizeof(struct agent_arena) * arena_count
+		sizeof(struct memory_arena) * arena_count
 	);
 	if (arenas == NULL) {
 		yanet_error_add(err, "failed to allocate memory for arenas");
@@ -187,7 +187,7 @@ agent_attach(
 		goto unlock;
 	}
 
-	memset(arenas, 0, sizeof(struct agent_arena) * arena_count);
+	memset(arenas, 0, sizeof(struct memory_arena) * arena_count);
 	SET_OFFSET_OF(&new_agent->arenas, arenas);
 
 	while (new_agent->arena_count < arena_count) {
@@ -297,9 +297,9 @@ agent_resize(struct agent *agent, size_t new_size, yanet_error **err) {
 	// we need add one more arena in this case.
 
 	if (need_arena_count > agent->arena_count) {
-		struct agent_arena *arenas = memory_balloc(
+		struct memory_arena *arenas = memory_balloc(
 			&cp_config->memory_context,
-			need_arena_count * sizeof(struct agent_arena)
+			need_arena_count * sizeof(struct memory_arena)
 		);
 		if (arenas == NULL) {
 			yanet_error_add(err, "failed to allocate arenas array");
@@ -333,7 +333,7 @@ agent_resize(struct agent *agent, size_t new_size, yanet_error **err) {
 					&cp_config->memory_context,
 					arenas,
 					need_arena_count *
-						sizeof(struct agent_arena)
+						sizeof(struct memory_arena)
 				);
 				ret = -1;
 				goto unlock;
@@ -356,7 +356,7 @@ agent_resize(struct agent *agent, size_t new_size, yanet_error **err) {
 			);
 		}
 
-		struct agent_arena *prev_arenas = ADDR_OF(&agent->arenas);
+		struct memory_arena *prev_arenas = ADDR_OF(&agent->arenas);
 		for (size_t i = 0; i < agent->arena_count; ++i) {
 			SET_OFFSET_OF(
 				&arenas[i].data, ADDR_OF(&prev_arenas[i].data)
@@ -367,7 +367,7 @@ agent_resize(struct agent *agent, size_t new_size, yanet_error **err) {
 		memory_bfree(
 			&cp_config->memory_context,
 			prev_arenas,
-			agent->arena_count * sizeof(struct agent_arena)
+			agent->arena_count * sizeof(struct memory_arena)
 		);
 		agent->arena_count = need_arena_count;
 	}
@@ -387,7 +387,7 @@ agent_cleanup(struct agent *agent) {
 	// memory_context_fini never touches freed arena memory.
 	memory_context_fini(&agent->memory_context);
 
-	struct agent_arena *arenas = ADDR_OF(&agent->arenas);
+	struct memory_arena *arenas = ADDR_OF(&agent->arenas);
 	if (arenas) {
 		for (uint64_t arena_idx = 0; arena_idx < agent->arena_count;
 		     ++arena_idx) {
@@ -400,7 +400,7 @@ agent_cleanup(struct agent *agent) {
 		memory_bfree(
 			&cp_config->memory_context,
 			arenas,
-			sizeof(struct agent_arena) * agent->arena_count
+			sizeof(struct memory_arena) * agent->arena_count
 		);
 	}
 

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 
 #include "common/memory.h"
+#include "common/memory_owner.h"
 
 #include "lib/errors/errors.h"
 
@@ -16,11 +17,6 @@ struct cp_device;
 struct cp_object;
 
 struct agent;
-
-struct agent_arena {
-	void *data;
-	uint64_t size;
-};
 
 struct agent_storage {
 	char name[80];
@@ -72,7 +68,7 @@ struct agent {
 	char name[80];
 
 	uint64_t arena_count;
-	struct agent_arena *arenas;
+	struct memory_arena *arenas;
 
 	struct agent_storage *storage;
 

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -24,7 +24,7 @@ _Static_assert(
 	"struct module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct dp_config) == 1184,
+	sizeof(struct dp_config) == 1192,
 	"struct dp_config size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 16
+#define YANET_MODULE_ABI_VERSION 17
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,7 @@ endif
 # translation unit's ccache manifest.
 yanet_conf = configuration_data()
 yanet_conf.set('DEBUG_NAT64', get_option('buildtype') == 'debug')
+yanet_conf.set('YANET_DEBUG', get_option('buildtype') == 'debug')
 yanet_conf.set('ENABLE_TRACE_LOG', get_option('trace').enabled())
 yanet_conf.set('MBUF_MAX_SIZE', get_option('mbuf_max_size'))
 

--- a/tests/common/go/memory_owner_test.go
+++ b/tests/common/go/memory_owner_test.go
@@ -1,0 +1,134 @@
+package memoryowner
+
+import (
+	"sync"
+	"testing"
+	"unsafe"
+)
+
+func TestOwnerGrowsOnMissAndReturnsToBaseline(t *testing.T) {
+	f := newOwnerFixture(1 << 20)
+	defer f.fini()
+
+	sizes := []uint64{8, 24, 96, 480, 1000, 2040, 3000}
+	var blocks []unsafe.Pointer
+	var heldBytes uint64
+	for range 4 {
+		for _, sz := range sizes {
+			p := f.balloc(sz)
+			if p == nil {
+				t.Fatalf("alloc of %d bytes failed", sz)
+			}
+			blocks = append(blocks, p)
+			heldBytes += reqBlock(sz)
+		}
+	}
+	if f.arenaCount() == 0 {
+		t.Fatal("owner never borrowed an arena")
+	}
+
+	ingested := f.ingestedTotal()
+	if ingested < heldBytes {
+		t.Fatalf("ingested %d bytes cannot hold %d allocated", ingested, heldBytes)
+	}
+
+	for i, p := range blocks {
+		f.bfree(p, sizes[i%len(sizes)])
+	}
+	if got := f.ownerFreeSize(); got != ingested {
+		t.Fatalf("owner free size after round-trip = %d, want ingested %d", got, ingested)
+	}
+
+	f.releaseAll()
+	if got := f.freeSize(); got != f.baseline {
+		t.Fatalf("parent free size after release = %d, want baseline %d", got, f.baseline)
+	}
+}
+
+func TestOwnerExhaustionIsTruthful(t *testing.T) {
+	granule := granuleBlock()
+	f := newOwnerFixture(granule)
+	defer f.fini()
+
+	req := uint64(8<<10) - 2*redZone()
+	expected := granule / reqBlock(req)
+
+	count := 0
+	for f.balloc(req) != nil {
+		count++
+	}
+	if count != int(expected) {
+		t.Fatalf("single-granule parent yielded %d blocks, want %d", count, expected)
+	}
+	if got := f.ownerFreeSize(); got != 0 {
+		t.Fatalf("owner reported exhaustion with %d free bytes", got)
+	}
+
+	f.releaseAll()
+	if got := f.freeSize(); got != f.baseline {
+		t.Fatalf("parent free size after release = %d, want baseline %d", got, f.baseline)
+	}
+}
+
+func TestOwnerGrowthFailurePropagates(t *testing.T) {
+	f := newOwnerFixture(granuleBlock() - 4096)
+	defer f.fini()
+
+	if p := f.balloc(16); p != nil {
+		t.Fatal("alloc must fail when the parent cannot fund growth")
+	}
+	if f.arenaCount() != 0 {
+		t.Fatalf("failed growth tracked %d arenas", f.arenaCount())
+	}
+	if got := f.ownerFreeSize(); got != 0 {
+		t.Fatalf("owner free size after failed growth = %d, want 0", got)
+	}
+	if got := f.freeSize(); got != f.baseline {
+		t.Fatalf("parent free size after failed growth = %d, want baseline %d", got, f.baseline)
+	}
+}
+
+func TestConcurrentMissesBorrowNoSurplus(t *testing.T) {
+	granule := granuleBlock()
+	f := newOwnerFixture(1 << 20)
+	defer f.fini()
+
+	req := uint64(8<<10) - 2*redZone()
+	perGranule := int(granule / reqBlock(req))
+	goroutines := 4
+	perGoroutine := perGranule / 2
+	total := goroutines * perGoroutine
+
+	var wg sync.WaitGroup
+	held := make([][]unsafe.Pointer, goroutines)
+	for g := range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range perGoroutine {
+				p := f.balloc(req)
+				if p == nil {
+					t.Errorf("goroutine %d: allocation failed before exhaustion", g)
+					return
+				}
+				held[g] = append(held[g], p)
+			}
+		}()
+	}
+	wg.Wait()
+
+	wantGranules := (total + perGranule - 1) / perGranule
+	if got := f.arenaCount(); got != wantGranules {
+		t.Fatalf("concurrent misses borrowed %d granules, want the minimum %d", got, wantGranules)
+	}
+
+	for g := range held {
+		for _, p := range held[g] {
+			f.bfree(p, req)
+		}
+	}
+	f.releaseAll()
+	if got := f.freeSize(); got != f.baseline {
+		t.Fatalf("parent free size after release = %d, want baseline %d", got, f.baseline)
+	}
+}

--- a/tests/common/go/owner_cgo.go
+++ b/tests/common/go/owner_cgo.go
@@ -1,0 +1,166 @@
+package memoryowner
+
+/*
+#cgo CFLAGS: -I../../..
+#include <stdlib.h>
+#include "common/memory.h"
+#include "common/memory_owner.h"
+
+// Reads an arena's borrowed size through the offset-pointer discipline;
+// the ADDR_OF macro itself is not callable from Go.
+static size_t owner_arena_size(struct memory_owner *owner, uint64_t idx) {
+	struct memory_arena *arenas = ADDR_OF(&owner->arenas);
+	return (size_t)arenas[idx].size;
+}
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// Go regression coverage for the C memory_owner growth path: the
+// sanitized-build and thread-stress cases stay in the C suites, while
+// the behavioral contract — grow on miss, truthful exhaustion, failure
+// propagation, no surplus granules under concurrent misses, and exact
+// release — is exercised through the production headers.
+
+const (
+	arenaAlign = 1 << 21
+	minGranule = 64 << 10
+)
+
+// ownerFixture is a parent context over one malloc'd arena plus an
+// owner bound to it, both driven through the production headers.
+type ownerFixture struct {
+	raw      unsafe.Pointer
+	ba       *C.struct_block_allocator
+	ctx      *C.struct_memory_context
+	owner    *C.struct_memory_owner
+	octx     *C.struct_memory_context
+	baseline uint64
+}
+
+// newOwnerFixture builds a parent context over one arena of arenaSz
+// bytes plus a 4 KiB slack block, and an owner bound to it. The slack
+// funds the owner's arenas tracking array so the first growth succeeds;
+// passing arenaSz below the granule size starves it on purpose.
+func newOwnerFixture(arenaSz uint64) *ownerFixture {
+	f := &ownerFixture{}
+	f.raw = C.malloc(C.size_t(arenaSz + 4096 + arenaAlign))
+	if f.raw == nil {
+		panic("arena malloc failed")
+	}
+
+	f.ba = (*C.struct_block_allocator)(C.malloc(C.sizeof_struct_block_allocator))
+	f.ctx = (*C.struct_memory_context)(C.malloc(C.sizeof_struct_memory_context))
+	f.owner = (*C.struct_memory_owner)(C.malloc(C.sizeof_struct_memory_owner))
+	f.octx = (*C.struct_memory_context)(C.malloc(C.sizeof_struct_memory_context))
+	if f.ba == nil || f.ctx == nil || f.owner == nil || f.octx == nil {
+		panic("struct malloc failed")
+	}
+
+	if rc := C.block_allocator_init(f.ba); rc != 0 {
+		panic("block_allocator_init failed")
+	}
+	C.block_allocator_put_arena(
+		f.ba,
+		unsafe.Pointer((uintptr(f.raw)+arenaAlign-1)&^uintptr(arenaAlign-1)),
+		C.size_t(arenaSz+4096),
+	)
+
+	name := C.CString("go-parent")
+	rc := C.memory_context_init(f.ctx, name, f.ba)
+	C.free(unsafe.Pointer(name))
+	if rc != 0 {
+		panic("memory_context_init failed")
+	}
+	oname := C.CString("go-owner")
+	rc = C.memory_owner_init(f.owner, f.ctx, oname)
+	C.free(unsafe.Pointer(oname))
+	if rc != 0 {
+		panic("memory_owner_init failed")
+	}
+	oname2 := C.CString("go-owner-alloc")
+	rc = C.memory_context_init(f.octx, oname2, &f.owner.allocator)
+	C.free(unsafe.Pointer(oname2))
+	if rc != 0 {
+		panic("owner context init failed")
+	}
+	f.baseline = f.freeSize()
+	return f
+}
+
+func (f *ownerFixture) fini() {
+	C.memory_context_fini(f.octx)
+	C.memory_context_fini(f.ctx)
+	C.free(unsafe.Pointer(f.octx))
+	C.free(unsafe.Pointer(f.owner))
+	C.free(unsafe.Pointer(f.ctx))
+	C.free(unsafe.Pointer(f.ba))
+	C.free(f.raw)
+}
+
+// balloc requests sz bytes through the owner-bound context.
+func (f *ownerFixture) balloc(sz uint64) unsafe.Pointer {
+	return C.memory_balloc(f.octx, C.size_t(sz))
+}
+
+// bfree returns a block of sz bytes through the owner-bound context.
+func (f *ownerFixture) bfree(p unsafe.Pointer, sz uint64) {
+	C.memory_bfree(f.octx, p, C.size_t(sz))
+}
+
+// releaseAll returns every borrowed arena to the parent context.
+func (f *ownerFixture) releaseAll() {
+	C.memory_owner_release_all(f.owner)
+}
+
+func (f *ownerFixture) freeSize() uint64 {
+	return uint64(C.block_allocator_free_size(f.ba))
+}
+
+func (f *ownerFixture) ownerFreeSize() uint64 {
+	return uint64(C.block_allocator_free_size(&f.owner.allocator))
+}
+
+func (f *ownerFixture) arenaCount() int {
+	return int(f.owner.arena_count)
+}
+
+// redZone is the C sanitizer red-zone width of this build.
+func redZone() uint64 {
+	return uint64(C.ASAN_RED_ZONE)
+}
+
+// granuleBlock is the parent pool block one minimum granule occupies.
+func granuleBlock() uint64 {
+	return uint64(C.block_allocator_pool_size(
+		nil,
+		C.block_allocator_pool_index(nil, minGranule+2*C.ASAN_RED_ZONE),
+	))
+}
+
+// reqBlock is the owner pool block one request of sz user bytes lands in.
+func reqBlock(sz uint64) uint64 {
+	return uint64(C.block_allocator_pool_size(
+		nil,
+		C.block_allocator_pool_index(nil, C.size_t(sz+2*C.ASAN_RED_ZONE)),
+	))
+}
+
+// ingestedTotal sums the pool-rounded blocks of every borrowed arena.
+func (f *ownerFixture) ingestedTotal() uint64 {
+	total := uint64(0)
+	for idx := C.uint64_t(0); idx < f.owner.arena_count; idx++ {
+		size := C.owner_arena_size(f.owner, idx)
+		total += uint64(C.block_allocator_pool_size(
+			&f.owner.allocator,
+			C.block_allocator_pool_index(
+				&f.owner.allocator,
+				size+2*C.ASAN_RED_ZONE,
+			),
+		))
+	}
+	return total
+}

--- a/tests/common/memory_owner_test.c
+++ b/tests/common/memory_owner_test.c
@@ -1,0 +1,827 @@
+// Functional tests for struct memory_owner: a block_allocator that grows
+// on demand by borrowing arenas from a parent memory context and returns
+// them wholesale on release.
+
+#include "common/memory.h"
+#include "common/memory_owner.h"
+#include "common/numutils.h"
+#include "common/test_assert.h"
+#include "lib/logging/log.h"
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define PARENT_ARENA_ALIGN (1u << 21) // 2 MiB
+#define PARENT_RAW_SZ ((size_t)(1u << 22))
+
+// A parent memory_context over one 2 MiB arena, the role cp_config's
+// context plays for real agents.
+struct parent_fixture {
+	void *raw;
+	void *arena;
+	struct block_allocator ba;
+	struct memory_context ctx;
+};
+
+static int
+parent_fixture_init(struct parent_fixture *fx) {
+	fx->raw = malloc(PARENT_RAW_SZ + PARENT_ARENA_ALIGN);
+	TEST_ASSERT(fx->raw != NULL, "failed to allocate parent raw buffer");
+	uintptr_t aligned = ((uintptr_t)fx->raw + PARENT_ARENA_ALIGN - 1) &
+			    ~(uintptr_t)(PARENT_ARENA_ALIGN - 1);
+	fx->arena = (void *)aligned;
+
+	TEST_ASSERT(
+		block_allocator_init(&fx->ba) == 0,
+		"parent allocator init failed"
+	);
+	block_allocator_put_arena(&fx->ba, fx->arena, PARENT_ARENA_ALIGN);
+	TEST_ASSERT(
+		memory_context_init(&fx->ctx, "parent", &fx->ba) == 0,
+		"parent context init failed"
+	);
+	return 0;
+}
+
+static void
+parent_fixture_fini(struct parent_fixture *fx) {
+	memory_context_fini(&fx->ctx);
+	free(fx->raw);
+}
+
+// A context bound to the owner's allocator, the shape module contexts
+// will take: named, allocating through the owner, not spliced anywhere.
+static int
+owner_context_init(
+	struct memory_context *ctx, struct memory_owner *owner, const char *name
+) {
+	TEST_ASSERT(
+		memory_context_init(ctx, name, &owner->allocator) == 0,
+		"owner-bound context init failed"
+	);
+	return 0;
+}
+
+// Splices an owner-bound context into a parent context's child list under
+// the parent's allocator lock, reproducing the shape the cp_module
+// lifecycle will create: child list on the parent, allocations on the
+// owner's separate allocator.
+static void
+owner_child_splice(
+	struct memory_context *child,
+	struct memory_context *parent,
+	struct block_allocator *parent_alloc
+) {
+	spinlock_lock(&parent_alloc->lock);
+	SET_OFFSET_OF(&child->parent, parent);
+	EQUATE_OFFSET(&child->next_sibling, &parent->first_child);
+	SET_OFFSET_OF(&parent->first_child, child);
+	spinlock_unlock(&parent_alloc->lock);
+}
+
+// Growth on exhaustion: the owner starts empty, the first allocation
+// borrows one 64 KiB granule, and a request larger than the granule grows
+// to the next power of two covering it.
+static int
+test_grow_on_exhaustion(void) {
+	struct parent_fixture fx;
+	TEST_ASSERT(parent_fixture_init(&fx) == 0, "fixture init failed");
+
+	struct memory_owner owner;
+	TEST_ASSERT(
+		memory_owner_init(&owner, &fx.ctx, "owner") == 0,
+		"memory_owner_init failed"
+	);
+	TEST_ASSERT(owner.arena_count == 0, "fresh owner must have no arenas");
+
+	struct memory_context octx;
+	TEST_ASSERT(
+		owner_context_init(&octx, &owner, "owner-ctx") == 0,
+		"owner-bound context init failed"
+	);
+
+	size_t parent_base = block_allocator_free_size(&fx.ba);
+
+	void *p = memory_balloc(&octx, 128);
+	TEST_ASSERT(p != NULL, "first owner allocation must trigger growth");
+	TEST_ASSERT(owner.arena_count == 1, "first allocation must grow once");
+
+	struct memory_arena *arenas = ADDR_OF(&owner.arenas);
+	TEST_ASSERT(
+		arenas[0].size ==
+			MEMORY_OWNER_MIN_GRANULE - 2 * ASAN_RED_ZONE,
+		"small request must borrow the minimum granule, got %" PRIu64,
+		arenas[0].size
+	);
+	// One whole granule block is ingested; the 128-byte request takes a
+	// single pool block out of it. Express both through the allocator's
+	// pool math so red-zone inflation stays exact.
+	size_t ingested = block_allocator_pool_size(
+		&owner.allocator,
+		block_allocator_pool_index(
+			&owner.allocator,
+			(size_t)arenas[0].size + 2 * ASAN_RED_ZONE
+		)
+	);
+	size_t taken = block_allocator_pool_size(
+		&owner.allocator,
+		block_allocator_pool_index(
+			&owner.allocator, 128 + 2 * ASAN_RED_ZONE
+		)
+	);
+	TEST_ASSERT(
+		block_allocator_free_size(&owner.allocator) == ingested - taken,
+		"fresh granule must be one whole block minus the request taken "
+		"from it"
+	);
+	// Both the granule and the arenas array consume pool-rounded blocks
+	// in the parent, red zones included; compute them with the
+	// allocator's own pool math to stay exact in sanitized builds too.
+	size_t granule_block = block_allocator_pool_size(
+		&fx.ba,
+		block_allocator_pool_index(&fx.ba, MEMORY_OWNER_MIN_GRANULE)
+	);
+	size_t array_internal =
+		owner.arena_capacity * sizeof(struct memory_arena) +
+		2 * ASAN_RED_ZONE;
+	size_t array_block = block_allocator_pool_size(
+		&fx.ba, block_allocator_pool_index(&fx.ba, array_internal)
+	);
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.ba) ==
+			parent_base - granule_block - array_block,
+		"parent must lose exactly one granule plus the arenas array "
+		"to the borrow"
+	);
+
+	memory_bfree(&octx, p, 128);
+
+	// A request above the minimum granule borrows the covering pool
+	// block, minus the parent's own red-zone pair.
+	void *big = memory_balloc(&octx, 200000);
+	TEST_ASSERT(big != NULL, "grow-to-need allocation failed");
+	TEST_ASSERT(owner.arena_count == 2, "second allocation must grow");
+	arenas = ADDR_OF(&owner.arenas);
+	TEST_ASSERT(
+		arenas[1].size ==
+			block_allocator_pool_size(
+				&owner.allocator,
+				block_allocator_pool_index(
+					&owner.allocator,
+					200000 + 2 * ASAN_RED_ZONE
+				)
+			) -
+				2 * ASAN_RED_ZONE,
+		"large request must borrow the covering pool block"
+	);
+	memory_bfree(&octx, big, 200000);
+
+	memory_owner_release_all(&owner);
+	memory_context_fini(&octx);
+	parent_fixture_fini(&fx);
+	return 0;
+}
+
+// release_all returns every borrowed byte to the parent, and the owner
+// re-inits and keeps working after a release.
+static int
+test_release_all_returns_arenas(void) {
+	struct parent_fixture fx;
+	TEST_ASSERT(parent_fixture_init(&fx) == 0, "fixture init failed");
+
+	size_t parent_base = block_allocator_free_size(&fx.ba);
+
+	struct memory_owner owner;
+	struct memory_context octx;
+	TEST_ASSERT(
+		memory_owner_init(&owner, &fx.ctx, "owner") == 0,
+		"memory_owner_init failed"
+	);
+	TEST_ASSERT(
+		owner_context_init(&octx, &owner, "owner-ctx") == 0,
+		"owner-bound context init failed"
+	);
+
+	void *slots[6] = {0};
+	size_t sizes[6] = {8, 128, 512, 4096, 20000, 100000};
+	for (size_t idx = 0; idx < 6; ++idx) {
+		slots[idx] = memory_balloc(&octx, sizes[idx]);
+		TEST_ASSERT(
+			slots[idx] != NULL, "alloc of %zu failed", sizes[idx]
+		);
+	}
+	for (size_t idx = 0; idx < 6; ++idx) {
+		memory_bfree(&octx, slots[idx], sizes[idx]);
+	}
+
+	TEST_ASSERT(
+		owner.arena_count > 0, "allocations must have grown the owner"
+	);
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.ba) < parent_base,
+		"parent must hold borrowed arenas before release"
+	);
+
+	memory_owner_release_all(&owner);
+
+	TEST_ASSERT(owner.arena_count == 0, "release must reset arena_count");
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.ba) == parent_base,
+		"release_all must return every borrowed byte to the parent"
+	);
+
+	// Re-init and reuse after a release.
+	TEST_ASSERT(
+		memory_owner_init(&owner, &fx.ctx, "owner2") == 0,
+		"re-init after release failed"
+	);
+	void *p = memory_balloc(&octx, 64);
+	TEST_ASSERT(p != NULL, "allocation after re-init failed");
+	TEST_ASSERT(owner.arena_count == 1, "re-init owner must grow afresh");
+	memory_bfree(&octx, p, 64);
+	memory_owner_release_all(&owner);
+
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.ba) == parent_base,
+		"second release must also return every borrowed byte"
+	);
+
+	memory_context_fini(&octx);
+	parent_fixture_fini(&fx);
+	return 0;
+}
+
+// memory_brealloc inside an owner-bound context, including a realloc big
+// enough to trigger growth for the destination.
+static int
+test_realloc_in_owner_context(void) {
+	struct parent_fixture fx;
+	TEST_ASSERT(parent_fixture_init(&fx) == 0, "fixture init failed");
+
+	struct memory_owner owner;
+	struct memory_context octx;
+	TEST_ASSERT(
+		memory_owner_init(&owner, &fx.ctx, "owner") == 0,
+		"memory_owner_init failed"
+	);
+	TEST_ASSERT(
+		owner_context_init(&octx, &owner, "owner-ctx") == 0,
+		"owner-bound context init failed"
+	);
+
+	uint8_t *a = memory_balloc(&octx, 100);
+	TEST_ASSERT(a != NULL, "initial alloc failed");
+	for (size_t idx = 0; idx < 100; ++idx) {
+		a[idx] = (uint8_t)idx;
+	}
+	uint64_t arenas_before = owner.arena_count;
+
+	// 100000 > 64 KiB, so the destination allocation grows a new granule.
+	uint8_t *b = memory_brealloc(&octx, a, 100, 100000);
+	TEST_ASSERT(b != NULL, "realloc with growth failed");
+	TEST_ASSERT(
+		owner.arena_count > arenas_before,
+		"growing realloc must borrow a new arena"
+	);
+	for (size_t idx = 0; idx < 100; ++idx) {
+		TEST_ASSERT(
+			b[idx] == (uint8_t)idx,
+			"realloc corrupted payload at %zu",
+			idx
+		);
+	}
+
+	// Shrink back: no growth, payload preserved.
+	uint8_t *c = memory_brealloc(&octx, b, 100000, 64);
+	TEST_ASSERT(c != NULL, "shrinking realloc failed");
+	for (size_t idx = 0; idx < 64; ++idx) {
+		TEST_ASSERT(
+			c[idx] == (uint8_t)idx,
+			"shrink corrupted payload at %zu",
+			idx
+		);
+	}
+	memory_bfree(&octx, c, 64);
+
+	// realloc-to-zero frees.
+	uint8_t *d = memory_balloc(&octx, 32);
+	TEST_ASSERT(d != NULL, "alloc before realloc-to-zero failed");
+	TEST_ASSERT(
+		memory_brealloc(&octx, d, 32, 0) == NULL,
+		"realloc to zero must return NULL"
+	);
+
+	memory_owner_release_all(&owner);
+	memory_context_fini(&octx);
+	parent_fixture_fini(&fx);
+	return 0;
+}
+
+// Single-threaded shape of the memory_context_fini parent-lock fix: a
+// child bound to a different allocator than the parent unlinks cleanly.
+static int
+test_fini_owner_child_under_foreign_parent(void) {
+	struct parent_fixture fx;
+	TEST_ASSERT(parent_fixture_init(&fx) == 0, "fixture init failed");
+
+	struct memory_owner owner;
+	TEST_ASSERT(
+		memory_owner_init(&owner, &fx.ctx, "owner") == 0,
+		"memory_owner_init failed"
+	);
+
+	// Two owner-bound children plus one plain child on the same parent.
+	struct memory_context ob1, ob2, plain;
+	owner_context_init(&ob1, &owner, "ob1");
+	owner_context_init(&ob2, &owner, "ob2");
+	owner_child_splice(&ob1, &fx.ctx, &fx.ba);
+	owner_child_splice(&ob2, &fx.ctx, &fx.ba);
+	TEST_ASSERT(
+		memory_context_init_from(&plain, &fx.ctx, "plain") == 0,
+		"plain child init failed"
+	);
+
+	size_t children = 0;
+	struct memory_context *child = ADDR_OF(&fx.ctx.first_child);
+	while (child != NULL) {
+		++children;
+		child = ADDR_OF(&child->next_sibling);
+	}
+	TEST_ASSERT(
+		children == 3, "parent must hold 3 children, got %zu", children
+	);
+
+	// Fini a middle child: the unlink touches the parent's list, the
+	// detach its own; allocators differ for the owner-bound ones.
+	memory_context_fini(&ob1);
+	children = 0;
+	child = ADDR_OF(&fx.ctx.first_child);
+	while (child != NULL) {
+		TEST_ASSERT(
+			child != &ob1, "fini'd owner child must be unlinked"
+		);
+		++children;
+		child = ADDR_OF(&child->next_sibling);
+	}
+	TEST_ASSERT(
+		children == 2, "parent must hold 2 children, got %zu", children
+	);
+
+	memory_context_fini(&ob2);
+	memory_context_fini(&plain);
+	TEST_ASSERT(
+		ADDR_OF(&fx.ctx.first_child) == NULL,
+		"parent must have no children left"
+	);
+
+	memory_owner_release_all(&owner);
+	parent_fixture_fini(&fx);
+	return 0;
+}
+
+#if defined(YANET_DEBUG)
+// Wrong-allocator tripwire: a block borrowed by the parent's own
+// allocator, freed through the owner-bound context, must abort.
+static void
+phase_tripwire_wrong_free(void) {
+	struct parent_fixture fx;
+	if (parent_fixture_init(&fx) != 0) {
+		_exit(3);
+	}
+
+	struct memory_owner owner;
+	struct memory_context octx;
+	if (memory_owner_init(&owner, &fx.ctx, "owner") != 0) {
+		_exit(3);
+	}
+	if (owner_context_init(&octx, &owner, "owner-ctx") != 0) {
+		_exit(3);
+	}
+
+	// Prime the owner so its tripwire state is fully built.
+	void *own = memory_balloc(&octx, 64);
+	if (own == NULL) {
+		_exit(3);
+	}
+
+	void *foreign = memory_balloc(&fx.ctx, 64);
+	if (foreign == NULL) {
+		_exit(3);
+	}
+
+	memory_bfree(&octx, foreign, 64);
+
+	// Not reached when the tripwire fires.
+	_exit(0);
+}
+
+static int
+test_tripwire_wrong_free_aborts(void) {
+	pid_t pid = fork();
+	TEST_ASSERT(pid >= 0, "fork failed");
+	if (pid == 0) {
+		phase_tripwire_wrong_free();
+		_exit(0);
+	}
+	int status = 0;
+	TEST_ASSERT(waitpid(pid, &status, 0) == pid, "waitpid failed");
+	TEST_ASSERT(
+		WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT,
+		"freeing a foreign block through the owner-bound context must "
+		"abort (status %d)",
+		status
+	);
+	return 0;
+}
+#else
+static int
+test_tripwire_wrong_free_aborts(void) {
+	LOG(INFO, "tripwire compiled out (non-debug build), skipping");
+	return 0;
+}
+#endif
+
+// A growth failure must surface as a clean NULL from balloc with no lock
+// left held and no arena half-tracked. The owner's own embedded
+// allocator is the only growth binding, so both entry points — a
+// context bound to the owner and the raw allocator — share one
+// contract.
+static int
+test_grow_failure_propagates(void) {
+	struct parent_fixture fx;
+	TEST_ASSERT(parent_fixture_init(&fx) == 0, "fixture init failed");
+
+	struct memory_owner owner;
+	struct memory_context octx;
+	TEST_ASSERT(
+		memory_owner_init(&owner, &fx.ctx, "owner") == 0,
+		"memory_owner_init failed"
+	);
+	TEST_ASSERT(
+		owner_context_init(&octx, &owner, "owner-ctx") == 0,
+		"owner-bound context init failed"
+	);
+
+	// Exhaust the parent so the owner's own growth fails.
+	void *drain = memory_balloc(
+		&fx.ctx, block_allocator_free_size(&fx.ba) - 2 * ASAN_RED_ZONE
+	);
+	TEST_ASSERT(drain != NULL, "parent drain failed");
+
+	TEST_ASSERT(
+		memory_balloc(&octx, 4096) == NULL,
+		"balloc must return NULL when growth fails"
+	);
+	TEST_ASSERT(
+		owner.arena_count == 0,
+		"failed growth must not leave a tracked arena"
+	);
+	TEST_ASSERT(
+		block_allocator_free_size(&owner.allocator) == 0,
+		"owner free_size after failed growth proves its lock is "
+		"released and nothing was ingested"
+	);
+
+	// Same contract through the raw embedded allocator: the failed
+	// grow falls through to the final rescan, which still finds
+	// nothing, and both locks come back released.
+	TEST_ASSERT(
+		block_allocator_balloc(&owner.allocator, 16) == NULL,
+		"failing grow must yield NULL"
+	);
+	TEST_ASSERT(
+		block_allocator_free_size(&owner.allocator) == 0,
+		"free_size after the raw-allocator failure proves the owner "
+		"lock is released"
+	);
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.ba) == 0,
+		"drained parent free_size proves the parent lock is released"
+	);
+
+	// The owner still works for blocks already inside its arenas once
+	// the parent recovers: release the drain, grow again.
+	memory_bfree(&fx.ctx, drain, PARENT_ARENA_ALIGN - 2 * ASAN_RED_ZONE);
+	void *p = memory_balloc(&octx, 4096);
+	TEST_ASSERT(p != NULL, "owner must recover after parent recovers");
+	memory_bfree(&octx, p, 4096);
+
+	memory_owner_release_all(&owner);
+	memory_context_fini(&octx);
+	parent_fixture_fini(&fx);
+	return 0;
+}
+
+// Owners chain through contexts: B borrows from a context bound to A's
+// allocator, so growing B cascades B -> A -> root. This exercises the
+// owner -> parent lock nesting the grow and release comments promise,
+// and the children-first teardown returns the root to its baseline.
+static int
+test_chained_owners(void) {
+	struct parent_fixture fx;
+	TEST_ASSERT(parent_fixture_init(&fx) == 0, "fixture init failed");
+
+	size_t parent_base = block_allocator_free_size(&fx.ba);
+
+	struct memory_owner owner_a;
+	TEST_ASSERT(
+		memory_owner_init(&owner_a, &fx.ctx, "A") == 0,
+		"owner A init failed"
+	);
+	struct memory_context actx;
+	TEST_ASSERT(
+		memory_context_init(&actx, "a-ctx", &owner_a.allocator) == 0,
+		"A-bound context init failed"
+	);
+
+	struct memory_owner owner_b;
+	TEST_ASSERT(
+		memory_owner_init(&owner_b, &actx, "B") == 0,
+		"owner B init failed"
+	);
+	struct memory_context bctx;
+	TEST_ASSERT(
+		memory_context_init(&bctx, "b-ctx", &owner_b.allocator) == 0,
+		"B-bound context init failed"
+	);
+
+	// One allocation through B cascades: B misses, borrows its granule
+	// from A, A misses, borrows from the root. B's granule consumes
+	// A's whole ingested block, so B's arenas array then forces a
+	// second A granule.
+	void *p = memory_balloc(&bctx, 256);
+	TEST_ASSERT(p != NULL, "chained allocation failed");
+	TEST_ASSERT(owner_b.arena_count == 1, "B must borrow from A");
+	size_t b_ask = MEMORY_OWNER_MIN_GRANULE - 2 * ASAN_RED_ZONE;
+	TEST_ASSERT(
+		ADDR_OF(&owner_b.arenas)[0].size == b_ask,
+		"B granule must be minimum-sized"
+	);
+
+	size_t a_granule = b_ask;
+	size_t ia_block = block_allocator_pool_size(
+		&owner_a.allocator,
+		block_allocator_pool_index(
+			&owner_a.allocator, a_granule + 2 * ASAN_RED_ZONE
+		)
+	);
+	size_t gb_block = block_allocator_pool_size(
+		&owner_a.allocator,
+		block_allocator_pool_index(&owner_a.allocator, b_ask)
+	);
+	size_t ab_block = block_allocator_pool_size(
+		&owner_a.allocator,
+		block_allocator_pool_index(
+			&owner_a.allocator,
+			4 * sizeof(struct memory_arena) + 2 * ASAN_RED_ZONE
+		)
+	);
+	uint64_t expect_a_count = (ia_block - gb_block >= ab_block) ? 1 : 2;
+
+	TEST_ASSERT(
+		owner_a.arena_count == expect_a_count,
+		"A must grow exactly %" PRIu64 " times, got %" PRIu64,
+		expect_a_count,
+		owner_a.arena_count
+	);
+	struct memory_arena *a_arenas = ADDR_OF(&owner_a.arenas);
+	for (uint64_t idx = 0; idx < owner_a.arena_count; ++idx) {
+		TEST_ASSERT(
+			a_arenas[idx].size == a_granule,
+			"every A granule must be %zu bytes",
+			a_granule
+		);
+	}
+
+	// Byte accounting at A while B holds its borrow: whole granule
+	// blocks ingested, B's granule and B's arenas array taken out,
+	// expressed through the allocator's own pool math so red zones
+	// stay exact in sanitized builds.
+	TEST_ASSERT(
+		block_allocator_free_size(&owner_a.allocator) ==
+			expect_a_count * ia_block - gb_block - ab_block,
+		"A must account for exactly B's granule and arenas array"
+	);
+
+	memory_bfree(&bctx, p, 256);
+
+	// Teardown children-first: releasing B returns its granule and
+	// array to A's pools, then releasing A returns the root to its
+	// exact baseline.
+	memory_owner_release_all(&owner_b);
+	TEST_ASSERT(owner_a.arena_count == expect_a_count, "A outlives B");
+	TEST_ASSERT(
+		block_allocator_free_size(&owner_a.allocator) ==
+			expect_a_count * ia_block,
+		"releasing B must return its whole borrow to A's pools"
+	);
+	memory_owner_release_all(&owner_a);
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.ba) == parent_base,
+		"chained teardown must return the root to its exact baseline"
+	);
+
+	memory_context_fini(&bctx);
+	memory_context_fini(&actx);
+	parent_fixture_fini(&fx);
+	return 0;
+}
+
+// A grow-to-need request just under the parent's public maximum must
+// still borrow successfully under ASan: the parent block class is
+// derived from the requesting pool, and asking for the block minus the
+// parent's red-zone pair keeps its own addition inside the same class
+// instead of rounding past the public maximum.
+static int
+test_asan_max_range_grow(void) {
+	size_t arena_sz = ((size_t)128u << 20); // 128 MiB
+	size_t arena_align = ((size_t)128u << 20);
+	void *raw = malloc(arena_sz + arena_align);
+	TEST_ASSERT(raw != NULL, "failed to allocate max-range raw buffer");
+	uintptr_t aligned = ((uintptr_t)raw + arena_align - 1) &
+			    ~(uintptr_t)(arena_align - 1);
+	void *arena = (void *)aligned;
+
+	struct block_allocator ba;
+	struct memory_context ctx;
+	TEST_ASSERT(
+		block_allocator_init(&ba) == 0, "parent allocator init failed"
+	);
+	block_allocator_put_arena(&ba, arena, arena_sz);
+	TEST_ASSERT(
+		memory_context_init(&ctx, "max-range-parent", &ba) == 0,
+		"parent context init failed"
+	);
+	size_t parent_base = block_allocator_free_size(&ba);
+
+	struct memory_owner owner;
+	TEST_ASSERT(
+		memory_owner_init(&owner, &ctx, "max-range-owner") == 0,
+		"owner init failed"
+	);
+	struct memory_context octx;
+	TEST_ASSERT(
+		memory_context_init(&octx, "max-range-alloc", &owner.allocator) ==
+			0,
+		"owner context init failed"
+	);
+
+	// Above the 32 MiB rounding midpoint: grows through a 64 MiB-class
+	// parent block without the red zones pushing it a pool higher.
+	size_t request = ((size_t)40u << 20);
+	void *block = memory_balloc(&octx, request);
+	TEST_ASSERT(block != NULL, "max-range grow failed under red zones");
+	memset(block, 0x5a, request);
+	memory_bfree(&octx, block, request);
+
+	TEST_ASSERT(owner.arena_count == 1, "one grow must cover the request");
+	memory_owner_release_all(&owner);
+	TEST_ASSERT(
+		block_allocator_free_size(&ba) == parent_base,
+		"release must return the granule"
+	);
+
+	memory_context_fini(&octx);
+	memory_context_fini(&ctx);
+	free(raw);
+	return 0;
+}
+
+#if ASAN_RED_ZONE > 0
+// Child phase for the wholesale-release poisoning test: fills one granule
+// with two half-block allocations, releases the owner wholesale, then
+// reads the upper allocation. The release must poison the entire
+// pool-rounded block, not just the public granule, or the read survives.
+static void
+phase_release_poisons_upper_half(void) {
+	size_t arena_sz = ((size_t)1 << 20);
+	size_t arena_align = ((size_t)1 << 20);
+	void *raw = malloc(arena_sz + arena_align);
+	if (raw == NULL) {
+		_exit(3);
+	}
+	uintptr_t aligned = ((uintptr_t)raw + arena_align - 1) &
+			    ~(uintptr_t)(arena_align - 1);
+
+	struct block_allocator ba;
+	if (block_allocator_init(&ba) != 0) {
+		_exit(3);
+	}
+	block_allocator_put_arena(&ba, (void *)aligned, arena_sz);
+
+	struct memory_context ctx;
+	if (memory_context_init(&ctx, "poison-parent", &ba) != 0) {
+		_exit(3);
+	}
+	struct memory_owner owner;
+	if (memory_owner_init(&owner, &ctx, "poison-owner") != 0) {
+		_exit(3);
+	}
+	struct memory_context octx;
+	if (memory_context_init(&octx, "poison-alloc", &owner.allocator) != 0) {
+		_exit(3);
+	}
+
+	size_t granule_block = block_allocator_pool_size(
+		&owner.allocator,
+		block_allocator_pool_index(
+			&owner.allocator, MEMORY_OWNER_MIN_GRANULE
+		)
+	);
+	size_t half_req = granule_block / 2 - 2 * ASAN_RED_ZONE;
+	void *first = memory_balloc(&octx, half_req);
+	void *second = memory_balloc(&octx, half_req);
+	if (first == NULL || second == NULL) {
+		_exit(3);
+	}
+
+	memory_owner_release_all(&owner);
+
+	volatile unsigned char *upper =
+		first > second ? (volatile unsigned char *)first
+			       : (volatile unsigned char *)second;
+	// The granule plus its red-zone pair equals the whole parent
+	// block, so the symmetric free poisons every byte of it. The last
+	// byte of the upper half is the farthest from the granule's start:
+	// any sizing that leaves a rounded-up gap unpoisoned lets this
+	// read survive.
+	unsigned char probe = upper[half_req - 1];
+	(void)probe;
+	_exit(0);
+}
+
+static int
+test_release_poisons_whole_block(void) {
+	pid_t pid = fork();
+	TEST_ASSERT(pid >= 0, "fork failed");
+	if (pid == 0) {
+		phase_release_poisons_upper_half();
+		_exit(0);
+	}
+	int status = 0;
+	TEST_ASSERT(waitpid(pid, &status, 0) == pid, "waitpid failed");
+	TEST_ASSERT(
+		!(WIFEXITED(status) &&
+		  (WEXITSTATUS(status) == 0 || WEXITSTATUS(status) == 3)),
+		"reading a live block after wholesale release must be trapped "
+		"(clean exit or setup failure, status %d)",
+		status
+	);
+	return 0;
+}
+#else
+static int
+test_release_poisons_whole_block(void) {
+	LOG(INFO, "poison check compiled out (non-asan build), skipping");
+	return 0;
+}
+#endif
+
+int
+main(void) {
+	log_enable_name("info");
+
+	if (test_grow_on_exhaustion() != 0) {
+		LOG(ERROR, "test_grow_on_exhaustion failed");
+		return -1;
+	}
+	if (test_release_all_returns_arenas() != 0) {
+		LOG(ERROR, "test_release_all_returns_arenas failed");
+		return -1;
+	}
+	if (test_realloc_in_owner_context() != 0) {
+		LOG(ERROR, "test_realloc_in_owner_context failed");
+		return -1;
+	}
+	if (test_fini_owner_child_under_foreign_parent() != 0) {
+		LOG(ERROR, "test_fini_owner_child_under_foreign_parent failed");
+		return -1;
+	}
+	if (test_tripwire_wrong_free_aborts() != 0) {
+		LOG(ERROR, "test_tripwire_wrong_free_aborts failed");
+		return -1;
+	}
+	if (test_grow_failure_propagates() != 0) {
+		LOG(ERROR, "test_grow_failure_propagates failed");
+		return -1;
+	}
+	if (test_chained_owners() != 0) {
+		LOG(ERROR, "test_chained_owners failed");
+		return -1;
+	}
+	if (test_asan_max_range_grow() != 0) {
+		LOG(ERROR, "test_asan_max_range_grow failed");
+		return -1;
+	}
+	if (test_release_poisons_whole_block() != 0) {
+		LOG(ERROR, "test_release_poisons_whole_block failed");
+		return -1;
+	}
+
+	LOG(INFO, "memory_owner tests: OK");
+	return 0;
+}

--- a/tests/common/memory_owner_thread_stress_test.c
+++ b/tests/common/memory_owner_thread_stress_test.c
@@ -1,0 +1,834 @@
+// Threaded stress tests for struct memory_owner: concurrent growth to
+// parent exhaustion, the memory_context_fini parent-lock unlink raced
+// against sibling splices, and the failed-grow rescan raced by two
+// granule allocators. Every test asserts exact byte accounting and no
+// hang; per-test detail lives with each test below.
+
+#include "common/asan.h"
+#include "common/memory.h"
+#include "common/memory_owner.h"
+#include "common/test_assert.h"
+#include "lib/logging/log.h"
+
+#include <inttypes.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// The parent arena is aligned to its own 8 MiB size. block_allocator_
+// put_arena caps a chunk by MEMORY_BLOCK_ALLOCATOR_MAX_ALIGN, not by the
+// position's true alignment, so an 8 MiB arena on a merely 2 MiB-aligned
+// base would be ingested as one misaligned 8 MiB block and corrupt every
+// split below it.
+#define PARENT_ARENA_ALIGN (1u << 23)
+#define PARENT_ARENA_SIZE ((size_t)(8u << 20)) // 8 MiB
+#define PARENT_RAW_SZ ((size_t)(16u << 20))
+
+#define THREAD_COUNT 8
+#define GROW_ITERATIONS 6000
+#define SPLICE_ITERATIONS 4000
+#define SLOTS_PER_THREAD 12
+
+// A request whose internal size is exactly the minimum granule, so
+// every allocation misses the free lists and races a fresh grow.
+#define GRANULE_REQUEST (MEMORY_OWNER_MIN_GRANULE - 2 * ASAN_RED_ZONE)
+#define GRANULE_RACE_THREADS 2
+#define GRANULE_RACE_CAP (PARENT_ARENA_SIZE / MEMORY_OWNER_MIN_GRANULE)
+
+// Mixed sizes so one 64 KiB granule serves many allocations and the
+// borrow chain runs on nearly every alloc.
+static const size_t kSizes[] = {8, 24, 96, 480, 1000, 2040, 3000};
+#define NUM_SIZES (sizeof(kSizes) / sizeof(kSizes[0]))
+
+static atomic_int g_failures = 0;
+
+#define THREAD_CHECK(cond, msg, ...)                                           \
+	do {                                                                   \
+		if (!(cond)) {                                                 \
+			LOG(ERROR, "THREAD ASSERT FAILED: " msg, ##__VA_ARGS__ \
+			);                                                     \
+			atomic_fetch_add(&g_failures, 1);                      \
+		}                                                              \
+	} while (0)
+
+struct fixture {
+	void *raw;
+	struct block_allocator ba;
+	struct memory_context ctx;
+	struct memory_owner owner;
+	struct memory_context octx;
+};
+
+static struct fixture *g_fx;
+
+static int
+fixture_init(struct fixture *fx) {
+	fx->raw = malloc(PARENT_RAW_SZ + PARENT_ARENA_ALIGN);
+	TEST_ASSERT(fx->raw != NULL, "failed to allocate raw buffer");
+	uintptr_t aligned = ((uintptr_t)fx->raw + PARENT_ARENA_ALIGN - 1) &
+			    ~(uintptr_t)(PARENT_ARENA_ALIGN - 1);
+
+	TEST_ASSERT(
+		block_allocator_init(&fx->ba) == 0,
+		"parent allocator init failed"
+	);
+	block_allocator_put_arena(&fx->ba, (void *)aligned, PARENT_ARENA_SIZE);
+	TEST_ASSERT(
+		memory_context_init(&fx->ctx, "parent", &fx->ba) == 0,
+		"parent context init failed"
+	);
+	TEST_ASSERT(
+		memory_owner_init(&fx->owner, &fx->ctx, "owner") == 0,
+		"memory_owner_init failed"
+	);
+	TEST_ASSERT(
+		memory_context_init(
+			&fx->octx, "owner-ctx", &fx->owner.allocator
+		) == 0,
+		"owner-bound context init failed"
+	);
+	return 0;
+}
+
+static void
+fixture_fini(struct fixture *fx) {
+	memory_context_fini(&fx->octx);
+	memory_context_fini(&fx->ctx);
+	free(fx->raw);
+}
+
+static int
+cmp_ptr(const void *a, const void *b) {
+	void *const *pa = (void *const *)a;
+	void *const *pb = (void *const *)b;
+	if (*pa < *pb) {
+		return -1;
+	}
+	if (*pa > *pb) {
+		return 1;
+	}
+	return 0;
+}
+
+// Splices an owner-bound context into the shared parent's child list the
+// way the cp_module lifecycle will: list on the parent, allocations on
+// the owner's separate allocator.
+static void
+owner_child_splice(struct memory_context *child, struct fixture *fx) {
+	spinlock_lock(&fx->ba.lock);
+	SET_OFFSET_OF(&child->parent, &fx->ctx);
+	EQUATE_OFFSET(&child->next_sibling, &fx->ctx.first_child);
+	SET_OFFSET_OF(&fx->ctx.first_child, child);
+	spinlock_unlock(&fx->ba.lock);
+}
+
+// Alloc/free churn through the shared owner-bound context. A NULL
+// allocation means the parent cannot satisfy growth any more, so the
+// thread drains its remaining slots and stops.
+static void *
+grow_worker(void *arg) {
+	unsigned seed = *(unsigned *)arg;
+
+	void *slots[SLOTS_PER_THREAD];
+	size_t slot_sizes[SLOTS_PER_THREAD];
+	memset(slots, 0, sizeof(slots));
+	memset(slot_sizes, 0, sizeof(slot_sizes));
+
+	int exhausted = 0;
+	for (int iter = 0; iter < GROW_ITERATIONS && !exhausted; ++iter) {
+		int idx = (int)(rand_r(&seed) % SLOTS_PER_THREAD);
+		if (slots[idx] != NULL) {
+			memory_bfree(&g_fx->octx, slots[idx], slot_sizes[idx]);
+			slots[idx] = NULL;
+			continue;
+		}
+
+		size_t size = kSizes[rand_r(&seed) % NUM_SIZES];
+		void *ptr = memory_balloc(&g_fx->octx, size);
+		if (ptr == NULL) {
+			exhausted = 1;
+			continue;
+		}
+		THREAD_CHECK(
+			((uintptr_t)ptr & 7) == 0,
+			"unaligned block %p from the owner",
+			ptr
+		);
+		memset(ptr, (int)(seed & 0xff), size);
+		slots[idx] = ptr;
+		slot_sizes[idx] = size;
+	}
+
+	for (int idx = 0; idx < SLOTS_PER_THREAD; ++idx) {
+		if (slots[idx] != NULL) {
+			memory_bfree(&g_fx->octx, slots[idx], slot_sizes[idx]);
+			slots[idx] = NULL;
+		}
+	}
+	return NULL;
+}
+
+// Walks every pool free list and reports a node whose address is not
+// aligned to its pool's block size — the fingerprint of a mismatched or
+// duplicated free having entered the in-band lists.
+static int
+check_pool_alignment(struct block_allocator *ba, const char *tag) {
+	for (size_t p = 0; p < MEMORY_BLOCK_ALLOCATOR_EXP; ++p) {
+		size_t blk = (size_t)1 << (MEMORY_BLOCK_ALLOCATOR_MIN_BITS + p);
+		void *node = ADDR_OF(&ba->pools[p].free_list);
+		size_t n = 0;
+		while (node != NULL) {
+			if ((uintptr_t)node & (blk - 1)) {
+				LOG(ERROR,
+				    "%s pool[%zu] node %p misaligned for block "
+				    "size %zu (node %zu)",
+				    tag,
+				    p,
+				    node,
+				    blk,
+				    n);
+				return -1;
+			}
+			// The in-band link is poisoned between uses, exactly
+			// as the allocator's own readers see it.
+			asan_unpoison_memory_region(node, sizeof(void *));
+			void *next = ADDR_OF((void **)node);
+			asan_poison_memory_region(node, sizeof(void *));
+			node = next;
+			++n;
+		}
+		if (n != (size_t)ba->pools[p].free) {
+			LOG(ERROR,
+			    "%s pool[%zu] walked %zu nodes, counter says %llu",
+			    tag,
+			    p,
+			    n,
+			    (unsigned long long)ba->pools[p].free);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+// Verifies that concurrent growth through one owner never corrupts the
+// owner's pools: after the churn, an exhaustive alloc-until-NULL sweep
+// recovers every borrowed byte exactly once, release_all returns the
+// parent to its exact baseline, and the arena bookkeeping stays within
+// the parent's capacity.
+static int
+test_concurrent_growth(void) {
+	struct fixture fx;
+	TEST_ASSERT(fixture_init(&fx) == 0, "fixture init failed");
+	g_fx = &fx;
+	atomic_store(&g_failures, 0);
+
+	size_t parent_base = block_allocator_free_size(&fx.ba);
+
+	pthread_t threads[THREAD_COUNT];
+	unsigned seeds[THREAD_COUNT];
+	for (int idx = 0; idx < THREAD_COUNT; ++idx) {
+		seeds[idx] = (unsigned)(0xc0ffeeu + (unsigned)idx * 7919u);
+		TEST_ASSERT(
+			pthread_create(
+				&threads[idx], NULL, grow_worker, &seeds[idx]
+			) == 0,
+			"pthread_create failed for thread %d",
+			idx
+		);
+	}
+	for (int idx = 0; idx < THREAD_COUNT; ++idx) {
+		pthread_join(threads[idx], NULL);
+	}
+
+	TEST_ASSERT(
+		atomic_load(&g_failures) == 0,
+		"one or more grow workers observed a broken invariant"
+	);
+
+	TEST_ASSERT(
+		check_pool_alignment(&fx.ba, "parent") == 0,
+		"parent free lists corrupted during churn"
+	);
+	TEST_ASSERT(
+		check_pool_alignment(&fx.owner.allocator, "owner") == 0,
+		"owner free lists corrupted during churn"
+	);
+
+	TEST_ASSERT(fx.owner.arena_count > 0, "churn never grew the owner");
+	size_t arena_bytes = 0;
+	// What the owner's pools actually hold: each granule is ingested as
+	// its pool-rounded true block, which red zones inflate.
+	size_t ingested_bytes = 0;
+	struct memory_arena *arenas = ADDR_OF(&fx.owner.arenas);
+	for (uint64_t idx = 0; idx < fx.owner.arena_count; ++idx) {
+		arena_bytes += (size_t)arenas[idx].size;
+		ingested_bytes += block_allocator_pool_size(
+			&fx.owner.allocator,
+			block_allocator_pool_index(
+				&fx.owner.allocator,
+				(size_t)arenas[idx].size + 2 * ASAN_RED_ZONE
+			)
+		);
+	}
+	// Every granule is disjoint and at least 64 KiB, so the parent's
+	// 8 MiB bounds the arena count even counting grow races.
+	TEST_ASSERT(
+		fx.owner.arena_count <=
+			PARENT_ARENA_SIZE / MEMORY_OWNER_MIN_GRANULE,
+		"arena_count %" PRIu64 " exceeds parent capacity",
+		fx.owner.arena_count
+	);
+
+	size_t owner_free = block_allocator_free_size(&fx.owner.allocator);
+	TEST_ASSERT(
+		owner_free == ingested_bytes,
+		"owner free size %zu must equal ingested arena bytes %zu",
+		owner_free,
+		ingested_bytes
+	);
+
+	// Finish exhausting the parent so the sweep below terminates on a
+	// grow failure rather than borrowing fresh granules mid-sweep.
+	void *drain[256];
+	size_t drain_count = 0;
+	for (;;) {
+		void *p = memory_balloc(&fx.ctx, MEMORY_OWNER_MIN_GRANULE);
+		if (p == NULL) {
+			break;
+		}
+		TEST_ASSERT(
+			drain_count < 256,
+			"parent drain exceeded expected block count"
+		);
+		drain[drain_count++] = p;
+	}
+
+	// Exhaustive sweep over the real free lists with growth disabled by
+	// the drained parent: duplicate pointers or a wrong leftover sum is
+	// how a corrupted in-band list shows up.
+	size_t sweep_cap = arena_bytes / MEMORY_BLOCK_ALLOCATOR_MIN_SIZE + 16;
+	void **swept = malloc(sweep_cap * sizeof(void *));
+	TEST_ASSERT(swept != NULL, "failed to allocate sweep bookkeeping");
+
+	size_t swept_count = 0;
+	for (;;) {
+		void *p = memory_balloc(
+			&fx.octx, MEMORY_BLOCK_ALLOCATOR_MIN_SIZE
+		);
+		if (p == NULL) {
+			break;
+		}
+		TEST_ASSERT(
+			swept_count < sweep_cap,
+			"sweep exceeded cap %zu; free list likely corrupted",
+			sweep_cap
+		);
+		swept[swept_count++] = p;
+	}
+#if !defined(HAVE_ASAN)
+	// Exact only without red zones: they inflate every block's internal
+	// size, shifting the split arithmetic. Uniqueness and the empty
+	// leftover below still catch corruption under ASAN.
+	TEST_ASSERT(
+		swept_count == arena_bytes / MEMORY_BLOCK_ALLOCATOR_MIN_SIZE,
+		"sweep recovered %zu blocks, expected exactly arena bytes / 8 "
+		"(%zu)",
+		swept_count,
+		arena_bytes / MEMORY_BLOCK_ALLOCATOR_MIN_SIZE
+	);
+#endif
+#if !defined(HAVE_ASAN)
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.owner.allocator) == 0,
+		"owner still reports free bytes after exhaustive sweep"
+	);
+#else
+	// Red zones inflate the sweep request's internal size, so fragments
+	// below it can survive; only progress, not emptiness, is assertable.
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.owner.allocator) < arena_bytes,
+		"owner free size did not shrink below the borrowed total"
+	);
+#endif
+
+	qsort(swept, swept_count, sizeof(void *), cmp_ptr);
+	for (size_t idx = 1; idx < swept_count; ++idx) {
+		TEST_ASSERT(
+			swept[idx] != swept[idx - 1],
+			"sweep returned the same block twice: %p",
+			swept[idx]
+		);
+	}
+
+	// Round-trip every swept block back through the owner before the
+	// wholesale release.
+	for (size_t idx = 0; idx < swept_count; ++idx) {
+		memory_bfree(
+			&fx.octx, swept[idx], MEMORY_BLOCK_ALLOCATOR_MIN_SIZE
+		);
+	}
+	free(swept);
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.owner.allocator) ==
+			ingested_bytes,
+		"owner free size must round-trip to the ingested total"
+	);
+
+	memory_owner_release_all(&fx.owner);
+	for (size_t idx = 0; idx < drain_count; ++idx) {
+		memory_bfree(&fx.ctx, drain[idx], MEMORY_OWNER_MIN_GRANULE);
+	}
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.ba) == parent_base,
+		"release_all must return the parent to its exact baseline"
+	);
+
+	fixture_fini(&fx);
+	return 0;
+}
+
+// One cycle of an owner-bound child: splice under the parent's lock,
+// allocate through the owner's allocator, fini through the parent-lock
+// unlink path.
+static void
+owner_child_cycle(struct fixture *fx, unsigned *seed) {
+	struct memory_context child;
+	if (memory_context_init(&child, "ob-child", &fx->owner.allocator) !=
+	    0) {
+		THREAD_CHECK(0, "owner child init failed");
+		return;
+	}
+	owner_child_splice(&child, fx);
+
+	size_t size = kSizes[rand_r(seed) % NUM_SIZES];
+	void *p = memory_balloc(&child, size);
+	if (p != NULL) {
+		memory_bfree(&child, p, size);
+	}
+
+	memory_context_fini(&child);
+}
+
+// One cycle of a plain child sharing the parent's allocator.
+static void
+plain_child_cycle(struct fixture *fx, unsigned *seed) {
+	struct memory_context child;
+	if (memory_context_init_from(&child, &fx->ctx, "plain-child") != 0) {
+		THREAD_CHECK(0, "plain child init failed");
+		return;
+	}
+
+	size_t size = kSizes[rand_r(seed) % NUM_SIZES];
+	void *p = memory_balloc(&child, size);
+	if (p != NULL) {
+		memory_bfree(&child, p, size);
+	}
+
+	memory_context_fini(&child);
+}
+
+// Owner-bound children, plain children, and direct parent churn all race
+// on the parent's child list and its allocator.
+static void *
+splice_worker(void *arg) {
+	struct fixture *fx = g_fx;
+	unsigned seed = *(unsigned *)arg;
+
+	for (int iter = 0; iter < SPLICE_ITERATIONS; ++iter) {
+		switch (iter % 3) {
+		case 0:
+			owner_child_cycle(fx, &seed);
+			break;
+		case 1:
+			plain_child_cycle(fx, &seed);
+			break;
+		case 2: {
+			size_t size = kSizes[rand_r(&seed) % NUM_SIZES];
+			void *p = memory_balloc(&fx->ctx, size);
+			if (p != NULL) {
+				memory_bfree(&fx->ctx, p, size);
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+	return NULL;
+}
+
+// Verifies the memory_context_fini parent-lock fix under load: finishing
+// an owner-bound child (own allocator) must serialize against siblings
+// splicing into the same parent list.
+static int
+test_concurrent_fini_vs_splice(void) {
+	struct fixture fx;
+	TEST_ASSERT(fixture_init(&fx) == 0, "fixture init failed");
+	g_fx = &fx;
+	atomic_store(&g_failures, 0);
+
+	pthread_t threads[THREAD_COUNT];
+	unsigned seeds[THREAD_COUNT];
+	for (int idx = 0; idx < THREAD_COUNT; ++idx) {
+		seeds[idx] = (unsigned)(0xbeefu + (unsigned)idx * 104729u);
+		TEST_ASSERT(
+			pthread_create(
+				&threads[idx], NULL, splice_worker, &seeds[idx]
+			) == 0,
+			"pthread_create failed for thread %d",
+			idx
+		);
+	}
+	for (int idx = 0; idx < THREAD_COUNT; ++idx) {
+		pthread_join(threads[idx], NULL);
+	}
+
+	TEST_ASSERT(
+		atomic_load(&g_failures) == 0,
+		"one or more splice workers observed a broken invariant"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&fx.ctx.first_child) == NULL,
+		"parent must have no children left after churn"
+	);
+
+	// The owner must still be fully serviceable after the storm.
+	void *p = memory_balloc(&fx.octx, 128);
+	TEST_ASSERT(p != NULL, "owner alloc failed after churn");
+	memory_bfree(&fx.octx, p, 128);
+
+	fixture_fini(&fx);
+	return 0;
+}
+
+struct granule_race_arg {
+	unsigned seed;
+	void *blocks[GRANULE_RACE_CAP];
+	size_t count;
+};
+
+// Holds whole-granule blocks until the parent can no longer fund a
+// granule. A NULL means the grow failed and the post-failure rescan
+// found nothing; a block means the rescan or the first scan won.
+static void *
+granule_race_worker(void *arg) {
+	struct granule_race_arg *ctx = arg;
+
+	size_t count = 0;
+	while (count < GRANULE_RACE_CAP) {
+		void *p = memory_balloc(&g_fx->octx, GRANULE_REQUEST);
+		if (p == NULL) {
+			break;
+		}
+		memset(p, (int)(ctx->seed & 0xff), GRANULE_REQUEST);
+		ctx->blocks[count++] = p;
+	}
+
+	ctx->count = count;
+	return NULL;
+}
+
+// Verifies the failed-grow rescan under a real race: two threads race
+// whole-granule allocations until the parent cannot fund another
+// granule, so one grow of a concurrent pair fails into the rescan.
+// Every assertion holds in every interleaving — no hang, exact owner
+// accounting for both possible loser outcomes, and a clean return to
+// baseline.
+static int
+test_false_exhaustion_race(void) {
+	struct fixture fx;
+	TEST_ASSERT(fixture_init(&fx) == 0, "fixture init failed");
+	g_fx = &fx;
+	atomic_store(&g_failures, 0);
+
+	size_t parent_base = block_allocator_free_size(&fx.ba);
+
+	pthread_t threads[GRANULE_RACE_THREADS];
+	struct granule_race_arg args[GRANULE_RACE_THREADS];
+	for (int idx = 0; idx < GRANULE_RACE_THREADS; ++idx) {
+		args[idx].seed = (unsigned)(0xd1ceu + (unsigned)idx * 6151u);
+		args[idx].count = 0;
+		TEST_ASSERT(
+			pthread_create(
+				&threads[idx],
+				NULL,
+				granule_race_worker,
+				&args[idx]
+			) == 0,
+			"pthread_create failed for thread %d",
+			idx
+		);
+	}
+	for (int idx = 0; idx < GRANULE_RACE_THREADS; ++idx) {
+		TEST_ASSERT(
+			pthread_join(threads[idx], NULL) == 0,
+			"pthread_join failed for thread %d",
+			idx
+		);
+	}
+	size_t total = args[0].count + args[1].count;
+
+	TEST_ASSERT(total >= 1, "the parent must fund at least one granule");
+	TEST_ASSERT(
+		fx.owner.arena_count >= 1, "the race must have grown the owner"
+	);
+	TEST_ASSERT(
+		fx.owner.arena_count <=
+			PARENT_ARENA_SIZE / MEMORY_OWNER_MIN_GRANULE,
+		"arena_count %" PRIu64 " exceeds parent capacity",
+		fx.owner.arena_count
+	);
+
+	// Exact accounting: each granule is ingested as its pool-rounded
+	// true block, each held request takes one request-pool block out,
+	// and nothing else consumes the owner's pools.
+	size_t req_block = block_allocator_pool_size(
+		&fx.owner.allocator,
+		block_allocator_pool_index(
+			&fx.owner.allocator, GRANULE_REQUEST + 2 * ASAN_RED_ZONE
+		)
+	);
+	size_t ingested = 0;
+	struct memory_arena *arenas = ADDR_OF(&fx.owner.arenas);
+	for (uint64_t idx = 0; idx < fx.owner.arena_count; ++idx) {
+		ingested += block_allocator_pool_size(
+			&fx.owner.allocator,
+			block_allocator_pool_index(
+				&fx.owner.allocator,
+				(size_t)arenas[idx].size + 2 * ASAN_RED_ZONE
+			)
+		);
+	}
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.owner.allocator) +
+				total * req_block ==
+			ingested,
+		"owner free size %zu + %zu held blocks must equal the ingested "
+		"total %zu",
+		block_allocator_free_size(&fx.owner.allocator),
+		total * req_block,
+		ingested
+	);
+
+	// The workers hold their blocks, so an exhaustive sweep recovers
+	// exactly the free remainder — every granule splits into whole
+	// request-sized blocks, nothing smaller can be hiding.
+	size_t expect_swept = ingested / req_block - total;
+	void *swept[GRANULE_RACE_CAP];
+	size_t swept_count = 0;
+	for (;;) {
+		void *p = memory_balloc(&fx.octx, GRANULE_REQUEST);
+		if (p == NULL) {
+			break;
+		}
+		TEST_ASSERT(
+			swept_count < GRANULE_RACE_CAP,
+			"sweep exceeded the parent's block capacity"
+		);
+		swept[swept_count++] = p;
+	}
+	TEST_ASSERT(
+		swept_count == expect_swept,
+		"sweep recovered %zu blocks, expected the free remainder %zu",
+		swept_count,
+		expect_swept
+	);
+	qsort(swept, swept_count, sizeof(void *), cmp_ptr);
+	for (size_t idx = 1; idx < swept_count; ++idx) {
+		TEST_ASSERT(
+			swept[idx] != swept[idx - 1],
+			"sweep returned the same block twice: %p",
+			swept[idx]
+		);
+	}
+
+	// Round-trip every block, swept and held, back through the owner
+	// before the wholesale release.
+	for (size_t idx = 0; idx < swept_count; ++idx) {
+		memory_bfree(&fx.octx, swept[idx], GRANULE_REQUEST);
+	}
+	for (int t = 0; t < GRANULE_RACE_THREADS; ++t) {
+		for (size_t idx = 0; idx < args[t].count; ++idx) {
+			memory_bfree(
+				&fx.octx, args[t].blocks[idx], GRANULE_REQUEST
+			);
+		}
+	}
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.owner.allocator) == ingested,
+		"owner free size must round-trip to the ingested total"
+	);
+
+	memory_owner_release_all(&fx.owner);
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.ba) == parent_base,
+		"release_all must return the parent to its exact baseline"
+	);
+
+	fixture_fini(&fx);
+	return 0;
+}
+
+// A request that fits many times into one minimum granule, so a single
+// successful growth must satisfy a long run of allocations.
+#define SHARED_REQ ((size_t)8 * 1024 - 2 * ASAN_RED_ZONE)
+#define SHARED_THREADS 2
+
+struct shared_exhaustion_arg {
+	size_t count;
+	void *blocks[256];
+};
+
+// Allocates until NULL, then proves the NULL was truthful: after a
+// correct exhaustion no free block can reappear, because the parent
+// funds no further growth and this phase never frees.
+static void *
+shared_exhaustion_worker(void *arg) {
+	struct shared_exhaustion_arg *ctx = arg;
+
+	while (ctx->count < 256) {
+		void *p = memory_balloc(&g_fx->octx, SHARED_REQ);
+		if (p == NULL) {
+			break;
+		}
+		memset(p, 0x3c, SHARED_REQ);
+		ctx->blocks[ctx->count++] = p;
+	}
+
+	THREAD_CHECK(
+		block_allocator_free_size(&g_fx->owner.allocator) == 0,
+		"exhaustion reported while the owner still has free blocks"
+	);
+	return NULL;
+}
+
+// Two threads drain a parent that funds exactly one granule. Growth
+// serializes on the owner lock for its whole body, so whichever thread
+// loses the granule blocks on that lock for its final rescan and finds
+// the winner's installed arena: the combined take must equal the
+// granule's full capacity, and neither thread may see a NULL while
+// free blocks remain.
+static int
+test_single_granule_shared_exhaustion(void) {
+	size_t granule_block = block_allocator_pool_size(
+		NULL,
+		block_allocator_pool_index(
+			NULL, MEMORY_OWNER_MIN_GRANULE + 2 * ASAN_RED_ZONE
+		)
+	);
+	size_t expected = granule_block / (SHARED_REQ + 2 * ASAN_RED_ZONE);
+	size_t arena_sz = granule_block + ((size_t)4 << 10);
+
+	// The arena must start at the allocator's maximum block alignment:
+	// put_arena splits from the start alignment, and anything below it
+	// fragments the granule into alignment-sized blocks no grow can use.
+	size_t arena_align = MEMORY_BLOCK_ALLOCATOR_MAX_ALIGN;
+
+	void *raw = malloc(arena_sz + arena_align);
+	TEST_ASSERT(raw != NULL, "failed to allocate raw buffer");
+	uintptr_t aligned = ((uintptr_t)raw + arena_align - 1) &
+			    ~(uintptr_t)(arena_align - 1);
+
+	struct fixture fx;
+	fx.raw = raw;
+	TEST_ASSERT(block_allocator_init(&fx.ba) == 0, "parent init failed");
+	block_allocator_put_arena(&fx.ba, (void *)aligned, arena_sz);
+	TEST_ASSERT(
+		memory_context_init(&fx.ctx, "one-granule-parent", &fx.ba) == 0,
+		"parent context init failed"
+	);
+	size_t parent_base = block_allocator_free_size(&fx.ba);
+
+	TEST_ASSERT(
+		memory_owner_init(&fx.owner, &fx.ctx, "one-granule") == 0,
+		"owner init failed"
+	);
+	TEST_ASSERT(
+		memory_context_init(
+			&fx.octx, "one-granule-ctx", &fx.owner.allocator
+		) == 0,
+		"owner context init failed"
+	);
+	g_fx = &fx;
+	atomic_store(&g_failures, 0);
+
+	pthread_t threads[SHARED_THREADS];
+	struct shared_exhaustion_arg args[SHARED_THREADS];
+	for (int idx = 0; idx < SHARED_THREADS; ++idx) {
+		args[idx].count = 0;
+		TEST_ASSERT(
+			pthread_create(
+				&threads[idx],
+				NULL,
+				shared_exhaustion_worker,
+				&args[idx]
+			) == 0,
+			"pthread_create failed for thread %d",
+			idx
+		);
+	}
+	for (int idx = 0; idx < SHARED_THREADS; ++idx) {
+		TEST_ASSERT(
+			pthread_join(threads[idx], NULL) == 0,
+			"pthread_join failed for thread %d",
+			idx
+		);
+	}
+	TEST_ASSERT(atomic_load(&g_failures) == 0, "a worker assertion fired");
+
+	size_t total = args[0].count + args[1].count;
+	TEST_ASSERT(
+		total == expected,
+		"two threads recovered %zu of %zu blocks in the single "
+		"funded granule",
+		total,
+		expected
+	);
+	TEST_ASSERT(
+		fx.owner.arena_count == 1,
+		"the parent must fund exactly one granule"
+	);
+
+	for (int t = 0; t < SHARED_THREADS; ++t) {
+		for (size_t idx = 0; idx < args[t].count; ++idx) {
+			memory_bfree(&fx.octx, args[t].blocks[idx], SHARED_REQ);
+		}
+	}
+	memory_owner_release_all(&fx.owner);
+	TEST_ASSERT(
+		block_allocator_free_size(&fx.ba) == parent_base,
+		"release_all must return the parent to its exact baseline"
+	);
+
+	memory_context_fini(&fx.octx);
+	memory_context_fini(&fx.ctx);
+	free(raw);
+	return 0;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	if (test_concurrent_growth() != 0) {
+		LOG(ERROR, "test_concurrent_growth failed");
+		return -1;
+	}
+	if (test_concurrent_fini_vs_splice() != 0) {
+		LOG(ERROR, "test_concurrent_fini_vs_splice failed");
+		return -1;
+	}
+	if (test_false_exhaustion_race() != 0) {
+		LOG(ERROR, "test_false_exhaustion_race failed");
+		return -1;
+	}
+	if (test_single_granule_shared_exhaustion() != 0) {
+		LOG(ERROR, "test_single_granule_shared_exhaustion failed");
+		return -1;
+	}
+
+	LOG(INFO, "memory_owner thread stress tests: OK");
+	return 0;
+}

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -100,6 +100,24 @@ balloc_thread_stress_test = executable(
 )
 test('balloc_thread_stress', balloc_thread_stress_test, suite: ['common'])
 
+memory_owner_test = executable(
+  'memory_owner_test',
+  ['memory_owner_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: dependencies,
+)
+test('memory_owner', memory_owner_test, suite: ['common'])
+
+memory_owner_thread_stress_test = executable(
+  'memory_owner_thread_stress_test',
+  ['memory_owner_thread_stress_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: dependencies + [thread_dep],
+)
+test('memory_owner_thread_stress', memory_owner_thread_stress_test, suite: ['common'])
+
 executable(
   'balloc_bench',
   ['balloc_bench.c'],


### PR DESCRIPTION
- Add memory owners that embed a growable block allocator, borrowing power-of-two granules (64 KiB minimum, grown to the request) from a parent memory context and returning them wholesale on release.
- Lay the groundwork for replacing per-type module destroy routines with wholesale arena release in a follow-up.
- Bind growth through an offset pointer rather than a stored code pointer, so attached processes resolve the grow call through their own link.
- Abort in debug builds when a block is freed through an owner-bound context from outside its arenas.
- Fix memory context finalization to unlink under the parent's allocator lock, a latent race once child contexts can allocate through different allocators.
- Rename the agent arena record to memory arena and move the definition to common.
- Bump the module ABI version for the changed shared-memory layouts and add unit and thread-stress tests for growth, wholesale release, and the tripwire.