### PR TITLE
fix(operator): reject a null server block instead of crashing at startup

### DIFF
--- a/common/go/operator/options.go
+++ b/common/go/operator/options.go
@@ -10,7 +10,7 @@ import (
 )
 
 type grpcServerOption struct {
-	Config   *GRPCServerConfig
+	Config   GRPCServerConfig
 	Services []ServiceRegistrar
 }
 
@@ -86,7 +86,7 @@ func WithGateways(register RegisterConfig, gateways ...GatewayConfig) Option {
 // metrics or operator APIs without director registration.
 //
 // When this option is not supplied, the operator does not bind a listener.
-func WithGRPCServer(cfg *GRPCServerConfig, services ...ServiceRegistrar) Option {
+func WithGRPCServer(cfg GRPCServerConfig, services ...ServiceRegistrar) Option {
 	return func(o *options) {
 		o.GRPCServer = &grpcServerOption{
 			Config:   cfg,

--- a/common/go/operator/server.go
+++ b/common/go/operator/server.go
@@ -32,7 +32,6 @@ func WithGRPCLog(log *zap.Logger) GRPCServerOption {
 
 // GRPCServer wraps a grpc.Server with the operator's service set.
 type GRPCServer struct {
-	cfg    *GRPCServerConfig
 	server *grpc.Server
 	log    *zap.Logger
 }
@@ -41,7 +40,7 @@ type GRPCServer struct {
 // registrars applied to a fresh grpc.Server and returns registered
 // service names.
 func NewGRPCServer(
-	cfg *GRPCServerConfig,
+	cfg GRPCServerConfig,
 	services []ServiceRegistrar,
 	options ...GRPCServerOption,
 ) (*GRPCServer, []string) {
@@ -57,7 +56,6 @@ func NewGRPCServer(
 	}
 
 	return &GRPCServer{
-		cfg:    cfg,
 		server: server,
 		log:    opts.Log,
 	}, serviceNames

--- a/common/go/operator/server_test.go
+++ b/common/go/operator/server_test.go
@@ -48,7 +48,7 @@ func TestGRPCServer_Run_ShutsDownWithOpenStream(t *testing.T) {
 		return ynpb.ReadinessService_ServiceDesc.ServiceName
 	}
 
-	server, serviceNames := NewGRPCServer(&GRPCServerConfig{}, []ServiceRegistrar{registrar}, WithGRPCLog(zap.NewNop()))
+	server, serviceNames := NewGRPCServer(GRPCServerConfig{}, []ServiceRegistrar{registrar}, WithGRPCLog(zap.NewNop()))
 	require.Equal(t, []string{ynpb.ReadinessService_ServiceDesc.ServiceName}, serviceNames)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/operators/decap/internal/operator/cfg.go
+++ b/operators/decap/internal/operator/cfg.go
@@ -14,12 +14,12 @@ import (
 
 // Config is the top-level YAML configuration for yanet-decap-operator.
 type Config struct {
-	Logging   logging.Config             `yaml:"logging"`
-	Server    *operator.GRPCServerConfig `yaml:"server"`
-	Gateways  []operator.GatewayConfig   `yaml:"gateways"`
-	Register  operator.RegisterConfig    `yaml:"register"`
-	Reconcile operator.ReconcileConfig   `yaml:"reconcile"`
-	Functions []FunctionConfig           `yaml:"functions"`
+	Logging   logging.Config            `yaml:"logging"`
+	Server    operator.GRPCServerConfig `yaml:"server"`
+	Gateways  []operator.GatewayConfig  `yaml:"gateways"`
+	Register  operator.RegisterConfig   `yaml:"register"`
+	Reconcile operator.ReconcileConfig  `yaml:"reconcile"`
+	Functions []FunctionConfig          `yaml:"functions"`
 }
 
 // Default resets the config to built-in defaults.
@@ -75,7 +75,7 @@ func DefaultConfig() *Config {
 		Logging: logging.Config{
 			Level: zapcore.InfoLevel,
 		},
-		Server: &operator.GRPCServerConfig{
+		Server: operator.GRPCServerConfig{
 			Endpoint: xcfg.MustNonEmptyString("[::1]:50004"),
 		},
 		Reconcile: operator.ReconcileConfig{

--- a/operators/forward/internal/operator/cfg.go
+++ b/operators/forward/internal/operator/cfg.go
@@ -13,12 +13,12 @@ import (
 
 // Config is the top-level YAML configuration for yanet-forward-operator.
 type Config struct {
-	Logging   logging.Config             `yaml:"logging"`
-	Server    *operator.GRPCServerConfig `yaml:"server"`
-	Gateways  []operator.GatewayConfig   `yaml:"gateways"`
-	Register  operator.RegisterConfig    `yaml:"register"`
-	Reconcile operator.ReconcileConfig   `yaml:"reconcile"`
-	Functions []FunctionConfig           `yaml:"functions"`
+	Logging   logging.Config            `yaml:"logging"`
+	Server    operator.GRPCServerConfig `yaml:"server"`
+	Gateways  []operator.GatewayConfig  `yaml:"gateways"`
+	Register  operator.RegisterConfig   `yaml:"register"`
+	Reconcile operator.ReconcileConfig  `yaml:"reconcile"`
+	Functions []FunctionConfig          `yaml:"functions"`
 }
 
 // Default resets the config to built-in defaults.
@@ -74,7 +74,7 @@ func DefaultConfig() *Config {
 		Logging: logging.Config{
 			Level: zapcore.InfoLevel,
 		},
-		Server: &operator.GRPCServerConfig{
+		Server: operator.GRPCServerConfig{
 			Endpoint: xcfg.MustNonEmptyString("[::1]:50003"),
 		},
 		Reconcile: operator.ReconcileConfig{

--- a/operators/pipeline/internal/operator/cfg.go
+++ b/operators/pipeline/internal/operator/cfg.go
@@ -12,12 +12,12 @@ import (
 
 // Config is the top-level YAML configuration for yanet-pipeline-operator.
 type Config struct {
-	Logging   logging.Config             `yaml:"logging"`
-	Server    *operator.GRPCServerConfig `yaml:"server"`
-	Gateways  []operator.GatewayConfig   `yaml:"gateways"`
-	Register  operator.RegisterConfig    `yaml:"register"`
-	Reconcile operator.ReconcileConfig   `yaml:"reconcile"`
-	Stages    []StageConfig              `yaml:"stages"`
+	Logging   logging.Config            `yaml:"logging"`
+	Server    operator.GRPCServerConfig `yaml:"server"`
+	Gateways  []operator.GatewayConfig  `yaml:"gateways"`
+	Register  operator.RegisterConfig   `yaml:"register"`
+	Reconcile operator.ReconcileConfig  `yaml:"reconcile"`
+	Stages    []StageConfig             `yaml:"stages"`
 }
 
 func (m *Config) Default() {
@@ -44,7 +44,7 @@ func DefaultConfig() *Config {
 		Logging: logging.Config{
 			Level: zapcore.InfoLevel,
 		},
-		Server: &operator.GRPCServerConfig{
+		Server: operator.GRPCServerConfig{
 			Endpoint: xcfg.MustNonEmptyString("localhost:50001"),
 		},
 		Reconcile: operator.ReconcileConfig{

--- a/operators/route/internal/operator/cfg.go
+++ b/operators/route/internal/operator/cfg.go
@@ -35,12 +35,12 @@ const (
 
 // Config is the top-level YAML configuration for yanet-route-operator.
 type Config struct {
-	Logging   logging.Config             `yaml:"logging"`
-	Server    *operator.GRPCServerConfig `yaml:"server"`
-	Gateways  []operator.GatewayConfig   `yaml:"gateways"`
-	Register  operator.RegisterConfig    `yaml:"register"`
-	Reconcile operator.ReconcileConfig   `yaml:"reconcile"`
-	Static    StaticConfig               `yaml:"static"`
+	Logging   logging.Config            `yaml:"logging"`
+	Server    operator.GRPCServerConfig `yaml:"server"`
+	Gateways  []operator.GatewayConfig  `yaml:"gateways"`
+	Register  operator.RegisterConfig   `yaml:"register"`
+	Reconcile operator.ReconcileConfig  `yaml:"reconcile"`
+	Static    StaticConfig              `yaml:"static"`
 	// Function is the single gateway-side network function published by
 	// this operator. Re-applied every reconcile pass — idempotent updates.
 	Function       FunctionConfig       `yaml:"function"`
@@ -113,7 +113,7 @@ func DefaultConfig() *Config {
 		Logging: logging.Config{
 			Level: zapcore.InfoLevel,
 		},
-		Server: &operator.GRPCServerConfig{
+		Server: operator.GRPCServerConfig{
 			Endpoint: xcfg.MustNonEmptyString("localhost:50002"),
 		},
 		Reconcile: operator.ReconcileConfig{


### PR DESCRIPTION
An operator configuration that cleared the `server:` block, written either as a bare `server:` key or as an explicit `server: null`, decoded into a nil pointer and wiped the default endpoint. The operator then died at startup on a nil dereference while reading that endpoint, rather than reporting a configuration error. All four operators built on `common/go/operator` shared the gap.

- Make the `server:` block a plain value instead of a pointer in `decap`, `pipeline`, `route` and `forward`. Nil stops being representable, so the dereference in `NewOperator` is unreachable, and a cleared block is caught by the null-block check the loader already runs — reported with the key and the line it sits on, no new validation code.
- Take the gRPC server configuration by value through `WithGRPCServer` and `NewGRPCServer` for the same reason: an operator that runs without a server says so by omitting the option, never by passing an empty one. `*GRPCServerConfig` no longer appears anywhere, so the guarantee lives in the type rather than in a rule callers must remember.
- Drop the write-only `cfg` field from `GRPCServer`, dead since it was added.

No tests are added: the rejection is `xcfg`'s, covered by its own tests, and the field's shape is now enforced by the compiler.

Rejected alternatives, both measured rather than argued: a nil check in each operator's `Validate()` leaves the dereference reachable for the next operator that forgets it, and `xcfg.Optional` seeds `new(T)` plus `Default()` on decode, so for a type without a `Default()` a partial `server:` block would silently discard the operator's defaults.

`WithGRPCServer` changing shape is a breaking change for any out-of-tree caller, which the `neighbours` operator in the private repo may be. It breaks at compile time, which is the right failure mode, but an adapter that passes `*cfg.Server` while keeping a pointer field would move the same nil dereference to its own call site.

`controlplane/yncp` keeps the pointer-plus-nil-check shape for its `gateway:` block; aligning it is filed as #2113.

Closes #2100.