### PR TITLE
fix(cli): restore default broken-pipe handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,6 +3089,7 @@ dependencies = [
  "erased-serde",
  "http",
  "humantime",
+ "libc",
  "log",
  "prost",
  "prost-types",

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -34,3 +34,6 @@ serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 thiserror = "1"
 humantime = "2"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -12,10 +12,13 @@ pub mod logging;
 pub mod metrics;
 pub mod output;
 
+mod signal;
+
 /// Initialise the logger and output backend from a `Format` choice.
 ///
 /// Must be called exactly once from `main` before any `output::*` helper.
 /// Panics if called twice or if the logger fails to install.
 pub fn init<F: Format>(verbosity: u8, format: F) {
+    self::signal::init();
     self::output::init(verbosity, format);
 }

--- a/cli/core/src/signal.rs
+++ b/cli/core/src/signal.rs
@@ -1,0 +1,11 @@
+/// Restore Unix's default handling so a closed output pipe ends the CLI
+/// without a printing panic.
+#[cfg(unix)]
+pub fn init() {
+    // SAFETY: both values are valid arguments for the Unix signal API.
+    let previous = unsafe { libc::signal(libc::SIGPIPE, libc::SIG_DFL) };
+    assert_ne!(previous, libc::SIG_ERR, "failed to set SIGPIPE handler");
+}
+
+#[cfg(not(unix))]
+pub fn init() {}


### PR DESCRIPTION
- Restore Unix default SIGPIPE behavior for text-producing CLI commands.
- Apply the behavior through shared CLI initialization so fwstate and other module output stop without a panic when downstream closes stdout.

Closes #2130.