### PR TITLE
chore(controlplane): drop the gateway config pointer to reject null blocks

### DIFF
--- a/controlplane/gateway/cfg.go
+++ b/controlplane/gateway/cfg.go
@@ -74,9 +74,14 @@ func (m *RegistryConfig) Validate() error {
 	return nil
 }
 
+// Default resets the config to built-in defaults.
+func (m *Config) Default() {
+	*m = DefaultConfig()
+}
+
 // DefaultConfig returns a Config with sensible defaults.
-func DefaultConfig() *Config {
-	return &Config{
+func DefaultConfig() Config {
+	return Config{
 		Server: ServerConfig{
 			Endpoint: "[::1]:8080",
 		},

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -147,7 +147,7 @@ func WithListener(listener net.Listener) GatewayOption {
 //
 // Think of it as gRPC middleware if it were a single process.
 type Gateway struct {
-	cfg              *Config
+	cfg              Config
 	server           *grpc.Server
 	listener         net.Listener
 	services         []Service
@@ -158,7 +158,7 @@ type Gateway struct {
 }
 
 // NewGateway creates a new Gateway API.
-func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
+func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 	opts := newGatewayOptions()
 	for _, o := range options {
 		o(opts)
@@ -166,10 +166,8 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	log := opts.Log
 	registry := NewBackendRegistry()
 
-	// The endpoint is what the gateway's own loopback dial, TLS SNI host, and
-	// out-of-process service registration target. It follows the injected
-	// listener's real address when one is supplied, and cfg.Server.Endpoint
-	// otherwise, without ever mutating cfg, which the caller owns.
+	// The endpoint backs loopback dial, SNI host, and registration; it
+	// follows the injected listener, else the configured server endpoint.
 	endpoint := cfg.Server.Endpoint
 	if opts.Listener != nil {
 		endpoint = opts.Listener.Addr().String()

--- a/controlplane/yncp/cfg.go
+++ b/controlplane/yncp/cfg.go
@@ -1,8 +1,6 @@
 package yncp
 
 import (
-	"errors"
-
 	"go.uber.org/zap/zapcore"
 
 	"github.com/yanet-platform/yanet2/common/go/logging"
@@ -18,7 +16,7 @@ type Config struct {
 	// communicate with dataplane.
 	MemoryPath string `yaml:"memory_path"`
 	// Gateway configuration.
-	Gateway *gateway.Config `json:"gateway" yaml:"gateway"`
+	Gateway gateway.Config `json:"gateway" yaml:"gateway"`
 	// Modules configuration. A module absent from the document is not
 	// started.
 	Modules bundle.ModulesConfig `json:"modules" yaml:"modules"`
@@ -29,17 +27,6 @@ type Config struct {
 
 func (m *Config) Default() {
 	*m = *DefaultConfig()
-}
-
-// Validate rejects a document that clears the defaulted gateway block, be it
-// a bare "gateway:" key or an explicit "gateway: null", either of which
-// yaml.v3 decodes into a nil Gateway rather than leaving the default intact.
-func (m *Config) Validate() error {
-	if m.Gateway == nil {
-		return errors.New("gateway: must not be empty or null")
-	}
-
-	return nil
 }
 
 func DefaultConfig() *Config {

--- a/controlplane/yncp/cfg_test.go
+++ b/controlplane/yncp/cfg_test.go
@@ -66,10 +66,13 @@ func Test_GatewayWithoutInstanceID_FailsValidation(t *testing.T) {
 	require.Contains(t, err.Error(), "gateway.instance_id")
 }
 
-// Test_ExplicitNullGateway_FailsValidation asserts that a document clearing
-// the defaulted gateway block, either as a bare "gateway:" key or as an
-// explicit "gateway: null", fails to load with an error naming the gateway
-// instead of panicking on a nil dereference downstream.
+// Test_ExplicitNullGateway_FailsValidation asserts that a bare "gateway:" key
+// or an explicit "gateway: null" is rejected by the null-block check.
+//
+// The field is a plain value, so a cleared block is no longer representable
+// and the rejection needs no hand-written validation. A null block used to
+// decode into a nil pointer that panicked on the first dereference; the
+// loader's null-block check now fails the document with the key and line.
 func Test_ExplicitNullGateway_FailsValidation(t *testing.T) {
 	for name, input := range map[string]string{
 		"bare key":   "gateway:\n",
@@ -79,7 +82,7 @@ func Test_ExplicitNullGateway_FailsValidation(t *testing.T) {
 			cfg := yncp.DefaultConfig()
 			err := xcfg.Decode([]byte(input), cfg)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "gateway")
+			require.Equal(t, `key "gateway" at line 1 has no value; give it a body or remove the key`, err.Error())
 		})
 	}
 }


### PR DESCRIPTION
- Make `yncp.Config.Gateway` a plain `gateway.Config` value, so a bare `gateway:` key or `gateway: null` is no longer representable and is rejected by xcfg's null-block check with the key and line, instead of decoding to a nil pointer that panicked on the first dereference downstream.
- Drop the hand-written `Validate()` nil check the value-field shape makes redundant; the contract now lives in the type.
- Add `Default()` to `gateway.Config` and make `gateway.DefaultConfig()` and `NewGateway` take and return it by value, matching the value-field shape from #2100 and removing the last pointer pass at the call site.
- Tighten the null-gateway test to assert the exact null-block message.

Closes #2113.