### PR TITLE
refactor(decap): carry prefixes as structured networks over the wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,6 +3217,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
 ]
 
 [[package]]

--- a/modules/decap/cli/Cargo.toml
+++ b/modules/decap/cli/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
+commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 netip = "0.3"
 bitmap = { path = "../../../common/rust/bitmap", version = "0.1" }
 log = "0.4"

--- a/modules/decap/cli/build.rs
+++ b/modules/decap/cli/build.rs
@@ -6,8 +6,9 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
+        .extern_path(".common.commonpb.v1", "::commonpb::pb")
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["decappb/v1/decap.proto"], &["../controlplane"])?;
+        .compile_protos(&["decappb/v1/decap.proto"], &["../controlplane", "../../.."])?;
 
     Ok(())
 }

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -177,7 +177,7 @@ impl DecapService {
     pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Error> {
         let request = UpdateConfigRequest {
             name: cmd.config_name.clone(),
-            prefixes: cmd.prefixes.iter().map(|p| p.to_string()).collect(),
+            prefixes: cmd.prefixes.into_iter().map(Into::into).collect(),
         };
         log::trace!("update config request: {request:?}");
         let response = self

--- a/modules/decap/controlplane/decappb/v1/decap.proto
+++ b/modules/decap/controlplane/decappb/v1/decap.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package modules.decap.controlplane.decappb.v1;
 
+import "common/commonpb/v1/ipnetwork.proto";
+
 option go_package = "github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1;decappb";
 
 // DecapService is a service for decapsulation module.
@@ -26,12 +28,14 @@ message ListConfigsResponse { repeated string configs = 1; }
 message ShowConfigRequest { string name = 1; }
 
 // ShowConfigResponse contains the configuration details of the decap module.
-message ShowConfigResponse { repeated string prefixes = 1; }
+message ShowConfigResponse {
+  repeated common.commonpb.v1.ContiguousIPNetwork prefixes = 1;
+}
 
 // UpdateConfigRequest carries the full desired prefix set for the named config.
 message UpdateConfigRequest {
   string name = 1;
-  repeated string prefixes = 2;
+  repeated common.commonpb.v1.ContiguousIPNetwork prefixes = 2;
 }
 
 // UpdateConfigResponse is the response to an UpdateConfig call.

--- a/modules/decap/controlplane/service.go
+++ b/modules/decap/controlplane/service.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/xnetip"
 	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
@@ -95,9 +96,16 @@ func (m *DecapService) ShowConfig(
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
 
-	prefixes := make([]string, 0, len(entry.Prefixes))
+	prefixes := make([]*commonpb.ContiguousIPNetwork, 0, len(entry.Prefixes))
 	for _, p := range entry.Prefixes {
-		prefixes = append(prefixes, p.String())
+		network, err := commonpb.NewContiguousIPNetworkFromPrefix(p)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal,
+				"failed to convert prefix %q: %v", p, err,
+			)
+		}
+		prefixes = append(prefixes, network)
 	}
 
 	return &decappb.ShowConfigResponse{Prefixes: prefixes}, nil
@@ -115,14 +123,15 @@ func (m *DecapService) UpdateConfig(
 
 	prefixes := make([]netip.Prefix, 0, len(req.GetPrefixes()))
 	for _, p := range req.GetPrefixes() {
-		prefix, err := netip.ParsePrefix(p)
+		prefix, err := p.ToPrefix()
 		if err != nil {
 			return nil, status.Errorf(
 				codes.InvalidArgument,
-				"failed to parse prefix %q: %v", p, err,
+				"failed to convert prefix (addr=%x, prefix_len=%d): %v",
+				p.GetAddr().GetAddr(), p.GetPrefixLen(), err,
 			)
 		}
-		prefixes = append(prefixes, prefix.Masked())
+		prefixes = append(prefixes, prefix)
 	}
 
 	prefixes = slices.Compact(

--- a/modules/decap/controlplane/service_test.go
+++ b/modules/decap/controlplane/service_test.go
@@ -14,8 +14,31 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/google/go-cmp/cmp"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
+
+func mustNetworks(t *testing.T, cidrs ...string) []*commonpb.ContiguousIPNetwork {
+	t.Helper()
+	networks := make([]*commonpb.ContiguousIPNetwork, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		network, err := commonpb.ParseContiguousIPNetwork(cidr)
+		require.NoError(t, err)
+		networks = append(networks, network)
+	}
+	return networks
+}
+
+func networkStrings(t *testing.T, networks []*commonpb.ContiguousIPNetwork) []string {
+	t.Helper()
+	strs := make([]string, 0, len(networks))
+	for _, network := range networks {
+		prefix, err := network.ToPrefix()
+		require.NoError(t, err)
+		strs = append(strs, prefix.String())
+	}
+	return strs
+}
 
 var errInjectedBackend = errors.New("injected backend failure")
 
@@ -58,7 +81,7 @@ func Test_DecapService_UpdateAndShow(t *testing.T) {
 
 	resp, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
 		Name:     "decap0",
-		Prefixes: []string{prefix},
+		Prefixes: mustNetworks(t, prefix),
 	})
 	require.NotNil(t, resp)
 	require.NoError(t, err)
@@ -66,7 +89,9 @@ func Test_DecapService_UpdateAndShow(t *testing.T) {
 	show, err := svc.ShowConfig(t.Context(), &decappb.ShowConfigRequest{Name: "decap0"})
 	require.NotNil(t, show)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]string{prefix}, show.Prefixes))
+	require.Len(t, show.Prefixes, 1)
+	require.Equal(t, []byte{10, 0, 0, 0}, show.Prefixes[0].GetAddr().GetAddr())
+	require.Equal(t, uint32(24), show.Prefixes[0].GetPrefixLen())
 }
 
 func Test_DecapService_UpdateFullyReplaces(t *testing.T) {
@@ -74,20 +99,20 @@ func Test_DecapService_UpdateFullyReplaces(t *testing.T) {
 
 	_, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
 		Name:     "decap0",
-		Prefixes: []string{"10.0.0.0/24", "10.0.1.0/24"},
+		Prefixes: mustNetworks(t, "10.0.0.0/24", "10.0.1.0/24"),
 	})
 	require.NoError(t, err)
 
 	_, err = svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
 		Name:     "decap0",
-		Prefixes: []string{"192.168.0.0/16"},
+		Prefixes: mustNetworks(t, "192.168.0.0/16"),
 	})
 	require.NoError(t, err)
 
 	show, err := svc.ShowConfig(t.Context(), &decappb.ShowConfigRequest{Name: "decap0"})
 	require.NotNil(t, show)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]string{"192.168.0.0/16"}, show.Prefixes))
+	require.Empty(t, cmp.Diff([]string{"192.168.0.0/16"}, networkStrings(t, show.Prefixes)))
 }
 
 func Test_DecapService_ListUpdateList(t *testing.T) {
@@ -101,7 +126,7 @@ func Test_DecapService_ListUpdateList(t *testing.T) {
 
 	_, err = svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
 		Name:     "decap0",
-		Prefixes: []string{"10.0.0.0/24"},
+		Prefixes: mustNetworks(t, "10.0.0.0/24"),
 	})
 	require.NoError(t, err)
 
@@ -118,7 +143,7 @@ func Test_DecapService_EmptyConfigName(t *testing.T) {
 	t.Run("UpdateConfig", func(t *testing.T) {
 		resp, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
 			Name:     "",
-			Prefixes: []string{"10.0.0.0/24"},
+			Prefixes: mustNetworks(t, "10.0.0.0/24"),
 		})
 		require.Nil(t, resp)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -132,14 +157,42 @@ func Test_DecapService_EmptyConfigName(t *testing.T) {
 }
 
 func Test_DecapService_InvalidPrefix(t *testing.T) {
-	svc := newTestService(t)
+	tests := []struct {
+		name    string
+		network *commonpb.ContiguousIPNetwork
+	}{
+		{
+			name: "address length is neither 4 nor 16 bytes",
+			network: &commonpb.ContiguousIPNetwork{
+				Addr:      &commonpb.IPAddress{Addr: []byte{10, 0, 0}},
+				PrefixLen: 24,
+			},
+		},
+		{
+			name: "prefix length exceeds address bit length",
+			network: &commonpb.ContiguousIPNetwork{
+				Addr:      &commonpb.IPAddress{Addr: []byte{10, 0, 0, 0}},
+				PrefixLen: 33,
+			},
+		},
+	}
 
-	resp, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
-		Name:     "decap0",
-		Prefixes: []string{"not-a-prefix"},
-	})
-	require.Nil(t, resp)
-	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newTestService(t)
+
+			resp, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
+				Name:     "decap0",
+				Prefixes: []*commonpb.ContiguousIPNetwork{tt.network},
+			})
+			require.Nil(t, resp)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+			list, err := svc.ListConfigs(t.Context(), &decappb.ListConfigsRequest{})
+			require.NoError(t, err)
+			assert.Empty(t, list.Configs)
+		})
+	}
 }
 
 func Test_DecapService_UpdateFailureAtomic(t *testing.T) {
@@ -149,13 +202,13 @@ func Test_DecapService_UpdateFailureAtomic(t *testing.T) {
 
 	_, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
 		Name:     name,
-		Prefixes: []string{"10.0.0.0/24"},
+		Prefixes: mustNetworks(t, "10.0.0.0/24"),
 	})
 	require.NoError(t, err)
 
 	_, err = svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
 		Name:     name,
-		Prefixes: []string{"10.0.1.0/24"},
+		Prefixes: mustNetworks(t, "10.0.1.0/24"),
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.Internal, status.Code(err))
@@ -163,7 +216,7 @@ func Test_DecapService_UpdateFailureAtomic(t *testing.T) {
 	show, err := svc.ShowConfig(ctx, &decappb.ShowConfigRequest{Name: name})
 	require.NotNil(t, show)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]string{"10.0.0.0/24"}, show.Prefixes))
+	require.Empty(t, cmp.Diff([]string{"10.0.0.0/24"}, networkStrings(t, show.Prefixes)))
 }
 
 func Test_DecapService_DeduplicatePrefixes(t *testing.T) {
@@ -172,14 +225,14 @@ func Test_DecapService_DeduplicatePrefixes(t *testing.T) {
 
 	_, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
 		Name:     "decap0",
-		Prefixes: []string{prefix, prefix, prefix},
+		Prefixes: mustNetworks(t, prefix, prefix, prefix),
 	})
 	require.NoError(t, err)
 
 	show, err := svc.ShowConfig(t.Context(), &decappb.ShowConfigRequest{Name: "decap0"})
 	require.NotNil(t, show)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]string{prefix}, show.Prefixes))
+	require.Empty(t, cmp.Diff([]string{prefix}, networkStrings(t, show.Prefixes)))
 }
 
 func Test_DecapService_ConcurrentAccess(t *testing.T) {
@@ -187,6 +240,8 @@ func Test_DecapService_ConcurrentAccess(t *testing.T) {
 
 	const goroutines = 10
 	const iterations = 100
+
+	networks := mustNetworks(t, "10.0.0.0/24")
 
 	g, ctx := errgroup.WithContext(t.Context())
 
@@ -196,7 +251,7 @@ func Test_DecapService_ConcurrentAccess(t *testing.T) {
 				name := fmt.Sprintf("config-%d-%d", idx, jdx)
 				_, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
 					Name:     name,
-					Prefixes: []string{"10.0.0.0/24"},
+					Prefixes: networks,
 				})
 				if err != nil {
 					return err

--- a/modules/decap/web/usePrefixDraft.test.ts
+++ b/modules/decap/web/usePrefixDraft.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+const { showConfig, updateConfig } = vi.hoisted(() => ({
+    showConfig: vi.fn(),
+    updateConfig: vi.fn(),
+}));
+
+vi.mock('@yanet/core/api', async () => {
+    const actual = await vi.importActual<typeof import('@yanet/core/api')>('@yanet/core/api');
+    return {
+        ...actual,
+        inventoryConfigNames: vi.fn(async () => ['decap0']),
+        API: {
+            ...actual.API,
+            decap: { showConfig, updateConfig },
+        },
+    };
+});
+
+import { usePrefixDraft } from './usePrefixDraft';
+
+describe('usePrefixDraft load', () => {
+    beforeEach(() => {
+        showConfig.mockReset();
+        updateConfig.mockReset();
+        updateConfig.mockResolvedValue({});
+    });
+
+    it('produces one row per wire element and keeps the prefix string as row identity', async () => {
+        showConfig.mockResolvedValue({
+            prefixes: [{ network: '10.0.0.0/8' }, { network: '2001:db8::/32' }],
+        });
+
+        const { result } = renderHook(() => usePrefixDraft());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        const rows = result.current.draftRows('decap0');
+        expect(rows).toHaveLength(2);
+        expect(rows.map((r) => r.prefix)).toEqual(['10.0.0.0/8', '2001:db8::/32']);
+        expect(rows.map((r) => r.id)).toEqual(['10.0.0.0/8', '2001:db8::/32']);
+    });
+
+    it('yields an empty row list when prefixes is omitted from the response', async () => {
+        showConfig.mockResolvedValue({});
+
+        const { result } = renderHook(() => usePrefixDraft());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        expect(result.current.loadFailed).toBe(false);
+        expect(result.current.draftRows('decap0')).toEqual([]);
+    });
+});
+
+describe('usePrefixDraft commitConfig', () => {
+    beforeEach(() => {
+        showConfig.mockReset();
+        updateConfig.mockReset();
+        showConfig.mockResolvedValue({ prefixes: [] });
+        updateConfig.mockResolvedValue({});
+    });
+
+    it('sends exactly one object-shaped wire element per draft row, in order, dropping none', async () => {
+        const { result } = renderHook(() => usePrefixDraft());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        act(() => {
+            result.current.dispatchDraft({
+                type: 'ADD_ROW', configName: 'decap0', row: { id: 'row-1', prefix: '10.0.0.0/8' },
+            });
+        });
+        act(() => {
+            result.current.dispatchDraft({
+                type: 'ADD_ROW', configName: 'decap0', row: { id: 'row-2', prefix: '' },
+            });
+        });
+        act(() => {
+            result.current.dispatchDraft({
+                type: 'ADD_ROW', configName: 'decap0', row: { id: 'row-3', prefix: 'not-a-cidr' },
+            });
+        });
+
+        await act(async () => {
+            await result.current.commitConfig('decap0');
+        });
+
+        expect(updateConfig).toHaveBeenCalledTimes(1);
+        const sent = updateConfig.mock.calls[0][0];
+        expect(sent.name).toBe('decap0');
+        expect(sent.prefixes).toEqual([
+            { network: '10.0.0.0/8' },
+            { network: '' },
+            { network: 'not-a-cidr' },
+        ]);
+    });
+});

--- a/modules/decap/web/usePrefixDraft.ts
+++ b/modules/decap/web/usePrefixDraft.ts
@@ -21,7 +21,10 @@ export const usePrefixDraft = (): UsePrefixDraftResult => {
         const configNames = await inventoryConfigNames('decap');
         return loadKnownConfigs(configNames, async (name): Promise<{ name: string; rows: PrefixRowItem[] }> => {
             const resp = await API.decap.showConfig({ name });
-            const rows: PrefixRowItem[] = (resp.prefixes ?? []).map((p) => ({ id: p, prefix: p }));
+            const rows: PrefixRowItem[] = (resp.prefixes ?? []).map((net) => {
+                const p = net.network ?? '';
+                return { id: p, prefix: p };
+            });
             return { name, rows };
         }, { onDropped: warnConfigsUnknown('decap-configs-unknown', 'decap') });
     }, []);
@@ -30,7 +33,8 @@ export const usePrefixDraft = (): UsePrefixDraftResult => {
         configName: string,
         draftRows: PrefixRowItem[],
     ): Promise<void> => {
-        await API.decap.updateConfig({ name: configName, prefixes: draftRows.map((r) => r.prefix) });
+        const prefixes = draftRows.map((r) => ({ network: r.prefix }));
+        await API.decap.updateConfig({ name: configName, prefixes });
     }, []);
 
     return useDraft<PrefixRowItem>({

--- a/operators/decap/internal/operator/prefixes.go
+++ b/operators/decap/internal/operator/prefixes.go
@@ -2,10 +2,11 @@ package operator
 
 import (
 	"fmt"
-	"net/netip"
 	"os"
 
 	"gopkg.in/yaml.v3"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 )
 
 // yamlPrefixFile is the top-level YAML structure for a decap prefixes file.
@@ -19,9 +20,9 @@ type yamlPrefixFile struct {
 //	  - 10.0.0.0/8
 //	  - 2000::/3
 //
-// Each entry is parsed with netip.ParsePrefix to fail fast on malformed
-// input. The returned slice contains canonical Masked().String() forms.
-func LoadDecapPrefixes(path string) ([]string, error) {
+// Each entry is parsed and masked with commonpb.ParseContiguousIPNetwork to
+// fail fast on malformed input.
+func LoadDecapPrefixes(path string) ([]*commonpb.ContiguousIPNetwork, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read prefixes file %q: %w", path, err)
@@ -32,13 +33,13 @@ func LoadDecapPrefixes(path string) ([]string, error) {
 		return nil, fmt.Errorf("failed to parse prefixes file %q: %w", path, err)
 	}
 
-	out := make([]string, 0, len(file.Prefixes))
+	out := make([]*commonpb.ContiguousIPNetwork, 0, len(file.Prefixes))
 	for idx, s := range file.Prefixes {
-		prefix, err := netip.ParsePrefix(s)
+		network, err := commonpb.ParseContiguousIPNetwork(s)
 		if err != nil {
-			return nil, fmt.Errorf("prefixes[%d]: failed to parse prefix %q: %w", idx, s, err)
+			return nil, fmt.Errorf("prefixes[%d]: %w", idx, err)
 		}
-		out = append(out, prefix.Masked().String())
+		out = append(out, network)
 	}
 	return out, nil
 }

--- a/operators/decap/internal/operator/source.go
+++ b/operators/decap/internal/operator/source.go
@@ -3,13 +3,14 @@ package operator
 import (
 	"go.uber.org/zap"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/operator"
 )
 
 // ModuleConfig holds the desired prefix set for one decap module config.
 type ModuleConfig struct {
 	Name     string
-	Prefixes []string
+	Prefixes []*commonpb.ContiguousIPNetwork
 }
 
 // State is the desired payload pushed by each reconcile pass.

--- a/web/src/core/api/decap.ts
+++ b/web/src/core/api/decap.ts
@@ -1,16 +1,17 @@
 import { createService, type CallOptions } from './client';
+import type { ContiguousIPNetworkWire } from '../utils/netip';
 
 export interface ShowConfigRequest {
     name?: string;
 }
 
 export interface ShowConfigResponse {
-    prefixes?: string[];
+    prefixes?: ContiguousIPNetworkWire[];
 }
 
 export interface DecapUpdateConfigRequest {
     name?: string;
-    prefixes?: string[];
+    prefixes?: ContiguousIPNetworkWire[];
 }
 
 export interface DecapUpdateConfigResponse { }

--- a/web/src/core/utils/netip.ts
+++ b/web/src/core/utils/netip.ts
@@ -750,6 +750,11 @@ export type IPAddressWire = {
     addr?: string | number[] | Uint8Array;
 };
 
+// Wire-format shape of commonpb.ContiguousIPNetwork from the gRPC-JSON gateway: {network: "10.0.0.0/8"}.
+export type ContiguousIPNetworkWire = {
+    network?: string;
+};
+
 // Wire-format shape of an IP range as returned by the gRPC-JSON gateway.
 // Both endpoints are plain IP strings — Go's IPRange.MarshalJSON flattens
 // the nested IPAddress shape into top-level strings rather than nesting


### PR DESCRIPTION
The decap prefix fields now carry a structured network message instead of a plain CIDR string, so a prefix is parsed and validated once at the edge rather than reparsed and revalidated on every hop.

This is a deliberate coordinated wire break: both fields keep their numbers and change type in place, with no deprecated string kept alongside. Deployed decap clients break, which was accepted rather than avoided.

The break fails loudly in both deployment directions. A CIDR string's leading byte can never be a valid field tag for the new message, so an old client against a new server, and the reverse, fail at unmarshal rather than silently misreading a prefix.

The breaking-change check fails here by design and is waived for this pull request alone. No exclusion is added to the repository configuration, so decap keeps its breaking-change protection on every later pull request.

This knowingly deviates from the documented protobuf compatibility policy, which freezes this surface. The deviation is limited to this one change, and nothing in the tree encodes it.

The control plane, its operator, the command-line client and the web page move together. The operator's on-disk prefix file format is unchanged, and the command-line client's human and machine-readable output is byte-identical for valid input.

Closes #1950.