### PR TITLE
fix(controlplane): derive shared memory unmap length from the mapping

### DIFF
--- a/api/agent.h
+++ b/api/agent.h
@@ -46,10 +46,12 @@ yanet_shm_attach(const char *path);
 
 // Detaches from YANET shared memory segment.
 //
-// Releases all resources associated with the shared memory handle.
-// After this call, the handle becomes invalid and must not be used.
-//
-// @param shm Handle to shared memory segment obtained from yanet_shm_attach()
+// Unmaps exactly the range that yanet_shm_attach() mapped, regardless of how
+// far the dataplane has got in initialising the segment, and frees the
+// handle. The handle must be one returned by yanet_shm_attach() and not NULL;
+// after this call it becomes invalid and must not be used, whatever the
+// outcome. Returns 0 on success, -1 with errno set if the mapping could not
+// be released.
 int
 yanet_shm_detach(struct yanet_shm *shm);
 

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -25,6 +25,10 @@ type SharedMemory struct {
 	ptr *C.struct_yanet_shm
 }
 
+// NewSharedMemoryFromRaw wraps an opaque C shared-memory handle.
+//
+// The pointer is the process-local handle the C API hands out, not the
+// segment itself; it must only be used through the C API.
 func NewSharedMemoryFromRaw(ptr unsafe.Pointer) *SharedMemory {
 	return &SharedMemory{ptr: (*C.struct_yanet_shm)(ptr)}
 }
@@ -35,7 +39,7 @@ func AttachSharedMemory(path string) (*SharedMemory, error) {
 	defer C.free(unsafe.Pointer(cPath))
 
 	ptr, err := C.yanet_shm_attach(cPath)
-	if err != nil {
+	if ptr == nil {
 		return nil, fmt.Errorf(
 			"failed to attach to shared memory %q: %w",
 			path,
@@ -50,18 +54,28 @@ func AttachSharedMemory(path string) (*SharedMemory, error) {
 //
 // Every agent attached to the segment must be closed before detaching,
 // because the mapping is unmapped and a later agent operation would fault.
+// The mapping length travels inside the handle, so detaching works at any
+// point after a successful attach, including before the dataplane has
+// written the segment header. The handle is consumed whatever the outcome,
+// so a second call is a no-op.
 func (m *SharedMemory) Detach() error {
-	if m.ptr != nil {
-		if _, err := C.yanet_shm_detach(m.ptr); err != nil {
-			return fmt.Errorf("failed to detach shared memory: %w", err)
-		}
+	if m.ptr == nil {
+		return nil
+	}
 
-		m.ptr = nil
+	ptr := m.ptr
+	m.ptr = nil
+	if rc, err := C.yanet_shm_detach(ptr); rc != 0 {
+		return fmt.Errorf("failed to detach shared memory: %w", err)
 	}
 
 	return nil
 }
 
+// AsRawPtr returns the opaque C shared-memory handle.
+//
+// The pointer is the process-local handle, not the segment itself; it must
+// only be used through the C API.
 func (m *SharedMemory) AsRawPtr() unsafe.Pointer {
 	return unsafe.Pointer(m.ptr)
 }

--- a/controlplane/ffi/shm_test.go
+++ b/controlplane/ffi/shm_test.go
@@ -1,0 +1,64 @@
+package ffi_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+// createStorageFile returns the path of a zero-filled file of the given size.
+//
+// This is the state the dataplane leaves its storage in before it writes the
+// segment header.
+func createStorageFile(t *testing.T, size int64) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "yanet")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, file.Truncate(size))
+	require.NoError(t, file.Close())
+
+	return path
+}
+
+// verifies that a segment attached before the dataplane has written its
+// header reports not ready and still detaches cleanly.
+//
+// This is the path the director's readiness backoff takes on a startup
+// timeout.
+func Test_SharedMemory_Detach_UninitialisedSegment(t *testing.T) {
+	path := createStorageFile(t, 2<<20)
+
+	shm, err := ffi.AttachSharedMemory(path)
+	require.NoError(t, err)
+	require.False(t, shm.DataplaneReady(0))
+
+	require.NoError(t, shm.Detach())
+}
+
+// verifies that detaching an already detached handle is a no-op rather than
+// a double release.
+func Test_SharedMemory_Detach_Twice(t *testing.T) {
+	path := createStorageFile(t, 2<<20)
+
+	shm, err := ffi.AttachSharedMemory(path)
+	require.NoError(t, err)
+
+	require.NoError(t, shm.Detach())
+	require.NoError(t, shm.Detach())
+}
+
+// verifies that attaching to a missing storage file fails with an error
+// instead of handing out a handle with nothing behind it.
+func Test_SharedMemory_Attach_MissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing")
+
+	shm, err := ffi.AttachSharedMemory(path)
+	require.Error(t, err)
+	require.Nil(t, shm)
+}

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1,6 +1,7 @@
 #include "agent.h"
 
 #include <linux/mman.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -44,42 +45,45 @@ yanet_shm_attach(const char *path) {
 		return NULL;
 	}
 
-	void *ptr = mmap(
-		NULL, stat.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0
-	);
+	size_t size = (size_t)stat.st_size;
+	void *ptr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	close(fd);
 	if (ptr == MAP_FAILED) {
 		return NULL;
 	}
 
-	struct yanet_shm *shm = (struct yanet_shm *)ptr;
+	struct yanet_shm *shm = malloc(sizeof(*shm));
+	if (shm == NULL) {
+		int saved_errno = errno;
+		munmap(ptr, size);
+		errno = saved_errno;
+		return NULL;
+	}
+	shm->base = ptr;
+	shm->size = size;
 	return shm;
 }
 
 int
 yanet_shm_detach(struct yanet_shm *shm) {
-	// calculate total size of shared memory
-	size_t size = 0;
-	struct dp_config *dp_config = (struct dp_config *)shm;
-	uint32_t instance_count = dp_config->instance_count;
-	for (uint32_t instance_idx = 0; instance_idx < instance_count;
-	     ++instance_idx) {
-		size += dp_config->storage_size;
-		dp_config = dp_config_nextk(dp_config, 1);
-	}
-
-	return munmap(shm, size);
+	// The handle is released whatever the unmap reports: a caller has no
+	// way to retry with a better length, so keeping the handle alive
+	// would only turn a leaked mapping into a dangling pointer as well.
+	int rc = munmap(shm->base, shm->size);
+	free(shm);
+	return rc;
 }
 
 struct dp_config *
 yanet_shm_dp_config(struct yanet_shm *shm, uint32_t instance_idx) {
-	return dp_config_nextk((struct dp_config *)shm, instance_idx);
+	return dp_config_nextk((struct dp_config *)shm->base, instance_idx);
 }
 
 int
 agent_dp_config_ready(struct yanet_shm *shm, uint32_t instance_idx) {
 	uint32_t count = __atomic_load_n(
-		&((struct dp_config *)shm)->instance_count, __ATOMIC_ACQUIRE
+		&((struct dp_config *)shm->base)->instance_count,
+		__ATOMIC_ACQUIRE
 	);
 	if (instance_idx >= count) {
 		return 0;

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -17,6 +17,19 @@ struct cp_object;
 
 struct agent;
 
+// Process-local handle to a mapped shared-memory segment.
+//
+// Carries the mapping length next to its base address so that releasing
+// the segment never depends on what the segment header says: the dataplane
+// sizes the storage file long before it fills the header in, and a detach
+// in that window must still unmap exactly what was mapped. A harness that
+// backs the segment with its own memory embeds this struct and hands out a
+// pointer to it; such a handle must never be detached.
+struct yanet_shm {
+	void *base;
+	size_t size;
+};
+
 struct agent_arena {
 	void *data;
 	uint64_t size;

--- a/lib/controlplane/agent/agent_test.c
+++ b/lib/controlplane/agent/agent_test.c
@@ -1,10 +1,14 @@
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
 
 #include "api/agent.h"
 #include "api/counter.h"
 #include "common/memory_address.h"
 #include "common/test_assert.h"
+#include "lib/controlplane/agent/agent.h"
 #include "lib/controlplane/config/zone.h"
 #include "lib/dataplane/config/agent.h"
 #include "lib/dataplane/config/bootstrap.h"
@@ -25,10 +29,10 @@ test_attach_zeroed_segment_returns_error() {
 	void *storage = calloc(1, TEST_STORAGE_SIZE);
 	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
 
-	struct yanet_shm *shm = (struct yanet_shm *)storage;
+	struct yanet_shm shm = {.base = storage, .size = TEST_STORAGE_SIZE};
 
 	yanet_error *err = NULL;
-	struct agent *result = agent_attach(shm, 0, "test-agent", 4096, &err);
+	struct agent *result = agent_attach(&shm, 0, "test-agent", 4096, &err);
 
 	TEST_ASSERT_NULL(
 		result, "agent_attach on zeroed segment must return NULL"
@@ -99,8 +103,8 @@ test_ready_predicate_zeroed_segment_returns_false() {
 	void *storage = calloc(1, TEST_STORAGE_SIZE);
 	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
 
-	struct yanet_shm *shm = (struct yanet_shm *)storage;
-	int ready = agent_dp_config_ready(shm, 0);
+	struct yanet_shm shm = {.base = storage, .size = TEST_STORAGE_SIZE};
+	int ready = agent_dp_config_ready(&shm, 0);
 	TEST_ASSERT(ready == 0, "predicate must return 0 on a zeroed segment");
 
 	free(storage);
@@ -133,8 +137,8 @@ test_ready_predicate_initialised_segment_returns_true() {
 	cp_config_unlock(cp_config);
 	dp_config_mark_ready(dp_config);
 
-	struct yanet_shm *shm = (struct yanet_shm *)storage;
-	int ready = agent_dp_config_ready(shm, 0);
+	struct yanet_shm shm = {.base = storage, .size = TEST_STORAGE_SIZE};
+	int ready = agent_dp_config_ready(&shm, 0);
 	TEST_ASSERT(
 		ready == 1,
 		"predicate must return 1 after the full readiness sequence"
@@ -182,9 +186,9 @@ test_attach_initialised_segment_succeeds() {
 	cp_config_unlock(cp_config);
 	dp_config_mark_ready(dp_config);
 
-	struct yanet_shm *shm = (struct yanet_shm *)storage;
+	struct yanet_shm shm = {.base = storage, .size = TEST_STORAGE_SIZE};
 	yanet_error *err = NULL;
-	struct agent *result = agent_attach(shm, 0, "test-agent", 4096, &err);
+	struct agent *result = agent_attach(&shm, 0, "test-agent", 4096, &err);
 
 	TEST_ASSERT_NOT_NULL(
 		result, "agent_attach must succeed on an initialised segment"
@@ -265,6 +269,133 @@ test_get_port_counters_zero_port_count_returns_empty_list() {
 	return TEST_SUCCESS;
 }
 
+// Reports whether the page at the given address is still mapped in this
+// process.
+//
+// Synchronising an unmapped range fails with ENOMEM, so a successful call
+// proves the page is still there. Probed right after the detach, before
+// anything else could reuse the address range.
+static int
+page_mapped(void *addr) {
+	long page_size = sysconf(_SC_PAGESIZE);
+	return msync(addr, (size_t)page_size, MS_ASYNC) == 0;
+}
+
+// Attaches to a fresh zero-filled storage file of the given size, the state
+// the dataplane leaves the storage in before it writes the header.
+//
+// The file is unlinked as soon as it is attached, so a failing assertion
+// never leaves it behind; the mapping outlives the directory entry. Returns
+// NULL if the file could not be created or attached.
+static struct yanet_shm *
+attach_storage_file(size_t size) {
+	char path[] = "/tmp/yanet-shm-test-XXXXXX";
+	int fd = mkstemp(path);
+	if (fd == -1) {
+		return NULL;
+	}
+	int rc = ftruncate(fd, (off_t)size);
+	close(fd);
+	if (rc != 0) {
+		unlink(path);
+		return NULL;
+	}
+	struct yanet_shm *shm = yanet_shm_attach(path);
+	unlink(path);
+	return shm;
+}
+
+// Verify that detaching a segment whose header the dataplane has not written
+// yet releases the whole mapping instead of failing, which is the state the
+// director's readiness backoff attaches in.
+static int
+test_detach_uninitialised_segment_releases_mapping() {
+	struct yanet_shm *shm = attach_storage_file(TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(shm, "attach to a zeroed storage file failed");
+
+	uint8_t *base = (uint8_t *)yanet_shm_dp_config(shm, 0);
+	long page_size = sysconf(_SC_PAGESIZE);
+	TEST_ASSERT(page_mapped(base), "attach must map the segment");
+
+	errno = 0;
+	int rc = yanet_shm_detach(shm);
+	TEST_ASSERT(
+		rc == 0,
+		"detach of an uninitialised segment must succeed, got %s",
+		strerror(errno)
+	);
+	TEST_ASSERT(!page_mapped(base), "detach must unmap the first page");
+	TEST_ASSERT(
+		!page_mapped(base + TEST_STORAGE_SIZE - page_size),
+		"detach must unmap the last page"
+	);
+	return TEST_SUCCESS;
+}
+
+// Verify that detaching releases what was mapped even when the header
+// understates the segment, as it does while the dataplane is still writing
+// it: a detach that trusted the header would leave the tail mapped.
+static int
+test_detach_understated_header_releases_whole_mapping() {
+	struct yanet_shm *shm = attach_storage_file(2 * TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(shm, "attach to a zeroed storage file failed");
+
+	struct dp_config *dp_config = yanet_shm_dp_config(shm, 0);
+	dp_config->instance_count = 1;
+	dp_config->storage_size = TEST_STORAGE_SIZE;
+
+	uint8_t *base = (uint8_t *)dp_config;
+	long page_size = sysconf(_SC_PAGESIZE);
+	errno = 0;
+	int rc = yanet_shm_detach(shm);
+	TEST_ASSERT(rc == 0, "detach must succeed, got %s", strerror(errno));
+	TEST_ASSERT(
+		!page_mapped(base + TEST_STORAGE_SIZE),
+		"detach must unmap the part the header does not cover"
+	);
+	TEST_ASSERT(
+		!page_mapped(base + 2 * TEST_STORAGE_SIZE - page_size),
+		"detach must unmap the last page"
+	);
+	return TEST_SUCCESS;
+}
+
+// Verify that detaching a fully initialised, file-backed segment still
+// releases exactly the mapping.
+static int
+test_detach_initialised_segment_releases_mapping() {
+	struct yanet_shm *shm = attach_storage_file(TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(shm, "attach to a zeroed storage file failed");
+
+	struct dp_config *dp_config = NULL;
+	struct cp_config *cp_config = NULL;
+	int rc = dp_storage_init(
+		0,
+		0,
+		yanet_shm_dp_config(shm, 0),
+		TEST_DP_MEMORY,
+		TEST_CP_MEMORY,
+		&dp_config,
+		&cp_config
+	);
+	TEST_ASSERT(rc == 0, "dp_storage_init failed");
+	dp_config->instance_count = 1;
+	cp_config_unlock(cp_config);
+	dp_config_mark_ready(dp_config);
+
+	uint8_t *base = (uint8_t *)dp_config;
+	long page_size = sysconf(_SC_PAGESIZE);
+	errno = 0;
+	rc = yanet_shm_detach(shm);
+	TEST_ASSERT(rc == 0, "detach must succeed, got %s", strerror(errno));
+	TEST_ASSERT(!page_mapped(base), "detach must unmap the first page");
+	TEST_ASSERT(
+		!page_mapped(base + TEST_STORAGE_SIZE - page_size),
+		"detach must unmap the last page"
+	);
+	return TEST_SUCCESS;
+}
+
 int
 main() {
 	log_enable_name("error");
@@ -326,6 +457,32 @@ main() {
 		LOG(ERROR,
 		    "test_get_port_counters_zero_port_count_returns_empty_list "
 		    "failed");
+	}
+
+	++tests_count;
+	if (test_detach_uninitialised_segment_releases_mapping() !=
+	    TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_detach_uninitialised_segment_releases_mapping failed"
+		);
+	}
+
+	++tests_count;
+	if (test_detach_understated_header_releases_whole_mapping() !=
+	    TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_detach_understated_header_releases_whole_mapping "
+		    "failed");
+	}
+
+	++tests_count;
+	if (test_detach_initialised_segment_releases_mapping() !=
+	    TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_detach_initialised_segment_releases_mapping failed");
 	}
 
 	if (tests_failed != 0) {

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -37,6 +37,11 @@
 struct dataplane_ut {
 	void *arena;
 	size_t arena_size;
+	// Shared-memory handle over the arena, handed out to agents.
+	//
+	// Owned by the harness: it is never detached, because the arena is
+	// heap memory that the harness frees itself.
+	struct yanet_shm shm;
 	struct dp_config *dp_config;
 	struct cp_config *cp_config;
 	struct agent *agent;
@@ -119,6 +124,8 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		return NULL;
 	}
 	memset(ut->arena, 0, ut->arena_size);
+	ut->shm.base = ut->arena;
+	ut->shm.size = ut->arena_size;
 
 	// Lay out dp_config and cp_config inside the arena.
 	if (dp_storage_init(
@@ -436,8 +443,7 @@ dataplane_ut_free(struct dataplane_ut *ut) {
 
 struct yanet_shm *
 dataplane_ut_shm(struct dataplane_ut *ut) {
-	// The arena base address serves as the opaque shm handle.
-	return (struct yanet_shm *)ut->arena;
+	return &ut->shm;
 }
 
 void

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -64,7 +64,9 @@ void
 dataplane_ut_free(struct dataplane_ut *ut);
 
 // Return the shared-memory handle backing this harness.
-// Suitable for passing to agent_attach.
+//
+// Suitable for passing to agent_attach. The handle is owned by the harness
+// and lives until dataplane_ut_free; it must not be detached.
 struct yanet_shm *
 dataplane_ut_shm(struct dataplane_ut *ut);
 


### PR DESCRIPTION
- The shared-memory handle now carries the mapping length next to its base address, so detaching unmaps exactly what attach mapped regardless of how far the dataplane has got in writing the segment header.
- A control plane that attached inside the dataplane's startup window, as the director's readiness backoff does, previously computed an unmap length of zero from the empty header, failed with EINVAL and kept the mapping; a partially written header left the tail mapped, and a header claiming more than the file holds would have unmapped address space the process never mapped.
- The handle is a process-local heap object created by attach and consumed by detach whatever the outcome; the public signatures and the Go wrapper keep their shape, and every accessor goes through the handle's base address.
- The in-process dataplane harness embeds the handle over its own arena, and the four agent tests that cast raw memory to the handle now build a local one.
- Three file-backed C scenarios pin the behaviour (zeroed header, header understating the file, fully initialised header), each probing that the mapping is really gone, and Go tests cover the director path, a double detach and a missing file.
- Closes #2017.
