### PR TITLE
refactor(auth): resolve identities from authenticated subjects

### DIFF
--- a/controlplane/internal/auth/basic/authenticator.go
+++ b/controlplane/internal/auth/basic/authenticator.go
@@ -66,7 +66,7 @@ func (m *BasicAuthenticator) Authenticate(
 	}
 
 	return &core.AuthInfo{
-		Username:   username,
+		Subject:    core.NewLocalSubject(username),
 		AuthMethod: "basic",
 	}, nil
 }

--- a/controlplane/internal/auth/basic/factory_test.go
+++ b/controlplane/internal/auth/basic/factory_test.go
@@ -69,7 +69,10 @@ func TestNewFromConfig(t *testing.T) {
 
 	authInfo, err := authenticator.Authenticate(t.Context(), validToken, requestInfo)
 	require.NoError(t, err)
-	require.Equal(t, &core.AuthInfo{Username: "alice", AuthMethod: "basic"}, authInfo)
+	require.Equal(t, &core.AuthInfo{
+		Subject:    core.NewLocalSubject("alice"),
+		AuthMethod: "basic",
+	}, authInfo)
 
 	wrongToken := basicToken("alice", "wrong-password")
 	_, err = authenticator.Authenticate(t.Context(), wrongToken, requestInfo)

--- a/controlplane/internal/auth/core/types.go
+++ b/controlplane/internal/auth/core/types.go
@@ -14,13 +14,61 @@ type RequestInfo struct {
 	FullMethod string
 }
 
+// VerifiedAssertion marks credential attributes whose authenticity has been
+// established.
+//
+// Implementations must only be returned after the carrying credential has been
+// fully validated. Verification does not make an attribute an authorization
+// decision; an identity provider must still interpret it.
+type VerifiedAssertion interface {
+	// AssertionType identifies the assertion format for provider dispatch.
+	AssertionType() string
+}
+
+// Subject identifies the entity proven by a credential.
+//
+// The authority namespace and its stable identifier form the subject key.
+// Account lookup names and verified attributes are auxiliary data and are not
+// part of that key.
+type Subject struct {
+	// Issuer scopes the identifier to the authority that assigned it.
+	//
+	// For OIDC this is the exact `iss` value. Local authenticators use `local`.
+	Issuer string
+	// Identifier is the stable value assigned within the issuer namespace.
+	//
+	// For OIDC this is `sub`; it need not be human-readable or usable as a
+	// system account name.
+	Identifier string
+	// Login is an optional account lookup name for file, NSS, or LDAP providers.
+	//
+	// It may be mutable and must not be treated as a globally stable subject
+	// identifier.
+	Login string
+	// Assertion contains optional verified attributes from the credential.
+	//
+	// A claims-backed identity provider may interpret them, while lookup-based
+	// providers can ignore them.
+	Assertion VerifiedAssertion
+}
+
+// NewLocalSubject creates a local subject with one value serving as both its
+// stable identifier and account lookup name.
+func NewLocalSubject(login string) Subject {
+	return Subject{
+		Issuer:     "local",
+		Identifier: login,
+		Login:      login,
+	}
+}
+
 // AuthInfo contains the result of token validation by an authenticator.
 //
-// It carries only the information that the authenticator can extract from the
-// token itself.
+// It carries the authenticated subject separately from the method that proved
+// it.
 type AuthInfo struct {
-	// Username is the authenticated username extracted from the token.
-	Username string
+	// Subject is the entity established by the authenticator.
+	Subject Subject
 	// AuthMethod is the authentication method used.
 	AuthMethod string
 }

--- a/controlplane/internal/auth/identity/composite.go
+++ b/controlplane/internal/auth/identity/composite.go
@@ -6,12 +6,18 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
 )
 
 // Provider provides access to identities from a specific source.
 type Provider interface {
 	Name() string
-	GetIdentity(ctx context.Context, username string) (Identity, error)
+	// ResolveIdentity derives an account identity from an authenticated subject.
+	ResolveIdentity(
+		ctx context.Context,
+		subject core.Subject,
+	) (Identity, error)
 }
 
 // CompositeIdentityProvider implements chain of responsibility pattern.
@@ -60,18 +66,27 @@ func (m *CompositeIdentityProvider) Name() string {
 	return "composite"
 }
 
-// GetIdentity tries each provider until one succeeds.
-func (m *CompositeIdentityProvider) GetIdentity(ctx context.Context, username string) (Identity, error) {
+// ResolveIdentity tries each provider until one resolves the subject.
+func (m *CompositeIdentityProvider) ResolveIdentity(
+	ctx context.Context,
+	subject core.Subject,
+) (Identity, error) {
+	matchedSubject := false
 	for _, provider := range m.providers {
-		identity, err := provider.GetIdentity(ctx, username)
+		identity, err := provider.ResolveIdentity(ctx, subject)
 		if err == nil {
 			m.log.Debug("identity found",
-				zap.String("username", username),
+				zap.String("username", identity.Username),
 				zap.String("provider", provider.Name()),
 			)
 			return identity, nil
 		}
 
+		if errors.Is(err, ErrSubjectUnsupported) {
+			continue
+		}
+
+		matchedSubject = true
 		if errors.Is(err, ErrIdentityNotFound) {
 			continue
 		}
@@ -83,5 +98,8 @@ func (m *CompositeIdentityProvider) GetIdentity(ctx context.Context, username st
 		return Identity{}, fmt.Errorf("provider %s: %w", provider.Name(), err)
 	}
 
+	if !matchedSubject {
+		return Identity{}, ErrSubjectUnsupported
+	}
 	return Identity{}, ErrIdentityNotFound
 }

--- a/controlplane/internal/auth/identity/composite_test.go
+++ b/controlplane/internal/auth/identity/composite_test.go
@@ -1,0 +1,185 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/identity"
+)
+
+var errProviderFailure = errors.New("provider failure")
+
+type testAssertion struct{}
+
+func (m *testAssertion) AssertionType() string {
+	return "test"
+}
+
+type identityProviderStub struct {
+	providerName string
+	resolve      func(context.Context, core.Subject) (identity.Identity, error)
+}
+
+// newIdentityProviderStub returns a provider with caller-controlled resolution.
+func newIdentityProviderStub(
+	name string,
+	resolve func(context.Context, core.Subject) (identity.Identity, error),
+) *identityProviderStub {
+	return &identityProviderStub{
+		providerName: name,
+		resolve:      resolve,
+	}
+}
+
+func (m *identityProviderStub) Name() string {
+	return m.providerName
+}
+
+func (m *identityProviderStub) ResolveIdentity(
+	ctx context.Context,
+	subject core.Subject,
+) (identity.Identity, error) {
+	return m.resolve(ctx, subject)
+}
+
+// Test_CompositeIdentityProvider_UnsupportedSubjectFallsThrough verifies that
+// the complete authenticated subject reaches the next applicable provider.
+func Test_CompositeIdentityProvider_UnsupportedSubjectFallsThrough(t *testing.T) {
+	assertion := &testAssertion{}
+	subject := core.Subject{
+		Issuer:     "https://issuer.example",
+		Identifier: "subject-42",
+		Login:      "alice",
+		Assertion:  assertion,
+	}
+	wantIdentity := identity.Identity{
+		Username: "alice",
+		Groups:   []string{"operators"},
+	}
+
+	unsupportedProvider := newIdentityProviderStub(
+		"unsupported",
+		func(
+			ctx context.Context,
+			received core.Subject,
+		) (identity.Identity, error) {
+			return identity.Identity{}, identity.ErrSubjectUnsupported
+		},
+	)
+	resolvingProvider := newIdentityProviderStub(
+		"resolving",
+		func(
+			ctx context.Context,
+			received core.Subject,
+		) (identity.Identity, error) {
+			require.Equal(t, subject, received)
+			return wantIdentity, nil
+		},
+	)
+	provider := identity.NewCompositeIdentityProvider([]identity.Provider{
+		unsupportedProvider,
+		resolvingProvider,
+	})
+
+	resolved, err := provider.ResolveIdentity(t.Context(), subject)
+	require.NoError(t, err)
+	assert.Equal(t, wantIdentity, resolved)
+}
+
+// Test_CompositeIdentityProvider_MissingIdentityFallsThrough verifies that an
+// absent account can still be supplied by a later applicable provider.
+func Test_CompositeIdentityProvider_MissingIdentityFallsThrough(t *testing.T) {
+	missingProvider := newIdentityProviderStub(
+		"missing",
+		func(
+			ctx context.Context,
+			subject core.Subject,
+		) (identity.Identity, error) {
+			return identity.Identity{}, identity.ErrIdentityNotFound
+		},
+	)
+	fallbackProvider := newIdentityProviderStub(
+		"fallback",
+		func(
+			ctx context.Context,
+			subject core.Subject,
+		) (identity.Identity, error) {
+			return identity.Identity{Username: "alice"}, nil
+		},
+	)
+	provider := identity.NewCompositeIdentityProvider([]identity.Provider{
+		missingProvider,
+		fallbackProvider,
+	})
+
+	resolved, err := provider.ResolveIdentity(
+		t.Context(),
+		core.NewLocalSubject("alice"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "alice", resolved.Username)
+}
+
+// Test_CompositeIdentityProvider_ProviderErrorStopsResolution verifies that a
+// provider failure cannot be bypassed by a later identity source.
+func Test_CompositeIdentityProvider_ProviderErrorStopsResolution(t *testing.T) {
+	fallbackCalled := false
+	failingProvider := newIdentityProviderStub(
+		"failing",
+		func(
+			ctx context.Context,
+			subject core.Subject,
+		) (identity.Identity, error) {
+			return identity.Identity{}, errProviderFailure
+		},
+	)
+	fallbackProvider := newIdentityProviderStub(
+		"fallback",
+		func(
+			ctx context.Context,
+			subject core.Subject,
+		) (identity.Identity, error) {
+			fallbackCalled = true
+			return identity.Identity{Username: "alice"}, nil
+		},
+	)
+	provider := identity.NewCompositeIdentityProvider([]identity.Provider{
+		failingProvider,
+		fallbackProvider,
+	})
+
+	_, err := provider.ResolveIdentity(
+		t.Context(),
+		core.NewLocalSubject("alice"),
+	)
+	require.ErrorIs(t, err, errProviderFailure)
+	assert.False(t, fallbackCalled)
+}
+
+// Test_CompositeIdentityProvider_AllProvidersUnsupported verifies that an
+// unhandled subject remains distinguishable from an absent account.
+func Test_CompositeIdentityProvider_AllProvidersUnsupported(t *testing.T) {
+	unsupportedProvider := newIdentityProviderStub(
+		"unsupported",
+		func(
+			ctx context.Context,
+			subject core.Subject,
+		) (identity.Identity, error) {
+			return identity.Identity{}, identity.ErrSubjectUnsupported
+		},
+	)
+	provider := identity.NewCompositeIdentityProvider([]identity.Provider{
+		unsupportedProvider,
+	})
+
+	_, err := provider.ResolveIdentity(t.Context(), core.Subject{
+		Issuer:     "https://issuer.example",
+		Identifier: "subject-42",
+	})
+	require.ErrorIs(t, err, identity.ErrSubjectUnsupported)
+}

--- a/controlplane/internal/auth/identity/file.go
+++ b/controlplane/internal/auth/identity/file.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/yanet-platform/yanet2/common/go/rcucache"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
 )
 
 type userName = string
@@ -41,13 +42,17 @@ func (m *IdentityProvider) Name() string {
 	return "file"
 }
 
-// GetIdentity retrieves an identity by username.
-func (m *IdentityProvider) GetIdentity(
+// ResolveIdentity retrieves an identity by the subject's account lookup name.
+func (m *IdentityProvider) ResolveIdentity(
 	ctx context.Context,
-	username string,
+	subject core.Subject,
 ) (Identity, error) {
+	if subject.Login == "" {
+		return Identity{}, ErrSubjectUnsupported
+	}
+
 	view := m.identities.View()
-	identity, ok := view.Lookup(username)
+	identity, ok := view.Lookup(subject.Login)
 	if !ok {
 		return Identity{}, ErrIdentityNotFound
 	}

--- a/controlplane/internal/auth/identity/file_test.go
+++ b/controlplane/internal/auth/identity/file_test.go
@@ -1,0 +1,44 @@
+package identity_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/identity"
+)
+
+// Test_IdentityProvider_ResolveByLogin verifies that an external subject can
+// resolve a local account through its optional login alias.
+func Test_IdentityProvider_ResolveByLogin(t *testing.T) {
+	wantIdentity := identity.Identity{
+		Username: "alice",
+		Groups:   []string{"operators"},
+	}
+	provider := identity.NewIdentityProvider(map[string]identity.Identity{
+		"alice": wantIdentity,
+	})
+	subject := core.Subject{
+		Issuer:     "https://issuer.example",
+		Identifier: "subject-42",
+		Login:      "alice",
+	}
+
+	resolved, err := provider.ResolveIdentity(t.Context(), subject)
+	require.NoError(t, err)
+	assert.Equal(t, wantIdentity, resolved)
+}
+
+// Test_IdentityProvider_MissingLoginIsUnsupported verifies that a lookup-only
+// provider does not reinterpret a stable external identifier as an account name.
+func Test_IdentityProvider_MissingLoginIsUnsupported(t *testing.T) {
+	provider := identity.NewIdentityProvider(map[string]identity.Identity{})
+
+	_, err := provider.ResolveIdentity(t.Context(), core.Subject{
+		Issuer:     "https://issuer.example",
+		Identifier: "subject-42",
+	})
+	require.ErrorIs(t, err, identity.ErrSubjectUnsupported)
+}

--- a/controlplane/internal/auth/identity/identity.go
+++ b/controlplane/internal/auth/identity/identity.go
@@ -7,6 +7,9 @@ import (
 var (
 	// ErrIdentityNotFound is returned when a requested identity does not exist.
 	ErrIdentityNotFound = errors.New("identity not found")
+	// ErrSubjectUnsupported is returned when a provider cannot resolve the
+	// authenticated subject shape.
+	ErrSubjectUnsupported = errors.New("authenticated subject unsupported")
 )
 
 // Identity represents a user account with authentication and authorization

--- a/controlplane/internal/auth/manager.go
+++ b/controlplane/internal/auth/manager.go
@@ -207,15 +207,16 @@ func (m *Manager) Authenticate(
 	return nil, fmt.Errorf("no authenticator supports the given token")
 }
 
-// buildPrincipal resolves the identity and assembles a Principal from AuthInfo.
+// buildPrincipal resolves an authenticated subject into its authorization
+// context.
 func (m *Manager) buildPrincipal(
 	ctx context.Context,
 	authInfo *core.AuthInfo,
 ) (*core.Principal, error) {
-	// Anonymous path: skip identity resolution.
+	// Anonymous requests do not have an account identity to resolve.
 	if authInfo.AuthMethod == "none" {
 		return &core.Principal{
-			User:        authInfo.Username,
+			User:        authInfo.Subject.Identifier,
 			Groups:      []string{},
 			AuthMethod:  authInfo.AuthMethod,
 			AuthTime:    time.Now(),
@@ -227,19 +228,19 @@ func (m *Manager) buildPrincipal(
 		return nil, fmt.Errorf("no identity provider configured")
 	}
 
-	ident, err := m.identityProvider.GetIdentity(ctx, authInfo.Username)
+	ident, err := m.identityProvider.ResolveIdentity(ctx, authInfo.Subject)
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Unauthenticated,
-			"identity lookup failed for user %q: %v",
-			authInfo.Username, err,
+			"identity lookup failed for subject %q from issuer %q: %v",
+			authInfo.Subject.Identifier, authInfo.Subject.Issuer, err,
 		)
 	}
 
 	if ident.Disabled {
 		return nil, status.Errorf(
 			codes.Unauthenticated,
-			"account %q is disabled", authInfo.Username,
+			"account %q is disabled", ident.Username,
 		)
 	}
 

--- a/controlplane/internal/auth/none/authenticator.go
+++ b/controlplane/internal/auth/none/authenticator.go
@@ -34,7 +34,7 @@ func (m *NoneAuthenticator) Authenticate(
 	reqInfo *core.RequestInfo,
 ) (*core.AuthInfo, error) {
 	return &core.AuthInfo{
-		Username:   "anonymous",
+		Subject:    core.NewLocalSubject("anonymous"),
 		AuthMethod: "none",
 	}, nil
 }

--- a/controlplane/internal/auth/none/authenticator_test.go
+++ b/controlplane/internal/auth/none/authenticator_test.go
@@ -67,8 +67,11 @@ func TestNoneAuthenticator_Authenticate(t *testing.T) {
 				t.Fatal("Authenticate() returned nil authInfo")
 			}
 
-			if authInfo.Username != "anonymous" {
-				t.Errorf("authInfo.Username = %q, want %q", authInfo.Username, "anonymous")
+			if authInfo.Subject != core.NewLocalSubject("anonymous") {
+				t.Errorf(
+					"authInfo.Subject = %#v, want local anonymous subject",
+					authInfo.Subject,
+				)
 			}
 
 			if authInfo.AuthMethod != "none" {

--- a/controlplane/internal/auth/sshcert/authenticator.go
+++ b/controlplane/internal/auth/sshcert/authenticator.go
@@ -112,19 +112,9 @@ func (m *Authenticator) IsTokenSupported(token string) bool {
 // Authenticate validates the SSH certificate token and returns authentication
 // info.
 //
-// Verification steps:
-//  1. Parse and validate token fields.
-//  2. Check timestamp window (replay protection).
-//  3. Check method binding.
-//  4. Parse SSH certificate from token.
-//  5. Check key type (ecdsa-sha2-nistp256 only).
-//  6. Check certificate type (UserCert).
-//  7. Check certificate validity period.
-//  8. Verify CA signature.
-//  9. Check KRL.
-//  10. Extract username from principals.
-//  11. Verify token signature.
-//  12. Return AuthInfo with the username.
+// Validation covers request binding and freshness, certificate constraints,
+// CA trust, revocation, and the token signature. The first certificate
+// principal becomes the local account lookup name.
 func (m *Authenticator) Authenticate(
 	ctx context.Context,
 	rawToken string,
@@ -221,7 +211,7 @@ func (m *Authenticator) Authenticate(
 	)
 
 	return &core.AuthInfo{
-		Username:   username,
+		Subject:    core.NewLocalSubject(username),
 		AuthMethod: "sshcert",
 	}, nil
 }

--- a/controlplane/internal/auth/sshcert/authenticator_test.go
+++ b/controlplane/internal/auth/sshcert/authenticator_test.go
@@ -74,7 +74,7 @@ func TestAuthenticator_HappyPath(t *testing.T) {
 		&core.RequestInfo{FullMethod: "/test.Service/Method"},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "alice", authInfo.Username)
+	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 	assert.Equal(t, "sshcert", authInfo.AuthMethod)
 }
 
@@ -325,7 +325,7 @@ func TestAuthenticator_NopRevocationChecker(t *testing.T) {
 		&core.RequestInfo{FullMethod: "/test.Service/Method"},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "alice", authInfo.Username)
+	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 	assert.Equal(t, "sshcert", authInfo.AuthMethod)
 }
 

--- a/controlplane/internal/auth/sshcert/factory_test.go
+++ b/controlplane/internal/auth/sshcert/factory_test.go
@@ -206,7 +206,10 @@ func TestNewFromConfigCASources(t *testing.T) {
 
 			authInfo, err := authenticator.Authenticate(t.Context(), token, requestInfo)
 			require.NoError(t, err)
-			require.Equal(t, &core.AuthInfo{Username: "alice", AuthMethod: "sshcert"}, authInfo)
+			require.Equal(t, &core.AuthInfo{
+				Subject:    core.NewLocalSubject("alice"),
+				AuthMethod: "sshcert",
+			}, authInfo)
 		})
 	}
 
@@ -252,7 +255,10 @@ func TestNewFromConfigKRLSource(t *testing.T) {
 
 		authInfo, err := authenticator.Authenticate(t.Context(), token, requestInfo)
 		require.NoError(t, err)
-		require.Equal(t, &core.AuthInfo{Username: "alice", AuthMethod: "sshcert"}, authInfo)
+		require.Equal(t, &core.AuthInfo{
+			Subject:    core.NewLocalSubject("alice"),
+			AuthMethod: "sshcert",
+		}, authInfo)
 	})
 }
 

--- a/controlplane/internal/auth/sshcert/token_test.go
+++ b/controlplane/internal/auth/sshcert/token_test.go
@@ -59,7 +59,7 @@ func TestParseToken(t *testing.T) {
 		&core.RequestInfo{FullMethod: "/test.Service/Method"},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "alice", authInfo.Username)
+	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 }
 
 func TestParseToken_WrongPrefix(t *testing.T) {

--- a/controlplane/internal/auth/sshkey/authenticator.go
+++ b/controlplane/internal/auth/sshkey/authenticator.go
@@ -82,13 +82,9 @@ func (m *Authenticator) IsTokenSupported(token string) bool {
 
 // Authenticate validates the SSH key token and returns authentication info.
 //
-// Verification steps:
-//  1. Parse and validate token fields.
-//  2. Check timestamp window (replay protection).
-//  3. Check method binding (token.Method == reqInfo.FullMethod).
-//  4. Look up public keys for the username.
-//  5. Verify SSH signature against known keys.
-//  6. Return AuthInfo with the username.
+// Validation covers request binding and freshness before checking the token
+// signature against the locally registered keys. The claimed username becomes
+// the local account lookup name.
 func (m *Authenticator) Authenticate(
 	ctx context.Context,
 	rawToken string,
@@ -138,7 +134,7 @@ func (m *Authenticator) Authenticate(
 	)
 
 	return &core.AuthInfo{
-		Username:   token.Username,
+		Subject:    core.NewLocalSubject(token.Username),
 		AuthMethod: "sshkey",
 	}, nil
 }

--- a/controlplane/internal/auth/sshkey/authenticator_test.go
+++ b/controlplane/internal/auth/sshkey/authenticator_test.go
@@ -91,7 +91,7 @@ func TestAuthenticate_Ed25519(t *testing.T) {
 
 	authInfo, err := auth.Authenticate(context.Background(), token, reqInfo)
 	require.NoError(t, err)
-	assert.Equal(t, "alice", authInfo.Username)
+	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 	assert.Equal(t, "sshkey", authInfo.AuthMethod)
 }
 
@@ -106,7 +106,7 @@ func TestAuthenticate_RSA(t *testing.T) {
 
 	authInfo, err := auth.Authenticate(context.Background(), token, reqInfo)
 	require.NoError(t, err)
-	assert.Equal(t, "bob", authInfo.Username)
+	assert.Equal(t, core.NewLocalSubject("bob"), authInfo.Subject)
 	assert.Equal(t, "sshkey", authInfo.AuthMethod)
 }
 
@@ -121,7 +121,7 @@ func TestAuthenticate_ECDSA(t *testing.T) {
 
 	authInfo, err := auth.Authenticate(context.Background(), token, reqInfo)
 	require.NoError(t, err)
-	assert.Equal(t, "charlie", authInfo.Username)
+	assert.Equal(t, core.NewLocalSubject("charlie"), authInfo.Subject)
 	assert.Equal(t, "sshkey", authInfo.AuthMethod)
 }
 
@@ -209,7 +209,7 @@ func TestAuthenticate_NilRequestInfo(t *testing.T) {
 
 	authInfo, err := auth.Authenticate(context.Background(), token, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "alice", authInfo.Username)
+	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 }
 
 func TestAuthenticate_EmptyFullMethod(t *testing.T) {
@@ -223,5 +223,5 @@ func TestAuthenticate_EmptyFullMethod(t *testing.T) {
 	emptyReqInfo := &core.RequestInfo{}
 	authInfo, err := auth.Authenticate(context.Background(), token, emptyReqInfo)
 	require.NoError(t, err)
-	assert.Equal(t, "alice", authInfo.Username)
+	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 }

--- a/controlplane/internal/auth/sshkey/factory_test.go
+++ b/controlplane/internal/auth/sshkey/factory_test.go
@@ -113,7 +113,10 @@ func TestNewFromConfig(t *testing.T) {
 
 	authInfo, err := authenticator.Authenticate(t.Context(), token, requestInfo)
 	require.NoError(t, err)
-	require.Equal(t, &core.AuthInfo{Username: "alice", AuthMethod: "sshkey"}, authInfo)
+	require.Equal(t, &core.AuthInfo{
+		Subject:    core.NewLocalSubject("alice"),
+		AuthMethod: "sshkey",
+	}, authInfo)
 }
 
 // TestNewFromConfigTimeWindow verifies that time_window from the config is

--- a/controlplane/internal/auth/sshkey/token_test.go
+++ b/controlplane/internal/auth/sshkey/token_test.go
@@ -29,7 +29,7 @@ func TestParseToken(t *testing.T) {
 		&core.RequestInfo{FullMethod: "/test.Service/Method"},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "alice", authInfo.Username)
+	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 }
 
 func authenticateRawKeyToken(t *testing.T, raw string) error {


### PR DESCRIPTION
- Replace username-only authentication results with issuer-scoped subjects and optional verified assertions.
- Route complete subjects through identity providers while preserving ordered fallback and fail-closed provider errors.
- Cover subject propagation, lookup aliases, and composite-provider fallback semantics.