### PR TITLE
refactor(common,fwstate): centralize power-of-two rounding

### DIFF
--- a/common/exp_array.h
+++ b/common/exp_array.h
@@ -42,7 +42,7 @@ mem_array_free_exp(
 		return;
 	}
 
-	uint64_t capacity = 1 << uint64_log_up(count);
+	uint64_t capacity = next_power_of_two(count);
 	memory_bfree(memory_context, array, capacity * item_size);
 }
 
@@ -59,7 +59,7 @@ mem_array_alloc_exp(
 		}
 		return NULL;
 	}
-	uint64_t capacity = 1 << uint64_log_up(count);
+	uint64_t capacity = next_power_of_two(count);
 	if (res_capacity) {
 		*res_capacity = capacity;
 	}

--- a/common/go/xmath/xmath.go
+++ b/common/go/xmath/xmath.go
@@ -1,0 +1,16 @@
+package xmath
+
+import "math/bits"
+
+// NextPowerOfTwo32 returns the smallest power of two not less than the input.
+//
+// It returns zero when the result does not fit in 32 bits.
+func NextPowerOfTwo32(value uint32) uint32 {
+	if value <= 1 {
+		return 1
+	}
+	if value > 1<<31 {
+		return 0
+	}
+	return uint32(1) << bits.Len32(value-1)
+}

--- a/common/go/xmath/xmath_test.go
+++ b/common/go/xmath/xmath_test.go
@@ -1,0 +1,46 @@
+package xmath_test
+
+import (
+	"testing"
+
+	"github.com/yanet-platform/yanet2/common/go/xmath"
+)
+
+// verifies that 32-bit inputs round up to a representable power or report
+// overflow.
+func Test_NextPowerOfTwo32_RoundsUpAndReportsOverflow(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    uint32
+		expected uint32
+	}{
+		{name: "zero returns one", input: 0, expected: 1},
+		{name: "one returns one", input: 1, expected: 1},
+		{name: "exact power is unchanged", input: 8, expected: 8},
+		{name: "non-power rounds upward", input: 9, expected: 16},
+		{
+			name:     "highest representable power is unchanged",
+			input:    1 << 31,
+			expected: 1 << 31,
+		},
+		{
+			name:     "above maximum power reports overflow",
+			input:    (1 << 31) + 1,
+			expected: 0,
+		},
+		{name: "maximum uint32 reports overflow", input: ^uint32(0), expected: 0},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := xmath.NextPowerOfTwo32(testCase.input); got != testCase.expected {
+				t.Errorf(
+					"NextPowerOfTwo32(%d) = %d, want %d",
+					testCase.input,
+					got,
+					testCase.expected,
+				)
+			}
+		})
+	}
+}

--- a/common/numutils.h
+++ b/common/numutils.h
@@ -24,23 +24,19 @@ uint64_log_down(uint64_t value) {
 	return sizeof(long long) * 8 - 1 - __builtin_clzll(value);
 }
 
-/**
- * @brief Align number up to next power of 2
- * @param x Input number
- * @return Next power of 2, or 0 if overflow
- */
+// next_power_of_two returns the smallest power of two not less than the input.
+//
+// Zero maps to one. Values above 2^63 saturate at 2^63 because the next
+// power would overflow the return type.
 static inline uint64_t
-align_up_pow2(uint64_t x) {
-	// Hacker's delight 2nd Chapter 3. Power-of-2 Boundaries
-	// Rounding Up
-	x--;
-	x |= x >> 1;
-	x |= x >> 2;
-	x |= x >> 4;
-	x |= x >> 8;
-	x |= x >> 16;
-	x |= x >> 32;
-	return x + 1;
+next_power_of_two(uint64_t value) {
+	if (value <= 1) {
+		return 1;
+	}
+	if (value > (1ull << 63)) {
+		return 1ull << 63;
+	}
+	return 1ull << (64 - __builtin_clzll(value - 1));
 }
 
 /**

--- a/common/range_collector.h
+++ b/common/range_collector.h
@@ -36,7 +36,7 @@ range_collector_init(
 static inline void
 range_collector_free(struct range_collector *collector, uint8_t key_size) {
 	if (collector->mask_count) {
-		uint64_t capacity = 1 << uint64_log_up(collector->mask_count);
+		uint64_t capacity = next_power_of_two(collector->mask_count);
 		memory_bfree(
 			ADDR_OF(&collector->memory_context),
 			ADDR_OF(&collector->masks),

--- a/common/range_index.h
+++ b/common/range_index.h
@@ -117,7 +117,7 @@ range_index_free(struct range_index *range_index) {
 		radix_free(&range_index->radix);
 		return;
 	}
-	uint64_t capacity = 1 << uint64_log_up(range_index->count);
+	uint64_t capacity = next_power_of_two(range_index->count);
 	memory_bfree(
 		ADDR_OF(&range_index->memory_context),
 		ADDR_OF(&range_index->values),

--- a/common/registry.h
+++ b/common/registry.h
@@ -349,7 +349,7 @@ value_registry_fini(struct value_registry *registry) {
 	}
 
 	if (registry->range_count) {
-		uint64_t capacity = 1 << uint64_log_up(registry->range_count);
+		uint64_t capacity = next_power_of_two(registry->range_count);
 
 		memory_bfree(
 			memory_context,

--- a/common/ttlmap/detail/bucket.h
+++ b/common/ttlmap/detail/bucket.h
@@ -5,6 +5,7 @@
 #include "key_value.h"
 
 #include "../../container_of.h"
+#include "../../numutils.h"
 
 #define TTLMAP_FOUND (0b01)
 #define TTLMAP_INSERTED (0b10)
@@ -131,12 +132,7 @@ static inline size_t
 __ttlmap_bucket_count(size_t kv_entries) { // NOLINT
 	size_t buckets = (kv_entries + __TTLMAP_BUCKET_ENTRIES - 1) /
 			 __TTLMAP_BUCKET_ENTRIES;
-	size_t max_bit = 63 - __builtin_clzll(buckets);
-	if (buckets != (1ull << max_bit)) {
-		++max_bit;
-	}
-	size_t res = 1ull << max_bit;
-	return res;
+	return next_power_of_two(buckets);
 }
 
 #define __TTLMAP_BUCKET_FIND_WITH_ID(map_ptr, bucket_id, key_type, value_type) \

--- a/lib/fwstate/fwmap.h
+++ b/lib/fwstate/fwmap.h
@@ -750,7 +750,7 @@ fwmap_new(const fwmap_config_t *user_config, struct memory_context *ctx) {
 		index_size = 16;
 	}
 	// Ensure index_size is a power of 2.
-	index_size = align_up_pow2(index_size);
+	index_size = next_power_of_two(index_size);
 	if (!index_size) {
 		errno = EINVAL;
 		return NULL;
@@ -770,7 +770,7 @@ fwmap_new(const fwmap_config_t *user_config, struct memory_context *ctx) {
 			errno = EINVAL;
 			return NULL;
 		}
-		extra_size = align_up_pow2(extra_size);
+		extra_size = next_power_of_two(extra_size);
 	}
 
 	uint32_t keys_per_chunk = FWMAP_CHUNK_MAX_SIZE / config.key_size;

--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -384,9 +384,12 @@ fwstate_module_setup_maps(
 			? stats_v4.extra_bucket_count
 			: stats_v6.extra_bucket_count;
 
-	uint32_t requested_index_size = (uint32_t)align_up_pow2(index_size);
+	uint32_t requested_index_size =
+		index_size ? (uint32_t)next_power_of_two(index_size) : 0;
 	uint32_t requested_extra_bucket_count =
-		(uint32_t)align_up_pow2(extra_bucket_count);
+		extra_bucket_count
+			? (uint32_t)next_power_of_two(extra_bucket_count)
+			: 0;
 
 	bool map_config_changed = false;
 	if (requested_index_size != 0 &&

--- a/modules/fwstate/bindings/go/cfwstate/cgo.go
+++ b/modules/fwstate/bindings/go/cfwstate/cgo.go
@@ -5,7 +5,6 @@ package cfwstate
 //#cgo LDFLAGS: -L../../../../../build/lib/counters -lcounters
 //
 //#include "api/agent.h"
-//#include "common/numutils.h"
 //#include "modules/fwstate/api/fwstate_cp.h"
 //#include "lib/fwstate/config.h"
 //#include "lib/fwstate/fwmap.h"

--- a/modules/fwstate/bindings/go/cfwstate/safe.go
+++ b/modules/fwstate/bindings/go/cfwstate/safe.go
@@ -3,7 +3,6 @@ package cfwstate
 //#include "lib/fwstate/config.h"
 //#include "lib/fwstate/fwstate_cursor.h"
 //#include "modules/fwstate/api/fwstate_cp.h"
-//#include "common/numutils.h"
 import "C"
 
 import (

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -1,6 +1,15 @@
 dependencies = [lib_common_dep, lib_logging_dep]
 thread_dep = dependency('threads')
 
+numutils_test = executable(
+  'numutils_test',
+  ['numutils_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: dependencies,
+)
+test('numutils', numutils_test, suite: ['common'])
+
 lpm_test = executable(
   'lpm_test',
   ['lpm_test.c',],

--- a/tests/common/numutils_test.c
+++ b/tests/common/numutils_test.c
@@ -1,0 +1,32 @@
+#include "common/numutils.h"
+
+#include <assert.h>
+#include <stdint.h>
+
+static void
+test_next_power_of_two_returns_one_for_small_values(void) {
+	assert(next_power_of_two(0) == 1);
+	assert(next_power_of_two(1) == 1);
+}
+
+static void
+test_next_power_of_two_rounds_nonpowers_up(void) {
+	assert(next_power_of_two(2) == 2);
+	assert(next_power_of_two(3) == 4);
+	assert(next_power_of_two((1ull << 62) + 1) == (1ull << 63));
+}
+
+static void
+test_next_power_of_two_saturates_at_highest_supported_power(void) {
+	assert(next_power_of_two(1ull << 63) == (1ull << 63));
+	assert(next_power_of_two((1ull << 63) + 1) == (1ull << 63));
+	assert(next_power_of_two(UINT64_MAX) == (1ull << 63));
+}
+
+int
+main(void) {
+	test_next_power_of_two_returns_one_for_small_values();
+	test_next_power_of_two_rounds_nonpowers_up();
+	test_next_power_of_two_saturates_at_highest_supported_power();
+	return 0;
+}

--- a/tests/fwstate/fwmap_basic_test.c
+++ b/tests/fwstate/fwmap_basic_test.c
@@ -56,11 +56,11 @@ verify_constants(void) {
 	assert(FWMAP_BUCKET_SIZE == sizeof(fwmap_bucket_t));
 
 	/* Chunk index max size must be power of 2 for efficient masking */
-	assert(align_up_pow2(FWMAP_CHUNK_INDEX_MAX_SIZE) ==
+	assert(next_power_of_two(FWMAP_CHUNK_INDEX_MAX_SIZE) ==
 	       FWMAP_CHUNK_INDEX_MAX_SIZE);
 
 	/* Chunk mask must be one less than a power of 2 */
-	assert(align_up_pow2(FWMAP_CHUNK_INDEX_MASK + 1) ==
+	assert(next_power_of_two(FWMAP_CHUNK_INDEX_MASK + 1) ==
 	       FWMAP_CHUNK_INDEX_MASK + 1);
 
 	printf("  Constants verification passed\n");


### PR DESCRIPTION
- Centralizes power-of-two rounding in shared C and Go helpers.
- Removes the fwstate cgo dependency for 32-bit map-size normalization.
- Adds boundary tests for representable and overflowing inputs.