### PR TITLE
refactor(fwstate)!: drop optional from sync_suppress_timeout

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -26,3 +26,9 @@ breaking:
     - PACKAGE
   ignore:
     - modules/balancer2
+  # sync_suppress_timeout intentionally dropped proto3 optional presence; the
+  # wire format (field 13, varint) is unchanged. Drop this waiver once main
+  # carries the plain field.
+  ignore_only:
+    FIELD_SAME_CARDINALITY:
+      - modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -172,7 +172,7 @@ pub struct UpdateCmd {
 
     /// Sync suppression window: skip redundant state-sync refreshes whose
     /// new expiry lands within this window of the current one (e.g., "8s").
-    /// "0s" disables suppression.
+    /// Omitted or zero keeps the currently configured window.
     #[arg(long, value_parser = parse_duration)]
     pub sync_suppress_timeout: Option<Duration>,
 }

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -282,7 +282,7 @@ impl FWStateService {
         }
 
         if let Some(suppress) = cmd.sync_suppress_timeout {
-            sync_config.sync_suppress_timeout = Some(suppress.as_nanos() as u64);
+            sync_config.sync_suppress_timeout = suppress.as_nanos() as u64;
         }
 
         let request = UpdateConfigRequest {

--- a/modules/fwstate/controlplane/fwstatepb/v1/convert.go
+++ b/modules/fwstate/controlplane/fwstatepb/v1/convert.go
@@ -76,10 +76,7 @@ func (m *SyncConfig) ToCWithDefaults(current cfwstate.SyncConfig) cfwstate.SyncC
 	if cfg.Default == 0 {
 		cfg.Default = current.Default
 	}
-	// The sync_suppress_timeout field is optional: a request that omits it (nil,
-	// e.g. from a client unaware of the field) inherits the current window, while
-	// an explicit value — including zero, the documented disable — overrides.
-	if m.SyncSuppressTimeout == nil {
+	if cfg.SyncSuppressTimeout == 0 {
 		cfg.SyncSuppressTimeout = current.SyncSuppressTimeout
 	}
 
@@ -97,7 +94,7 @@ func FromCSyncConfig(cfg cfwstate.SyncConfig) *SyncConfig {
 		Tcp:                 cfg.Tcp,
 		Udp:                 cfg.Udp,
 		Default:             cfg.Default,
-		SyncSuppressTimeout: &cfg.SyncSuppressTimeout,
+		SyncSuppressTimeout: cfg.SyncSuppressTimeout,
 	}
 }
 

--- a/modules/fwstate/controlplane/fwstatepb/v1/convert_test.go
+++ b/modules/fwstate/controlplane/fwstatepb/v1/convert_test.go
@@ -38,41 +38,32 @@ func TestSyncConfig_ToCWithDefaults(t *testing.T) {
 	})
 }
 
-// TestSyncSuppressTimeoutRoundTrip verifies that sync_suppress_timeout, an
-// optional field, behaves correctly through the Pb->C->Pb round-trip and the
-// ToCWithDefaults merge: an explicit value (including zero = disable)
-// overrides, while an absent field inherits the current window.
+// TestSyncSuppressTimeoutRoundTrip verifies that sync_suppress_timeout
+// behaves correctly through the Pb->C->Pb round-trip and the
+// ToCWithDefaults merge: a non-zero value overrides, while a zero value
+// inherits the current window.
 func TestSyncSuppressTimeoutRoundTrip(t *testing.T) {
 	const suppress uint64 = 8e9
 
 	t.Run("round_trip", func(t *testing.T) {
-		pb := &SyncConfig{SyncSuppressTimeout: u64Ptr(suppress)}
+		pb := &SyncConfig{SyncSuppressTimeout: suppress}
 		got := FromCSyncConfig(pb.ToC())
 		require.Equal(t, suppress, got.GetSyncSuppressTimeout())
 	})
 
-	t.Run("explicit_zero_disables", func(t *testing.T) {
-		// An explicit zero is the documented disable value and must override,
-		// not inherit, the current window.
-		current := cfwstate.SyncConfig{SyncSuppressTimeout: suppress}
-		pb := &SyncConfig{SyncSuppressTimeout: u64Ptr(0)}
-		cfg := pb.ToCWithDefaults(current)
-		require.Equal(t, uint64(0), cfg.SyncSuppressTimeout)
-	})
-
-	t.Run("explicit_override", func(t *testing.T) {
-		current := cfwstate.SyncConfig{SyncSuppressTimeout: suppress}
-		pb := &SyncConfig{SyncSuppressTimeout: u64Ptr(1e9)}
-		cfg := pb.ToCWithDefaults(current)
-		require.Equal(t, uint64(1e9), cfg.SyncSuppressTimeout)
-	})
-
-	t.Run("absent_inherits", func(t *testing.T) {
-		// A client that omits the field (nil) keeps the current window, so an
-		// older web form does not silently disable suppression.
+	t.Run("zero_inherits", func(t *testing.T) {
+		// Zero is indistinguishable from omitted and inherits the current
+		// window, like every other scalar in the merge.
 		current := cfwstate.SyncConfig{SyncSuppressTimeout: suppress}
 		pb := &SyncConfig{}
 		cfg := pb.ToCWithDefaults(current)
 		require.Equal(t, suppress, cfg.SyncSuppressTimeout)
+	})
+
+	t.Run("explicit_override", func(t *testing.T) {
+		current := cfwstate.SyncConfig{SyncSuppressTimeout: suppress}
+		pb := &SyncConfig{SyncSuppressTimeout: 1e9}
+		cfg := pb.ToCWithDefaults(current)
+		require.Equal(t, uint64(1e9), cfg.SyncSuppressTimeout)
 	})
 }

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
@@ -167,9 +167,6 @@ message SyncConfig {
   // whose new expiry lands within this window of the current one is discarded
   // (the fwmap record is left untouched), debouncing refreshes for busy
   // sessions. Every entry TTL is inflated by this value so the effective
-  // keep-alive never falls below the configured timeout. Zero disables it.
-  //
-  // Optional so that clients unaware of the field (an older web form) can omit
-  // it and keep the current window, while an explicit zero disables it.
-  optional uint64 sync_suppress_timeout = 13;
+  // keep-alive never falls below the configured timeout.
+  uint64 sync_suppress_timeout = 13;
 }

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate_test.go
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate_test.go
@@ -10,9 +10,6 @@ import (
 
 const cfwstateTTL48Max = cfwstate.TTL48Max
 
-// u64Ptr is a convenience for setting optional uint64 proto fields in tests.
-func u64Ptr(v uint64) *uint64 { return &v }
-
 func TestValidateSyncConfigTimeouts(t *testing.T) {
 	valid := &SyncConfig{
 		TcpSynAck: 120e9,
@@ -48,7 +45,7 @@ func TestValidateSyncConfigTimeoutsSuppressOverflow(t *testing.T) {
 	// overflows the 48-bit field.
 	overflowing := &SyncConfig{
 		Tcp:                 cfwstateTTL48Max,
-		SyncSuppressTimeout: u64Ptr(1),
+		SyncSuppressTimeout: 1,
 	}
 	err := overflowing.ValidateTimeouts()
 	require.Error(t, err)
@@ -59,6 +56,6 @@ func TestValidateSyncConfigTimeoutsSuppressOverflow(t *testing.T) {
 	require.NoError(t, (&SyncConfig{Tcp: cfwstateTTL48Max}).ValidateTimeouts())
 	require.NoError(t, (&SyncConfig{
 		Tcp:                 120e9,
-		SyncSuppressTimeout: u64Ptr(8e9),
+		SyncSuppressTimeout: 8e9,
 	}).ValidateTimeouts())
 }


### PR DESCRIPTION
- Make `sync_suppress_timeout` a plain proto3 scalar consistent with every other `SyncConfig` timeout field; the merge in `ToCWithDefaults` now treats an omitted or zero value as keep the current window.
- Breaking: an explicit zero no longer disables suppression through `UpdateConfig`; once set, the window changes only via another non-zero value or by recreating the config. Fresh configs still default to suppression disabled.
- Wire format is unchanged (field 13, varint); old and new clients interoperate in both directions.
- The fwstate CLI assigns the plain scalar and its `--sync-suppress-timeout` doc now says omitted or zero keeps the configured window.