### PR TITLE
refactor(acl,fwstate)!: build module configs in one shot

### DIFF
--- a/modules/acl/api/controlplane.c
+++ b/modules/acl/api/controlplane.c
@@ -108,9 +108,23 @@ acl_module_config_destroy(struct cp_module *cp_module) {
 	);
 }
 
+static int
+acl_module_compile_rules(
+	struct cp_module *cp_module,
+	struct acl_rule *acl_rules,
+	uint32_t rule_count,
+	const struct fwstate_sync_emit_config *emit_config,
+	yanet_error **err
+);
+
 struct cp_module *
 acl_module_config_init(
-	struct agent *agent, const char *name, yanet_error **err
+	struct agent *agent,
+	const char *name,
+	struct acl_rule *acl_rules,
+	uint32_t rule_count,
+	const struct fwstate_sync_emit_config *emit_config,
+	yanet_error **err
 ) {
 	struct acl_module_config *config =
 		(struct acl_module_config *)memory_balloc(
@@ -153,7 +167,7 @@ acl_module_config_init(
 	memset(&config->net6_share_dst, 0, sizeof(config->net6_share_dst));
 
 	// Initialize fwstate_cfg with NULL pointers and zero the emission
-	// sync config, which acl_module_config_update overwrites with the
+	// sync config, which acl_module_config_init overwrites with the
 	// caller's config when one is given.
 	memset(&config->fwstate_cfg, 0, sizeof(struct fwstate_config));
 	memset(&config->sync_config, 0, sizeof(struct fwstate_sync_emit_config)
@@ -213,6 +227,19 @@ acl_module_config_init(
 			return NULL;
 		}
 		*counters[i].dst = id;
+	}
+
+	// A config handle is built exactly once: the ruleset is compiled
+	// before the module is ever visible to a registry. A compile
+	// failure tears the whole module down through the registered
+	// destructor, which frees every partial allocation the compile
+	// made — the same state a caller-side Free of a failed update
+	// used to reach.
+	if (acl_module_compile_rules(
+		    &config->cp_module, acl_rules, rule_count, emit_config, err
+	    )) {
+		acl_module_config_destroy(&config->cp_module);
+		return NULL;
 	}
 
 	return &config->cp_module;
@@ -647,8 +674,13 @@ acl_module_init_net6_share(
 	return 0;
 }
 
-int
-acl_module_config_update(
+// Compile the ruleset into a freshly initialized ACL module config.
+//
+// Static on purpose: the only entry point is acl_module_config_init,
+// which owns the config's whole lifetime — a second update of a built
+// config is not part of the module's contract.
+static int
+acl_module_compile_rules(
 	struct cp_module *cp_module,
 	struct acl_rule *acl_rules,
 	uint32_t rule_count,
@@ -854,8 +886,7 @@ acl_module_config_update(
 			   (ts_end.tv_nsec - ts_start.tv_nsec));
 
 	// Copy the emission sync config that drives CREATE_STATE frames, or
-	// clear the one a previous update installed so a reused config emits
-	// none.
+	// leave the zeroed one in place so the config emits none.
 	if (emit_config != NULL) {
 		config->sync_config = *emit_config;
 	} else {
@@ -903,7 +934,7 @@ acl_module_config_set_fwstate_config(
 	);
 
 	// Only the borrowed maps cross over. The emission sync config comes
-	// from acl_module_config_update.
+	// from acl_module_config_init.
 	EQUATE_OFFSET(
 		&config->fwstate_cfg.fw4state, &fwstate_config->cfg.fw4state
 	);

--- a/modules/acl/api/controlplane.h
+++ b/modules/acl/api/controlplane.h
@@ -21,11 +21,6 @@ struct agent;
 struct cp_module;
 struct fwstate_sync_emit_config;
 
-struct cp_module *
-acl_module_config_init(
-	struct agent *agent, const char *name, yanet_error **err
-);
-
 void
 acl_module_config_free(struct cp_module *cp_module);
 
@@ -56,14 +51,19 @@ struct acl_rule {
 	enum filter_ip_fragment fragment;
 };
 
-// Compile rules into the ACL config and set the emission-side sync
-// parameters.
+// Allocate the ACL module config and compile the rules into it in one
+// step: a config handle is fully built at construction and never updated
+// afterwards.
 //
-// emit_config is copied by value when non-NULL and drives the CREATE_STATE
-// sync frames.
-int
-acl_module_config_update(
-	struct cp_module *cp_module,
+// rules and rule_count describe the ruleset to compile (rule_count may be
+// zero). emit_config is copied by value when non-NULL and drives the
+// CREATE_STATE sync frames; NULL leaves the emission config zeroed.
+//
+// Returns NULL with err set on failure; nothing is left allocated.
+struct cp_module *
+acl_module_config_init(
+	struct agent *agent,
+	const char *name,
 	struct acl_rule *rules,
 	uint32_t rule_count,
 	const struct fwstate_sync_emit_config *emit_config,

--- a/modules/acl/bindings/go/cacl/cgo.go
+++ b/modules/acl/bindings/go/cacl/cgo.go
@@ -10,11 +10,14 @@ package cacl
 import "C"
 
 import (
+	"errors"
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	cfwstate "github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 )
 
 // ModuleConfig is an opaque handle to the ACL module configuration in
@@ -23,13 +26,51 @@ type ModuleConfig struct {
 	ptr ffi.ModuleConfig
 }
 
-// NewModuleConfig allocates a new ACL module configuration via the C API.
-func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
+// NewModuleConfig allocates a new ACL module configuration and compiles
+// the given rules into it in one step: a config handle is constructed
+// once and never updated afterwards.
+//
+// Pass nil emitConfig for a ruleset that emits no sync packets.
+func NewModuleConfig(
+	agent *ffi.Agent,
+	name string,
+	rules []AclRule,
+	emitConfig *cfwstate.SyncEmitConfig,
+) (*ModuleConfig, error) {
+	pinner := &runtime.Pinner{}
+	defer pinner.Unpin()
+
+	cRules := make([]C.struct_acl_rule, len(rules))
+	for idx, rule := range rules {
+		cRules[idx] = rule.cBuild(pinner)
+	}
+
+	var cRulesPtr *C.struct_acl_rule
+	if len(cRules) > 0 {
+		cRulesPtr = &cRules[0]
+	}
+
+	var cEmitPtr unsafe.Pointer
+	if emitConfig != nil {
+		cEmitPtr = cfwstate.NewCEmitSyncConfig(*emitConfig)
+		if cEmitPtr == nil {
+			return nil, errors.New("failed to allocate ACL sync emission config")
+		}
+		defer cfwstate.FreeCEmitSyncConfig(cEmitPtr)
+	}
+
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
 	var cErr *C.yanet_error
-	ptr := C.acl_module_config_init((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
+	ptr := C.acl_module_config_init(
+		(*C.struct_agent)(agent.AsRawPtr()),
+		cName,
+		cRulesPtr,
+		C.uint32_t(len(cRules)),
+		(*C.struct_fwstate_sync_emit_config)(cEmitPtr),
+		&cErr,
+	)
 	if ptr == nil {
 		return nil, fmt.Errorf("failed to initialize module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}

--- a/modules/acl/bindings/go/cacl/safe.go
+++ b/modules/acl/bindings/go/cacl/safe.go
@@ -5,15 +5,11 @@ package cacl
 import "C"
 
 import (
-	"errors"
-	"fmt"
 	"runtime"
 	"unsafe"
 
-	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	cfwstate "github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 )
 
 // Action kind constants mirror the C ACL_RULE_ACTION_KIND_* enum values.
@@ -61,49 +57,6 @@ type AclConfigInfo struct {
 	FilterRuleCountIp6     uint64
 	FilterRuleCountIp6Port uint64
 	FilterRuleCountVlan    uint64
-}
-
-// UpdateRules compiles the given rules into C structures, attaches the
-// optional emission-side sync configuration, and pushes the config into
-// shared memory.
-//
-// Pass nil emitConfig for a ruleset that emits no sync packets.
-func (m *ModuleConfig) UpdateRules(rules []AclRule, emitConfig *cfwstate.SyncEmitConfig) error {
-	pinner := &runtime.Pinner{}
-	defer pinner.Unpin()
-
-	cRules := make([]C.struct_acl_rule, len(rules))
-	for idx, rule := range rules {
-		cRules[idx] = rule.cBuild(pinner)
-	}
-
-	var cRulesPtr *C.struct_acl_rule
-	if len(cRules) > 0 {
-		cRulesPtr = &cRules[0]
-	}
-
-	var cEmitPtr unsafe.Pointer
-	if emitConfig != nil {
-		cEmitPtr = cfwstate.NewCEmitSyncConfig(*emitConfig)
-		if cEmitPtr == nil {
-			return errors.New("failed to allocate ACL sync emission config")
-		}
-		defer cfwstate.FreeCEmitSyncConfig(cEmitPtr)
-	}
-
-	var cErr *C.yanet_error
-	rc := C.acl_module_config_update(
-		m.asRawPtr(),
-		cRulesPtr,
-		C.uint32_t(len(cRules)),
-		(*C.struct_fwstate_sync_emit_config)(cEmitPtr),
-		&cErr,
-	)
-	if rc != 0 {
-		return fmt.Errorf("failed to update ACL config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
-	}
-
-	return nil
 }
 
 // SetFwStateConfig links the given fwstate module config to this ACL config.

--- a/modules/acl/controlplane/acl_adapter.go
+++ b/modules/acl/controlplane/acl_adapter.go
@@ -248,20 +248,8 @@ func (m *ACLService) createLinkedHandles(
 			return nil, fmt.Errorf("ACL config %q not found", name)
 		}
 
-		handle, err := m.backend.NewModule(name)
-		if err != nil {
-			for _, h := range newHandles {
-				h.Free()
-			}
-
-			return nil, fmt.Errorf("failed to create ACL module config %q: %w", name, err)
-		}
-
-		handle.SetFwStateConfig(fwstateConfig.AsFFIModule())
-
 		rules, err := convertRules(entry.published.rules)
 		if err != nil {
-			handle.Free()
 			for _, h := range newHandles {
 				h.Free()
 			}
@@ -275,14 +263,16 @@ func (m *ACLService) createLinkedHandles(
 			emitCfg = &emit
 		}
 
-		if err := handle.UpdateRules(rules, emitCfg); err != nil {
-			handle.Free()
+		handle, err := m.backend.NewModule(name, rules, emitCfg)
+		if err != nil {
 			for _, h := range newHandles {
 				h.Free()
 			}
 
-			return nil, fmt.Errorf("failed to update ACL module config %q: %w", name, err)
+			return nil, fmt.Errorf("failed to create ACL module config %q: %w", name, err)
 		}
+
+		handle.SetFwStateConfig(fwstateConfig.AsFFIModule())
 
 		newHandles[name] = handle
 	}

--- a/modules/acl/controlplane/backend.go
+++ b/modules/acl/controlplane/backend.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
+	cfwstate "github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 )
 
 // backend is the production Backend implementation backed by *ffi.Agent.
@@ -17,8 +18,12 @@ func NewBackend(agent *ffi.Agent) Backend {
 	return &backend{agent: agent}
 }
 
-func (m *backend) NewModule(name string) (ModuleHandle, error) {
-	handle, err := cacl.NewModuleConfig(m.agent, name)
+func (m *backend) NewModule(
+	name string,
+	rules []cacl.AclRule,
+	emitConfig *cfwstate.SyncEmitConfig,
+) (ModuleHandle, error) {
+	handle, err := cacl.NewModuleConfig(m.agent, name, rules, emitConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module config: %w", err)
 	}

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -24,12 +24,12 @@ import (
 )
 
 // ModuleHandle is a handle to an ACL module configuration written to
-// shared memory. Operations on the handle mutate the underlying C config;
+// shared memory. The handle is fully built — rules compiled, emission
+// sync config installed — at construction and never updated afterwards;
 // Free releases it.
 type ModuleHandle interface {
 	Free()
 	AsFFIModule() ffi.ModuleConfig
-	UpdateRules(rules []cacl.AclRule, emitConfig *cfwstate.SyncEmitConfig) error
 	SetFwStateConfig(fw ffi.ModuleConfig)
 	TransferFwStateConfig(old ffi.ModuleConfig)
 	GetInfo() *cacl.AclConfigInfo
@@ -37,9 +37,14 @@ type ModuleHandle interface {
 
 // Backend abstracts shared-memory operations for the ACL service.
 type Backend interface {
-	// NewModule allocates a new ACL module config in shared memory.
-	// The returned handle is not yet published to the dataplane.
-	NewModule(name string) (ModuleHandle, error)
+	// NewModule allocates a new ACL module config in shared memory with
+	// the ruleset compiled into it. The returned handle is not yet
+	// published to the dataplane.
+	NewModule(
+		name string,
+		rules []cacl.AclRule,
+		emitConfig *cfwstate.SyncEmitConfig,
+	) (ModuleHandle, error)
 	// UpdateModule publishes handle to dp_config_gen so the dataplane
 	// picks it up on the next round.
 	UpdateModule(handle ModuleHandle) error
@@ -198,11 +203,10 @@ type ACLService struct {
 	// snapshot publishes stay totally ordered with map mutations. The
 	// snapshot rebuild calls GetInfo, a cgo accessor that copies a handful
 	// of integers out of an already-compiled C module, so it is cheap to
-	// run under mu.Lock. The long-running work (backend.NewModule,
-	// handle.UpdateRules, backend.UpdateModule, and the C compile they
-	// trigger) runs under the target entry's updateMu instead, outside any
-	// mu section, so a compile for one config never blocks a read or a
-	// compile for another.
+	// run under mu.Lock. The long-running work (backend.NewModule with
+	// its C compile, and backend.UpdateModule) runs under the target
+	// entry's updateMu instead, outside any mu section, so a compile for
+	// one config never blocks a read or a compile for another.
 	mu      sync.RWMutex
 	backend Backend
 	// configs maps a name to its entry. See configEntry for the entry
@@ -595,20 +599,15 @@ func (m *ACLService) UpdateConfig(
 			return err
 		}
 
-		handle, err := m.backend.NewModule(name)
-		if err != nil {
-			return status.Errorf(codes.Internal, "failed to create module config: %v", err)
-		}
-
 		var emitCfg *cfwstate.SyncEmitConfig
 		if syncConfig != nil {
 			emit := syncConfig.ToC()
 			emitCfg = &emit
 		}
 
-		if err := handle.UpdateRules(rules, emitCfg); err != nil {
-			handle.Free()
-			return status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		handle, err := m.backend.NewModule(name, rules, emitCfg)
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to create module config: %v", err)
 		}
 
 		fwstateName := ""

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -81,7 +81,7 @@ func (m *fakeHandle) Name() string {
 	return m.name
 }
 
-// Rules returns a copy of the rules passed to UpdateRules.
+// Rules returns a copy of the rules the handle was constructed with.
 func (m *fakeHandle) Rules() []cacl.AclRule {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -93,16 +93,7 @@ func (m *fakeHandle) AsFFIModule() ffi.ModuleConfig {
 	return ffi.ModuleConfig{}
 }
 
-func (m *fakeHandle) UpdateRules(rules []cacl.AclRule, emitConfig *cfwstate.SyncEmitConfig) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.rules = rules
-	m.emitConfig = emitConfig
-	return nil
-}
-
-// EmitConfig returns the emit config passed to the last UpdateRules call,
+// EmitConfig returns the emit config the handle was constructed with,
 // so a test can assert a relink carried the stored sync config over.
 func (m *fakeHandle) EmitConfig() *cfwstate.SyncEmitConfig {
 	m.mu.Lock()
@@ -260,10 +251,9 @@ func newMetricsSnapshotHarness(testingTB testing.TB) (*dataplaneut.Harness, *ffi
 	moduleNames := []string{"acl0", "a", "b", "c", "d"}
 	moduleConfigs := make([]ffi.ModuleConfig, 0, len(moduleNames))
 	for _, name := range moduleNames {
-		moduleConfig, moduleErr := cacl.NewModuleConfig(agent, name)
+		moduleConfig, moduleErr := cacl.NewModuleConfig(agent, name, nil, nil)
 		require.NoError(testingTB, moduleErr)
 		testingTB.Cleanup(moduleConfig.Free)
-		require.NoError(testingTB, moduleConfig.UpdateRules(nil, nil))
 		moduleConfigs = append(moduleConfigs, moduleConfig.AsFFIModule())
 	}
 	require.NoError(testingTB, agent.UpdateModules(moduleConfigs))
@@ -299,7 +289,11 @@ func newMetricsSnapshotHarness(testingTB testing.TB) (*dataplaneut.Harness, *ffi
 	return harness, agent
 }
 
-func (m *fakeBackend) NewModule(name string) (acl.ModuleHandle, error) {
+func (m *fakeBackend) NewModule(
+	name string,
+	rules []cacl.AclRule,
+	emitConfig *cfwstate.SyncEmitConfig,
+) (acl.ModuleHandle, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -307,7 +301,7 @@ func (m *fakeBackend) NewModule(name string) (acl.ModuleHandle, error) {
 		return nil, m.newModuleErr
 	}
 
-	h := &fakeHandle{name: name}
+	h := &fakeHandle{name: name, rules: rules, emitConfig: emitConfig}
 	m.created = append(m.created, h)
 	return h, nil
 }
@@ -380,8 +374,6 @@ func unwrapFakeHandle(handle acl.ModuleHandle) *fakeHandle {
 	switch typedHandle := handle.(type) {
 	case *fakeHandle:
 		return typedHandle
-	case *compileBlockingHandle:
-		return unwrapFakeHandle(typedHandle.ModuleHandle)
 	default:
 		return nil
 	}
@@ -404,16 +396,17 @@ func (m *fakeBackend) DeleteCalls() int {
 }
 
 // compileBlock synchronizes one blocked compile with the test: entered
-// signals that UpdateRules has started, release lets it return.
+// signals that the compile inside NewModule has started, release lets it
+// return.
 type compileBlock struct {
 	entered chan struct{}
 	release chan struct{}
 }
 
 // compileBlockingBackend wraps fakeBackend so a test can arm a specific
-// config name's next UpdateRules call to block until released, proving
+// config name's next NewModule compile to block until released, proving
 // overlap or ordering between compiles via channel synchronization instead
-// of timing. Every UpdateRules call, blocked or not, is recorded in
+// of timing. Every NewModule call, blocked or not, is recorded in
 // entryOrder for tests that only need to assert relative ordering.
 type compileBlockingBackend struct {
 	*fakeBackend
@@ -430,9 +423,9 @@ func newCompileBlockingBackend() *compileBlockingBackend {
 	}
 }
 
-// blockCompile arms the next UpdateRules call for name to block until the
+// blockCompile arms the next NewModule compile for name to block until the
 // returned release function is called. The returned channel closes once
-// that call has entered UpdateRules.
+// that call has entered the compile.
 func (m *compileBlockingBackend) blockCompile(name string) (<-chan struct{}, func()) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -448,7 +441,7 @@ func (m *compileBlockingBackend) blockCompile(name string) (<-chan struct{}, fun
 	})
 }
 
-// recordEntry logs that UpdateRules for name has started and returns and
+// recordEntry logs that the compile for name has started and returns and
 // consumes any block armed for name.
 func (m *compileBlockingBackend) recordEntry(name string) *compileBlock {
 	m.mu.Lock()
@@ -461,7 +454,7 @@ func (m *compileBlockingBackend) recordEntry(name string) *compileBlock {
 	return block
 }
 
-// entryOrder returns the config names in the order their UpdateRules calls
+// entryOrder returns the config names in the order their compiles
 // started.
 func (m *compileBlockingBackend) entryOrder() []string {
 	m.mu.Lock()
@@ -470,30 +463,17 @@ func (m *compileBlockingBackend) entryOrder() []string {
 	return append([]string(nil), m.entries...)
 }
 
-func (m *compileBlockingBackend) NewModule(name string) (acl.ModuleHandle, error) {
-	handle, err := m.fakeBackend.NewModule(name)
-	if err != nil {
-		return nil, err
-	}
-
-	return &compileBlockingHandle{ModuleHandle: handle, backend: m, name: name}, nil
-}
-
-// compileBlockingHandle records and optionally blocks its UpdateRules call
-// before delegating to the wrapped fakeHandle.
-type compileBlockingHandle struct {
-	acl.ModuleHandle
-	backend *compileBlockingBackend
-	name    string
-}
-
-func (m *compileBlockingHandle) UpdateRules(rules []cacl.AclRule, emitConfig *cfwstate.SyncEmitConfig) error {
-	block := m.backend.recordEntry(m.name)
+func (m *compileBlockingBackend) NewModule(
+	name string,
+	rules []cacl.AclRule,
+	emitConfig *cfwstate.SyncEmitConfig,
+) (acl.ModuleHandle, error) {
+	block := m.recordEntry(name)
 	if block != nil {
 		close(block.entered)
 		<-block.release
 	}
-	return m.ModuleHandle.UpdateRules(rules, emitConfig)
+	return m.fakeBackend.NewModule(name, rules, emitConfig)
 }
 
 func newTestService(b acl.Backend) *acl.ACLService {
@@ -984,7 +964,7 @@ func TestDeleteConfig_WaitsBehindInFlightCreate(t *testing.T) {
 		updateDone <- err
 	}()
 
-	waitOnChan(t, entered, "create did not reach UpdateRules")
+	waitOnChan(t, entered, "create did not reach the compile")
 
 	deleteDone := make(chan error, 1)
 	go func() {
@@ -1298,7 +1278,7 @@ func TestMetricsSnapshotOrderingSurvivesConcurrentBarrage(t *testing.T) {
 
 // TestUpdateConfig_CompilesInParallel verifies that UpdateConfig calls for
 // different names compile concurrently: both are proven to be inside
-// UpdateRules at the same time via channel synchronization, not timing.
+// compiles at the same time via channel synchronization, not timing.
 func TestUpdateConfig_CompilesInParallel(t *testing.T) {
 	backend := newCompileBlockingBackend()
 	svc := newTestService(backend)
@@ -1322,9 +1302,9 @@ func TestUpdateConfig_CompilesInParallel(t *testing.T) {
 	}()
 
 	// Neither release fires until both signal that they are inside
-	// UpdateRules, so a pass here proves the two compiles overlapped.
-	waitOnChan(t, enteredA, "config \"a\" did not reach UpdateRules")
-	waitOnChan(t, enteredB, "config \"b\" did not reach UpdateRules")
+	// compile, so a pass here proves the two compiles overlapped.
+	waitOnChan(t, enteredA, "config \"a\" did not reach the compile")
+	waitOnChan(t, enteredB, "config \"b\" did not reach the compile")
 
 	releaseA()
 	releaseB()
@@ -1365,7 +1345,7 @@ func TestShowAndListConfigs_DoNotWaitForCompile(t *testing.T) {
 		updateDone <- err
 	}()
 
-	waitOnChan(t, entered, "update did not reach UpdateRules")
+	waitOnChan(t, entered, "update did not reach the compile")
 
 	type showResult struct {
 		resp *aclpb.ShowConfigResponse
@@ -1413,7 +1393,7 @@ func TestShowAndListConfigs_DoNotWaitForCompile(t *testing.T) {
 }
 
 // TestUpdateConfig_SameNameSerializes verifies that two UpdateConfig calls
-// for the same name serialize: the second cannot reach UpdateRules until the
+// for the same name serialize: the second cannot reach the compile until the
 // first has released the per-name lock, which is proven by lock acquisition
 // order rather than a sleep-based race check.
 func TestUpdateConfig_SameNameSerializes(t *testing.T) {
@@ -1431,11 +1411,11 @@ func TestUpdateConfig_SameNameSerializes(t *testing.T) {
 		doneFirst <- err
 	}()
 
-	waitOnChan(t, enteredFirst, "first update did not reach UpdateRules")
+	waitOnChan(t, enteredFirst, "first update did not reach the compile")
 
 	// Arm a second block before starting the second call: since the first
 	// block was already consumed, this block will only fire once the second
-	// call reaches UpdateRules on its own turn.
+	// call reaches the compile on its own turn.
 	enteredSecond, releaseSecond := backend.blockCompile("a")
 	t.Cleanup(releaseSecond)
 
@@ -1454,10 +1434,10 @@ func TestUpdateConfig_SameNameSerializes(t *testing.T) {
 		t.Fatal("first UpdateConfig did not finish after release")
 	}
 
-	// The second call can only reach UpdateRules by acquiring the per-name
+	// The second call can only reach the compile by acquiring the per-name
 	// lock, which the first call releases only when it returns above — so
 	// this signal firing at all proves the ordering, not merely its timing.
-	waitOnChan(t, enteredSecond, "second update did not reach UpdateRules after the first finished")
+	waitOnChan(t, enteredSecond, "second update did not reach the compile after the first finished")
 
 	releaseSecond()
 

--- a/modules/acl/tests/functional/acl_bench_dataset_test.go
+++ b/modules/acl/tests/functional/acl_bench_dataset_test.go
@@ -691,12 +691,9 @@ func datasetBenchSetup(b *testing.B) *datasetBenchState {
 		}
 		backend := acl.NewBackend(agent)
 
-		handle, err := backend.NewModule("dataset")
+		handle, err := backend.NewModule("dataset", rules, nil)
 		if err != nil {
 			datasetBenchErr = err
-			return
-		}
-		if datasetBenchErr = handle.UpdateRules(rules, nil); datasetBenchErr != nil {
 			return
 		}
 		if datasetBenchErr = backend.UpdateModule(handle); datasetBenchErr != nil {
@@ -845,12 +842,9 @@ func datasetTopoBenchSetup(b *testing.B) *datasetBenchState {
 		}
 		backend := acl.NewBackend(agent)
 
-		handle, err := backend.NewModule("dataset")
+		handle, err := backend.NewModule("dataset", rules, nil)
 		if err != nil {
 			topoBenchErr = err
-			return
-		}
-		if topoBenchErr = handle.UpdateRules(rules, nil); topoBenchErr != nil {
 			return
 		}
 		if topoBenchErr = backend.UpdateModule(handle); topoBenchErr != nil {

--- a/modules/acl/tests/functional/acl_fwstate_agent_test.go
+++ b/modules/acl/tests/functional/acl_fwstate_agent_test.go
@@ -53,7 +53,7 @@ func setupACLFWStateHarness(tb testing.TB) (*ffi.Agent, acl.Backend) {
 func TestACL_FWStateAgentSharing_ParkedModuleSurvivesUnrelatedDrain(t *testing.T) {
 	agent, backend := setupACLFWStateHarness(t)
 
-	fwCfg, err := cfwstate.NewModuleConfig(agent, "fw0")
+	fwCfg, err := cfwstate.NewModuleConfig(agent, "fw0", nil, nil, cfwstate.MapConfig{}, 0)
 	require.NoError(t, err)
 	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{fwCfg.AsFFIModule()}))
 

--- a/modules/acl/tests/functional/acl_sync_config_test.go
+++ b/modules/acl/tests/functional/acl_sync_config_test.go
@@ -69,11 +69,10 @@ func TestACL_UpdateRules_EmitConfigDrivesSyncFrames(t *testing.T) {
 
 	h, agent, backend := setupACLHarness(t, []string{"port0"})
 
-	handle, err := backend.NewModule("sync-emit")
+	handle, err := backend.NewModule("sync-emit", []cacl.AclRule{rule}, syncEmitConfig())
 	require.NoError(t, err)
 	t.Cleanup(handle.Free)
 
-	require.NoError(t, handle.UpdateRules([]cacl.AclRule{rule}, syncEmitConfig()))
 	require.NoError(t, backend.UpdateModule(handle))
 	wireACLPipeline(t, agent, "port0", "sync-emit")
 
@@ -83,10 +82,9 @@ func TestACL_UpdateRules_EmitConfigDrivesSyncFrames(t *testing.T) {
 }
 
 // TestACL_UpdateRules_NilEmitConfigClearsPreviousSyncConfig verifies the
-// nil contract of the exported binding: a later UpdateRules with a nil emit
-// config clears the previously installed one on the same handle, so the
-// published config emits no state-sync frames instead of crafting them to
-// the stale destination.
+// nil contract of the exported binding: a replacement config constructed
+// with a nil emit config emits no state-sync frames, instead of crafting
+// them to the destination the previous config installed.
 func TestACL_UpdateRules_NilEmitConfigClearsPreviousSyncConfig(t *testing.T) {
 	rule := allow4Rule(
 		filter.IPNets{filter.UnspecifiedIPv4},
@@ -95,22 +93,45 @@ func TestACL_UpdateRules_NilEmitConfigClearsPreviousSyncConfig(t *testing.T) {
 	)
 	rule.Actions = []cacl.AclAction{{Kind: cacl.ActionCreateState}, {Kind: cacl.ActionAllow}}
 
-	// The same handle compiles the rules twice, and the second compile
-	// allocates fresh filter tables in the module arena next to the
-	// first, so the harness carries a larger agent arena (the sizes the
-	// net6-share tests proved under ASan).
+	// The replacement constructs a second config in the same module
+	// arena next to the first, so the harness carries a larger agent
+	// arena (the sizes the net6-share tests proved under ASan).
 	h, agent, backend := setupACLHarnessSized(t, []string{"port0"}, 192*datasize.MB, 48*datasize.MB)
 
-	handle, err := backend.NewModule("sync-emit")
+	emitHandle, err := backend.NewModule("sync-emit", []cacl.AclRule{rule}, syncEmitConfig())
 	require.NoError(t, err)
-	t.Cleanup(handle.Free)
-
-	require.NoError(t, handle.UpdateRules([]cacl.AclRule{rule}, syncEmitConfig()))
-	require.NoError(t, handle.UpdateRules([]cacl.AclRule{rule}, nil))
-	require.NoError(t, backend.UpdateModule(handle))
+	t.Cleanup(emitHandle.Free)
+	require.NoError(t, backend.UpdateModule(emitHandle))
 	wireACLPipeline(t, agent, "port0", "sync-emit")
 
 	result, err := h.HandlePackets(syncStatePacket(t))
+	require.NoError(t, err)
+	require.Len(t, result.Output, 2, "the emit config must drive a state-sync frame first")
+
+	handle, err := backend.NewModule("sync-emit", []cacl.AclRule{rule}, nil)
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+
+	// A module publish waits for a worker round to acknowledge the new
+	// generation, and only HandlePackets drives rounds in this harness.
+	// Drive bare rounds until the replacement publish completes.
+	publishDone := make(chan error, 1)
+	go func() {
+		publishDone <- backend.UpdateModule(handle)
+	}()
+	publishing := true
+	for publishing {
+		select {
+		case err := <-publishDone:
+			require.NoError(t, err)
+			publishing = false
+		default:
+			_, err := h.HandlePackets()
+			require.NoError(t, err)
+		}
+	}
+
+	result, err = h.HandlePackets(syncStatePacket(t))
 	require.NoError(t, err)
 	require.Len(t, result.Output, 1, "a nil emit config must clear the previously installed one")
 }

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -113,11 +113,10 @@ func applyACLRules(
 ) acl.ModuleHandle {
 	tb.Helper()
 
-	handle, err := backend.NewModule(name)
+	handle, err := backend.NewModule(name, rules, nil)
 	require.NoError(tb, err)
 	tb.Cleanup(handle.Free)
 
-	require.NoError(tb, handle.UpdateRules(rules, nil))
 	require.NoError(tb, backend.UpdateModule(handle))
 	return handle
 }
@@ -1814,10 +1813,6 @@ func TestACL_IPv6Fragment_LaterFragment(t *testing.T) {
 func TestACL_RejectsNonContiguousIPv4Mask(t *testing.T) {
 	_, _, backend := setupACLHarness(t, []string{"port0"})
 
-	handle, err := backend.NewModule("reject4")
-	require.NoError(t, err)
-	t.Cleanup(handle.Free)
-
 	badMask := netip.AddrFrom4([4]byte{0xff, 0x00, 0xff, 0x00})
 	rules := []cacl.AclRule{
 		allow4Rule(
@@ -1827,7 +1822,7 @@ func TestACL_RejectsNonContiguousIPv4Mask(t *testing.T) {
 		),
 	}
 
-	err = handle.UpdateRules(rules, nil)
+	_, err := backend.NewModule("reject4", rules, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "non-contiguous")
 }
@@ -1837,10 +1832,6 @@ func TestACL_RejectsNonContiguousIPv4Mask(t *testing.T) {
 // time instead of being silently mis-classified.
 func TestACL_RejectsNonBiContiguousIPv6Mask(t *testing.T) {
 	_, _, backend := setupACLHarness(t, []string{"port0"})
-
-	handle, err := backend.NewModule("reject6")
-	require.NoError(t, err)
-	t.Cleanup(handle.Free)
 
 	badMask := netip.AddrFrom16([16]byte{
 		0xff, 0x00, 0xff, 0x00, 0, 0, 0, 0,
@@ -1854,7 +1845,7 @@ func TestACL_RejectsNonBiContiguousIPv6Mask(t *testing.T) {
 		),
 	}
 
-	err = handle.UpdateRules(rules, nil)
+	_, err := backend.NewModule("reject6", rules, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "bi-contiguous")
 }

--- a/modules/decap/controlplane/decappb/v1/decap.proto
+++ b/modules/decap/controlplane/decappb/v1/decap.proto
@@ -28,9 +28,7 @@ message ListConfigsResponse { repeated string configs = 1; }
 message ShowConfigRequest { string name = 1; }
 
 // ShowConfigResponse contains the configuration details of the decap module.
-message ShowConfigResponse {
-  repeated common.commonpb.v1.ContiguousIPNetwork prefixes = 1;
-}
+message ShowConfigResponse { repeated common.commonpb.v1.ContiguousIPNetwork prefixes = 1; }
 
 // UpdateConfigRequest carries the full desired prefix set for the named config.
 message UpdateConfigRequest {

--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -4,6 +4,7 @@
 #include "fwstate_cp.h"
 
 #include "common/container_of.h"
+#include "common/numutils.h"
 #include "lib/controlplane/agent/agent.h"
 #include "lib/errors/errors.h"
 #include "lib/fwstate/config.h"
@@ -38,7 +39,7 @@ fwstate_config_fini(struct fwstate_config *config, struct agent *agent) {
 }
 
 // Set default timeout values for fwstate configuration
-static void
+void
 fwstate_config_set_defaults(struct fwstate_sync_config *config) {
 	memset(config, 0, sizeof(struct fwstate_sync_config));
 	config->timeouts.tcp_syn_ack = FW_STATE_DEFAULT_TIMEOUT;
@@ -52,9 +53,24 @@ fwstate_config_set_defaults(struct fwstate_sync_config *config) {
 static void
 fwstate_module_config_destroy(struct cp_module *cp_module);
 
+static int
+fwstate_module_setup_maps(
+	struct fwstate_module_config *config,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count
+);
+
 struct cp_module *
 fwstate_module_config_new(
-	struct agent *agent, const char *name, yanet_error **err
+	struct agent *agent,
+	const char *name,
+	struct cp_module *old,
+	const struct fwstate_sync_config *sync_config,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count,
+	yanet_error **err
 ) {
 	struct fwstate_module_config *config =
 		(struct fwstate_module_config *)memory_balloc(
@@ -155,24 +171,36 @@ fwstate_module_config_new(
 		*counters[i].dst = id;
 	}
 
+	// One-shot construction: propagate the replaced config's sync
+	// config and borrowed map offsets (or start from defaults for a
+	// fresh config), install the caller's final sync config, then
+	// create or grow the maps. Nothing mutates the config afterwards.
+	if (old != NULL) {
+		struct fwstate_module_config *old_config = container_of(
+			old, struct fwstate_module_config, cp_module
+		);
+		config->sync_config = old_config->sync_config;
+		EQUATE_OFFSET(&config->cfg.fw4state, &old_config->cfg.fw4state);
+		EQUATE_OFFSET(&config->cfg.fw6state, &old_config->cfg.fw6state);
+	}
+
+	if (sync_config != NULL) {
+		config->sync_config = *sync_config;
+	}
+
+	if (fwstate_module_setup_maps(
+		    config, index_size, extra_bucket_count, worker_count
+	    )) {
+		yanet_error_add(err, "failed to setup fwstate maps");
+		// The propagated map offsets are borrowed from old: clear
+		// them so the destructor frees no borrowed chain.
+		config->cfg.fw4state = NULL;
+		config->cfg.fw6state = NULL;
+		fwstate_module_config_destroy(&config->cp_module);
+		return NULL;
+	}
+
 	return &config->cp_module;
-}
-
-void
-fwstate_module_config_propogate(
-	struct cp_module *new_cp_module, struct cp_module *old_cp_module
-) {
-	struct fwstate_module_config *new = container_of(
-		new_cp_module, struct fwstate_module_config, cp_module
-	);
-
-	struct fwstate_module_config *old = container_of(
-		old_cp_module, struct fwstate_module_config, cp_module
-	);
-
-	new->sync_config = old->sync_config;
-	EQUATE_OFFSET(&new->cfg.fw4state, &old->cfg.fw4state);
-	EQUATE_OFFSET(&new->cfg.fw6state, &old->cfg.fw6state);
 }
 
 static void
@@ -210,7 +238,9 @@ fwstate_module_config_detach_maps(struct cp_module *cp_module) {
 	config->cfg.fw6state = NULL;
 }
 
-int
+// Create the config's firewall state maps. Static on purpose: the only
+// entry point is fwstate_module_config_new.
+static int
 fwstate_config_create_maps(
 	struct cp_module *cp_module,
 	uint32_t index_size,
@@ -262,6 +292,9 @@ fwstate_config_create_maps(
 	return 0;
 }
 
+// Prepend a new layer to the config's maps: a map-chain operation, not
+// a config update — the config's sync rules and links never change
+// after construction.
 int
 fwstate_config_insert_new_layer(
 	struct cp_module *cp_module,
@@ -316,14 +349,67 @@ fwstate_config_insert_new_layer(
 	return 0;
 }
 
-void
-fwstate_module_config_set_sync_config(
-	struct cp_module *cp_module, struct fwstate_sync_config *sync_config
+// Decide between creating fresh maps and growing the propagated ones
+// with a new layer: a requested size that differs from the propagated
+// maps' aligned current size prepends a new layer carrying the raw
+// requested sizes; equal or zero sizes keep the chain untouched. A zero
+// worker count leaves the config unmapped — the module then counts and
+// drops that family's sync frames without inserting.
+static int
+fwstate_module_setup_maps(
+	struct fwstate_module_config *config,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count
 ) {
-	struct fwstate_module_config *config = container_of(
-		cp_module, struct fwstate_module_config, cp_module
+	struct cp_module *cp_module = &config->cp_module;
+
+	if (worker_count == 0) {
+		return 0;
+	}
+
+	if (config->cfg.fw4state == NULL) {
+		return fwstate_config_create_maps(
+			cp_module, index_size, extra_bucket_count, worker_count
+		);
+	}
+
+	fwmap_stats_t stats_v4 = fwstate_config_get_map_stats(cp_module, false);
+	fwmap_stats_t stats_v6 = fwstate_config_get_map_stats(cp_module, true);
+	uint32_t current_index_size = stats_v4.index_size > stats_v6.index_size
+					      ? stats_v4.index_size
+					      : stats_v6.index_size;
+	uint32_t current_extra_bucket_count =
+		stats_v4.extra_bucket_count > stats_v6.extra_bucket_count
+			? stats_v4.extra_bucket_count
+			: stats_v6.extra_bucket_count;
+
+	uint32_t requested_index_size = (uint32_t)align_up_pow2(index_size);
+	uint32_t requested_extra_bucket_count =
+		(uint32_t)align_up_pow2(extra_bucket_count);
+
+	bool map_config_changed = false;
+	if (requested_index_size != 0 &&
+	    requested_index_size != current_index_size) {
+		map_config_changed = true;
+		current_index_size = index_size;
+	}
+	if (requested_extra_bucket_count != 0 &&
+	    requested_extra_bucket_count != current_extra_bucket_count) {
+		map_config_changed = true;
+		current_extra_bucket_count = extra_bucket_count;
+	}
+
+	if (!map_config_changed) {
+		return 0;
+	}
+
+	return fwstate_config_insert_new_layer(
+		cp_module,
+		current_index_size,
+		current_extra_bucket_count,
+		worker_count
 	);
-	config->sync_config = *sync_config;
 }
 
 struct fwmap_stats

--- a/modules/fwstate/api/fwstate_cp.h
+++ b/modules/fwstate/api/fwstate_cp.h
@@ -16,14 +16,40 @@ struct layermap_list;
 // Opaque handle for outdated layers that need to be freed
 typedef struct fwstate_outdated_layers fwstate_outdated_layers_t;
 
+// Set the C-side default receive-side sync timeouts.
+void
+fwstate_config_set_defaults(struct fwstate_sync_config *config);
+
+// Allocate an fwstate module config fully built in one step: a config
+// handle is created once and never updated afterwards.
+//
+// old names the config this one replaces, or NULL for a fresh config.
+// From old the sync config and the borrowed map offsets propagate; with
+// old NULL the maps are created fresh from index_size and
+// extra_bucket_count (zero falls back to the fwmap defaults) and the
+// sync config starts from fwstate_config_set_defaults.
+//
+// When old is given, its maps are kept unless the aligned
+// index_size/extra_bucket_count pair differs from the sizes the
+// propagated maps carry, in which case a new layer with the requested
+// sizes is prepended to both chains.
+//
+// sync_config is the final receive-side sync config to install, or NULL
+// to keep the propagated or default one. A zero worker_count leaves the
+// config unmapped: no maps are created and the propagated chain, if
+// any, is kept as is.
+//
+// Returns NULL with err set on failure; nothing is left allocated.
 struct cp_module *
 fwstate_module_config_new(
-	struct agent *agent, const char *name, yanet_error **err
-);
-
-void
-fwstate_module_config_propogate(
-	struct cp_module *new_cp_module, struct cp_module *old_cp_module
+	struct agent *agent,
+	const char *name,
+	struct cp_module *old,
+	const struct fwstate_sync_config *sync_config,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count,
+	yanet_error **err
 );
 
 void
@@ -32,27 +58,15 @@ fwstate_module_config_free(struct cp_module *cp_module);
 void
 fwstate_module_config_detach_maps(struct cp_module *cp_module);
 
-// Create firewall state maps for the configuration
-int
-fwstate_config_create_maps(
-	struct cp_module *cp_module,
-	uint32_t index_size,
-	uint32_t extra_bucket_count,
-	uint16_t worker_count
-);
-
-// Insert new layer to existing firewall state maps
+// Prepend a new layer to the config's existing maps. This grows the map
+// chain only: the config's sync rules and links never change after
+// construction.
 int
 fwstate_config_insert_new_layer(
 	struct cp_module *cp_module,
 	uint32_t index_size,
 	uint32_t extra_bucket_count,
 	uint16_t worker_count
-);
-
-void
-fwstate_module_config_set_sync_config(
-	struct cp_module *cp_module, struct fwstate_sync_config *sync_config
 );
 
 struct fwmap_stats

--- a/modules/fwstate/bindings/go/cfwstate/cgo.go
+++ b/modules/fwstate/bindings/go/cfwstate/cgo.go
@@ -29,21 +29,84 @@ type ModuleConfig struct {
 	generation uint64
 }
 
-// NewModuleConfig creates a new FWState module configuration.
-func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
+// DefaultSyncConfig returns the C-side default receive-side sync
+// configuration, the baseline a fresh config starts from before the
+// caller's request is merged over it.
+func DefaultSyncConfig() SyncConfig {
+	var cSyncConfig C.struct_fwstate_sync_config
+	C.fwstate_config_set_defaults(&cSyncConfig)
+	return newSyncConfigFromC(&cSyncConfig)
+}
+
+// NewModuleConfig creates an FWState module configuration fully built in
+// one step: a config handle is constructed once and never updated
+// afterwards.
+//
+// old names the config this one replaces, or nil for a fresh config.
+// From old the sync config and the borrowed map offsets propagate; with
+// old nil the maps are created fresh from mapConfig. When old is given,
+// its maps are kept unless mapConfig asks for a different aligned size
+// pair, in which case a new layer with the requested sizes is prepended.
+//
+// syncConfig is the final receive-side sync config to install, or nil to
+// keep the propagated or default one. A zero workerCount leaves the
+// config unmapped: no maps are created and the propagated chain, if
+// any, is kept as is.
+func NewModuleConfig(
+	agent *ffi.Agent,
+	name string,
+	old *ModuleConfig,
+	syncConfig *SyncConfig,
+	mapConfig MapConfig,
+	workerCount uint16,
+) (*ModuleConfig, error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
+	var cOld *C.struct_cp_module
+	if old != nil {
+		cOld = old.asRawPtr()
+	}
+
+	var cSync *C.struct_fwstate_sync_config
+	if syncConfig != nil {
+		cSyncConfig := syncConfig.toC()
+		cSync = &cSyncConfig
+	}
+
 	var cErr *C.yanet_error
-	ptr := C.fwstate_module_config_new((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
+	ptr := C.fwstate_module_config_new(
+		(*C.struct_agent)(agent.AsRawPtr()),
+		cName,
+		cOld,
+		cSync,
+		C.uint32_t(mapConfig.IndexSize),
+		C.uint32_t(mapConfig.ExtraBucketCount),
+		C.uint16_t(workerCount),
+		&cErr,
+	)
 	if ptr == nil {
 		return nil, fmt.Errorf("failed to initialize FWState module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}
 
-	return &ModuleConfig{
+	m := &ModuleConfig{
 		name: name,
 		ptr:  ffi.NewModuleConfig(unsafe.Pointer(ptr)),
-	}, nil
+	}
+
+	// Generation mirrors the former CreateMaps bookkeeping: fresh maps
+	// start at 1, a propagated config keeps the old generation and
+	// advances it exactly when the map sizes changed.
+	if old != nil {
+		m.generation = old.generation
+		if old.GetMapConfig() != m.GetMapConfig() {
+			m.generation++
+		}
+	} else {
+		m.generation = 1
+	}
+
+	return m, nil
 }
 
 func (m *ModuleConfig) Name() string {
@@ -60,10 +123,6 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 
 func (m *ModuleConfig) Generation() uint64 {
 	return m.generation
-}
-
-func (m *ModuleConfig) PropagateConfig(old *ModuleConfig) {
-	C.fwstate_module_config_propogate(m.asRawPtr(), old.asRawPtr())
 }
 
 func (m *ModuleConfig) DetachMaps() {

--- a/modules/fwstate/bindings/go/cfwstate/safe.go
+++ b/modules/fwstate/bindings/go/cfwstate/safe.go
@@ -165,62 +165,26 @@ type OutdatedLayers struct {
 	ptr unsafe.Pointer
 }
 
-// CreateMaps creates firewall state maps.
-func (m *ModuleConfig) CreateMaps(
+// InsertLayer prepends a new layer to the config's maps.
+//
+// This is a map-chain operation, not a config update: the config's sync
+// rules and links never change after construction; only the chain grows.
+func (m *ModuleConfig) InsertLayer(
 	mapConfig MapConfig,
 	workerCount uint16,
 ) error {
-	mapConfigChanged := false
-	mapsStats := m.GetMapsStats()
-	currentIndexSize := max(mapsStats.IPv4.IndexSize, mapsStats.IPv6.IndexSize)
-	currentExtraBucketCount := max(mapsStats.IPv4.ExtraBucketCount, mapsStats.IPv6.ExtraBucketCount)
-	mapsExist := currentIndexSize != 0
-	requestedIndexSize := uint32(C.align_up_pow2(C.uint64_t(mapConfig.IndexSize)))
-	requestedExtraBucketCount := uint32(C.align_up_pow2(C.uint64_t(mapConfig.ExtraBucketCount)))
-
-	if requestedIndexSize != 0 && requestedIndexSize != currentIndexSize {
-		mapConfigChanged = true
-		currentIndexSize = mapConfig.IndexSize
-	}
-	if requestedExtraBucketCount != 0 && requestedExtraBucketCount != currentExtraBucketCount {
-		mapConfigChanged = true
-		currentExtraBucketCount = mapConfig.ExtraBucketCount
-	}
-	if mapsExist {
-		if !mapConfigChanged {
-			return nil
-		}
-
-		if rc, cErr := C.fwstate_config_insert_new_layer(
-			m.asRawPtr(),
-			C.uint32_t(currentIndexSize),
-			C.uint32_t(currentExtraBucketCount),
-			C.uint16_t(workerCount),
-		); rc != 0 {
-			return fmt.Errorf("failed to insert new layer: error code=%d, cErr=%v", rc, cErr)
-		}
-
-		m.generation++
-		return nil
-	}
-
-	if rc, cErr := C.fwstate_config_create_maps(
+	rc, cErr := C.fwstate_config_insert_new_layer(
 		m.asRawPtr(),
-		C.uint32_t(currentIndexSize),
-		C.uint32_t(currentExtraBucketCount),
+		C.uint32_t(mapConfig.IndexSize),
+		C.uint32_t(mapConfig.ExtraBucketCount),
 		C.uint16_t(workerCount),
-	); rc != 0 {
-		return fmt.Errorf("failed to create maps: error code=%d, cErr=%v", rc, cErr)
+	)
+	if rc != 0 {
+		return fmt.Errorf("failed to insert new layer: error code=%d, cErr=%v", rc, cErr)
 	}
 
 	m.generation++
 	return nil
-}
-
-// SetSyncConfig sets the synchronization configuration.
-func (m *ModuleConfig) SetSyncConfig(req SyncConfig) {
-	cSyncConfig := req.toC()
-	C.fwstate_module_config_set_sync_config(m.asRawPtr(), &cSyncConfig)
 }
 
 // GetMapsStats retrieves IPv4 and IPv6 map stats.

--- a/modules/fwstate/controlplane/concurrency_test.go
+++ b/modules/fwstate/controlplane/concurrency_test.go
@@ -41,7 +41,7 @@ type providerAction struct {
 	entered      chan struct{}
 	release      <-chan struct{}
 	linkedConfig []ffi.ModuleConfig
-	mapConfig    *fwstatepb.MapConfig
+	insertLayer  *fwstatepb.MapConfig
 	err          error
 }
 type mutationEvent struct{ operation, phase string }
@@ -78,8 +78,8 @@ func (m *blockingACLProvider) RelinkConfigs(
 	if action.release != nil {
 		<-action.release
 	}
-	if action.err == nil && action.mapConfig != nil {
-		action.err = config.CreateMaps(action.mapConfig, 1)
+	if action.err == nil && action.insertLayer != nil {
+		action.err = config.InsertLayer(action.insertLayer, 1)
 	}
 	if action.err != nil {
 		return action.err
@@ -178,7 +178,10 @@ func TestFWStateReadsDoNotWaitForRelink(t *testing.T) {
 	tasks := newAsyncTasks(t)
 	provider := newBlockingACLProvider()
 	service := fwstate.NewFWStateService(agent, provider)
-	provider.relinks <- providerAction{entered: make(chan struct{}), mapConfig: &fwstatepb.MapConfig{IndexSize: 2048, ExtraBucketCount: 64}}
+	provider.relinks <- providerAction{
+		entered:     make(chan struct{}),
+		insertLayer: &fwstatepb.MapConfig{IndexSize: 2048, ExtraBucketCount: 64},
+	}
 	_, err := service.UpdateConfig(t.Context(), concurrencyUpdateRequest(name, 1024, 9999))
 	require.NoError(t, err)
 	releaseChannel := make(chan struct{})

--- a/modules/fwstate/controlplane/delete_test.go
+++ b/modules/fwstate/controlplane/delete_test.go
@@ -88,10 +88,9 @@ func newACLDeleteTestConfig(
 ) *cacl.ModuleConfig {
 	testingTB.Helper()
 
-	config, err := cacl.NewModuleConfig(agent, name)
+	config, err := cacl.NewModuleConfig(agent, name, nil, nil)
 	require.NoError(testingTB, err)
 	testingTB.Cleanup(config.Free)
-	require.NoError(testingTB, config.UpdateRules(nil, nil))
 
 	return config
 }
@@ -122,13 +121,19 @@ func TestDeleteModuleConfigUsesRegisteredType(t *testing.T) {
 	const configName = "fwstate-config"
 
 	_, agent := newDeleteTestHarness(t, []string{"fwstate"}, "fwstate-agent-instance")
-	config, err := fwstate.NewFWStateModuleConfig(agent, configName)
+	config, err := fwstate.NewFWStateModuleConfig(
+		agent,
+		configName,
+		nil,
+		nil,
+		&fwstatepb.MapConfig{
+			IndexSize:        1024,
+			ExtraBucketCount: 64,
+		},
+		1,
+	)
 	require.NoError(t, err)
 	t.Cleanup(config.Free)
-	require.NoError(t, config.CreateMaps(&fwstatepb.MapConfig{
-		IndexSize:        1024,
-		ExtraBucketCount: 64,
-	}, 1))
 	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{config.AsFFIModule()}))
 
 	require.NoError(t, agent.DeleteModuleConfig(fwstateModuleType, configName))

--- a/modules/fwstate/controlplane/ffi.go
+++ b/modules/fwstate/controlplane/ffi.go
@@ -14,28 +14,48 @@ type CursorEntry = cfwstate.CursorEntry
 type OutdatedLayers = cfwstate.OutdatedLayers
 type mapStats = cfwstate.MapStats
 
-func NewFWStateModuleConfig(agent *ffi.Agent, name string) (*FwStateConfig, error) {
-	moduleCfg, err := cfwstate.NewModuleConfig(agent, name)
+func NewFWStateModuleConfig(
+	agent *ffi.Agent,
+	name string,
+	old *FwStateConfig,
+	syncConfig *fwstatepb.SyncConfig,
+	mapConfig *fwstatepb.MapConfig,
+	workerCount uint16,
+) (*FwStateConfig, error) {
+	var oldModule *cfwstate.ModuleConfig
+	current := cfwstate.DefaultSyncConfig()
+	if old != nil {
+		oldModule = old.ModuleConfig
+		current = old.ModuleConfig.GetSyncConfig()
+	}
+
+	var finalSync *cfwstate.SyncConfig
+	if syncConfig != nil {
+		// The request's zero fields inherit the propagated or default
+		// values, exactly the values a second update used to merge.
+		merged := syncConfig.ToCWithDefaults(current)
+		finalSync = &merged
+	}
+
+	moduleCfg, err := cfwstate.NewModuleConfig(
+		agent,
+		name,
+		oldModule,
+		finalSync,
+		mapConfig.ToC(),
+		workerCount,
+	)
 	if err != nil {
 		return nil, err
 	}
 	return &FwStateConfig{ModuleConfig: moduleCfg}, nil
 }
 
-func (m *FwStateConfig) CreateMaps(
+func (m *FwStateConfig) InsertLayer(
 	mapConfig *fwstatepb.MapConfig,
 	workerCount uint16,
 ) error {
-	return m.ModuleConfig.CreateMaps(mapConfig.ToC(), workerCount)
-}
-
-func (m *FwStateConfig) PropagateConfig(old *FwStateConfig) {
-	m.ModuleConfig.PropagateConfig(old.ModuleConfig)
-}
-
-func (m *FwStateConfig) SetSyncConfig(req *fwstatepb.SyncConfig) {
-	cfg := req.ToCWithDefaults(m.ModuleConfig.GetSyncConfig())
-	m.ModuleConfig.SetSyncConfig(cfg)
+	return m.ModuleConfig.InsertLayer(mapConfig.ToC(), workerCount)
 }
 
 func (m *FwStateConfig) GetSyncConfig() *fwstatepb.SyncConfig {

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -249,16 +249,7 @@ func (m *FWStateService) UpdateConfig(
 	m.log.Debug("update fwstate config", zap.String("config", name))
 
 	err := m.withMutation("update", func() error {
-		newConfig, err := NewFWStateModuleConfig(m.agent, name)
-		if err != nil {
-			m.log.Error("failed to create fwstate config",
-				zap.String("config", name),
-				zap.Error(err),
-			)
-			return status.Errorf(codes.Internal, "failed to create fwstate config: %v", err)
-		}
-
-		oldConfig, err := m.prepareUpdate(name, newConfig, req)
+		oldConfig, newConfig, err := m.prepareUpdate(name, req)
 		if err != nil {
 			return err
 		}
@@ -294,41 +285,49 @@ func (m *FWStateService) UpdateConfig(
 	return &fwstatepb.UpdateConfigResponse{}, nil
 }
 
+// prepareUpdate builds the replacement config for name in one step: the
+// old config's sync config and map chain propagate, the request's sync
+// config merges over them, and the maps are created or grown. The state
+// lock stays held so the old handle cannot disappear mid-construction.
 func (m *FWStateService) prepareUpdate(
 	name string,
-	newConfig *FwStateConfig,
 	req *fwstatepb.UpdateConfigRequest,
-) (*FwStateConfig, error) {
+) (*FwStateConfig, *FwStateConfig, error) {
 	m.stateMu.Lock()
 	defer m.stateMu.Unlock()
 
 	oldConfig := m.configs[name]
-	if oldConfig != nil {
-		newConfig.PropagateConfig(oldConfig)
-	}
-
-	// Set sync config
-	newConfig.SetSyncConfig(req.SyncConfig)
-
-	// Validate sync config after setting
-	syncConfig := newConfig.GetSyncConfig()
-	if err := validateSyncConfig(syncConfig); err != nil {
-		newConfig.DetachMaps()
-		newConfig.Free()
-		m.log.Error("invalid sync config", zap.String("config", name), zap.Error(err))
-		return nil, status.Errorf(codes.InvalidArgument, "invalid sync config: %v", err)
-	}
 
 	dpConfig := m.agent.DPConfig()
-
-	if err := newConfig.CreateMaps(req.MapConfig, uint16(dpConfig.WorkerCount())); err != nil {
-		newConfig.DetachMaps() // in order not to pull them out from under the feet of another module
-		newConfig.Free()
-		m.log.Error("failed to create fwstate maps", zap.String("config", name), zap.Error(err))
-		return nil, status.Errorf(codes.Internal, "failed to create fwstate maps: %v", err)
+	newConfig, err := NewFWStateModuleConfig(
+		m.agent,
+		name,
+		oldConfig,
+		req.SyncConfig,
+		req.MapConfig,
+		uint16(dpConfig.WorkerCount()),
+	)
+	if err != nil {
+		m.log.Error("failed to create fwstate config",
+			zap.String("config", name),
+			zap.Error(err),
+		)
+		return nil, nil, status.Errorf(codes.Internal, "failed to create fwstate config: %v", err)
 	}
 
-	return oldConfig, nil
+	// Validate the installed sync config: the request's zero fields were
+	// merged over the propagated or default values at construction.
+	if err := validateSyncConfig(newConfig.GetSyncConfig()); err != nil {
+		if oldConfig != nil {
+			// The map offsets are borrowed from the old config.
+			newConfig.DetachMaps()
+		}
+		newConfig.Free()
+		m.log.Error("invalid sync config", zap.String("config", name), zap.Error(err))
+		return nil, nil, status.Errorf(codes.InvalidArgument, "invalid sync config: %v", err)
+	}
+
+	return oldConfig, newConfig, nil
 }
 
 func (m *FWStateService) publishUpdate(

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -47,45 +47,44 @@ func fwstateModuleConfig(memCtx testutils.MemoryContext) (*C.struct_cp_module, *
 		panic("failed to allocate agent")
 	}
 
-	// Use the proper API to create the module config
+	// Use the proper API to create the module config: one-shot
+	// construction installs the sync settings and creates the maps.
 	cName := C.CString("test")
 	defer C.free(unsafe.Pointer(cName))
 
-	var cErr *C.yanet_error
-	cpModule := C.fwstate_module_config_new(agent, cName, &cErr)
-	if cpModule == nil {
-		panic(fmt.Sprintf("failed to initialize fwstate module config: %v", cerrors.FromC(unsafe.Pointer(cErr))))
-	}
-
-	// Create maps using the proper API
-	rc := C.fwstate_config_create_maps(
-		cpModule,
-		C.uint32_t(1024),
-		C.uint32_t(64),
-		C.uint16_t(1),
-	)
-	if rc != 0 {
-		panic(fmt.Sprintf("failed to create maps: rc=%d", rc))
-	}
-
-	// Get the fwstate_module_config to set sync settings
-	m := (*C.struct_fwstate_module_config)(unsafe.Pointer(cpModule))
+	var syncConfig C.struct_fwstate_sync_config
+	C.fwstate_config_set_defaults(&syncConfig)
 
 	// Configure sync settings
 	// Multicast IPv6 address: ff02::1
 	multicastAddr := [16]C.uint8_t{0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
 	for i := range 16 {
-		m.sync_config.dst_addr_multicast[i] = multicastAddr[i]
+		syncConfig.dst_addr_multicast[i] = multicastAddr[i]
 	}
-	m.sync_config.port_multicast = C.uint16_t(0x0f27) // 9999 in network byte order
+	syncConfig.port_multicast = C.uint16_t(0x0f27) // 9999 in network byte order
 
 	// Set timeouts (in nanoseconds)
-	m.sync_config.timeouts.tcp_syn_ack = C.uint64_t(120e9)
-	m.sync_config.timeouts.tcp_syn = C.uint64_t(120e9)
-	m.sync_config.timeouts.tcp_fin = C.uint64_t(120e9)
-	m.sync_config.timeouts.tcp = C.uint64_t(120e9)
-	m.sync_config.timeouts.udp = C.uint64_t(30e9)
-	m.sync_config.timeouts.default_ = C.uint64_t(16e9)
+	syncConfig.timeouts.tcp_syn_ack = C.uint64_t(120e9)
+	syncConfig.timeouts.tcp_syn = C.uint64_t(120e9)
+	syncConfig.timeouts.tcp_fin = C.uint64_t(120e9)
+	syncConfig.timeouts.tcp = C.uint64_t(120e9)
+	syncConfig.timeouts.udp = C.uint64_t(30e9)
+	syncConfig.timeouts.default_ = C.uint64_t(16e9)
+
+	var cErr *C.yanet_error
+	cpModule := C.fwstate_module_config_new(
+		agent,
+		cName,
+		nil,
+		&syncConfig,
+		C.uint32_t(1024),
+		C.uint32_t(64),
+		C.uint16_t(1),
+		&cErr,
+	)
+	if cpModule == nil {
+		panic(fmt.Sprintf("failed to initialize fwstate module config: %v", cerrors.FromC(unsafe.Pointer(cErr))))
+	}
 
 	// Link the counter registry and spawn a per-worker counter storage once,
 	// so counter values accumulate across fwstateHandlePackets calls.

--- a/modules/fwstate/tests/functional/fwstate_test.go
+++ b/modules/fwstate/tests/functional/fwstate_test.go
@@ -63,11 +63,7 @@ func setupFWStateHarness(t *testing.T) (*dataplaneut.Harness, *ffi.Agent) {
 func configureFWState(t *testing.T, agent *ffi.Agent, name string) {
 	t.Helper()
 
-	modCfg, err := cfwstate.NewModuleConfig(agent, name)
-	require.NoError(t, err)
-	t.Cleanup(modCfg.Free)
-
-	modCfg.SetSyncConfig(cfwstate.SyncConfig{
+	syncConfig := cfwstate.SyncConfig{
 		DstAddrMulticast: [16]byte{
 			0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
 		},
@@ -78,12 +74,21 @@ func configureFWState(t *testing.T, agent *ffi.Agent, name string) {
 		Tcp:           uint64(120e9),
 		Udp:           uint64(30e9),
 		Default:       uint64(16e9),
-	})
+	}
 
-	require.NoError(t, modCfg.CreateMaps(cfwstate.MapConfig{
-		IndexSize:        1024,
-		ExtraBucketCount: 64,
-	}, 1))
+	modCfg, err := cfwstate.NewModuleConfig(
+		agent,
+		name,
+		nil,
+		&syncConfig,
+		cfwstate.MapConfig{
+			IndexSize:        1024,
+			ExtraBucketCount: 64,
+		},
+		1,
+	)
+	require.NoError(t, err)
+	t.Cleanup(modCfg.Free)
 
 	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{modCfg.AsFFIModule()}))
 }

--- a/modules/fwstate/tests/functional/map_chain_lifetime_test.go
+++ b/modules/fwstate/tests/functional/map_chain_lifetime_test.go
@@ -46,10 +46,7 @@ func mapChainAgentRootMemoryNode(t *testing.T, shm *ffi.SharedMemory, name strin
 func newMapChainConfig(t *testing.T, agent *ffi.Agent, name string) *cfwstate.ModuleConfig {
 	t.Helper()
 
-	modCfg, err := cfwstate.NewModuleConfig(agent, name)
-	require.NoError(t, err)
-
-	modCfg.SetSyncConfig(cfwstate.SyncConfig{
+	syncConfig := cfwstate.SyncConfig{
 		DstAddrMulticast: [16]byte{
 			0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
 		},
@@ -60,12 +57,20 @@ func newMapChainConfig(t *testing.T, agent *ffi.Agent, name string) *cfwstate.Mo
 		Tcp:           uint64(120e9),
 		Udp:           uint64(30e9),
 		Default:       uint64(16e9),
-	})
+	}
 
-	require.NoError(t, modCfg.CreateMaps(cfwstate.MapConfig{
-		IndexSize:        1024,
-		ExtraBucketCount: 64,
-	}, 1))
+	modCfg, err := cfwstate.NewModuleConfig(
+		agent,
+		name,
+		nil,
+		&syncConfig,
+		cfwstate.MapConfig{
+			IndexSize:        1024,
+			ExtraBucketCount: 64,
+		},
+		1,
+	)
+	require.NoError(t, err)
 
 	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{modCfg.AsFFIModule()}))
 
@@ -111,13 +116,18 @@ func TestFWStateUpdate_SecondUpdateKeepsLiveMaps(t *testing.T) {
 	require.Len(t, entriesBefore, 1)
 	keyBefore := entriesBefore[0].Key
 
-	v2, err := cfwstate.NewModuleConfig(agent, "fw0")
+	v2, err := cfwstate.NewModuleConfig(
+		agent,
+		"fw0",
+		v1,
+		nil,
+		cfwstate.MapConfig{
+			IndexSize:        1024,
+			ExtraBucketCount: 64,
+		},
+		1,
+	)
 	require.NoError(t, err)
-	v2.PropagateConfig(v1)
-	require.NoError(t, v2.CreateMaps(cfwstate.MapConfig{
-		IndexSize:        1024,
-		ExtraBucketCount: 64,
-	}, 1))
 	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{v2.AsFFIModule()}))
 
 	afterPublish := mapChainAgentRootMemoryNode(t, shm, agentName)
@@ -128,7 +138,9 @@ func TestFWStateUpdate_SecondUpdateKeepsLiveMaps(t *testing.T) {
 	// The construction is straddled by a checkpoint, so a premature drain of the
 	// first generation there cannot be masked by that config's own later release
 	// landing on the same count.
-	other, err := cfwstate.NewModuleConfig(agent, "fw1")
+	// Zero worker count: an unmapped config, the same footprint the
+	// pre-merge construction used to leave.
+	other, err := cfwstate.NewModuleConfig(agent, "fw1", nil, nil, cfwstate.MapConfig{}, 0)
 	require.NoError(t, err)
 
 	afterUnrelatedCreate := mapChainAgentRootMemoryNode(t, shm, agentName)
@@ -160,7 +172,7 @@ func TestFWStateUpdate_SecondUpdateKeepsLiveMaps(t *testing.T) {
 	//
 	// This is the exact call that would have destroyed its map chain out from
 	// under the new generation, had the earlier detach not already run.
-	other2, err := cfwstate.NewModuleConfig(agent, "fw2")
+	other2, err := cfwstate.NewModuleConfig(agent, "fw2", nil, nil, cfwstate.MapConfig{}, 0)
 	require.NoError(t, err)
 	t.Cleanup(other2.Free)
 

--- a/tests/pipeline/dispatch_test.go
+++ b/tests/pipeline/dispatch_test.go
@@ -109,10 +109,6 @@ func setupACLBackend(
 func publishMatchAllACL(t *testing.T, backend acl.Backend, name string, action uint32) {
 	t.Helper()
 
-	handle, err := backend.NewModule(name)
-	require.NoError(t, err)
-	t.Cleanup(handle.Free)
-
 	rule := cacl.AclRule{
 		Actions:       []cacl.AclAction{{Kind: action}},
 		Devices:       filter.Devices{{Name: "port0"}},
@@ -127,7 +123,9 @@ func publishMatchAllACL(t *testing.T, backend acl.Backend, name string, action u
 		},
 		Fragment: filter.FragmentAny,
 	}
-	require.NoError(t, handle.UpdateRules([]cacl.AclRule{rule}, nil))
+	handle, err := backend.NewModule(name, []cacl.AclRule{rule}, nil)
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
 	require.NoError(t, backend.UpdateModule(handle))
 }
 


### PR DESCRIPTION
Merge each module's config construction and update into a single routine: acl_module_config_init now compiles the ruleset at allocation, and fwstate_module_config_new propagates the replaced config, installs the final sync config, and creates or grows the maps. A config handle is fully built at construction and never updated afterwards, so the acl_module_config_update, fwstate_module_config_propogate and fwstate_module_config_set_sync_config entry points disappear.