### PR TITLE
fix(dataplane): reject out-of-contract RSS reports at the topology boundary

### DIFF
--- a/lib/dataplane/config/topology.c
+++ b/lib/dataplane/config/topology.c
@@ -42,7 +42,9 @@ dp_topology_set_device_rss(
 	// overflows a consumer's fixed-size stack buffer or under-reads a
 	// short key.
 	if (reta_size == 0 || reta_size > DP_TOPOLOGY_RSS_RETA_SIZE_MAX ||
-	    key_len < DP_TOPOLOGY_RSS_KEY_LEN_MIN) {
+	    (reta_size & (reta_size - 1)) != 0 ||
+	    key_len < DP_TOPOLOGY_RSS_KEY_LEN_MIN || key == NULL ||
+	    reta == NULL) {
 		return -1;
 	}
 

--- a/lib/dataplane/config/topology.h
+++ b/lib/dataplane/config/topology.h
@@ -76,10 +76,11 @@ dp_topology_alloc_devices(struct dp_config *dp_config, size_t count);
 // dp_config->memory_context.
 //
 // Enforces the contract every consumer of dp_port's RSS fields relies on:
-// reta_size must be in (0, DP_TOPOLOGY_RSS_RETA_SIZE_MAX] and key_len must
-// be at least DP_TOPOLOGY_RSS_KEY_LEN_MIN. A call outside that contract is
-// rejected outright — nothing is allocated or stored, and rss_valid stays
-// false — so the device falls back to its non-RSS-aware path instead of an
+// reta_size must be a power of two in (0, DP_TOPOLOGY_RSS_RETA_SIZE_MAX],
+// key_len must be at least DP_TOPOLOGY_RSS_KEY_LEN_MIN, and key and reta
+// must both be non-NULL. A call outside that contract is rejected
+// outright — nothing is allocated or stored, and rss_valid stays false — so
+// the device falls back to its non-RSS-aware path instead of an
 // out-of-contract report reaching a consumer. An out-of-range device_id is
 // rejected the same way.
 //


### PR DESCRIPTION
The device topology layer is the single trust boundary that lets every consumer of a port's RSS state use the redirection table size and the key length without re-checking them, but it enforced only part of the contract it advertised.

- Reject a redirection table whose size is not a power of two. Consumers select a slot by masking a hash with the size minus one, which is equivalent to a modulo only when the size is a power of two.
- Reject a null key or redirection table pointer. Both were copied unchecked once the size and length tests passed, at a boundary whose stated threat model is a producer that bypasses the hardware path.
- This is a steering-correctness fix rather than a memory-safety one. Masking never produced an out-of-range slot, but a non-power-of-two size left most of the table unreachable, so worker ownership silently disagreed with the hardware and the affected traffic was refused with no diagnostic.
- No driver reports a non-power-of-two table size, so there is no behaviour change on real hardware. The audit covered the drivers in production use and the one the functional tests run against, and each rounds its table size to a power of two. This closes the hole for a non-hardware producer, which is what the boundary exists to defend against.
- Rejection is safe at the only caller, which already warns and falls back to the non-RSS path, so a device carrying an out-of-contract report now takes the same documented fallback as any device without usable RSS state.
- The null-pointer check was folded into this change rather than deferred, since it closes the same gap in the same guard statement.
- No test accompanies the change, at the request of the task owner.

Closes #1735.