### PR TITLE
fix(xcfg): reject null values for slice fields

### DIFF
--- a/common/go/xcfg/known_keys.go
+++ b/common/go/xcfg/known_keys.go
@@ -126,7 +126,7 @@ func isTransparentToWalk(t reflect.Type) bool {
 	if reflect.PointerTo(t).Implements(textUnmarshalerType) {
 		return false
 	}
-	return t.Kind() == reflect.Struct || t.Kind() == reflect.Map
+	return t.Kind() == reflect.Struct || t.Kind() == reflect.Map || t.Kind() == reflect.Slice
 }
 
 // walkKnownKeys matches node's shape against t, appending the dotted path of

--- a/common/go/xcfg/known_keys_test.go
+++ b/common/go/xcfg/known_keys_test.go
@@ -799,8 +799,16 @@ func Test_Decode_NullPositions(t *testing.T) {
 			},
 		},
 		{
-			name:  "slice field not reported",
-			input: "required: r\nnonemptystring: s\nnonzero: 1\nslice:\n",
+			name:     "slice field reported",
+			input:    "required: r\nnonemptystring: s\nnonzero: 1\nslice:\n",
+			wantErr:  true,
+			contains: []string{`"slice"`, "line 4"},
+			seed: func(cfg *nullArmsConfig) {
+				cfg.Slice = []knownKeysInner{{Addr: "default"}}
+			},
+			check: func(t *testing.T, cfg *nullArmsConfig) {
+				require.Equal(t, []knownKeysInner{{Addr: "default"}}, cfg.Slice)
+			},
 		},
 		{
 			name:  "yaml.Node field not reported",


### PR DESCRIPTION
Treat direct slice fields like other transparent configuration blocks when checking explicit null values.

- Rejects an explicit null at a direct slice-typed configuration field instead of silently erasing a default.
- Keeps explicit empty slices valid and preserves the existing pointer behavior.
- Audited production and test YAML configurations that use xcfg; no intentional null slice-as-clear contract was found.

Closes #2101.