### PR TITLE
refactor(dscp): migrate prefix fields to commonpb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3294,6 +3294,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
 ]
 
 [[package]]

--- a/common/commonpb/v1/ipnetwork.go
+++ b/common/commonpb/v1/ipnetwork.go
@@ -31,6 +31,40 @@ func ParseContiguousIPNetwork(s string) (*ContiguousIPNetwork, error) {
 	return NewContiguousIPNetworkFromPrefix(prefix)
 }
 
+// NetworksFromPrefixes creates ContiguousIPNetwork messages from netip.Prefix
+// values, masking off any host bits.
+//
+// Returns an error if any prefix is not valid.
+func NetworksFromPrefixes(prefixes []netip.Prefix) ([]*ContiguousIPNetwork, error) {
+	networks := make([]*ContiguousIPNetwork, 0, len(prefixes))
+	for idx, prefix := range prefixes {
+		network, err := NewContiguousIPNetworkFromPrefix(prefix)
+		if err != nil {
+			return nil, fmt.Errorf("prefixes[%d]: %w", idx, err)
+		}
+		networks = append(networks, network)
+	}
+
+	return networks, nil
+}
+
+// PrefixesFromNetworks converts ContiguousIPNetwork messages to masked
+// netip.Prefix values.
+//
+// Returns an error if any network is malformed.
+func PrefixesFromNetworks(networks []*ContiguousIPNetwork) ([]netip.Prefix, error) {
+	prefixes := make([]netip.Prefix, 0, len(networks))
+	for idx, network := range networks {
+		prefix, err := network.ToPrefix()
+		if err != nil {
+			return nil, fmt.Errorf("prefixes[%d]: %w", idx, err)
+		}
+		prefixes = append(prefixes, prefix)
+	}
+
+	return prefixes, nil
+}
+
 // ToPrefix converts the ContiguousIPNetwork back to a netip.Prefix value.
 //
 // Returns an error if addr is malformed or if prefix_len exceeds the

--- a/common/commonpb/v1/ipnetwork_test.go
+++ b/common/commonpb/v1/ipnetwork_test.go
@@ -162,6 +162,38 @@ func TestParseContiguousIPNetwork_Invalid(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestContiguousIPNetwork_SliceConversions verifies that slice conversion
+// masks host bits and preserves IPv4 and IPv6 prefixes in both directions.
+func TestContiguousIPNetwork_SliceConversions(t *testing.T) {
+	prefixes := []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.1/24"),
+		netip.MustParsePrefix("2001:db8::1/32"),
+	}
+	want := []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/24"),
+		netip.MustParsePrefix("2001:db8::/32"),
+	}
+
+	networks, err := commonpb.NetworksFromPrefixes(prefixes)
+	require.NoError(t, err)
+
+	got, err := commonpb.PrefixesFromNetworks(networks)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestContiguousIPNetwork_SliceConversions_Invalid verifies that conversion
+// errors identify the failing prefix position.
+func TestContiguousIPNetwork_SliceConversions_Invalid(t *testing.T) {
+	_, err := commonpb.NetworksFromPrefixes([]netip.Prefix{{}})
+	require.ErrorContains(t, err, "prefixes[0]")
+
+	_, err = commonpb.PrefixesFromNetworks([]*commonpb.ContiguousIPNetwork{{
+		Addr: &commonpb.IPAddress{Addr: []byte{10, 0, 0}},
+	}})
+	require.ErrorContains(t, err, "prefixes[0]")
+}
+
 // TestContiguousIPNetwork_AsLogValue asserts the log-friendly string form,
 // including the "invalid" fallback for an undecodable message.
 func TestContiguousIPNetwork_AsLogValue(t *testing.T) {

--- a/modules/decap/controlplane/service.go
+++ b/modules/decap/controlplane/service.go
@@ -96,16 +96,9 @@ func (m *DecapService) ShowConfig(
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
 
-	prefixes := make([]*commonpb.ContiguousIPNetwork, 0, len(entry.Prefixes))
-	for _, p := range entry.Prefixes {
-		network, err := commonpb.NewContiguousIPNetworkFromPrefix(p)
-		if err != nil {
-			return nil, status.Errorf(
-				codes.Internal,
-				"failed to convert prefix %q: %v", p, err,
-			)
-		}
-		prefixes = append(prefixes, network)
+	prefixes, err := commonpb.NetworksFromPrefixes(entry.Prefixes)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to convert prefixes: %v", err)
 	}
 
 	return &decappb.ShowConfigResponse{Prefixes: prefixes}, nil
@@ -121,17 +114,9 @@ func (m *DecapService) UpdateConfig(
 		return nil, errConfigNameRequired
 	}
 
-	prefixes := make([]netip.Prefix, 0, len(req.GetPrefixes()))
-	for _, p := range req.GetPrefixes() {
-		prefix, err := p.ToPrefix()
-		if err != nil {
-			return nil, status.Errorf(
-				codes.InvalidArgument,
-				"failed to convert prefix (addr=%x, prefix_len=%d): %v",
-				p.GetAddr().GetAddr(), p.GetPrefixLen(), err,
-			)
-		}
-		prefixes = append(prefixes, prefix)
+	prefixes, err := commonpb.PrefixesFromNetworks(req.GetPrefixes())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
 	}
 
 	prefixes = slices.Compact(
@@ -146,10 +131,7 @@ func (m *DecapService) UpdateConfig(
 
 	cfg := &config{Prefixes: prefixes}
 	if err := m.updateConfig(name, cfg); err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"failed to update module config %q: %v", name, err,
-		)
+		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
 	return &decappb.UpdateConfigResponse{}, nil

--- a/modules/dscp/cli/Cargo.toml
+++ b/modules/dscp/cli/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
+commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 netip = "0.3"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }

--- a/modules/dscp/cli/build.rs
+++ b/modules/dscp/cli/build.rs
@@ -6,8 +6,9 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
+        .extern_path(".common.commonpb.v1", "::commonpb::pb")
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["dscppb/v1/dscp.proto"], &["../controlplane"])?;
+        .compile_protos(&["dscppb/v1/dscp.proto"], &["../controlplane", "../../.."])?;
 
     Ok(())
 }

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -3,6 +3,7 @@ use clap_complete::{
     CompleteEnv,
     engine::{ArgValueCandidates, CompletionCandidate},
 };
+use commonpb::pb::ContiguousIpNetwork;
 use dscppb::{
     AddPrefixesRequest, DscpConfig, RemovePrefixesRequest, SetDscpMarkingRequest, ShowConfigRequest,
     ShowConfigResponse, dscp_service_client::DscpServiceClient,
@@ -207,7 +208,7 @@ impl DscpService {
     pub async fn add_prefixes(&mut self, cmd: AddPrefixesCmd) -> Result<(), Error> {
         let request = AddPrefixesRequest {
             name: cmd.config_name.clone(),
-            prefixes: cmd.prefix.iter().map(|p| p.to_string()).collect(),
+            prefixes: cmd.prefix.iter().copied().map(ContiguousIpNetwork::from).collect(),
         };
         log::trace!("AddPrefixesRequest: {request:?}");
         let response = self
@@ -230,7 +231,7 @@ impl DscpService {
     pub async fn remove_prefixes(&mut self, cmd: RemovePrefixesCmd) -> Result<(), Error> {
         let request = RemovePrefixesRequest {
             name: cmd.config_name.clone(),
-            prefixes: cmd.prefix.iter().map(|p| p.to_string()).collect(),
+            prefixes: cmd.prefix.iter().copied().map(ContiguousIpNetwork::from).collect(),
         };
         log::trace!("RemovePrefixesRequest: {request:?}");
         let response = self

--- a/modules/dscp/controlplane/dscppb/meson.build
+++ b/modules/dscp/controlplane/dscppb/meson.build
@@ -1,4 +1,5 @@
 proto_dir = join_paths(meson.current_source_dir(), 'v1')
+root_dir = meson.project_source_root()
 proto_files = [join_paths(proto_dir, 'dscp.proto')]
 
 protoc_gen = custom_target(
@@ -8,6 +9,7 @@ protoc_gen = custom_target(
   command: [
     protoc,
     '-I', proto_dir,
+    '-I', root_dir,
     '--go_out=paths=source_relative:' + proto_dir,
     '--go-grpc_out=paths=source_relative:' + proto_dir,
     '@INPUT@',

--- a/modules/dscp/controlplane/dscppb/v1/dscp.proto
+++ b/modules/dscp/controlplane/dscppb/v1/dscp.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package modules.dscp.controlplane.dscppb.v1;
 
+import "common/commonpb/v1/ipnetwork.proto";
+
 option go_package = "github.com/yanet-platform/yanet2/modules/dscp/controlplane/dscppb/v1;dscppb";
 
 // DscpService is a service for Differentiated Services Code Point module.
@@ -22,7 +24,7 @@ service DscpService {
 }
 
 message Config {
-  repeated string prefixes = 2;
+  repeated common.commonpb.v1.ContiguousIPNetwork prefixes = 2;
   DscpConfig dscp_config = 3;
 }
 
@@ -49,7 +51,7 @@ message ShowConfigResponse { Config config = 1; }
 // AddPrefixesRequest adds prefixes to the input filter of the dscp module.
 message AddPrefixesRequest {
   string name = 1;
-  repeated string prefixes = 2;
+  repeated common.commonpb.v1.ContiguousIPNetwork prefixes = 2;
 }
 message AddPrefixesResponse {}
 
@@ -57,7 +59,7 @@ message AddPrefixesResponse {}
 // module.
 message RemovePrefixesRequest {
   string name = 1;
-  repeated string prefixes = 2;
+  repeated common.commonpb.v1.ContiguousIPNetwork prefixes = 2;
 }
 message RemovePrefixesResponse {}
 

--- a/modules/dscp/controlplane/service.go
+++ b/modules/dscp/controlplane/service.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/xnetip"
 	"github.com/yanet-platform/yanet2/modules/dscp/controlplane/dscppb/v1"
 )
@@ -105,9 +106,9 @@ func (m *DscpService) ShowConfig(
 		return nil, status.Error(codes.NotFound, "config not found")
 	}
 
-	prefixes := make([]string, 0, len(config.Prefixes))
-	for _, p := range config.Prefixes {
-		prefixes = append(prefixes, p.String())
+	prefixes, err := commonpb.NetworksFromPrefixes(config.Prefixes)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to convert prefixes: %v", err)
 	}
 
 	response.Config = &dscppb.Config{
@@ -130,9 +131,9 @@ func (m *DscpService) AddPrefixes(
 	}
 
 	name := request.GetName()
-	toAdd, err := parsePrefixes(request.GetPrefixes())
+	toAdd, err := commonpb.PrefixesFromNetworks(request.GetPrefixes())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
 	}
 
 	m.mu.Lock()
@@ -151,10 +152,7 @@ func (m *DscpService) AddPrefixes(
 	)
 
 	if err := m.updateModuleConfig(name, cfg); err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"failed to update module config %q: %v", name, err,
-		)
+		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
 	return &dscppb.AddPrefixesResponse{}, nil
@@ -169,9 +167,9 @@ func (m *DscpService) RemovePrefixes(
 	}
 
 	name := request.GetName()
-	toRemove, err := parsePrefixes(request.GetPrefixes())
+	toRemove, err := commonpb.PrefixesFromNetworks(request.GetPrefixes())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
 	}
 
 	m.mu.Lock()
@@ -192,10 +190,7 @@ func (m *DscpService) RemovePrefixes(
 	)
 
 	if err := m.updateModuleConfig(name, cfg); err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"failed to update module config %q: %v", name, err,
-		)
+		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
 	return &dscppb.RemovePrefixesResponse{}, nil
@@ -226,10 +221,7 @@ func (m *DscpService) SetDscpMarking(
 	}
 
 	if err := m.updateModuleConfig(name, cfg); err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"failed to update module config %q: %v", name, err,
-		)
+		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
 	return &dscppb.SetDscpMarkingResponse{}, nil
@@ -255,21 +247,4 @@ func (m *DscpService) updateModuleConfig(name string, cfg *config) error {
 	}
 
 	return nil
-}
-
-func parsePrefixes(prefixes []string) ([]netip.Prefix, error) {
-	out := make([]netip.Prefix, 0, len(prefixes))
-	for _, p := range prefixes {
-		prefix, err := netip.ParsePrefix(p)
-		if err != nil {
-			return nil, status.Errorf(
-				codes.InvalidArgument,
-				"failed to parse prefix %q: %v", p, err,
-			)
-		}
-
-		out = append(out, prefix.Masked())
-	}
-
-	return out, nil
 }

--- a/modules/dscp/controlplane/service_test.go
+++ b/modules/dscp/controlplane/service_test.go
@@ -12,10 +12,47 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/modules/dscp/controlplane/dscppb/v1"
 )
 
 var errBackendFailure = fmt.Errorf("backend failure")
+
+// mustNetworks returns structured networks for valid CIDR test inputs.
+func mustNetworks(t *testing.T, prefixes ...string) []*commonpb.ContiguousIPNetwork {
+	t.Helper()
+
+	networks := make([]*commonpb.ContiguousIPNetwork, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		network, err := commonpb.ParseContiguousIPNetwork(prefix)
+		require.NoError(t, err)
+		networks = append(networks, network)
+	}
+
+	return networks
+}
+
+// networkStrings returns canonical CIDR text for valid structured networks.
+func networkStrings(t *testing.T, networks []*commonpb.ContiguousIPNetwork) []string {
+	t.Helper()
+
+	prefixes := make([]string, 0, len(networks))
+	for _, network := range networks {
+		prefix, err := network.ToPrefix()
+		require.NoError(t, err)
+		prefixes = append(prefixes, prefix.String())
+	}
+
+	return prefixes
+}
+
+// malformedNetwork returns a network with an invalid address length.
+func malformedNetwork() *commonpb.ContiguousIPNetwork {
+	return &commonpb.ContiguousIPNetwork{
+		Addr:      &commonpb.IPAddress{Addr: []byte{10, 0, 0}},
+		PrefixLen: 24,
+	}
+}
 
 type mockModuleHandle struct {
 }
@@ -62,6 +99,8 @@ func (m *flakyBackend) UpdateModule(
 	return m.backend.UpdateModule(name, prefixes, flag, mark)
 }
 
+// Test_DscpService_ListShowAddRemoveSetMarking verifies that prefix mutations
+// and marking updates remain visible through the structured response.
 func Test_DscpService_ListShowAddRemoveSetMarking(t *testing.T) {
 	t.Parallel()
 
@@ -77,11 +116,8 @@ func Test_DscpService_ListShowAddRemoveSetMarking(t *testing.T) {
 
 	{
 		response, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
-			Name: "dscp0",
-			Prefixes: []string{
-				"10.0.0.0/24",
-				"2001:db8::/32",
-			},
+			Name:     "dscp0",
+			Prefixes: mustNetworks(t, "10.0.0.0/24", "2001:db8::/32"),
 		})
 		require.NotNil(t, response)
 		require.NoError(t, err)
@@ -99,7 +135,11 @@ func Test_DscpService_ListShowAddRemoveSetMarking(t *testing.T) {
 		require.NotNil(t, response)
 		require.NoError(t, err)
 		assert.Empty(t, response.Config.DscpConfig)
-		assert.Equal(t, []string{"10.0.0.0/24", "2001:db8::/32"}, response.Config.Prefixes)
+		assert.Equal(
+			t,
+			[]string{"10.0.0.0/24", "2001:db8::/32"},
+			networkStrings(t, response.Config.Prefixes),
+		)
 	}
 
 	{
@@ -125,7 +165,7 @@ func Test_DscpService_ListShowAddRemoveSetMarking(t *testing.T) {
 	{
 		response, err := service.RemovePrefixes(ctx, &dscppb.RemovePrefixesRequest{
 			Name:     "dscp0",
-			Prefixes: []string{"10.0.0.0/24"},
+			Prefixes: mustNetworks(t, "10.0.0.0/24"),
 		})
 		require.NotNil(t, response)
 		require.NoError(t, err)
@@ -135,10 +175,16 @@ func Test_DscpService_ListShowAddRemoveSetMarking(t *testing.T) {
 		response, err := service.ShowConfig(ctx, &dscppb.ShowConfigRequest{Name: "dscp0"})
 		require.NotNil(t, response)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"2001:db8::/32"}, response.Config.Prefixes)
+		assert.Equal(
+			t,
+			[]string{"2001:db8::/32"},
+			networkStrings(t, response.Config.Prefixes),
+		)
 	}
 }
 
+// Test_DscpService_RequestValidation verifies that invalid names, networks,
+// and marking values are rejected with InvalidArgument.
 func Test_DscpService_RequestValidation(t *testing.T) {
 	t.Parallel()
 	service := newTestService(t)
@@ -153,7 +199,7 @@ func Test_DscpService_RequestValidation(t *testing.T) {
 	t.Run("AddPrefixesInvalidName", func(t *testing.T) {
 		response, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
 			Name:     "",
-			Prefixes: []string{"10.0.0.0/24"},
+			Prefixes: mustNetworks(t, "10.0.0.0/24"),
 		})
 		require.Nil(t, response)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -162,7 +208,7 @@ func Test_DscpService_RequestValidation(t *testing.T) {
 	t.Run("RemovePrefixesInvalidName", func(t *testing.T) {
 		response, err := service.RemovePrefixes(ctx, &dscppb.RemovePrefixesRequest{
 			Name:     "",
-			Prefixes: []string{"10.0.0.0/24"},
+			Prefixes: mustNetworks(t, "10.0.0.0/24"),
 		})
 		require.Nil(t, response)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -179,7 +225,7 @@ func Test_DscpService_RequestValidation(t *testing.T) {
 	t.Run("AddPrefixesInvalidPrefix", func(t *testing.T) {
 		response, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
 			Name:     "dscp0",
-			Prefixes: []string{"bad-prefix"},
+			Prefixes: []*commonpb.ContiguousIPNetwork{malformedNetwork()},
 		})
 		require.Nil(t, response)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -188,7 +234,7 @@ func Test_DscpService_RequestValidation(t *testing.T) {
 	t.Run("RemovePrefixesInvalidPrefix", func(t *testing.T) {
 		response, err := service.RemovePrefixes(ctx, &dscppb.RemovePrefixesRequest{
 			Name:     "dscp0",
-			Prefixes: []string{"bad-prefix"},
+			Prefixes: []*commonpb.ContiguousIPNetwork{malformedNetwork()},
 		})
 		require.Nil(t, response)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -219,6 +265,8 @@ func Test_DscpService_RequestValidation(t *testing.T) {
 	})
 }
 
+// Test_DscpService_NoUpdateOnFailure verifies that a failed backend update
+// leaves the last successfully published configuration visible.
 func Test_DscpService_NoUpdateOnFailure(t *testing.T) {
 	t.Parallel()
 
@@ -229,13 +277,13 @@ func Test_DscpService_NoUpdateOnFailure(t *testing.T) {
 
 	_, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
 		Name:     name,
-		Prefixes: []string{"10.0.0.0/24"},
+		Prefixes: mustNetworks(t, "10.0.0.0/24"),
 	})
 	require.NoError(t, err)
 
 	_, err = service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
 		Name:     name,
-		Prefixes: []string{"20.0.0.0/24"},
+		Prefixes: mustNetworks(t, "20.0.0.0/24"),
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.Internal, status.Code(err))
@@ -243,9 +291,11 @@ func Test_DscpService_NoUpdateOnFailure(t *testing.T) {
 	response, err := service.ShowConfig(ctx, &dscppb.ShowConfigRequest{Name: name})
 	require.NotNil(t, response)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"10.0.0.0/24"}, response.Config.Prefixes)
+	assert.Equal(t, []string{"10.0.0.0/24"}, networkStrings(t, response.Config.Prefixes))
 }
 
+// Test_DscpService_ConcurrentAccess verifies that concurrent mutations and
+// reads complete without a data race.
 func Test_DscpService_ConcurrentAccess(t *testing.T) {
 	t.Parallel()
 	service := newTestService(t)
@@ -262,7 +312,7 @@ func Test_DscpService_ConcurrentAccess(t *testing.T) {
 				if j%3 == 0 {
 					if _, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
 						Name:     name,
-						Prefixes: []string{fmt.Sprintf("10.%d.%d.0/24", i, j)},
+						Prefixes: mustNetworks(t, fmt.Sprintf("10.%d.%d.0/24", i, j)),
 					}); err != nil {
 						return err
 					}
@@ -271,7 +321,7 @@ func Test_DscpService_ConcurrentAccess(t *testing.T) {
 				if j%3 == 1 {
 					if _, err := service.RemovePrefixes(ctx, &dscppb.RemovePrefixesRequest{
 						Name:     name,
-						Prefixes: []string{fmt.Sprintf("10.%d.%d.0/24", i, j)},
+						Prefixes: mustNetworks(t, fmt.Sprintf("10.%d.%d.0/24", i, j)),
 					}); err != nil {
 						return err
 					}


### PR DESCRIPTION
Migrate the dscp prefix fields from strings to the shared structured network message and update every dscp consumer.

- Replace the three dscp prefix fields with `common.commonpb.v1.ContiguousIPNetwork` at the existing field numbers as an intentional coordinated wire break.
- Reuse common slice conversions in both dscp and decap control planes, preserving malformed-input validation and normalization.
- Update the Rust dscp CLI and protobuf generation paths to use the shared Rust commonpb type.
- The repository buf breaking check is expected to report the three intentional dscp field type changes; no buf configuration or workflow was changed.

Assumptions:
- All dscp control-plane deployments and CLI clients are upgraded together; old string-based dscp messages are not supported by this change.
- Existing field numbers and the gRPC service name remain unchanged, so only the prefix field encoding is deliberately coordinated.
- The existing `ContiguousIPNetwork` normalization semantics (mask host bits and validate address family/prefix length) are the desired dscp semantics.

Closes #1951.