### PR TITLE
fix(xcfg): reject a config key present with a null value

### DIFF
--- a/common/go/xcfg/known_keys.go
+++ b/common/go/xcfg/known_keys.go
@@ -1,6 +1,7 @@
 package xcfg
 
 import (
+	"encoding"
 	"fmt"
 	"maps"
 	"reflect"
@@ -14,6 +15,8 @@ var yamlNodeType = reflect.TypeFor[yaml.Node]()
 
 var yamlUnmarshalerType = reflect.TypeFor[yaml.Unmarshaler]()
 
+var textUnmarshalerType = reflect.TypeFor[encoding.TextUnmarshaler]()
+
 // walkableType is implemented by a wrapper whose keys decode into a
 // different type than the wrapper itself, such as Optional[T], so the walk
 // can check that type's fields instead of stopping at isOpaqueToWalk.
@@ -24,11 +27,23 @@ type walkableType interface {
 // mergeTag is the resolved tag yaml.v3 assigns to a "<<" merge key.
 const mergeTag = "!!merge"
 
+const nullTag = "!!null"
+
 // unknownKey records one mapping key with no matching field, along with the
 // document line it sits on, so the reported error can point straight at it.
 type unknownKey struct {
 	Path string
 	Line int
+}
+
+type nullValue struct {
+	Path string
+	Line int
+}
+
+type findings struct {
+	Unknown []unknownKey
+	Nulls   []nullValue
 }
 
 // CheckKnownKeys reports every YAML mapping key in data that has no matching
@@ -44,20 +59,31 @@ func CheckKnownKeys[T any](data []byte) error {
 	return checkKnownKeys(data, reflect.TypeFor[T]())
 }
 
-// checkKnownKeys drives the same walk as CheckKnownKeys against a
-// reflect.Type, letting Decode reuse it for a destination value's runtime
-// type without a type parameter.
+// checkKnownKeys drives the same walk as CheckKnownKeys against the
+// reflect.Type its type parameter resolves to.
 func checkKnownKeys(data []byte, t reflect.Type) error {
-	var doc yaml.Node
-	if err := yaml.Unmarshal(data, &doc); err != nil {
+	collected, err := walkDocument(data, t)
+	if err != nil {
 		return err
 	}
+	return unknownKeysError(collected.Unknown)
+}
+
+func walkDocument(data []byte, t reflect.Type) (*findings, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	collected := &findings{}
 	if len(doc.Content) == 0 {
-		return nil
+		return collected, nil
 	}
 
-	var unknown []unknownKey
-	walkKnownKeys(doc.Content[0], t, "", &unknown, map[*yaml.Node]bool{})
+	walkKnownKeys(doc.Content[0], t, "", collected, map[*yaml.Node]bool{})
+	return collected, nil
+}
+
+func unknownKeysError(unknown []unknownKey) error {
 	if len(unknown) == 0 {
 		return nil
 	}
@@ -72,8 +98,39 @@ func checkKnownKeys(data []byte, t reflect.Type) error {
 	return fmt.Errorf("unknown keys specified: %s", strings.Join(parts, ", "))
 }
 
+func nullValuesError(nulls []nullValue) error {
+	if len(nulls) == 0 {
+		return nil
+	}
+	if len(nulls) == 1 {
+		return fmt.Errorf("key %q at line %d has no value; give it a body or remove the key", nulls[0].Path, nulls[0].Line)
+	}
+
+	parts := make([]string, len(nulls))
+	for idx, null := range nulls {
+		parts[idx] = fmt.Sprintf("%q at line %d", null.Path, null.Line)
+	}
+	return fmt.Errorf("keys with no value: %s", strings.Join(parts, ", "))
+}
+
+func isTransparentToWalk(t reflect.Type) bool {
+	if t.Kind() == reflect.Interface || t == yamlNodeType {
+		return false
+	}
+	if wt, ok := reflect.Zero(t).Interface().(walkableType); ok {
+		return isTransparentToWalk(wt.WalkType())
+	}
+	if isOpaqueToWalk(t) {
+		return false
+	}
+	if reflect.PointerTo(t).Implements(textUnmarshalerType) {
+		return false
+	}
+	return t.Kind() == reflect.Struct || t.Kind() == reflect.Map
+}
+
 // walkKnownKeys matches node's shape against t, appending the dotted path of
-// every mapping key that has no corresponding field to unknown.
+// every mapping key that has no corresponding field to collected.
 //
 // visiting holds the alias targets already on the current descent path, so
 // a self-referential merge anchor is caught here instead of recursing
@@ -81,10 +138,11 @@ func checkKnownKeys(data []byte, t reflect.Type) error {
 // not into a node tree, and LoadConfig catches it separately, so stopping
 // silently is enough. The entry is removed on return, so a legitimate
 // anchor reused at sibling paths is still walked at each site.
-func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, unknown *[]unknownKey, visiting map[*yaml.Node]bool) {
+func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, collected *findings, visiting map[*yaml.Node]bool) {
 	if node == nil {
 		return
 	}
+	line := node.Line
 	if node.Kind == yaml.AliasNode {
 		target := node.Alias
 		if target == nil || visiting[target] {
@@ -95,6 +153,13 @@ func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, unknown *[]unkn
 		node = target
 	}
 
+	if node.ShortTag() == nullTag {
+		if t.Kind() != reflect.Pointer && isTransparentToWalk(t) {
+			collected.Nulls = append(collected.Nulls, nullValue{Path: path, Line: line})
+		}
+		return
+	}
+
 	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
@@ -102,7 +167,7 @@ func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, unknown *[]unkn
 		return
 	}
 	if wt, ok := reflect.Zero(t).Interface().(walkableType); ok {
-		walkKnownKeys(node, wt.WalkType(), path, unknown, visiting)
+		walkKnownKeys(node, wt.WalkType(), path, collected, visiting)
 		return
 	}
 	if isOpaqueToWalk(t) {
@@ -111,11 +176,13 @@ func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, unknown *[]unkn
 
 	switch node.Kind {
 	case yaml.MappingNode:
-		walkMappingNode(node, t, path, unknown, visiting)
+		walkMappingNode(node, t, path, collected, visiting)
 	case yaml.SequenceNode:
-		walkSequenceNode(node, t, path, unknown, visiting)
+		walkSequenceNode(node, t, path, collected, visiting)
 	}
 }
+
+type mappingResolver func(key string) (reflect.Type, bool)
 
 // walkMappingNode checks a YAML mapping node against a struct or map type.
 //
@@ -123,69 +190,146 @@ func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, unknown *[]unkn
 // against, so it is skipped without reporting — for example a mapping
 // value against a plain scalar field is a shape mismatch that yaml.v3
 // itself rejects on the strict decode path.
-func walkMappingNode(node *yaml.Node, t reflect.Type, path string, unknown *[]unknownKey, visiting map[*yaml.Node]bool) {
+func walkMappingNode(node *yaml.Node, t reflect.Type, path string, collected *findings, visiting map[*yaml.Node]bool) {
+	var resolve mappingResolver
+	skipComplexKey := false
 	switch t.Kind() {
 	case reflect.Struct:
 		fields, inlineElem := collectFields(t)
-		for idx := 0; idx+1 < len(node.Content); idx += 2 {
-			keyNode, valueNode := node.Content[idx], node.Content[idx+1]
-			if keyNode.Tag == mergeTag {
-				walkMergeValue(valueNode, t, path, unknown, visiting)
-				continue
+		skipComplexKey = true
+		resolve = func(key string) (reflect.Type, bool) {
+			if fieldType, ok := fields[key]; ok {
+				return fieldType, true
 			}
-			// A complex key (a YAML sequence or mapping key) has no scalar
-			// name to check against a field or record as unknown.
-			if keyNode.Kind == yaml.SequenceNode || keyNode.Kind == yaml.MappingNode {
-				continue
+			if inlineElem != nil {
+				return inlineElem, true
 			}
-
-			fieldPath := joinPath(path, keyNode.Value)
-			fieldType, ok := fields[keyNode.Value]
-			switch {
-			case ok:
-				walkKnownKeys(valueNode, fieldType, fieldPath, unknown, visiting)
-			case inlineElem != nil:
-				walkKnownKeys(valueNode, inlineElem, fieldPath, unknown, visiting)
-			default:
-				*unknown = append(*unknown, unknownKey{Path: fieldPath, Line: keyNode.Line})
-			}
+			return nil, false
 		}
 	case reflect.Map:
 		elemType := t.Elem()
-		for idx := 0; idx+1 < len(node.Content); idx += 2 {
-			fieldPath := joinPath(path, node.Content[idx].Value)
-			walkKnownKeys(node.Content[idx+1], elemType, fieldPath, unknown, visiting)
+		resolve = func(key string) (reflect.Type, bool) {
+			return elemType, true
 		}
+	default:
+		return
+	}
+
+	claimed := map[string]bool{}
+	mergeValue := walkMappingKeys(node, resolve, skipComplexKey, path, collected, visiting, claimed)
+	if mergeValue != nil {
+		walkMergeValue(mergeValue, resolve, skipComplexKey, path, collected, visiting, claimed)
 	}
 }
 
-// walkMergeValue walks a "<<" merge key's value against t, the struct type
-// of the mapping it merges into, since merged keys land in that mapping
-// rather than under a field of their own.
+func isMergeKey(keyNode *yaml.Node) bool {
+	if keyNode.Kind != yaml.ScalarNode || keyNode.Value != "<<" {
+		return false
+	}
+	return keyNode.Tag == "" || keyNode.Tag == "!" || keyNode.ShortTag() == mergeTag
+}
+
+func mappingKeyName(keyNode *yaml.Node) string {
+	if keyNode.Kind == yaml.AliasNode && keyNode.Alias != nil {
+		return keyNode.Alias.Value
+	}
+	return keyNode.Value
+}
+
+type mappingKeyEntry struct {
+	ValueNode *yaml.Node
+	Line      int
+}
+
+func walkMappingKeys(node *yaml.Node, resolve mappingResolver, skipComplexKey bool, path string, collected *findings, visiting map[*yaml.Node]bool, claimed map[string]bool) *yaml.Node {
+	var mergeValue *yaml.Node
+	var order []string
+	last := map[string]mappingKeyEntry{}
+	for idx := 0; idx+1 < len(node.Content); idx += 2 {
+		keyNode, valueNode := node.Content[idx], node.Content[idx+1]
+		if isMergeKey(keyNode) {
+			mergeValue = valueNode
+			continue
+		}
+		if skipComplexKey && (keyNode.Kind == yaml.SequenceNode || keyNode.Kind == yaml.MappingNode) {
+			continue
+		}
+		key := mappingKeyName(keyNode)
+		if !claimed[key] {
+			order = append(order, key)
+		}
+		claimed[key] = true
+		last[key] = mappingKeyEntry{ValueNode: valueNode, Line: keyNode.Line}
+	}
+	for _, key := range order {
+		entry := last[key]
+		walkMappingEntry(resolve, key, entry.Line, entry.ValueNode, path, collected, visiting)
+	}
+	return mergeValue
+}
+
+func walkMappingEntry(resolve mappingResolver, key string, line int, valueNode *yaml.Node, path string, collected *findings, visiting map[*yaml.Node]bool) {
+	fieldPath := joinPath(path, key)
+	if fieldType, ok := resolve(key); ok {
+		walkKnownKeys(valueNode, fieldType, fieldPath, collected, visiting)
+		return
+	}
+	collected.Unknown = append(collected.Unknown, unknownKey{Path: fieldPath, Line: line})
+}
+
+// walkMergeValue walks a "<<" merge key's value, resolving each merged
+// key's value against the receiving mapping via resolve, since merged
+// keys land in that mapping rather than under a field of their own.
 //
 // The value can also be a scalar or a sequence of scalars — shapes YAML
 // permits, though neither carries keys to check. A sequence value is
 // walked in place rather than routed through walkSequenceNode, since its
-// elements share t rather than a slice element type.
-func walkMergeValue(node *yaml.Node, t reflect.Type, path string, unknown *[]unknownKey, visiting map[*yaml.Node]bool) {
+// elements share resolve rather than a slice element type.
+func walkMergeValue(node *yaml.Node, resolve mappingResolver, skipComplexKey bool, path string, collected *findings, visiting map[*yaml.Node]bool, claimed map[string]bool) {
+	if node.ShortTag() == nullTag {
+		return
+	}
 	if node.Kind == yaml.SequenceNode {
 		for _, item := range node.Content {
-			walkKnownKeys(item, t, path, unknown, visiting)
+			if item.ShortTag() == nullTag {
+				continue
+			}
+			walkMergeSource(item, resolve, skipComplexKey, path, collected, visiting, claimed)
 		}
 		return
 	}
-	walkKnownKeys(node, t, path, unknown, visiting)
+	walkMergeSource(node, resolve, skipComplexKey, path, collected, visiting, claimed)
+}
+
+func walkMergeSource(node *yaml.Node, resolve mappingResolver, skipComplexKey bool, path string, collected *findings, visiting map[*yaml.Node]bool, claimed map[string]bool) {
+	if node.Kind == yaml.AliasNode {
+		target := node.Alias
+		if target == nil || visiting[target] {
+			return
+		}
+		visiting[target] = true
+		defer delete(visiting, target)
+		node = target
+	}
+	if node.Kind != yaml.MappingNode {
+		return
+	}
+
+	mergeValue := walkMappingKeys(node, resolve, skipComplexKey, path, collected, visiting, claimed)
+	if mergeValue != nil {
+		walkMergeValue(mergeValue, resolve, skipComplexKey, path, collected, visiting, claimed)
+	}
 }
 
 // walkSequenceNode checks each element of a YAML sequence node against a
 // slice or array type's element type.
-func walkSequenceNode(node *yaml.Node, t reflect.Type, path string, unknown *[]unknownKey, visiting map[*yaml.Node]bool) {
+func walkSequenceNode(node *yaml.Node, t reflect.Type, path string, collected *findings, visiting map[*yaml.Node]bool) {
 	if t.Kind() != reflect.Slice && t.Kind() != reflect.Array {
 		return
 	}
 	elemType := t.Elem()
 	for idx, item := range node.Content {
-		walkKnownKeys(item, elemType, fmt.Sprintf("%s[%d]", path, idx), unknown, visiting)
+		walkKnownKeys(item, elemType, fmt.Sprintf("%s[%d]", path, idx), collected, visiting)
 	}
 }
 

--- a/common/go/xcfg/known_keys_test.go
+++ b/common/go/xcfg/known_keys_test.go
@@ -1,6 +1,7 @@
 package xcfg_test
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -330,15 +331,11 @@ type optionalAliasConfig struct {
 
 // Test_CheckKnownKeys_AliasedMapKeyStillChecked is a regression test for an
 // alias used as a YAML mapping key, mirroring yncp.Config's modules block.
-//
-// An alias key node's Value holds its anchor name rather than the value it
-// resolves to, so the fixture names the anchor after the field it targets
-// (decap) for the walk to match it against Decap's struct field.
 func Test_CheckKnownKeys_AliasedMapKeyStillChecked(t *testing.T) {
 	input := `
-name: &decap decap
+name: &anchor decap
 modules:
-  *decap:
+  *anchor:
     a: x
     b: y
     bogus: z
@@ -360,8 +357,8 @@ type mapAliasConfig struct {
 // Test_CheckKnownKeys_AliasedMapKeyInMapField is the map-branch counterpart
 // to Test_CheckKnownKeys_AliasedMapKeyStillChecked.
 //
-// A map key accepts any name, so the alias's anchor name lands directly as
-// the map key rather than needing to match a struct field tag.
+// A map key accepts any name, so the alias resolves to the scalar it points
+// at rather than needing to match a struct field tag.
 func Test_CheckKnownKeys_AliasedMapKeyInMapField(t *testing.T) {
 	input := `
 name: &n foo
@@ -373,7 +370,48 @@ modules:
 `
 	err := xcfg.CheckKnownKeys[mapAliasConfig]([]byte(input))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "modules.n.bogus")
+	require.Contains(t, err.Error(), "modules.foo.bogus")
+}
+
+type aliasedKeyNullConfig struct {
+	Struct knownKeysInner       `yaml:"struct"`
+	Extra  map[string]yaml.Node `yaml:",inline"`
+}
+
+// Test_Decode_AliasedKeyNullValueReportedAtResolvedFieldPath asserts a null under an aliased key is reported at the field the alias resolves to.
+func Test_Decode_AliasedKeyNullValueReportedAtResolvedFieldPath(t *testing.T) {
+	input := "key: &key struct\n*key:\n"
+	var cfg aliasedKeyNullConfig
+	err := xcfg.Decode([]byte(input), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"struct"`)
+	require.Contains(t, err.Error(), "has no value")
+}
+
+// Test_Decode_AliasedKeyKnownFields_NoUnknownKeyError asserts the same aliased-key document produces no unknown-key error under WithKnownFields.
+func Test_Decode_AliasedKeyKnownFields_NoUnknownKeyError(t *testing.T) {
+	input := "key: &key struct\n*key:\n"
+	err := xcfg.Decode([]byte(input), new(aliasedKeyNullConfig), xcfg.WithKnownFields())
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "unknown key")
+}
+
+// Test_Decode_DuplicateResolvedKey_BodyLastAccepted asserts a plain key and an aliased key resolving to the same entry: the last one, a body, wins and is accepted.
+func Test_Decode_DuplicateResolvedKey_BodyLastAccepted(t *testing.T) {
+	input := "tag: &anchor a\nmodules:\n  a:\n  *anchor:\n    addr: real\n"
+	var cfg mapMergeConfig
+	err := xcfg.Decode([]byte(input), &cfg)
+	require.NoError(t, err)
+}
+
+// Test_Decode_DuplicateResolvedKey_NullLastReported mirrors Test_Decode_DuplicateResolvedKey_BodyLastAccepted: the last occurrence, a null, wins and is reported.
+func Test_Decode_DuplicateResolvedKey_NullLastReported(t *testing.T) {
+	input := "tag: &anchor a\nmodules:\n  *anchor:\n    addr: real\n  a:\n"
+	var cfg mapMergeConfig
+	err := xcfg.Decode([]byte(input), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"modules.a"`)
+	require.Contains(t, err.Error(), "has no value")
 }
 
 // Test_CheckKnownKeys_NullKeyStillReported pins that a YAML null key (a
@@ -461,4 +499,394 @@ modules:
 	err := xcfg.Decode([]byte(input), new(complexMapKeyConfig), xcfg.WithKnownFields())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "bogus")
+}
+
+// Test_Decode_MergedComplexKeyNullReported pins that a merged entry under a complex map key is walked like a direct one, so its null is still reported.
+func Test_Decode_MergedComplexKeyNullReported(t *testing.T) {
+	input := `
+base: &b
+  ? [x, y]
+  :
+modules:
+  <<: *b
+`
+	var cfg complexMapKeyConfig
+	err := xcfg.Decode([]byte(input), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "has no value")
+}
+
+// Test_Decode_NullMergeValue_YAMLNativeErrorSurfaces asserts that a null merge key value is not flagged null, leaving yaml.v3's own merge error.
+func Test_Decode_NullMergeValue_YAMLNativeErrorSurfaces(t *testing.T) {
+	var cfg knownKeysConfig
+	err := xcfg.Decode([]byte("inner:\n  <<:\n  addr: x\n"), &cfg)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "has no value")
+	require.Contains(t, err.Error(), "map merge requires map or sequence of maps as the value")
+}
+
+// Test_Decode_NullMergeValueAtRoot_YAMLNativeErrorSurfaces is the document-root counterpart of the null merge value test.
+func Test_Decode_NullMergeValueAtRoot_YAMLNativeErrorSurfaces(t *testing.T) {
+	var cfg knownKeysConfig
+	err := xcfg.Decode([]byte("<<:\nname: x\n"), &cfg)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "has no value")
+	require.Contains(t, err.Error(), "map merge requires map or sequence of maps as the value")
+}
+
+// Test_Decode_NullMergeValueSequenceElement_YAMLNativeErrorSurfaces is the sequence-element counterpart of the null merge value test.
+func Test_Decode_NullMergeValueSequenceElement_YAMLNativeErrorSurfaces(t *testing.T) {
+	var cfg knownKeysConfig
+	err := xcfg.Decode([]byte("inner:\n  <<: [~]\n  addr: x\n"), &cfg)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "has no value")
+	require.Contains(t, err.Error(), "map merge requires map or sequence of maps as the value")
+}
+
+type mapMergeConfig struct {
+	Modules map[string]knownKeysInner `yaml:"modules"`
+	Extra   map[string]yaml.Node      `yaml:",inline"`
+}
+
+// Test_Decode_NullMergeValueMapField_YAMLNativeErrorSurfaces is the map-typed-field counterpart of Test_Decode_NullMergeValue_YAMLNativeErrorSurfaces.
+func Test_Decode_NullMergeValueMapField_YAMLNativeErrorSurfaces(t *testing.T) {
+	var cfg mapMergeConfig
+	err := xcfg.Decode([]byte("modules:\n  <<:\n  a:\n    addr: x\n"), &cfg)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "has no value")
+	require.Contains(t, err.Error(), "map merge requires map or sequence of maps as the value")
+}
+
+// Test_CheckKnownKeys_MergeIntoMapFieldCheckedAgainstElementType asserts a merged entry is checked against the map's element type at its real dotted path.
+func Test_CheckKnownKeys_MergeIntoMapFieldCheckedAgainstElementType(t *testing.T) {
+	input := `
+base: &b
+  a:
+    addr: 1.2.3.4
+  c:
+    addr: 5.6.7.8
+    bogus: true
+modules:
+  <<: *b
+`
+	err := xcfg.CheckKnownKeys[mapMergeConfig]([]byte(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "modules.c.bogus")
+	require.NotContains(t, err.Error(), "<<")
+}
+
+// Test_Decode_MergeSourceNullOverriddenByExplicitKey_Accepted asserts a merge source's null-valued key is unreported once an explicit key overrides it.
+func Test_Decode_MergeSourceNullOverriddenByExplicitKey_Accepted(t *testing.T) {
+	input := `
+base: &b
+  a:
+modules:
+  a:
+    addr: x
+  <<: *b
+`
+	var cfg mapMergeConfig
+	err := xcfg.Decode([]byte(input), &cfg)
+	require.NoError(t, err)
+}
+
+// Test_Decode_MergeSequenceEarlierSourceOverridesLaterNull asserts an earlier merge source's key wins over a later source's null for the same key.
+func Test_Decode_MergeSequenceEarlierSourceOverridesLaterNull(t *testing.T) {
+	input := `
+s1: &s1
+  a:
+    addr: x
+s2: &s2
+  a:
+  b:
+modules:
+  <<: [*s1, *s2]
+`
+	var cfg mapMergeConfig
+	err := xcfg.Decode([]byte(input), &cfg)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), `"modules.a"`)
+	require.Contains(t, err.Error(), `"modules.b"`)
+}
+
+type shadowMergeInner struct {
+	Addr string `yaml:"addr"`
+}
+
+type shadowMergeConfig struct {
+	Inner shadowMergeInner `yaml:"inner"`
+	// Extra swallows the merge anchor's own top-level key so it never reports.
+	Extra map[string]yaml.Node `yaml:",inline"`
+}
+
+// Test_Decode_MergeSourceUnknownKeyShadowedByExplicitKeyNotDuplicated asserts a merge source's unknown key already bound explicitly is not reported twice.
+func Test_Decode_MergeSourceUnknownKeyShadowedByExplicitKeyNotDuplicated(t *testing.T) {
+	input := `
+base: &b
+  bogus: true
+inner:
+  bogus: kept
+  <<: *b
+`
+	err := xcfg.Decode([]byte(input), new(shadowMergeConfig), xcfg.WithKnownFields())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unknown key "inner.bogus"`)
+	require.NotContains(t, err.Error(), "unknown keys specified")
+}
+
+// Test_Decode_NestedMergeSourceOwnKeyOverridesMergedNull_Accepted asserts a merge source's own explicit key wins over a body it itself merges in as null.
+func Test_Decode_NestedMergeSourceOwnKeyOverridesMergedNull_Accepted(t *testing.T) {
+	input := `
+base: &base
+  a:
+mid: &mid
+  <<: *base
+  a:
+    addr: real
+modules:
+  <<: *mid
+`
+	var cfg mapMergeConfig
+	err := xcfg.Decode([]byte(input), &cfg)
+	require.NoError(t, err)
+}
+
+// Test_Decode_NestedMergeSourceOwnNullOverridesMergedBody_Reported pins the #1947 collapse: a merge source's own null key wins over a body it merges in and is still rejected.
+func Test_Decode_NestedMergeSourceOwnNullOverridesMergedBody_Reported(t *testing.T) {
+	input := `
+base: &base
+  a:
+    addr: real
+mid: &mid
+  <<: *base
+  a:
+modules:
+  <<: *mid
+`
+	var cfg mapMergeConfig
+	err := xcfg.Decode([]byte(input), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"modules.a"`)
+	require.Contains(t, err.Error(), "has no value")
+}
+
+// Test_Decode_MergeSourceShadowedSubtreeUnknownKeyNotReported asserts a merged source's whole nested subtree is shadowed, unknown keys inside it included.
+func Test_Decode_MergeSourceShadowedSubtreeUnknownKeyNotReported(t *testing.T) {
+	input := `
+base: &base
+  a:
+    addr: x
+    bogus: true
+mid: &mid
+  <<: *base
+  a:
+    addr: y
+modules:
+  <<: *mid
+`
+	err := xcfg.Decode([]byte(input), new(mapMergeConfig), xcfg.WithKnownFields())
+	require.NoError(t, err)
+}
+
+type optionalScalarConfig struct {
+	Name xcfg.Optional[string] `yaml:"name"`
+}
+
+// Test_Decode_OptionalScalarNull_NotReported asserts a null Optional[string] is left silent, matching a null plain string field.
+func Test_Decode_OptionalScalarNull_NotReported(t *testing.T) {
+	var cfg optionalScalarConfig
+	err := xcfg.Decode([]byte("name:\n"), &cfg)
+	require.NoError(t, err)
+}
+
+type aliasNullPositionConfig struct {
+	Inner knownKeysInner            `yaml:"inner"`
+	M     map[string]knownKeysInner `yaml:"m"`
+}
+
+// Test_Decode_NullThroughAlias_ReportsAliasSiteLine asserts that a null reached through an alias is reported at the alias site's line, not the anchor's.
+func Test_Decode_NullThroughAlias_ReportsAliasSiteLine(t *testing.T) {
+	var cfg aliasNullPositionConfig
+	err := xcfg.Decode([]byte("inner: &b\nm:\n  k: *b\n"), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"m.k" at line 3`)
+}
+
+// Test_Decode_UnknownKeyWinsOverNullUnderKnownFields asserts that an unknown-key error takes precedence over a null-value error under WithKnownFields.
+func Test_Decode_UnknownKeyWinsOverNullUnderKnownFields(t *testing.T) {
+	input := "name: foo\ninner:\nbogus: 1\n"
+	var cfg knownKeysConfig
+	err := xcfg.Decode([]byte(input), &cfg, xcfg.WithKnownFields())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bogus")
+	require.NotContains(t, err.Error(), "has no value")
+}
+
+type nullArmsConfig struct {
+	Optional       xcfg.Optional[knownKeysInner]  `yaml:"optional"`
+	Struct         knownKeysInner                 `yaml:"struct"`
+	Map            map[string]string              `yaml:"map"`
+	Required       xcfg.Required[string]          `yaml:"required"`
+	NonEmptyString xcfg.NonEmptyString            `yaml:"nonemptystring"`
+	NonZero        xcfg.NonZero[int]              `yaml:"nonzero"`
+	Scalar         string                         `yaml:"scalar"`
+	Slice          []knownKeysInner               `yaml:"slice"`
+	Node           yaml.Node                      `yaml:"node"`
+	PtrStruct      *knownKeysInner                `yaml:"ptrstruct"`
+	PtrOptional    *xcfg.Optional[knownKeysInner] `yaml:"ptroptional"`
+}
+
+type nullArmCase struct {
+	name        string
+	input       string
+	wantErr     bool
+	contains    []string
+	notContains []string
+	seed        func(*nullArmsConfig)
+	check       func(*testing.T, *nullArmsConfig)
+}
+
+// Test_Decode_NullPositions asserts, per isTransparentToWalk arm, whether a null at that field's position is reported here.
+func Test_Decode_NullPositions(t *testing.T) {
+	cases := []nullArmCase{
+		{
+			name:     "optional field reported",
+			input:    "optional:\nrequired: r\nnonemptystring: s\nnonzero: 1\n",
+			wantErr:  true,
+			contains: []string{`"optional"`, "line 1"},
+		},
+		{
+			name:     "struct field reported",
+			input:    "struct:\nrequired: r\nnonemptystring: s\nnonzero: 1\n",
+			wantErr:  true,
+			contains: []string{`"struct"`, "line 1"},
+		},
+		{
+			name:     "map field reported",
+			input:    "map:\nrequired: r\nnonemptystring: s\nnonzero: 1\n",
+			wantErr:  true,
+			contains: []string{`"map"`, "line 1"},
+		},
+		{
+			name:        "required field left to its own Validate error",
+			input:       "required:\nnonemptystring: s\nnonzero: 1\n",
+			wantErr:     true,
+			contains:    []string{"value must be set explicitly"},
+			notContains: []string{"no value"},
+		},
+		{
+			name:        "nonemptystring field left to its own Validate error",
+			input:       "required: r\nnonemptystring:\nnonzero: 1\n",
+			wantErr:     true,
+			contains:    []string{"non-empty string is required"},
+			notContains: []string{"no value"},
+		},
+		{
+			name:        "nonzero field left to its own Validate error",
+			input:       "required: r\nnonemptystring: s\nnonzero:\n",
+			wantErr:     true,
+			contains:    []string{"non-zero value is required"},
+			notContains: []string{"no value"},
+		},
+		{
+			name:  "scalar field not reported",
+			input: "required: r\nnonemptystring: s\nnonzero: 1\nscalar:\n",
+			seed: func(cfg *nullArmsConfig) {
+				cfg.Scalar = "preserved"
+			},
+			check: func(t *testing.T, cfg *nullArmsConfig) {
+				require.Equal(t, "preserved", cfg.Scalar)
+			},
+		},
+		{
+			name:  "slice field not reported",
+			input: "required: r\nnonemptystring: s\nnonzero: 1\nslice:\n",
+		},
+		{
+			name:  "yaml.Node field not reported",
+			input: "required: r\nnonemptystring: s\nnonzero: 1\nnode:\n",
+		},
+		{
+			name:  "pointer to struct not reported",
+			input: "required: r\nnonemptystring: s\nnonzero: 1\nptrstruct:\n",
+		},
+		{
+			name:  "pointer to Optional[T] not reported",
+			input: "required: r\nnonemptystring: s\nnonzero: 1\nptroptional:\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg nullArmsConfig
+			if tc.seed != nil {
+				tc.seed(&cfg)
+			}
+			err := xcfg.Decode([]byte(tc.input), &cfg, xcfg.WithKnownFields())
+			if !tc.wantErr {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, s := range tc.contains {
+					require.Contains(t, err.Error(), s)
+				}
+				for _, s := range tc.notContains {
+					require.NotContains(t, err.Error(), s)
+				}
+			}
+			if tc.check != nil {
+				tc.check(t, &cfg)
+			}
+		})
+	}
+}
+
+// Test_Decode_EmptyMappingValue_NoNullError asserts that an explicit empty mapping is not treated as null.
+func Test_Decode_EmptyMappingValue_NoNullError(t *testing.T) {
+	var cfg nullArmsConfig
+	err := xcfg.Decode([]byte("required: r\nnonemptystring: s\nnonzero: 1\noptional: {}\n"), &cfg)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Optional.Unwrap())
+}
+
+type textUnmarshalerConfig struct {
+	Addr netip.Addr `yaml:"addr"`
+}
+
+// Test_Decode_NullTextUnmarshalerFieldPreservesSeededValue asserts a null against a field decoding through encoding.TextUnmarshaler is left silent, keeping its seeded value.
+func Test_Decode_NullTextUnmarshalerFieldPreservesSeededValue(t *testing.T) {
+	seeded := netip.MustParseAddr("127.0.0.1")
+	cfg := textUnmarshalerConfig{Addr: seeded}
+	err := xcfg.Decode([]byte("addr:\n"), &cfg, xcfg.WithKnownFields())
+	require.NoError(t, err)
+	require.Equal(t, seeded, cfg.Addr)
+}
+
+type optionalTextUnmarshalerConfig struct {
+	Addr xcfg.Optional[netip.Addr] `yaml:"addr"`
+}
+
+// Test_Decode_NullOptionalTextUnmarshalerFieldNotReported asserts the same silence holds through Optional[T].
+func Test_Decode_NullOptionalTextUnmarshalerFieldNotReported(t *testing.T) {
+	var cfg optionalTextUnmarshalerConfig
+	err := xcfg.Decode([]byte("addr:\n"), &cfg, xcfg.WithKnownFields())
+	require.NoError(t, err)
+}
+
+// Test_Decode_ExplicitMergeTagOnOrdinaryKeyNullReported asserts a key carrying an explicit "!!merge" tag but a non-"<<" name is an ordinary key, so a null there is still reported rather than silently swallowed as a merge source.
+func Test_Decode_ExplicitMergeTagOnOrdinaryKeyNullReported(t *testing.T) {
+	input := "modules:\n  !!merge a:\n"
+	var cfg mapMergeConfig
+	err := xcfg.Decode([]byte(input), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"modules.a"`)
+	require.Contains(t, err.Error(), "has no value")
+}
+
+// Test_Decode_QuotedMergeKeyStaysOrdinaryKey asserts a quoted "<<" key stays an ordinary map entry rather than being classified as a merge, so its aliased value is checked as an entry body and not spread into the receiving mapping.
+func Test_Decode_QuotedMergeKeyStaysOrdinaryKey(t *testing.T) {
+	input := "base: &b\n  addr: x\n  bogus: y\nmodules:\n  \"<<\": *b\n"
+	err := xcfg.Decode([]byte(input), new(mapMergeConfig), xcfg.WithKnownFields())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"modules.<<.bogus"`)
 }

--- a/common/go/xcfg/load.go
+++ b/common/go/xcfg/load.go
@@ -81,18 +81,28 @@ func LoadConfig[T any](path string, options ...Option) (*T, error) {
 
 // Decode deserializes YAML data into dst and then recursively validates all
 // fields that implement "validatable".
+// It also rejects a key present with a null value, whether or not WithKnownFields is set.
 func Decode(buf []byte, dst any, options ...Option) error {
 	opts := newOptions()
 	for _, o := range options {
 		o(opts)
 	}
 
+	f, err := walkDocument(buf, reflect.TypeOf(dst))
+	if err != nil {
+		return err
+	}
 	if opts.KnownFields {
-		if err := checkKnownKeys(buf, reflect.TypeOf(dst)); err != nil {
+		if err := unknownKeysError(f.Unknown); err != nil {
 			return err
 		}
+	}
+	if err := nullValuesError(f.Nulls); err != nil {
+		return err
+	}
 
-		// The checkKnownKeys helper runs first so an unknown key always reports
+	if opts.KnownFields {
+		// The walk above runs first so an unknown key always reports
 		// through its operator-facing message rather than yaml.v3's own. This decode
 		// is what actually populates dst.
 		dec := yaml.NewDecoder(bytes.NewReader(buf))

--- a/controlplane/bundle/cfg_test.go
+++ b/controlplane/bundle/cfg_test.go
@@ -70,3 +70,23 @@ func Test_NewBundle_ConfiguredModuleWithBadPath_FailsNamingModule(t *testing.T) 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "decap module")
 }
+
+// Test_Decode_NullModuleBlock_Rejected asserts that a null module block is rejected naming the module.
+func Test_Decode_NullModuleBlock_Rejected(t *testing.T) {
+	var cfg struct {
+		Modules bundle.ModulesConfig `yaml:"modules"`
+	}
+	err := xcfg.Decode([]byte("modules:\n  route:\n"), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "modules.route")
+}
+
+// Test_Decode_NullDeviceBlock_Rejected asserts that a null device block is rejected naming the device.
+func Test_Decode_NullDeviceBlock_Rejected(t *testing.T) {
+	var cfg struct {
+		Devices bundle.DevicesConfig `yaml:"devices"`
+	}
+	err := xcfg.Decode([]byte("devices:\n  plain:\n"), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "devices.plain")
+}

--- a/controlplane/yncp/cfg_test.go
+++ b/controlplane/yncp/cfg_test.go
@@ -84,6 +84,22 @@ func Test_ExplicitNullGateway_FailsValidation(t *testing.T) {
 	}
 }
 
+// Test_NullTopLevelModules_FailsValidation asserts that a null top-level "modules:" block is rejected naming modules and its line.
+func Test_NullTopLevelModules_FailsValidation(t *testing.T) {
+	cfg := yncp.DefaultConfig()
+	err := xcfg.Decode([]byte("gateway:\n  instance_id: 0\nmodules:\n"), cfg)
+	require.Error(t, err)
+	require.Equal(t, `key "modules" at line 3 has no value; give it a body or remove the key`, err.Error())
+}
+
+// Test_NullTopLevelDevices_FailsValidation asserts that a null top-level "devices:" block is rejected naming devices and its line.
+func Test_NullTopLevelDevices_FailsValidation(t *testing.T) {
+	cfg := yncp.DefaultConfig()
+	err := xcfg.Decode([]byte("gateway:\n  instance_id: 0\ndevices:\n"), cfg)
+	require.Error(t, err)
+	require.Equal(t, `key "devices" at line 3 has no value; give it a body or remove the key`, err.Error())
+}
+
 // Test_ModuleBlock_StrayNestedKey_RejectedByKnownFields asserts that a key
 // nested inside a module's own block, not just at the document's top level,
 // is rejected when loading through the director's WithKnownFields path.


### PR DESCRIPTION
A module key written with no value — `route:` with its body commented out — decoded identically to the key being absent from the document, so the module was never started and the only trace was an informational log line. The same collapse applied to a null top-level `modules:` or `devices:` block, which started a control plane with no modules at all and no error. This is the adjacent half of the gap #1918 closed for a genuinely absent key.

- The rejection runs during the walk over the parsed document, not inside the configuration wrappers, because the YAML library returns before consulting a type's own decoding when the node is null — so no wrapper ever gets the chance to notice, and the distinction is unrecoverable at that level. It applies to every caller of the decoder, not only to the ones that asked for unknown-key checking.
- The rule is expressed as the complement of the walk's existing stop conditions rather than as a list of known types, so a wrapper added later is classified correctly without being enumerated here. A wrapper is classified by the type it decodes into, which leaves an optional scalar exactly as silent as a plain one.
- Optional blocks, plain nested blocks and maps are rejected, naming the dotted path and the line, and telling the operator to give the key a body or remove it. An absent key stays silent, and an explicit empty mapping still reaches the block's own validation, so neither existing spelling changes meaning.
- Wrappers that carry their own decoding keep reporting through their own messages, so a required field left empty still says it must be set explicitly rather than being reported here.
- Pointer-typed blocks are deliberately excluded, which keeps the gateway block reporting through its own validation and leaves that message and its test untouched.
- Rejecting a null plain nested block is a deliberate scope choice rather than a consequence: at that position a null preserves defaults and so erases nothing in general, but the top-level modules block is exactly such a position and every field under it is optional, so there it does erase.
- The walk follows the YAML library's own merge semantics rather than approximating them, because a divergence either rejects a document that decodes or stays silent about one that erases a block. A merge key is a merge wherever it appears, including into a map, and its content is checked against the receiving mapping rather than against a field named after the merge key. A mapping's own keys are matched before anything it merges, at every nesting depth, so a key the receiving mapping or an earlier source already binds is never reported out of a source the library discards. A mapping that repeats the merge key cannot decode at all, so which of the two the walk would have applied is unobservable and left untested.
- A key written as an alias is named by the value it resolves to rather than by its anchor, which is what the library decodes it as. The two existing alias tests anchored a name identical to the value it resolved to and so could not tell the two apart; renaming the anchor gives them that power, and the fixture note that recorded the old behaviour as a constraint is gone.
- A null merge value is left to the YAML library's own merge error rather than being reported as a missing key, and a null reached through an alias is reported at the alias site rather than at the anchor.

Closes #1947.
