### PR TITLE
fix(counters): handle a missing worker execution context in a counter read

### DIFF
--- a/lib/controlplane/agent/counters.c
+++ b/lib/controlplane/agent/counters.c
@@ -135,7 +135,9 @@ cp_counter_storage_copy_tags(const struct cp_counter_storage *storage) {
 // newly allocated memory, stashed behind the handle's opaque value array.
 //
 // The pointer array and every worker's value block live in one allocation:
-// the pointer array first, then each worker's values back to back.
+// the pointer array first, then each worker's values back to back. A
+// worker handed no storage reads back as zeros, which is what it has
+// contributed.
 //
 // The caller guarantees the per-worker storages stay alive for the
 // duration of this call.
@@ -163,6 +165,10 @@ counter_handle_copy_values(
 			continue;
 		}
 		values[w_idx] = value_blocks + w_idx * dst->size;
+		if (worker_storages[w_idx] == NULL) {
+			memset(values[w_idx], 0, dst->size * sizeof(uint64_t));
+			continue;
+		}
 		struct counter_value_handle *handle =
 			counter_get_value_handle(idx, worker_storages[w_idx]);
 		memcpy(values[w_idx],
@@ -212,7 +218,9 @@ fill_counter_handle(
 // a worker without an execution context. Every worker registry is built
 // by the same execution-context traversal, so the match order is
 // identical across workers: for match index i, every worker's array
-// names the same tag set at that index.
+// names the same tag set at that index. That alignment holds because one
+// generation builds every worker's context in a single pass; installing
+// contexts per worker would have to establish it another way.
 struct worker_counter_matches {
 	struct cp_counter_storage ***by_worker;
 	uint64_t worker_count;
@@ -313,18 +321,26 @@ counter_handle_list_build_metadata(
 	struct matched_counter **out_sources,
 	yanet_error **err
 ) {
-	// A worker set with no execution context yet (the initial generation
-	// before any install) yields an empty list.
-	if (matches->worker_count == 0 || matches->by_worker[0] == NULL) {
+	// Any worker carrying a context of this generation matches the same
+	// storages in the same order, so the first one that carries a context
+	// describes the whole list. A generation no worker carries a context
+	// of describes nothing and yields an empty list.
+	uint64_t source_worker = 0;
+	while (source_worker < matches->worker_count &&
+	       matches->by_worker[source_worker] == NULL) {
+		++source_worker;
+	}
+	if (source_worker == matches->worker_count) {
 		*out_sources = NULL;
 		return counter_handle_list_alloc(matches->worker_count, 0, err);
 	}
-	struct cp_counter_storage **matches0 = matches->by_worker[0];
+	struct cp_counter_storage **described =
+		matches->by_worker[source_worker];
 
 	size_t match_count = 0;
-	for (size_t i = 0; matches0[i] != NULL; ++i) {
+	for (size_t i = 0; described[i] != NULL; ++i) {
 		struct counter_storage *storage =
-			ADDR_OF(&matches0[i]->storage);
+			ADDR_OF(&described[i]->storage);
 		match_count += counter_registry_match_count(
 			ADDR_OF(&storage->registry), names
 		);
@@ -348,8 +364,8 @@ counter_handle_list_build_metadata(
 	}
 
 	size_t next = 0;
-	for (size_t i = 0; matches0[i] != NULL; ++i) {
-		struct cp_counter_storage *cp_storage = matches0[i];
+	for (size_t i = 0; described[i] != NULL; ++i) {
+		struct cp_counter_storage *cp_storage = described[i];
 		struct counter_storage *storage = ADDR_OF(&cp_storage->storage);
 		struct counter_registry *registry = ADDR_OF(&storage->registry);
 		struct counter *counters = ADDR_OF(&registry->names);
@@ -392,6 +408,8 @@ counter_handle_list_build_metadata(
 
 // Copy every matched counter's per-worker value snapshot into the list
 // built by the metadata pass.
+//
+// A worker the generation carries no context for contributes zeros.
 static int
 counter_handle_list_fill_values(
 	struct counter_handle_list *list,
@@ -413,6 +431,10 @@ counter_handle_list_fill_values(
 		size_t m_idx = sources[k].m_idx;
 		uint64_t r_idx = sources[k].r_idx;
 		for (uint64_t w_idx = 0; w_idx < worker_count; ++w_idx) {
+			if (matches->by_worker[w_idx] == NULL) {
+				worker_storages[w_idx] = NULL;
+				continue;
+			}
 			struct cp_counter_storage *cps =
 				matches->by_worker[w_idx][m_idx];
 			worker_storages[w_idx] = ADDR_OF(&cps->storage);

--- a/lib/controlplane/tests/counters_test.c
+++ b/lib/controlplane/tests/counters_test.c
@@ -7,6 +7,9 @@
  * fix: a value-page surface (the agent counters API snapshots
  * handle->values under cp_config_lock) and a tag-string surface (tags are
  * strdup'd instead of borrowed from the freed generation arena).
+ *
+ * GH#1926 joins them: a read against a generation whose execution context
+ * is absent on a worker must answer rather than reach into that worker.
  */
 
 #include "api/agent.h"
@@ -15,8 +18,11 @@
 #include "common/test_assert.h"
 #include "devices/plain/api/controlplane.h"
 #include "lib/controlplane/agent/agent.h"
+#include "lib/controlplane/config/cp_counter.h"
 #include "lib/controlplane/config/cp_pipeline.h"
 #include "lib/controlplane/config/zone.h"
+#include "lib/counters/counters.h"
+#include "lib/dataplane/pipeline/econtext.h"
 #include "lib/dataplane_ut/dataplane_ut.h"
 #include "lib/errors/errors.h"
 #include "lib/logging/log.h"
@@ -27,6 +33,12 @@
 #include <string.h>
 
 #define CNT_TEST_MEMORY_LIMIT (4u * 1024u * 1024u)
+#define CNT_TEST_WORKER_COUNT 4
+
+// Written straight into one worker's counter storage, so a value copied
+// from a worker is told apart from the zeros of a worker without a
+// context.
+#define CNT_TEST_MARKER 4242
 
 static int
 install_empty_pipeline(
@@ -226,6 +238,94 @@ test_tag_strings_survive_generation_swap(struct yanet_shm *shm) {
 	return TEST_SUCCESS;
 }
 
+// Verifies that a tagged counter read still describes its counters when
+// the published generation carries an execution context for some workers
+// and not for others, reporting zeros for a worker that carries none and
+// its own values for a worker that does.
+//
+// A worker registering after an install is what leaves a live generation
+// short of contexts. The harness fixes its worker set at startup, so the
+// state is staged by detaching one context, put back right after the read
+// so teardown still reclaims it.
+static int
+test_read_survives_absent_worker_context(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent =
+		agent_attach(shm, 0, "cnt-1926", CNT_TEST_MEMORY_LIMIT, &err);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct dp_config *dp_config = agent_dp_config(agent);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	TEST_ASSERT_SUCCESS(
+		install_empty_pipeline(dp_config, cp_config, "pipe0"),
+		"failed to install pipe0"
+	);
+	TEST_ASSERT_SUCCESS(
+		install_device(agent, dp_config, cp_config, "dev0", "pipe0"),
+		"failed to install dev0 with input pipeline pipe0"
+	);
+
+	struct cp_config_gen *config_gen = ADDR_OF(&cp_config->cp_config_gen);
+	struct config_gen_ectx *marked =
+		cp_config_gen_worker_ectx(config_gen, 1);
+	TEST_ASSERT_NOT_NULL(marked, "the second worker has no context");
+
+	const struct counter_tag tags[] = {
+		{.key = "device", .value = "dev0"},
+		{.key = "pipeline", .value = "pipe0"},
+		{.key = "kind", .value = "pipeline"},
+	};
+	struct cp_counter_storage **found =
+		cp_config_counter_storage_registry_find(
+			ADDR_OF(&marked->counter_storage_registry),
+			tags,
+			3,
+			NULL
+		);
+	TEST_ASSERT_NOT_NULL(found, "the registry lookup failed");
+	TEST_ASSERT_NOT_NULL(found[0], "no counter storage matched pipe0");
+	counter_get_address(0, ADDR_OF(&found[0]->storage))[0] =
+		CNT_TEST_MARKER;
+	free(found);
+
+	// Before the fix the read described the whole list from the first
+	// worker alone and then indexed every worker's matches
+	// unconditionally.
+	struct config_gen_ectx **ectxs = ADDR_OF(&config_gen->config_gen_ectxs);
+	struct config_gen_ectx *detached = ADDR_OF(ectxs);
+	ectxs[0] = NULL;
+
+	struct counter_handle_list *list =
+		yanet_get_pipeline_counters(dp_config, "dev0", "pipe0");
+	SET_OFFSET_OF(ectxs, detached);
+
+	TEST_ASSERT_NOT_NULL(list, "the read failed with a context detached");
+	TEST_ASSERT(list->count > 0, "the read described no counters");
+	TEST_ASSERT_EQUAL(
+		list->instance_count,
+		CNT_TEST_WORKER_COUNT,
+		"the read lost workers"
+	);
+
+	struct counter_handle *handle = yanet_get_counter(list, 0);
+	TEST_ASSERT_EQUAL(
+		yanet_get_counter_value(handle->values, 0, 0),
+		0,
+		"the worker without a context did not report zero"
+	);
+	TEST_ASSERT_EQUAL(
+		yanet_get_counter_value(handle->values, 0, 1),
+		CNT_TEST_MARKER,
+		"the marked worker lost its value"
+	);
+
+	yanet_counter_handle_list_free(list);
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
 int
 main(void) {
 	log_enable_name("debug");
@@ -236,7 +336,7 @@ main(void) {
 	struct dataplane_ut_config cfg = {
 		.cp_memory = 1u << 25,
 		.dp_memory = 1u << 20,
-		.worker_count = 1,
+		.worker_count = CNT_TEST_WORKER_COUNT,
 		.devices = port_names,
 		.device_count = 1,
 		.modules = NULL,
@@ -261,6 +361,9 @@ main(void) {
 	int res = test_value_snapshot_survives_removal(shm);
 	if (res == TEST_SUCCESS) {
 		res = test_tag_strings_survive_generation_swap(shm);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_read_survives_absent_worker_context(shm);
 	}
 
 	dataplane_ut_free(ut);


### PR DESCRIPTION
A counter read walked every worker's match set as soon as the first worker had one, so a worker the published generation carries no execution context for was a NULL dereference. The earlier take leaned on an all-or-none rule — a generation carries a context for every worker or for none. That rule does not hold, so the read now works from the per-worker premise: every worker owns its own execution context, and whether it has one says nothing about its neighbours.

The mixed state is reachable, not theoretical. A generation freezes its context count at install time while the read sizes itself by the live worker count, and workers register one at a time, so a worker that comes up after the last install has no context in a generation the read still walks.

- Describe the handle list from the first worker whose execution context the generation carries, so a read no longer answers empty when the first worker has none.
- Report zeros for a worker the generation carries no context for, instead of indexing its absent match set and dereferencing NULL.
- Note that the cross-worker ordering the read leans on comes from one generation building every context in a single pass, so a design that installs them per worker has to establish it another way.
- Cover a generation whose execution context is absent on a worker in the counter read tests; it segfaults against current main, and drops every counter from the answer if only the dereference is guarded.

Closes #1926.
