### PR TITLE
refactor(fwstate): split fwtable layer unlink from free across a gene…

### DIFF
--- a/lib/fwstate/fwtable.h
+++ b/lib/fwstate/fwtable.h
@@ -12,14 +12,16 @@
 //
 // The head fwmap is the active (read-write) layer; each layer reachable
 // through fwmap_t::next is progressively older.  The control plane
-// grows the chain with fwtable_insert_layer_cp and reclaims expired
-// layers with fwtable_trim_stale_cp.  The dataplane searches the chain
-// with fwtable_lookup and writes through fwtable_insert.
+// grows the chain with fwtable_insert_layer_cp, reclaims expired
+// layers with fwtable_unlink_stale_cp, and frees them with
+// fwtable_free_stale once a config generation barrier has elapsed.
+// The dataplane searches the chain with fwtable_lookup and writes
+// through fwtable_insert.
 //
-// Trim reuses fwmap_t::next to thread stale layers, so the dataplane
+// Unlink reuses fwmap_t::next to thread stale layers, so the dataplane
 // reads the chain and table head with acquire loads and the control
-// plane publishes them with release stores; see fwtable_trim_stale_cp
-// for the reader-lifetime precondition.
+// plane publishes them with release stores; see
+// fwtable_unlink_stale_cp for the reader-lifetime precondition.
 typedef struct fwtable {
 	fwmap_t *head;
 	fwmap_t *stale;
@@ -50,8 +52,11 @@ fwtable_insert_layer_cp(
 
 // Free every layer in the stale chain.
 //
-// Called internally by fwtable_trim_stale_cp (to release the previous
-// generation) and usable standalone during table destruction.
+// Safe only after a config generation barrier that every worker
+// advanced past since the layers were unlinked: a reader that started
+// before the unlink can still be walking them, and it is the barrier
+// that proves no such reader remains. Also usable standalone during
+// table destruction, where no concurrent readers exist.
 static inline void
 fwtable_free_stale(fwtable_t *table, struct memory_context *ctx) {
 	fwmap_t *layer = ADDR_OF(&table->stale);
@@ -63,23 +68,17 @@ fwtable_free_stale(fwtable_t *table, struct memory_context *ctx) {
 	SET_OFFSET_OF(&table->stale, NULL);
 }
 
-// Reclaim an expired tail layer from the active chain.
+// Unlink an expired tail layer from the active chain.
 //
-// First frees the stale layers reclaimed last call, then, if the
-// oldest layer past the head is expired, atomically unlinks it to
-// table->stale.  Only the tail is trimmed, so middle next links stay
-// intact and a reader walking from the head always reaches the current
-// tail; the head is never trimmed.
-//
-// Trimmed layers are freed on the next call, so a dataplane reader
-// must not span two consecutive trims — the caller bounds reader
-// duration below one trim interval.  Returns 0.
+// If the oldest layer past the head is expired, atomically unlinks it
+// into table->stale without freeing anything.  Only the tail is
+// unlinked, so middle next links stay intact and a reader walking from
+// the head always reaches the current tail; the head is never
+// unlinked.  The unlinked layers are released by fwtable_free_stale
+// after the caller's generation barrier elapses; a failed barrier
+// simply leaves them parked for a later round.  Returns 0.
 static inline int
-fwtable_trim_stale_cp(
-	fwtable_t *table, struct memory_context *ctx, uint64_t now
-) {
-	fwtable_free_stale(table, ctx);
-
+fwtable_unlink_stale_cp(fwtable_t *table, uint64_t now) {
 	fwmap_t *head = ADDR_OF(&table->head);
 	if (!head || !head->next) {
 		return 0;

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -98,11 +98,11 @@ message ListConfigsResponse { repeated string configs = 1; }
 // The receive-side parameters (timeouts, suppression) belong to the
 // fwstate module's own configuration.
 message SyncConfig {
-  common.commonpb.v1.MACAddress dst_ether = 1;          // Destination MAC address;
+  common.commonpb.v1.MACAddress dst_ether = 1;         // Destination MAC address;
   common.commonpb.v1.IPAddress dst_addr_multicast = 2; // Multicast IPv6 address;
-  uint32 port_multicast = 3;                            // Multicast port;
+  uint32 port_multicast = 3;                           // Multicast port;
   common.commonpb.v1.IPAddress dst_addr_unicast = 4;   // Unicast IPv6 address;
-  uint32 port_unicast = 5;                            // Unicast port;
+  uint32 port_unicast = 5;                             // Unicast port;
 }
 
 // Request for per-rule counters. An empty name returns the rule counters

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
@@ -143,17 +143,17 @@ message MapConfig {
 // window. The emission addressing for modules that synthesize sync
 // packets lives with the ACL module's own configuration.
 message SyncConfig {
-  common.commonpb.v1.IPAddress src_addr = 1;           // IPv6 source address stamped on forwarded internal frames;
+  common.commonpb.v1.IPAddress src_addr = 1; // IPv6 source address stamped on forwarded internal frames;
   // Deprecated: the emission-side destination MAC moved to the ACL
   // module's SyncConfig; fwstate ignores this field.
-  common.commonpb.v1.MACAddress dst_ether = 2 [deprecated = true];
+  common.commonpb.v1.MACAddress dst_ether = 2 [ deprecated = true ];
   common.commonpb.v1.IPAddress dst_addr_multicast = 3; // Multicast IPv6 address matched on incoming sync packets;
   uint32 port_multicast = 4;                           // Multicast port;
   // Deprecated: the emission-side unicast destination moved to the ACL
   // module's SyncConfig; fwstate ignores this field.
-  common.commonpb.v1.IPAddress dst_addr_unicast = 5 [deprecated = true];
+  common.commonpb.v1.IPAddress dst_addr_unicast = 5 [ deprecated = true ];
   // Deprecated: see dst_addr_unicast.
-  uint32 port_unicast = 6 [deprecated = true];         // Unused;
+  uint32 port_unicast = 6 [ deprecated = true ]; // Unused;
 
   // Connection timeouts
   uint64 tcp_syn_ack = 7; // TCP SYN-ACK timeout in nanoseconds;

--- a/objects/fwstate/api/fwstate_map_object.c
+++ b/objects/fwstate/api/fwstate_map_object.c
@@ -226,12 +226,17 @@ fwstate_map_v4_object_insert_layer(
 }
 
 int
-fwstate_map_v4_object_trim_stale_layers(
+fwstate_map_v4_object_unlink_stale_layers(
 	struct fwstate_map_v4_object *self, uint64_t now
 ) {
+	return fwtable_unlink_stale_cp(&self->table, now);
+}
+
+void
+fwstate_map_v4_object_free_stale_layers(struct fwstate_map_v4_object *self) {
 	struct agent *agent = ADDR_OF(&self->cp_object.agent);
 
-	return fwtable_trim_stale_cp(&self->table, &agent->memory_context, now);
+	fwtable_free_stale(&self->table, &agent->memory_context);
 }
 
 // --- IPv6 object -------------------------------------------------------------
@@ -346,12 +351,17 @@ fwstate_map_v6_object_insert_layer(
 }
 
 int
-fwstate_map_v6_object_trim_stale_layers(
+fwstate_map_v6_object_unlink_stale_layers(
 	struct fwstate_map_v6_object *self, uint64_t now
 ) {
+	return fwtable_unlink_stale_cp(&self->table, now);
+}
+
+void
+fwstate_map_v6_object_free_stale_layers(struct fwstate_map_v6_object *self) {
 	struct agent *agent = ADDR_OF(&self->cp_object.agent);
 
-	return fwtable_trim_stale_cp(&self->table, &agent->memory_context, now);
+	fwtable_free_stale(&self->table, &agent->memory_context);
 }
 
 // --- object factories --------------------------------------------------------

--- a/objects/fwstate/api/fwstate_map_v4_object.h
+++ b/objects/fwstate/api/fwstate_map_v4_object.h
@@ -77,13 +77,21 @@ fwstate_map_v4_object_insert_layer(
 	uint16_t worker_count
 );
 
-// Trim stale layers from the object's table chain.
+// Unlink stale layers from the object's table chain.
 //
-// Returns 0 on success or -1 on error. Trimmed layers are tracked in the
-// fwtable stale chain and freed on the next trim call (giving the
-// dataplane one trim cycle to quiesce), so the caller has nothing to
-// free.
+// Returns 0 on success or -1 on error. Unlinked layers are parked in
+// the fwtable stale chain; the caller frees them with
+// fwstate_map_v4_object_free_stale_layers after a config generation
+// barrier has elapsed.
 int
-fwstate_map_v4_object_trim_stale_layers(
+fwstate_map_v4_object_unlink_stale_layers(
 	struct fwstate_map_v4_object *self, uint64_t now
 );
+
+// Free the layers parked by fwstate_map_v4_object_unlink_stale_layers.
+//
+// Safe only after a generation barrier that every worker advanced past
+// since the unlink: the barrier is what proves no reader is still
+// walking the parked chain.
+void
+fwstate_map_v4_object_free_stale_layers(struct fwstate_map_v4_object *self);

--- a/objects/fwstate/api/fwstate_map_v6_object.h
+++ b/objects/fwstate/api/fwstate_map_v6_object.h
@@ -77,13 +77,21 @@ fwstate_map_v6_object_insert_layer(
 	uint16_t worker_count
 );
 
-// Trim stale layers from the object's table chain.
+// Unlink stale layers from the object's table chain.
 //
-// Returns 0 on success or -1 on error. Trimmed layers are tracked in the
-// fwtable stale chain and freed on the next trim call (giving the
-// dataplane one trim cycle to quiesce), so the caller has nothing to
-// free.
+// Returns 0 on success or -1 on error. Unlinked layers are parked in
+// the fwtable stale chain; the caller frees them with
+// fwstate_map_v6_object_free_stale_layers after a config generation
+// barrier has elapsed.
 int
-fwstate_map_v6_object_trim_stale_layers(
+fwstate_map_v6_object_unlink_stale_layers(
 	struct fwstate_map_v6_object *self, uint64_t now
 );
+
+// Free the layers parked by fwstate_map_v6_object_unlink_stale_layers.
+//
+// Safe only after a generation barrier that every worker advanced past
+// since the unlink: the barrier is what proves no reader is still
+// walking the parked chain.
+void
+fwstate_map_v6_object_free_stale_layers(struct fwstate_map_v6_object *self);

--- a/objects/fwstate/bindings/go/cfwstate/map.go
+++ b/objects/fwstate/bindings/go/cfwstate/map.go
@@ -254,28 +254,46 @@ func (m *MapObjectConfig) ResolveMap(layerIndex uint32) unsafe.Pointer {
 	return unsafe.Pointer(ptr)
 }
 
-// TrimStaleLayers trims stale layers from the fwtable chain.
+// UnlinkStaleLayers parks expired layers in the fwtable stale chain.
 //
-// Trimmed layers are tracked in the fwtable stale chain and freed on the
-// next trim call (giving the dataplane one trim cycle to quiesce), so the
-// caller has nothing to free.
-func (m *MapObjectConfig) TrimStaleLayers(now uint64) error {
+// The parked layers stay allocated until FreeStaleLayers releases
+// them after the caller's generation barrier has elapsed; a failed
+// barrier leaves them parked for a later round.
+func (m *MapObjectConfig) UnlinkStaleLayers(now uint64) error {
 	var rc C.int
 	if m.kind == KindV6 {
-		rc = C.fwstate_map_v6_object_trim_stale_layers(
+		rc = C.fwstate_map_v6_object_unlink_stale_layers(
 			C.fwstate_map_v6_from_cp_object(m.asRawPtr()),
 			C.uint64_t(now),
 		)
 	} else {
-		rc = C.fwstate_map_v4_object_trim_stale_layers(
+		rc = C.fwstate_map_v4_object_unlink_stale_layers(
 			C.fwstate_map_v4_from_cp_object(m.asRawPtr()),
 			C.uint64_t(now),
 		)
 	}
 	if rc != 0 {
-		return fmt.Errorf("failed to trim stale layers: error code=%d", rc)
+		return fmt.Errorf("failed to unlink stale layers: error code=%d", rc)
 	}
 	m.generation++
+	return nil
+}
+
+// FreeStaleLayers releases the layers parked by UnlinkStaleLayers.
+//
+// Safe only after a generation barrier that every worker advanced past
+// since the unlink: the barrier is what proves no reader is still
+// walking the parked chain.
+func (m *MapObjectConfig) FreeStaleLayers() error {
+	if m.kind == KindV6 {
+		C.fwstate_map_v6_object_free_stale_layers(
+			C.fwstate_map_v6_from_cp_object(m.asRawPtr()),
+		)
+	} else {
+		C.fwstate_map_v4_object_free_stale_layers(
+			C.fwstate_map_v4_from_cp_object(m.asRawPtr()),
+		)
+	}
 	return nil
 }
 

--- a/objects/fwstate/controlplane/map_service.go
+++ b/objects/fwstate/controlplane/map_service.go
@@ -56,17 +56,19 @@ func ClampBatchSize(n uint32) uint32 {
 // mapStats is the bindings-level stats shape carried across CGo.
 type mapStats = cfwstate.MapStats
 
-// MapLayerTrimmer reclaims layers whose deadline has passed.
+// MapLayerReclaimer parks and releases a fwtable's stale layers around
+// the generation barrier.
 //
 // [cfwstate.MapObjectConfig] satisfies this interface; the seam lets unit
-// tests record trim calls without a live shared-memory handle.
-type MapLayerTrimmer interface {
-	TrimStaleLayers(now uint64) error
+// tests record reclamation calls without a live shared-memory handle.
+type MapLayerReclaimer interface {
+	UnlinkStaleLayers(now uint64) error
+	FreeStaleLayers() error
 }
 
 // Compile-time assertion that [cfwstate.MapObjectConfig] satisfies
-// [MapLayerTrimmer].
-var _ MapLayerTrimmer = (*cfwstate.MapObjectConfig)(nil)
+// [MapLayerReclaimer].
+var _ MapLayerReclaimer = (*cfwstate.MapObjectConfig)(nil)
 
 // MapOption configures an FWStateMapService.
 type MapOption func(*mapOptions)
@@ -362,13 +364,12 @@ func (m *FWStateMapService) GetMapStats(
 // InsertLayer inserts a new layer into the fwtable chain of a named
 // fwstate-map.
 //
-// After the new layer is committed in place (the table head now points at
-// the new active layer), layers whose deadline has passed are reclaimed.
-// mu stays held across the insert and the stale-layer reclamation.
-// ReclaimStaleLayers publishes its own generation barrier before freeing,
-// because the fwmap chain is shared memory walked across all generations
-// for fallback lookups and a worker can be mid-walk on a just-unlinked
-// layer.
+// The insert and the stale-layer reclamation are separate routines
+// bracketed by one config generation update: the new layer becomes the
+// active head, expired tails are unlinked, and a single published
+// generation that every worker advanced past both makes the rotation
+// durable and gates the release of the unlinked layers. mu stays held
+// across both.
 func (m *FWStateMapService) InsertLayer(
 	ctx context.Context,
 	req *fwstatemappb.InsertLayerRequest,
@@ -480,37 +481,43 @@ func (m *FWStateMapService) ListEntries(
 	}
 }
 
-// ReclaimStaleLayers unlinks expired layers and waits for every dataplane
-// worker to advance past the current generation.
+// ReclaimStaleLayers unlinks expired layers, advances every dataplane
+// worker past a new config generation, then frees the unlinked layers.
 //
-// TrimStaleLayers atomically moves stale layers from the active chain to
-// the fwtable's stale chain so new walks skip them, but a worker already
-// mid-chain-walk can still be reading a just-unlinked layer. Publishing a
-// new generation via the barrier waits until every worker changed
-// generation, guaranteeing no in-flight walk can touch the unlinked memory.
-// The trimmed layers are then freed by the next TrimStaleLayers call,
-// giving the dataplane one trim cycle to quiesce.
+// UnlinkStaleLayers atomically moves stale layers from the active chain
+// to the fwtable's stale chain so new walks skip them, but a worker
+// already mid-chain-walk can still be reading a just-unlinked layer.
+// The barrier publishes a new generation and waits until every worker
+// changed generation, proving no in-flight walk can touch the unlinked
+// memory; only then does FreeStaleLayers release it.
 //
-// If the barrier fails the stale chain is not advanced on the next trim,
-// so the layers remain allocated for one more cycle — a rare leak, not a
-// correctness or use-after-free issue. The caller must hold mu because
-// trim mutates the shared map head chain. now is real-time nanoseconds,
-// matching the domain the dataplane stamps layer deadlines in.
+// If the barrier fails the parked layers stay allocated and are freed
+// by a later round after a successful barrier — a rare leak, never a
+// use-after-free. The caller must hold mu because unlink mutates the
+// shared map head chain. now is real-time nanoseconds, matching the
+// domain the dataplane stamps layer deadlines in.
 func (m *FWStateMapService) ReclaimStaleLayers(
-	trimmer MapLayerTrimmer,
+	reclaimer MapLayerReclaimer,
 	mapCP cfwstate.MapObjectConfig,
 	now uint64,
 ) {
-	if err := trimmer.TrimStaleLayers(now); err != nil {
+	if err := reclaimer.UnlinkStaleLayers(now); err != nil {
 		m.log.Error(
-			"failed to trim stale layers; stale chain not advanced",
+			"failed to unlink stale layers; layers left on the active chain",
 			zap.Error(err),
 		)
 		return
 	}
 	if err := m.barrier(mapCP); err != nil {
 		m.log.Error(
-			"generation barrier failed after layer trim; stale chain not advanced on next trim",
+			"generation barrier failed after layer unlink; parked layers retained for a later round",
+			zap.Error(err),
+		)
+		return
+	}
+	if err := reclaimer.FreeStaleLayers(); err != nil {
+		m.log.Error(
+			"failed to free unlinked stale layers",
 			zap.Error(err),
 		)
 		return

--- a/objects/fwstate/controlplane/map_service_test.go
+++ b/objects/fwstate/controlplane/map_service_test.go
@@ -121,35 +121,53 @@ func TestMapLabeler(t *testing.T) {
 	require.Nil(t, fwstatemap.MapLabeler("", &fwstatemappb.ListMapsRequest{}))
 }
 
-// recordingTrimmer is a MapLayerTrimmer test double that records trim
-// calls so stale-layer reclamation can be asserted without a live
-// shared-memory handle.
-type recordingTrimmer struct {
-	mu       sync.Mutex
-	trimCall []uint64
-	trimErr  error
-	onTrim   func()
+// recordingReclaimer is a MapLayerReclaimer test double that records
+// unlink and free calls so stale-layer reclamation can be asserted
+// without a live shared-memory handle.
+type recordingReclaimer struct {
+	mu        sync.Mutex
+	unlinkAt  []uint64
+	unlinkErr error
+	freeCalls int
+	onUnlink  func()
+	onFree    func()
 }
 
-func (m *recordingTrimmer) TrimStaleLayers(now uint64) error {
+func (m *recordingReclaimer) UnlinkStaleLayers(now uint64) error {
 	m.mu.Lock()
-	m.trimCall = append(m.trimCall, now)
+	m.unlinkAt = append(m.unlinkAt, now)
 	m.mu.Unlock()
-	if m.onTrim != nil {
-		m.onTrim()
+	if m.onUnlink != nil {
+		m.onUnlink()
 	}
-	return m.trimErr
+	return m.unlinkErr
 }
 
-func (m *recordingTrimmer) trimCalls() []uint64 {
+func (m *recordingReclaimer) FreeStaleLayers() error {
+	m.mu.Lock()
+	m.freeCalls++
+	m.mu.Unlock()
+	if m.onFree != nil {
+		m.onFree()
+	}
+	return nil
+}
+
+func (m *recordingReclaimer) unlinkCalls() []uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return append([]uint64(nil), m.trimCall...)
+	return append([]uint64(nil), m.unlinkAt...)
+}
+
+func (m *recordingReclaimer) frees() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.freeCalls
 }
 
 // recordingBarrier captures generation-barrier invocations so the RCU
-// grace period between layer trim and the next trim call can be asserted
-// without a live agent.
+// grace period between layer unlink and free can be asserted without a
+// live agent.
 type recordingBarrier struct {
 	mu    sync.Mutex
 	calls int
@@ -169,44 +187,46 @@ func (m *recordingBarrier) count() int {
 	return m.calls
 }
 
-// TestReclaimStaleLayers verifies that ReclaimStaleLayers trims stale
-// layers and runs the generation barrier on the success path.
+// TestReclaimStaleLayers verifies that ReclaimStaleLayers unlinks stale
+// layers, runs the generation barrier, then frees the parked layers.
 func TestReclaimStaleLayers(t *testing.T) {
-	trimmer := &recordingTrimmer{}
+	reclaimer := &recordingReclaimer{}
 	barrier := &recordingBarrier{}
 
 	svc := fwstatemap.NewFWStateMapServiceForTest(barrier.invoke)
 
-	svc.ReclaimStaleLayers(trimmer, cfwstate.MapObjectConfig{}, 123456)
+	svc.ReclaimStaleLayers(reclaimer, cfwstate.MapObjectConfig{}, 123456)
 
-	require.Equal(t, []uint64{123456}, trimmer.trimCalls())
-	require.Equal(t, 1, barrier.count(), "generation barrier must run after trim")
+	require.Equal(t, []uint64{123456}, reclaimer.unlinkCalls())
+	require.Equal(t, 1, barrier.count(), "generation barrier must run after unlink")
+	require.Equal(t, 1, reclaimer.frees(), "parked layers must be freed after the barrier")
 }
 
-// TestReclaimStaleLayersTrimFailureSkipsBarrier verifies that a trim
-// failure skips the generation barrier without panicking.
-func TestReclaimStaleLayersTrimFailureSkipsBarrier(t *testing.T) {
-	trimmer := &recordingTrimmer{trimErr: errors.New("trim failed")}
+// TestReclaimStaleLayersUnlinkFailureSkipsBarrier verifies that an
+// unlink failure skips the generation barrier and the free without
+// panicking.
+func TestReclaimStaleLayersUnlinkFailureSkipsBarrier(t *testing.T) {
+	reclaimer := &recordingReclaimer{unlinkErr: errors.New("unlink failed")}
 	barrier := &recordingBarrier{}
 
 	svc := fwstatemap.NewFWStateMapServiceForTest(barrier.invoke)
 
-	svc.ReclaimStaleLayers(trimmer, cfwstate.MapObjectConfig{}, 0)
+	svc.ReclaimStaleLayers(reclaimer, cfwstate.MapObjectConfig{}, 0)
 
-	require.Equal(t, []uint64{0}, trimmer.trimCalls())
-	require.Equal(t, 0, barrier.count(), "barrier must not run when trim fails")
+	require.Equal(t, []uint64{0}, reclaimer.unlinkCalls())
+	require.Equal(t, 0, barrier.count(), "barrier must not run when unlink fails")
+	require.Equal(t, 0, reclaimer.frees(), "nothing was parked, so nothing is freed")
 }
 
-// TestReclaimStaleLayersBarrierRunsAfterTrim verifies that the generation
-// barrier runs only after TrimStaleLayers completes successfully.
+// TestReclaimStaleLayersBarrierRunsBeforeFree verifies that the
+// generation barrier elapses between unlink and free.
 //
 // Regression guard for a use-after-free: the fwmap layer chain is shared
 // memory walked across all config generations for fallback lookups. A
 // worker can be mid-walk on a just-unlinked layer at the moment
-// TrimStaleLayers moves it into the stale chain. Advancing the stale chain
-// before the grace period can free memory a worker still reads. The
-// generation barrier must elapse between trim and the next reclaim.
-func TestReclaimStaleLayersBarrierRunsAfterTrim(t *testing.T) {
+// UnlinkStaleLayers parks it. Freeing before the grace period would
+// release memory a worker still reads.
+func TestReclaimStaleLayersBarrierRunsBeforeFree(t *testing.T) {
 	var eventsMu sync.Mutex
 	var events []string
 	record := func(event string) {
@@ -215,8 +235,9 @@ func TestReclaimStaleLayersBarrierRunsAfterTrim(t *testing.T) {
 		eventsMu.Unlock()
 	}
 
-	trimmer := &recordingTrimmer{
-		onTrim: func() { record("trim") },
+	reclaimer := &recordingReclaimer{
+		onUnlink: func() { record("unlink") },
+		onFree:   func() { record("free") },
 	}
 
 	svc := fwstatemap.NewFWStateMapServiceForTest(func(cfwstate.MapObjectConfig) error {
@@ -224,31 +245,35 @@ func TestReclaimStaleLayersBarrierRunsAfterTrim(t *testing.T) {
 		return nil
 	})
 
-	svc.ReclaimStaleLayers(trimmer, cfwstate.MapObjectConfig{}, 1)
+	svc.ReclaimStaleLayers(reclaimer, cfwstate.MapObjectConfig{}, 1)
 
 	eventsMu.Lock()
 	require.Equal(
 		t,
-		[]string{"trim", "barrier"},
+		[]string{"unlink", "barrier", "free"},
 		events,
-		"barrier must follow trim, never precede it",
+		"free must follow the generation barrier, never precede it",
 	)
 	eventsMu.Unlock()
 }
 
-// TestReclaimStaleLayersBarrierFailureIsLogged verifies that when the
-// generation barrier fails, ReclaimStaleLayers returns without panicking
-// and the trim is recorded as having run.
-func TestReclaimStaleLayersBarrierFailureIsLogged(t *testing.T) {
-	trimmer := &recordingTrimmer{}
+// TestReclaimStaleLayersBarrierFailureRetainsLayers verifies that a
+// failed generation barrier leaves the parked layers allocated.
+//
+// Freeing after a failed barrier could release memory a worker still
+// walks; the layers must survive for a later round with a successful
+// barrier.
+func TestReclaimStaleLayersBarrierFailureRetainsLayers(t *testing.T) {
+	reclaimer := &recordingReclaimer{}
 	barrier := &recordingBarrier{err: errors.New("generation barrier failed")}
 
 	svc := fwstatemap.NewFWStateMapServiceForTest(barrier.invoke)
 
-	svc.ReclaimStaleLayers(trimmer, cfwstate.MapObjectConfig{}, 1)
+	svc.ReclaimStaleLayers(reclaimer, cfwstate.MapObjectConfig{}, 1)
 
-	require.Equal(t, []uint64{1}, trimmer.trimCalls(), "trim runs unconditionally")
-	require.Equal(t, 1, barrier.count(), "barrier must run after trim")
+	require.Equal(t, []uint64{1}, reclaimer.unlinkCalls(), "unlink runs unconditionally")
+	require.Equal(t, 1, barrier.count(), "barrier must run after unlink")
+	require.Equal(t, 0, reclaimer.frees(), "parked layers must be retained when the barrier fails")
 }
 
 // TestListMapsEmpty verifies that a fresh service reports no maps.


### PR DESCRIPTION
…ration barrier

The combined trim freed the previously parked layers at the start of the next trim, so a failed generation barrier was followed by an unconditional free. Unlinking and freeing are now separate routines: unlink severs the expired tail into the stale chain and frees nothing, and the map service frees the parked layers immediately after the generation update that every worker advanced past. A failed barrier leaves the parked layers for a later round, never freeing memory a worker may still walk.