### PR TITLE
refactor(route): migrate operator prefix fields to commonpb

### DIFF
--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -258,23 +258,48 @@ impl TryFrom<IpNetwork> for pb::ContiguousIpNetwork {
     }
 }
 
+/// Decodes the address and prefix length a `ContiguousIpNetwork` carries.
+///
+/// Shared by both network conversions below so the wire validation lives in
+/// one place and the two decode paths cannot drift apart.
+fn decode_ip_network(net: &pb::ContiguousIpNetwork) -> Result<(IpAddr, u8), Box<dyn Error>> {
+    let addr = net.addr.as_ref().ok_or("invalid IP network: missing address")?;
+    let addr = IpAddr::try_from(addr)?;
+    let prefix_len: u8 = net
+        .prefix_len
+        .try_into()
+        .map_err(|_| format!("invalid prefix length {}: exceeds 255", net.prefix_len))?;
+
+    Ok((addr, prefix_len))
+}
+
 impl TryFrom<&pb::ContiguousIpNetwork> for IpNetwork {
     type Error = Box<dyn Error>;
 
     /// Masks host bits to `prefix_len` rather than rejecting them.
     fn try_from(net: &pb::ContiguousIpNetwork) -> Result<Self, Self::Error> {
-        let addr = net.addr.as_ref().ok_or("invalid IP network: missing address")?;
-        let addr = IpAddr::try_from(addr)?;
-        let prefix_len: u8 = net
-            .prefix_len
-            .try_into()
-            .map_err(|_| format!("invalid prefix length {}: exceeds 255", net.prefix_len))?;
+        let (addr, prefix_len) = decode_ip_network(net)?;
 
         let result = match addr {
             IpAddr::V4(v4) => IpNetwork::try_from((v4, prefix_len)),
             IpAddr::V6(v6) => IpNetwork::try_from((v6, prefix_len)),
         };
         result.map_err(|e| format!("invalid prefix length {prefix_len}: {e}").into())
+    }
+}
+
+impl TryFrom<&pb::ContiguousIpNetwork> for Contiguous<IpNetwork> {
+    type Error = Box<dyn Error>;
+
+    /// Masks host bits to `prefix_len`, like the [`IpNetwork`] conversion.
+    ///
+    /// A mask built from a prefix length is contiguous by construction, so
+    /// this never has to reject a non-contiguous mask.
+    fn try_from(net: &pb::ContiguousIpNetwork) -> Result<Self, Self::Error> {
+        let (addr, prefix_len) = decode_ip_network(net)?;
+
+        Contiguous::<IpNetwork>::try_from((addr, prefix_len))
+            .map_err(|e| format!("invalid prefix length {prefix_len}: {e}").into())
     }
 }
 
@@ -648,6 +673,53 @@ mod test {
         assert_eq!(32, msg.prefix_len);
         let got = IpNetwork::try_from(&msg).unwrap();
         assert_eq!(*net, got);
+    }
+
+    /// The `Contiguous<IpNetwork>` decode accepts exactly what the bare
+    /// `IpNetwork` one does, since both go through `decode_ip_network`, and
+    /// keeps the contiguity guarantee in the type.
+    #[test]
+    fn contiguous_ip_network_contiguous_round_trip() {
+        for cidr in ["10.0.0.0/24", "2001:db8::/32"] {
+            let net = Contiguous::<IpNetwork>::parse(cidr).unwrap();
+            let msg = pb::ContiguousIpNetwork::from(net);
+            let got = Contiguous::<IpNetwork>::try_from(&msg).unwrap();
+            assert_eq!(net, got, "round trip must preserve {cidr}");
+        }
+    }
+
+    /// Mirrors [`contiguous_ip_network_try_from_masks_host_bits_v4`] for the
+    /// `Contiguous<IpNetwork>` decode.
+    #[test]
+    fn contiguous_ip_network_contiguous_try_from_masks_host_bits() {
+        let msg = pb::ContiguousIpNetwork {
+            addr: Some(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))),
+            prefix_len: 24,
+        };
+        let got = Contiguous::<IpNetwork>::try_from(&msg).unwrap();
+        assert_eq!(Contiguous::<IpNetwork>::parse("10.0.0.0/24").unwrap(), got);
+    }
+
+    /// Both decodes reject the same malformed messages, since the shared
+    /// `decode_ip_network` is what rejects them.
+    #[test]
+    fn contiguous_ip_network_contiguous_try_from_rejects_malformed() {
+        let malformed = [
+            pb::ContiguousIpNetwork { addr: None, prefix_len: 24 },
+            pb::ContiguousIpNetwork {
+                addr: Some(pb::IpAddress { addr: vec![10, 0, 0] }),
+                prefix_len: 24,
+            },
+            pb::ContiguousIpNetwork {
+                addr: Some(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)))),
+                prefix_len: 33,
+            },
+        ];
+
+        for msg in &malformed {
+            assert!(Contiguous::<IpNetwork>::try_from(msg).is_err(), "must reject {msg:?}");
+            assert!(IpNetwork::try_from(msg).is_err(), "must reject {msg:?}");
+        }
     }
 
     /// `Display` alone would hide a wrong-family or unmasked encoding, so

--- a/operators/bird-adapter/internal/rib/routes.go
+++ b/operators/bird-adapter/internal/rib/routes.go
@@ -103,7 +103,11 @@ func convertLargeCommunity(community LargeCommunity) *routepb.LargeCommunity {
 	}
 }
 
-func ToPBRoute(route *Route) *routepb.Route {
+// ToPBRoute converts an adapter Route to the wire Route message.
+//
+// Returns an error if the route carries an invalid prefix, which the
+// structured wire message cannot represent.
+func ToPBRoute(route *Route) (*routepb.Route, error) {
 	communities := make([]*routepb.LargeCommunity, 0, len(route.LargeCommunities))
 	for _, c := range route.LargeCommunities {
 		communities = append(communities, convertLargeCommunity(c))
@@ -121,8 +125,13 @@ func ToPBRoute(route *Route) *routepb.Route {
 		originAS = route.ASPath[len(route.ASPath)-1]
 	}
 
+	prefix, err := commonpb.NewContiguousIPNetworkFromPrefix(route.Prefix)
+	if err != nil {
+		return nil, fmt.Errorf("invalid prefix %q: %w", route.Prefix, err)
+	}
+
 	return &routepb.Route{
-		Prefix:           route.Prefix.String(),
+		Prefix:           prefix,
 		NextHop:          commonpb.NewIPAddressFromAddr(route.NextHop),
 		Peer:             peer,
 		PeerAs:           peerAS,
@@ -134,7 +143,7 @@ func ToPBRoute(route *Route) *routepb.Route {
 		LargeCommunities: communities,
 		GlobalId:         route.GlobalID,
 		Ifindex:          route.Ifindex,
-	}
+	}, nil
 }
 
 func ToPBMPLSRoute(route *Route, source netip.Addr) *routemplspb.Rule {

--- a/operators/bird-adapter/service.go
+++ b/operators/bird-adapter/service.go
@@ -444,10 +444,19 @@ func (m *AdapterService) processBirdImport(
 				continue
 			}
 
-			err := (*currentStream).Send(&routepb.Update{
+			route, err := rib.ToPBRoute(&routes[idx])
+			if err != nil {
+				clientLog.Debug("route cannot be converted to protobuf, skip",
+					zap.String("prefix", routes[idx].Prefix.String()),
+					zap.Error(err),
+				)
+				continue
+			}
+
+			err = (*currentStream).Send(&routepb.Update{
 				Name:     name,
 				IsDelete: routes[idx].ToRemove,
-				Route:    rib.ToPBRoute(&routes[idx]),
+				Route:    route,
 			})
 			if err != nil {
 				// This error stops bird.Export, triggering reconnection in runBirdImportLoop

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -16,6 +16,7 @@ use clap_complete::{
     engine::{ArgValueCandidates, CompletionCandidate},
 };
 use colored::Colorize;
+use commonpb::pb::ContiguousIpNetwork;
 use netip::{Contiguous, IpNetwork};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
@@ -323,7 +324,7 @@ impl RouteService {
 
         let request = InsertRouteRequest {
             name: cmd.name.clone(),
-            prefix: cmd.prefix.to_string(),
+            prefix: Some(ContiguousIpNetwork::from(cmd.prefix)),
             nexthop_addrs,
             do_flush: true,
             source_id: cmd.source.to_proto().into(),
@@ -361,7 +362,7 @@ impl RouteService {
 
         let request = DeleteRouteRequest {
             name: cmd.name.clone(),
-            prefix: cmd.prefix.to_string(),
+            prefix: Some(ContiguousIpNetwork::from(cmd.prefix)),
             nexthop_addrs,
             do_flush: true,
             source_id: cmd.source.to_proto().into(),
@@ -448,12 +449,14 @@ impl Display for Communities {
 }
 
 /// A destination prefix as reported by the server: either successfully
-/// parsed, or the raw string that failed to parse.
+/// decoded, or the debug rendering of the wire message that failed to
+/// decode.
 ///
-/// The malformed case keeps the original string instead of discarding it, so
-/// two different malformed values never compare equal and are never grouped
-/// into the same ECMP set. Every parsed value orders before every malformed
-/// one. Malformed values order lexicographically by their raw string.
+/// The malformed case keeps a rendering of the original message instead of
+/// discarding it, so two different malformed values never compare equal and
+/// are never grouped into the same ECMP set. Every parsed value orders
+/// before every malformed one. Malformed values order lexicographically by
+/// that rendering.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PrefixValue {
     Parsed(Contiguous<IpNetwork>),
@@ -550,9 +553,9 @@ pub struct RouteEntry {
 impl From<operatorpb::Route> for RouteEntry {
     fn from(route: operatorpb::Route) -> Self {
         let communities = route.large_communities.into_iter().map(|c| c.into()).collect();
-        let prefix = match Contiguous::<IpNetwork>::parse(&route.prefix) {
-            Ok(prefix) => PrefixValue::Parsed(prefix),
-            Err(..) => PrefixValue::Malformed(route.prefix),
+        let prefix = match route.prefix.as_ref().map(Contiguous::<IpNetwork>::try_from) {
+            Some(Ok(prefix)) => PrefixValue::Parsed(prefix),
+            _ => PrefixValue::Malformed(format!("{:?}", route.prefix)),
         };
 
         Self {
@@ -625,14 +628,17 @@ where
 mod test {
     use super::*;
 
-    /// `next_hop`/`peer` need no `serialize_with` override: a plain
-    /// `Option<commonpb::pb::IpAddress>` field already serializes as the
-    /// plain address string, or `null` when absent, through that type's
-    /// own `Serialize` impl. This pins that output byte-for-byte.
+    /// `prefix`/`next_hop`/`peer` need no `serialize_with` override: plain
+    /// `Option<commonpb::pb::ContiguousIpNetwork>` and
+    /// `Option<commonpb::pb::IpAddress>` fields already serialize as the
+    /// CIDR or plain address string, or `null` when absent, through those
+    /// types' own `Serialize` impls. This pins that output byte-for-byte,
+    /// including that the structured prefix still renders as the same
+    /// `"10.0.0.0/8"` string the wire string field used to produce.
     #[test]
-    fn route_next_hop_and_peer_serialize_without_a_field_override() {
+    fn route_prefix_next_hop_and_peer_serialize_without_a_field_override() {
         let route = operatorpb::Route {
-            prefix: "10.0.0.0/8".to_owned(),
+            prefix: Some("10.0.0.0/8".parse().unwrap()),
             next_hop: Some(commonpb::pb::IpAddress::from(IpAddr::V4(core::net::Ipv4Addr::new(
                 192, 0, 2, 1,
             )))),
@@ -747,20 +753,59 @@ mod test {
         entry_with(PrefixValue::Malformed(prefix_str.to_string()), source, is_best)
     }
 
-    /// A malformed prefix string from the server converts into a
-    /// `RouteEntry` carrying the raw string, instead of aborting the
-    /// process.
+    /// A prefix the server sends as a message that cannot be decoded --
+    /// missing, wrong `addr` length, or a prefix length past the family
+    /// bound -- converts into a `RouteEntry` carrying the malformed marker,
+    /// instead of aborting the process.
     #[test]
     fn route_entry_from_malformed_prefix_does_not_panic() {
-        let route = operatorpb::Route {
-            prefix: "not-a-prefix".to_owned(),
-            is_best: true,
-            ..Default::default()
+        let malformed = [
+            None,
+            Some(ContiguousIpNetwork { addr: None, prefix_len: 8 }),
+            Some(ContiguousIpNetwork {
+                addr: Some(commonpb::pb::IpAddress { addr: vec![10, 0, 0] }),
+                prefix_len: 8,
+            }),
+            Some(ContiguousIpNetwork {
+                addr: Some(commonpb::pb::IpAddress { addr: vec![10, 0, 0, 0] }),
+                prefix_len: 33,
+            }),
+        ];
+
+        for prefix in malformed {
+            let route = operatorpb::Route {
+                prefix,
+                is_best: true,
+                ..Default::default()
+            };
+
+            let entry = RouteEntry::from(route);
+
+            assert!(
+                matches!(entry.prefix.0, PrefixValue::Malformed(..)),
+                "expected a malformed prefix, got {:?}",
+                entry.prefix.0
+            );
+            assert_eq!("invalid", entry.prefix.0.to_string());
+        }
+    }
+
+    /// Two prefixes that both fail to decode stay distinct values, so
+    /// `annotate_ecmp_groups` never folds unrelated malformed routes into
+    /// one ECMP group.
+    #[test]
+    fn route_entry_malformed_prefixes_stay_distinct() {
+        let entry_of = |addr: Vec<u8>| {
+            RouteEntry::from(operatorpb::Route {
+                prefix: Some(ContiguousIpNetwork {
+                    addr: Some(commonpb::pb::IpAddress { addr }),
+                    prefix_len: 8,
+                }),
+                ..Default::default()
+            })
         };
 
-        let entry = RouteEntry::from(route);
-
-        assert_eq!(PrefixValue::Malformed("not-a-prefix".to_owned()), entry.prefix.0);
+        assert_ne!(entry_of(vec![10, 0, 0]).prefix.0, entry_of(vec![10, 0]).prefix.0);
     }
 
     /// Two best routes sharing a prefix are marked with ECMP size 2; a prefix

--- a/operators/route/internal/operator/service_route.go
+++ b/operators/route/internal/operator/service_route.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
 	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
 	"github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
@@ -156,7 +157,11 @@ func (m *RouteService) ShowRoutes(
 
 			bestMask := routesList.BestPerSourceMask()
 			for idx, r := range routesList.Routes {
-				response.Routes = append(response.Routes, operatorpb.FromRIBRoute(&r, bestMask[idx]))
+				route, err := operatorpb.FromRIBRoute(&r, bestMask[idx])
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "failed to convert route: %v", err)
+				}
+				response.Routes = append(response.Routes, route)
 			}
 		}
 	}
@@ -191,14 +196,23 @@ func (m *RouteService) LookupRoute(
 		return &operatorpb.LookupRouteResponse{}, nil
 	}
 
+	matched, err := commonpb.NewContiguousIPNetworkFromPrefix(prefix)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to convert matched prefix %q: %v", prefix, err)
+	}
+
 	response := &operatorpb.LookupRouteResponse{
-		Prefix: prefix.String(),
+		Prefix: matched,
 		Routes: make([]*operatorpb.Route, 0, len(routes.Routes)),
 	}
 
 	bestMask := routes.BestPerSourceMask()
 	for idx, r := range routes.Routes {
-		response.Routes = append(response.Routes, operatorpb.FromRIBRoute(&r, bestMask[idx]))
+		route, err := operatorpb.FromRIBRoute(&r, bestMask[idx])
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to convert route: %v", err)
+		}
+		response.Routes = append(response.Routes, route)
 	}
 
 	return response, nil
@@ -213,9 +227,9 @@ func (m *RouteService) InsertRoute(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	prefix, err := netip.ParsePrefix(req.GetPrefix())
+	prefix, err := req.GetPrefix().ToPrefix()
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix %q: %v", req.GetPrefix(), err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid prefix: %v", err)
 	}
 
 	addrs := req.GetNexthopAddrs()
@@ -268,9 +282,9 @@ func (m *RouteService) DeleteRoute(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	prefix, err := netip.ParsePrefix(req.GetPrefix())
+	prefix, err := req.GetPrefix().ToPrefix()
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid prefix: %v", err)
 	}
 
 	addrs := req.GetNexthopAddrs()

--- a/operators/route/internal/operator/service_route_test.go
+++ b/operators/route/internal/operator/service_route_test.go
@@ -15,6 +15,16 @@ import (
 	operatorpb "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
 )
 
+// mustNetwork builds the wire prefix message from a CIDR string.
+func mustNetwork(t *testing.T, s string) *commonpb.ContiguousIPNetwork {
+	t.Helper()
+
+	network, err := commonpb.ParseContiguousIPNetwork(s)
+	require.NoError(t, err)
+
+	return network
+}
+
 // TestShowRoutes_StaticECMP_BothBest verifies that two static ECMP nexthops
 // for the same prefix both carry is_best=true.
 func TestShowRoutes_StaticECMP_BothBest(t *testing.T) {
@@ -25,7 +35,7 @@ func TestShowRoutes_StaticECMP_BothBest(t *testing.T) {
 
 	_, err := svc.InsertRoute(t.Context(), &operatorpb.InsertRouteRequest{
 		Name:         "route0",
-		Prefix:       "10.0.0.0/24",
+		Prefix:       mustNetwork(t, "10.0.0.0/24"),
 		NexthopAddrs: []*commonpb.IPAddress{nh1, nh2},
 		SourceId:     operatorpb.RouteSourceID_ROUTE_SOURCE_ID_STATIC,
 	})
@@ -48,7 +58,7 @@ func TestShowRoutes_BirdDifferentPref_OnlyBetterIsBest(t *testing.T) {
 	// Insert the lower-Pref route first so ordering is not insertion-order.
 	_, err := svc.InsertRoute(t.Context(), &operatorpb.InsertRouteRequest{
 		Name:         "route0",
-		Prefix:       "10.1.0.0/24",
+		Prefix:       mustNetwork(t, "10.1.0.0/24"),
 		NexthopAddrs: []*commonpb.IPAddress{commonpb.NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.2"))},
 		SourceId:     operatorpb.RouteSourceID_ROUTE_SOURCE_ID_STATIC,
 	})
@@ -128,7 +138,7 @@ func TestLookupRoute_ThreeWay(t *testing.T) {
 	t.Run("matching route", func(t *testing.T) {
 		_, err := svc.InsertRoute(t.Context(), &operatorpb.InsertRouteRequest{
 			Name:         "route0",
-			Prefix:       "10.0.0.0/24",
+			Prefix:       mustNetwork(t, "10.0.0.0/24"),
 			NexthopAddrs: []*commonpb.IPAddress{commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.168.1.1"))},
 			SourceId:     operatorpb.RouteSourceID_ROUTE_SOURCE_ID_STATIC,
 		})
@@ -136,7 +146,9 @@ func TestLookupRoute_ThreeWay(t *testing.T) {
 
 		resp, err := svc.LookupRoute(t.Context(), &operatorpb.LookupRouteRequest{Name: "route0", IpAddr: addr})
 		require.NoError(t, err)
-		require.Equal(t, "10.0.0.0/24", resp.GetPrefix())
+		matched, err := resp.GetPrefix().ToPrefix()
+		require.NoError(t, err)
+		require.Equal(t, netip.MustParsePrefix("10.0.0.0/24"), matched)
 		require.Len(t, resp.GetRoutes(), 1)
 	})
 }
@@ -146,7 +158,7 @@ func TestInsertRoute_NonStaticMultipleNexthops_InvalidArgument(t *testing.T) {
 
 	req := &operatorpb.InsertRouteRequest{
 		Name:   "route0",
-		Prefix: "10.0.0.0/24",
+		Prefix: mustNetwork(t, "10.0.0.0/24"),
 		NexthopAddrs: []*commonpb.IPAddress{
 			commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.168.1.1")),
 			commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.168.1.2")),
@@ -159,6 +171,80 @@ func TestInsertRoute_NonStaticMultipleNexthops_InvalidArgument(t *testing.T) {
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	require.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// TestInsertRoute_MalformedPrefix_InvalidArgument verifies that a prefix
+// the shared type cannot decode never reaches the RIB.
+//
+// Every malformed shape stays on the InvalidArgument path, and a rejected
+// insert leaves no RIB behind for the named config.
+func TestInsertRoute_MalformedPrefix_InvalidArgument(t *testing.T) {
+	nexthops := []*commonpb.IPAddress{commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.168.1.1"))}
+
+	testCases := []struct {
+		name   string
+		prefix *commonpb.ContiguousIPNetwork
+	}{
+		{
+			name:   "missing prefix",
+			prefix: nil,
+		},
+		{
+			name:   "missing addr",
+			prefix: &commonpb.ContiguousIPNetwork{PrefixLen: 24},
+		},
+		{
+			name:   "addr of invalid length",
+			prefix: &commonpb.ContiguousIPNetwork{Addr: &commonpb.IPAddress{Addr: []byte{10, 0, 0}}, PrefixLen: 24},
+		},
+		{
+			name:   "prefix length beyond address family",
+			prefix: &commonpb.ContiguousIPNetwork{Addr: &commonpb.IPAddress{Addr: []byte{10, 0, 0, 0}}, PrefixLen: 33},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			svc := NewRouteService(neigh.NewNeighTable())
+
+			_, err := svc.InsertRoute(t.Context(), &operatorpb.InsertRouteRequest{
+				Name:         "route0",
+				Prefix:       testCase.prefix,
+				NexthopAddrs: nexthops,
+				SourceId:     operatorpb.RouteSourceID_ROUTE_SOURCE_ID_STATIC,
+			})
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+			_, ok := svc.ribs.Get("route0")
+			require.False(t, ok, "a rejected insert must not create a RIB")
+		})
+	}
+}
+
+// TestInsertRoute_HostBitsAreMasked verifies that host bits below the
+// prefix length are masked off before the route reaches the RIB.
+//
+// The route is therefore stored, and reported back, under its network
+// address rather than under the address the caller sent.
+func TestInsertRoute_HostBitsAreMasked(t *testing.T) {
+	svc := NewRouteService(neigh.NewNeighTable())
+
+	_, err := svc.InsertRoute(t.Context(), &operatorpb.InsertRouteRequest{
+		Name: "route0",
+		// 10.0.0.7/24 with host bits deliberately left set.
+		Prefix:       &commonpb.ContiguousIPNetwork{Addr: &commonpb.IPAddress{Addr: []byte{10, 0, 0, 7}}, PrefixLen: 24},
+		NexthopAddrs: []*commonpb.IPAddress{commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.168.1.1"))},
+		SourceId:     operatorpb.RouteSourceID_ROUTE_SOURCE_ID_STATIC,
+	})
+	require.NoError(t, err)
+
+	resp, err := svc.ShowRoutes(t.Context(), &operatorpb.ShowRoutesRequest{Name: "route0"})
+	require.NoError(t, err)
+	require.Len(t, resp.GetRoutes(), 1)
+
+	prefix, err := resp.GetRoutes()[0].GetPrefix().ToPrefix()
+	require.NoError(t, err)
+	require.Equal(t, netip.MustParsePrefix("10.0.0.0/24"), prefix)
 }
 
 // TestShowRoutes_ConfiguredModule_NoRIBYet_Success verifies that ShowRoutes

--- a/operators/route/operatorpb/v1/convert.go
+++ b/operators/route/operatorpb/v1/convert.go
@@ -3,7 +3,6 @@ package operatorpb
 import (
 	"fmt"
 	"math"
-	"net/netip"
 	"time"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
@@ -11,7 +10,10 @@ import (
 )
 
 // FromRIBRoute converts an internal rib.Route to the wire Route message.
-func FromRIBRoute(route *rib.Route, isBest bool) *Route {
+//
+// Returns an error if the route carries an invalid prefix, which the
+// structured wire message cannot represent.
+func FromRIBRoute(route *rib.Route, isBest bool) (*Route, error) {
 	communities := make([]*LargeCommunity, 0, len(route.LargeCommunities))
 	for _, c := range route.LargeCommunities {
 		communities = append(communities, convertLargeCommunity(c))
@@ -22,8 +24,13 @@ func FromRIBRoute(route *rib.Route, isBest bool) *Route {
 		peer = commonpb.NewIPAddressFromAddr(route.Peer)
 	}
 
+	prefix, err := commonpb.NewContiguousIPNetworkFromPrefix(route.Prefix)
+	if err != nil {
+		return nil, fmt.Errorf("invalid prefix %q: %w", route.Prefix, err)
+	}
+
 	return &Route{
-		Prefix:           route.Prefix.String(),
+		Prefix:           prefix,
 		NextHop:          commonpb.NewIPAddressFromAddr(route.NextHop),
 		Peer:             peer,
 		PeerAs:           route.PeerAS,
@@ -35,7 +42,7 @@ func FromRIBRoute(route *rib.Route, isBest bool) *Route {
 		IsBest:           isBest,
 		GlobalId:         route.GlobalID,
 		Ifindex:          route.Ifindex,
-	}
+	}, nil
 }
 
 func convertLargeCommunity(community rib.LargeCommunity) *LargeCommunity {
@@ -48,13 +55,16 @@ func convertLargeCommunity(community rib.LargeCommunity) *LargeCommunity {
 
 // ToRIBRoute converts a wire Route message to the internal rib.Route
 // representation.
+//
+// The prefix is masked to its prefix length, so host bits set by the
+// sender never reach the RIB.
 func ToRIBRoute(route *Route, toRemove bool) (*rib.Route, error) {
 	if route == nil {
 		return nil, fmt.Errorf("update.Route cannot be nil")
 	}
-	prefix, err := netip.ParsePrefix(route.GetPrefix())
+	prefix, err := route.GetPrefix().ToPrefix()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid prefix: %w", err)
 	}
 	nexthop, err := route.GetNextHop().ToAddr()
 	if err != nil {

--- a/operators/route/operatorpb/v1/route.proto
+++ b/operators/route/operatorpb/v1/route.proto
@@ -5,6 +5,7 @@ package operators.route.operatorpb.v1;
 option go_package = "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1;operatorpb";
 
 import "common/commonpb/v1/ipaddr.proto";
+import "common/commonpb/v1/ipnetwork.proto";
 
 // RouteService is the operator-owned routing surface.
 service RouteService {
@@ -59,7 +60,7 @@ message LookupRouteRequest {
 // LookupRouteResponse contains the matching routes for the IP address.
 message LookupRouteResponse {
   // Prefix is the prefix that matched with the IP address.
-  string prefix = 1;
+  common.commonpb.v1.ContiguousIPNetwork prefix = 1;
   // Matching routes for the IP address, sorted with best path first.
   repeated Route routes = 2;
 }
@@ -67,8 +68,9 @@ message LookupRouteResponse {
 // InsertRouteRequest is the request to insert a route.
 message InsertRouteRequest {
   string name = 1;
-  // The destination prefix of the route.
-  string prefix = 2;
+  // The destination prefix of the route. Host bits below the prefix
+  // length are masked off by the server.
+  common.commonpb.v1.ContiguousIPNetwork prefix = 2;
   // NexthopAddrs is the list of nexthop IP addresses.
   repeated common.commonpb.v1.IPAddress nexthop_addrs = 3;
 
@@ -86,7 +88,9 @@ message InsertRouteResponse {}
 // DeleteRouteRequest is the request to delete a route.
 message DeleteRouteRequest {
   string name = 1;
-  string prefix = 2;
+  // The destination prefix of the route. Host bits below the prefix
+  // length are masked off by the server.
+  common.commonpb.v1.ContiguousIPNetwork prefix = 2;
   // NexthopAddrs is the list of nexthop IP addresses.
   repeated common.commonpb.v1.IPAddress nexthop_addrs = 3;
 
@@ -123,7 +127,7 @@ message ListConfigsResponse { repeated string configs = 1; }
 
 // Route represents a routing table entry.
 message Route {
-  string prefix = 1;
+  common.commonpb.v1.ContiguousIPNetwork prefix = 1;
   common.commonpb.v1.IPAddress next_hop = 2;
   common.commonpb.v1.IPAddress peer = 3;
   uint64 route_distinguisher = 4;

--- a/operators/route/web/LookupDrawer.tsx
+++ b/operators/route/web/LookupDrawer.tsx
@@ -4,7 +4,7 @@ import { toaster } from '@yanet/core/utils';
 import { stringToIPAddress, ipAddressToString } from '@yanet/core/utils/netip';
 import { parseIPAddress } from '@yanet/core/utils';
 import type { Route } from '@yanet/core/api/routes';
-import { bestPathReason } from './utils';
+import { bestPathReason, routePrefix } from './utils';
 import { BestPill, SourceChip } from './cells';
 
 export interface LookupDrawerProps {
@@ -67,7 +67,7 @@ const LookupDrawer: React.FC<LookupDrawerProps> = ({
                 ip_addr: ipAddr,
             });
             setResult({
-                prefix: res.prefix ?? '',
+                prefix: res.prefix?.network ?? '',
                 routes: res.routes ?? [],
             });
         } catch (err) {
@@ -212,7 +212,7 @@ const LookupDrawer: React.FC<LookupDrawerProps> = ({
                                                         <BestPill isBest={r.is_best ?? false} />
                                                     </td>
                                                     <td className="yn-cell-mono yn-cell-strong">
-                                                        {r.prefix || '—'}
+                                                        {routePrefix(r) || '—'}
                                                     </td>
                                                     <td className="yn-cell-mono yn-cell-muted">
                                                         {ipAddressToString(r.next_hop) || '—'}

--- a/operators/route/web/RIBTable.tsx
+++ b/operators/route/web/RIBTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Route } from '@yanet/core/api/routes';
 import { ipAddressToString } from '@yanet/core/utils/netip';
-import { getRouteId } from './utils';
+import { getRouteId, routePrefix } from './utils';
 import { BestPill, SourceChip, FamilyBadge, ConflictBadge } from './cells';
 import type { RouteSortableColumn, RouteSortState } from './types';
 import { VirtualTable } from '@yanet/core/components/VirtualTable';
@@ -44,10 +44,11 @@ export const RIBTable: React.FC<RIBTableProps> = ({
             gridTrack: 'minmax(190px, 1.3fr)',
             sortKey: 'prefix',
             renderCell: (route) => {
-                const prefixConflictCount = conflictMap?.get(route.prefix || '') ?? 1;
+                const prefix = routePrefix(route);
+                const prefixConflictCount = conflictMap?.get(prefix) ?? 1;
                 return (
                     <div style={{ display: 'flex', alignItems: 'center', gap: 9, overflow: 'hidden' }}>
-                        {route.prefix && <FamilyBadge prefix={route.prefix} />}
+                        {prefix && <FamilyBadge prefix={prefix} />}
                         <span
                             className="yn-cell-mono"
                             style={{
@@ -59,7 +60,7 @@ export const RIBTable: React.FC<RIBTableProps> = ({
                                 fontWeight: route.is_best ? 600 : 500,
                                 color: route.is_best ? 'var(--yn-text)' : 'var(--yn-text-2)',
                             }}
-                        >{route.prefix || '-'}</span>
+                        >{prefix || '-'}</span>
                         {prefixConflictCount > 1 && <ConflictBadge count={prefixConflictCount} />}
                     </div>
                 );

--- a/operators/route/web/RouteDrawer.tsx
+++ b/operators/route/web/RouteDrawer.tsx
@@ -3,7 +3,7 @@ import { Button, Icon, Switch } from '@gravity-ui/uikit';
 import { Plus, TrashBin } from '@gravity-ui/icons';
 import { DraftItemDrawer } from '@yanet/core/components/draft';
 import { ipAddressToString } from '@yanet/core/utils/netip';
-import { validatePrefix, validateNexthop } from './utils';
+import { validatePrefix, validateNexthop, routePrefix } from './utils';
 import type { Route } from '@yanet/core/api/routes';
 import { CidrPrefixField } from '@yanet/core/components';
 import { BestPill, SourceChip } from './cells';
@@ -49,7 +49,7 @@ const RouteDrawer: React.FC<RouteDrawerProps> = ({
 
     useEffect(() => {
         if (open) {
-            setPrefix(mode === 'edit' && route ? (route.prefix || '') : '');
+            setPrefix(mode === 'edit' && route ? routePrefix(route) : '');
             setNexthopRows(
                 mode === 'edit' && route
                     ? [makeRow(ipAddressToString(route.next_hop))]
@@ -58,7 +58,7 @@ const RouteDrawer: React.FC<RouteDrawerProps> = ({
             setDoFlush(false);
             setSubmitting(false);
         }
-    }, [open, mode, route?.prefix, route?.next_hop]);
+    }, [open, mode, route?.prefix?.network, route?.next_hop]);
 
     const nexthopErrors = nexthopRows.map((row) => validateNexthop(row.value));
     const prefixError = validatePrefix(prefix);

--- a/operators/route/web/RoutePage.tsx
+++ b/operators/route/web/RoutePage.tsx
@@ -14,7 +14,7 @@ import { useRIB } from './useRIB';
 import { RIBTable } from './RIBTable';
 import RouteDrawer from './RouteDrawer';
 import LookupDrawer from './LookupDrawer';
-import { getRouteId, sortComparators, planRouteSubmit, groupByPrefix, filterByFamily } from './utils';
+import { getRouteId, sortComparators, planRouteSubmit, groupByPrefix, filterByFamily, routePrefix, toWirePrefix } from './utils';
 import type { RouteSortState, RouteSortableColumn, IPFamily } from './types';
 import { FamilyFilter } from '@yanet/core/components/VirtualTable';
 import '@yanet/core/styles/chrome.scss';
@@ -73,13 +73,13 @@ const RoutePage: React.FC = () => {
         }
 
         if (conflictsOnly) {
-            res = res.filter((r) => (conflictMap.get(r.prefix || '') ?? 1) > 1);
+            res = res.filter((r) => (conflictMap.get(routePrefix(r)) ?? 1) > 1);
         }
 
         const q = search.trim().toLowerCase();
         if (q) {
             res = res.filter((r) =>
-                (r.prefix || '').toLowerCase().includes(q) ||
+                routePrefix(r).toLowerCase().includes(q) ||
                 ipAddressToString(r.next_hop).toLowerCase().includes(q) ||
                 ipAddressToString(r.peer).toLowerCase().includes(q)
             );
@@ -165,7 +165,7 @@ const RoutePage: React.FC = () => {
                 if (op.type === 'delete') {
                     await API.route.deleteRoute({
                         name: currentConfig,
-                        prefix: op.prefix,
+                        prefix: toWirePrefix(op.prefix),
                         nexthop_addrs: [op.nexthop],
                         do_flush: false,
                         source_id: RouteSourceID.STATIC,
@@ -173,7 +173,7 @@ const RoutePage: React.FC = () => {
                 } else {
                     await API.route.insertRoute({
                         name: currentConfig,
-                        prefix: op.prefix,
+                        prefix: toWirePrefix(op.prefix),
                         nexthop_addrs: op.nexthops,
                         do_flush: op.doFlush,
                         source_id: RouteSourceID.STATIC,
@@ -190,14 +190,15 @@ const RoutePage: React.FC = () => {
     }, [currentConfig, reload, drawer.mode, drawer.route]);
 
     const handleDeleteRoute = useCallback(async (route: Route): Promise<void> => {
-        if (!route.prefix || !route.next_hop) {
+        const prefix = routePrefix(route);
+        if (!prefix || !route.next_hop) {
             toaster.warning('route-delete-invalid', 'Route has no prefix or next-hop');
             return;
         }
         try {
             await API.route.deleteRoute({
                 name: currentConfig,
-                prefix: route.prefix,
+                prefix: toWirePrefix(prefix),
                 nexthop_addrs: [route.next_hop],
                 do_flush: true,
                 source_id: RouteSourceID.STATIC,
@@ -238,21 +239,22 @@ const RoutePage: React.FC = () => {
         let skipped = 0;
         let deleted = 0;
         for (const route of routes) {
-            if (!route.prefix || !route.next_hop) {
+            const prefix = routePrefix(route);
+            if (!prefix || !route.next_hop) {
                 skipped++;
                 continue;
             }
             try {
                 await API.route.deleteRoute({
                     name: currentConfig,
-                    prefix: route.prefix,
+                    prefix: toWirePrefix(prefix),
                     nexthop_addrs: [route.next_hop],
                     do_flush: true,
                     source_id: RouteSourceID.STATIC,
                 });
                 deleted++;
             } catch (err) {
-                toaster.error('bulk-delete-error', `Failed to delete route ${route.prefix}`, err);
+                toaster.error('bulk-delete-error', `Failed to delete route ${prefix}`, err);
             }
         }
         await reload();
@@ -280,7 +282,7 @@ const RoutePage: React.FC = () => {
 
     const handleShowInTable = useCallback((prefix: string): void => {
         handleClearFilters();
-        const matchedRow = allRows.find((r) => r.prefix === prefix);
+        const matchedRow = allRows.find((r) => routePrefix(r) === prefix);
         if (matchedRow) {
             const id = getRouteId(matchedRow);
             setFlashRowId(null);
@@ -373,9 +375,9 @@ const RoutePage: React.FC = () => {
     const routeRowAdapter = useMemo((): RowAdapter<Route> => ({
         rows: allRows,
         getId: getRouteId,
-        getLabel: (r) => r.prefix || '(no prefix)',
+        getLabel: (r) => routePrefix(r) || '(no prefix)',
         getSub: (r) => ipAddressToString(r.next_hop) || '—',
-        searchText: (r) => (r.prefix || '') + ' ' + ipAddressToString(r.next_hop),
+        searchText: (r) => routePrefix(r) + ' ' + ipAddressToString(r.next_hop),
         onSelect: (id) => handleJumpToRow(id),
         icon: '→',
         max: 7,

--- a/operators/route/web/utils.test.ts
+++ b/operators/route/web/utils.test.ts
@@ -1,7 +1,25 @@
 import { describe, it, expect } from 'vitest';
-import { planRouteSubmit, validatePrefix, validateNexthop, sortComparators, prefixIPFamily, groupByPrefix, filterByFamily, bestPathReason, getRouteId } from './utils';
-import { stringToIPAddress } from '@yanet/core/utils/netip';
+import { planRouteSubmit, validatePrefix, validateNexthop, sortComparators, prefixIPFamily, groupByPrefix, filterByFamily, bestPathReason, getRouteId, routePrefix, toWirePrefix } from './utils';
+import { stringToIPAddress, type ContiguousIPNetwork } from '@yanet/core/utils/netip';
 import type { Route } from '@yanet/core/api/routes';
+
+/** Builds the wire prefix message a server response carries. */
+const net = (cidr: string): ContiguousIPNetwork => ({ network: cidr });
+
+describe('routePrefix', () => {
+    it('reads the CIDR string out of the wire message', () => {
+        expect(routePrefix({ prefix: net('10.0.0.0/8') })).toBe('10.0.0.0/8');
+    });
+
+    it('yields an empty string when the server sent no prefix', () => {
+        expect(routePrefix({})).toBe('');
+        expect(routePrefix({ prefix: {} })).toBe('');
+    });
+
+    it('round-trips through toWirePrefix', () => {
+        expect(routePrefix({ prefix: toWirePrefix('2001:db8::/32') })).toBe('2001:db8::/32');
+    });
+});
 
 describe('planRouteSubmit', () => {
     const ip = (s: string) => stringToIPAddress(s)!;
@@ -39,7 +57,7 @@ describe('planRouteSubmit', () => {
     });
 
     it('edit mode, no key change: produces a single insert op without delete', () => {
-        const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
+        const original: Route = { prefix: net('10.0.0.0/8'), next_hop: ip('192.168.1.1') };
         const ops = planRouteSubmit(
             'edit',
             { prefix: '10.0.0.0/8', nexthopIps: [ip('192.168.1.1')], doFlush: false },
@@ -52,7 +70,7 @@ describe('planRouteSubmit', () => {
     });
 
     it('edit mode, prefix changed: produces delete then insert', () => {
-        const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
+        const original: Route = { prefix: net('10.0.0.0/8'), next_hop: ip('192.168.1.1') };
         const ops = planRouteSubmit(
             'edit',
             { prefix: '172.16.0.0/12', nexthopIps: [ip('192.168.1.1')], doFlush: false },
@@ -72,7 +90,7 @@ describe('planRouteSubmit', () => {
     });
 
     it('edit mode, nexthop changed: produces delete then insert', () => {
-        const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
+        const original: Route = { prefix: net('10.0.0.0/8'), next_hop: ip('192.168.1.1') };
         const ops = planRouteSubmit(
             'edit',
             { prefix: '10.0.0.0/8', nexthopIps: [ip('10.0.0.1')], doFlush: true },
@@ -89,7 +107,7 @@ describe('planRouteSubmit', () => {
     });
 
     it('edit mode, both prefix and nexthop changed: produces delete then insert', () => {
-        const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
+        const original: Route = { prefix: net('10.0.0.0/8'), next_hop: ip('192.168.1.1') };
         const ops = planRouteSubmit(
             'edit',
             { prefix: '172.16.0.0/12', nexthopIps: [ip('10.0.0.1')], doFlush: false },
@@ -116,7 +134,7 @@ describe('planRouteSubmit', () => {
     });
 
     it('edit mode, original has no next_hop: skips delete, produces only insert', () => {
-        const original: Route = { prefix: '10.0.0.0/8' };
+        const original: Route = { prefix: net('10.0.0.0/8') };
         const ops = planRouteSubmit(
             'edit',
             { prefix: '172.16.0.0/12', nexthopIps: [ip('192.168.1.1')], doFlush: false },
@@ -173,8 +191,8 @@ describe('sortComparators', () => {
     const makeRoute = (overrides: Partial<Route>): Route => ({ ...overrides });
 
     it('prefix: sorts lexicographically by prefix string', () => {
-        const a = makeRoute({ prefix: '10.0.0.0/8' });
-        const b = makeRoute({ prefix: '192.168.0.0/16' });
+        const a = makeRoute({ prefix: net('10.0.0.0/8') });
+        const b = makeRoute({ prefix: net('192.168.0.0/16') });
         expect(sortComparators.prefix(a, b)).toBeLessThan(0);
         expect(sortComparators.prefix(b, a)).toBeGreaterThan(0);
         expect(sortComparators.prefix(a, a)).toBe(0);
@@ -215,9 +233,9 @@ describe('prefixIPFamily', () => {
 describe('groupByPrefix', () => {
     it('groups routes with the same prefix together', () => {
         const routes: Route[] = [
-            { prefix: '10.0.0.0/8' },
-            { prefix: '::/0' },
-            { prefix: '10.0.0.0/8' },
+            { prefix: net('10.0.0.0/8') },
+            { prefix: net('::/0') },
+            { prefix: net('10.0.0.0/8') },
         ];
         const m = groupByPrefix(routes);
         expect(m.get('10.0.0.0/8')).toHaveLength(2);
@@ -231,9 +249,9 @@ describe('groupByPrefix', () => {
 
 describe('filterByFamily', () => {
     const routes: Route[] = [
-        { prefix: '::/0' },
-        { prefix: '0.0.0.0/0' },
-        { prefix: '2001:db8::/32' },
+        { prefix: net('::/0') },
+        { prefix: net('0.0.0.0/0') },
+        { prefix: net('2001:db8::/32') },
     ];
 
     it('returns all routes for family "all"', () => {
@@ -243,13 +261,13 @@ describe('filterByFamily', () => {
     it('returns only IPv6 routes for family "v6"', () => {
         const v6 = filterByFamily(routes, 'v6');
         expect(v6).toHaveLength(2);
-        expect(v6.every((r) => r.prefix?.includes(':'))).toBe(true);
+        expect(v6.every((r) => routePrefix(r).includes(':'))).toBe(true);
     });
 
     it('returns only IPv4 routes for family "v4"', () => {
         const v4 = filterByFamily(routes, 'v4');
         expect(v4).toHaveLength(1);
-        expect(v4[0].prefix).toBe('0.0.0.0/0');
+        expect(routePrefix(v4[0])).toBe('0.0.0.0/0');
     });
 });
 
@@ -281,7 +299,7 @@ describe('bestPathReason', () => {
 
 describe('getRouteId', () => {
     const base: Route = {
-        prefix: '::/0',
+        prefix: net('::/0'),
         next_hop: { addr: 'fe80::a1a' },
         peer: { addr: '::' },
         route_distinguisher: '',
@@ -318,7 +336,7 @@ describe('getRouteId', () => {
     });
 
     it('missing optional fields fall back to 0 or empty string, not "undefined"', () => {
-        const minimal: Route = { prefix: '10.0.0.0/8' };
+        const minimal: Route = { prefix: net('10.0.0.0/8') };
         const id = getRouteId(minimal);
         expect(id).not.toContain('undefined');
         // next_hop.addr='' peer.addr='' rd='' source=0 pref=0 peerAs=0 originAs=0 med=0 asPathLen=0

--- a/operators/route/web/utils.ts
+++ b/operators/route/web/utils.ts
@@ -1,7 +1,16 @@
 import type { Route } from '@yanet/core/api/routes';
 import { parseCIDRPrefix, parseIPAddress, CIDRParseError, IPParseError } from '@yanet/core/utils';
-import { ipAddressToString, type IPAddressWire } from '@yanet/core/utils/netip';
+import { ipAddressToString, type ContiguousIPNetwork, type IPAddressWire } from '@yanet/core/utils/netip';
 import type { RouteSortableColumn, IPFamily } from './types';
+
+/** Reads a route's destination prefix as a CIDR string.
+ *
+ * Empty when the server sent no prefix — the page keeps prefixes as strings
+ * everywhere below this boundary. */
+export const routePrefix = (route: Route): string => route.prefix?.network ?? '';
+
+/** Wraps a CIDR string into the wire prefix message. */
+export const toWirePrefix = (prefix: string): ContiguousIPNetwork => ({ network: prefix });
 
 export interface RouteSubmitParams {
     prefix: string;
@@ -25,11 +34,12 @@ export const planRouteSubmit = (
     originalNexthopStr: string,
 ): RouteSubmitOp[] => {
     const ops: RouteSubmitOp[] = [];
+    const originalPrefix = original ? routePrefix(original) : '';
     const keyChanged = mode === 'edit'
         && !!original
-        && (original.prefix !== params.prefix || originalNexthopStr !== newNexthopStr);
-    if (keyChanged && original?.prefix && original.next_hop) {
-        ops.push({ type: 'delete', prefix: original.prefix, nexthop: original.next_hop });
+        && (originalPrefix !== params.prefix || originalNexthopStr !== newNexthopStr);
+    if (keyChanged && originalPrefix && original?.next_hop) {
+        ops.push({ type: 'delete', prefix: originalPrefix, nexthop: original.next_hop });
     }
     ops.push({ type: 'insert', prefix: params.prefix, nexthops: params.nexthopIps, doFlush: params.doFlush });
     return ops;
@@ -39,7 +49,7 @@ export const ROUTE_SOURCES = ['Unknown', 'Static', 'BIRD'] as const;
 
 /** Returns a stable string key for a route row. */
 export const getRouteId = (route: Route): string =>
-    `${route.prefix ?? ''}_${String(route.next_hop?.addr ?? '')}_${String(route.peer?.addr ?? '')}_${route.route_distinguisher ?? ''}_${route.source ?? 0}_${route.pref ?? 0}_${route.peer_as ?? 0}_${route.origin_as ?? 0}_${route.med ?? 0}_${route.as_path_len ?? 0}`;
+    `${routePrefix(route)}_${String(route.next_hop?.addr ?? '')}_${String(route.peer?.addr ?? '')}_${route.route_distinguisher ?? ''}_${route.source ?? 0}_${route.pref ?? 0}_${route.peer_as ?? 0}_${route.origin_as ?? 0}_${route.med ?? 0}_${route.as_path_len ?? 0}`;
 
 /** Validates a CIDR prefix string. Returns an error message or undefined when valid. */
 export const validatePrefix = (prefix: string): string | undefined => {
@@ -92,7 +102,7 @@ export const prefixIPFamily = (prefix: string): IPFamily => {
 export const groupByPrefix = (routes: Route[]): Map<string, Route[]> => {
     const m = new Map<string, Route[]>();
     for (const r of routes) {
-        const key = r.prefix || '';
+        const key = routePrefix(r);
         const group = m.get(key);
         if (group) {
             group.push(r);
@@ -106,7 +116,7 @@ export const groupByPrefix = (routes: Route[]): Map<string, Route[]> => {
 /** Filters routes by IP family. Returns all routes when family is 'all'. */
 export const filterByFamily = (routes: Route[], family: IPFamily): Route[] => {
     if (family === 'all') return routes;
-    return routes.filter((r) => prefixIPFamily(r.prefix || '') === family);
+    return routes.filter((r) => prefixIPFamily(routePrefix(r)) === family);
 };
 
 /** Returns a human-readable reason why the first candidate beats the second,
@@ -151,7 +161,7 @@ export const bestPathReason = (cands: Route[]): string => {
 
 /** Sort comparators for each sortable column. */
 export const sortComparators: Record<RouteSortableColumn, (a: Route, b: Route) => number> = {
-    prefix: (a, b) => (a.prefix || '').localeCompare(b.prefix || ''),
+    prefix: (a, b) => routePrefix(a).localeCompare(routePrefix(b)),
     next_hop: (a, b) => ipAddressToString(a.next_hop).localeCompare(ipAddressToString(b.next_hop)),
     peer: (a, b) => ipAddressToString(a.peer).localeCompare(ipAddressToString(b.peer)),
     is_best: (a, b) => (a.is_best ? 1 : 0) - (b.is_best ? 1 : 0),

--- a/web/src/core/api/decap.ts
+++ b/web/src/core/api/decap.ts
@@ -1,17 +1,17 @@
 import { createService, type CallOptions } from './client';
-import type { ContiguousIPNetworkWire } from '../utils/netip';
+import type { ContiguousIPNetwork } from '../utils/netip';
 
 export interface ShowConfigRequest {
     name?: string;
 }
 
 export interface ShowConfigResponse {
-    prefixes?: ContiguousIPNetworkWire[];
+    prefixes?: ContiguousIPNetwork[];
 }
 
 export interface DecapUpdateConfigRequest {
     name?: string;
-    prefixes?: ContiguousIPNetworkWire[];
+    prefixes?: ContiguousIPNetwork[];
 }
 
 export interface DecapUpdateConfigResponse { }

--- a/web/src/core/api/routes.ts
+++ b/web/src/core/api/routes.ts
@@ -1,6 +1,6 @@
 import { createService, type CallOptions } from './client';
 import type { MACAddress } from './neighbours';
-import type { IPAddressWire, IPRangeWire } from '../utils/netip';
+import type { ContiguousIPNetwork, IPAddressWire, IPRangeWire } from '../utils/netip';
 
 // Route types
 
@@ -17,7 +17,7 @@ export interface LargeCommunity {
 }
 
 export interface Route {
-    prefix?: string;
+    prefix?: ContiguousIPNetwork;
     next_hop?: IPAddressWire;
     peer?: IPAddressWire;
     route_distinguisher?: string | number; // uint64
@@ -46,7 +46,7 @@ export interface ShowRoutesResponse {
 
 export interface InsertRouteRequest {
     name?: string;
-    prefix?: string;
+    prefix?: ContiguousIPNetwork;
     nexthop_addrs?: IPAddressWire[];
     do_flush?: boolean;
     source_id?: RouteSourceID;
@@ -57,7 +57,7 @@ export interface InsertRouteResponse {
 
 export interface DeleteRouteRequest {
     name?: string;
-    prefix?: string;
+    prefix?: ContiguousIPNetwork;
     nexthop_addrs?: IPAddressWire[];
     do_flush?: boolean;
     source_id?: RouteSourceID;
@@ -107,7 +107,7 @@ export interface LookupRouteRequest {
 }
 
 export interface LookupRouteResponse {
-    prefix?: string;
+    prefix?: ContiguousIPNetwork;
     routes?: Route[];
 }
 

--- a/web/src/core/utils/netip.ts
+++ b/web/src/core/utils/netip.ts
@@ -751,7 +751,7 @@ export type IPAddressWire = {
 };
 
 // Wire-format shape of commonpb.ContiguousIPNetwork from the gRPC-JSON gateway: {network: "10.0.0.0/8"}.
-export type ContiguousIPNetworkWire = {
+export type ContiguousIPNetwork = {
     network?: string;
 };
 


### PR DESCRIPTION
Migrate the route operator prefix fields from strings to the shared structured network message and update every consumer.

- Replace the four `prefix` fields in `operators/route/operatorpb/v1/route.proto` with `common.commonpb.v1.ContiguousIPNetwork` at their existing field numbers, as an intentional coordinated wire break.
- Mask host bits on every prefix entering the RIB: `10.0.0.7/24` is now stored and reported as `10.0.0.0/24`, where `netip.ParsePrefix` previously kept the host bits.
- Report a prefix the structured message cannot represent as a conversion error — `Internal` on the operator response paths, a skipped route with a log line on the bird-adapter send path, next to the existing invalid-next_hop skip.
- Add a shared `Contiguous<IpNetwork>` decode to the Rust commonpb crate and move the route CLI onto the structured prefix; its `--format json` output is unchanged byte for byte.
- Move the route web page onto the `{network: "..."}` wire shape through a boundary accessor, and rename the shared TypeScript wire type from `ContiguousIPNetworkWire` to `ContiguousIPNetwork` so it mirrors the proto message.

Compatibility strategy: a coordinated break at the existing field numbers, the same strategy #2126 used for dscp. All route operator peers in this repository — gateway, CLI, bird-adapter, web — are updated together; old string-based messages are not supported. `buf breaking` is expected to report exactly the four intentional field type changes and nothing else; no buf configuration or workflow was changed.

Closes #1952.