### PR TITLE
feat(fwstate): manage fwstate-map objects over the gateway

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -186,6 +186,8 @@ type Config struct {
 	// PluginDir is the directory scanned for module .so plugins. An empty
 	// value loads only the statically-linked built-ins.
 	PluginDir string
+	// ObjectsToLoad registers standalone shared-memory object types (e.g. "fwstate_map_v4") in the dataplane config.
+	ObjectsToLoad []string
 	// Workers optionally assigns each worker's device and queue.
 	//
 	// When nil, every worker defaults to device 0 with queue id equal to
@@ -268,6 +270,9 @@ func NewHarness(cfg Config) (*Harness, error) {
 	cDevicesToLoad, freeDevicesToLoad := toCStringArray(cfg.DevicesToLoad)
 	defer freeDevicesToLoad()
 
+	cObjectsToLoad, freeObjectsToLoad := toCStringArray(cfg.ObjectsToLoad)
+	defer freeObjectsToLoad()
+
 	cCfg := C.struct_dataplane_ut_config{
 		cp_memory:             C.size_t(cfg.CPMemory),
 		dp_memory:             C.size_t(cfg.DPMemory),
@@ -275,6 +280,7 @@ func NewHarness(cfg Config) (*Harness, error) {
 		device_count:          C.size_t(len(cfg.Devices)),
 		module_count:          C.size_t(len(cfg.Modules)),
 		devices_to_load_count: C.size_t(len(cfg.DevicesToLoad)),
+		objects_to_load_count: C.size_t(len(cfg.ObjectsToLoad)),
 	}
 
 	// Assign C-heap copies of the pointer arrays so the C struct contains
@@ -293,6 +299,11 @@ func NewHarness(cfg Config) (*Harness, error) {
 		cArr := C.alloc_cptr_array(&cDevicesToLoad[0], C.size_t(len(cDevicesToLoad)))
 		defer C.free_cptr_array(cArr)
 		cCfg.devices_to_load = cArr
+	}
+	if len(cfg.ObjectsToLoad) > 0 {
+		cArr := C.alloc_cptr_array(&cObjectsToLoad[0], C.size_t(len(cObjectsToLoad)))
+		defer C.free_cptr_array(cArr)
+		cCfg.objects_to_load = cArr
 	}
 	if cfg.PluginDir != "" {
 		cPluginDir := C.CString(cfg.PluginDir)

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -32,6 +32,7 @@
 #include "lib/dataplane/config/bootstrap.h"
 #include "lib/dataplane/config/counter_storage.h"
 #include "lib/dataplane/config/module_loader.h"
+#include "lib/dataplane/config/object_loader.h"
 #include "lib/dataplane/config/plugin_loader.h"
 #include "lib/dataplane/config/topology.h"
 #include "lib/dataplane/packet/data.h"
@@ -576,6 +577,18 @@ dataplane_init(
 		     ++i) {
 			if (dp_load_device(
 				    instance->dp_config, bin_hndl, devices[i]
+			    ) == -1) {
+				return -1;
+			}
+		}
+
+		static const char *objects[] = {
+			"fwstate_map_v4", "fwstate_map_v6"
+		};
+		for (size_t i = 0; i < sizeof(objects) / sizeof(objects[0]);
+		     ++i) {
+			if (dp_load_object(
+				    instance->dp_config, bin_hndl, objects[i]
 			    ) == -1) {
 				return -1;
 			}

--- a/dataplane/meson.build
+++ b/dataplane/meson.build
@@ -52,6 +52,10 @@ dependencies = lib_dependencies + [
   lib_fwstate_dp_dep,
   lib_blackhole_dp_dep,
 
+  # objects
+  # Startup resolves these constructors by dlsym on this executable, so they must be linked in and exported.
+  lib_fwstate_objects_dep,
+
   #devices
   lib_dev_plain_dp_dep,
   lib_dev_vlan_dp_dep,

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -12,6 +12,7 @@ import (
 	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
 	fwstate "github.com/yanet-platform/yanet2/modules/fwstate/controlplane"
 	fwstatepb "github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
+	fwstatemap "github.com/yanet-platform/yanet2/objects/fwstate/controlplane"
 )
 
 const (
@@ -50,6 +51,7 @@ type ACLModule struct {
 	metricsService        *MetricsService
 	fwstateService        *fwstate.FWStateService
 	fwstateMetricsService *fwstate.MetricsService
+	mapService            *fwstatemap.FWStateMapService
 }
 
 // NewACLModule creates a new ACL module instance.
@@ -98,6 +100,11 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 	)
 	fwstateMetricsService := fwstate.NewMetricsService(fwstateService)
 
+	mapService := fwstatemap.NewFWStateMapService(
+		agent,
+		fwstatemap.WithLog(log),
+	)
+
 	return &ACLModule{
 		cfg:                   cfg,
 		shm:                   shm,
@@ -106,6 +113,7 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 		metricsService:        metricsService,
 		fwstateService:        fwstateService,
 		fwstateMetricsService: fwstateMetricsService,
+		mapService:            mapService,
 	}, nil
 }
 
@@ -123,6 +131,7 @@ func (m *ACLModule) ServicesNames() []string {
 		aclpb.MetricsService_ServiceDesc.ServiceName,
 		fwstate.FWStateServiceName,
 		fwstate.FWStateMetricsServiceName,
+		fwstatemap.ServiceName,
 	}
 }
 
@@ -131,6 +140,7 @@ func (m *ACLModule) RegisterService(server *grpc.Server) {
 	aclpb.RegisterMetricsServiceServer(server, m.metricsService)
 	fwstatepb.RegisterFWStateServiceServer(server, m.fwstateService)
 	fwstatepb.RegisterMetricsServiceServer(server, m.fwstateMetricsService)
+	m.mapService.Register(server)
 }
 
 // UnaryServerInterceptors returns the gRPC unary interceptors for this module.
@@ -140,6 +150,9 @@ func (m *ACLModule) UnaryServerInterceptors() []grpc.UnaryServerInterceptor {
 		interceptors = append(interceptors, si)
 	}
 	if si := m.fwstateService.UnaryServerInterceptor(); si != nil {
+		interceptors = append(interceptors, si)
+	}
+	if si := m.mapService.UnaryServerInterceptor(); si != nil {
 		interceptors = append(interceptors, si)
 	}
 	return interceptors

--- a/modules/fwstate/cli/build.rs
+++ b/modules/fwstate/cli/build.rs
@@ -2,6 +2,7 @@ use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/fwstatepb/v1/fwstate.proto");
+    println!("cargo:rerun-if-changed=../../../objects/fwstate/controlplane/fwstatemappb/v1/fwstatemap.proto");
     println!("cargo:rerun-if-changed=../../../common/commonpb/v1/ipaddr.proto");
     println!("cargo:rerun-if-changed=../../../common/commonpb/v1/macaddr.proto");
     println!("cargo:rerun-if-changed=../../../common/commonpb/v1/metric.proto");
@@ -11,7 +12,13 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["fwstatepb/v1/fwstate.proto"], &["../controlplane", "../../.."])?;
+        .compile_protos(
+            &[
+                "fwstatepb/v1/fwstate.proto",
+                "../../../objects/fwstate/controlplane/fwstatemappb/v1/fwstatemap.proto",
+            ],
+            &["../controlplane", "../../.."],
+        )?;
 
     Ok(())
 }

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -29,7 +29,64 @@ pub enum ModeCmd {
     Entries(EntriesCmd),
     /// Show fwstate metrics
     Metrics(MetricsCmd),
+    /// Manage standalone fwstate-map objects
+    Map {
+        #[clap(subcommand)]
+        command: MapCmd,
+    },
 }
+
+/// Address family of a fwstate-map object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum MapKind {
+    /// IPv4 state table
+    V4,
+    /// IPv6 state table
+    V6,
+}
+
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum MapCmd {
+    /// Create a named fwstate-map and publish it
+    Create(MapCreateCmd),
+    /// Delete a named fwstate-map
+    Delete(MapDeleteCmd),
+    /// List registered fwstate-map objects
+    List(MapListCmd),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct MapCreateCmd {
+    /// Name of the fwstate-map to create
+    #[arg(long = "name", short = 'n')]
+    pub map_name: String,
+
+    /// Address family of the state table this map owns
+    #[arg(long)]
+    pub kind: MapKind,
+
+    /// Size of the hash table index (0 uses the service default)
+    #[arg(long)]
+    pub index_size: Option<u32>,
+
+    /// Number of extra collision buckets (0 uses the service default)
+    #[arg(long)]
+    pub extra_bucket_count: Option<u32>,
+
+    /// Per-worker state sizing (0 derives the dataplane worker count)
+    #[arg(long)]
+    pub worker_count: Option<u32>,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct MapDeleteCmd {
+    /// Name of the fwstate-map to delete
+    #[arg(long = "name", short = 'n')]
+    pub map_name: String,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct MapListCmd {}
 
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -4,10 +4,15 @@ use core::{
 };
 use std::collections::HashMap;
 
-use args::{DeleteCmd, DirectionArg, EntriesCmd, Family, LinkCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
+use args::{
+    DeleteCmd, DirectionArg, EntriesCmd, Family, LinkCmd, MapCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd,
+};
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
 use commonpb::pb::{GetMetricsRequest, IpAddress, Metric as ProtoMetric};
+use fwstatemappb::{
+    CreateMapRequest, DeleteMapRequest, ListMapsRequest, fw_state_map_service_client::FwStateMapServiceClient,
+};
 use fwstatepb::{
     DeleteConfigRequest, Direction, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest, ListEntriesRequest,
     ShowConfigRequest, UpdateConfigRequest, fw_state_service_client::FwStateServiceClient,
@@ -35,11 +40,21 @@ pub mod fwstatepb {
     tonic::include_proto!("modules.fwstate.controlplane.fwstatepb.v1");
 }
 
+#[allow(clippy::std_instead_of_core, non_snake_case)]
+pub mod fwstatemappb {
+    use serde::Serialize;
+
+    tonic::include_proto!("objects.fwstate.controlplane.fwstatemappb.v1");
+}
+
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.fwstate.controlplane.fwstatepb.v1.FWStateService";
 
 /// The fully-qualified gRPC service name for the metrics service.
 const METRICS_SERVICE_NAME: &str = "modules.fwstate.controlplane.fwstatepb.v1.MetricsService";
+
+/// The fully-qualified gRPC service name for the fwstate-map service.
+const MAP_SERVICE_NAME: &str = "objects.fwstate.controlplane.fwstatemappb.v1.FWStateMapService";
 
 /// FWState module CLI.
 #[derive(Debug, Clone, Parser)]
@@ -67,6 +82,7 @@ fn parse_ipv6(s: &str) -> Result<IpAddress, String> {
 pub struct FWStateService {
     service: Service<FwStateServiceClient<LayeredChannel>>,
     metrics: Service<MetricsServiceClient<LayeredChannel>>,
+    maps: Service<FwStateMapServiceClient<LayeredChannel>>,
 }
 
 /// State an `entries` dump carries across its batches and both maps.
@@ -120,8 +136,13 @@ impl FWStateService {
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
         });
+        let maps = Service::new(&conn, MAP_SERVICE_NAME, |channel| {
+            FwStateMapServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        });
 
-        Ok(Self { service, metrics })
+        Ok(Self { service, metrics, maps })
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
@@ -500,6 +521,83 @@ impl FWStateService {
 
         Ok(())
     }
+
+    pub async fn manage_maps(&mut self, cmd: MapCmd) -> Result<(), Error> {
+        match cmd {
+            MapCmd::Create(cmd) => self.map_create(cmd).await,
+            MapCmd::Delete(cmd) => self.map_delete(cmd).await,
+            MapCmd::List(cmd) => self.map_list(cmd).await,
+        }
+    }
+
+    pub async fn map_create(&mut self, cmd: args::MapCreateCmd) -> Result<(), Error> {
+        let request = CreateMapRequest {
+            name: cmd.map_name.clone(),
+            kind: match cmd.kind {
+                args::MapKind::V4 => fwstatemappb::Kind::V4.into(),
+                args::MapKind::V6 => fwstatemappb::Kind::V6.into(),
+            },
+            index_size: cmd.index_size.unwrap_or(0),
+            extra_bucket_count: cmd.extra_bucket_count.unwrap_or(0),
+            worker_count: cmd.worker_count.unwrap_or(0),
+        };
+        log::trace!("CreateMapRequest: {request:?}");
+        self.maps
+            .client()
+            .create_map(request)
+            .await
+            .map_err(self.maps.status("map create"))?;
+
+        output::success("map create", format_args!("Created fwstate-map {}.", cmd.map_name));
+
+        Ok(())
+    }
+
+    pub async fn map_delete(&mut self, cmd: args::MapDeleteCmd) -> Result<(), Error> {
+        let request = DeleteMapRequest { name: cmd.map_name.clone() };
+        log::trace!("DeleteMapRequest: {request:?}");
+        self.maps
+            .client()
+            .delete_map(request)
+            .await
+            .map_err(self.maps.status("map delete"))?;
+
+        output::success("map delete", format_args!("Deleted fwstate-map {}.", cmd.map_name));
+
+        Ok(())
+    }
+
+    pub async fn map_list(&mut self, _cmd: args::MapListCmd) -> Result<(), Error> {
+        let request = ListMapsRequest {};
+        let response = self
+            .maps
+            .client()
+            .list_maps(request)
+            .await
+            .map_err(self.maps.status("map list"))?
+            .into_inner();
+
+        output::data(
+            || &response.maps,
+            || {
+                if response.maps.is_empty() {
+                    output::empty_with_hint(
+                        format_args!("No fwstate-map objects found."),
+                        format_args!("create one with 'yanet-cli-fwstate map create --name <name> --kind <v4|v6>'"),
+                    );
+                    return;
+                }
+
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&response.maps)
+                        .expect("fwstate-map list JSON serialization must not fail")
+                );
+            },
+        );
+
+        Ok(())
+    }
 }
 
 /// Formats an address and port as an endpoint, bracketing IPv6.
@@ -794,6 +892,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::Stats(cmd) => service.get_stats(cmd).await,
         ModeCmd::Entries(cmd) => service.list_entries(cmd, format).await,
         ModeCmd::Metrics(cmd) => service.metrics(cmd).await,
+        ModeCmd::Map { command } => service.manage_maps(command).await,
     }
 }
 

--- a/objects/fwstate/controlplane/fwstatemappb/v1/fwstatemap.proto
+++ b/objects/fwstate/controlplane/fwstatemappb/v1/fwstatemap.proto
@@ -82,6 +82,7 @@ message CreateMapRequest {
   Kind kind = 2;
   uint32 index_size = 3;
   uint32 extra_bucket_count = 4;
+  // worker_count sizes the per-worker state; zero derives the dataplane's current worker count.
   uint32 worker_count = 5;
 }
 

--- a/objects/fwstate/controlplane/map_service.go
+++ b/objects/fwstate/controlplane/map_service.go
@@ -3,13 +3,16 @@ package fwstatemap
 // FWStateMapService.mu is the only lock in this service. Every RPC and
 // ReclaimStaleLayers acquires it for the whole operation: CreateMap and
 // InsertLayer mutate the in-memory map registry and the shared-memory
-// layer chain atomically, and ListEntries snapshots a config value under
-// it before releasing it for the cursor read. There are no collaborating
-// services to order against in this standalone objects controlplane.
+// layer chain atomically, and ListEntries runs its cursor read under it
+// so a concurrent DeleteMap or layer reclamation cannot free the fwtable
+// or a layer mid-read. There are no collaborating services to order
+// against in this standalone objects controlplane.
 
 import (
 	"context"
 	"io"
+	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,6 +31,8 @@ import (
 // maxWorkerCount is the highest value accepted for worker_count, matching
 // the width of the C-side uint16 parameter of fwstate_map insert_layer.
 const maxWorkerCount uint32 = 65535
+
+const maxMapNameLen = 80
 
 const (
 	// DefaultListEntriesBatchSize is the batch size used when the caller
@@ -228,10 +233,14 @@ func (m *FWStateMapService) CreateMap(
 	req *fwstatemappb.CreateMapRequest,
 ) (*fwstatemappb.CreateMapResponse, error) {
 	name := req.GetName()
-	if name == "" {
-		return nil, status.Error(codes.InvalidArgument, "map name is required")
+	if err := ValidateMapName(name); err != nil {
+		return nil, err
 	}
-	if err := ValidateWorkerCount(req.GetWorkerCount()); err != nil {
+
+	workerCount, err := ResolveCreateWorkerCount(
+		req.GetWorkerCount(), m.dpWorkerCountOf(),
+	)
+	if err != nil {
 		return nil, err
 	}
 	kind := kindFromProto(req.GetKind())
@@ -258,7 +267,7 @@ func (m *FWStateMapService) CreateMap(
 	if err := mapConfig.CreateMap(
 		req.GetIndexSize(),
 		req.GetExtraBucketCount(),
-		uint16(req.GetWorkerCount()),
+		workerCount,
 	); err != nil {
 		mapConfig.Free()
 		m.log.Error("failed to create fwstate-map table",
@@ -378,7 +387,10 @@ func (m *FWStateMapService) InsertLayer(
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "map name is required")
 	}
-	if err := ValidateWorkerCount(req.GetWorkerCount()); err != nil {
+	workerCount, err := ResolveCreateWorkerCount(
+		req.GetWorkerCount(), m.dpWorkerCountOf(),
+	)
+	if err != nil {
 		return nil, err
 	}
 
@@ -393,7 +405,7 @@ func (m *FWStateMapService) InsertLayer(
 	if err := fwMap.Config().InsertLayer(
 		req.GetIndexSize(),
 		req.GetExtraBucketCount(),
-		uint16(req.GetWorkerCount()),
+		workerCount,
 	); err != nil {
 		m.log.Error("failed to insert fwstate-map layer",
 			zap.String("map", name), zap.Error(err))
@@ -427,6 +439,20 @@ func (m *FWStateMapService) ListEntries(
 		}
 
 		count := ClampBatchSize(req.GetBatchSize())
+		if req.GetDirection() == fwstatemappb.Direction_BACKWARD {
+			backward = true
+		} else if req.GetDirection() == fwstatemappb.Direction_FORWARD {
+			backward = false
+		} else {
+			return status.Error(codes.InvalidArgument, "invalid direction")
+		}
+
+		index, err := ResolveReadIndex(backward, req.GetIndex())
+		if err != nil {
+			return err
+		}
+
+		now := uint64(time.Now().UnixNano())
 
 		m.mu.Lock()
 		fwMap, ok := m.maps[mapName]
@@ -436,10 +462,6 @@ func (m *FWStateMapService) ListEntries(
 		}
 
 		mapCfg := *fwMap.Config()
-		m.mu.Unlock()
-
-		now := uint64(time.Now().UnixNano())
-		backward := req.GetDirection() == fwstatemappb.Direction_BACKWARD
 
 		var entries []cfwstate.CursorEntry
 		var newIndex int64
@@ -448,16 +470,32 @@ func (m *FWStateMapService) ListEntries(
 		if backward {
 			entries, newIndex, hasMore, err = mapCfg.ReadBackward(
 				req.GetLayerIndex(),
-				req.GetIndex(), req.GetIncludeExpired(),
+				index, req.GetIncludeExpired(),
 				now, count,
 			)
 		} else {
 			entries, newIndex, hasMore, err = mapCfg.ReadForward(
 				req.GetLayerIndex(),
-				req.GetIndex(), req.GetIncludeExpired(),
+				index, req.GetIncludeExpired(),
 				now, count,
 			)
 		}
+
+		if err == nil && backward && newIndex == 0 {
+			var tail []cfwstate.CursorEntry
+			tail, newIndex, hasMore, err = mapCfg.ReadBackward(
+				req.GetLayerIndex(),
+				0, req.GetIncludeExpired(),
+				now, 1,
+			)
+			entries = append(entries, tail...)
+		}
+
+		if backward && len(entries) == 0 {
+			hasMore = false
+		}
+
+		m.mu.Unlock()
 
 		if err != nil {
 			return status.Errorf(codes.Internal, "cursor read failed: %v", err)
@@ -533,6 +571,64 @@ func ValidateWorkerCount(workerCount uint32) error {
 		return status.Errorf(codes.InvalidArgument, "worker_count %d exceeds maximum %d", workerCount, maxWorkerCount)
 	}
 	return nil
+}
+
+func (m *FWStateMapService) dpWorkerCountOf() func() uint32 {
+	if m.agent == nil {
+		return nil
+	}
+	return func() uint32 { return m.agent.DPConfig().WorkerCount() }
+}
+
+// ResolveCreateWorkerCount settles the per-worker sizing for CreateMap and InsertLayer, deriving a zero count from the dataplane's worker count and rejecting an explicit mismatch.
+func ResolveCreateWorkerCount(
+	workerCount uint32,
+	dpWorkerCount func() uint32,
+) (uint16, error) {
+	if dpWorkerCount != nil {
+		dpCount := dpWorkerCount()
+		if workerCount == 0 {
+			workerCount = dpCount
+		} else if workerCount != dpCount {
+			return 0, status.Errorf(
+				codes.InvalidArgument,
+				"worker_count %d does not match the dataplane worker count %d",
+				workerCount, dpCount,
+			)
+		}
+	}
+	if err := ValidateWorkerCount(workerCount); err != nil {
+		return 0, err
+	}
+	return uint16(workerCount), nil
+}
+
+// ValidateMapName rejects names that cannot round-trip through the fixed-size C object registry.
+func ValidateMapName(name string) error {
+	if name == "" {
+		return status.Error(codes.InvalidArgument, "map name is required")
+	}
+	if len(name) >= maxMapNameLen {
+		return status.Errorf(codes.InvalidArgument, "map name must be shorter than %d bytes", maxMapNameLen)
+	}
+	if strings.IndexByte(name, 0) != -1 {
+		return status.Error(codes.InvalidArgument, "map name must not contain NUL bytes")
+	}
+	return nil
+}
+
+// ResolveReadIndex rejects negative forward cursors and maps a zero backward cursor to the scan's upper bound.
+func ResolveReadIndex(backward bool, index int64) (int64, error) {
+	if backward {
+		if index == 0 {
+			return math.MaxInt64, nil
+		}
+		return index, nil
+	}
+	if index < 0 {
+		return 0, status.Error(codes.InvalidArgument, "index must not be negative for forward reads")
+	}
+	return index, nil
 }
 
 // MapStatsToProto converts bindings-level map stats into the proto form.

--- a/objects/fwstate/controlplane/map_service_test.go
+++ b/objects/fwstate/controlplane/map_service_test.go
@@ -2,14 +2,20 @@ package fwstatemap_test
 
 import (
 	"errors"
+	"io"
+	"math"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/objects/fwstate/bindings/go/cfwstate"
 	fwstatemap "github.com/yanet-platform/yanet2/objects/fwstate/controlplane"
@@ -85,6 +91,121 @@ func TestClampBatchSize(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, fwstatemap.ClampBatchSize(tc.in))
+		})
+	}
+}
+
+// TestValidateMapName verifies that names the fixed-size C registry cannot store are rejected.
+func TestValidateMapName(t *testing.T) {
+	cases := []struct {
+		name    string
+		mapName string
+		wantErr bool
+	}{
+		{name: "empty rejected", mapName: "", wantErr: true},
+		{name: "normal name passes", mapName: "fwstate0-v4"},
+		{name: "longest name passes", mapName: strings.Repeat("a", 79)},
+		{name: "name at limit rejected", mapName: strings.Repeat("a", 80), wantErr: true},
+		{name: "far over limit rejected", mapName: strings.Repeat("a", 200), wantErr: true},
+		{name: "embedded NUL rejected", mapName: "a\x00b", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := fwstatemap.ValidateMapName(tc.mapName)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// TestResolveCreateWorkerCount verifies that the per-worker sizing is derived from, and matched against, the dataplane worker count.
+func TestResolveCreateWorkerCount(t *testing.T) {
+	dpCount := func() uint32 { return 4 }
+
+	cases := []struct {
+		name         string
+		workerCount  uint32
+		dpWorkerFunc func() uint32
+		want         uint16
+		wantErr      bool
+	}{
+		{
+			name:        "zero derives the dataplane count",
+			workerCount: 0, dpWorkerFunc: dpCount, want: 4,
+		},
+		{
+			name:        "matching explicit value passes",
+			workerCount: 4, dpWorkerFunc: dpCount, want: 4,
+		},
+		{
+			name:        "mismatching explicit value rejected",
+			workerCount: 1, dpWorkerFunc: dpCount, wantErr: true,
+		},
+		{
+			name:        "above dataplane count rejected",
+			workerCount: 8, dpWorkerFunc: dpCount, wantErr: true,
+		},
+		{
+			name:        "agentless zero still rejected",
+			workerCount: 0, dpWorkerFunc: nil, wantErr: true,
+		},
+		{
+			name:        "agentless explicit value passes",
+			workerCount: 2, dpWorkerFunc: nil, want: 2,
+		},
+		{
+			name:        "agentless out of range rejected",
+			workerCount: 65536, dpWorkerFunc: nil, wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := fwstatemap.ResolveCreateWorkerCount(tc.workerCount, tc.dpWorkerFunc)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+				return
+			}
+			require.Error(t, err)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// TestResolveReadIndex verifies the forward-cursor rejection and the backward start-cursor translation.
+func TestResolveReadIndex(t *testing.T) {
+	cases := []struct {
+		name     string
+		backward bool
+		index    int64
+		want     int64
+		wantErr  bool
+	}{
+		{name: "forward zero passes", index: 0, want: 0},
+		{name: "forward positive passes", index: 42, want: 42},
+		{name: "forward negative rejected", index: -1, wantErr: true},
+		{name: "forward min rejected", index: math.MinInt64, wantErr: true},
+		{name: "backward zero becomes upper bound", backward: true, index: 0, want: math.MaxInt64},
+		{name: "backward continuation passes", backward: true, index: 7, want: 7},
+		{name: "backward exhausted sentinel passes", backward: true, index: -1, want: -1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := fwstatemap.ResolveReadIndex(tc.backward, tc.index)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+				return
+			}
+			require.Error(t, err)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
 		})
 	}
 }
@@ -322,4 +443,74 @@ func TestListMapsConcurrent(t *testing.T) {
 		})
 	}
 	require.NoError(t, group.Wait())
+}
+
+type fakeListEntriesStream struct {
+	grpc.BidiStreamingServer[fwstatemappb.ListEntriesRequest, fwstatemappb.ListEntriesResponse]
+	requests  []*fwstatemappb.ListEntriesRequest
+	responses []*fwstatemappb.ListEntriesResponse
+}
+
+func (m *fakeListEntriesStream) Recv() (*fwstatemappb.ListEntriesRequest, error) {
+	if len(m.requests) == 0 {
+		return nil, io.EOF
+	}
+	req := m.requests[0]
+	m.requests = m.requests[1:]
+	return req, nil
+}
+
+func (m *fakeListEntriesStream) Send(
+	resp *fwstatemappb.ListEntriesResponse,
+) error {
+	m.responses = append(m.responses, resp)
+	return nil
+}
+
+// TestListEntriesEmptyMapTerminates verifies that both dump directions end on a map with no entries.
+func TestListEntriesEmptyMapTerminates(t *testing.T) {
+	h, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(64 * datasize.MB),
+		DPMemory:      uint64(4 * datasize.MB),
+		WorkerCount:   1,
+		ObjectsToLoad: []string{"fwstate_map_v4", "fwstate_map_v6"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	shm := h.SharedMemory()
+	agent, err := shm.AgentAttach("fwstatemap-test", 0, 16*datasize.MB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	svc := fwstatemap.NewFWStateMapService(agent)
+	_, err = svc.CreateMap(t.Context(), &fwstatemappb.CreateMapRequest{
+		Name:             "empty-v4",
+		Kind:             fwstatemappb.Kind_V4,
+		IndexSize:        1024,
+		ExtraBucketCount: 64,
+	})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name      string
+		direction fwstatemappb.Direction
+	}{
+		{name: "backward", direction: fwstatemappb.Direction_BACKWARD},
+		{name: "forward", direction: fwstatemappb.Direction_FORWARD},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stream := &fakeListEntriesStream{
+				requests: []*fwstatemappb.ListEntriesRequest{{
+					MapName:   "empty-v4",
+					Direction: tc.direction,
+					BatchSize: 10,
+				}},
+			}
+			require.NoError(t, svc.ListEntries(stream))
+			require.Len(t, stream.responses, 1)
+			require.Empty(t, stream.responses[0].GetEntries())
+			require.False(t, stream.responses[0].GetHasMore())
+		})
+	}
 }

--- a/objects/fwstate/meson.build
+++ b/objects/fwstate/meson.build
@@ -1,4 +1,5 @@
+subdir('api')
+
 if not dataplane_only
-  subdir('api')
   subdir('controlplane')
 endif


### PR DESCRIPTION
The dataplane registers the fwstate-map object types at startup, so a control plane can create objects without a unit-test harness. The acl module hosts the map service on its agent, next to the fwstate service, and the fwstate CLI gains map create, delete, and list subcommands. A create request without an explicit worker count derives the dataplane's current worker count.

Ported from the feat/acl-map-object-lookup branch, without the named-map config cutover that branch carries: main still sizes fwstate maps inline, so the functional-test rework stays behind with it.