### PR TITLE
chore(acl): remove stray include reaching into dataplane binary worker header

### DIFF
--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -11,7 +11,6 @@
 #include "dataplane/module/module.h"
 #include "dataplane/packet/packet.h"
 #include "dataplane/time/clock.h"
-#include "dataplane/worker.h"
 #include "dataplane/worker/worker.h"
 #include "fwstate/lookup.h"
 #include "fwstate/sync.h"


### PR DESCRIPTION
`modules/acl/dataplane/dataplane.c` included `"dataplane/worker.h"`, which with acl's include-directory ordering (`-I..` before `-Ilib`) resolves into the dataplane binary's root-level `dataplane/worker.h` rather than into `lib/`, exposing the binary's internal worker types and functions to a packet-processing module.

- The include was dead code: none of the symbols it declares (`struct dataplane_worker`, `dataplane_worker_init/start/stop`, the `worker_*_ctx` structs) is referenced in the file.
- The worker-family uses that remain (`dp_worker->current_time`, `worker_packet_alloc`, `worker_packet_free`) come from `lib/dataplane/config/zone.h` and `lib/dataplane/worker/worker.h`, already included on the next line.
- Verified in a worktree build: `meson setup build` clean, the acl object `modules/acl/dataplane/libacl_dp.a.p/dataplane.c.o` compiles without error, and `gcc -H -fsyntax-only` with acl's exact flags no longer resolves any include under the repository root's `dataplane/`.
- Change is C-only in a dataplane static lib (`libacl_dp.a`, linked into `yanet-dataplane` only, not into CGO/Go), so the shm layout and module ABI are untouched.

Closes #2112.