### PR TITLE
fix(route,maptrie): stop the rib cleanup from panicking on multi-path prefixes

### DIFF
--- a/common/go/maptrie/map_trie.go
+++ b/common/go/maptrie/map_trie.go
@@ -143,9 +143,16 @@ func (m *MapTrie[K, Q, V]) Matches(query Q) []K {
 // The function first normalizes the prefix with masking, then either inserts a new
 // value using the onEmpty callback or updates an existing value using the onUpdate
 // callback.
+//
+// A key whose significant bit count falls outside the addressable range is
+// rejected and neither callback runs, so a malformed key costs a caller its
+// entry rather than the whole process.
 func (m *MapTrie[K, Q, V]) InsertOrUpdate(prefix K, onEmpty func() V, onUpdate func(V) V) {
 	prefix = prefix.Masked()
 	bits := prefix.Bits()
+	if bits < 0 || bits >= len(m) {
+		return
+	}
 
 	if currValue, ok := m[bits][prefix]; ok {
 		m[bits][prefix] = onUpdate(currValue)
@@ -169,9 +176,15 @@ func (m *MapTrie[K, Q, V]) Len() int {
 
 // UpdateOrDelete updates existing entry and deletes it from the MapTrie if update
 // indicates that updated entry becomes empty.
+//
+// A key whose significant bit count falls outside the addressable range matches
+// no entry, so the update callback does not run.
 func (m *MapTrie[K, Q, V]) UpdateOrDelete(prefix K, update func(V) (V, bool)) {
 	prefix = prefix.Masked()
 	bits := prefix.Bits()
+	if bits < 0 || bits >= len(m) {
+		return
+	}
 
 	if value, ok := m[bits][prefix]; ok {
 		if newValue, zero := update(value); zero {
@@ -183,6 +196,11 @@ func (m *MapTrie[K, Q, V]) UpdateOrDelete(prefix K, update func(V) (V, bool)) {
 }
 
 // Dump creates a flat map containing all prefixes and their values from the MapTrie.
+//
+// Values are copied by assignment, so a value carrying a slice, a map or a
+// pointer still shares that storage with the trie. Mutating what such a value
+// points at mutates the trie; a caller that intends to modify a dumped value
+// must deep-copy it first.
 func (m MapTrie[K, Q, V]) Dump() map[K]V {
 	out := make(map[K]V, m.Len())
 

--- a/common/go/maptrie/map_trie_test.go
+++ b/common/go/maptrie/map_trie_test.go
@@ -427,6 +427,38 @@ func Test_MapTrie_InsertMany(t *testing.T) {
 	}
 }
 
+// Test_MapTrie_InsertOrUpdate_InvalidKey verifies that inserting a key with no
+// significant bit count stores nothing instead of crashing the process.
+//
+// The trie indexes its level array by the bit count of the key, and a
+// zero-value prefix reports minus one, so an unchecked index would take the
+// whole process down on a key a caller built by mistake.
+func Test_MapTrie_InsertOrUpdate_InvalidKey(t *testing.T) {
+	trie := NewMapTrie[netip.Prefix, netip.Addr, int](0)
+
+	require.NotPanics(t, func() {
+		trie.InsertOrUpdate(netip.Prefix{}, onEmpty(1), onUpdate(1))
+	})
+	assert.Equal(t, 0, trie.Len(), "an invalid key must not become a stored entry")
+}
+
+// Test_MapTrie_UpdateOrDelete_InvalidKey verifies that updating a key with no
+// significant bit count neither crashes nor invokes the update callback.
+func Test_MapTrie_UpdateOrDelete_InvalidKey(t *testing.T) {
+	trie := NewMapTrie[netip.Prefix, netip.Addr, int](0)
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.0.0/16"), onEmpty(1), onUpdate(1))
+
+	called := false
+	require.NotPanics(t, func() {
+		trie.UpdateOrDelete(netip.Prefix{}, func(v int) (int, bool) {
+			called = true
+			return v, false
+		})
+	})
+	assert.False(t, called, "an invalid key matches no entry, so the update must not run")
+	assert.Equal(t, 1, trie.Len(), "an invalid key must not disturb the stored entries")
+}
+
 var benchDataInsertuniqAddrs, benchDataInsertuniqPrefixes = initTestData(1_000_000, 400_000, false)
 
 func Benchmark_MapTrie_InsertUniq(b *testing.B) {

--- a/operators/route/internal/rib/rib.go
+++ b/operators/route/internal/rib/rib.go
@@ -186,6 +186,12 @@ func (m *RIB) Update(routes ...Route) {
 	m.stats.OnChanged()
 }
 
+// update applies the given routes to the RIB, inserting each one or removing
+// it when it is marked as withdrawn. The caller must hold the write lock.
+//
+// The routes must not share storage with anything the RIB already holds: a
+// removal rewrites the path list of the affected entry, and a caller passing
+// that same list would have it change underneath the walk.
 func (m *RIB) update(routes ...Route) {
 	for _, route := range routes {
 		if route.ToRemove {
@@ -267,7 +273,20 @@ func (m *RIB) CleanupTask(sessionID uint64, quit chan bool, ttl time.Duration) {
 		}
 	}()
 
-	for _, routeList := range m.routes.Dump() {
+	isStale := func(route Route) bool {
+		return route.SourceID == RouteSourceBird && route.SessionID <= sessionID
+	}
+
+	// Take the prefixes first so the pass walks a snapshot rather than the
+	// structure it rewrites.
+	prefixes := make([]netip.Prefix, 0, m.routes.Len())
+	for bits := range m.routes {
+		for prefix := range m.routes[bits] {
+			prefixes = append(prefixes, prefix)
+		}
+	}
+
+	for _, prefix := range prefixes {
 		select {
 		case <-quit:
 			m.log.Info("RIB: cleanup task interrupted during cleanup",
@@ -278,14 +297,35 @@ func (m *RIB) CleanupTask(sessionID uint64, quit chan bool, ttl time.Duration) {
 		default:
 		}
 
-		for idx := range routeList.Routes {
-			if routeList.Routes[idx].SourceID == RouteSourceBird &&
-				routeList.Routes[idx].SessionID <= sessionID {
-				removedCount++
-				routeList.Routes[idx].ToRemove = true
+		m.routes.UpdateOrDelete(prefix, func(rl RoutesList) (RoutesList, bool) {
+			stale := 0
+			for _, route := range rl.Routes {
+				if isStale(route) {
+					stale++
+				}
 			}
-		}
-		m.update(routeList.Routes...)
+			if stale == 0 {
+				return rl, false
+			}
+
+			removedCount += stale
+			m.stats.OnRouteRemoved(stale)
+
+			if stale == len(rl.Routes) {
+				m.stats.OnPrefixRemoved()
+				return rl, true
+			}
+
+			// Give the survivors an array of their own, so that the path list
+			// of an entry is never rewritten in place.
+			kept := make([]Route, 0, len(rl.Routes)-stale)
+			for _, route := range rl.Routes {
+				if !isStale(route) {
+					kept = append(kept, route)
+				}
+			}
+			return RoutesList{Routes: kept}, false
+		})
 	}
 
 	m.log.Info("RIB: cleanup task completed",

--- a/operators/route/internal/rib/rib_test.go
+++ b/operators/route/internal/rib/rib_test.go
@@ -3,6 +3,7 @@ package rib
 import (
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -11,6 +12,49 @@ import (
 func newTestRIB(t *testing.T) *RIB {
 	t.Helper()
 	return NewRIB()
+}
+
+// birdRoute builds a BGP path identified by the given peer and global ID, as
+// BIRD identity is the peer and global ID pair rather than the nexthop.
+func birdRoute(prefix netip.Prefix, peer string, globalID uint32, sessionID uint64) Route {
+	return Route{
+		SessionID: sessionID,
+		Prefix:    prefix,
+		NextHop:   netip.MustParseAddr("2001:db8:ff::1"),
+		Peer:      netip.MustParseAddr(peer),
+		GlobalID:  globalID,
+		SourceID:  RouteSourceBird,
+		UpdatedAt: time.Now(),
+	}
+}
+
+// peersForPrefix returns the peers of the routes stored for the given prefix,
+// in RIB order.
+func peersForPrefix(t *testing.T, r *RIB, prefix netip.Prefix) []netip.Addr {
+	t.Helper()
+	var peers []netip.Addr
+	for _, route := range routesForPrefix(t, r, prefix) {
+		peers = append(peers, route.Peer)
+	}
+	return peers
+}
+
+// countDump returns the prefix and route totals actually stored in the RIB,
+// asserting on the way that every stored key is a usable prefix.
+func countDump(t *testing.T, r *RIB) (prefixes int, routes int) {
+	t.Helper()
+	for prefix, list := range r.DumpRoutes().Dump() {
+		require.True(t, prefix.IsValid(), "RIB must not store an invalid prefix")
+		prefixes++
+		routes += len(list.Routes)
+	}
+	return prefixes, routes
+}
+
+// runCleanup runs a cleanup pass for the given session with no TTL delay.
+func runCleanup(t *testing.T, r *RIB, sessionID uint64) {
+	t.Helper()
+	r.CleanupTask(sessionID, make(chan bool), 0)
 }
 
 // routesForPrefix returns the routes stored for the given prefix, or nil if the
@@ -98,4 +142,94 @@ func TestRemoveUnicastRoute_StaticSingle(t *testing.T) {
 
 	routes = routesForPrefix(t, r, pfx)
 	require.Nil(t, routes, "prefix entry must be absent after removing the sole nexthop")
+}
+
+// Test_RIB_CleanupTask_MultiPathPrefixPartiallyStale verifies that a cleanup
+// pass drops every expired path of a prefix and keeps the later-session one.
+//
+// Cleanup walks the routes of one prefix while the removal of an earlier path
+// shifts the very slice it walks, so the surviving path must be neither
+// skipped nor mistaken for a removal candidate.
+func Test_RIB_CleanupTask_MultiPathPrefixPartiallyStale(t *testing.T) {
+	pfx := netip.MustParsePrefix("2001:db8::/64")
+	fresh := netip.MustParseAddr("2001:db8::d")
+
+	r := newTestRIB(t)
+	r.Update(
+		birdRoute(pfx, "2001:db8::a", 1, 1),
+		birdRoute(pfx, "2001:db8::b", 2, 1),
+		birdRoute(pfx, "2001:db8::c", 3, 1),
+		birdRoute(pfx, fresh.String(), 4, 2),
+	)
+	require.Len(t, routesForPrefix(t, r, pfx), 4, "setup: all four paths must be present")
+
+	runCleanup(t, r, 1)
+
+	require.Equal(t, []netip.Addr{fresh}, peersForPrefix(t, r, pfx),
+		"only the path of the later session may survive a cleanup of session 1")
+}
+
+// Test_RIB_CleanupTask_MultiPathPrefixFullyStale verifies that a cleanup pass
+// removes the prefix entirely once every one of its BGP paths has expired.
+func Test_RIB_CleanupTask_MultiPathPrefixFullyStale(t *testing.T) {
+	pfx := netip.MustParsePrefix("2001:db8::/64")
+
+	r := newTestRIB(t)
+	r.Update(
+		birdRoute(pfx, "2001:db8::a", 1, 1),
+		birdRoute(pfx, "2001:db8::b", 2, 1),
+		birdRoute(pfx, "2001:db8::c", 3, 1),
+	)
+	require.Len(t, routesForPrefix(t, r, pfx), 3, "setup: all three paths must be present")
+
+	runCleanup(t, r, 1)
+
+	require.Nil(t, routesForPrefix(t, r, pfx),
+		"prefix entry must be absent once all of its paths expired")
+}
+
+// Test_RIB_CleanupTask_KeepsStaticRoute verifies that a cleanup pass leaves a
+// static route sharing a prefix with expired BGP paths in place.
+//
+// Staleness is scoped to BIRD-sourced routes, and a static route carries no
+// session, so no session number may ever expire it.
+func Test_RIB_CleanupTask_KeepsStaticRoute(t *testing.T) {
+	pfx := netip.MustParsePrefix("2001:db8::/64")
+	nh := netip.MustParseAddr("2001:db8::ffff")
+
+	r := newTestRIB(t)
+	r.Update(
+		birdRoute(pfx, "2001:db8::a", 1, 1),
+		birdRoute(pfx, "2001:db8::b", 2, 1),
+	)
+	require.NoError(t, r.AddUnicastRoute(pfx, nh, RouteSourceStatic))
+
+	runCleanup(t, r, 1)
+
+	routes := routesForPrefix(t, r, pfx)
+	require.Len(t, routes, 1, "the static route must be the only survivor")
+	require.Equal(t, RouteSourceStatic, routes[0].SourceID)
+	require.Equal(t, nh, routes[0].NextHop)
+}
+
+// Test_RIB_CleanupTask_StatsMatchContents verifies that the counters reported
+// after a cleanup pass agree with what the RIB actually holds.
+func Test_RIB_CleanupTask_StatsMatchContents(t *testing.T) {
+	stale := netip.MustParsePrefix("2001:db8:1::/64")
+	mixed := netip.MustParsePrefix("2001:db8:2::/64")
+
+	r := newTestRIB(t)
+	r.Update(
+		birdRoute(stale, "2001:db8::a", 1, 1),
+		birdRoute(stale, "2001:db8::b", 2, 1),
+		birdRoute(mixed, "2001:db8::a", 3, 1),
+		birdRoute(mixed, "2001:db8::b", 4, 2),
+	)
+
+	runCleanup(t, r, 1)
+
+	prefixes, routes := countDump(t, r)
+	stats := r.Stats()
+	require.Equal(t, prefixes, stats.Prefixes, "prefix counter must match the stored prefixes")
+	require.Equal(t, routes, stats.Routes, "route counter must match the stored routes")
 }


### PR DESCRIPTION
The RIB cleanup pass handed its own live path list to the update path, which shifted and cleared that list underneath the walk, so any prefix carrying two or more BGP paths crashed the route operator on a production host.

- Rewrite `RIB.CleanupTask` to walk a snapshot of the prefix keys and filter each path list into fresh storage through one `UpdateOrDelete` per prefix, instead of marking `ToRemove` in place and replaying the live slice through `RIB.update`.
- Fix the two defects the aliasing hid: paths that a `slices.Delete` shift moved behind the cursor were never removed, and the ones that survived kept a `ToRemove` mark in the live RIB forever.
- Count removals from what was actually dropped, so `RIB.Stats` agrees with `RIB.DumpRoutes` after a pass.
- Reject a key whose `Bits()` falls outside `[0, 129)` in `maptrie.InsertOrUpdate` and `maptrie.UpdateOrDelete` instead of indexing the level array with it, and document that `maptrie.Dump` copies values by assignment, which is what let the cleanup mutate live entries in the first place.
- Cover the regression in `operators/route/internal/rib` and `common/go/maptrie`; all six new tests fail against `6069cb23` with the reported `index out of range [-1]`.

Mechanism, for the record: `MapTrie.Dump` copies values by assignment, so each `RoutesList` shared its backing array with the live entry; `m.update(routeList.Routes...)` passed that array by reference; `RoutesList.Remove` calls `slices.Delete`, which since Go 1.22 zeroes the vacated tail; and the `range` in `update` kept the original length, so a later iteration read a zeroed `Route` whose `ToRemove` is false and whose `Prefix.Bits()` is `-1`. Any prefix with two or more paths where a removal happens before the last iteration reaches it, which is every ECMP prefix once a BIRD session expires.

Side effect of the rewrite: the pass no longer allocates a map of the whole RIB under the write lock, and the repeated `slices.Delete` calls per prefix are gone, so a cleanup is linear in the paths it inspects.

Out of scope, worth separate issues: `CleanupTask` holds the write lock for the whole pass, and the goroutine started at `service_route.go:417` still runs without `recover`.

Closes #2136.