### PR TITLE
fix(xcfg): bound alias expansion in the configuration document walk

### DIFF
--- a/common/go/xcfg/known_keys.go
+++ b/common/go/xcfg/known_keys.go
@@ -29,6 +29,119 @@ const mergeTag = "!!merge"
 
 const nullTag = "!!null"
 
+// Alias expansion work is capped so a merge DAG cannot dominate startup before
+// the YAML decoder applies its own guard.
+const maxAliasExpansionWork = 10_000
+
+type walkState struct {
+	// Complete reports whether the expansion bound was not exhausted.
+	Complete           bool
+	visiting           map[*yaml.Node]bool
+	aliasDepth         int
+	maxExpansionWork   int
+	aliasExpansionWork int
+}
+
+func newWalkState(maxExpansionWork int) *walkState {
+	return &walkState{
+		Complete:         true,
+		visiting:         map[*yaml.Node]bool{},
+		maxExpansionWork: maxExpansionWork,
+	}
+}
+
+func (m *walkState) reserveExpansion(expansionWork int) bool {
+	if !m.Complete {
+		return false
+	}
+	if m.maxExpansionWork == 0 {
+		return true
+	}
+	if expansionWork > m.maxExpansionWork-m.aliasExpansionWork {
+		m.Complete = false
+		return false
+	}
+	m.aliasExpansionWork += expansionWork
+	return true
+}
+
+// ReserveExpansion counts work performed while following an alias.
+func (m *walkState) ReserveExpansion(expansionWork int) bool {
+	if !m.Complete {
+		return false
+	}
+	if m.aliasDepth == 0 {
+		return true
+	}
+	return m.reserveExpansion(expansionWork)
+}
+
+// EnterAlias skips cycles and marks the walk incomplete at the expansion bound.
+func (m *walkState) EnterAlias(node *yaml.Node) (*yaml.Node, bool) {
+	target := node.Alias
+	if target == nil || m.visiting[target] {
+		return nil, false
+	}
+	if !m.reserveExpansion(1) {
+		return nil, false
+	}
+	m.aliasDepth++
+	m.visiting[target] = true
+	return target, true
+}
+
+// LeaveAlias removes a completed target from the current descent path.
+func (m *walkState) LeaveAlias(target *yaml.Node) {
+	m.aliasDepth--
+	delete(m.visiting, target)
+}
+
+type walkPath struct {
+	parent    *walkPath
+	segment   string
+	separator string
+}
+
+// Field returns a child path for a mapping key.
+func (m *walkPath) Field(key string) *walkPath {
+	separator := "."
+	if m == nil {
+		separator = ""
+	}
+	return &walkPath{
+		parent:    m,
+		segment:   key,
+		separator: separator,
+	}
+}
+
+// Index returns a child path for a sequence element.
+func (m *walkPath) Index(idx int) *walkPath {
+	return &walkPath{
+		parent:  m,
+		segment: fmt.Sprintf("[%d]", idx),
+	}
+}
+
+// String renders the path from the document root.
+func (m *walkPath) String() string {
+	var reversed []string
+	length := 0
+	for m != nil {
+		part := m.separator + m.segment
+		reversed = append(reversed, part)
+		length += len(part)
+		m = m.parent
+	}
+
+	var rendered strings.Builder
+	rendered.Grow(length)
+	for _, part := range slices.Backward(reversed) {
+		rendered.WriteString(part)
+	}
+	return rendered.String()
+}
+
 // unknownKey records one mapping key with no matching field, along with the
 // document line it sits on, so the reported error can point straight at it.
 type unknownKey struct {
@@ -46,15 +159,14 @@ type findings struct {
 	Nulls   []nullValue
 }
 
-// CheckKnownKeys reports every YAML mapping key in data that has no matching
-// field in T.
+// CheckKnownKeys reports YAML mapping keys with no matching destination field.
 //
 // It walks the parsed node tree directly against T's reflected shape
 // instead of driving yaml.v3's own strict decoder, so it keeps working
 // across a field whose type implements UnmarshalYAML by re-decoding
 // through a fresh, non-strict decoder. WithKnownFields runs the same walk
-// as part of Decode. Every unknown key is collected into one error, each
-// named by its dotted path rooted at the document and the line it sits on.
+// as part of Decode. Unknown keys are collected into one error, each named by
+// its dotted path rooted at the document and the line it sits on.
 func CheckKnownKeys[T any](data []byte) error {
 	return checkKnownKeys(data, reflect.TypeFor[T]())
 }
@@ -62,25 +174,37 @@ func CheckKnownKeys[T any](data []byte) error {
 // checkKnownKeys drives the same walk as CheckKnownKeys against the
 // reflect.Type its type parameter resolves to.
 func checkKnownKeys(data []byte, t reflect.Type) error {
-	collected, err := walkDocument(data, t)
+	collected, complete, err := walkDocument(data, t, maxAliasExpansionWork)
+	if err != nil {
+		return err
+	}
+	if err := unknownKeysError(collected.Unknown); err != nil || complete {
+		return err
+	}
+
+	if err := yaml.Unmarshal(data, reflect.New(t).Interface()); err != nil {
+		return err
+	}
+	collected, _, err = walkDocument(data, t, 0)
 	if err != nil {
 		return err
 	}
 	return unknownKeysError(collected.Unknown)
 }
 
-func walkDocument(data []byte, t reflect.Type) (*findings, error) {
+func walkDocument(data []byte, t reflect.Type, maxExpansionWork int) (*findings, bool, error) {
 	var doc yaml.Node
 	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	collected := &findings{}
 	if len(doc.Content) == 0 {
-		return collected, nil
+		return collected, true, nil
 	}
 
-	walkKnownKeys(doc.Content[0], t, "", collected, map[*yaml.Node]bool{})
-	return collected, nil
+	state := newWalkState(maxExpansionWork)
+	walkKnownKeys(doc.Content[0], t, nil, collected, state)
+	return collected, state.Complete, nil
 }
 
 func unknownKeysError(unknown []unknownKey) error {
@@ -131,31 +255,26 @@ func isTransparentToWalk(t reflect.Type) bool {
 
 // walkKnownKeys matches node's shape against t, appending the dotted path of
 // every mapping key that has no corresponding field to collected.
-//
-// visiting holds the alias targets already on the current descent path, so
-// a self-referential merge anchor is caught here instead of recursing
-// forever — yaml.v3 only rejects that cycle when decoding into a Go value,
-// not into a node tree, and LoadConfig catches it separately, so stopping
-// silently is enough. The entry is removed on return, so a legitimate
-// anchor reused at sibling paths is still walked at each site.
-func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, collected *findings, visiting map[*yaml.Node]bool) {
+func walkKnownKeys(node *yaml.Node, t reflect.Type, path *walkPath, collected *findings, state *walkState) {
 	if node == nil {
 		return
 	}
 	line := node.Line
 	if node.Kind == yaml.AliasNode {
-		target := node.Alias
-		if target == nil || visiting[target] {
+		target, ok := state.EnterAlias(node)
+		if !ok {
 			return
 		}
-		visiting[target] = true
-		defer delete(visiting, target)
+		defer state.LeaveAlias(target)
 		node = target
+	}
+	if !state.ReserveExpansion(1) {
+		return
 	}
 
 	if node.ShortTag() == nullTag {
 		if t.Kind() != reflect.Pointer && isTransparentToWalk(t) {
-			collected.Nulls = append(collected.Nulls, nullValue{Path: path, Line: line})
+			collected.Nulls = append(collected.Nulls, nullValue{Path: path.String(), Line: line})
 		}
 		return
 	}
@@ -167,7 +286,7 @@ func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, collected *find
 		return
 	}
 	if wt, ok := reflect.Zero(t).Interface().(walkableType); ok {
-		walkKnownKeys(node, wt.WalkType(), path, collected, visiting)
+		walkKnownKeys(node, wt.WalkType(), path, collected, state)
 		return
 	}
 	if isOpaqueToWalk(t) {
@@ -176,9 +295,9 @@ func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, collected *find
 
 	switch node.Kind {
 	case yaml.MappingNode:
-		walkMappingNode(node, t, path, collected, visiting)
+		walkMappingNode(node, t, path, collected, state)
 	case yaml.SequenceNode:
-		walkSequenceNode(node, t, path, collected, visiting)
+		walkSequenceNode(node, t, path, collected, state)
 	}
 }
 
@@ -190,7 +309,7 @@ type mappingResolver func(key string) (reflect.Type, bool)
 // against, so it is skipped without reporting — for example a mapping
 // value against a plain scalar field is a shape mismatch that yaml.v3
 // itself rejects on the strict decode path.
-func walkMappingNode(node *yaml.Node, t reflect.Type, path string, collected *findings, visiting map[*yaml.Node]bool) {
+func walkMappingNode(node *yaml.Node, t reflect.Type, path *walkPath, collected *findings, state *walkState) {
 	var resolve mappingResolver
 	skipComplexKey := false
 	switch t.Kind() {
@@ -216,9 +335,12 @@ func walkMappingNode(node *yaml.Node, t reflect.Type, path string, collected *fi
 	}
 
 	claimed := map[string]bool{}
-	mergeValue := walkMappingKeys(node, resolve, skipComplexKey, path, collected, visiting, claimed)
+	mergeValue := walkMappingKeys(node, resolve, skipComplexKey, path, collected, state, claimed)
+	if !state.Complete {
+		return
+	}
 	if mergeValue != nil {
-		walkMergeValue(mergeValue, resolve, skipComplexKey, path, collected, visiting, claimed)
+		walkMergeValue(mergeValue, resolve, skipComplexKey, path, collected, state, claimed)
 	}
 }
 
@@ -241,7 +363,11 @@ type mappingKeyEntry struct {
 	Line      int
 }
 
-func walkMappingKeys(node *yaml.Node, resolve mappingResolver, skipComplexKey bool, path string, collected *findings, visiting map[*yaml.Node]bool, claimed map[string]bool) *yaml.Node {
+func walkMappingKeys(node *yaml.Node, resolve mappingResolver, skipComplexKey bool, path *walkPath, collected *findings, state *walkState, claimed map[string]bool) *yaml.Node {
+	if !state.ReserveExpansion(len(node.Content) / 2) {
+		return nil
+	}
+
 	var mergeValue *yaml.Node
 	var order []string
 	last := map[string]mappingKeyEntry{}
@@ -263,18 +389,21 @@ func walkMappingKeys(node *yaml.Node, resolve mappingResolver, skipComplexKey bo
 	}
 	for _, key := range order {
 		entry := last[key]
-		walkMappingEntry(resolve, key, entry.Line, entry.ValueNode, path, collected, visiting)
+		walkMappingEntry(resolve, key, entry.Line, entry.ValueNode, path, collected, state)
+		if !state.Complete {
+			return nil
+		}
 	}
 	return mergeValue
 }
 
-func walkMappingEntry(resolve mappingResolver, key string, line int, valueNode *yaml.Node, path string, collected *findings, visiting map[*yaml.Node]bool) {
-	fieldPath := joinPath(path, key)
+func walkMappingEntry(resolve mappingResolver, key string, line int, valueNode *yaml.Node, path *walkPath, collected *findings, state *walkState) {
+	fieldPath := path.Field(key)
 	if fieldType, ok := resolve(key); ok {
-		walkKnownKeys(valueNode, fieldType, fieldPath, collected, visiting)
+		walkKnownKeys(valueNode, fieldType, fieldPath, collected, state)
 		return
 	}
-	collected.Unknown = append(collected.Unknown, unknownKey{Path: fieldPath, Line: line})
+	collected.Unknown = append(collected.Unknown, unknownKey{Path: fieldPath.String(), Line: line})
 }
 
 // walkMergeValue walks a "<<" merge key's value, resolving each merged
@@ -285,59 +414,69 @@ func walkMappingEntry(resolve mappingResolver, key string, line int, valueNode *
 // permits, though neither carries keys to check. A sequence value is
 // walked in place rather than routed through walkSequenceNode, since its
 // elements share resolve rather than a slice element type.
-func walkMergeValue(node *yaml.Node, resolve mappingResolver, skipComplexKey bool, path string, collected *findings, visiting map[*yaml.Node]bool, claimed map[string]bool) {
+func walkMergeValue(node *yaml.Node, resolve mappingResolver, skipComplexKey bool, path *walkPath, collected *findings, state *walkState, claimed map[string]bool) {
+	if !state.ReserveExpansion(1) {
+		return
+	}
 	if node.ShortTag() == nullTag {
 		return
 	}
 	if node.Kind == yaml.SequenceNode {
 		for _, item := range node.Content {
+			if !state.ReserveExpansion(1) {
+				return
+			}
 			if item.ShortTag() == nullTag {
 				continue
 			}
-			walkMergeSource(item, resolve, skipComplexKey, path, collected, visiting, claimed)
+			walkMergeSource(item, resolve, skipComplexKey, path, collected, state, claimed)
+			if !state.Complete {
+				return
+			}
 		}
 		return
 	}
-	walkMergeSource(node, resolve, skipComplexKey, path, collected, visiting, claimed)
+	walkMergeSource(node, resolve, skipComplexKey, path, collected, state, claimed)
 }
 
-func walkMergeSource(node *yaml.Node, resolve mappingResolver, skipComplexKey bool, path string, collected *findings, visiting map[*yaml.Node]bool, claimed map[string]bool) {
+func walkMergeSource(node *yaml.Node, resolve mappingResolver, skipComplexKey bool, path *walkPath, collected *findings, state *walkState, claimed map[string]bool) {
 	if node.Kind == yaml.AliasNode {
-		target := node.Alias
-		if target == nil || visiting[target] {
+		target, ok := state.EnterAlias(node)
+		if !ok {
 			return
 		}
-		visiting[target] = true
-		defer delete(visiting, target)
+		defer state.LeaveAlias(target)
 		node = target
+	}
+	if !state.ReserveExpansion(1) {
+		return
 	}
 	if node.Kind != yaml.MappingNode {
 		return
 	}
 
-	mergeValue := walkMappingKeys(node, resolve, skipComplexKey, path, collected, visiting, claimed)
+	mergeValue := walkMappingKeys(node, resolve, skipComplexKey, path, collected, state, claimed)
+	if !state.Complete {
+		return
+	}
 	if mergeValue != nil {
-		walkMergeValue(mergeValue, resolve, skipComplexKey, path, collected, visiting, claimed)
+		walkMergeValue(mergeValue, resolve, skipComplexKey, path, collected, state, claimed)
 	}
 }
 
 // walkSequenceNode checks each element of a YAML sequence node against a
 // slice or array type's element type.
-func walkSequenceNode(node *yaml.Node, t reflect.Type, path string, collected *findings, visiting map[*yaml.Node]bool) {
+func walkSequenceNode(node *yaml.Node, t reflect.Type, path *walkPath, collected *findings, state *walkState) {
 	if t.Kind() != reflect.Slice && t.Kind() != reflect.Array {
 		return
 	}
 	elemType := t.Elem()
 	for idx, item := range node.Content {
-		walkKnownKeys(item, elemType, fmt.Sprintf("%s[%d]", path, idx), collected, visiting)
+		walkKnownKeys(item, elemType, path.Index(idx), collected, state)
+		if !state.Complete {
+			return
+		}
 	}
-}
-
-func joinPath(path, key string) string {
-	if path == "" {
-		return key
-	}
-	return path + "." + key
 }
 
 // isOpaqueToWalk reports whether t is a struct with no exported fields

--- a/common/go/xcfg/known_keys_test.go
+++ b/common/go/xcfg/known_keys_test.go
@@ -1,8 +1,11 @@
 package xcfg_test
 
 import (
+	"fmt"
 	"net/netip"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -231,6 +234,186 @@ name: x
 	require.Contains(t, err.Error(), "base.bogus")
 	require.Contains(t, err.Error(), "inner.bogus")
 	require.Contains(t, err.Error(), "a.bogus")
+}
+
+// aliasExpansionDocument returns a doubling merge DAG and a shadowed fallback.
+func aliasExpansionDocument(levels int) []byte {
+	var document strings.Builder
+	document.WriteString("good: &good\n  value:\n    addr: kept\n")
+	document.WriteString("a0: &a0\n  value:\n    addr: base\n")
+	for level := 1; level <= levels; level++ {
+		fmt.Fprintf(
+			&document,
+			"a%d: &a%d\n  <<: [*a%d, *a%d]\n",
+			level,
+			level,
+			level-1,
+			level-1,
+		)
+	}
+	document.WriteString("shadowed:\n  <<: [*good, {value: }]\n")
+	return []byte(document.String())
+}
+
+// Test_Decode_ExcessiveAliasExpansion_NativeError verifies that a merge DAG
+// reaches the native guard with and without known-field checking.
+//
+// The shadowed null fallback ensures an exhausted preflight cannot manufacture
+// its own error by continuing after it skips a higher-priority alias.
+func Test_Decode_ExcessiveAliasExpansion_NativeError(t *testing.T) {
+	input := aliasExpansionDocument(30)
+	testCases := []struct {
+		name    string
+		options []xcfg.Option
+	}{
+		{
+			name: "without known-field checking returns native error",
+		},
+		{
+			name:    "with known-field checking returns native error",
+			options: []xcfg.Option{xcfg.WithKnownFields()},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			decoded := make(chan error, 1)
+			go func() {
+				var config map[string]map[string]knownKeysInner
+				decoded <- xcfg.Decode(input, &config, testCase.options...)
+			}()
+
+			select {
+			case err := <-decoded:
+				require.EqualError(t, err, "yaml: document contains excessive aliasing")
+			case <-time.After(time.Second):
+				t.Fatal("decoding did not terminate within one second")
+			}
+		})
+	}
+}
+
+type deepAliasNode struct {
+	// Next follows the preceding anchored mapping.
+	Next *deepAliasNode `yaml:"next"`
+}
+
+type deepAliasConfig struct {
+	// Anchors keeps physical definitions opaque to the decoder.
+	Anchors yaml.Node `yaml:"anchors"`
+	// Root exposes the anchored chain as transparent configuration.
+	Root deepAliasNode `yaml:"root"`
+}
+
+// deepAliasPathDocument returns an anchored chain with a growing field path.
+func deepAliasPathDocument(levels int) []byte {
+	var document strings.Builder
+	document.WriteString("anchors:\n  a0: &a0 {}\n")
+	for level := 1; level <= levels; level++ {
+		fmt.Fprintf(
+			&document,
+			"  a%d: &a%d {next: *a%d}\n",
+			level,
+			level,
+			level-1,
+		)
+	}
+	fmt.Fprintf(&document, "root: *a%d\n", levels)
+	return []byte(document.String())
+}
+
+// Test_Decode_DeepAliasPath_NativeErrorBeforePathExpansion verifies that a
+// growing field path reaches the native alias guard without quadratic delay.
+func Test_Decode_DeepAliasPath_NativeErrorBeforePathExpansion(t *testing.T) {
+	input := deepAliasPathDocument(20_000)
+	decoded := make(chan error, 1)
+	go func() {
+		var config deepAliasConfig
+		decoded <- xcfg.Decode(input, &config)
+	}()
+
+	select {
+	case err := <-decoded:
+		require.EqualError(t, err, "yaml: document contains excessive aliasing")
+	case <-time.After(5 * time.Second):
+		t.Fatal("decoding did not terminate within five seconds")
+	}
+}
+
+type opaqueAliasConfig struct {
+	// Anchor holds the large opaque YAML value.
+	Anchor yaml.Node `yaml:"anchor"`
+	// Copies holds aliases that reuse the opaque value.
+	Copies []yaml.Node `yaml:"copies"`
+	// Block is a transparent field whose null must still be rejected.
+	Block knownKeysInner `yaml:"block"`
+}
+
+// opaqueAliasReuseDocument returns a large opaque anchor before a null block.
+func opaqueAliasReuseDocument(anchorValues, copies int) []byte {
+	var document strings.Builder
+	document.WriteString("anchor: &large [")
+	for value := range anchorValues {
+		if value > 0 {
+			document.WriteByte(',')
+		}
+		fmt.Fprintf(&document, "%d", value)
+	}
+	document.WriteString("]\ncopies:\n")
+	for range copies {
+		document.WriteString("  - *large\n")
+	}
+	document.WriteString("block:\n")
+	return []byte(document.String())
+}
+
+// Test_Decode_OpaqueAliasReuse_LaterNullStillRejected verifies that reusing a
+// large opaque anchor cannot hide a later body-less block.
+func Test_Decode_OpaqueAliasReuse_LaterNullStillRejected(t *testing.T) {
+	input := opaqueAliasReuseDocument(1_001, 100)
+	var config opaqueAliasConfig
+	err := xcfg.Decode(input, &config)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"block"`)
+	require.Contains(t, err.Error(), "has no value")
+}
+
+type transparentAliasConfig struct {
+	// Anchor holds the large transparent YAML mapping.
+	Anchor map[string]string `yaml:"anchor"`
+	// Copies holds aliases that must be inspected as mappings.
+	Copies []map[string]string `yaml:"copies"`
+	// Block is a transparent field whose null must still be rejected.
+	Block knownKeysInner `yaml:"block"`
+}
+
+// transparentAliasReuseDocument returns a reused mapping before a null block.
+func transparentAliasReuseDocument(anchorEntries, copies int) []byte {
+	var document strings.Builder
+	document.WriteString("anchor: &large {")
+	for entry := range anchorEntries {
+		if entry > 0 {
+			document.WriteByte(',')
+		}
+		fmt.Fprintf(&document, "k%d: value", entry)
+	}
+	document.WriteString("}\ncopies:\n")
+	for range copies {
+		document.WriteString("  - *large\n")
+	}
+	document.WriteString("block:\n")
+	return []byte(document.String())
+}
+
+// Test_Decode_TransparentAliasReuse_LaterNullStillRejected verifies that a
+// native-accepted expansion cannot truncate checks of later fields.
+func Test_Decode_TransparentAliasReuse_LaterNullStillRejected(t *testing.T) {
+	input := transparentAliasReuseDocument(1_001, 50)
+	var config transparentAliasConfig
+	err := xcfg.Decode(input, &config)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"block"`)
+	require.Contains(t, err.Error(), "has no value")
 }
 
 func Test_CheckKnownKeys_UntaggedFieldLowercasedNameNotFlagged(t *testing.T) {

--- a/common/go/xcfg/load.go
+++ b/common/go/xcfg/load.go
@@ -88,35 +88,63 @@ func Decode(buf []byte, dst any, options ...Option) error {
 		o(opts)
 	}
 
-	f, err := walkDocument(buf, reflect.TypeOf(dst))
+	collected, complete, err := walkDocument(
+		buf,
+		reflect.TypeOf(dst),
+		maxAliasExpansionWork,
+	)
 	if err != nil {
 		return err
 	}
 	if opts.KnownFields {
-		if err := unknownKeysError(f.Unknown); err != nil {
+		if err := unknownKeysError(collected.Unknown); err != nil {
 			return err
 		}
 	}
-	if err := nullValuesError(f.Nulls); err != nil {
+	if err := nullValuesError(collected.Nulls); err != nil {
 		return err
 	}
 
-	if opts.KnownFields {
-		// The walk above runs first so an unknown key always reports
-		// through its operator-facing message rather than yaml.v3's own. This decode
-		// is what actually populates dst.
-		dec := yaml.NewDecoder(bytes.NewReader(buf))
-		dec.KnownFields(true)
-		if err := dec.Decode(dst); err != nil && !errors.Is(err, io.EOF) {
+	decoded := false
+	if !complete {
+		if err := decodeYAML(buf, dst, false); err != nil {
 			return err
 		}
-	} else {
-		if err := yaml.Unmarshal(buf, dst); err != nil {
+		decoded = true
+
+		collected, _, err = walkDocument(buf, reflect.TypeOf(dst), 0)
+		if err != nil {
+			return err
+		}
+		if opts.KnownFields {
+			if err := unknownKeysError(collected.Unknown); err != nil {
+				return err
+			}
+		}
+		if err := nullValuesError(collected.Nulls); err != nil {
 			return err
 		}
 	}
 
+	if !decoded {
+		if err := decodeYAML(buf, dst, opts.KnownFields); err != nil {
+			return err
+		}
+	}
 	return validate(reflect.ValueOf(dst), "")
+}
+
+func decodeYAML(buf []byte, dst any, knownFields bool) error {
+	if !knownFields {
+		return yaml.Unmarshal(buf, dst)
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(buf))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(dst); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
 }
 
 func validate(v reflect.Value, path string) error {


### PR DESCRIPTION
- Bounds configuration inspection by alias-expanded node count while preserving cycle handling.
- Stops partial inspection cleanly so yaml.v3 retains its native excessive-aliasing diagnostic in both decode modes.
- Covers compact doubling merge DAGs and shadowed lower-priority merge content.
- Closes #2110.