### PR TITLE
chore(agents): set the reviewer's dispatch policy

### DIFF
--- a/.rulesync/subagents/architect.md
+++ b/.rulesync/subagents/architect.md
@@ -82,6 +82,9 @@ Provides technical guidance on: RFC compliance, DPDK APIs, packet formats, proto
 
 Reviews code quality and verifies task completeness: conventions, safety, builds, tests.
 **Use after**: implementation is done, to verify everything works and meets standards.
+**Never split**: the reviewer is one agent, never split per language or per scope — blocking findings concentrate on cross-language seams, so a per-language reviewer would only ever see one end of every cross-layer assumption, and a review's round state (the first round's complete blocking set, the frozen surface, the per-artifact rewrite cap) has a single owner by construction.
+**Dispatch tier**: set the model tier at dispatch through the `Agent` tool's `model` parameter, never by editing the reviewer's own charter — pass `sonnet` only for a diff confined to TypeScript or to the Rust CLI that touches no packet path, no shared-memory or ABI surface, no CGO boundary, and no concurrent code (a spawned task or thread, mutably shared state across them, a channel, or a lock — not `async`/`await` used purely sequentially); omit `model` otherwise, and always on those four surfaces, which leaves the reviewer's own default in force.
+**Second pass**: on a diff touching the packet path, a shared-memory/ABI surface, or the CGO boundary, dispatch a second reviewer as a deliberately independent full-scope pass — tell it in that brief that it is full scope — and merge the two finding sets yourself, routing, once, any finding both raise at the higher of the two severities; this mandate to dispatch a pair binds round 1 only, and from round 2 the merged set has one named owner, with `## Review-Fix Loop` item 4 governing unchanged.
 
 ### `planner` — Multi-Horizon Planning Partner (read-only on code, both repos, public-first)
 


### PR DESCRIPTION
The reviewer entry in the architect's charter said when to use the reviewer and nothing about how to dispatch it. Three rules now sit there.

- The reviewer is never split per language or per scope. Blocking findings concentrate on cross-language seams, so a per-language reviewer would see one end of every cross-layer assumption, and a review's round state — the first round's complete blocking set, the frozen surface, the per-artifact rewrite cap — has a single owner by construction. Splitting was measured against the local session corpus before being rejected: the language-specific part of the reviewer's charter is roughly an eighth of it, a third of reviews already span two or more languages, and a quarter of non-empty blocking sets name more than one.
- The model tier is chosen at dispatch rather than by editing the reviewer's own charter. The cheaper tier is reserved for changes that cannot reach the packet path, shared memory, the foreign-function boundary or concurrency, and the term the exclusion leans on is defined in place so the rule has one reading rather than several.
- A change that does reach those surfaces gets a second, deliberately independent full-scope review at the first round, and the architect merges the two finding sets, routing an overlapping finding once at the higher severity. The mandate binds the first round only, so the existing review loop keeps a single owner of round state from the second round on.

The entry cites no measurements, so it cannot go stale as the corpus moves. Nothing outside that one catalogue entry changes.
