### PR TITLE
fix(dataplane): bind worker counters by name instead of hard-coded indices

### DIFF
--- a/dataplane/device.c
+++ b/dataplane/device.c
@@ -89,6 +89,7 @@ dataplane_device_start(
 	for (uint32_t wrk_idx = 0; wrk_idx < device->worker_count; ++wrk_idx) {
 		struct dataplane_worker *worker = device->workers + wrk_idx;
 		if (dataplane_worker_start(worker)) {
+			LOG(ERROR, "failed to start worker %u", wrk_idx);
 			return -1;
 		}
 	}

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -42,6 +42,7 @@
 #include "dataplane/dataplane.h"
 #include "dataplane/device.h"
 
+#include "lib/counters/counters.h"
 #include "lib/dataplane/config/zone.h"
 #include "lib/dataplane/module/packet_front.h"
 #include "lib/dataplane/packet/data.h"
@@ -61,6 +62,7 @@
 
 #include <rte_ethdev.h>
 
+#include <stddef.h>
 #include <string.h>
 
 static void
@@ -523,36 +525,12 @@ error_mempool:
 
 int
 dataplane_worker_start(struct dataplane_worker *worker) {
-
-	struct dp_worker *dp_worker = worker->dp_worker;
-	struct dp_config *dp_config = worker->instance->dp_config;
-	struct counter_storage **worker_counter_storages =
-		ADDR_OF_NONNULL(&dp_config->worker_counter_storages);
-	struct counter_storage *worker_counter_storage =
-		ADDR_OF_NONNULL(worker_counter_storages + dp_worker->idx);
-	// FIXME: do not use hard-coded counter identifiers
-	dp_worker->iterations = counter_get_address(0, worker_counter_storage);
-
-	dp_worker->rx_count =
-		counter_get_address(1, worker_counter_storage) + 0;
-	dp_worker->rx_size = counter_get_address(1, worker_counter_storage) + 1;
-
-	dp_worker->tx_count =
-		counter_get_address(2, worker_counter_storage) + 0;
-	dp_worker->tx_size = counter_get_address(2, worker_counter_storage) + 1;
-
-	dp_worker->remote_rx_count =
-		counter_get_address(3, worker_counter_storage) + 0;
-
-	dp_worker->remote_tx_count =
-		counter_get_address(4, worker_counter_storage) + 0;
-	dp_worker->rx_bursts = counter_get_address(5, worker_counter_storage);
-
-	dp_worker->local_tx_drops =
-		counter_get_address(6, worker_counter_storage);
-	dp_worker->remote_tx_drops =
-		counter_get_address(7, worker_counter_storage);
-	dp_worker->drop_count = counter_get_address(8, worker_counter_storage);
+	if (worker_counters_bind(
+		    worker->dp_worker, worker->instance->dp_config
+	    )) {
+		LOG(ERROR, "failed to bind counters");
+		return -1;
+	}
 
 	pthread_attr_t wrk_th_attr;
 	pthread_attr_init(&wrk_th_attr);

--- a/lib/counters/counters.c
+++ b/lib/counters/counters.c
@@ -1,5 +1,6 @@
 #include "counters.h"
 
+#include "common/memory_address.h"
 #include "common/numutils.h"
 #include "common/strutils.h"
 
@@ -75,6 +76,11 @@ counter_registry_lookup_index(
 	}
 
 	return (uint64_t)-1;
+}
+
+uint64_t
+counter_registry_lookup_size(struct counter_registry *registry, uint64_t idx) {
+	return ADDR_OF(&registry->names)[idx].size;
 }
 
 static int

--- a/lib/counters/counters.h
+++ b/lib/counters/counters.h
@@ -51,6 +51,14 @@ counter_registry_register(
 	yanet_error **err
 );
 
+uint64_t
+counter_registry_lookup_index(
+	struct counter_registry *registry, const char *name
+);
+
+uint64_t
+counter_registry_lookup_size(struct counter_registry *registry, uint64_t idx);
+
 void
 counter_registry_fini(struct counter_registry *registry);
 

--- a/lib/dataplane/worker/counters.c
+++ b/lib/dataplane/worker/counters.c
@@ -1,20 +1,65 @@
 #include "counters.h"
 
+#include <stddef.h>
+
+#include "common/memory_address.h"
 #include "lib/counters/counters.h"
 #include "lib/dataplane/config/zone.h"
 #include "lib/errors/errors.h"
 #include "lib/logging/log.h"
 
+const struct worker_counter_spec worker_counter_specs[] = {
+	{"iterations", 1},
+	{"rx", 2},
+	{"tx", 2},
+	{"remote_rx", 2},
+	{"remote_tx", 2},
+	{"rx_bursts", WORKER_RX_BURST_SIZE + 1},
+	{"local_tx_drops", 1},
+	{"remote_tx_drops", 1},
+	{"drops", 1},
+};
+
+const size_t worker_counter_spec_count =
+	sizeof(worker_counter_specs) / sizeof(worker_counter_specs[0]);
+
+const struct worker_counter_field worker_counter_fields[] = {
+	{offsetof(struct dp_worker, iterations), "iterations", 0},
+	{offsetof(struct dp_worker, rx_count), "rx", 0},
+	{offsetof(struct dp_worker, rx_size), "rx", 1},
+	{offsetof(struct dp_worker, tx_count), "tx", 0},
+	{offsetof(struct dp_worker, tx_size), "tx", 1},
+	{offsetof(struct dp_worker, remote_rx_count), "remote_rx", 0},
+	{offsetof(struct dp_worker, remote_tx_count), "remote_tx", 0},
+	{offsetof(struct dp_worker, rx_bursts), "rx_bursts", 0},
+	{offsetof(struct dp_worker, local_tx_drops), "local_tx_drops", 0},
+	{offsetof(struct dp_worker, remote_tx_drops), "remote_tx_drops", 0},
+	{offsetof(struct dp_worker, drop_count), "drops", 0},
+};
+
+const size_t worker_counter_field_count =
+	sizeof(worker_counter_fields) / sizeof(worker_counter_fields[0]);
+
+static uint64_t **
+field_pointer(
+	struct dp_worker *dp_worker, const struct worker_counter_field *field
+) {
+	return (uint64_t **)((char *)dp_worker + field->offset);
+}
+
 static int
-register_one(struct dp_config *dp_config, const char *name, uint64_t size) {
+register_one(
+	struct dp_config *dp_config, const struct worker_counter_spec *spec
+) {
 	yanet_error *err = NULL;
 	uint64_t rc = counter_registry_register(
-		&dp_config->worker_counters, name, size, &err
+		&dp_config->worker_counters, spec->name, spec->size, &err
 	);
 	if (rc == COUNTER_INVALID) {
 		LOG(ERROR,
-		    "failed to register '%s' counter: %s",
-		    name,
+		    "failed to register counter '%s' of size %lu: %s",
+		    spec->name,
+		    spec->size,
 		    yanet_error_message(err));
 		yanet_error_free(err);
 		return -1;
@@ -24,32 +69,74 @@ register_one(struct dp_config *dp_config, const char *name, uint64_t size) {
 
 int
 worker_counters_register(struct dp_config *dp_config) {
-	if (register_one(dp_config, "iterations", 1)) {
+	for (size_t idx = 0; idx < worker_counter_spec_count; ++idx) {
+		if (register_one(dp_config, worker_counter_specs + idx)) {
+			return -1;
+		}
+	}
+	return 0;
+}
+
+// Resolve the address of the counter value a worker field is bound to, or NULL
+// if the counter is missing or too small to hold that value.
+static uint64_t *
+counter_value_address(
+	struct dp_worker *dp_worker,
+	struct dp_config *dp_config,
+	const struct worker_counter_field *field
+) {
+	struct counter_registry *registry = &dp_config->worker_counters;
+	uint64_t idx = counter_registry_lookup_index(registry, field->counter);
+	if (idx == COUNTER_INVALID) {
+		LOG(ERROR, "counter '%s' not found", field->counter);
+		return NULL;
+	}
+
+	uint64_t value_count = counter_registry_lookup_size(registry, idx);
+	if (field->value_idx >= value_count) {
+		LOG(ERROR,
+		    "counter '%s': value %lu is out of range, size is %lu",
+		    field->counter,
+		    field->value_idx,
+		    value_count);
+		return NULL;
+	}
+
+	struct counter_storage **storages =
+		ADDR_OF_NONNULL(&dp_config->worker_counter_storages);
+	struct counter_storage *storage =
+		ADDR_OF_NONNULL(storages + dp_worker->idx);
+
+	return counter_get_address(idx, storage) + field->value_idx;
+}
+
+int
+worker_counters_bind(struct dp_worker *dp_worker, struct dp_config *dp_config) {
+	uint64_t *original[worker_counter_field_count];
+	int failed = 0;
+
+	for (size_t idx = 0; idx < worker_counter_field_count; ++idx) {
+		const struct worker_counter_field *field =
+			worker_counter_fields + idx;
+		uint64_t **pointer = field_pointer(dp_worker, field);
+		original[idx] = *pointer;
+
+		uint64_t *address =
+			counter_value_address(dp_worker, dp_config, field);
+		if (address == NULL) {
+			failed = 1;
+		} else {
+			*pointer = address;
+		}
+	}
+
+	if (failed) {
+		for (size_t idx = 0; idx < worker_counter_field_count; ++idx) {
+			*field_pointer(dp_worker, worker_counter_fields + idx) =
+				original[idx];
+		}
 		return -1;
 	}
-	if (register_one(dp_config, "rx", 2)) {
-		return -1;
-	}
-	if (register_one(dp_config, "tx", 2)) {
-		return -1;
-	}
-	if (register_one(dp_config, "remote_rx", 2)) {
-		return -1;
-	}
-	if (register_one(dp_config, "remote_tx", 2)) {
-		return -1;
-	}
-	if (register_one(dp_config, "rx_bursts", WORKER_RX_BURST_SIZE + 1)) {
-		return -1;
-	}
-	if (register_one(dp_config, "local_tx_drops", 1)) {
-		return -1;
-	}
-	if (register_one(dp_config, "remote_tx_drops", 1)) {
-		return -1;
-	}
-	if (register_one(dp_config, "drops", 1)) {
-		return -1;
-	}
+
 	return 0;
 }

--- a/lib/dataplane/worker/counters.h
+++ b/lib/dataplane/worker/counters.h
@@ -1,10 +1,41 @@
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include "lib/errors/errors.h"
+
 struct dp_config;
+struct dp_worker;
 
 enum {
 	WORKER_RX_BURST_SIZE = 32,
 };
+
+// A worker counter as it is registered.
+struct worker_counter_spec {
+	const char *name;
+	uint64_t size;
+};
+
+// A worker field that receives the address of a single counter value.
+//
+// The offset locates the pointer field inside the worker struct, the counter
+// is named, and the value index picks the slot inside it whose address that
+// field receives.
+struct worker_counter_field {
+	size_t offset;
+	const char *counter;
+	uint64_t value_idx;
+};
+
+// The standard worker counters.
+extern const struct worker_counter_spec worker_counter_specs[];
+extern const size_t worker_counter_spec_count;
+
+// The worker fields bound to those counters.
+extern const struct worker_counter_field worker_counter_fields[];
+extern const size_t worker_counter_field_count;
 
 // Register standard worker counters in dp_config->worker_counters. Caller must
 // initialise the registry via counter_registry_init before calling.
@@ -12,3 +43,14 @@ enum {
 // Returns 0 on success, -1 if any counter fails to register.
 int
 worker_counters_register(struct dp_config *dp_config);
+
+// Point a worker's counter fields at their storage slots.
+//
+// Every counter is resolved by name and its addressed value must fall inside
+// the size it was registered with. The worker's counter storage must already
+// be spawned and wired into the config. On failure the worker's fields are left
+// unchanged.
+//
+// Returns 0 on success, -1 if any field fails to resolve.
+int
+worker_counters_bind(struct dp_worker *dp_worker, struct dp_config *dp_config);

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -45,46 +45,6 @@ struct dataplane_ut {
 	struct plugin_registry plugins;
 };
 
-// Counter indices used by wire_worker_counters to address the
-// standard worker counter slots by their registration order.
-enum {
-	WORKER_CTR_ITERATIONS = 0,
-	WORKER_CTR_RX = 1,
-	WORKER_CTR_TX = 2,
-	WORKER_CTR_REMOTE_RX = 3,
-	WORKER_CTR_REMOTE_TX = 4,
-	WORKER_CTR_RX_BURSTS = 5,
-};
-
-// Wire counter address pointers for a single dp_worker.
-//
-// The worker's counter storage must already be spawned and wired into
-// dp_config before calling this.
-static void
-wire_worker_counters(struct dp_worker *dp_worker, struct dp_config *dp_config) {
-	struct counter_storage *storage = ADDR_OF_NONNULL(
-		ADDR_OF_NONNULL(&dp_config->worker_counter_storages) +
-		dp_worker->idx
-	);
-
-	dp_worker->iterations =
-		counter_get_address(WORKER_CTR_ITERATIONS, storage);
-
-	dp_worker->rx_count = counter_get_address(WORKER_CTR_RX, storage) + 0;
-	dp_worker->rx_size = counter_get_address(WORKER_CTR_RX, storage) + 1;
-
-	dp_worker->tx_count = counter_get_address(WORKER_CTR_TX, storage) + 0;
-	dp_worker->tx_size = counter_get_address(WORKER_CTR_TX, storage) + 1;
-
-	dp_worker->remote_rx_count =
-		counter_get_address(WORKER_CTR_REMOTE_RX, storage) + 0;
-
-	dp_worker->remote_tx_count =
-		counter_get_address(WORKER_CTR_REMOTE_TX, storage) + 0;
-	dp_worker->rx_bursts =
-		counter_get_address(WORKER_CTR_RX_BURSTS, storage);
-}
-
 struct dataplane_ut *
 dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 	if (cfg == NULL) {
@@ -359,7 +319,13 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		}
 		dp_worker->rx_burst_size = WORKER_RX_BURST_SIZE;
 
-		wire_worker_counters(dp_worker, ut->dp_config);
+		if (worker_counters_bind(dp_worker, ut->dp_config)) {
+			LOG(ERROR,
+			    "dataplane_ut_new: failed to bind worker "
+			    "counters");
+			dataplane_ut_free(ut);
+			return NULL;
+		}
 
 		SET_OFFSET_OF(dp_workers + idx, dp_worker);
 	}

--- a/lib/tests/dataplane/meson.build
+++ b/lib/tests/dataplane/meson.build
@@ -110,3 +110,17 @@ worker_clone_test = executable(
   include_directories: yanet_rootdir,
 )
 test('worker_clone', worker_clone_test, suite: 'lib_worker')
+
+worker_counters_test = executable(
+  'worker_counters_test',
+  'worker_counters_test.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_worker_dp_dep,
+    lib_counters_dep,
+    lib_logging_dep,
+  ],
+  include_directories: yanet_rootdir,
+)
+test('worker_counters', worker_counters_test, suite: 'lib_worker')

--- a/lib/tests/dataplane/worker_counters_test.c
+++ b/lib/tests/dataplane/worker_counters_test.c
@@ -1,0 +1,253 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#include "common/memory_address.h"
+#include "common/test_assert.h"
+
+#include "lib/counters/counters.h"
+#include "lib/dataplane/config/counter_storage.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/dataplane/worker/counters.h"
+#include "lib/logging/log.h"
+#include "lib/tests/dataplane/fixture.h"
+
+static uint64_t **
+field_pointer(struct dp_worker *dp_worker, size_t idx) {
+	return (uint64_t **)((char *)dp_worker +
+			     worker_counter_fields[idx].offset);
+}
+
+// Registers the standard counters with the entry at the given position
+// overridden, then spawns storage for one worker. A NULL name or a zero size
+// keeps what the specification declares.
+static int
+setup_registry(
+	struct dataplane_test_fixture *fixture,
+	const char *fixture_name,
+	size_t position,
+	const char *name,
+	uint64_t size
+) {
+	TEST_ASSERT_SUCCESS(
+		dataplane_test_fixture_init(fixture, fixture_name, 1),
+		"fixture init failed"
+	);
+
+	struct dp_config *cfg = &fixture->dp_config;
+	TEST_ASSERT_SUCCESS(
+		counter_registry_init(
+			&cfg->worker_counters, &cfg->memory_context, 0
+		),
+		"registry init failed"
+	);
+
+	for (size_t idx = 0; idx < worker_counter_spec_count; ++idx) {
+		const struct worker_counter_spec *spec =
+			worker_counter_specs + idx;
+		const char *counter_name = spec->name;
+		uint64_t counter_size = spec->size;
+		if (idx == position) {
+			if (name != NULL) {
+				counter_name = name;
+			}
+			if (size != 0) {
+				counter_size = size;
+			}
+		}
+
+		yanet_error *err = NULL;
+		TEST_ASSERT(
+			counter_registry_register(
+				&cfg->worker_counters,
+				counter_name,
+				counter_size,
+				&err
+			) != COUNTER_INVALID,
+			"failed to register counter '%s'",
+			counter_name
+		);
+	}
+
+	TEST_ASSERT_SUCCESS(
+		dp_counter_storage_init(cfg, NULL, 1),
+		"counter storage init failed"
+	);
+
+	return TEST_SUCCESS;
+}
+
+// Verifies that registering the standard counters and binding a worker points
+// every field at the value its own counter name and value index resolve to.
+static int
+test_bind_resolves_every_field_by_name(void) {
+	struct dataplane_test_fixture fixture;
+	TEST_ASSERT_SUCCESS(
+		dataplane_test_fixture_init(
+			&fixture, "worker_counters_bind", 1
+		),
+		"fixture init failed"
+	);
+	struct dp_config *cfg = &fixture.dp_config;
+
+	TEST_ASSERT_SUCCESS(
+		counter_registry_init(
+			&cfg->worker_counters, &cfg->memory_context, 0
+		),
+		"registry init failed"
+	);
+
+	TEST_ASSERT_SUCCESS(
+		worker_counters_register(cfg), "registration failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		dp_counter_storage_init(cfg, NULL, 1),
+		"counter storage init failed"
+	);
+
+	struct dp_worker dp_worker;
+	memset(&dp_worker, 0, sizeof(dp_worker));
+	dp_worker.idx = 0;
+
+	TEST_ASSERT_SUCCESS(
+		worker_counters_bind(&dp_worker, cfg), "bind failed"
+	);
+
+	struct counter_storage *storage = ADDR_OF_NONNULL(
+		ADDR_OF_NONNULL(&cfg->worker_counter_storages) + dp_worker.idx
+	);
+
+	for (size_t idx = 0; idx < worker_counter_field_count; ++idx) {
+		const struct worker_counter_field *field =
+			worker_counter_fields + idx;
+
+		uint64_t counter_idx = counter_registry_lookup_index(
+			&cfg->worker_counters, field->counter
+		);
+		TEST_ASSERT(
+			counter_idx != COUNTER_INVALID,
+			"counter '%s' is missing from the registry",
+			field->counter
+		);
+
+		TEST_ASSERT_EQUAL(
+			(uintptr_t)*field_pointer(&dp_worker, idx),
+			(uintptr_t)(counter_get_address(counter_idx, storage) +
+				    field->value_idx),
+			"field bound to counter '%s' value %lu holds a foreign "
+			"address",
+			field->counter,
+			field->value_idx
+		);
+	}
+
+	dataplane_test_fixture_fini(&fixture);
+	return TEST_SUCCESS;
+}
+
+// Verifies that binding rejects a registry that does not match the
+// specification and leaves every field as it was instead of half wiring the
+// worker.
+static int
+test_bind_rejects_mismatched_registration(void) {
+	static struct {
+		const char *description;
+		size_t position;
+		const char *name;
+		uint64_t size;
+	} cases[] = {
+		{"counter registered under a different name", 4, "renamed", 0},
+		{"counter registered with too few values", 1, NULL, 1},
+	};
+
+	for (size_t case_idx = 0; case_idx < sizeof(cases) / sizeof(cases[0]);
+	     ++case_idx) {
+		struct dataplane_test_fixture fixture;
+		TEST_ASSERT_SUCCESS(
+			setup_registry(
+				&fixture,
+				"worker_counters_mismatch",
+				cases[case_idx].position,
+				cases[case_idx].name,
+				cases[case_idx].size
+			),
+			"setup failed for %s",
+			cases[case_idx].description
+		);
+
+		struct dp_worker dp_worker;
+		memset(&dp_worker, 0, sizeof(dp_worker));
+		dp_worker.idx = 0;
+		uint64_t sentinel = 0;
+		for (size_t idx = 0; idx < worker_counter_field_count; ++idx) {
+			*field_pointer(&dp_worker, idx) = &sentinel;
+		}
+
+		TEST_ASSERT(
+			worker_counters_bind(&dp_worker, &fixture.dp_config) !=
+				0,
+			"bind must fail for %s",
+			cases[case_idx].description
+		);
+
+		for (size_t idx = 0; idx < worker_counter_field_count; ++idx) {
+			TEST_ASSERT_EQUAL(
+				(uintptr_t)*field_pointer(&dp_worker, idx),
+				(uintptr_t)&sentinel,
+				"field bound to counter '%s' must be left "
+				"unchanged for %s",
+				worker_counter_fields[idx].counter,
+				cases[case_idx].description
+			);
+		}
+
+		dataplane_test_fixture_fini(&fixture);
+	}
+
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	LOG(INFO, "=== Starting Worker Counters Test Suite ===");
+
+	struct {
+		const char *name;
+		int (*fn)(void);
+	} tests[] = {
+		{"bind_resolves_every_field_by_name",
+		 test_bind_resolves_every_field_by_name},
+		{"bind_rejects_mismatched_registration",
+		 test_bind_rejects_mismatched_registration},
+	};
+
+	size_t total = sizeof(tests) / sizeof(tests[0]);
+	size_t failed = 0;
+
+	for (size_t idx = 0; idx < total; ++idx) {
+		LOG(INFO,
+		    "[%zu/%zu] running %s...",
+		    idx + 1,
+		    total,
+		    tests[idx].name);
+		if (tests[idx].fn() != TEST_SUCCESS) {
+			LOG(ERROR, "%s FAILED", tests[idx].name);
+			++failed;
+		} else {
+			LOG(INFO, "%s passed", tests[idx].name);
+		}
+	}
+
+	if (failed == 0) {
+		LOG(INFO, "=== All %zu worker counters tests passed! ===", total
+		);
+	} else {
+		LOG(ERROR,
+		    "=== %zu/%zu worker counters tests failed ===",
+		    failed,
+		    total);
+	}
+
+	return failed == 0 ? TEST_SUCCESS : TEST_FAILED;
+}


### PR DESCRIPTION
fix(dataplane): bind worker counters by name instead of hard-coded indices

- The dataplane bound worker counter slots with the literal indices 0..8, while the control plane resolves the same counters by name, so inserting or removing a counter anywhere but at the end silently shifted every later slot and reported wrong numbers with no error.
- Describe the worker counters in two tables in `lib/dataplane/worker/counters.c`: one lists the name and size of every counter that is registered, the other maps each worker pointer field to a counter name and a value index inside it.
- Add `worker_counters_bind`, which resolves every field by counter name, checks that the value index fits the size the counter was registered with, and leaves the worker unchanged if any field fails to resolve.
- `dataplane_worker_start` and `dataplane_ut_new` now call `worker_counters_bind` instead of repeating the index arithmetic, and both the `FIXME` in `dataplane/worker.c` and the hard-coded index enum in `dataplane_ut` are gone.
- Declare `counter_registry_lookup_index` in the public header and add `counter_registry_lookup_size`, so the size of a counter can be checked at bind time. No shared-memory layout change.
- Log which worker failed to start in `dataplane_device_start`.
- Add `lib/tests/dataplane/worker_counters_test.c`: it checks that every field lands on the address its own name and value index resolve to, and that a renamed or undersized counter makes binding fail without half-wiring the worker.
- Reordering or inserting a counter in the specification table no longer mislabels a later slot.

Closes #2093.
