### PR TITLE
feat(agents): add issue creation skill

### DIFF
--- a/.agents/skills/issue-create/SKILL.md
+++ b/.agents/skills/issue-create/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: issue-create
+description: >-
+  Draft, create, or triage one complete GitHub issue in yanet2 or
+  yanet2-private, including evidence, deduplication, planning metadata and
+  dependencies; also create planner-owned epic containers. Use when asked to
+  formulate, file, create or triage an issue, and whenever planner creates one.
+---
+
+# issue-create
+
+Turn one repository-visible outcome into the shortest self-contained English
+issue that another engineer can close. Inspect code and GitHub, but never edit
+repository files, run git writes, or exceed the caller's build/test posture.
+
+## Modes and authorization
+
+- `draft` — return one exact GitHub-ready leaf and its metadata; no writes.
+- `create` — an explicit create/file/open verb authorizes publication and all
+  metadata writes without a second preview.
+- `triage <n>` — complete an existing issue without changing its lifecycle.
+- `container` — planner-only epic after its complete child tree is designed.
+- `decompose` belongs to planner. One leaf has one independently closable
+  outcome: usually one PR, or one bounded evidence-backed verdict/decision.
+
+## Admission
+
+- Repositories are public `yanet-platform/yanet2` and private
+  `yanet-platform/yanet2-private`. Prefer public for shared code; a private-only
+  delta may depend on public work. Never expose private context or literal
+  secrets publicly. Treat security findings as ordinary Bugs under this rule.
+- Search open and closed issues and PRs in both repositories by concepts and
+  exact symbols. An exact open issue wins. A closed match needs a regression or
+  independent delta. An active matching PR requires user reconfirmation before
+  a tracking issue is created.
+- Multiple independently deliverable outcomes route to `planner decompose`.
+  An uncreated prerequisite does too. Existing prerequisites use a native
+  dependency plus `blocked`; all issues remain visible on their primary board.
+- The outcome must be deliverable through tracked repository changes. Findings
+  confined to agent memory, `.agent-state`, `.arch`, or other ignored/local
+  trees stay in prose and never become GitHub issues.
+- A current change's follow-up needs explicit author agreement, independent
+  value, and a still-correct parent change that meets its acceptance criteria.
+  Link it and block it until merge; never defer a correctness/security defect
+  introduced by that change.
+- A clear outcome with an unresolved external contract may be filed with
+  `needs-architect` and explicit decision points. If the closing outcome,
+  privacy boundary, or repository cannot be established, ask one blocking
+  question instead of guessing.
+- A user-observed unexpected symptom is a Bug without a known root cause. A
+  static hypothesis not otherwise proven is a Task whose outcome is confirmation.
+
+## Issue contract
+
+- Title is `<type>(<scope>): <lowercase brief>` using an allowed commit type.
+  Bugs normally use `fix`, Features `feat`, and Tasks the semantic type. An epic
+  keeps the semantic type and gains label `epic`; never use `epic(scope)`.
+- Body schemas, omitting empty optional sections:
+  - Bug: `Motivation` (observed behavior/impact), `Evidence`, `Scope`, `Acceptance`.
+  - Feature: `Motivation`, `Outcome`, `Scope`, `Acceptance`.
+  - Task: `Motivation`, `Closing outcome`, `Scope`, `Acceptance`.
+  - Container: `Goal`, `Scope`, `Children`, `Done`.
+- State observable properties before possible implementation. Add Constraints,
+  Out of scope, Alternatives, or Source only when informative. Acceptance is a
+  short checklist; investigations close on a verdict plus evidence/repro, and
+  decisions close on a recorded choice plus affected contracts.
+- Distinguish reproduced, code-proven, user-reported, and hypothetical claims.
+  Use stable blob links and explain what each proves. Do not invent impact,
+  cause, solution, or tests. The issue must stand without inaccessible links.
+
+## Metadata
+
+- Type is `Bug | Feature | Task`. New issues use applicable existing labels
+  only: `debt`, `chore`, `epic`, `blocked`, `needs-architect`, and minimal
+  `C:*`/`M:*` owners. Type replaces `bug`/`enhancement`; never add legacy `T:*`,
+  `go`, or `refactoring`, and never create a label.
+- Priority measures impact and urgency: Urgent/P0 active severe production or
+  safety; High/P1 serious correctness or production blocker; Medium/P2 meaningful
+  behavior or reliability; Low/P3 latent gaps, debt and polish. Board and effort
+  do not raise it.
+- Effort covers the whole path to closure: Low/S known/local, Medium/M several
+  linked surfaces or bounded investigation, High/L tightly coupled uncertainty.
+  Independently splittable High work routes to planner. A container's Issue Type
+  follows its overall Bug, Feature, or Task outcome.
+- Primary board: private → #10; public packet-path/shared-memory/CGO safety →
+  #7; CI/packaging/deployment/dev-test infra → #9; other public work → #8.
+  Add #11 only when its live description matches; never mutate legacy #5.
+- A new issue is unassigned and Todo. Do not set milestones. Existing blockers
+  use GitHub's native relation and label `blocked`.
+
+## Publish and triage
+
+Before any write, read [the GitHub operation map](references/github.md). Discover
+all IDs live, create with `gh issue create --body-file -`, apply every field and
+relation, then read back the complete postconditions. After an ambiguous 5xx,
+reconcile exact title/repository/author/time before at most one retry. A partial
+write resumes the same issue through triage; never compensate by closing or
+creating another.
+
+Triage preserves state, assignee, milestone and In Progress/Done. Rewrite title
+or body only for the current user's issue or with explicit permission; otherwise
+leave one concrete suggestion. Missing blocking facts get label `question`, one
+specific comment and an `INCOMPLETE` result. Exact duplicates get label
+`duplicate` and a canonical link but are not closed. Remove only redundant
+`bug`/`enhancement`, keep unknown labels, leave exactly one correct primary board,
+and preserve projects outside #7–#11.
+
+## Report
+
+Draft reports the exact repository, title, body and metadata separately from
+assumptions/stops. Publish reports the URL and read-back Type, labels,
+Priority/Effort, projects/Status, dependencies and any unmet postcondition.

--- a/.agents/skills/issue-create/references/github.md
+++ b/.agents/skills/issue-create/references/github.md
@@ -1,0 +1,62 @@
+# GitHub operation map
+
+Use explicit repositories in every command. Never hardcode node IDs or reuse IDs
+from agent memory: discover names and numbers immediately before a write.
+
+## Preflight and discovery
+
+- Verify `gh auth status`, repository visibility, labels, and write access.
+- Search both repositories' issues and PRs before creating anything. Private
+  search results never enter a public body.
+- Query `repository.issueTypes` for `Bug | Feature | Task` and the target issue's
+  `id`, type, labels, assignees, state, milestone, field values, project items,
+  dependencies and sub-issues.
+- Query `organization(login:"yanet-platform").issueFields` for live `Priority`
+  and `Effort` field/option IDs.
+- Query `organization.projectsV2` by project number. For each target project,
+  discover its `Status` field and `Todo | In Progress | Done` option IDs. Read
+  #11's current description before deciding membership.
+- A missing or ambiguous expected name is a pre-write stop, not permission to
+  choose the first result.
+
+## Create and ordinary metadata
+
+Feed body through stdin, never an argument or traced temporary file:
+
+```bash
+printf '%s' "$body" | gh issue create --repo "$repo" --title "$title" \
+  --body-file - --label "$labels"
+```
+
+Omit `--label` when empty. Use `gh issue edit` for label changes and, when
+content edits are authorized, `--body-file -`. Use `gh issue comment` for
+provenance, missing-information and duplicate comments.
+
+## GraphQL mutations
+
+Query current state first, skip satisfied operations, and build mutations with
+variables and the IDs just discovered:
+
+- Type: `updateIssue(input:{id, issueTypeId})`.
+- Priority/Effort: `setIssueFieldValue(input:{issueId, issueFields:[...]})`.
+- Add board item: `addProjectV2ItemById(input:{projectId, contentId})`.
+- Set Status: `updateProjectV2ItemFieldValue(input:{projectId,itemId,fieldId,value})`.
+- Remove a wrong owned board: `deleteProjectV2Item(input:{projectId,itemId})`.
+- Dependency: `addBlockedBy(input:{issueId,blockingIssueId})`.
+- Epic child: `addSubIssue(input:{issueId,subIssueId})`.
+
+After adding a project, query the issue again to obtain its new item ID before
+setting Status. Container mode creates the fully drafted epic first, then creates
+and immediately links each deduplicated child; a rerun reconciles the existing
+partial tree.
+
+## Reconciliation and read-back
+
+If create returns a transport/5xx error, query recent non-PR issues in that
+repository and filter by exact title, current viewer, and creation time. One
+match is the created issue; no match permits one retry; multiple matches stop.
+
+Success requires read-back of title/body, Type, exact managed labels,
+Priority/Effort, one primary project and its Status, optional #11, dependencies,
+and no assignee for a new issue. Report the issue URL plus every missing
+postcondition; repair partial state with `triage`, never a second create.

--- a/.claude/skills/issue-create
+++ b/.claude/skills/issue-create
@@ -1,0 +1,1 @@
+../../.agents/skills/issue-create

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report observed unexpected YANET behavior
+title: 'fix(<scope>): '
+labels: ''
+type: Bug
+assignees: ''
+
+---
+
+<!-- Replace title placeholders and search existing issues and pull requests before submitting. -->
+
+## Motivation
+
+<!-- Describe the observed and expected behavior plus any measured impact. -->
+
+## Evidence
+
+<!-- Give reproduction, environment, logs, or code evidence and state what is only a hypothesis. -->
+
+## Scope
+
+<!-- Bound the affected behavior without prescribing an unproven fix. -->
+
+## Acceptance
+
+<!-- List observable and verifiable completion criteria. -->
+
+<!-- - [ ] Observable completion criterion. -->
+
+<!-- Add Constraints, Out of scope, Alternatives, or Source only when informative. -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,20 +1,31 @@
 ---
 name: Feature request
-about: Suggest an idea for YANET
-title: ''
-labels: enhancement
+about: Propose one independently closable YANET outcome
+title: 'feat(<scope>): '
+labels: ''
+type: Feature
 assignees: ''
 
 ---
 
-**Motivation**
-What the problem is?
+<!-- Replace title placeholders and search existing issues and pull requests before submitting. -->
 
-**Possible solution**
-What you want to happen?
+## Motivation
 
-**Definition of done**
-What are the criteria for closing this issue?
+<!-- Explain the user or operator problem and why it matters. -->
 
-**Alternatives**
-Any alternative solutions or features you've considered.
+## Outcome
+
+<!-- State the observable result without locking in an unproven implementation. -->
+
+## Scope
+
+<!-- Bound one independently closable outcome and name what it does not include. -->
+
+## Acceptance
+
+<!-- List observable and verifiable completion criteria. -->
+
+<!-- - [ ] Observable completion criterion. -->
+
+<!-- Add Constraints, Out of scope, Alternatives, Evidence, or Source only when informative. -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,31 @@
+---
+name: Task
+about: Track one investigation, decision, debt, or maintenance outcome
+title: '<type>(<scope>): '
+labels: ''
+type: Task
+assignees: ''
+
+---
+
+<!-- Replace title placeholders and search existing issues and pull requests before submitting. -->
+
+## Motivation
+
+<!-- Explain the current cost, gap, or uncertainty. -->
+
+## Closing outcome
+
+<!-- State the independently verifiable result that closes this task. -->
+
+## Scope
+
+<!-- Bound one outcome and exclude independently deliverable follow-ups. -->
+
+## Acceptance
+
+<!-- List observable criteria; a decision or investigation must produce evidence. -->
+
+<!-- - [ ] Observable completion criterion. -->
+
+<!-- Add Constraints, Out of scope, Alternatives, Evidence, or Source only when informative. -->

--- a/.gitignore
+++ b/.gitignore
@@ -156,10 +156,12 @@ deploy/packages/
 # no change here.
 .agents/skills/*
 !.agents/skills/autopilot
+!.agents/skills/issue-create
 !.agents/skills/review-change
 !.agents/skills/ship-pr
 .claude/skills/*
 !.claude/skills/autopilot
+!.claude/skills/issue-create
 !.claude/skills/review-change
 !.claude/skills/ship-pr
 

--- a/.rulesync/subagents/planner.md
+++ b/.rulesync/subagents/planner.md
@@ -3,49 +3,66 @@ targets:
   - '*'
 name: planner
 description: >-
-  Plans on GitHub: decomposes a goal into an epic + sub-issue tree, ranks what
-  to do next, pulls a filtered batch of open tech debt for a period, ingests
-  surfaced debt, closes finished work. Never writes code or repo files.
+  Orchestrates GitHub planning: decomposes goals, ranks next work, queries debt,
+  ingests findings and manages issue lifecycle. Uses issue-create for every
+  issue unit; never writes code or repository files.
 claudecode:
   model: sonnet
   tools: 'Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch, Agent(fast-explorer)'
   color: yellow
   memory: project
   effort: medium
+  skills:
+    - issue-create
 codexcli:
   model: gpt-5.6-sol
   model_reasoning_effort: high
 ---
-You are the planner for YANET2 (`AGENTS.md` for what the project is). The plan IS GitHub: every item is an issue; you read and write it with `gh` (`gh issue`, `gh api`, `gh project`). You never write a repository file, never run git writes or builds. Read code with `fast-explorer` or directly, read-only.
+You are the planner for YANET2 (`AGENTS.md` for the project). The plan IS
+GitHub. At the start of every run, load and follow
+`.agents/skills/issue-create/SKILL.md`; it owns repositories, privacy,
+deduplication, issue content, planning metadata, boards and issue mutations.
 
-## Constants
-
-- Repos: public `yanet-platform/yanet2`, private `yanet-platform/yanet2-private`. The user is whoever `gh` is logged in as — use `@me` (`--assignee @me`, `assignee:@me`), never a hardcoded login. Private material is never referenced from a public issue; an epic and its children live in one repo.
-- Boards (org projects, owner `yanet-platform`), each issue on exactly one: any private issue → **#10 NGFW platform**; public issue about packet-path, shared-memory or CGO-boundary safety → **#7 Packet-path safety**; CI/packaging/deployment/dev-and-test infra → **#9 Release and operations**; otherwise → **#8 Platform quality**. **#11 FW to the production** is an extra initiative tracker added on top when the issue matches its description (read the project description for borderline calls). **#5** is off limits. Deferred work sits on no board (`no:project`).
-- Types `Bug | Feature | Task`; labels `debt`, `chore`, `epic`, `blocked`, `needs-architect`, area `C:<component>` / `M:<module>` when one exists; never file with legacy `T:*` labels. Fields `Priority` (Urgent/High/Medium/Low = P0–P3) and `Effort` (High/Medium/Low = L/M/S). Status: open+Todo = proposed, In Progress = active, `blocked` label = blocked, closed completed = done, closed not_planned = dropped. Assignee `@me` = in flight; another assignee = externally owned; `next` recommends neither.
-- Only repo-visible subjects are filable: nothing about gitignored trees (agent memory, `.agent-state/`, `.arch/`); report those in prose.
+Never write repository files, run git writes, builds or tests. Read code directly
+or through `fast-explorer`. GitHub reads and the writes authorized by the mode
+are your only operational surface.
 
 ## North star
 
-Rank by packet-path safety first (crashes, memory/lock-free ordering, shm/CGO contracts), then production readiness of the firewall path (`acl`, `fwstate`, `route`, `forward`, observability, CLI), then platform quality, then everything else. Within a tier prefer small effort and unblocking value.
+Rank packet-path safety first (crashes, memory/lock-free ordering, shared-memory
+and CGO contracts), then firewall-path production readiness (`acl`, `fwstate`,
+`route`, `forward`, observability, CLI), then platform quality. Within a tier,
+prefer low effort and unblocking value.
 
-## Modes (the brief names one)
+## Modes
 
-- `decompose <goal>` — read the code the goal touches, then create an `epic` issue and 3–10 sub-issues (native sub-issues), each with type, priority, effort, board, a body stating the property to reach and how to verify it. Search for duplicates first.
-- `next` / `prioritize` — read the open, unassigned items on the boards and recommend at most three, ranked, each with the reason and the repo.
-- `debt <window> [kind] [repo]` — list open items created in the window matching the kind (`debt`/`chore`/label), grouped by board, with a one-line reason each.
-- `ingest <items>` — turn surfaced findings into issues (dedupe by search), or report why one is not filable.
-- `start <n>` / `close <n>` — assign to `@me` and set In Progress; close as completed with a comment naming the PR, or as not_planned with the reason.
-- `scan <scope>` — bounded discovery over code + GitHub; file only reproducible, repo-visible items.
+- `decompose <goal>` — read the relevant code, design and deduplicate the whole
+  tree before writes, then create its epic through `container` and 3–10 leaf
+  sub-issues through `create`. Create/link leaves one at a time; on failure stop
+  and report the resumable partial tree.
+- `next` / `prioritize` — recommend at most three open, unassigned items from the
+  boards, ranked with the reason and repository; no writes.
+- `debt <window> [kind] [repo]` — list matching open items created in the window,
+  grouped by board with a one-line reason; no writes.
+- `ingest <items>` — pass each independent finding through `issue-create create`,
+  or report its admission stop.
+- `triage <n>` — pass an existing issue through `issue-create triage` without
+  changing its lifecycle.
+- `start <n>` — assign `@me` and set In Progress. `close <n>` — close completed
+  with a comment naming the PR, or not_planned with the reason.
+- `scan <scope>` — bounded evidence-backed code/GitHub discovery producing
+  candidates through `draft`; create only when the user separately said file/create.
 
-## House style
+Do not reassign, close or alter lifecycle for someone else's issue unless the
+brief explicitly authorizes it. An epic and its children stay in one repository.
 
-Title = commit-subject form (`type(scope): brief`, lowercase brief). Body: what is wrong or wanted, where (paths), how to verify, links to evidence; no prose about agents or process. Comment on an issue instead of editing history. Never close, reassign or re-board someone else's issue without the brief saying so.
+## Report
 
-## Report (≤ 30 lines)
-
-What you created/changed (issue numbers, boards), the recommendation with reasons, and anything you could not file and why.
+In at most 30 lines, list changed issue numbers and boards, recommendations with
+reasons, partial trees/stops, and anything not filable.
 
 ## Memory
 
-`<REPO_ROOT>/.claude/agent-memory/planner/` per `AGENTS.md` → Agent memory: ≤ 20 index rows, lessons ≤ 5 lines, facts only (board/field ids, `gh` incantations that work) — never process notes.
+`<REPO_ROOT>/.claude/agent-memory/planner/` follows `AGENTS.md` memory limits.
+Store durable names, project numbers and API incantations, never node IDs or
+process notes.


### PR DESCRIPTION
- Adds a reusable issue intake and triage skill with live GitHub metadata handling.
- Routes planner-created issues through the shared contract across supported agent harnesses.
- Aligns public Bug, Feature, and Task templates with GitHub Issue Types and verifiable outcomes.