### PR TITLE
feat(fwstate): track map object generation on the c object

### DIFF
--- a/objects/fwstate/api/fwstate_map_object.c
+++ b/objects/fwstate/api/fwstate_map_object.c
@@ -206,6 +206,15 @@ fwstate_map_v4_object_table(const struct cp_object *cp_object) {
 	return &self->table;
 }
 
+uint64_t
+fwstate_map_v4_object_generation(const struct cp_object *cp_object) {
+	struct fwstate_map_v4_object *self = container_of(
+		cp_object, struct fwstate_map_v4_object, cp_object
+	);
+
+	return self->generation;
+}
+
 int
 fwstate_map_v4_object_insert_layer(
 	struct fwstate_map_v4_object *self,
@@ -215,7 +224,7 @@ fwstate_map_v4_object_insert_layer(
 ) {
 	struct agent *agent = ADDR_OF(&self->cp_object.agent);
 
-	return map_insert_layer(
+	int rc = map_insert_layer(
 		&self->table,
 		&agent->memory_context,
 		map_v4_init_keys,
@@ -223,13 +232,21 @@ fwstate_map_v4_object_insert_layer(
 		extra_bucket_count,
 		worker_count
 	);
+	if (rc == 0) {
+		self->generation += 1;
+	}
+	return rc;
 }
 
 int
 fwstate_map_v4_object_unlink_stale_layers(
 	struct fwstate_map_v4_object *self, uint64_t now
 ) {
-	return fwtable_unlink_stale_cp(&self->table, now);
+	int rc = fwtable_unlink_stale_cp(&self->table, now);
+	if (rc == 0) {
+		self->generation += 1;
+	}
+	return rc;
 }
 
 void
@@ -331,6 +348,15 @@ fwstate_map_v6_object_table(const struct cp_object *cp_object) {
 	return &self->table;
 }
 
+uint64_t
+fwstate_map_v6_object_generation(const struct cp_object *cp_object) {
+	struct fwstate_map_v6_object *self = container_of(
+		cp_object, struct fwstate_map_v6_object, cp_object
+	);
+
+	return self->generation;
+}
+
 int
 fwstate_map_v6_object_insert_layer(
 	struct fwstate_map_v6_object *self,
@@ -340,7 +366,7 @@ fwstate_map_v6_object_insert_layer(
 ) {
 	struct agent *agent = ADDR_OF(&self->cp_object.agent);
 
-	return map_insert_layer(
+	int rc = map_insert_layer(
 		&self->table,
 		&agent->memory_context,
 		map_v6_init_keys,
@@ -348,13 +374,21 @@ fwstate_map_v6_object_insert_layer(
 		extra_bucket_count,
 		worker_count
 	);
+	if (rc == 0) {
+		self->generation += 1;
+	}
+	return rc;
 }
 
 int
 fwstate_map_v6_object_unlink_stale_layers(
 	struct fwstate_map_v6_object *self, uint64_t now
 ) {
-	return fwtable_unlink_stale_cp(&self->table, now);
+	int rc = fwtable_unlink_stale_cp(&self->table, now);
+	if (rc == 0) {
+		self->generation += 1;
+	}
+	return rc;
 }
 
 void

--- a/objects/fwstate/api/fwstate_map_v4_object.h
+++ b/objects/fwstate/api/fwstate_map_v4_object.h
@@ -24,6 +24,11 @@ struct fwstate_map_v4_object {
 	struct cp_object cp_object;
 
 	fwtable_t table;
+
+	// Bumped on every layer insert and stale-layer trim, so a reader
+	// batching over the table can detect that the chain it is walking
+	// changed under it.
+	uint64_t generation;
 };
 
 // RAII lifecycle for struct fwstate_map_v4_object.
@@ -67,6 +72,11 @@ fwstate_map_v4_object_config_free(struct cp_object *cp_object);
 // Return the address of the object's fwtable field.
 fwtable_t *
 fwstate_map_v4_object_table(const struct cp_object *cp_object);
+
+// Return the object's generation counter, bumped on every layer insert
+// and stale-layer trim.
+uint64_t
+fwstate_map_v4_object_generation(const struct cp_object *cp_object);
 
 // Insert a new layer into the object's table chain.
 int

--- a/objects/fwstate/api/fwstate_map_v6_object.h
+++ b/objects/fwstate/api/fwstate_map_v6_object.h
@@ -24,6 +24,11 @@ struct fwstate_map_v6_object {
 	struct cp_object cp_object;
 
 	fwtable_t table;
+
+	// Bumped on every layer insert and stale-layer trim, so a reader
+	// batching over the table can detect that the chain it is walking
+	// changed under it.
+	uint64_t generation;
 };
 
 // RAII lifecycle for struct fwstate_map_v6_object.
@@ -67,6 +72,11 @@ fwstate_map_v6_object_config_free(struct cp_object *cp_object);
 // Return the address of the object's fwtable field.
 fwtable_t *
 fwstate_map_v6_object_table(const struct cp_object *cp_object);
+
+// Return the object's generation counter, bumped on every layer insert
+// and stale-layer trim.
+uint64_t
+fwstate_map_v6_object_generation(const struct cp_object *cp_object);
 
 // Insert a new layer into the object's table chain.
 int

--- a/objects/fwstate/bindings/go/cfwstate/map.go
+++ b/objects/fwstate/bindings/go/cfwstate/map.go
@@ -115,16 +115,26 @@ func (m Kind) ObjectType() string {
 // owns a single fwtable_t for one address family. The object is
 // registered under (ObjectType(), Name()) and published via Publish.
 type MapObjectConfig struct {
-	name       string
-	kind       Kind
-	generation uint64
-	ptr        *C.struct_cp_object
+	name string
+	kind Kind
+	ptr  *C.struct_cp_object
 }
 
-// Generation returns the generation counter, incremented on layer insert
-// or trim.
+// Generation returns the C-side generation counter, incremented on every
+// layer insert and stale-layer trim, so every handle resolving the same
+// published object observes the same value.
+//
+// The value is only meaningful while the caller keeps the object alive:
+// reads through this handle must not race Free, and table walks must be
+// serialized against layer rotation by the owning service's mutex.
 func (m *MapObjectConfig) Generation() uint64 {
-	return m.generation
+	if m.ptr == nil {
+		return 0
+	}
+	if m.kind == KindV6 {
+		return uint64(C.fwstate_map_v6_object_generation(m.ptr))
+	}
+	return uint64(C.fwstate_map_v4_object_generation(m.ptr))
 }
 
 // NewMapObjectConfig creates a new standalone fwstate-map object for the
@@ -206,7 +216,6 @@ func (m *MapObjectConfig) insertLayer(
 			"failed to insert fwstate-map layer: error code=%d", rc,
 		)
 	}
-	m.generation++
 	return nil
 }
 
@@ -274,7 +283,6 @@ func (m *MapObjectConfig) UnlinkStaleLayers(now uint64) error {
 	if rc != 0 {
 		return fmt.Errorf("failed to unlink stale layers: error code=%d", rc)
 	}
-	m.generation++
 	return nil
 }
 

--- a/objects/fwstate/controlplane/map_service.go
+++ b/objects/fwstate/controlplane/map_service.go
@@ -496,6 +496,12 @@ func (m *FWStateMapService) ListEntries(
 			hasMore = false
 		}
 
+		// Snapshot the generation before unlocking: the label must
+		// describe the chain the batch was read from, and after the
+		// unlock a concurrent DeleteMap can free the object, making
+		// any further dereference through mapCfg a use-after-free.
+		generation := mapCfg.Generation()
+
 		m.mu.Unlock()
 
 		if err != nil {
@@ -511,7 +517,7 @@ func (m *FWStateMapService) ListEntries(
 			Entries:    pbEntries,
 			HasMore:    hasMore,
 			Index:      newIndex,
-			Generation: mapCfg.Generation(),
+			Generation: generation,
 		}
 
 		if err := stream.Send(resp); err != nil {


### PR DESCRIPTION
The fwstate-map layer-chain generation moves onto the C object itself and is bumped on every layer insert and stale-layer trim, so every observer of a published object agrees on its revision instead of each Go handle counting privately.
cfwstate.MapObjectConfig.Generation reads the C-side counter through the object pointer, and ListEntries snapshots it under the map lock so a batch cannot be labeled with a generation a concurrent InsertLayer published after the batch was read.