### PR TITLE
fix(dataplane): bound packet recirculation

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -185,12 +185,15 @@ type WorkerSpec struct {
 // WorkerCount must be >= 1.
 // Devices, Modules, DevicesToLoad, and ObjectsToLoad may be empty.
 type Config struct {
-	CPMemory      uint64
-	DPMemory      uint64
-	WorkerCount   uint64
-	Devices       []string
-	Modules       []string
-	DevicesToLoad []string
+	CPMemory    uint64
+	DPMemory    uint64
+	WorkerCount uint64
+	// PacketRecircLimit bounds total redirects per packet. Zero selects the
+	// production default; nonzero values use the production range.
+	PacketRecircLimit uint16
+	Devices           []string
+	Modules           []string
+	DevicesToLoad     []string
 	// ObjectsToLoad registers standalone shared-memory object types (e.g. "fwstate_map_v4") in the dataplane config.
 	ObjectsToLoad []string
 	// PluginDir is the directory scanned for module .so plugins. An empty
@@ -238,6 +241,16 @@ type Harness struct {
 // NewHarness constructs a Harness from cfg.
 // Free must be called when the test is done.
 func NewHarness(cfg Config) (*Harness, error) {
+	if cfg.PacketRecircLimit != 0 &&
+		(cfg.PacketRecircLimit < uint16(C.PACKET_RECIRC_LIMIT_MIN) ||
+			cfg.PacketRecircLimit > uint16(C.PACKET_RECIRC_LIMIT_MAX)) {
+		return nil, fmt.Errorf(
+			"packet recirculation limit %d is outside range %d..%d",
+			cfg.PacketRecircLimit,
+			uint16(C.PACKET_RECIRC_LIMIT_MIN),
+			uint16(C.PACKET_RECIRC_LIMIT_MAX),
+		)
+	}
 	if cfg.Workers != nil && uint64(len(cfg.Workers)) != cfg.WorkerCount {
 		return nil, fmt.Errorf(
 			"workers length %d does not match worker count %d",
@@ -285,6 +298,7 @@ func NewHarness(cfg Config) (*Harness, error) {
 		cp_memory:             C.size_t(cfg.CPMemory),
 		dp_memory:             C.size_t(cfg.DPMemory),
 		worker_count:          C.size_t(cfg.WorkerCount),
+		packet_recirc_limit:   C.uint16_t(cfg.PacketRecircLimit),
 		device_count:          C.size_t(len(cfg.Devices)),
 		module_count:          C.size_t(len(cfg.Modules)),
 		devices_to_load_count: C.size_t(len(cfg.DevicesToLoad)),
@@ -343,6 +357,11 @@ func NewHarness(cfg Config) (*Harness, error) {
 func (m *Harness) Free() {
 	C.dataplane_ut_free(m.ptr)
 	m.ptr = nil
+}
+
+// OutstandingMbufs returns mock-mempool allocations not yet reclaimed.
+func (m *Harness) OutstandingMbufs() uint64 {
+	return uint64(C.dataplane_ut_mempool_outstanding(m.ptr))
 }
 
 // SharedMemory returns the shared-memory handle backing this harness.
@@ -480,6 +499,7 @@ func (m *Harness) handleSegmentedPackets(
 		(*C.struct_packet_list)(unsafe.Pointer(packetList)),
 		&result,
 	)
+	defer C.dataplane_ut_round_result_free(&result)
 
 	pinner.Pin(&result)
 
@@ -558,6 +578,7 @@ func (m *Harness) handlePackets(
 		(*C.struct_packet_list)(unsafe.Pointer(packetList)),
 		&result,
 	)
+	defer C.dataplane_ut_round_result_free(&result)
 
 	pinner.Pin(&result)
 
@@ -681,7 +702,7 @@ func (m *Harness) Bench(
 	}
 
 	b.ResetTimer()
-	C.dataplane_ut_run_rounds(
+	rc := C.dataplane_ut_run_rounds(
 		m.ptr,
 		C.size_t(0),
 		(*C.struct_packet_list)(unsafe.Pointer(packetList)),
@@ -689,6 +710,9 @@ func (m *Harness) Bench(
 		reset,
 	)
 	b.StopTimer()
+	if rc != 0 {
+		b.Fatalf("failed to recycle benchmark packets: rc=%d", rc)
+	}
 
 	elapsed := b.Elapsed()
 	if elapsed > 0 {

--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -188,8 +188,8 @@ type Config struct {
 	CPMemory    uint64
 	DPMemory    uint64
 	WorkerCount uint64
-	// PacketRecircLimit bounds total redirects per packet. Zero selects the
-	// production default; nonzero values use the production range.
+	// PacketRecircLimit bounds total redirects across a packet lineage. Zero
+	// selects the production default; nonzero values use the production range.
 	PacketRecircLimit uint16
 	Devices           []string
 	Modules           []string
@@ -687,6 +687,7 @@ func (m *Harness) Bench(
 	if err != nil {
 		b.Fatalf("failed to build packet list: %v", err)
 	}
+	defer packetList.Free()
 
 	pinner.Pin(m)
 

--- a/bindings/go/dataplane_ut/dataplane_ut_test.go
+++ b/bindings/go/dataplane_ut/dataplane_ut_test.go
@@ -38,6 +38,9 @@ func TestHarnessLifecycle(t *testing.T) {
 	require.NotNil(t, shm)
 }
 
+// TestNewHarnessRejectsInvalidPacketRecircLimit verifies that NewHarness
+// rejects a packet recirculation limit outside the 4..256 range on the Go
+// side instead of passing it through to the C layer.
 func TestNewHarnessRejectsInvalidPacketRecircLimit(t *testing.T) {
 	for _, limit := range []uint16{3, 257} {
 		t.Run(fmt.Sprintf("limit_%d", limit), func(t *testing.T) {

--- a/bindings/go/dataplane_ut/dataplane_ut_test.go
+++ b/bindings/go/dataplane_ut/dataplane_ut_test.go
@@ -1,6 +1,7 @@
 package dataplaneut
 
 import (
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -35,6 +36,21 @@ func TestHarnessLifecycle(t *testing.T) {
 
 	shm := h.SharedMemory()
 	require.NotNil(t, shm)
+}
+
+func TestNewHarnessRejectsInvalidPacketRecircLimit(t *testing.T) {
+	for _, limit := range []uint16{3, 257} {
+		t.Run(fmt.Sprintf("limit_%d", limit), func(t *testing.T) {
+			harness, err := NewHarness(Config{
+				CPMemory:          uint64(datasize.MB * 32),
+				DPMemory:          uint64(datasize.MB * 4),
+				WorkerCount:       1,
+				PacketRecircLimit: limit,
+			})
+			require.Error(t, err)
+			require.Nil(t, harness)
+		})
+	}
 }
 
 // TestTimeRoundTrip verifies that SetCurrentTime and CurrentTime agree and

--- a/bindings/go/dataplane_ut/dataplane_ut_test.go
+++ b/bindings/go/dataplane_ut/dataplane_ut_test.go
@@ -1,7 +1,6 @@
 package dataplaneut
 
 import (
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -38,17 +37,22 @@ func TestHarnessLifecycle(t *testing.T) {
 	require.NotNil(t, shm)
 }
 
-// TestNewHarnessRejectsInvalidPacketRecircLimit verifies that NewHarness
-// rejects a packet recirculation limit outside the 4..256 range on the Go
-// side instead of passing it through to the C layer.
-func TestNewHarnessRejectsInvalidPacketRecircLimit(t *testing.T) {
-	for _, limit := range []uint16{3, 257} {
-		t.Run(fmt.Sprintf("limit_%d", limit), func(t *testing.T) {
+// verifies that NewHarness rejects a packet recirculation limit outside
+// the 4..256 range on the Go side instead of passing it to the C layer.
+func Test_NewHarness_RejectsInvalidPacketRecircLimit(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		limit uint16
+	}{
+		{name: "below_minimum", limit: 3},
+		{name: "above_maximum", limit: 257},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
 			harness, err := NewHarness(Config{
 				CPMemory:          uint64(datasize.MB * 32),
 				DPMemory:          uint64(datasize.MB * 4),
 				WorkerCount:       1,
-				PacketRecircLimit: limit,
+				PacketRecircLimit: testCase.limit,
 			})
 			require.Error(t, err)
 			require.Nil(t, harness)

--- a/common/go/dataplane/packet.go
+++ b/common/go/dataplane/packet.go
@@ -10,6 +10,7 @@ package dataplane
 //#include "lib/utils/packet.h"
 import "C"
 import (
+	"bytes"
 	"fmt"
 	"runtime"
 	"unsafe"
@@ -134,6 +135,7 @@ func (packet *Packet) Data() PacketData {
 
 func (packet *Packet) Info() *framework.PacketInfo {
 	data := packet.Data()
+	data.Payload = bytes.Clone(data.Payload)
 	info, err := framework.NewPacketParser().ParsePacket(data.Payload)
 	if err != nil {
 		msg := fmt.Sprintf("failed to parse packet: %v", err)

--- a/common/go/dataplane/packet_test.go
+++ b/common/go/dataplane/packet_test.go
@@ -55,12 +55,13 @@ func TestPacket(t *testing.T) {
 	packet, err := NewPacketFromData(data)
 	require.NoError(t, err, "failed to create new packet from data")
 
-	defer packet.Free()
-
 	packetData := packet.Data()
 	assert.Equal(t, data, packetData)
 
 	packetInfo := packet.Info()
+	clear(packetData.Payload)
+	packet.Free()
+	assert.Equal(t, gopacketData, packetInfo.RawData)
 	assert.Equal(t, packetInfo.DstIP, ip.DstIP)
 	assert.Equal(t, packetInfo.SrcIP, ip.SrcIP)
 	assert.Equal(t, packetInfo.SrcPort, uint16(tcp.SrcPort))

--- a/dataplane.yaml
+++ b/dataplane.yaml
@@ -1,6 +1,7 @@
 dataplane:
   storage: /dev/hugepages/yanet
   dpdk_memory: 1024
+  packet_recirc_limit: 16
   instances:
     - dp_memory: 1073741824
       cp_memory: 2147483648

--- a/dataplane.yaml
+++ b/dataplane.yaml
@@ -1,7 +1,7 @@
 dataplane:
   storage: /dev/hugepages/yanet
   dpdk_memory: 1024
-  packet_recirc_limit: 16
+  packet_recirc_limit: 64
   instances:
     - dp_memory: 1073741824
       cp_memory: 2147483648

--- a/dataplane.yaml
+++ b/dataplane.yaml
@@ -1,6 +1,9 @@
 dataplane:
   storage: /dev/hugepages/yanet
   dpdk_memory: 1024
+  # Maximum self-redirects (recirculations) per packet lineage, shared by the
+  # input and output routes; 4..256, default 64. Packets exceeding the budget
+  # are dropped and counted in input_recirc_drop / output_recirc_drop.
   packet_recirc_limit: 64
   instances:
     - dp_memory: 1073741824

--- a/dataplane/config.c
+++ b/dataplane/config.c
@@ -7,6 +7,7 @@
 #include <yaml.h>
 
 #include "common/strutils.h"
+#include "lib/dataplane/packet/packet.h"
 
 static void
 print_scalar(const char *value, size_t length) {
@@ -40,6 +41,7 @@ parse_unsigned(
 	const char *field,
 	const char *value,
 	size_t length,
+	uint64_t min,
 	uint64_t max,
 	uint64_t *result
 ) {
@@ -53,13 +55,14 @@ parse_unsigned(
 	uintmax_t parsed = strtoumax(value, &end, 10);
 
 	if (*first == '-' || value == end || end != value + length ||
-	    errno == ERANGE || parsed > max) {
+	    errno == ERANGE || parsed < min || parsed > max) {
 		fprintf(stderr, "invalid %s value ", field);
 		print_scalar(value, length);
 		fprintf(stderr,
 			" (length %zu): expected an unsigned integer in range "
-			"0..%" PRIu64 "\n",
+			"%" PRIu64 "..%" PRIu64 "\n",
 			length,
+			min,
 			max);
 		return -1;
 	}
@@ -112,6 +115,7 @@ enum state {
 	state_dataplane,
 	state_dataplane_storage,
 	state_dataplane_dpdk_memory,
+	state_dataplane_packet_recirc_limit,
 	state_dataplane_iova_mode,
 
 	state_instances,
@@ -169,6 +173,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 	}
 
 	memset(dataplane, 0, sizeof(*dataplane));
+	dataplane->packet_recirc_limit = PACKET_RECIRC_LIMIT_DEFAULT;
 
 	struct dataplane_instance_config *instance = NULL;
 	struct dataplane_device_config *device = NULL;
@@ -216,11 +221,27 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "dataplane.dpdk_memory",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT64_MAX,
 					    &dataplane->dpdk_memory
 				    ) != 0) {
 					goto error;
 				}
+				state = state_dataplane;
+				break;
+			case state_dataplane_packet_recirc_limit:
+				if (parse_unsigned(
+					    "dataplane.packet_recirc_limit",
+					    start,
+					    scalar_length,
+					    PACKET_RECIRC_LIMIT_MIN,
+					    PACKET_RECIRC_LIMIT_MAX,
+					    &value
+				    ) != 0) {
+					goto error;
+				}
+				dataplane->packet_recirc_limit =
+					(uint16_t)value;
 				state = state_dataplane;
 				break;
 			case state_dataplane_iova_mode:
@@ -259,6 +280,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "instances.numa_id",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT16_MAX,
 					    &value
 				    ) != 0) {
@@ -272,6 +294,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "instances.dp_memory",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT64_MAX,
 					    &instance->dp_memory
 				    ) != 0) {
@@ -284,6 +307,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "instances.cp_memory",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT64_MAX,
 					    &instance->cp_memory
 				    ) != 0) {
@@ -315,6 +339,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "devices.mtu",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT32_MAX,
 					    &value
 				    ) != 0) {
@@ -328,6 +353,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "devices.max_lro_packet_size",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT64_MAX,
 					    &device->max_lro_packet_size
 				    ) != 0) {
@@ -341,6 +367,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "devices.rss_hash",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT64_MAX,
 					    &device->rss_hash
 				    ) != 0) {
@@ -355,6 +382,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "workers.core_id",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT16_MAX,
 					    &value
 				    ) != 0) {
@@ -369,6 +397,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "workers.instance_id",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT16_MAX,
 					    &value
 				    ) != 0) {
@@ -383,6 +412,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "workers.rx_queue_len",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT16_MAX,
 					    &value
 				    ) != 0) {
@@ -397,6 +427,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "workers.tx_queue_len",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT16_MAX,
 					    &value
 				    ) != 0) {
@@ -411,6 +442,7 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					    "workers.num_mbufs",
 					    start,
 					    scalar_length,
+					    0,
 					    UINT32_MAX,
 					    &value
 				    ) != 0) {
@@ -446,6 +478,9 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					state = state_dataplane_storage;
 				} else if (!strcmp("dpdk_memory", start)) {
 					state = state_dataplane_dpdk_memory;
+				} else if (!strcmp("packet_recirc_limit",
+						   start)) {
+					state = state_dataplane_packet_recirc_limit;
 				} else if (!strcmp("iova_mode", start)) {
 					state = state_dataplane_iova_mode;
 				} else if (!strcmp("instances", start)) {

--- a/dataplane/config.h
+++ b/dataplane/config.h
@@ -44,6 +44,7 @@ struct dataplane_connection_config {
 struct dataplane_config {
 	char storage[80];
 	uint64_t dpdk_memory;
+	uint16_t packet_recirc_limit;
 
 	// IOVA mode passed to DPDK EAL via --iova-mode.
 	// Empty string means "do not pass the flag" (EAL autodetect).

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -508,6 +508,8 @@ dataplane_init(
 			    instance_idx);
 			return -1;
 		}
+		instance->dp_config->packet_recirc_limit =
+			config->packet_recirc_limit;
 
 		// System agent for this instance.
 		//

--- a/dataplane/unittest/config/dataplane.yaml
+++ b/dataplane/unittest/config/dataplane.yaml
@@ -1,6 +1,7 @@
 dataplane:
   storage: /dev/hugepages/yanet
   dpdk_memory: 1024
+  packet_recirc_limit: 37
   instances:
     - numa_id: 0
       cp_memory: 2048

--- a/dataplane/unittest/config/main.c
+++ b/dataplane/unittest/config/main.c
@@ -1,5 +1,6 @@
 #include "assert.h"
 #include "config.h"
+#include "lib/dataplane/packet/packet.h"
 
 #include <fcntl.h>
 #include <string.h>
@@ -60,6 +61,7 @@ static void
 test_numeric_field_maximum_values(void) {
 	const char yaml[] = "dataplane:\n"
 			    "  dpdk_memory: 18446744073709551615\n"
+			    "  packet_recirc_limit: 256\n"
 			    "  instances:\n"
 			    "    - numa_id: 65535\n"
 			    "      dp_memory: 18446744073709551615\n"
@@ -80,6 +82,7 @@ test_numeric_field_maximum_values(void) {
 	assert(rc == 0);
 
 	assert(config->dpdk_memory == UINT64_MAX);
+	assert(config->packet_recirc_limit == PACKET_RECIRC_LIMIT_MAX);
 	assert(config->instance_count == 1);
 	assert(config->instances[0].numa_idx == UINT16_MAX);
 	assert(config->instances[0].dp_memory == UINT64_MAX);
@@ -96,6 +99,40 @@ test_numeric_field_maximum_values(void) {
 	assert(config->devices[0].workers[0].num_mbufs == UINT32_MAX);
 
 	dataplane_config_free(config);
+}
+
+static void
+test_packet_recirc_limit_default_and_bounds(void) {
+	const char *yamls[] = {
+		"dataplane: {}\n",
+		"dataplane:\n  packet_recirc_limit: 4\n",
+		"dataplane:\n  packet_recirc_limit: 256\n",
+		"dataplane:\n  packet_recirc_limit: 37\n",
+	};
+	const uint16_t expected[] = {
+		PACKET_RECIRC_LIMIT_DEFAULT,
+		PACKET_RECIRC_LIMIT_MIN,
+		PACKET_RECIRC_LIMIT_MAX,
+		37,
+	};
+
+	for (size_t idx = 0; idx < sizeof(yamls) / sizeof(yamls[0]); ++idx) {
+		struct dataplane_config *config = NULL;
+		assert(parse_yaml(yamls[idx], &config) == 0);
+		assert(config->packet_recirc_limit == expected[idx]);
+		dataplane_config_free(config);
+	}
+
+	const char *invalid[] = {
+		"dataplane:\n  packet_recirc_limit: 3\n",
+		"dataplane:\n  packet_recirc_limit: 257\n",
+	};
+	for (size_t idx = 0; idx < sizeof(invalid) / sizeof(invalid[0]);
+	     ++idx) {
+		struct dataplane_config *config = NULL;
+		assert(parse_yaml(invalid[idx], &config) == -1);
+		assert(config == NULL);
+	}
 }
 
 static void
@@ -206,6 +243,7 @@ test_valid_config(void) {
 	int rc = dataplane_config_init(f, &config);
 	assert(rc == 0);
 
+	assert(config->packet_recirc_limit == 37);
 	assert(config->instance_count == 3);
 	check_instance(config->instances, 0, 1024, 2048);
 	check_instance(config->instances + 1, 1, 512, 128);
@@ -229,6 +267,7 @@ main(int argc, char **argv) {
 
 	test_valid_config();
 	test_numeric_field_maximum_values();
+	test_packet_recirc_limit_default_and_bounds();
 	test_numeric_field_ranges();
 	test_resolve_connections_unknown_device();
 	test_resolve_connections_duplicate_device();

--- a/devices/trafgen/dataplane/dataplane.c
+++ b/devices/trafgen/dataplane/dataplane.c
@@ -1,7 +1,6 @@
 #include "dataplane.h"
 
 #include <stdint.h>
-#include <string.h>
 
 #include "config.h"
 
@@ -64,8 +63,6 @@ trafgen_emit_frame(
 	}
 	rte_memcpy(data, frames + offsets[frame_idx], len);
 
-	memset(packet, 0, sizeof(*packet));
-	packet->mbuf = mbuf;
 	packet->rx_device_id = dp_worker->device_id;
 	packet->tx_device_id = dp_worker->device_id;
 

--- a/devices/trafgen/dataplane/dataplane.c
+++ b/devices/trafgen/dataplane/dataplane.c
@@ -50,6 +50,9 @@ trafgen_emit_frame(
 		return 1;
 	}
 
+	// worker_packet_alloc returns zero-initialised packet metadata, so the
+	// caller's only obligations are setting the device ids and parsing the
+	// packet.
 	struct packet *packet = worker_packet_alloc(dp_worker);
 	if (packet == NULL) {
 		return -1;

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -244,6 +244,19 @@ cp_device_init(
 		goto err_out;
 	}
 
+	input->counter_packet_recirc_drop = counter_registry_register(
+		&self->counter_registry, "input_recirc_drop", 2, err
+	);
+	if (input->counter_packet_recirc_drop == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'input_recirc_drop' counter for "
+			"device '%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
 	input->counter_packet_pending_input = counter_registry_register(
 		&self->counter_registry, "input_pending_input", 2, err
 	);
@@ -317,6 +330,19 @@ cp_device_init(
 			err,
 			"failed to register 'output_drop' counter for device "
 			"'%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
+	output->counter_packet_recirc_drop = counter_registry_register(
+		&self->counter_registry, "output_recirc_drop", 2, err
+	);
+	if (output->counter_packet_recirc_drop == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'output_recirc_drop' counter for "
+			"device '%s'",
 			cfg->name
 		);
 		goto err_out;

--- a/lib/controlplane/config/cp_device.h
+++ b/lib/controlplane/config/cp_device.h
@@ -23,6 +23,7 @@ struct cp_device_entry {
 	uint64_t counter_packet_entry;
 	uint64_t counter_packet_tx;
 	uint64_t counter_packet_drop;
+	uint64_t counter_packet_recirc_drop;
 	uint64_t counter_packet_pending_input;
 	uint64_t counter_packet_pending_output;
 	uint64_t pipeline_count;

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -111,6 +111,7 @@ module_ectx_create(
 	SET_OFFSET_OF(&module_ectx->cp_module, cp_module);
 
 	SET_OFFSET_OF(&module_ectx->config_gen_ectx, config_gen_ectx);
+	module_ectx->packet_recirc_limit = dp_config->packet_recirc_limit;
 
 	struct dp_module *dp_module =
 		ADDR_OF(&dp_config->dp_modules) + cp_module->dp_module_idx;
@@ -1127,6 +1128,13 @@ device_entry_ectx_create(
 		&device_entry_ectx->counter_packet_drop,
 		counter_get_value_handle(
 			cp_device_entry->counter_packet_drop, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&device_entry_ectx->counter_packet_recirc_drop,
+		counter_get_value_handle(
+			cp_device_entry->counter_packet_recirc_drop,
+			counter_storage
 		)
 	);
 	SET_OFFSET_OF(

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "lib/counters/counters.h"
+#include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/pipeline/econtext.h"
 
 #include "lib/errors/errors.h"
@@ -27,13 +29,32 @@ config_gen_ectx_get_object(
 	return ADDR_OF(objects + index);
 }
 
+// Count a packet dropped after exhausting its device recirculation budget.
+//
+// Counter slot 0 stores packets. Slot 1 stores the full packet length across
+// all chained mbufs, unlike the first-segment byte tallies on packet fronts.
+static inline void
+device_entry_ectx_count_recirc_drop(
+	struct device_entry_ectx *entry_ectx, const struct packet *packet
+) {
+	uint64_t *counter = counter_handle_get_value(
+		ADDR_OF_NONNULL(&entry_ectx->counter_packet_recirc_drop)
+	);
+	counter[0] += 1;
+	counter[1] += rte_pktmbuf_pkt_len(packet_to_mbuf(packet));
+}
+
 // Route a packet to its target device's input entry, counting it as
 // pending_input on the originating schedule.
 //
 // The packet lands on the target device entry's schedule input so the next
 // round picks it up. When the target device is absent from this generation
 // the packet is dropped on the originating schedule instead of being
-// stranded. packet->tx_device_id must already name the destination.
+// stranded. Input and output routes share the packet lineage budget; an
+// exhausted budget drops on the originating schedule and increments the target
+// entry's input_recirc_drop counter. packet->tx_device_id names the
+// destination. The pending counters count every route attempt, including
+// dropped packets.
 static inline void
 module_ectx_route_input(
 	struct module_ectx *module_ectx,
@@ -52,9 +73,16 @@ module_ectx_route_input(
 		packet_front_drop(packet_front, packet);
 		return;
 	}
-	packet_front_input(
-		&ADDR_OF(&device_ectx->input_pipelines)->schedule, packet
-	);
+	struct device_entry_ectx *entry_ectx =
+		ADDR_OF(&device_ectx->input_pipelines);
+	if (!packet_recirc_try_redirect(
+		    packet, module_ectx->packet_recirc_limit
+	    )) {
+		device_entry_ectx_count_recirc_drop(entry_ectx, packet);
+		packet_front_drop(packet_front, packet);
+		return;
+	}
+	packet_front_input(&entry_ectx->schedule, packet);
 }
 
 // Route a packet to its target device's output entry, counting it as
@@ -63,7 +91,10 @@ module_ectx_route_input(
 // Symmetric to module_ectx_route_input: the packet is placed on the target
 // device's output-pipelines schedule, or dropped on the originating schedule
 // when the device is gone. packet->tx_device_id must already name the
-// destination.
+// destination. Input and output routes share the packet lineage budget; an
+// exhausted budget drops on the originating schedule and increments the target
+// entry's output_recirc_drop counter. The pending counters count every route
+// attempt, including dropped packets.
 static inline void
 module_ectx_route_output(
 	struct module_ectx *module_ectx,
@@ -82,9 +113,16 @@ module_ectx_route_output(
 		packet_front_drop(packet_front, packet);
 		return;
 	}
-	packet_front_input(
-		&ADDR_OF(&device_ectx->output_pipelines)->schedule, packet
-	);
+	struct device_entry_ectx *entry_ectx =
+		ADDR_OF(&device_ectx->output_pipelines);
+	if (!packet_recirc_try_redirect(
+		    packet, module_ectx->packet_recirc_limit
+	    )) {
+		device_entry_ectx_count_recirc_drop(entry_ectx, packet);
+		packet_front_drop(packet_front, packet);
+		return;
+	}
+	packet_front_input(&entry_ectx->schedule, packet);
 }
 
 // Build one execution context per worker.

--- a/lib/dataplane/config/bootstrap.c
+++ b/lib/dataplane/config/bootstrap.c
@@ -4,6 +4,7 @@
 #include "common/memory_address.h"
 #include "lib/controlplane/config/zone.h"
 #include "lib/dataplane/config/zone.h"
+#include "lib/dataplane/packet/packet.h"
 
 int
 dp_storage_init(
@@ -19,6 +20,7 @@ dp_storage_init(
 
 	dp_config->numa_idx = numa_idx;
 	dp_config->instance_idx = instance_idx;
+	dp_config->packet_recirc_limit = PACKET_RECIRC_LIMIT_DEFAULT;
 	dp_config->storage_size = dp_memory + cp_memory;
 
 	block_allocator_init(&dp_config->block_allocator);

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -28,7 +28,7 @@ _Static_assert(
 	"struct dp_config size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct packet) == 48,
+	sizeof(struct packet) == 56,
 	"struct packet size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
@@ -40,8 +40,12 @@ _Static_assert(
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct module_ectx) == 136,
+	sizeof(struct module_ectx) == 144,
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
+);
+_Static_assert(
+	sizeof(struct device_entry_ectx) == 216,
+	"struct device_entry_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
 	sizeof(struct config_gen_ectx) == 176,

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -117,6 +117,7 @@ struct dp_config {
 	 * Use it to attach workers
 	 */
 	uint32_t numa_idx;
+	uint16_t packet_recirc_limit;
 
 	uint64_t storage_size;
 

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 19
+#define YANET_MODULE_ABI_VERSION 20
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/packet/decap.c
+++ b/lib/dataplane/packet/decap.c
@@ -102,7 +102,6 @@ packet_decap(struct packet *packet) {
 	// And transport_header meta
 	packet->transport_header.type = next_transport;
 	packet->transport_header.offset = next_offset - tun_hdrs_size;
-	packet_recirc_mark_progress(packet);
 
 	return 0;
 }

--- a/lib/dataplane/packet/decap.c
+++ b/lib/dataplane/packet/decap.c
@@ -102,6 +102,7 @@ packet_decap(struct packet *packet) {
 	// And transport_header meta
 	packet->transport_header.type = next_transport;
 	packet->transport_header.offset = next_offset - tun_hdrs_size;
+	packet_recirc_mark_progress(packet);
 
 	return 0;
 }

--- a/lib/dataplane/packet/packet.h
+++ b/lib/dataplane/packet/packet.h
@@ -6,8 +6,7 @@
 
 #define PACKET_HEADER_TYPE_UNKNOWN 0
 
-#define PACKET_RECIRC_STALL_LIMIT UINT8_C(4)
-#define PACKET_RECIRC_LIMIT_DEFAULT UINT16_C(16)
+#define PACKET_RECIRC_LIMIT_DEFAULT UINT16_C(64)
 #define PACKET_RECIRC_LIMIT_MIN UINT16_C(4)
 #define PACKET_RECIRC_LIMIT_MAX UINT16_C(256)
 
@@ -48,8 +47,8 @@ struct packet {
 	uint16_t flags;
 	uint16_t vlan;
 
-	uint16_t recirc_total_count;
-	uint8_t recirc_stall_count;
+	uint16_t recirc_remaining;
+	uint8_t recirc_initialized;
 
 	uint32_t flow_label; // 12 unused bits + 20 bits of the label
 
@@ -63,30 +62,29 @@ struct packet {
 	struct transport_header transport_header;
 };
 
-// Consume one redirect from the packet's stall and lineage budgets.
+// Initialize a packet lineage's redirect credits once.
 
-// Returns false when either budget is exhausted and leaves both counters
-// unchanged in that case.
+// Initialization is lazy because packets enter a pipeline before its module
+// execution context supplies the configured limit.
+static inline void
+packet_recirc_init(struct packet *packet, uint16_t limit) {
+	if (!packet->recirc_initialized) {
+		packet->recirc_remaining = limit;
+		packet->recirc_initialized = 1;
+	}
+}
+
+// Consume one redirect from the packet lineage's assigned credits.
 static inline bool
 packet_recirc_try_redirect(struct packet *packet, uint16_t limit) {
-	if (packet->recirc_total_count >= limit ||
-	    packet->recirc_stall_count >= PACKET_RECIRC_STALL_LIMIT) {
+	packet_recirc_init(packet, limit);
+
+	if (packet->recirc_remaining == 0) {
 		return false;
 	}
 
-	packet->recirc_total_count += 1;
-	packet->recirc_stall_count += 1;
+	packet->recirc_remaining -= 1;
 	return true;
-}
-
-// Mark an irreversible packet-layer removal as recirculation progress.
-
-// Callers must invoke this only after the packet bytes and parse metadata have
-// been updated successfully. It renews the stall allowance but never the
-// packet lineage budget.
-static inline void
-packet_recirc_mark_progress(struct packet *packet) {
-	packet->recirc_stall_count = 0;
 }
 
 struct packet_list {

--- a/lib/dataplane/packet/packet.h
+++ b/lib/dataplane/packet/packet.h
@@ -1,9 +1,15 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 
 #define PACKET_HEADER_TYPE_UNKNOWN 0
+
+#define PACKET_RECIRC_STALL_LIMIT UINT8_C(4)
+#define PACKET_RECIRC_LIMIT_DEFAULT UINT16_C(16)
+#define PACKET_RECIRC_LIMIT_MIN UINT16_C(4)
+#define PACKET_RECIRC_LIMIT_MAX UINT16_C(256)
 
 enum packet_flag {
 	PACKET_FLAG_FRAGMENTED,
@@ -42,6 +48,9 @@ struct packet {
 	uint16_t flags;
 	uint16_t vlan;
 
+	uint16_t recirc_total_count;
+	uint8_t recirc_stall_count;
+
 	uint32_t flow_label; // 12 unused bits + 20 bits of the label
 
 	uint16_t fragment_offset;
@@ -53,6 +62,32 @@ struct packet {
 	struct network_header network_header;
 	struct transport_header transport_header;
 };
+
+// Consume one redirect from the packet's stall and lineage budgets.
+
+// Returns false when either budget is exhausted and leaves both counters
+// unchanged in that case.
+static inline bool
+packet_recirc_try_redirect(struct packet *packet, uint16_t limit) {
+	if (packet->recirc_total_count >= limit ||
+	    packet->recirc_stall_count >= PACKET_RECIRC_STALL_LIMIT) {
+		return false;
+	}
+
+	packet->recirc_total_count += 1;
+	packet->recirc_stall_count += 1;
+	return true;
+}
+
+// Mark an irreversible packet-layer removal as recirculation progress.
+
+// Callers must invoke this only after the packet bytes and parse metadata have
+// been updated successfully. It renews the stall allowance but never the
+// packet lineage budget.
+static inline void
+packet_recirc_mark_progress(struct packet *packet) {
+	packet->recirc_stall_count = 0;
+}
 
 struct packet_list {
 	struct packet *first;

--- a/lib/dataplane/packet/packet.h
+++ b/lib/dataplane/packet/packet.h
@@ -62,10 +62,12 @@ struct packet {
 	struct transport_header transport_header;
 };
 
-// Initialize a packet lineage's redirect credits once.
-
-// Initialization is lazy because packets enter a pipeline before its module
-// execution context supplies the configured limit.
+// Initialize a packet lineage's redirect credits once. Lazy because packets
+// enter a pipeline before its module execution context supplies the configured
+// limit, and the field is treated as "full budget" by every reader until the
+// first explicit consumption. Callers must invoke this before the first
+// redirect consumption on a freshly allocated packet, including after a
+// successful clone.
 static inline void
 packet_recirc_init(struct packet *packet, uint16_t limit) {
 	if (!packet->recirc_initialized) {

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -40,6 +40,7 @@ struct module_ectx {
 	uint64_t runtime_counter_storage_count;
 	struct counter_storage **runtime_counter_storages;
 	struct config_gen_ectx *config_gen_ectx;
+	uint16_t packet_recirc_limit;
 
 	uint64_t mc_index_size;
 	uint64_t *mc_index;
@@ -147,17 +148,17 @@ struct device_entry_ectx {
 	struct counter_value_handle *counter_packet_entry;
 	struct counter_value_handle *counter_packet_tx;
 	struct counter_value_handle *counter_packet_drop;
+	struct counter_value_handle *counter_packet_recirc_drop;
 	struct counter_value_handle *counter_packet_pending_input;
 	struct counter_value_handle *counter_packet_pending_output;
 	uint64_t pipeline_count;
 	struct pipeline_ectx **pipelines;
 	uint64_t pipeline_map_size;
-	// Per-entry scratch front the worker round demuxes traffic into.
+	// Per-entry inbox for packets awaiting processing.
 	//
-	// The round pops pending input/output for this device's entry point
-	// into this front, runs the entry, then merges the result back and
-	// leaves the front empty, so it is reused in place across rounds
-	// instead of being reinitialized on the stack every iteration.
+	// The worker detaches each batch before invoking the entry, so packets
+	// routed back here during processing remain queued for the next
+	// traversal.
 	struct packet_front schedule;
 	uint64_t pipeline_map[];
 };

--- a/lib/dataplane/worker/pipeline_round.c
+++ b/lib/dataplane/worker/pipeline_round.c
@@ -78,8 +78,13 @@ worker_pipeline_round(
 				continue;
 			}
 
+			// Detach the batch so redirects land in the reusable
+			// inbox.
+			struct packet_front active = *schedule;
+			packet_front_init(schedule);
+
 			device_ectx_process_input(
-				dp_worker, device_ectx, schedule
+				dp_worker, device_ectx, &active
 			);
 
 			/*
@@ -88,9 +93,9 @@ worker_pipeline_round(
 			 * The only chance for a packet to survive is being
 			 * routed into a device entry by a module.
 			 */
-			packet_front_drop_output(schedule);
+			packet_front_drop_output(&active);
 
-			packet_front_merge(packet_front, schedule);
+			packet_front_merge(packet_front, &active);
 		}
 
 		for (uint64_t idx = 0; idx < device_count; ++idx) {
@@ -111,11 +116,16 @@ worker_pipeline_round(
 				continue;
 			}
 
+			// Detach the batch so redirects land in the reusable
+			// inbox.
+			struct packet_front active = *schedule;
+			packet_front_init(schedule);
+
 			device_ectx_process_output(
-				dp_worker, device_ectx, schedule
+				dp_worker, device_ectx, &active
 			);
 
-			packet_front_merge(packet_front, schedule);
+			packet_front_merge(packet_front, &active);
 		}
 
 		force_poll = 0;

--- a/lib/dataplane/worker/worker.c
+++ b/lib/dataplane/worker/worker.c
@@ -35,9 +35,9 @@ worker_clone_packet(
 	struct packet *packet_clone = mbuf_to_packet(mbuf);
 	// Order is load-bearing: init the source budget first (no-op when the
 	// lineage is already initialized, so an already-spent source splits its
-	// remainder), snapshot into the clone, then partition floor/ceil. A swap
-	// of init and memcpy would copy uninitialized fields and re-init the
-	// clone to the full limit on its first redirect.
+	// remainder), snapshot into the clone, then partition floor/ceil. A
+	// swap of init and memcpy would copy uninitialized fields and re-init
+	// the clone to the full limit on its first redirect.
 	packet_recirc_init(packet, packet_recirc_limit);
 	rte_memcpy(packet_clone, packet, sizeof(struct packet));
 	packet_clone->mbuf = mbuf;

--- a/lib/dataplane/worker/worker.c
+++ b/lib/dataplane/worker/worker.c
@@ -32,9 +32,8 @@ worker_clone_packet(
 		return NULL;
 	}
 
-	packet_recirc_init(packet, packet_recirc_limit);
-
 	struct packet *packet_clone = mbuf_to_packet(mbuf);
+	packet_recirc_init(packet, packet_recirc_limit);
 	rte_memcpy(packet_clone, packet, sizeof(struct packet));
 	packet_clone->mbuf = mbuf;
 	packet_clone->next = NULL;

--- a/lib/dataplane/worker/worker.c
+++ b/lib/dataplane/worker/worker.c
@@ -3,6 +3,8 @@
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/packet/packet.h"
 
+#include <string.h>
+
 struct packet *
 worker_packet_alloc(struct dp_worker *dp_worker) {
 	struct rte_mbuf *mbuf = rte_pktmbuf_alloc(dp_worker->rx_mempool);
@@ -11,6 +13,7 @@ worker_packet_alloc(struct dp_worker *dp_worker) {
 	}
 
 	struct packet *packet = mbuf_to_packet(mbuf);
+	memset(packet, 0, sizeof(*packet));
 	packet->mbuf = mbuf;
 
 	return packet;

--- a/lib/dataplane/worker/worker.c
+++ b/lib/dataplane/worker/worker.c
@@ -20,7 +20,11 @@ worker_packet_alloc(struct dp_worker *dp_worker) {
 }
 
 struct packet *
-worker_clone_packet(struct dp_worker *dp_worker, struct packet *packet) {
+worker_clone_packet(
+	struct dp_worker *dp_worker,
+	struct packet *packet,
+	uint16_t packet_recirc_limit
+) {
 	struct rte_mbuf *mbuf = rte_pktmbuf_copy(
 		packet->mbuf, dp_worker->rx_mempool, 0, UINT32_MAX
 	);
@@ -28,10 +32,14 @@ worker_clone_packet(struct dp_worker *dp_worker, struct packet *packet) {
 		return NULL;
 	}
 
+	packet_recirc_init(packet, packet_recirc_limit);
+
 	struct packet *packet_clone = mbuf_to_packet(mbuf);
 	rte_memcpy(packet_clone, packet, sizeof(struct packet));
 	packet_clone->mbuf = mbuf;
 	packet_clone->next = NULL;
+	packet_clone->recirc_remaining = packet->recirc_remaining / 2;
+	packet->recirc_remaining -= packet_clone->recirc_remaining;
 
 	packet_refresh_data_len(packet_clone);
 	return packet_clone;

--- a/lib/dataplane/worker/worker.c
+++ b/lib/dataplane/worker/worker.c
@@ -33,6 +33,11 @@ worker_clone_packet(
 	}
 
 	struct packet *packet_clone = mbuf_to_packet(mbuf);
+	// Order is load-bearing: init the source budget first (no-op when the
+	// lineage is already initialized, so an already-spent source splits its
+	// remainder), snapshot into the clone, then partition floor/ceil. A swap
+	// of init and memcpy would copy uninitialized fields and re-init the
+	// clone to the full limit on its first redirect.
 	packet_recirc_init(packet, packet_recirc_limit);
 	rte_memcpy(packet_clone, packet, sizeof(struct packet));
 	packet_clone->mbuf = mbuf;

--- a/lib/dataplane/worker/worker.h
+++ b/lib/dataplane/worker/worker.h
@@ -5,12 +5,16 @@
 struct packet *
 worker_packet_alloc(struct dp_worker *worker);
 
-// Deep-copy a packet and its current recirculation counters.
+// Deep-copy a packet and partition its remaining recirculation credits.
 //
-// The clone spends its copied budget independently; no aggregate counter is
-// shared with the source packet.
+// The source keeps the odd credit so best-effort mirroring cannot consume it.
+// Allocation failure leaves the source packet unchanged.
 struct packet *
-worker_clone_packet(struct dp_worker *dp_worker, struct packet *packet);
+worker_clone_packet(
+	struct dp_worker *dp_worker,
+	struct packet *packet,
+	uint16_t packet_recirc_limit
+);
 
 void
 worker_packet_free(struct packet *packet);

--- a/lib/dataplane/worker/worker.h
+++ b/lib/dataplane/worker/worker.h
@@ -5,6 +5,10 @@
 struct packet *
 worker_packet_alloc(struct dp_worker *worker);
 
+// Deep-copy a packet and its current recirculation counters.
+//
+// The clone spends its copied budget independently; no aggregate counter is
+// shared with the source packet.
 struct packet *
 worker_clone_packet(struct dp_worker *dp_worker, struct packet *packet);
 

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -551,13 +551,43 @@ struct saved_packet {
 	uint16_t first_data_len;
 };
 
+static bool
+saved_packet_contains(
+	const struct saved_packet *saved,
+	size_t count,
+	const struct packet *packet
+) {
+	for (size_t idx = 0; idx < count; ++idx) {
+		if (saved[idx].pkt == packet) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static void
+saved_packet_list_free_extra(
+	struct packet_list *list, const struct saved_packet *saved, size_t count
+) {
+	struct packet *packet;
+	while ((packet = packet_list_pop(list)) != NULL) {
+		if (saved_packet_contains(saved, count, packet)) {
+			continue;
+		}
+
+		struct rte_mbuf *mbuf = packet_to_mbuf(packet);
+		if (mbuf->pool != NULL) {
+			rte_pktmbuf_free(mbuf);
+		} else {
+			free_packet(packet);
+		}
+	}
+}
+
 static int
 saved_packet_restore(struct saved_packet *saved) {
 	*saved->pkt = saved->state;
 	saved->pkt->next = NULL;
-	if (saved->data == NULL) {
-		return 0;
-	}
 
 	struct rte_mbuf *mbuf = packet_to_mbuf(saved->pkt);
 	if (rte_pktmbuf_pkt_len(mbuf) != saved->data_len ||
@@ -565,6 +595,9 @@ saved_packet_restore(struct saved_packet *saved) {
 	    mbuf->data_off != saved->first_data_off ||
 	    mbuf->data_len != saved->first_data_len) {
 		return -EINVAL;
+	}
+	if (saved->data == NULL) {
+		return 0;
 	}
 
 	uint32_t offset = 0;
@@ -625,12 +658,12 @@ dataplane_ut_run_rounds(
 		saved[idx].pkt = pkt;
 		saved[idx].state = *pkt;
 		snapshot_count = idx + 1;
+		struct rte_mbuf *mbuf = packet_to_mbuf(pkt);
+		saved[idx].data_len = rte_pktmbuf_pkt_len(mbuf);
+		saved[idx].segment_count = mbuf->nb_segs;
+		saved[idx].first_data_off = mbuf->data_off;
+		saved[idx].first_data_len = mbuf->data_len;
 		if (reset_payload) {
-			struct rte_mbuf *mbuf = packet_to_mbuf(pkt);
-			saved[idx].data_len = rte_pktmbuf_pkt_len(mbuf);
-			saved[idx].segment_count = mbuf->nb_segs;
-			saved[idx].first_data_off = mbuf->data_off;
-			saved[idx].first_data_len = mbuf->data_len;
 			saved[idx].data = malloc(saved[idx].data_len);
 			if (saved[idx].data == NULL) {
 				result = -ENOMEM;
@@ -659,9 +692,9 @@ dataplane_ut_run_rounds(
 	}
 	captured = 1;
 
-	// Assumes a fixed packet set: handlers forward or drop without
-	// allocating, freeing, or replicating packets. dataplane_ut_run does
-	// not free dropped packets, so saved[idx].pkt stays valid every round.
+	// The saved packet set must remain allocated and each round must return
+	// every saved packet through output or drop. Newly emitted packets are
+	// reclaimed below.
 	for (uint64_t round = 0; round < rounds; ++round) {
 		result = saved_packets_rebuild(saved, count, input);
 		if (result != 0) {
@@ -670,6 +703,10 @@ dataplane_ut_run_rounds(
 
 		struct dataplane_ut_round_result round_result;
 		dataplane_ut_run(ut, worker, input, &round_result);
+		saved_packet_list_free_extra(
+			&round_result.output, saved, count
+		);
+		saved_packet_list_free_extra(&round_result.drop, saved, count);
 	}
 
 	// Leave input holding all packets so the caller can free them.

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -6,6 +6,7 @@
 #define DATAPLANE_UT_HIGH_GEN 1000000000000000ULL
 
 #include <dlfcn.h>
+#include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -33,6 +34,7 @@
 #include "lib/dataplane_ut/mempool.h"
 #include "lib/errors/errors.h"
 #include "lib/logging/log.h"
+#include "lib/utils/packet.h"
 
 struct dataplane_ut {
 	void *arena;
@@ -62,6 +64,16 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 	}
 	if (cfg->worker_count < 1) {
 		LOG(ERROR, "dataplane_ut_new: worker_count must be at least 1");
+		return NULL;
+	}
+	if (cfg->packet_recirc_limit != 0 &&
+	    (cfg->packet_recirc_limit < PACKET_RECIRC_LIMIT_MIN ||
+	     cfg->packet_recirc_limit > PACKET_RECIRC_LIMIT_MAX)) {
+		LOG(ERROR,
+		    "dataplane_ut_new: packet_recirc_limit must be zero or in "
+		    "range %u..%u",
+		    (unsigned)PACKET_RECIRC_LIMIT_MIN,
+		    (unsigned)PACKET_RECIRC_LIMIT_MAX);
 		return NULL;
 	}
 
@@ -104,6 +116,9 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 
 	// Set instance_count — dp_storage_init leaves it at zero.
 	ut->dp_config->instance_count = 1;
+	ut->dp_config->packet_recirc_limit =
+		cfg->packet_recirc_limit == 0 ? PACKET_RECIRC_LIMIT_DEFAULT
+					      : cfg->packet_recirc_limit;
 
 	// Open the current binary so dlsym can resolve module/device symbols.
 	void *bin_hndl = dlopen(NULL, RTLD_NOW | RTLD_GLOBAL);
@@ -422,6 +437,30 @@ dataplane_ut_alloc_mbuf(struct dataplane_ut *ut) {
 	return rte_pktmbuf_alloc(ut->mempool);
 }
 
+static void
+dataplane_ut_packet_list_free(struct packet_list *list) {
+	struct packet *packet;
+	while ((packet = packet_list_pop(list)) != NULL) {
+		struct rte_mbuf *mbuf = packet_to_mbuf(packet);
+		if (mbuf->pool != NULL) {
+			rte_pktmbuf_free(mbuf);
+		} else {
+			free_packet(packet);
+		}
+	}
+}
+
+void
+dataplane_ut_round_result_free(struct dataplane_ut_round_result *result) {
+	dataplane_ut_packet_list_free(&result->output);
+	dataplane_ut_packet_list_free(&result->drop);
+}
+
+size_t
+dataplane_ut_mempool_outstanding(struct dataplane_ut *ut) {
+	return test_mempool_outstanding(ut->mempool);
+}
+
 void
 dataplane_ut_run(
 	struct dataplane_ut *ut,
@@ -501,19 +540,64 @@ dataplane_ut_run(
 	packet_list_concat(&result->drop, &packet_front.drop);
 }
 
-// Saved per-packet state used by dataplane_ut_run_rounds to reset each
-// packet before re-queuing it for the next round.
+// Saved per-packet state used by dataplane_ut_run_rounds.
 struct saved_packet {
 	struct packet *pkt;
-	uint16_t tx_device_id;
-	uint16_t rx_device_id;
-	// Payload snapshot (all segments) restored between rounds when
-	// requested, so header-mutating modules see fresh input every round.
+	struct packet state;
 	uint8_t *data;
 	uint32_t data_len;
+	uint16_t segment_count;
+	uint16_t first_data_off;
+	uint16_t first_data_len;
 };
 
-void
+static int
+saved_packet_restore(struct saved_packet *saved) {
+	*saved->pkt = saved->state;
+	saved->pkt->next = NULL;
+	if (saved->data == NULL) {
+		return 0;
+	}
+
+	struct rte_mbuf *mbuf = packet_to_mbuf(saved->pkt);
+	if (rte_pktmbuf_pkt_len(mbuf) != saved->data_len ||
+	    mbuf->nb_segs != saved->segment_count ||
+	    mbuf->data_off != saved->first_data_off ||
+	    mbuf->data_len != saved->first_data_len) {
+		return -EINVAL;
+	}
+
+	uint32_t offset = 0;
+	for (struct rte_mbuf *segment = mbuf; segment != NULL;
+	     segment = segment->next) {
+		if (segment->data_len > saved->data_len - offset) {
+			return -EINVAL;
+		}
+		memcpy(rte_pktmbuf_mtod(segment, void *),
+		       saved->data + offset,
+		       segment->data_len);
+		offset += segment->data_len;
+	}
+	return offset == saved->data_len ? 0 : -EINVAL;
+}
+
+static int
+saved_packets_rebuild(
+	struct saved_packet *saved, size_t count, struct packet_list *input
+) {
+	packet_list_init(input);
+	int result = 0;
+	for (size_t idx = 0; idx < count; ++idx) {
+		int rc = saved_packet_restore(&saved[idx]);
+		if (result == 0 && rc != 0) {
+			result = rc;
+		}
+		packet_list_add(input, saved[idx].pkt);
+	}
+	return result;
+}
+
+int
 dataplane_ut_run_rounds(
 	struct dataplane_ut *ut,
 	size_t worker,
@@ -523,84 +607,85 @@ dataplane_ut_run_rounds(
 ) {
 	size_t count = (size_t)packet_list_count(input);
 	if (rounds == 0 || count == 0) {
-		return;
+		return 0;
 	}
 
-	struct saved_packet *saved =
-		malloc(count * sizeof(struct saved_packet));
+	struct saved_packet *saved = calloc(count, sizeof(struct saved_packet));
 	if (saved == NULL) {
-		return;
+		return -ENOMEM;
 	}
 
-	// Pop every packet out of input and record its initial routing state.
+	int result = 0;
+	int captured = 0;
+	size_t snapshot_count = 0;
+
+	// Capture before draining input so allocation failures leave it intact.
+	struct packet *pkt = packet_list_first(input);
 	for (size_t idx = 0; idx < count; ++idx) {
-		struct packet *pkt = packet_list_pop(input);
 		saved[idx].pkt = pkt;
-		saved[idx].tx_device_id = pkt->tx_device_id;
-		saved[idx].rx_device_id = pkt->rx_device_id;
-		saved[idx].data = NULL;
-		saved[idx].data_len = 0;
+		saved[idx].state = *pkt;
+		snapshot_count = idx + 1;
 		if (reset_payload) {
 			struct rte_mbuf *mbuf = packet_to_mbuf(pkt);
 			saved[idx].data_len = rte_pktmbuf_pkt_len(mbuf);
+			saved[idx].segment_count = mbuf->nb_segs;
+			saved[idx].first_data_off = mbuf->data_off;
+			saved[idx].first_data_len = mbuf->data_len;
 			saved[idx].data = malloc(saved[idx].data_len);
 			if (saved[idx].data == NULL) {
-				LOG(ERROR,
-				    "run_rounds: no memory for a payload "
-				    "snapshot; packet %zu runs without reset",
-				    idx);
-				continue;
+				result = -ENOMEM;
+				goto cleanup;
 			}
+
 			uint32_t offset = 0;
-			for (struct rte_mbuf *seg = mbuf; seg != NULL;
-			     seg = seg->next) {
+			for (struct rte_mbuf *segment = mbuf; segment != NULL;
+			     segment = segment->next) {
+				if (segment->data_len >
+				    saved[idx].data_len - offset) {
+					result = -EINVAL;
+					goto cleanup;
+				}
 				memcpy(saved[idx].data + offset,
-				       rte_pktmbuf_mtod(seg, void *),
-				       seg->data_len);
-				offset += seg->data_len;
+				       rte_pktmbuf_mtod(segment, void *),
+				       segment->data_len);
+				offset += segment->data_len;
+			}
+			if (offset != saved[idx].data_len) {
+				result = -EINVAL;
+				goto cleanup;
 			}
 		}
+		pkt = pkt->next;
 	}
+	captured = 1;
 
 	// Assumes a fixed packet set: handlers forward or drop without
 	// allocating, freeing, or replicating packets. dataplane_ut_run does
 	// not free dropped packets, so saved[idx].pkt stays valid every round.
-	for (uint64_t r = 0; r < rounds; ++r) {
-		// Rebuild input from the saved snapshot.
-		for (size_t idx = 0; idx < count; ++idx) {
-			struct packet *pkt = saved[idx].pkt;
-			pkt->next = NULL;
-			pkt->tx_device_id = saved[idx].tx_device_id;
-			pkt->rx_device_id = saved[idx].rx_device_id;
-			if (saved[idx].data != NULL) {
-				uint32_t offset = 0;
-				for (struct rte_mbuf *seg = packet_to_mbuf(pkt);
-				     seg != NULL;
-				     seg = seg->next) {
-					memcpy(rte_pktmbuf_mtod(seg, void *),
-					       saved[idx].data + offset,
-					       seg->data_len);
-					offset += seg->data_len;
-				}
-			}
-			packet_list_add(input, pkt);
+	for (uint64_t round = 0; round < rounds; ++round) {
+		result = saved_packets_rebuild(saved, count, input);
+		if (result != 0) {
+			break;
 		}
 
-		struct dataplane_ut_round_result result;
-		dataplane_ut_run(ut, worker, input, &result);
+		struct dataplane_ut_round_result round_result;
+		dataplane_ut_run(ut, worker, input, &round_result);
 	}
 
 	// Leave input holding all packets so the caller can free them.
-	for (size_t idx = 0; idx < count; ++idx) {
-		struct packet *pkt = saved[idx].pkt;
-		pkt->next = NULL;
-		pkt->tx_device_id = saved[idx].tx_device_id;
-		pkt->rx_device_id = saved[idx].rx_device_id;
-		packet_list_add(input, pkt);
+cleanup:
+	if (captured) {
+		int restore_result = saved_packets_rebuild(saved, count, input);
+		if (result == 0) {
+			result = restore_result;
+		}
+	}
+	for (size_t idx = 0; idx < snapshot_count; ++idx) {
 		free(saved[idx].data);
 	}
 
 	free(saved);
+	return result;
 }
 
 int

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -24,6 +24,8 @@ struct dataplane_ut_config {
 	size_t cp_memory;
 	size_t dp_memory;
 	size_t worker_count;
+	// Zero selects PACKET_RECIRC_LIMIT_DEFAULT.
+	uint16_t packet_recirc_limit;
 
 	const char *const *devices;
 	size_t device_count;
@@ -93,6 +95,14 @@ struct dataplane_ut_round_result {
 	struct packet_list drop;
 };
 
+// Release all mbufs owned by a completed round result.
+void
+dataplane_ut_round_result_free(struct dataplane_ut_round_result *result);
+
+// Return the number of mock-mempool mbufs currently owned by callers.
+size_t
+dataplane_ut_mempool_outstanding(struct dataplane_ut *ut);
+
 // Run one pipeline round on worker_idx with the given input.
 //
 // input is drained to empty on return; result->output and result->drop
@@ -120,12 +130,10 @@ dataplane_ut_build_optimized(void);
 // Run rounds pipeline rounds on worker, recycling the packets in input each
 // time without allocating or printing.
 //
-// Before the loop, every packet is popped from input and its initial
-// tx_device_id and rx_device_id are recorded. Each round rebuilds input from
-// those snapshot pointers, resets next/tx_device_id/rx_device_id on each
-// packet, and calls dataplane_ut_run. The per-round result is discarded —
-// dataplane_ut_run moves packet nodes without freeing them, so the snapshot
-// pointers remain valid for every subsequent round.
+// Before the loop, every packet and its metadata are snapshotted. Each round
+// rebuilds input from those snapshot pointers and calls dataplane_ut_run. The
+// per-round result is discarded — the run moves packet nodes without freeing
+// them, so the snapshot pointers remain valid for every subsequent round.
 //
 // After the loop, input is rebuilt from the snapshot so the caller's list
 // holds all packets in a consistent state for freeing. The snapshot array is
@@ -134,13 +142,13 @@ dataplane_ut_build_optimized(void);
 // When reset_payload is nonzero, each packet's payload bytes are also
 // snapshotted at capture and restored before every round, so modules that
 // rewrite headers in place (for example route decrementing TTL) see fresh
-// input each round. Only the bytes are restored: mbuf geometry and parse
-// metadata are not, so modules that grow, shrink, or re-slice packets stay
-// out of scope. A failed per-packet snapshot allocation leaves that packet
-// without payload reset.
+// input each round. Modules that grow, shrink, or re-slice packets stay out of
+// scope and cause the run to fail rather than restoring bytes into changed
+// mbuf geometry.
 //
-// Returns immediately (leaving input intact) when rounds == 0 or
-// input is empty. Returns immediately on malloc failure.
+// Returns 0 on success, -ENOMEM when a snapshot cannot be allocated, and
+// -EINVAL when a handler changes mbuf geometry. Allocation failures leave input
+// intact; every other return leaves it rebuilt from the fixed packet set.
 //
 // Caveat: this primitive assumes each round's handlers only forward or drop the
 // fixed packet set. A handler that allocates, frees, or replicates packets per
@@ -149,7 +157,7 @@ dataplane_ut_build_optimized(void);
 // packet_front_output) is held only by the discarded per-round result, not by
 // the snapshot, so it leaks one mbuf per round. Do not benchmark configurations
 // that emit or drop-free packets through this primitive.
-void
+int
 dataplane_ut_run_rounds(
 	struct dataplane_ut *ut,
 	size_t worker,

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -132,31 +132,25 @@ dataplane_ut_build_optimized(void);
 //
 // Before the loop, every packet and its metadata are snapshotted. Each round
 // rebuilds input from those snapshot pointers and calls dataplane_ut_run. The
-// per-round result is discarded — the run moves packet nodes without freeing
-// them, so the snapshot pointers remain valid for every subsequent round.
+// per-round result is discarded after newly emitted packets are reclaimed.
 //
 // After the loop, input is rebuilt from the snapshot so the caller's list
 // holds all packets in a consistent state for freeing. The snapshot array is
 // freed before returning.
 //
-// When reset_payload is nonzero, each packet's payload bytes are also
-// snapshotted at capture and restored before every round, so modules that
-// rewrite headers in place (for example route decrementing TTL) see fresh
-// input each round. Modules that grow, shrink, or re-slice packets stay out of
-// scope and cause the run to fail rather than restoring bytes into changed
-// mbuf geometry.
+// Mbuf geometry is snapshotted and validated before every round. When
+// reset_payload is nonzero, each packet's payload bytes are also snapshotted
+// and restored, so modules that rewrite headers in place (for example route
+// decrementing TTL) see fresh input each round. Modules that grow, shrink, or
+// re-slice packets stay out of scope and cause the run to fail.
 //
 // Returns 0 on success, -ENOMEM when a snapshot cannot be allocated, and
 // -EINVAL when a handler changes mbuf geometry. Allocation failures leave input
 // intact; every other return leaves it rebuilt from the fixed packet set.
 //
-// Caveat: this primitive assumes each round's handlers only forward or drop the
-// fixed packet set. A handler that allocates, frees, or replicates packets per
-// round breaks the recycling contract: any new mbuf emitted (for example the
-// fwstate state-sync path, which calls worker_packet_alloc +
-// packet_front_output) is held only by the discarded per-round result, not by
-// the snapshot, so it leaks one mbuf per round. Do not benchmark configurations
-// that emit or drop-free packets through this primitive.
+// Handlers must not free or replicate the fixed packet set. Any newly emitted
+// packet is reclaimed from the discarded per-round result before the next
+// round, but a freed snapshot packet cannot be restored.
 int
 dataplane_ut_run_rounds(
 	struct dataplane_ut *ut,

--- a/lib/dataplane_ut/mempool.h
+++ b/lib/dataplane_ut/mempool.h
@@ -33,12 +33,13 @@ test_pool_enqueue(struct rte_mempool *mp, void *const *obj_table, unsigned n) {
 
 static int
 test_pool_dequeue(struct rte_mempool *mp, void **obj_table, unsigned n) {
+	const size_t poison = ((const size_t *)mp->pool_data)[1];
 	for (unsigned idx = 0; idx < n; idx++) {
 		void *ptr = aligned_alloc(64, mp->header_size + mp->elt_size);
 		if (ptr == NULL) {
 			rte_panic("failed to allocate object");
 		}
-		memset(ptr, 0, mp->header_size + mp->elt_size);
+		memset(ptr, poison ? 0xA5 : 0, mp->header_size + mp->elt_size);
 
 		struct rte_mempool_objhdr *hdr =
 			(struct rte_mempool_objhdr
@@ -77,14 +78,14 @@ test_mempool_create(void) {
 	rte_mempool_ops_table.num_ops = 0;
 	rte_mempool_register_ops(&test_pool_ops);
 
-	// The outstanding-object counter lives right after the private data,
-	// inside this same allocation, so every caller's plain free(mp) stays
-	// correct instead of leaking a separately-allocated counter.
+	// The outstanding-object counter and poison flag live right after the
+	// private data, inside this same allocation, so every caller's plain
+	// free(mp) stays correct instead of leaking separately-allocated state.
 	size_t private_data_size = sizeof(struct rte_pktmbuf_pool_private);
 	struct rte_mempool *mp =
 		calloc(1,
 		       sizeof(struct rte_mempool) + private_data_size +
-			       sizeof(size_t));
+			       2 * sizeof(size_t));
 	mp->flags |= RTE_MEMPOOL_F_POOL_CREATED;
 	mp->socket_id = 0;
 	mp->cache_size = 0;
@@ -112,4 +113,10 @@ test_mempool_free(struct rte_mempool *mp) {
 static inline size_t
 test_mempool_outstanding(const struct rte_mempool *mp) {
 	return *(const size_t *)mp->pool_data;
+}
+
+// Fill newly dequeued objects with a poison pattern for allocator tests.
+static inline void
+test_mempool_poison(struct rte_mempool *mp, int enabled) {
+	((size_t *)mp->pool_data)[1] = (size_t)enabled;
 }

--- a/lib/dataplane_ut/meson.build
+++ b/lib/dataplane_ut/meson.build
@@ -7,6 +7,7 @@ dependencies = [
   lib_config_cp_dep,
   lib_agent_cp_dep,
   lib_worker_dp_dep,
+  lib_lib_utils_dep,
   libdpdk_inc_dep,
 ]
 

--- a/lib/dataplane_ut/tests/meson.build
+++ b/lib/dataplane_ut/tests/meson.build
@@ -1,18 +1,39 @@
+smoke_test_c_args = yanet_c_args
+smoke_test_dependencies = [
+  lib_dataplane_ut_dep,
+  lib_logging_dep,
+  libdpdk_dep,
+]
+smoke_test_link_with = [lib_dev_plain_dp]
+smoke_test_link_args = yanet_link_args + [
+  '-Wl,-E',
+  '-Wl,--undefined=new_device_plain',
+  '-Wl,--export-dynamic-symbol=new_device_plain',
+]
+
+if not dataplane_only
+  smoke_test_c_args += ['-DYANET_DATAPLANE_UT_CONTROLPLANE']
+  smoke_test_dependencies += [
+    lib_dev_plain_api,
+    lib_dscp_cp_dep,
+    lib_forward_cp_dep,
+  ]
+  smoke_test_link_with += [lib_dscp_dp, lib_forward_dp]
+  smoke_test_link_args += [
+    '-Wl,--undefined=new_module_dscp',
+    '-Wl,--export-dynamic-symbol=new_module_dscp',
+    '-Wl,--undefined=new_module_forward',
+    '-Wl,--export-dynamic-symbol=new_module_forward',
+  ]
+endif
+
 smoke_test = executable(
   'dataplane_ut_smoke_test',
   ['smoke_test.c'],
-  c_args: yanet_c_args,
-  link_args: yanet_link_args + [
-    '-Wl,-E',
-    '-Wl,--undefined=new_device_plain',
-    '-Wl,--export-dynamic-symbol=new_device_plain',
-  ],
-  dependencies: [
-    lib_dataplane_ut_dep,
-    lib_logging_dep,
-    libdpdk_dep,
-  ],
-  link_with: [lib_dev_plain_dp],
+  c_args: smoke_test_c_args,
+  link_args: smoke_test_link_args,
+  dependencies: smoke_test_dependencies,
+  link_with: smoke_test_link_with,
   include_directories: yanet_rootdir,
 )
 test('dataplane_ut_smoke', smoke_test, suite: 'dataplane_ut')

--- a/lib/dataplane_ut/tests/meson.build
+++ b/lib/dataplane_ut/tests/meson.build
@@ -15,11 +15,14 @@ if not dataplane_only
   smoke_test_c_args += ['-DYANET_DATAPLANE_UT_CONTROLPLANE']
   smoke_test_dependencies += [
     lib_dev_plain_api,
+    lib_decap_cp_dep,
     lib_dscp_cp_dep,
     lib_forward_cp_dep,
   ]
-  smoke_test_link_with += [lib_dscp_dp, lib_forward_dp]
+  smoke_test_link_with += [lib_decap_dp, lib_dscp_dp, lib_forward_dp]
   smoke_test_link_args += [
+    '-Wl,--undefined=new_module_decap',
+    '-Wl,--export-dynamic-symbol=new_module_decap',
     '-Wl,--undefined=new_module_dscp',
     '-Wl,--export-dynamic-symbol=new_module_dscp',
     '-Wl,--undefined=new_module_forward',

--- a/lib/dataplane_ut/tests/smoke_test.c
+++ b/lib/dataplane_ut/tests/smoke_test.c
@@ -407,8 +407,7 @@ run_rounds_geometry_mismatch_test(void) {
 	gre->proto = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
 	struct rte_ipv4_hdr *inner = (struct rte_ipv4_hdr *)(gre + 1);
 	inner->version_ihl = RTE_IPV4_VHL_DEF;
-	inner->total_length =
-		rte_cpu_to_be_16(sizeof(struct rte_ipv4_hdr));
+	inner->total_length = rte_cpu_to_be_16(sizeof(struct rte_ipv4_hdr));
 	inner->next_proto_id = IPPROTO_TCP;
 	TEST_ASSERT_SUCCESS(parse_packet(packet), "parse_packet failed");
 

--- a/lib/dataplane_ut/tests/smoke_test.c
+++ b/lib/dataplane_ut/tests/smoke_test.c
@@ -160,7 +160,7 @@ run_round_restore_test(void) {
 		"device update failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
-	cp_device_plain_free(device);
+	cp_device_plain_free(device, &err);
 
 	struct dp_config *dp_config = yanet_shm_dp_config(shm, 0);
 	struct dp_worker **workers = ADDR_OF(&dp_config->workers);

--- a/lib/dataplane_ut/tests/smoke_test.c
+++ b/lib/dataplane_ut/tests/smoke_test.c
@@ -5,8 +5,283 @@
 #include "lib/dataplane/config/zone.h"
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/dataplane_ut/mempool.h"
 
+#ifdef YANET_DATAPLANE_UT_CONTROLPLANE
+#include "common/strutils.h"
+#include "devices/plain/api/controlplane.h"
+#include "lib/controlplane/agent/agent.h"
+#include "lib/dataplane/packet/dscp.h"
+#include "modules/dscp/api/controlplane.h"
+#include "modules/forward/api/controlplane.h"
+#endif
+
+#ifdef YANET_DATAPLANE_UT_CONTROLPLANE
+#include <rte_ether.h>
+#include <rte_ip.h>
+#endif
 #include <rte_mbuf.h>
+
+#ifdef YANET_DATAPLANE_UT_CONTROLPLANE
+#include <string.h>
+#endif
+
+#ifdef YANET_DATAPLANE_UT_CONTROLPLANE
+// Verifies that run_rounds restores routing metadata and packet payload after
+// modules mutate both while a bounded self-loop runs on every round.
+static int
+run_round_restore_test(void) {
+	const char *port_names[] = {"dev0"};
+	const char *module_names[] = {"dscp", "forward"};
+	const char *devs_to_load[] = {"plain"};
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 25,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = module_names,
+		.module_count = 2,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+	};
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	TEST_ASSERT_NOT_NULL(ut, "dataplane_ut_new returned NULL");
+
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	TEST_ASSERT_NOT_NULL(shm, "dataplane_ut_shm returned NULL");
+	yanet_error *err = NULL;
+	struct agent *agent =
+		agent_attach(shm, 0, "smoke-round-restore", 8u << 20, &err);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct cp_module *dscp = dscp_module_config_new(agent, "mark", &err);
+	TEST_ASSERT_NOT_NULL(dscp, "dscp_module_config_new failed");
+	uint8_t first_addr[4] = {0, 0, 0, 0};
+	uint8_t last_addr[4] = {255, 255, 255, 255};
+	TEST_ASSERT_SUCCESS(
+		dscp_module_config_add_prefix_v4(dscp, first_addr, last_addr),
+		"dscp prefix setup failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		dscp_module_config_set_dscp_marking(dscp, DSCP_MARK_ALWAYS, 42),
+		"dscp marking setup failed"
+	);
+
+	struct cp_module *forward =
+		forward_module_config_init(agent, "loop", &err);
+	TEST_ASSERT_NOT_NULL(forward, "forward_module_config_init failed");
+	struct forward_rule forward_rule = {0};
+	strtcpy(forward_rule.target, "dev0", sizeof(forward_rule.target));
+	strtcpy(forward_rule.counter, "loop", sizeof(forward_rule.counter));
+	forward_rule.mode = FORWARD_MODE_IN;
+	TEST_ASSERT_SUCCESS(
+		forward_module_config_update(forward, &forward_rule, 1, &err),
+		"forward rule setup failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct cp_module *modules[] = {dscp, forward};
+	TEST_ASSERT_SUCCESS(
+		agent_update_modules(agent, 2, modules, &err),
+		"module update failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	const char *chain_types[] = {"dscp", "forward"};
+	const char *chain_names[] = {"mark", "loop"};
+	struct cp_chain_config *chain =
+		cp_chain_config_create("chain", 2, chain_types, chain_names);
+	TEST_ASSERT_NOT_NULL(chain, "cp_chain_config_create failed");
+	struct cp_function_config *function =
+		cp_function_config_create("function", 1);
+	TEST_ASSERT_NOT_NULL(function, "cp_function_config_create failed");
+	TEST_ASSERT_SUCCESS(
+		cp_function_config_set_chain(function, 0, chain, 1),
+		"cp_function_config_set_chain failed"
+	);
+	struct cp_function_config *functions[] = {function};
+	TEST_ASSERT_SUCCESS(
+		agent_update_functions(agent, 1, functions, &err),
+		"function update failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_function_config_free(function);
+
+	struct cp_pipeline_config *input_pipeline =
+		cp_pipeline_config_create("input", 1);
+	TEST_ASSERT_NOT_NULL(
+		input_pipeline, "input pipeline allocation failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_pipeline_config_set_function(input_pipeline, 0, "function"),
+		"input pipeline setup failed"
+	);
+	struct cp_pipeline_config *output_pipeline =
+		cp_pipeline_config_create("output", 0);
+	TEST_ASSERT_NOT_NULL(
+		output_pipeline, "output pipeline allocation failed"
+	);
+	struct cp_pipeline_config *pipelines[] = {
+		input_pipeline, output_pipeline
+	};
+	TEST_ASSERT_SUCCESS(
+		agent_update_pipelines(agent, 2, pipelines, &err),
+		"pipeline update failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_pipeline_config_free(input_pipeline);
+	cp_pipeline_config_free(output_pipeline);
+
+	struct cp_device_plain_config *device_config =
+		cp_device_plain_config_new("dev0", 1, 1, &err);
+	TEST_ASSERT_NOT_NULL(
+		device_config, "cp_device_plain_config_new failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_device_plain_config_set_input_pipeline(
+			device_config, 0, "input", 1
+		),
+		"input device pipeline setup failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_device_plain_config_set_output_pipeline(
+			device_config, 0, "output", 1
+		),
+		"output device pipeline setup failed"
+	);
+	struct cp_device *device =
+		cp_device_plain_new(agent, device_config, &err);
+	cp_device_plain_config_free(device_config);
+	TEST_ASSERT_NOT_NULL(device, "cp_device_plain_new failed");
+	struct cp_device *devices[] = {device};
+	TEST_ASSERT_SUCCESS(
+		agent_update_devices(agent, 1, devices, &err),
+		"device update failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_device_plain_free(device);
+
+	struct dp_config *dp_config = yanet_shm_dp_config(shm, 0);
+	struct dp_worker **workers = ADDR_OF(&dp_config->workers);
+	struct dp_worker *dp_worker = ADDR_OF(workers);
+	size_t outstanding = test_mempool_outstanding(dp_worker->rx_mempool);
+	struct rte_mbuf *mbuf = dataplane_ut_alloc_mbuf(ut);
+	TEST_ASSERT_NOT_NULL(mbuf, "dataplane_ut_alloc_mbuf returned NULL");
+	struct packet *packet = mbuf_to_packet(mbuf);
+	packet->mbuf = mbuf;
+	uint8_t *data = (uint8_t *)rte_pktmbuf_append(
+		mbuf, sizeof(struct rte_ether_hdr) + sizeof(struct rte_ipv4_hdr)
+	);
+	TEST_ASSERT_NOT_NULL(data, "packet payload allocation failed");
+	memset(data, 0, mbuf->data_len);
+	struct rte_ether_hdr *ether = (struct rte_ether_hdr *)data;
+	ether->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+	struct rte_ipv4_hdr *ipv4 = (struct rte_ipv4_hdr *)(ether + 1);
+	ipv4->version_ihl = RTE_IPV4_VHL_DEF;
+	ipv4->total_length = rte_cpu_to_be_16(sizeof(struct rte_ipv4_hdr));
+	ipv4->dst_addr = rte_cpu_to_be_32(UINT32_C(0xc0000201));
+	TEST_ASSERT_SUCCESS(parse_packet(packet), "parse_packet failed");
+	uint8_t original_tos = ipv4->type_of_service;
+	uint16_t original_checksum = ipv4->hdr_checksum;
+
+	struct packet_list input;
+	packet_list_init(&input);
+	packet_list_add(&input, packet);
+	struct dataplane_ut_round_result first_result;
+	dataplane_ut_run(ut, 0, &input, &first_result);
+	TEST_ASSERT_EQUAL(
+		(long)(packet_list_count(&first_result.output) +
+		       packet_list_count(&first_result.drop)),
+		1L,
+		"configured pipeline must process the packet"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)ipv4->type_of_service,
+		(long)(42 << DSCP_MARK_SHIFT),
+		"dscp module must mutate the packet payload"
+	);
+	packet_list_concat(&input, &first_result.output);
+	packet_list_concat(&input, &first_result.drop);
+	ipv4->type_of_service = original_tos;
+	ipv4->hdr_checksum = original_checksum;
+	packet->rx_device_id = 0;
+	packet->tx_device_id = 0;
+	packet->recirc_total_count = 0;
+	packet->recirc_stall_count = 0;
+	TEST_ASSERT_SUCCESS(
+		dataplane_ut_run_rounds(ut, 0, &input, 3, 1),
+		"run_rounds failed"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)packet_list_count(&input),
+		1L,
+		"run_rounds must restore the fixed packet set"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)input.first->recirc_total_count,
+		0L,
+		"run_rounds must restore recirculation total"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)input.first->recirc_stall_count,
+		0L,
+		"run_rounds must restore recirculation stall count"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)input.first->rx_device_id,
+		0L,
+		"run_rounds must restore rx device id"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)input.first->tx_device_id,
+		0L,
+		"run_rounds must restore tx device id"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)ipv4->type_of_service,
+		(long)original_tos,
+		"run_rounds must restore the packet payload"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)test_mempool_outstanding(dp_worker->rx_mempool),
+		(long)(outstanding + 1),
+		"run_rounds must not change outstanding packet allocations"
+	);
+
+	packet = packet_list_pop(&input);
+	rte_pktmbuf_free(packet_to_mbuf(packet));
+	agent_detach(agent);
+	dataplane_ut_free(ut);
+	return TEST_SUCCESS;
+}
+#endif
+
+// Verifies that result cleanup returns packets to their owning DPDK pool.
+static int
+run_round_result_foreign_pool_test(void) {
+	struct rte_mempool *pool = test_mempool_create();
+	struct rte_mbuf *mbuf = rte_pktmbuf_alloc(pool);
+	TEST_ASSERT_NOT_NULL(mbuf, "foreign-pool mbuf allocation failed");
+
+	struct packet *packet = mbuf_to_packet(mbuf);
+	*packet = (struct packet){.mbuf = mbuf};
+
+	struct dataplane_ut_round_result result;
+	packet_list_init(&result.output);
+	packet_list_init(&result.drop);
+	packet_list_add(&result.output, packet);
+	dataplane_ut_round_result_free(&result);
+
+	size_t outstanding = test_mempool_outstanding(pool);
+	test_mempool_free(pool);
+	TEST_ASSERT_EQUAL(
+		(long)outstanding,
+		0L,
+		"result cleanup must return a packet to its owning pool"
+	);
+	return TEST_SUCCESS;
+}
 
 int
 main(void) {
@@ -29,6 +304,10 @@ main(void) {
 
 	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
 	TEST_ASSERT_NOT_NULL(ut, "dataplane_ut_new returned NULL");
+	TEST_ASSERT_SUCCESS(
+		run_round_result_foreign_pool_test(),
+		"foreign-pool result cleanup test failed"
+	);
 
 	struct yanet_shm *shm = dataplane_ut_shm(ut);
 	TEST_ASSERT_NOT_NULL(shm, "dataplane_ut_shm returned NULL");
@@ -50,6 +329,11 @@ main(void) {
 		);
 
 		struct dp_config *dp_config = yanet_shm_dp_config(shm, 0);
+		TEST_ASSERT_EQUAL(
+			dp_config->packet_recirc_limit,
+			PACKET_RECIRC_LIMIT_DEFAULT,
+			"test storage must use the default recirculation limit"
+		);
 		struct dp_worker **workers = ADDR_OF(&dp_config->workers);
 		struct dp_worker *dp_worker = ADDR_OF(workers);
 		struct cp_config *cp_config = ADDR_OF(&dp_config->cp_config);
@@ -111,6 +395,36 @@ main(void) {
 	// Input validation: NULL cfg must return NULL, not crash.
 	struct dataplane_ut *bad = dataplane_ut_new(NULL);
 	TEST_ASSERT_NULL(bad, "dataplane_ut_new(NULL) should return NULL");
+
+	// Optional recirculation limits accept the production range and reject
+	// invalid values before a harness is published.
+	{
+		struct dataplane_ut_config custom_cfg = cfg;
+		custom_cfg.packet_recirc_limit = 37;
+		struct dataplane_ut *custom = dataplane_ut_new(&custom_cfg);
+		TEST_ASSERT_NOT_NULL(
+			custom, "custom recirculation limit rejected"
+		);
+		struct dp_config *custom_dp_config =
+			yanet_shm_dp_config(dataplane_ut_shm(custom), 0);
+		TEST_ASSERT_EQUAL(
+			custom_dp_config->packet_recirc_limit,
+			37,
+			"custom recirculation limit must reach runtime config"
+		);
+		dataplane_ut_free(custom);
+
+		custom_cfg.packet_recirc_limit = 3;
+		TEST_ASSERT_NULL(
+			dataplane_ut_new(&custom_cfg),
+			"recirculation limit below the accepted range must fail"
+		);
+		custom_cfg.packet_recirc_limit = 257;
+		TEST_ASSERT_NULL(
+			dataplane_ut_new(&custom_cfg),
+			"recirculation limit above the accepted range must fail"
+		);
+	}
 
 	// Input validation: a worker bound to a device_id outside the
 	// configured topology must return NULL, not crash.
@@ -183,8 +497,52 @@ main(void) {
 			rte_pktmbuf_free(packet_to_mbuf(dropped));
 		}
 
+		// Recycled rounds must restore packet routing state after every
+		// run.
+		struct rte_mbuf *round_mbuf = dataplane_ut_alloc_mbuf(ut);
+		TEST_ASSERT_NOT_NULL(
+			round_mbuf, "dataplane_ut_alloc_mbuf returned NULL"
+		);
+		struct packet *round_packet = mbuf_to_packet(round_mbuf);
+		memset(round_packet, 0, sizeof(*round_packet));
+		round_packet->mbuf = round_mbuf;
+		round_packet->recirc_total_count = 3;
+		round_packet->recirc_stall_count = 2;
+
+		struct packet_list rounds_input;
+		packet_list_init(&rounds_input);
+		packet_list_add(&rounds_input, round_packet);
+		TEST_ASSERT_SUCCESS(
+			dataplane_ut_run_rounds(ut, 0, &rounds_input, 5, 0),
+			"run_rounds failed"
+		);
+		TEST_ASSERT_EQUAL(
+			(long)packet_list_count(&rounds_input),
+			1L,
+			"run_rounds must restore the fixed packet set"
+		);
+		TEST_ASSERT_EQUAL(
+			(long)rounds_input.first->recirc_total_count,
+			3L,
+			"run_rounds must restore recirculation total"
+		);
+		TEST_ASSERT_EQUAL(
+			(long)rounds_input.first->recirc_stall_count,
+			2L,
+			"run_rounds must restore recirculation stall count"
+		);
+		round_packet = packet_list_pop(&rounds_input);
+		rte_pktmbuf_free(packet_to_mbuf(round_packet));
+
 		dataplane_ut_free(ut);
 	}
+
+#ifdef YANET_DATAPLANE_UT_CONTROLPLANE
+	TEST_ASSERT_SUCCESS(
+		run_round_restore_test(),
+		"run_rounds mutation and restore test failed"
+	);
+#endif
 
 	return 0;
 }

--- a/lib/dataplane_ut/tests/smoke_test.c
+++ b/lib/dataplane_ut/tests/smoke_test.c
@@ -169,6 +169,7 @@ run_round_restore_test(void) {
 	struct rte_mbuf *mbuf = dataplane_ut_alloc_mbuf(ut);
 	TEST_ASSERT_NOT_NULL(mbuf, "dataplane_ut_alloc_mbuf returned NULL");
 	struct packet *packet = mbuf_to_packet(mbuf);
+	memset(packet, 0, sizeof(*packet));
 	packet->mbuf = mbuf;
 	uint8_t *data = (uint8_t *)rte_pktmbuf_append(
 		mbuf, sizeof(struct rte_ether_hdr) + sizeof(struct rte_ipv4_hdr)
@@ -207,8 +208,8 @@ run_round_restore_test(void) {
 	ipv4->hdr_checksum = original_checksum;
 	packet->rx_device_id = 0;
 	packet->tx_device_id = 0;
-	packet->recirc_total_count = 0;
-	packet->recirc_stall_count = 0;
+	packet->recirc_remaining = 0;
+	packet->recirc_initialized = 0;
 	TEST_ASSERT_SUCCESS(
 		dataplane_ut_run_rounds(ut, 0, &input, 3, 1),
 		"run_rounds failed"
@@ -219,14 +220,14 @@ run_round_restore_test(void) {
 		"run_rounds must restore the fixed packet set"
 	);
 	TEST_ASSERT_EQUAL(
-		(long)input.first->recirc_total_count,
+		(long)input.first->recirc_remaining,
 		0L,
-		"run_rounds must restore recirculation total"
+		"run_rounds must restore recirculation remaining budget"
 	);
 	TEST_ASSERT_EQUAL(
-		(long)input.first->recirc_stall_count,
+		(long)input.first->recirc_initialized,
 		0L,
-		"run_rounds must restore recirculation stall count"
+		"run_rounds must restore recirculation initialization state"
 	);
 	TEST_ASSERT_EQUAL(
 		(long)input.first->rx_device_id,
@@ -506,8 +507,8 @@ main(void) {
 		struct packet *round_packet = mbuf_to_packet(round_mbuf);
 		memset(round_packet, 0, sizeof(*round_packet));
 		round_packet->mbuf = round_mbuf;
-		round_packet->recirc_total_count = 3;
-		round_packet->recirc_stall_count = 2;
+		round_packet->recirc_remaining = 61;
+		round_packet->recirc_initialized = 1;
 
 		struct packet_list rounds_input;
 		packet_list_init(&rounds_input);
@@ -522,14 +523,15 @@ main(void) {
 			"run_rounds must restore the fixed packet set"
 		);
 		TEST_ASSERT_EQUAL(
-			(long)rounds_input.first->recirc_total_count,
-			3L,
-			"run_rounds must restore recirculation total"
+			(long)rounds_input.first->recirc_remaining,
+			61L,
+			"run_rounds must restore recirculation remaining budget"
 		);
 		TEST_ASSERT_EQUAL(
-			(long)rounds_input.first->recirc_stall_count,
-			2L,
-			"run_rounds must restore recirculation stall count"
+			(long)rounds_input.first->recirc_initialized,
+			1L,
+			"run_rounds must restore recirculation initialization "
+			"state"
 		);
 		round_packet = packet_list_pop(&rounds_input);
 		rte_pktmbuf_free(packet_to_mbuf(round_packet));

--- a/lib/dataplane_ut/tests/smoke_test.c
+++ b/lib/dataplane_ut/tests/smoke_test.c
@@ -8,23 +8,24 @@
 #include "lib/dataplane_ut/mempool.h"
 
 #ifdef YANET_DATAPLANE_UT_CONTROLPLANE
+#include <errno.h>
+#include <string.h>
+
 #include "common/strutils.h"
 #include "devices/plain/api/controlplane.h"
 #include "lib/controlplane/agent/agent.h"
 #include "lib/dataplane/packet/dscp.h"
+#include "modules/decap/api/controlplane.h"
 #include "modules/dscp/api/controlplane.h"
 #include "modules/forward/api/controlplane.h"
 #endif
 
 #ifdef YANET_DATAPLANE_UT_CONTROLPLANE
 #include <rte_ether.h>
+#include <rte_gre.h>
 #include <rte_ip.h>
 #endif
 #include <rte_mbuf.h>
-
-#ifdef YANET_DATAPLANE_UT_CONTROLPLANE
-#include <string.h>
-#endif
 
 #ifdef YANET_DATAPLANE_UT_CONTROLPLANE
 // Verifies that run_rounds restores routing metadata and packet payload after
@@ -248,6 +249,188 @@ run_round_restore_test(void) {
 		(long)test_mempool_outstanding(dp_worker->rx_mempool),
 		(long)(outstanding + 1),
 		"run_rounds must not change outstanding packet allocations"
+	);
+
+	packet = packet_list_pop(&input);
+	rte_pktmbuf_free(packet_to_mbuf(packet));
+	agent_detach(agent);
+	dataplane_ut_free(ut);
+	return TEST_SUCCESS;
+}
+
+// Verifies that run_rounds reports -EINVAL when a module mutates mbuf
+// geometry: decap strips tunnel headers with rte_pktmbuf_adj, so the second
+// round's restore sees a packet whose length no longer matches the snapshot.
+static int
+run_rounds_geometry_mismatch_test(void) {
+	const char *port_names[] = {"dev0"};
+	const char *module_names[] = {"decap"};
+	const char *devs_to_load[] = {"plain"};
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 25,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = module_names,
+		.module_count = 1,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+	};
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	TEST_ASSERT_NOT_NULL(ut, "dataplane_ut_new returned NULL");
+
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	TEST_ASSERT_NOT_NULL(shm, "dataplane_ut_shm returned NULL");
+	yanet_error *err = NULL;
+	struct agent *agent =
+		agent_attach(shm, 0, "smoke-geometry-mismatch", 8u << 20, &err);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct cp_module *decap =
+		decap_module_config_new(agent, "unwrap", &err);
+	TEST_ASSERT_NOT_NULL(decap, "decap_module_config_new failed");
+	uint8_t first_addr[4] = {0, 0, 0, 0};
+	uint8_t last_addr[4] = {255, 255, 255, 255};
+	TEST_ASSERT_SUCCESS(
+		decap_module_config_add_prefix_v4(decap, first_addr, last_addr),
+		"decap prefix setup failed"
+	);
+
+	struct cp_module *modules[] = {decap};
+	TEST_ASSERT_SUCCESS(
+		agent_update_modules(agent, 1, modules, &err),
+		"module update failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	const char *chain_types[] = {"decap"};
+	const char *chain_names[] = {"unwrap"};
+	struct cp_chain_config *chain =
+		cp_chain_config_create("chain", 1, chain_types, chain_names);
+	TEST_ASSERT_NOT_NULL(chain, "cp_chain_config_create failed");
+	struct cp_function_config *function =
+		cp_function_config_create("function", 1);
+	TEST_ASSERT_NOT_NULL(function, "cp_function_config_create failed");
+	TEST_ASSERT_SUCCESS(
+		cp_function_config_set_chain(function, 0, chain, 1),
+		"cp_function_config_set_chain failed"
+	);
+	struct cp_function_config *functions[] = {function};
+	TEST_ASSERT_SUCCESS(
+		agent_update_functions(agent, 1, functions, &err),
+		"function update failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_function_config_free(function);
+
+	struct cp_pipeline_config *input_pipeline =
+		cp_pipeline_config_create("input", 1);
+	TEST_ASSERT_NOT_NULL(
+		input_pipeline, "input pipeline allocation failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_pipeline_config_set_function(input_pipeline, 0, "function"),
+		"input pipeline setup failed"
+	);
+	struct cp_pipeline_config *output_pipeline =
+		cp_pipeline_config_create("output", 0);
+	TEST_ASSERT_NOT_NULL(
+		output_pipeline, "output pipeline allocation failed"
+	);
+	struct cp_pipeline_config *pipelines[] = {
+		input_pipeline, output_pipeline
+	};
+	TEST_ASSERT_SUCCESS(
+		agent_update_pipelines(agent, 2, pipelines, &err),
+		"pipeline update failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_pipeline_config_free(input_pipeline);
+	cp_pipeline_config_free(output_pipeline);
+
+	struct cp_device_plain_config *device_config =
+		cp_device_plain_config_new("dev0", 1, 1, &err);
+	TEST_ASSERT_NOT_NULL(
+		device_config, "cp_device_plain_config_new failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_device_plain_config_set_input_pipeline(
+			device_config, 0, "input", 1
+		),
+		"input device pipeline setup failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_device_plain_config_set_output_pipeline(
+			device_config, 0, "output", 1
+		),
+		"output device pipeline setup failed"
+	);
+	struct cp_device *device =
+		cp_device_plain_new(agent, device_config, &err);
+	cp_device_plain_config_free(device_config);
+	TEST_ASSERT_NOT_NULL(device, "cp_device_plain_new failed");
+	struct cp_device *devices[] = {device};
+	TEST_ASSERT_SUCCESS(
+		agent_update_devices(agent, 1, devices, &err),
+		"device update failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_device_plain_free(device, &err);
+
+	struct dp_config *dp_config = yanet_shm_dp_config(shm, 0);
+	struct dp_worker **workers = ADDR_OF(&dp_config->workers);
+	struct dp_worker *dp_worker = ADDR_OF(workers);
+	size_t outstanding = test_mempool_outstanding(dp_worker->rx_mempool);
+	struct rte_mbuf *mbuf = dataplane_ut_alloc_mbuf(ut);
+	TEST_ASSERT_NOT_NULL(mbuf, "dataplane_ut_alloc_mbuf returned NULL");
+	struct packet *packet = mbuf_to_packet(mbuf);
+	memset(packet, 0, sizeof(*packet));
+	packet->mbuf = mbuf;
+
+	// ether + outer IPv4 (GRE) + 4-byte GRE header + inner IPv4
+	const size_t payload_len = sizeof(struct rte_ether_hdr) +
+				   2 * sizeof(struct rte_ipv4_hdr) + 4;
+	uint8_t *data = (uint8_t *)rte_pktmbuf_append(mbuf, payload_len);
+	TEST_ASSERT_NOT_NULL(data, "packet payload allocation failed");
+	memset(data, 0, payload_len);
+	struct rte_ether_hdr *ether = (struct rte_ether_hdr *)data;
+	ether->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+	struct rte_ipv4_hdr *outer = (struct rte_ipv4_hdr *)(ether + 1);
+	outer->version_ihl = RTE_IPV4_VHL_DEF;
+	outer->total_length = rte_cpu_to_be_16(
+		sizeof(struct rte_ipv4_hdr) + 4 + sizeof(struct rte_ipv4_hdr)
+	);
+	outer->next_proto_id = IPPROTO_GRE;
+	outer->dst_addr = rte_cpu_to_be_32(UINT32_C(0xc0000201));
+	struct rte_gre_hdr *gre = (struct rte_gre_hdr *)(outer + 1);
+	gre->proto = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+	struct rte_ipv4_hdr *inner = (struct rte_ipv4_hdr *)(gre + 1);
+	inner->version_ihl = RTE_IPV4_VHL_DEF;
+	inner->total_length =
+		rte_cpu_to_be_16(sizeof(struct rte_ipv4_hdr));
+	inner->next_proto_id = IPPROTO_TCP;
+	TEST_ASSERT_SUCCESS(parse_packet(packet), "parse_packet failed");
+
+	struct packet_list input;
+	packet_list_init(&input);
+	packet_list_add(&input, packet);
+
+	int rc = dataplane_ut_run_rounds(ut, 0, &input, 3, 1);
+	TEST_ASSERT_EQUAL(
+		(long)rc,
+		(long)-EINVAL,
+		"run_rounds must reject mutated packet geometry"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)packet_list_count(&input),
+		1L,
+		"run_rounds must return the saved packet on failure"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)test_mempool_outstanding(dp_worker->rx_mempool),
+		(long)(outstanding + 1),
+		"run_rounds must not leak the mutated packet"
 	);
 
 	packet = packet_list_pop(&input);
@@ -543,6 +726,10 @@ main(void) {
 	TEST_ASSERT_SUCCESS(
 		run_round_restore_test(),
 		"run_rounds mutation and restore test failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		run_rounds_geometry_mismatch_test(),
+		"run_rounds geometry rejection test failed"
 	);
 #endif
 

--- a/lib/dataplane_ut/tests/smoke_test.c
+++ b/lib/dataplane_ut/tests/smoke_test.c
@@ -161,7 +161,12 @@ run_round_restore_test(void) {
 		"device update failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
-	cp_device_plain_free(device, &err);
+	// The live generation still references the device, so the destroy
+	// fails with EAGAIN and the handle stays dangling until agent_detach;
+	// free the allocated error chain instead of leaking it.
+	yanet_error *device_err = NULL;
+	cp_device_plain_free(device, &device_err);
+	yanet_error_free(device_err);
 
 	struct dp_config *dp_config = yanet_shm_dp_config(shm, 0);
 	struct dp_worker **workers = ADDR_OF(&dp_config->workers);
@@ -376,7 +381,10 @@ run_rounds_geometry_mismatch_test(void) {
 		"device update failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
-	cp_device_plain_free(device, &err);
+	// Dangling until agent_detach; the EAGAIN error chain must be freed.
+	yanet_error *device_err = NULL;
+	cp_device_plain_free(device, &device_err);
+	yanet_error_free(device_err);
 
 	struct dp_config *dp_config = yanet_shm_dp_config(shm, 0);
 	struct dp_worker **workers = ADDR_OF(&dp_config->workers);

--- a/lib/fuzzing/fuzzing.h
+++ b/lib/fuzzing/fuzzing.h
@@ -92,6 +92,7 @@ fuzzing_params_init(
 
 	// Initialize module_ectx to zero
 	memset(&params->module_ectx, 0, sizeof(params->module_ectx));
+	params->module_ectx.packet_recirc_limit = PACKET_RECIRC_LIMIT_DEFAULT;
 
 	// Initialize stubs for route module
 	// Route module uses module_ectx_encode_device which accesses mc_index

--- a/lib/tests/dataplane/meson.build
+++ b/lib/tests/dataplane/meson.build
@@ -43,6 +43,16 @@ parse_frag_test = executable(
 )
 test('parse_frag', parse_frag_test, suite: 'lib_packet')
 
+packet_recirc_test = executable(
+  'packet_recirc_test',
+  'packet_recirc_test.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: [lib_logging_dep],
+  include_directories: yanet_rootdir,
+)
+test('packet_recirc', packet_recirc_test, suite: 'lib_packet')
+
 encap_dscp_test = executable(
   'encap_dscp_test',
   'encap_dscp_test.c',

--- a/lib/tests/dataplane/packet_recirc_test.c
+++ b/lib/tests/dataplane/packet_recirc_test.c
@@ -3,71 +3,42 @@
 #include "lib/dataplane/packet/packet.h"
 
 static int
-test_stalled_redirects_stop_at_stall_limit(void) {
+test_redirect_initializes_remaining_budget(void) {
 	struct packet packet = {0};
-	for (uint8_t idx = 0; idx < PACKET_RECIRC_STALL_LIMIT; ++idx) {
-		TEST_ASSERT(
-			packet_recirc_try_redirect(&packet, 16),
-			"redirect within the stall limit must succeed"
-		);
-	}
-	TEST_ASSERT(
-		!packet_recirc_try_redirect(&packet, 16),
-		"redirect after the stall limit must fail"
-	);
-	TEST_ASSERT_EQUAL(
-		packet.recirc_total_count,
-		PACKET_RECIRC_STALL_LIMIT,
-		"stalled redirects must consume total budget"
-	);
-	TEST_ASSERT_EQUAL(
-		packet.recirc_stall_count,
-		PACKET_RECIRC_STALL_LIMIT,
-		"stalled redirects must consume stall budget"
-	);
-	return TEST_SUCCESS;
-}
-
-static int
-test_progress_resets_only_stall_budget(void) {
-	struct packet packet = {
-		.recirc_total_count = 3,
-		.recirc_stall_count = PACKET_RECIRC_STALL_LIMIT,
-	};
-	packet_recirc_mark_progress(&packet);
-	TEST_ASSERT_EQUAL(
-		packet.recirc_total_count,
-		3,
-		"progress must preserve total budget"
-	);
-	TEST_ASSERT_EQUAL(
-		packet.recirc_stall_count, 0, "progress must reset stall budget"
-	);
 	TEST_ASSERT(
 		packet_recirc_try_redirect(&packet, 16),
-		"redirect after progress must succeed"
+		"first redirect must succeed"
+	);
+	TEST_ASSERT_EQUAL(
+		packet.recirc_remaining,
+		15,
+		"first redirect must consume one total credit"
+	);
+	TEST_ASSERT_EQUAL(
+		packet.recirc_initialized,
+		1,
+		"first redirect must initialize recirculation state"
 	);
 	return TEST_SUCCESS;
 }
 
 static int
-test_progress_cannot_bypass_total_budget(void) {
+test_total_budget_stops_at_limit(void) {
 	struct packet packet = {0};
-	for (uint16_t idx = 0; idx < 4; ++idx) {
+	for (uint16_t idx = 0; idx < 5; ++idx) {
 		TEST_ASSERT(
-			packet_recirc_try_redirect(&packet, 4),
-			"redirect within total limit must succeed"
+			packet_recirc_try_redirect(&packet, 5),
+			"redirect within the total limit must succeed"
 		);
-		packet_recirc_mark_progress(&packet);
 	}
 	TEST_ASSERT(
-		!packet_recirc_try_redirect(&packet, 4),
-		"progress must not bypass total limit"
+		!packet_recirc_try_redirect(&packet, 5),
+		"redirect after the total limit must fail"
 	);
 	TEST_ASSERT_EQUAL(
-		packet.recirc_total_count,
-		4,
-		"total budget must remain exhausted"
+		packet.recirc_remaining,
+		0,
+		"total failure must preserve the exhausted budget"
 	);
 	return TEST_SUCCESS;
 }
@@ -82,16 +53,38 @@ test_maximum_total_budget(void) {
 			),
 			"redirect within maximum total limit must succeed"
 		);
-		packet_recirc_mark_progress(&packet);
 	}
 	TEST_ASSERT(
 		!packet_recirc_try_redirect(&packet, PACKET_RECIRC_LIMIT_MAX),
 		"redirect after maximum total limit must fail"
 	);
 	TEST_ASSERT_EQUAL(
-		packet.recirc_total_count,
-		PACKET_RECIRC_LIMIT_MAX,
-		"failed redirect must preserve the maximum total count"
+		packet.recirc_remaining,
+		0,
+		"failed redirect must preserve exhausted total budget"
+	);
+	return TEST_SUCCESS;
+}
+
+static int
+test_total_exhaustion_preserves_state(void) {
+	struct packet packet = {
+		.recirc_remaining = 0,
+		.recirc_initialized = 1,
+	};
+	TEST_ASSERT(
+		!packet_recirc_try_redirect(&packet, 64),
+		"redirect after total exhaustion must fail"
+	);
+	TEST_ASSERT_EQUAL(
+		packet.recirc_remaining,
+		0,
+		"total exhaustion must preserve remaining budget"
+	);
+	TEST_ASSERT_EQUAL(
+		packet.recirc_initialized,
+		1,
+		"total exhaustion must preserve initialization state"
 	);
 	return TEST_SUCCESS;
 }
@@ -99,16 +92,16 @@ test_maximum_total_budget(void) {
 int
 main(void) {
 	size_t failed = 0;
-	if (test_stalled_redirects_stop_at_stall_limit() != TEST_SUCCESS) {
+	if (test_redirect_initializes_remaining_budget() != TEST_SUCCESS) {
 		++failed;
 	}
-	if (test_progress_resets_only_stall_budget() != TEST_SUCCESS) {
-		++failed;
-	}
-	if (test_progress_cannot_bypass_total_budget() != TEST_SUCCESS) {
+	if (test_total_budget_stops_at_limit() != TEST_SUCCESS) {
 		++failed;
 	}
 	if (test_maximum_total_budget() != TEST_SUCCESS) {
+		++failed;
+	}
+	if (test_total_exhaustion_preserves_state() != TEST_SUCCESS) {
 		++failed;
 	}
 	return failed == 0 ? TEST_SUCCESS : TEST_FAILED;

--- a/lib/tests/dataplane/packet_recirc_test.c
+++ b/lib/tests/dataplane/packet_recirc_test.c
@@ -1,0 +1,115 @@
+#include "common/test_assert.h"
+
+#include "lib/dataplane/packet/packet.h"
+
+static int
+test_stalled_redirects_stop_at_stall_limit(void) {
+	struct packet packet = {0};
+	for (uint8_t idx = 0; idx < PACKET_RECIRC_STALL_LIMIT; ++idx) {
+		TEST_ASSERT(
+			packet_recirc_try_redirect(&packet, 16),
+			"redirect within the stall limit must succeed"
+		);
+	}
+	TEST_ASSERT(
+		!packet_recirc_try_redirect(&packet, 16),
+		"redirect after the stall limit must fail"
+	);
+	TEST_ASSERT_EQUAL(
+		packet.recirc_total_count,
+		PACKET_RECIRC_STALL_LIMIT,
+		"stalled redirects must consume total budget"
+	);
+	TEST_ASSERT_EQUAL(
+		packet.recirc_stall_count,
+		PACKET_RECIRC_STALL_LIMIT,
+		"stalled redirects must consume stall budget"
+	);
+	return TEST_SUCCESS;
+}
+
+static int
+test_progress_resets_only_stall_budget(void) {
+	struct packet packet = {
+		.recirc_total_count = 3,
+		.recirc_stall_count = PACKET_RECIRC_STALL_LIMIT,
+	};
+	packet_recirc_mark_progress(&packet);
+	TEST_ASSERT_EQUAL(
+		packet.recirc_total_count,
+		3,
+		"progress must preserve total budget"
+	);
+	TEST_ASSERT_EQUAL(
+		packet.recirc_stall_count, 0, "progress must reset stall budget"
+	);
+	TEST_ASSERT(
+		packet_recirc_try_redirect(&packet, 16),
+		"redirect after progress must succeed"
+	);
+	return TEST_SUCCESS;
+}
+
+static int
+test_progress_cannot_bypass_total_budget(void) {
+	struct packet packet = {0};
+	for (uint16_t idx = 0; idx < 4; ++idx) {
+		TEST_ASSERT(
+			packet_recirc_try_redirect(&packet, 4),
+			"redirect within total limit must succeed"
+		);
+		packet_recirc_mark_progress(&packet);
+	}
+	TEST_ASSERT(
+		!packet_recirc_try_redirect(&packet, 4),
+		"progress must not bypass total limit"
+	);
+	TEST_ASSERT_EQUAL(
+		packet.recirc_total_count,
+		4,
+		"total budget must remain exhausted"
+	);
+	return TEST_SUCCESS;
+}
+
+static int
+test_maximum_total_budget(void) {
+	struct packet packet = {0};
+	for (uint16_t idx = 0; idx < PACKET_RECIRC_LIMIT_MAX; ++idx) {
+		TEST_ASSERT(
+			packet_recirc_try_redirect(
+				&packet, PACKET_RECIRC_LIMIT_MAX
+			),
+			"redirect within maximum total limit must succeed"
+		);
+		packet_recirc_mark_progress(&packet);
+	}
+	TEST_ASSERT(
+		!packet_recirc_try_redirect(&packet, PACKET_RECIRC_LIMIT_MAX),
+		"redirect after maximum total limit must fail"
+	);
+	TEST_ASSERT_EQUAL(
+		packet.recirc_total_count,
+		PACKET_RECIRC_LIMIT_MAX,
+		"failed redirect must preserve the maximum total count"
+	);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	size_t failed = 0;
+	if (test_stalled_redirects_stop_at_stall_limit() != TEST_SUCCESS) {
+		++failed;
+	}
+	if (test_progress_resets_only_stall_budget() != TEST_SUCCESS) {
+		++failed;
+	}
+	if (test_progress_cannot_bypass_total_budget() != TEST_SUCCESS) {
+		++failed;
+	}
+	if (test_maximum_total_budget() != TEST_SUCCESS) {
+		++failed;
+	}
+	return failed == 0 ? TEST_SUCCESS : TEST_FAILED;
+}

--- a/lib/tests/dataplane/parse_frag_test.c
+++ b/lib/tests/dataplane/parse_frag_test.c
@@ -268,19 +268,19 @@ run_gre_accepted_case(bool inner_v6, uint16_t expect_ether_type) {
 		"outer network type is IPv4"
 	);
 	uint32_t pkt_len_before = rte_pktmbuf_pkt_len(p.mbuf);
-	p.recirc_total_count = 7;
-	p.recirc_stall_count = 3;
+	p.recirc_remaining = 57;
+	p.recirc_initialized = 1;
 
 	TEST_ASSERT_EQUAL(packet_decap(&p), 0, "rc");
 	TEST_ASSERT_EQUAL(
-		p.recirc_total_count,
-		7,
-		"successful decap preserves total recirculation count"
+		p.recirc_remaining,
+		57,
+		"successful decap preserves remaining recirculation budget"
 	);
 	TEST_ASSERT_EQUAL(
-		p.recirc_stall_count,
-		0,
-		"successful decap resets stalled recirculation count"
+		p.recirc_initialized,
+		1,
+		"successful decap preserves recirculation initialization state"
 	);
 	TEST_ASSERT_EQUAL(
 		p.network_header.type,
@@ -304,18 +304,18 @@ run_gre_accepted_case(bool inner_v6, uint16_t expect_ether_type) {
 
 static int
 assert_decap_failure_preserves_recirc(struct packet *packet) {
-	packet->recirc_total_count = 7;
-	packet->recirc_stall_count = 3;
+	packet->recirc_remaining = 57;
+	packet->recirc_initialized = 1;
 	TEST_ASSERT_EQUAL(packet_decap(packet), -1, "rc");
 	TEST_ASSERT_EQUAL(
-		packet->recirc_total_count,
-		7,
-		"failed decap preserves total recirculation count"
+		packet->recirc_remaining,
+		57,
+		"failed decap preserves remaining recirculation budget"
 	);
 	TEST_ASSERT_EQUAL(
-		packet->recirc_stall_count,
-		3,
-		"failed decap preserves stalled recirculation count"
+		packet->recirc_initialized,
+		1,
+		"failed decap preserves recirculation initialization state"
 	);
 	return TEST_SUCCESS;
 }

--- a/lib/tests/dataplane/parse_frag_test.c
+++ b/lib/tests/dataplane/parse_frag_test.c
@@ -268,8 +268,20 @@ run_gre_accepted_case(bool inner_v6, uint16_t expect_ether_type) {
 		"outer network type is IPv4"
 	);
 	uint32_t pkt_len_before = rte_pktmbuf_pkt_len(p.mbuf);
+	p.recirc_total_count = 7;
+	p.recirc_stall_count = 3;
 
 	TEST_ASSERT_EQUAL(packet_decap(&p), 0, "rc");
+	TEST_ASSERT_EQUAL(
+		p.recirc_total_count,
+		7,
+		"successful decap preserves total recirculation count"
+	);
+	TEST_ASSERT_EQUAL(
+		p.recirc_stall_count,
+		0,
+		"successful decap resets stalled recirculation count"
+	);
 	TEST_ASSERT_EQUAL(
 		p.network_header.type,
 		expect_ether_type,
@@ -287,6 +299,24 @@ run_gre_accepted_case(bool inner_v6, uint16_t expect_ether_type) {
 	);
 
 	free_packet(&p);
+	return TEST_SUCCESS;
+}
+
+static int
+assert_decap_failure_preserves_recirc(struct packet *packet) {
+	packet->recirc_total_count = 7;
+	packet->recirc_stall_count = 3;
+	TEST_ASSERT_EQUAL(packet_decap(packet), -1, "rc");
+	TEST_ASSERT_EQUAL(
+		packet->recirc_total_count,
+		7,
+		"failed decap preserves total recirculation count"
+	);
+	TEST_ASSERT_EQUAL(
+		packet->recirc_stall_count,
+		3,
+		"failed decap preserves stalled recirculation count"
+	);
 	return TEST_SUCCESS;
 }
 
@@ -314,7 +344,10 @@ test_gre_reject_ver(void) {
 	struct packet p;
 	TEST_ASSERT_SUCCESS(build_gre_encapped(&p, false), "build");
 	pkt_gre(&p)->ver = 1;
-	TEST_ASSERT_EQUAL(packet_decap(&p), -1, "rc");
+	TEST_ASSERT_SUCCESS(
+		assert_decap_failure_preserves_recirc(&p),
+		"failed decap changed recirculation state"
+	);
 	free_packet(&p);
 	return TEST_SUCCESS;
 }
@@ -325,7 +358,10 @@ test_gre_reject_res1(void) {
 	struct packet p;
 	TEST_ASSERT_SUCCESS(build_gre_encapped(&p, false), "build");
 	pkt_gre(&p)->res1 = 1;
-	TEST_ASSERT_EQUAL(packet_decap(&p), -1, "rc");
+	TEST_ASSERT_SUCCESS(
+		assert_decap_failure_preserves_recirc(&p),
+		"failed decap changed recirculation state"
+	);
 	free_packet(&p);
 	return TEST_SUCCESS;
 }
@@ -336,7 +372,10 @@ test_gre_reject_res2(void) {
 	struct packet p;
 	TEST_ASSERT_SUCCESS(build_gre_encapped(&p, false), "build");
 	pkt_gre(&p)->res2 = 1;
-	TEST_ASSERT_EQUAL(packet_decap(&p), -1, "rc");
+	TEST_ASSERT_SUCCESS(
+		assert_decap_failure_preserves_recirc(&p),
+		"failed decap changed recirculation state"
+	);
 	free_packet(&p);
 	return TEST_SUCCESS;
 }
@@ -347,7 +386,10 @@ test_gre_reject_res3(void) {
 	struct packet p;
 	TEST_ASSERT_SUCCESS(build_gre_encapped(&p, false), "build");
 	pkt_gre(&p)->res3 = 1;
-	TEST_ASSERT_EQUAL(packet_decap(&p), -1, "rc");
+	TEST_ASSERT_SUCCESS(
+		assert_decap_failure_preserves_recirc(&p),
+		"failed decap changed recirculation state"
+	);
 	free_packet(&p);
 	return TEST_SUCCESS;
 }

--- a/lib/tests/dataplane/worker_clone_test.c
+++ b/lib/tests/dataplane/worker_clone_test.c
@@ -68,14 +68,9 @@ assert_clone_correct(
 	TEST_ASSERT_EQUAL(clone->flags, src->flags, "flags preserved");
 	TEST_ASSERT_EQUAL(clone->vlan, src->vlan, "vlan preserved");
 	TEST_ASSERT_EQUAL(
-		clone->recirc_total_count,
-		src->recirc_total_count,
-		"recirculation total preserved"
-	);
-	TEST_ASSERT_EQUAL(
-		clone->recirc_stall_count,
-		src->recirc_stall_count,
-		"recirculation stall count preserved"
+		clone->recirc_initialized,
+		src->recirc_initialized,
+		"recirculation initialization state preserved"
 	);
 	TEST_ASSERT_EQUAL(
 		clone->fragment_offset,
@@ -101,8 +96,8 @@ set_metadata(struct packet *p, uint32_t hash, uint16_t flags, uint16_t vlan) {
 	p->hash = hash;
 	p->flags = flags;
 	p->vlan = vlan;
-	p->recirc_total_count = 3;
-	p->recirc_stall_count = 2;
+	p->recirc_remaining = 5;
+	p->recirc_initialized = 1;
 	p->fragment_offset = 42;
 	p->rx_device_id = 7;
 	p->tx_device_id = 3;
@@ -137,25 +132,40 @@ test_multi_segment(struct rte_mempool *pool) {
 	src.mbuf = segs[0];
 	set_metadata(&src, 0xDEADBEEF, 0x0001, 200);
 
-	struct packet *clone = worker_clone_packet(&dp_worker, &src);
+	struct packet *clone = worker_clone_packet(&dp_worker, &src, 64);
 
 	int rc = assert_clone_correct(&src, clone, src.mbuf->pkt_len);
 	if (rc == TEST_SUCCESS) {
+		TEST_ASSERT_EQUAL(
+			src.recirc_remaining,
+			3,
+			"source must keep the odd recirculation credit"
+		);
+		TEST_ASSERT_EQUAL(
+			clone->recirc_remaining,
+			2,
+			"clone must receive half the recirculation credits"
+		);
+		TEST_ASSERT_EQUAL(
+			src.recirc_remaining + clone->recirc_remaining,
+			5,
+			"cloning must preserve aggregate recirculation credits"
+		);
 		TEST_ASSERT(
 			packet_recirc_try_redirect(
 				clone, PACKET_RECIRC_LIMIT_DEFAULT
 			),
-			"clone must spend its inherited budget independently"
+			"clone must spend its assigned budget"
 		);
 		TEST_ASSERT_EQUAL(
-			src.recirc_total_count,
+			src.recirc_remaining,
 			3,
-			"clone redirect must not change source total count"
+			"clone redirect must not change the source's share"
 		);
 		TEST_ASSERT_EQUAL(
-			src.recirc_stall_count,
-			2,
-			"clone redirect must not change source stall count"
+			clone->recirc_remaining,
+			1,
+			"clone redirect must consume one assigned credit"
 		);
 	}
 
@@ -199,14 +209,14 @@ test_packet_alloc_resets_metadata(struct rte_mempool *pool) {
 	TEST_ASSERT_EQUAL(packet->flags, 0, "new packet flags must be zero");
 	TEST_ASSERT_EQUAL(packet->vlan, 0, "new packet vlan must be zero");
 	TEST_ASSERT_EQUAL(
-		packet->recirc_total_count,
+		packet->recirc_remaining,
 		0,
-		"new packet recirculation total must be zero"
+		"new packet recirculation remaining budget must be zero"
 	);
 	TEST_ASSERT_EQUAL(
-		packet->recirc_stall_count,
+		packet->recirc_initialized,
 		0,
-		"new packet recirculation stall count must be zero"
+		"new packet recirculation state must be uninitialized"
 	);
 	TEST_ASSERT_EQUAL(
 		packet->fragment_offset,
@@ -305,9 +315,24 @@ test_jumbo(struct rte_mempool *pool) {
 	memset(&src, 0, sizeof(src));
 	src.mbuf = segs[0];
 	set_metadata(&src, 0xABCDEF01, 0x0002, 300);
+	src.recirc_remaining = 0;
+	src.recirc_initialized = 0;
 
-	struct packet *clone = worker_clone_packet(&dp_worker, &src);
+	struct packet *clone = worker_clone_packet(&dp_worker, &src, 5);
 	int rc = assert_clone_correct(&src, clone, src.mbuf->pkt_len);
+	if (rc == TEST_SUCCESS) {
+		TEST_ASSERT_EQUAL(
+			src.recirc_remaining,
+			3,
+			"uninitialized source must keep the odd credit"
+		);
+		TEST_ASSERT_EQUAL(
+			clone->recirc_remaining,
+			2,
+			"uninitialized clone must receive half the configured "
+			"credits"
+		);
+	}
 
 	rte_pktmbuf_free(src.mbuf);
 	if (clone != NULL) {

--- a/lib/tests/dataplane/worker_clone_test.c
+++ b/lib/tests/dataplane/worker_clone_test.c
@@ -6,6 +6,7 @@
 
 #include "common/test_assert.h"
 
+#include "lib/controlplane/config/econtext.h"
 #include "lib/dataplane/config/zone.h"
 #include "lib/dataplane/packet/packet.h"
 #include "lib/dataplane/worker/worker.h"
@@ -67,6 +68,16 @@ assert_clone_correct(
 	TEST_ASSERT_EQUAL(clone->flags, src->flags, "flags preserved");
 	TEST_ASSERT_EQUAL(clone->vlan, src->vlan, "vlan preserved");
 	TEST_ASSERT_EQUAL(
+		clone->recirc_total_count,
+		src->recirc_total_count,
+		"recirculation total preserved"
+	);
+	TEST_ASSERT_EQUAL(
+		clone->recirc_stall_count,
+		src->recirc_stall_count,
+		"recirculation stall count preserved"
+	);
+	TEST_ASSERT_EQUAL(
 		clone->fragment_offset,
 		src->fragment_offset,
 		"fragment_offset preserved"
@@ -90,6 +101,8 @@ set_metadata(struct packet *p, uint32_t hash, uint16_t flags, uint16_t vlan) {
 	p->hash = hash;
 	p->flags = flags;
 	p->vlan = vlan;
+	p->recirc_total_count = 3;
+	p->recirc_stall_count = 2;
 	p->fragment_offset = 42;
 	p->rx_device_id = 7;
 	p->tx_device_id = 3;
@@ -127,6 +140,24 @@ test_multi_segment(struct rte_mempool *pool) {
 	struct packet *clone = worker_clone_packet(&dp_worker, &src);
 
 	int rc = assert_clone_correct(&src, clone, src.mbuf->pkt_len);
+	if (rc == TEST_SUCCESS) {
+		TEST_ASSERT(
+			packet_recirc_try_redirect(
+				clone, PACKET_RECIRC_LIMIT_DEFAULT
+			),
+			"clone must spend its inherited budget independently"
+		);
+		TEST_ASSERT_EQUAL(
+			src.recirc_total_count,
+			3,
+			"clone redirect must not change source total count"
+		);
+		TEST_ASSERT_EQUAL(
+			src.recirc_stall_count,
+			2,
+			"clone redirect must not change source stall count"
+		);
+	}
 
 	rte_pktmbuf_free(src.mbuf);
 	if (clone != NULL) {
@@ -141,6 +172,99 @@ err:
 		}
 	}
 	return TEST_FAILED;
+}
+
+static int
+test_packet_alloc_resets_metadata(struct rte_mempool *pool) {
+	struct dp_worker dp_worker = {0};
+	dp_worker.rx_mempool = pool;
+
+	test_mempool_poison(pool, 1);
+	struct packet *packet = worker_packet_alloc(&dp_worker);
+	test_mempool_poison(pool, 0);
+	TEST_ASSERT_NOT_NULL(packet, "packet allocation must succeed");
+	TEST_ASSERT_NULL(packet->next, "new packet chain pointer must be NULL");
+	TEST_ASSERT_EQUAL(packet->hash, 0, "new packet hash must be zero");
+	TEST_ASSERT_EQUAL(
+		packet->rx_device_id, 0, "new packet rx device must be zero"
+	);
+	TEST_ASSERT_EQUAL(
+		packet->tx_device_id, 0, "new packet tx device must be zero"
+	);
+	TEST_ASSERT_EQUAL(
+		packet->module_device_id,
+		0,
+		"new packet module device must be zero"
+	);
+	TEST_ASSERT_EQUAL(packet->flags, 0, "new packet flags must be zero");
+	TEST_ASSERT_EQUAL(packet->vlan, 0, "new packet vlan must be zero");
+	TEST_ASSERT_EQUAL(
+		packet->recirc_total_count,
+		0,
+		"new packet recirculation total must be zero"
+	);
+	TEST_ASSERT_EQUAL(
+		packet->recirc_stall_count,
+		0,
+		"new packet recirculation stall count must be zero"
+	);
+	TEST_ASSERT_EQUAL(
+		packet->fragment_offset,
+		0,
+		"new packet fragment offset must be zero"
+	);
+	TEST_ASSERT_EQUAL(
+		packet->data_len, 0, "new packet data length must be zero"
+	);
+	worker_packet_free(packet);
+	return TEST_SUCCESS;
+}
+
+static int
+test_recirc_drop_counts_full_packet(struct rte_mempool *pool) {
+	struct rte_mbuf *first = rte_pktmbuf_alloc(pool);
+	struct rte_mbuf *second = rte_pktmbuf_alloc(pool);
+	if (first == NULL || second == NULL) {
+		if (first != NULL) {
+			rte_pktmbuf_free(first);
+		}
+		if (second != NULL) {
+			rte_pktmbuf_free(second);
+		}
+		return TEST_FAILED;
+	}
+
+	const uint16_t first_len = 16;
+	const uint16_t second_len = 24;
+	if (rte_pktmbuf_append(first, first_len) == NULL ||
+	    rte_pktmbuf_append(second, second_len) == NULL) {
+		rte_pktmbuf_free(first);
+		rte_pktmbuf_free(second);
+		return TEST_FAILED;
+	}
+	first->next = second;
+	first->nb_segs = 2;
+	first->pkt_len = first_len + second_len;
+
+	struct packet packet = {
+		.mbuf = first,
+		.data_len = first_len,
+	};
+	struct device_entry_ectx entry = {0};
+	uint64_t counters[2] = {0, 0};
+	SET_OFFSET_OF(
+		&entry.counter_packet_recirc_drop,
+		(struct counter_value_handle *)counters
+	);
+
+	device_entry_ectx_count_recirc_drop(&entry, &packet);
+
+	TEST_ASSERT_EQUAL(counters[0], 1, "recirc drop packet count");
+	TEST_ASSERT_EQUAL(
+		counters[1], first_len + second_len, "recirc drop byte count"
+	);
+	rte_pktmbuf_free(first);
+	return TEST_SUCCESS;
 }
 
 /*
@@ -216,6 +340,10 @@ main(void) {
 		const char *name;
 		int (*fn)(struct rte_mempool *);
 	} tests[] = {
+		{"packet_alloc_resets_metadata",
+		 test_packet_alloc_resets_metadata},
+		{"recirc_drop_counts_full_packet",
+		 test_recirc_drop_counts_full_packet},
 		{"multi_segment", test_multi_segment},
 		{"jumbo", test_jumbo},
 	};

--- a/lib/utils/packet.c
+++ b/lib/utils/packet.c
@@ -166,8 +166,10 @@ fill_packet_net4(
 	uint8_t proto,
 	uint16_t flags
 ) {
-	packet->mbuf =
+	struct rte_mbuf *mbuf =
 		make_mbuf4(src_ip, dst_ip, src_port, dst_port, proto, flags);
+	memset(packet, 0, sizeof(*packet));
+	packet->mbuf = mbuf;
 	assert(packet->mbuf != NULL);
 	return parse_packet(packet);
 }
@@ -183,8 +185,10 @@ fill_packet_net6(
 	uint8_t proto,
 	uint16_t flags
 ) {
-	packet->mbuf =
+	struct rte_mbuf *mbuf =
 		make_mbuf6(src_ip, dst_ip, src_port, dst_port, proto, flags);
+	memset(packet, 0, sizeof(*packet));
+	packet->mbuf = mbuf;
 	assert(packet->mbuf != NULL);
 	return parse_packet(packet);
 }

--- a/lib/utils/test.c
+++ b/lib/utils/test.c
@@ -19,14 +19,14 @@ test_convert_packet() {
 	TEST_ASSERT_EQUAL(0, res, "failed to fill packet");
 	TEST_ASSERT_NULL(packet.next, "packet next pointer must be reset");
 	TEST_ASSERT_EQUAL(
-		packet.recirc_total_count,
+		packet.recirc_remaining,
 		0,
-		"packet recirculation total must be reset"
+		"packet recirculation remaining budget must be reset"
 	);
 	TEST_ASSERT_EQUAL(
-		packet.recirc_stall_count,
+		packet.recirc_initialized,
 		0,
-		"packet recirculation stall must be reset"
+		"packet recirculation state must be uninitialized"
 	);
 
 	// get raw packet data

--- a/lib/utils/test.c
+++ b/lib/utils/test.c
@@ -1,4 +1,5 @@
 #include <netinet/in.h>
+#include <string.h>
 
 #include "common/test_assert.h"
 #include "lib/dataplane/packet/packet.h"
@@ -10,11 +11,23 @@ test_convert_packet() {
 	struct packet packet;
 	uint8_t src[] = {192, 166, 22, 33};
 	uint8_t dst[] = {10, 101, 12, 3};
+	memset(&packet, 0xA5, sizeof(packet));
 
 	int res = fill_packet(
 		&packet, src, dst, 1010, 3032, IPPROTO_TCP, IPPROTO_IP, 0
 	);
 	TEST_ASSERT_EQUAL(0, res, "failed to fill packet");
+	TEST_ASSERT_NULL(packet.next, "packet next pointer must be reset");
+	TEST_ASSERT_EQUAL(
+		packet.recirc_total_count,
+		0,
+		"packet recirculation total must be reset"
+	);
+	TEST_ASSERT_EQUAL(
+		packet.recirc_stall_count,
+		0,
+		"packet recirculation stall must be reset"
+	);
 
 	// get raw packet data
 

--- a/modules/decap/tests/functional/decap_test.go
+++ b/modules/decap/tests/functional/decap_test.go
@@ -739,7 +739,7 @@ func TestDecap_NonIPPacket_UnchangedOutput(t *testing.T) {
 }
 
 // verifies that five nested tunnel removals can redirect to the final packet.
-func Test_Decap_NestedIPIPFiveLayersReachOutput(t *testing.T) {
+func TestDecap_NestedIPIPFiveLayersReachOutput(t *testing.T) {
 	h, agent, decapBackend := setupDecapHarness(t)
 	decapHandle, err := decapBackend.UpdateModule(
 		"nested",
@@ -937,7 +937,7 @@ func TestDecap_NestedIPIPStopsAtTotalLimit(t *testing.T) {
 }
 
 // verifies that a no-op decap does not add packet-lineage redirect credits.
-func Test_Decap_MissDoesNotRenewTotalLimit(t *testing.T) {
+func TestDecap_MissDoesNotRenewTotalLimit(t *testing.T) {
 	h, agent, decapBackend := setupDecapHarnessWithLimit(t, 4)
 	decapHandle, err := decapBackend.UpdateModule(
 		"miss",

--- a/modules/decap/tests/functional/decap_test.go
+++ b/modules/decap/tests/functional/decap_test.go
@@ -32,15 +32,23 @@ const (
 )
 
 func setupDecapHarness(t *testing.T) (*dataplaneut.Harness, *ffi.Agent, decap.Backend) {
+	return setupDecapHarnessWithLimit(t, 0)
+}
+
+func setupDecapHarnessWithLimit(
+	t *testing.T,
+	packetRecircLimit uint16,
+) (*dataplaneut.Harness, *ffi.Agent, decap.Backend) {
 	t.Helper()
 
 	h, err := dataplaneut.NewHarness(dataplaneut.Config{
-		CPMemory:      uint64(decapCPSize),
-		DPMemory:      uint64(decapDPSize),
-		WorkerCount:   1,
-		Devices:       []string{"port0"},
-		Modules:       []string{"decap", "forward"},
-		DevicesToLoad: []string{"plain"},
+		CPMemory:          uint64(decapCPSize),
+		DPMemory:          uint64(decapDPSize),
+		WorkerCount:       1,
+		PacketRecircLimit: packetRecircLimit,
+		Devices:           []string{"port0"},
+		Modules:           []string{"decap", "forward"},
+		DevicesToLoad:     []string{"plain"},
 	})
 	require.NoError(t, err)
 	t.Cleanup(h.Free)
@@ -728,4 +736,264 @@ func TestDecap_NonIPPacket_UnchangedOutput(t *testing.T) {
 	require.Len(t, res.Output, 1)
 	require.Empty(t, res.Drop)
 	require.Equal(t, pkt.Data(), res.Output[0].RawData[:len(pkt.Data())])
+}
+
+// TestDecap_NestedIPIPRecirculatesPastStallLimit verifies that each successful
+// tunnel removal renews the no-progress allowance while the total lineage
+// budget still bounds the packet.
+func TestDecap_NestedIPIPRecirculatesPastStallLimit(t *testing.T) {
+	h, agent, decapBackend := setupDecapHarness(t)
+	decapHandle, err := decapBackend.UpdateModule(
+		"nested",
+		[]netip.Prefix{netip.MustParsePrefix("4.5.6.0/24")},
+	)
+	require.NoError(t, err)
+	t.Cleanup(decapHandle.Free)
+
+	forwardBackend := forward.NewBackend(agent)
+	loopHandle, err := forwardBackend.UpdateModule("nested-loop", []cforward.ForwardRule{{
+		Target:  "port0",
+		Mode:    cforward.ModeIn,
+		Counter: "loop",
+		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:   filter.IPNets{filter.MustParseIPNet("4.5.6.0/24")},
+	}})
+	require.NoError(t, err)
+	t.Cleanup(loopHandle.Free)
+
+	sinkHandle, err := forwardBackend.UpdateModule("nested-sink", []cforward.ForwardRule{
+		{
+			Target:  "port0",
+			Mode:    cforward.ModeOut,
+			Counter: "sink4",
+			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		},
+		{
+			Target:  "port0",
+			Mode:    cforward.ModeOut,
+			Counter: "sink_l2",
+			Devices: filter.Devices{{Name: "port0"}},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(sinkHandle.Free)
+
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: "nested",
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name: "nested_chain",
+				Modules: []ffi.ChainModuleConfig{
+					{Type: "decap", Name: "nested"},
+					{Type: "forward", Name: "nested-loop"},
+					{Type: "forward", Name: "nested-sink"},
+				},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "nested",
+		Functions: []string{"nested"},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "nested-dummy"}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: "nested", Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "nested-dummy", Weight: 1}},
+	}}))
+
+	pkt := nestedIPv4Packet(t, 5)
+	expected := nestedIPv4Packet(t, 0)
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	requireSingleOutputEquals(t, result, expected)
+}
+
+func nestedIPv4Packet(t *testing.T, outerCount int) gopacket.Packet {
+	t.Helper()
+
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("00:00:00:00:00:01")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("00:11:22:33:44:55")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	outer := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolIPv4,
+		SrcIP:    net.ParseIP("192.0.2.1"),
+		DstIP:    net.ParseIP("4.5.6.7"),
+	}
+	inner := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolICMPv4,
+		SrcIP:    net.ParseIP("192.0.2.1"),
+		DstIP:    net.ParseIP("198.51.100.1"),
+	}
+	icmp := layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
+	}
+
+	outers := make([]layers.IPv4, outerCount)
+	packetLayers := make([]gopacket.SerializableLayer, 0, outerCount+3)
+	packetLayers = append(packetLayers, &eth)
+	for idx := range outers {
+		outers[idx] = outer
+		packetLayers = append(packetLayers, &outers[idx])
+	}
+	packetLayers = append(packetLayers, &inner, &icmp)
+	return xpacket.LayersToPacket(t, packetLayers...)
+}
+
+// TestDecap_NestedIPIPStopsAtTotalLimit verifies every supported harness
+// limit reaches module execution and fails on the first redirect beyond it.
+func TestDecap_NestedIPIPStopsAtTotalLimit(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		configured uint16
+		limit      uint16
+	}{
+		{name: "default", limit: 16},
+		{name: "minimum", configured: 4, limit: 4},
+		{name: "non_default", configured: 37, limit: 37},
+		{name: "maximum", configured: 256, limit: 256},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			limit := testCase.limit
+			h, agent, decapBackend := setupDecapHarnessWithLimit(t, testCase.configured)
+			decapHandle, err := decapBackend.UpdateModule(
+				"nested",
+				[]netip.Prefix{netip.MustParsePrefix("4.5.6.0/24")},
+			)
+			require.NoError(t, err)
+			t.Cleanup(decapHandle.Free)
+
+			forwardHandle, err := forward.NewBackend(agent).UpdateModule(
+				"loop",
+				[]cforward.ForwardRule{{
+					Target:  "port0",
+					Mode:    cforward.ModeIn,
+					Counter: "loop",
+					Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+					Dst4s:   filter.IPNets{filter.MustParseIPNet("4.5.6.0/24")},
+				}},
+			)
+			require.NoError(t, err)
+			t.Cleanup(forwardHandle.Free)
+
+			require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+				Name: "nested",
+				Chains: []ffi.FunctionChainConfig{{
+					Weight: 1,
+					Chain: ffi.ChainConfig{
+						Name: "nested_chain",
+						Modules: []ffi.ChainModuleConfig{
+							{Type: "decap", Name: "nested"},
+							{Type: "forward", Name: "loop"},
+						},
+					},
+				}},
+			}))
+			require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+				Name:      "nested",
+				Functions: []string{"nested"},
+			}))
+			require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+			require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+				Name:   "port0",
+				Input:  []ffi.DevicePipelineConfig{{Name: "nested", Weight: 1}},
+				Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+			}}))
+
+			packet := nestedIPv4Packet(t, int(limit)+2)
+			result, err := h.HandlePackets(packet)
+			require.NoError(t, err)
+			require.Empty(t, result.Output)
+			require.Len(t, result.Drop, 1)
+
+			packetSize := uint64(len(packet.Data()))
+			inputCount := uint64(limit) + 1
+			inputBytes := inputCount*packetSize -
+				20*uint64(limit)*inputCount/2
+			deviceCounters := dataplaneut.ValueCounters(
+				h.SharedMemory().DPConfig(0).DeviceCounters("port0"),
+			)
+			require.Equal(
+				t,
+				[]uint64{inputCount, inputBytes},
+				deviceCounters["input_rx"],
+			)
+			require.Equal(
+				t,
+				[]uint64{1, packetSize - uint64(limit+1)*20},
+				deviceCounters["input_recirc_drop"],
+			)
+		})
+	}
+}
+
+// TestDecap_MissDoesNotResetStallLimit verifies a no-op decap cannot renew
+// the no-progress allowance of a self-targeting forward loop.
+func TestDecap_MissDoesNotResetStallLimit(t *testing.T) {
+	h, agent, decapBackend := setupDecapHarness(t)
+	decapHandle, err := decapBackend.UpdateModule(
+		"miss",
+		[]netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")},
+	)
+	require.NoError(t, err)
+	t.Cleanup(decapHandle.Free)
+
+	forwardHandle, err := forward.NewBackend(agent).UpdateModule(
+		"loop",
+		[]cforward.ForwardRule{{
+			Target:  "port0",
+			Mode:    cforward.ModeIn,
+			Counter: "loop",
+			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		}},
+	)
+	require.NoError(t, err)
+	t.Cleanup(forwardHandle.Free)
+
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: "miss",
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name: "miss_chain",
+				Modules: []ffi.ChainModuleConfig{
+					{Type: "decap", Name: "miss"},
+					{Type: "forward", Name: "loop"},
+				},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "miss",
+		Functions: []string{"miss"},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: "miss", Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+
+	packet := nestedIPv4Packet(t, 1)
+	result, err := h.HandlePackets(packet)
+	require.NoError(t, err)
+	require.Empty(t, result.Output)
+	require.Len(t, result.Drop, 1)
+
+	packetSize := uint64(len(packet.Data()))
+	deviceCounters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port0"),
+	)
+	require.Equal(t, []uint64{5, 5 * packetSize}, deviceCounters["input_rx"])
+	require.Equal(t, []uint64{1, packetSize}, deviceCounters["input_recirc_drop"])
 }

--- a/modules/decap/tests/functional/decap_test.go
+++ b/modules/decap/tests/functional/decap_test.go
@@ -746,26 +746,26 @@ func Test_Decap_NestedIPIPFiveLayersReachOutput(t *testing.T) {
 		[]netip.Prefix{netip.MustParsePrefix("4.5.6.0/24")},
 	)
 	require.NoError(t, err)
-	t.Cleanup(decapHandle.Free)
+	t.Cleanup(func() { _ = decapHandle.Free() })
 
 	forwardBackend := forward.NewBackend(agent)
 	loopHandle, err := forwardBackend.UpdateModule("nested-loop", []cforward.ForwardRule{{
 		Target:  "port0",
 		Mode:    cforward.ModeIn,
 		Counter: "loop",
-		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
-		Dst4s:   filter.IPNets{filter.MustParseIPNet("4.5.6.0/24")},
+		Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+		Dst4s:   []xnetip.Contiguous[xnetip.Network4]{xnetip.MustParseContiguous4("4.5.6.0/24")},
 	}})
 	require.NoError(t, err)
-	t.Cleanup(loopHandle.Free)
+	t.Cleanup(func() { _ = loopHandle.Free() })
 
 	sinkHandle, err := forwardBackend.UpdateModule("nested-sink", []cforward.ForwardRule{
 		{
 			Target:  "port0",
 			Mode:    cforward.ModeOut,
 			Counter: "sink4",
-			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
-			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+			Dst4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
 		},
 		{
 			Target:  "port0",
@@ -775,7 +775,7 @@ func Test_Decap_NestedIPIPFiveLayersReachOutput(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	t.Cleanup(sinkHandle.Free)
+	t.Cleanup(func() { _ = sinkHandle.Free() })
 
 	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: "nested",
@@ -796,11 +796,12 @@ func Test_Decap_NestedIPIPFiveLayersReachOutput(t *testing.T) {
 		Functions: []string{"nested"},
 	}))
 	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "nested-dummy"}))
-	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: "nested", Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "nested-dummy", Weight: 1}},
-	}}))
+	}})
+	require.NoError(t, err)
 
 	pkt := nestedIPv4Packet(t, 5)
 	expected := nestedIPv4Packet(t, 0)
@@ -868,7 +869,7 @@ func TestDecap_NestedIPIPStopsAtTotalLimit(t *testing.T) {
 				[]netip.Prefix{netip.MustParsePrefix("4.5.6.0/24")},
 			)
 			require.NoError(t, err)
-			t.Cleanup(decapHandle.Free)
+			t.Cleanup(func() { _ = decapHandle.Free() })
 
 			forwardHandle, err := forward.NewBackend(agent).UpdateModule(
 				"loop",
@@ -876,12 +877,12 @@ func TestDecap_NestedIPIPStopsAtTotalLimit(t *testing.T) {
 					Target:  "port0",
 					Mode:    cforward.ModeIn,
 					Counter: "loop",
-					Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
-					Dst4s:   filter.IPNets{filter.MustParseIPNet("4.5.6.0/24")},
+					Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+					Dst4s:   []xnetip.Contiguous[xnetip.Network4]{xnetip.MustParseContiguous4("4.5.6.0/24")},
 				}},
 			)
 			require.NoError(t, err)
-			t.Cleanup(forwardHandle.Free)
+			t.Cleanup(func() { _ = forwardHandle.Free() })
 
 			require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 				Name: "nested",
@@ -901,11 +902,12 @@ func TestDecap_NestedIPIPStopsAtTotalLimit(t *testing.T) {
 				Functions: []string{"nested"},
 			}))
 			require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
-			require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+			_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
 				Name:   "port0",
 				Input:  []ffi.DevicePipelineConfig{{Name: "nested", Weight: 1}},
 				Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
-			}}))
+			}})
+			require.NoError(t, err)
 
 			packet := nestedIPv4Packet(t, int(limit)+2)
 			result, err := h.HandlePackets(packet)
@@ -942,7 +944,7 @@ func Test_Decap_MissDoesNotRenewTotalLimit(t *testing.T) {
 		[]netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")},
 	)
 	require.NoError(t, err)
-	t.Cleanup(decapHandle.Free)
+	t.Cleanup(func() { _ = decapHandle.Free() })
 
 	forwardHandle, err := forward.NewBackend(agent).UpdateModule(
 		"loop",
@@ -950,12 +952,12 @@ func Test_Decap_MissDoesNotRenewTotalLimit(t *testing.T) {
 			Target:  "port0",
 			Mode:    cforward.ModeIn,
 			Counter: "loop",
-			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
-			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+			Dst4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
 		}},
 	)
 	require.NoError(t, err)
-	t.Cleanup(forwardHandle.Free)
+	t.Cleanup(func() { _ = forwardHandle.Free() })
 
 	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: "miss",
@@ -975,11 +977,12 @@ func Test_Decap_MissDoesNotRenewTotalLimit(t *testing.T) {
 		Functions: []string{"miss"},
 	}))
 	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
-	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: "miss", Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
-	}}))
+	}})
+	require.NoError(t, err)
 
 	packet := nestedIPv4Packet(t, 1)
 	result, err := h.HandlePackets(packet)

--- a/modules/decap/tests/functional/decap_test.go
+++ b/modules/decap/tests/functional/decap_test.go
@@ -738,10 +738,8 @@ func TestDecap_NonIPPacket_UnchangedOutput(t *testing.T) {
 	require.Equal(t, pkt.Data(), res.Output[0].RawData[:len(pkt.Data())])
 }
 
-// TestDecap_NestedIPIPRecirculatesPastStallLimit verifies that each successful
-// tunnel removal renews the no-progress allowance while the total lineage
-// budget still bounds the packet.
-func TestDecap_NestedIPIPRecirculatesPastStallLimit(t *testing.T) {
+// verifies that five nested tunnel removals can redirect to the final packet.
+func Test_Decap_NestedIPIPFiveLayersReachOutput(t *testing.T) {
 	h, agent, decapBackend := setupDecapHarness(t)
 	decapHandle, err := decapBackend.UpdateModule(
 		"nested",
@@ -857,7 +855,7 @@ func TestDecap_NestedIPIPStopsAtTotalLimit(t *testing.T) {
 		configured uint16
 		limit      uint16
 	}{
-		{name: "default", limit: 16},
+		{name: "default", limit: 64},
 		{name: "minimum", configured: 4, limit: 4},
 		{name: "non_default", configured: 37, limit: 37},
 		{name: "maximum", configured: 256, limit: 256},
@@ -936,10 +934,9 @@ func TestDecap_NestedIPIPStopsAtTotalLimit(t *testing.T) {
 	}
 }
 
-// TestDecap_MissDoesNotResetStallLimit verifies a no-op decap cannot renew
-// the no-progress allowance of a self-targeting forward loop.
-func TestDecap_MissDoesNotResetStallLimit(t *testing.T) {
-	h, agent, decapBackend := setupDecapHarness(t)
+// verifies that a no-op decap does not add packet-lineage redirect credits.
+func Test_Decap_MissDoesNotRenewTotalLimit(t *testing.T) {
+	h, agent, decapBackend := setupDecapHarnessWithLimit(t, 4)
 	decapHandle, err := decapBackend.UpdateModule(
 		"miss",
 		[]netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")},

--- a/modules/decap/tests/functional/decap_test.go
+++ b/modules/decap/tests/functional/decap_test.go
@@ -739,7 +739,7 @@ func TestDecap_NonIPPacket_UnchangedOutput(t *testing.T) {
 }
 
 // verifies that five nested tunnel removals can redirect to the final packet.
-func TestDecap_NestedIPIPFiveLayersReachOutput(t *testing.T) {
+func Test_Decap_NestedIPIPFiveLayersReachOutput(t *testing.T) {
 	h, agent, decapBackend := setupDecapHarness(t)
 	decapHandle, err := decapBackend.UpdateModule(
 		"nested",
@@ -848,9 +848,9 @@ func nestedIPv4Packet(t *testing.T, outerCount int) gopacket.Packet {
 	return xpacket.LayersToPacket(t, packetLayers...)
 }
 
-// TestDecap_NestedIPIPStopsAtTotalLimit verifies every supported harness
-// limit reaches module execution and fails on the first redirect beyond it.
-func TestDecap_NestedIPIPStopsAtTotalLimit(t *testing.T) {
+// verifies that every supported harness limit reaches module execution and
+// fails on the first redirect beyond it.
+func Test_Decap_NestedIPIPStopsAtTotalLimit(t *testing.T) {
 	for _, testCase := range []struct {
 		name       string
 		configured uint16
@@ -937,7 +937,7 @@ func TestDecap_NestedIPIPStopsAtTotalLimit(t *testing.T) {
 }
 
 // verifies that a no-op decap does not add packet-lineage redirect credits.
-func TestDecap_MissDoesNotRenewTotalLimit(t *testing.T) {
+func Test_Decap_MissDoesNotRenewTotalLimit(t *testing.T) {
 	h, agent, decapBackend := setupDecapHarnessWithLimit(t, 4)
 	decapHandle, err := decapBackend.UpdateModule(
 		"miss",

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -522,7 +522,7 @@ func TestForward_ModeIn_IPv4(t *testing.T) {
 }
 
 // verifies that a recurring ingress redirect spends its total limit.
-func Test_Forward_ModeInSelfTargetStopsAtTotalLimit(t *testing.T) {
+func TestForward_ModeInSelfTargetStopsAtTotalLimit(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
@@ -561,7 +561,7 @@ func Test_Forward_ModeInSelfTargetStopsAtTotalLimit(t *testing.T) {
 }
 
 // verifies that an input recirculation drop is counted on the target device.
-func Test_Forward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
+func TestForward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
@@ -642,7 +642,7 @@ func Test_Forward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 }
 
 // verifies that input and output redirects share one packet-lineage limit.
-func Test_Forward_MixedModeLoopSharesTotalLimit(t *testing.T) {
+func TestForward_MixedModeLoopSharesTotalLimit(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
@@ -740,7 +740,7 @@ func Test_Forward_MixedModeLoopSharesTotalLimit(t *testing.T) {
 }
 
 // verifies that a recurring egress redirect spends its total limit.
-func Test_Forward_ModeOutSelfTargetStopsAtTotalLimit(t *testing.T) {
+func TestForward_ModeOutSelfTargetStopsAtTotalLimit(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -41,17 +41,27 @@ func setupForwardHarness(
 	t *testing.T,
 	devices []string,
 ) (*dataplaneut.Harness, *ffi.Agent, forward.Backend) {
+	return setupForwardHarnessWithLimit(t, devices, 0)
+}
+
+// Builds a forward harness with an explicit packet-lineage redirect limit.
+func setupForwardHarnessWithLimit(
+	t *testing.T,
+	devices []string,
+	packetRecircLimit uint16,
+) (*dataplaneut.Harness, *ffi.Agent, forward.Backend) {
 	t.Helper()
 
-	cfg := dataplaneut.Config{
-		CPMemory:      uint64(fwdCPSize),
-		DPMemory:      uint64(fwdDPSize),
-		WorkerCount:   1,
-		Devices:       devices,
-		Modules:       []string{"forward"},
-		DevicesToLoad: []string{"plain"},
+	config := dataplaneut.Config{
+		CPMemory:          uint64(fwdCPSize),
+		DPMemory:          uint64(fwdDPSize),
+		WorkerCount:       1,
+		PacketRecircLimit: packetRecircLimit,
+		Devices:           devices,
+		Modules:           []string{"forward"},
+		DevicesToLoad:     []string{"plain"},
 	}
-	h, err := dataplaneut.NewHarness(cfg)
+	h, err := dataplaneut.NewHarness(config)
 	require.NoError(t, err)
 	t.Cleanup(h.Free)
 
@@ -511,8 +521,8 @@ func TestForward_ModeIn_IPv4(t *testing.T) {
 	require.Equal(t, []uint64{0, 0}, deviceCounters["output_recirc_drop"])
 }
 
-// verifies that a recurring ingress redirect terminates with an accounted drop.
-func Test_Forward_ModeInSelfTargetStopsAtStallLimit(t *testing.T) {
+// verifies that a recurring ingress redirect spends its total limit.
+func Test_Forward_ModeInSelfTargetStopsAtTotalLimit(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
@@ -525,7 +535,7 @@ func Test_Forward_ModeInSelfTargetStopsAtStallLimit(t *testing.T) {
 		Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
 	}
 
-	h, agent, backend := setupForwardHarness(t, []string{"port0"})
+	h, agent, backend := setupForwardHarnessWithLimit(t, []string{"port0"}, 4)
 	applyRules(t, backend, "test", []cforward.ForwardRule{rule})
 	wireForwardPipeline(t, agent, "port0", "test", nil)
 
@@ -566,7 +576,9 @@ func Test_Forward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 		{name: "loop1", device: "port1", target: "port0"},
 	}
 
-	h, agent, backend := setupForwardHarness(t, []string{"port0", "port1"})
+	h, agent, backend := setupForwardHarnessWithLimit(
+		t, []string{"port0", "port1"}, 4,
+	)
 	for _, route := range routes {
 		applyRules(t, backend, route.name, []cforward.ForwardRule{{
 			Target:  route.target,
@@ -628,13 +640,15 @@ func Test_Forward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 	require.Equal(t, []uint64{0, 0}, port1Counters["output_recirc_drop"])
 }
 
-// verifies that input and output redirects share one packet stall budget.
-func Test_Forward_MixedModeLoopSharesStallLimit(t *testing.T) {
+// verifies that input and output redirects share one packet-lineage limit.
+func Test_Forward_MixedModeLoopSharesTotalLimit(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
 
-	h, agent, backend := setupForwardHarness(t, []string{"port0", "port1"})
+	h, agent, backend := setupForwardHarnessWithLimit(
+		t, []string{"port0", "port1"}, 4,
+	)
 	applyRules(t, backend, "to_input", []cforward.ForwardRule{{
 		Target:  "port1",
 		Mode:    cforward.ModeIn,
@@ -723,13 +737,13 @@ func Test_Forward_MixedModeLoopSharesStallLimit(t *testing.T) {
 	require.Equal(t, []uint64{0, 0}, port1Counters["output_recirc_drop"])
 }
 
-// verifies that a recurring egress redirect terminates with an accounted drop.
-func Test_Forward_ModeOutSelfTargetStopsAtStallLimit(t *testing.T) {
+// verifies that a recurring egress redirect spends its total limit.
+func Test_Forward_ModeOutSelfTargetStopsAtTotalLimit(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
 
-	h, agent, backend := setupForwardHarness(t, []string{"port0"})
+	h, agent, backend := setupForwardHarnessWithLimit(t, []string{"port0"}, 4)
 	applyRules(t, backend, "feeder", catchAllForwardRules("port0"))
 	applyRules(t, backend, "loop", catchAllForwardRules("port0"))
 
@@ -787,7 +801,9 @@ func TestForward_ModeOutCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 	packet := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	packetSize := uint64(len(packet.Data()))
 
-	h, agent, backend := setupForwardHarness(t, []string{"port0", "port1"})
+	h, agent, backend := setupForwardHarnessWithLimit(
+		t, []string{"port0", "port1"}, 4,
+	)
 	routes := []struct {
 		name   string
 		target string

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -503,6 +503,355 @@ func TestForward_ModeIn_IPv4(t *testing.T) {
 		ModuleName: "test",
 	}
 	dataplaneut.RequireModuleCounter(t, h, path, "rule0", 1, pktSize)
+
+	deviceCounters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port1"),
+	)
+	require.Equal(t, []uint64{0, 0}, deviceCounters["input_recirc_drop"])
+	require.Equal(t, []uint64{0, 0}, deviceCounters["output_recirc_drop"])
+}
+
+// verifies that a recurring ingress redirect terminates with an accounted drop.
+func Test_Forward_ModeInSelfTargetStopsAtStallLimit(t *testing.T) {
+	eth, ip4, _, icmp := fwdEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	pktSize := uint64(len(pkt.Data()))
+
+	rule := cforward.ForwardRule{
+		Target:  "port0",
+		Mode:    cforward.ModeIn,
+		Counter: "self",
+		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+	}
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0"})
+	applyRules(t, backend, "test", []cforward.ForwardRule{rule})
+	wireForwardPipeline(t, agent, "port0", "test", nil)
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output)
+	require.Len(t, result.Drop, 1)
+
+	deviceCounters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port0"),
+	)
+	require.Equal(
+		t,
+		[]uint64{1, pktSize},
+		deviceCounters["input_recirc_drop"],
+	)
+	require.Equal(
+		t,
+		[]uint64{5, 5 * pktSize},
+		deviceCounters["input_rx"],
+	)
+	require.Equal(t, []uint64{0, 0}, deviceCounters["output_recirc_drop"])
+}
+
+// verifies that an input recirculation drop is counted on the target device.
+func Test_Forward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
+	eth, ip4, _, icmp := fwdEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	pktSize := uint64(len(pkt.Data()))
+
+	type route struct {
+		name   string
+		device string
+		target string
+	}
+	routes := []route{
+		{name: "loop0", device: "port0", target: "port1"},
+		{name: "loop1", device: "port1", target: "port0"},
+	}
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0", "port1"})
+	for _, route := range routes {
+		applyRules(t, backend, route.name, []cforward.ForwardRule{{
+			Target:  route.target,
+			Mode:    cforward.ModeIn,
+			Counter: route.name,
+			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		}})
+		require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+			Name: route.name,
+			Chains: []ffi.FunctionChainConfig{{
+				Weight: 1,
+				Chain: ffi.ChainConfig{
+					Name:    route.name + "_chain",
+					Modules: []ffi.ChainModuleConfig{{Type: "forward", Name: route.name}},
+				},
+			}},
+		}))
+		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+			Name:      route.name,
+			Functions: []string{route.name},
+		}))
+		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+			Name: "dummy_out_" + route.device,
+		}))
+	}
+
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{
+		{
+			Name:   "port0",
+			Input:  []ffi.DevicePipelineConfig{{Name: "loop0", Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "dummy_out_port0", Weight: 1}},
+		},
+		{
+			Name:   "port1",
+			Input:  []ffi.DevicePipelineConfig{{Name: "loop1", Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "dummy_out_port1", Weight: 1}},
+		},
+	}))
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output)
+	require.Len(t, result.Drop, 1)
+
+	port0Counters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port0"),
+	)
+	port1Counters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port1"),
+	)
+	require.Equal(t, []uint64{0, 0}, port0Counters["input_recirc_drop"])
+	require.Equal(t, []uint64{0, 0}, port0Counters["output_recirc_drop"])
+	require.Equal(
+		t,
+		[]uint64{1, pktSize},
+		port1Counters["input_recirc_drop"],
+	)
+	require.Equal(t, []uint64{0, 0}, port1Counters["output_recirc_drop"])
+}
+
+// verifies that input and output redirects share one packet stall budget.
+func Test_Forward_MixedModeLoopSharesStallLimit(t *testing.T) {
+	eth, ip4, _, icmp := fwdEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	pktSize := uint64(len(pkt.Data()))
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0", "port1"})
+	applyRules(t, backend, "to_input", []cforward.ForwardRule{{
+		Target:  "port1",
+		Mode:    cforward.ModeIn,
+		Counter: "to_input",
+		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+	}})
+	applyRules(t, backend, "to_output", []cforward.ForwardRule{{
+		Target:  "port0",
+		Mode:    cforward.ModeOut,
+		Counter: "to_output",
+		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+	}})
+
+	for _, name := range []string{"to_input", "to_output"} {
+		require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+			Name: name,
+			Chains: []ffi.FunctionChainConfig{{
+				Weight: 1,
+				Chain: ffi.ChainConfig{
+					Name: name + "_chain",
+					Modules: []ffi.ChainModuleConfig{{
+						Type: "forward",
+						Name: name,
+					}},
+				},
+			}},
+		}))
+	}
+	for _, pipeline := range []struct {
+		name     string
+		function string
+	}{
+		{name: "to_input_in", function: "to_input"},
+		{name: "to_input_out", function: "to_input"},
+		{name: "to_output_in", function: "to_output"},
+	} {
+		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+			Name:      pipeline.name,
+			Functions: []string{pipeline.function},
+		}))
+	}
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name: "dummy_out_port1",
+	}))
+
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{
+		{
+			Name:   "port0",
+			Input:  []ffi.DevicePipelineConfig{{Name: "to_input_in", Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "to_input_out", Weight: 1}},
+		},
+		{
+			Name:   "port1",
+			Input:  []ffi.DevicePipelineConfig{{Name: "to_output_in", Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "dummy_out_port1", Weight: 1}},
+		},
+	}))
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output)
+	require.Len(t, result.Drop, 1)
+
+	port0Counters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port0"),
+	)
+	port1Counters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port1"),
+	)
+	require.Equal(t, []uint64{0, 0}, port0Counters["output_recirc_drop"])
+	require.Equal(t, []uint64{0, 0}, port0Counters["input_recirc_drop"])
+	require.Equal(t, []uint64{1, pktSize}, port0Counters["input_rx"])
+	require.Equal(
+		t, []uint64{2, 2 * pktSize}, port0Counters["output_rx"],
+	)
+	require.Equal(
+		t, []uint64{2, 2 * pktSize}, port1Counters["input_rx"],
+	)
+	require.Equal(
+		t,
+		[]uint64{1, pktSize},
+		port1Counters["input_recirc_drop"],
+	)
+	require.Equal(t, []uint64{0, 0}, port1Counters["output_recirc_drop"])
+}
+
+// verifies that a recurring egress redirect terminates with an accounted drop.
+func Test_Forward_ModeOutSelfTargetStopsAtStallLimit(t *testing.T) {
+	eth, ip4, _, icmp := fwdEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	pktSize := uint64(len(pkt.Data()))
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0"})
+	applyRules(t, backend, "feeder", catchAllForwardRules("port0"))
+	applyRules(t, backend, "loop", catchAllForwardRules("port0"))
+
+	for _, name := range []string{"feeder", "loop"} {
+		require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+			Name: name,
+			Chains: []ffi.FunctionChainConfig{{
+				Weight: 1,
+				Chain: ffi.ChainConfig{
+					Name: name + "_chain",
+					Modules: []ffi.ChainModuleConfig{{
+						Type: "forward",
+						Name: name,
+					}},
+				},
+			}},
+		}))
+		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+			Name:      name,
+			Functions: []string{name},
+		}))
+	}
+
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: "feeder", Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "loop", Weight: 1}},
+	}}))
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output)
+	require.Len(t, result.Drop, 1)
+
+	deviceCounters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port0"),
+	)
+	require.Equal(
+		t,
+		[]uint64{1, pktSize},
+		deviceCounters["output_recirc_drop"],
+	)
+	require.Equal(
+		t,
+		[]uint64{4, 4 * pktSize},
+		deviceCounters["output_rx"],
+	)
+	require.Equal(t, []uint64{0, 0}, deviceCounters["input_recirc_drop"])
+}
+
+// TestForward_ModeOutCrossDeviceLoopAttributesDropToTarget verifies an output
+// recirculation failure is charged to the entry the packet tried to enter.
+func TestForward_ModeOutCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
+	eth, ip4, _, icmp := fwdEtherLayers()
+	packet := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	packetSize := uint64(len(packet.Data()))
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0", "port1"})
+	routes := []struct {
+		name   string
+		target string
+	}{
+		{name: "feeder", target: "port1"},
+		{name: "loop0", target: "port1"},
+		{name: "loop1", target: "port0"},
+	}
+	for _, route := range routes {
+		applyRules(t, backend, route.name, []cforward.ForwardRule{{
+			Target:  route.target,
+			Mode:    cforward.ModeOut,
+			Counter: route.name,
+			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		}})
+		require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+			Name: route.name,
+			Chains: []ffi.FunctionChainConfig{{
+				Weight: 1,
+				Chain: ffi.ChainConfig{
+					Name: route.name + "_chain",
+					Modules: []ffi.ChainModuleConfig{{
+						Type: "forward",
+						Name: route.name,
+					}},
+				},
+			}},
+		}))
+		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+			Name:      route.name,
+			Functions: []string{route.name},
+		}))
+	}
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{
+		{
+			Name:   "port0",
+			Input:  []ffi.DevicePipelineConfig{{Name: "feeder", Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "loop0", Weight: 1}},
+		},
+		{
+			Name:   "port1",
+			Input:  []ffi.DevicePipelineConfig{{Name: "feeder", Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "loop1", Weight: 1}},
+		},
+	}))
+
+	result, err := h.HandlePackets(packet)
+	require.NoError(t, err)
+	require.Empty(t, result.Output)
+	require.Len(t, result.Drop, 1)
+
+	port0Counters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port0"),
+	)
+	port1Counters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port1"),
+	)
+	require.Equal(t, []uint64{0, 0}, port0Counters["output_recirc_drop"])
+	require.Equal(
+		t,
+		[]uint64{1, packetSize},
+		port1Counters["output_recirc_drop"],
+	)
 }
 
 // TestForward_UnmappedDevice verifies that a rule whose target device is not

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -522,7 +522,7 @@ func TestForward_ModeIn_IPv4(t *testing.T) {
 }
 
 // verifies that a recurring ingress redirect spends its total limit.
-func TestForward_ModeInSelfTargetStopsAtTotalLimit(t *testing.T) {
+func Test_Forward_ModeInSelfTargetStopsAtTotalLimit(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
@@ -561,7 +561,7 @@ func TestForward_ModeInSelfTargetStopsAtTotalLimit(t *testing.T) {
 }
 
 // verifies that an input recirculation drop is counted on the target device.
-func TestForward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
+func Test_Forward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
@@ -642,7 +642,7 @@ func TestForward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 }
 
 // verifies that input and output redirects share one packet-lineage limit.
-func TestForward_MixedModeLoopSharesTotalLimit(t *testing.T) {
+func Test_Forward_MixedModeLoopSharesTotalLimit(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
@@ -740,7 +740,7 @@ func TestForward_MixedModeLoopSharesTotalLimit(t *testing.T) {
 }
 
 // verifies that a recurring egress redirect spends its total limit.
-func TestForward_ModeOutSelfTargetStopsAtTotalLimit(t *testing.T) {
+func Test_Forward_ModeOutSelfTargetStopsAtTotalLimit(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
@@ -797,9 +797,9 @@ func TestForward_ModeOutSelfTargetStopsAtTotalLimit(t *testing.T) {
 	require.Equal(t, []uint64{0, 0}, deviceCounters["input_recirc_drop"])
 }
 
-// TestForward_ModeOutCrossDeviceLoopAttributesDropToTarget verifies an output
-// recirculation failure is charged to the entry the packet tried to enter.
-func TestForward_ModeOutCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
+// verifies that an output recirculation failure is charged to the entry
+// the packet tried to enter.
+func Test_Forward_ModeOutCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 	eth, ip4, _, icmp := fwdEtherLayers()
 	packet := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	packetSize := uint64(len(packet.Data()))

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -531,8 +531,8 @@ func Test_Forward_ModeInSelfTargetStopsAtTotalLimit(t *testing.T) {
 		Target:  "port0",
 		Mode:    cforward.ModeIn,
 		Counter: "self",
-		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
-		Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+		Dst4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
 	}
 
 	h, agent, backend := setupForwardHarnessWithLimit(t, []string{"port0"}, 4)
@@ -584,8 +584,8 @@ func Test_Forward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 			Target:  route.target,
 			Mode:    cforward.ModeIn,
 			Counter: route.name,
-			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
-			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+			Dst4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
 		}})
 		require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 			Name: route.name,
@@ -606,7 +606,7 @@ func Test_Forward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 		}))
 	}
 
-	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{
+	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{
 		{
 			Name:   "port0",
 			Input:  []ffi.DevicePipelineConfig{{Name: "loop0", Weight: 1}},
@@ -617,7 +617,8 @@ func Test_Forward_ModeInCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 			Input:  []ffi.DevicePipelineConfig{{Name: "loop1", Weight: 1}},
 			Output: []ffi.DevicePipelineConfig{{Name: "dummy_out_port1", Weight: 1}},
 		},
-	}))
+	})
+	require.NoError(t, err)
 
 	result, err := h.HandlePackets(pkt)
 	require.NoError(t, err)
@@ -653,15 +654,15 @@ func Test_Forward_MixedModeLoopSharesTotalLimit(t *testing.T) {
 		Target:  "port1",
 		Mode:    cforward.ModeIn,
 		Counter: "to_input",
-		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
-		Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+		Dst4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
 	}})
 	applyRules(t, backend, "to_output", []cforward.ForwardRule{{
 		Target:  "port0",
 		Mode:    cforward.ModeOut,
 		Counter: "to_output",
-		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
-		Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+		Dst4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
 	}})
 
 	for _, name := range []string{"to_input", "to_output"} {
@@ -696,7 +697,7 @@ func Test_Forward_MixedModeLoopSharesTotalLimit(t *testing.T) {
 		Name: "dummy_out_port1",
 	}))
 
-	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{
+	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{
 		{
 			Name:   "port0",
 			Input:  []ffi.DevicePipelineConfig{{Name: "to_input_in", Weight: 1}},
@@ -707,7 +708,8 @@ func Test_Forward_MixedModeLoopSharesTotalLimit(t *testing.T) {
 			Input:  []ffi.DevicePipelineConfig{{Name: "to_output_in", Weight: 1}},
 			Output: []ffi.DevicePipelineConfig{{Name: "dummy_out_port1", Weight: 1}},
 		},
-	}))
+	})
+	require.NoError(t, err)
 
 	result, err := h.HandlePackets(pkt)
 	require.NoError(t, err)
@@ -767,11 +769,12 @@ func Test_Forward_ModeOutSelfTargetStopsAtTotalLimit(t *testing.T) {
 		}))
 	}
 
-	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: "feeder", Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "loop", Weight: 1}},
-	}}))
+	}})
+	require.NoError(t, err)
 
 	result, err := h.HandlePackets(pkt)
 	require.NoError(t, err)
@@ -817,8 +820,8 @@ func TestForward_ModeOutCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 			Target:  route.target,
 			Mode:    cforward.ModeOut,
 			Counter: route.name,
-			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
-			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+			Dst4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
 		}})
 		require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 			Name: route.name,
@@ -838,7 +841,7 @@ func TestForward_ModeOutCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 			Functions: []string{route.name},
 		}))
 	}
-	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{
+	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{
 		{
 			Name:   "port0",
 			Input:  []ffi.DevicePipelineConfig{{Name: "feeder", Weight: 1}},
@@ -849,7 +852,8 @@ func TestForward_ModeOutCrossDeviceLoopAttributesDropToTarget(t *testing.T) {
 			Input:  []ffi.DevicePipelineConfig{{Name: "feeder", Weight: 1}},
 			Output: []ffi.DevicePipelineConfig{{Name: "loop1", Weight: 1}},
 		},
-	}))
+	})
+	require.NoError(t, err)
 
 	result, err := h.HandlePackets(packet)
 	require.NoError(t, err)

--- a/modules/mirror/dataplane/dataplane.c
+++ b/modules/mirror/dataplane/dataplane.c
@@ -30,7 +30,9 @@ mirror_clone(
 	void (*route)(struct module_ectx *, struct packet_front *, struct packet *),
 	uint16_t device_id
 ) {
-	struct packet *clone = worker_clone_packet(worker, packet);
+	struct packet *clone = worker_clone_packet(
+		worker, packet, module_ectx->packet_recirc_limit
+	);
 	if (clone == NULL) {
 		return;
 	}

--- a/modules/mirror/tests/functional/mirror_test.go
+++ b/modules/mirror/tests/functional/mirror_test.go
@@ -660,15 +660,15 @@ func TestMirror_OutputSelfLoopHasBoundedPopulation(t *testing.T) {
 		Target:  "port0",
 		Mode:    cmirror.ModeOut,
 		Counter: "mirror",
-		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
-		Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+		Dst4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
 	}})
 	forwardHandle, err := forward.NewBackend(agent).UpdateModule(
 		"sink",
 		catchAllForwardRules("port0"),
 	)
 	require.NoError(t, err)
-	t.Cleanup(forwardHandle.Free)
+	t.Cleanup(func() { _ = forwardHandle.Free() })
 
 	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: "loop",
@@ -691,11 +691,12 @@ func TestMirror_OutputSelfLoopHasBoundedPopulation(t *testing.T) {
 		Name:      "feeder",
 		Functions: []string{"loop"},
 	}))
-	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: "feeder", Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "loop", Weight: 1}},
-	}}))
+	}})
+	require.NoError(t, err)
 
 	require.Zero(t, h.OutstandingMbufs())
 	result, err := h.HandlePackets(packet)

--- a/modules/mirror/tests/functional/mirror_test.go
+++ b/modules/mirror/tests/functional/mirror_test.go
@@ -40,17 +40,27 @@ func setupMirrorHarness(
 	t *testing.T,
 	devices []string,
 ) (*dataplaneut.Harness, *ffi.Agent, mirror.Backend) {
+	return setupMirrorHarnessWithLimit(t, devices, 0)
+}
+
+// Builds a mirror harness with an explicit packet-lineage redirect limit.
+func setupMirrorHarnessWithLimit(
+	t *testing.T,
+	devices []string,
+	packetRecircLimit uint16,
+) (*dataplaneut.Harness, *ffi.Agent, mirror.Backend) {
 	t.Helper()
 
-	cfg := dataplaneut.Config{
-		CPMemory:      uint64(mirCPSize),
-		DPMemory:      uint64(mirDPSize),
-		WorkerCount:   1,
-		Devices:       devices,
-		Modules:       []string{"mirror", "forward"},
-		DevicesToLoad: []string{"plain"},
+	config := dataplaneut.Config{
+		CPMemory:          uint64(mirCPSize),
+		DPMemory:          uint64(mirDPSize),
+		WorkerCount:       1,
+		PacketRecircLimit: packetRecircLimit,
+		Devices:           devices,
+		Modules:           []string{"mirror", "forward"},
+		DevicesToLoad:     []string{"plain"},
 	}
-	h, err := dataplaneut.NewHarness(cfg)
+	h, err := dataplaneut.NewHarness(config)
 	require.NoError(t, err)
 	t.Cleanup(h.Free)
 
@@ -639,13 +649,13 @@ func TestMirror_EmptyRound(t *testing.T) {
 	dataplaneut.RequireModuleCounter(t, h, path, "rule0", 0, 0)
 }
 
-// TestMirror_OutputSelfLoopHasBoundedPopulation verifies every clone inherits
-// its source budget, spends it independently, and is reclaimed after conversion.
+// TestMirror_OutputSelfLoopHasBoundedPopulation verifies clones partition one
+// lineage budget and are reclaimed after conversion.
 func TestMirror_OutputSelfLoopHasBoundedPopulation(t *testing.T) {
 	eth, ip4, _, icmp := mirEtherLayers()
 	packet := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 
-	h, agent, backend := setupMirrorHarness(t, []string{"port0"})
+	h, agent, backend := setupMirrorHarnessWithLimit(t, []string{"port0"}, 4)
 	applyRules(t, backend, "loop", []cmirror.MirrorRule{{
 		Target:  "port0",
 		Mode:    cmirror.ModeOut,
@@ -691,7 +701,7 @@ func TestMirror_OutputSelfLoopHasBoundedPopulation(t *testing.T) {
 	result, err := h.HandlePackets(packet)
 	require.NoError(t, err)
 	require.Empty(t, result.Output)
-	require.Len(t, result.Drop, 32)
+	require.Len(t, result.Drop, 6)
 	require.Equal(t, packet.Data(), result.Drop[0].RawData[:len(packet.Data())])
 	require.Zero(t, h.OutstandingMbufs())
 
@@ -701,7 +711,12 @@ func TestMirror_OutputSelfLoopHasBoundedPopulation(t *testing.T) {
 	)
 	require.Equal(
 		t,
-		[]uint64{32, 32 * packetSize},
+		[]uint64{4, 4 * packetSize},
+		deviceCounters["output_rx"],
+	)
+	require.Equal(
+		t,
+		[]uint64{6, 6 * packetSize},
 		deviceCounters["output_recirc_drop"],
 	)
 }

--- a/modules/mirror/tests/functional/mirror_test.go
+++ b/modules/mirror/tests/functional/mirror_test.go
@@ -649,9 +649,9 @@ func TestMirror_EmptyRound(t *testing.T) {
 	dataplaneut.RequireModuleCounter(t, h, path, "rule0", 0, 0)
 }
 
-// TestMirror_OutputSelfLoopHasBoundedPopulation verifies clones partition one
-// lineage budget and are reclaimed after conversion.
-func TestMirror_OutputSelfLoopHasBoundedPopulation(t *testing.T) {
+// verifies that mirror clones partition one lineage budget and are
+// reclaimed after conversion.
+func Test_Mirror_OutputSelfLoopHasBoundedPopulation(t *testing.T) {
 	eth, ip4, _, icmp := mirEtherLayers()
 	packet := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 

--- a/modules/mirror/tests/functional/mirror_test.go
+++ b/modules/mirror/tests/functional/mirror_test.go
@@ -339,6 +339,7 @@ func TestMirror_ModeOut_IPv4(t *testing.T) {
 	// port1 -> dummy output pipeline -> packet_front.output.
 	require.Len(t, result.Output, 2, "re-routed ModeOut packet plus its mirror copy must reach output")
 	require.Empty(t, result.Drop, "ModeOut packet with valid device must not be dropped")
+	require.Zero(t, h.OutstandingMbufs())
 
 	path := dataplaneut.CounterPath{
 		Device:     "port0",
@@ -636,6 +637,73 @@ func TestMirror_EmptyRound(t *testing.T) {
 	require.Empty(t, result.Output, "empty round produces no output")
 	require.Empty(t, result.Drop, "empty round produces no drops")
 	dataplaneut.RequireModuleCounter(t, h, path, "rule0", 0, 0)
+}
+
+// TestMirror_OutputSelfLoopHasBoundedPopulation verifies every clone inherits
+// its source budget, spends it independently, and is reclaimed after conversion.
+func TestMirror_OutputSelfLoopHasBoundedPopulation(t *testing.T) {
+	eth, ip4, _, icmp := mirEtherLayers()
+	packet := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+
+	h, agent, backend := setupMirrorHarness(t, []string{"port0"})
+	applyRules(t, backend, "loop", []cmirror.MirrorRule{{
+		Target:  "port0",
+		Mode:    cmirror.ModeOut,
+		Counter: "mirror",
+		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+	}})
+	forwardHandle, err := forward.NewBackend(agent).UpdateModule(
+		"sink",
+		catchAllForwardRules("port0"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(forwardHandle.Free)
+
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: "loop",
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name: "loop_chain",
+				Modules: []ffi.ChainModuleConfig{
+					{Type: "mirror", Name: "loop"},
+					{Type: "forward", Name: "sink"},
+				},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "loop",
+		Functions: []string{"loop"},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "feeder",
+		Functions: []string{"loop"},
+	}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: "feeder", Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "loop", Weight: 1}},
+	}}))
+
+	require.Zero(t, h.OutstandingMbufs())
+	result, err := h.HandlePackets(packet)
+	require.NoError(t, err)
+	require.Empty(t, result.Output)
+	require.Len(t, result.Drop, 32)
+	require.Equal(t, packet.Data(), result.Drop[0].RawData[:len(packet.Data())])
+	require.Zero(t, h.OutstandingMbufs())
+
+	packetSize := uint64(len(packet.Data()))
+	deviceCounters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port0"),
+	)
+	require.Equal(
+		t,
+		[]uint64{32, 32 * packetSize},
+		deviceCounters["output_recirc_drop"],
+	)
 }
 
 // TestMirrorConfigMemoryLeak verifies the block allocator returns memory once a

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -786,9 +786,9 @@ func TestRoute_DeviceTranslation_Drop(t *testing.T) {
 	require.Len(t, result.Drop, 1, "expected exactly one dropped packet")
 }
 
-// TestRoute_OutputSelfLoopStopsAtTotalLimit verifies equal-length TTL updates
-// can use the full redirect budget before the target entry accounts the drop.
-func TestRoute_OutputSelfLoopStopsAtTotalLimit(t *testing.T) {
+// verifies that equal-length TTL updates can use the full redirect budget
+// before the target entry accounts the drop.
+func Test_Route_OutputSelfLoopStopsAtTotalLimit(t *testing.T) {
 	h, agent, backend := setupRouteHarnessWithLimit(t, "port0", 5)
 	applyFIB(t, backend, "loop", []FIBEntry{{
 		Prefix:   netip.MustParsePrefix("10.0.0.0/24"),

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -71,17 +71,27 @@ func setupRouteHarness(
 	tb testing.TB,
 	deviceName string,
 ) (*dataplaneut.Harness, *ffi.Agent, route.Backend) {
+	return setupRouteHarnessWithLimit(tb, deviceName, 0)
+}
+
+// Builds a route harness with an explicit packet-lineage redirect limit.
+func setupRouteHarnessWithLimit(
+	tb testing.TB,
+	deviceName string,
+	packetRecircLimit uint16,
+) (*dataplaneut.Harness, *ffi.Agent, route.Backend) {
 	tb.Helper()
 
-	cfg := dataplaneut.Config{
-		CPMemory:      uint64(routeCPSize),
-		DPMemory:      uint64(routeDPSize),
-		WorkerCount:   1,
-		Devices:       []string{deviceName},
-		Modules:       []string{"route"},
-		DevicesToLoad: []string{"plain"},
+	config := dataplaneut.Config{
+		CPMemory:          uint64(routeCPSize),
+		DPMemory:          uint64(routeDPSize),
+		WorkerCount:       1,
+		PacketRecircLimit: packetRecircLimit,
+		Devices:           []string{deviceName},
+		Modules:           []string{"route"},
+		DevicesToLoad:     []string{"plain"},
 	}
-	h, err := dataplaneut.NewHarness(cfg)
+	h, err := dataplaneut.NewHarness(config)
 	require.NoError(tb, err)
 	tb.Cleanup(h.Free)
 
@@ -776,10 +786,10 @@ func TestRoute_DeviceTranslation_Drop(t *testing.T) {
 	require.Len(t, result.Drop, 1, "expected exactly one dropped packet")
 }
 
-// TestRoute_OutputSelfLoopStopsAtStallLimit verifies a route nexthop targeting
-// its own output entry terminates and attributes the drop to that entry.
-func TestRoute_OutputSelfLoopStopsAtStallLimit(t *testing.T) {
-	h, agent, backend := setupRouteHarness(t, "port0")
+// TestRoute_OutputSelfLoopStopsAtTotalLimit verifies equal-length TTL updates
+// can use the full redirect budget before the target entry accounts the drop.
+func TestRoute_OutputSelfLoopStopsAtTotalLimit(t *testing.T) {
+	h, agent, backend := setupRouteHarnessWithLimit(t, "port0", 5)
 	applyFIB(t, backend, "loop", []FIBEntry{{
 		Prefix:   netip.MustParsePrefix("10.0.0.0/24"),
 		Nexthops: []FIBNexthop{routeNextHop},
@@ -826,7 +836,7 @@ func TestRoute_OutputSelfLoopStopsAtStallLimit(t *testing.T) {
 		[]uint64{1, packetSize},
 		deviceCounters["output_recirc_drop"],
 	)
-	require.Equal(t, []uint64{4, 4 * packetSize}, deviceCounters["output_rx"])
+	require.Equal(t, []uint64{5, 5 * packetSize}, deviceCounters["output_rx"])
 }
 
 // routeCounterNames lists every per-outcome counter registered by the route

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -776,6 +776,59 @@ func TestRoute_DeviceTranslation_Drop(t *testing.T) {
 	require.Len(t, result.Drop, 1, "expected exactly one dropped packet")
 }
 
+// TestRoute_OutputSelfLoopStopsAtStallLimit verifies a route nexthop targeting
+// its own output entry terminates and attributes the drop to that entry.
+func TestRoute_OutputSelfLoopStopsAtStallLimit(t *testing.T) {
+	h, agent, backend := setupRouteHarness(t, "port0")
+	applyFIB(t, backend, "loop", []FIBEntry{{
+		Prefix:   netip.MustParsePrefix("10.0.0.0/24"),
+		Nexthops: []FIBNexthop{routeNextHop},
+	}})
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: "loop",
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name: "loop_chain",
+				Modules: []ffi.ChainModuleConfig{{
+					Type: "route",
+					Name: "loop",
+				}},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "loop",
+		Functions: []string{"loop"},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "feeder",
+		Functions: []string{"loop"},
+	}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: "feeder", Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "loop", Weight: 1}},
+	}}))
+
+	packet := buildRouteIPv4Packet(t, "10.0.0.5", 64)
+	packetSize := uint64(len(packet.Data()))
+	result, err := h.HandlePackets(packet)
+	require.NoError(t, err)
+	require.Empty(t, result.Output)
+	require.Len(t, result.Drop, 1)
+
+	deviceCounters := dataplaneut.ValueCounters(
+		h.SharedMemory().DPConfig(0).DeviceCounters("port0"),
+	)
+	require.Equal(
+		t,
+		[]uint64{1, packetSize},
+		deviceCounters["output_recirc_drop"],
+	)
+	require.Equal(t, []uint64{4, 4 * packetSize}, deviceCounters["output_rx"])
+}
+
 // routeCounterNames lists every per-outcome counter registered by the route
 // module in modules/route/api/controlplane.c.
 //

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -815,11 +815,12 @@ func TestRoute_OutputSelfLoopStopsAtTotalLimit(t *testing.T) {
 		Name:      "feeder",
 		Functions: []string{"loop"},
 	}))
-	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: "feeder", Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "loop", Weight: 1}},
-	}}))
+	}})
+	require.NoError(t, err)
 
 	packet := buildRouteIPv4Packet(t, "10.0.0.5", 64)
 	packetSize := uint64(len(packet.Data()))

--- a/modules/unrdup/dataplane/dataplane.c
+++ b/modules/unrdup/dataplane/dataplane.c
@@ -92,10 +92,8 @@ unrdup_outer_end(struct packet *packet, uint32_t *end) {
 		}
 
 		*end = offset + rte_be_to_cpu_16(outer->total_length);
-	} else if (
-		packet->network_header.type ==
-		rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)
-	) {
+	} else if (packet->network_header.type ==
+		   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
 		if (offset + sizeof(struct rte_ipv6_hdr) > data_len) {
 			return -1;
 		}

--- a/modules/unrdup/dataplane/dataplane.c
+++ b/modules/unrdup/dataplane/dataplane.c
@@ -92,8 +92,10 @@ unrdup_outer_end(struct packet *packet, uint32_t *end) {
 		}
 
 		*end = offset + rte_be_to_cpu_16(outer->total_length);
-	} else if (packet->network_header.type ==
-		   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
+	} else if (
+		packet->network_header.type ==
+		rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)
+	) {
 		if (offset + sizeof(struct rte_ipv6_hdr) > data_len) {
 			return -1;
 		}
@@ -631,6 +633,7 @@ unrdup_source_is_set(const uint8_t *addr, uint8_t addr_len) {
 static void
 unrdup_forward_to_peer(
 	const struct unrdup_fanout *fanout,
+	struct module_ectx *module_ectx,
 	struct packet *packet,
 	const struct unrdup_peer *peer,
 	uint32_t entropy
@@ -656,7 +659,9 @@ unrdup_forward_to_peer(
 		return;
 	}
 
-	struct packet *clone = worker_clone_packet(fanout->dp_worker, packet);
+	struct packet *clone = worker_clone_packet(
+		fanout->dp_worker, packet, module_ectx->packet_recirc_limit
+	);
 	if (clone == NULL) {
 		unrdup_count_event(
 			fanout->counter_storage, config->clone_failed_counter_id
@@ -820,7 +825,11 @@ unrdup_handle_packets(
 		struct unrdup_peer *peers = ADDR_OF(&service->peers);
 		for (uint64_t idx = 0; idx < service->peer_count; ++idx) {
 			unrdup_forward_to_peer(
-				&fanout, packet, peers + idx, entropy
+				&fanout,
+				module_ectx,
+				packet,
+				peers + idx,
+				entropy
 			);
 		}
 

--- a/tests/functional/framework/harness.go
+++ b/tests/functional/framework/harness.go
@@ -31,8 +31,9 @@ func baselineTemplatePath(qemuImage, baselineTag string) string {
 // that relies solely on the modules statically linked into the dataplane
 // binary.
 type DataplaneOptions struct {
-	PluginDir string
-	Modules   []string
+	PluginDir         string
+	Modules           []string
+	PacketRecircLimit uint16
 }
 
 // DataplaneConfig returns the baseline dataplane YAML used by functional
@@ -40,6 +41,12 @@ type DataplaneOptions struct {
 func DataplaneConfig(opts DataplaneOptions) string {
 	plugins := ""
 	cpMemory := "134217728"
+	packetRecircLimit := ""
+	if opts.PacketRecircLimit != 0 {
+		packetRecircLimit = fmt.Sprintf(
+			"  packet_recirc_limit: %d\n", opts.PacketRecircLimit,
+		)
+	}
 	if opts.PluginDir != "" {
 		plugins = "  plugin_dir: " + opts.PluginDir + "\n"
 		if len(opts.Modules) > 0 {
@@ -62,7 +69,7 @@ dataplane:
   storage: /dev/hugepages/yanet
   dpdk_memory: 128
   loglevel: trace
-` + plugins + `  instances:
+` + packetRecircLimit + plugins + `  instances:
     - dp_memory: 100663296
       cp_memory: ` + cpMemory + `
       numa_id: 0

--- a/tests/functional/framework/qemu.go
+++ b/tests/functional/framework/qemu.go
@@ -1251,33 +1251,59 @@ func isKVMEnabled() bool {
 	return false
 }
 
+// existingVMPattern builds the pgrep -f pattern that detects a real QEMU
+// process running the given VM name. The opening [q] class prevents pgrep
+// from matching its own command line on macOS and Linux alike, and the
+// trailing ([[:space:]]|$) anchor stops "yanet-test-vm-foo" from matching
+// "yanet-test-vm-foobar".
+func existingVMPattern(vmName string) string {
+	return "[q]emu-system-x86_64.*[[:space:]]-name[[:space:]]+" +
+		regexp.QuoteMeta(vmName) + "([[:space:]]|$)"
+}
+
+// regexpMatch is a tiny indirection used by the unit tests so they can
+// compare a POSIX ERE pattern against a representative command line. The
+// patterns we ship only rely on literal tokens, [[:space:]] classes, and
+// basic quantifiers that Go's regexp engine handles equivalently.
+func regexpMatch(pattern, s string) (bool, error) {
+	return regexp.MatchString(pattern, s)
+}
+
+// pgrepRunner abstracts exec.Command so unit tests can substitute a fake.
+type pgrepRunner func(pattern string) string
+
+// realPgrepRunner is the production runner: shell out to pgrep -f.
+func realPgrepRunner(pattern string) string {
+	out, err := exec.Command("pgrep", "-f", pattern).Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
 // checkForExistingVM checks if there's already a running QEMU process with the given VM name.
 // This prevents conflicts when running tests in parallel or when a previous test didn't clean up properly.
 func (q *QEMUManager) checkForExistingVM(vmName string) error {
-	// Match QEMU itself and exclude pgrep's own command line from the result.
-	pattern := "[q]emu-system-x86_64.*[[:space:]]-name[[:space:]]+" +
-		regexp.QuoteMeta(vmName) + "([[:space:]]|$)"
-	cmd := exec.Command("pgrep", "-f", pattern)
-	output, err := cmd.Output()
+	return checkForExistingVMRun(q, vmName, realPgrepRunner)
+}
 
-	// pgrep returns exit code 1 if no processes found, which is what we want
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-			// No matching processes found - this is good
-			return nil
-		}
-		// Some other error occurred
-		q.log.Warnf("Failed to check for existing VM processes: %v", err)
-		return nil // Don't fail the test if pgrep itself fails
+// checkForExistingVMRun is the testable core. When pgrep finds no matches it
+// returns an empty string and we treat that as success. Any non-empty result
+// is an existing QEMU with our name and we return a duplicate-name error.
+func checkForExistingVMRun(
+	q *QEMUManager,
+	vmName string,
+	run pgrepRunner,
+) error {
+	output := run(existingVMPattern(vmName))
+	if len(output) == 0 {
+		return nil
 	}
-
-	// If we got output, there are matching processes
-	if len(output) > 0 {
-		processes := strings.TrimSpace(string(output))
-		q.log.Errorf("Found existing QEMU process(es) with VM name '%s':", vmName)
-		q.log.Errorf("%s", processes)
-		return fmt.Errorf("cannot start VM '%s': a QEMU process with this name is already running. Please stop the existing VM or use a different name. Process details:\n%s", vmName, processes)
-	}
-
-	return nil
+	processes := strings.TrimSpace(output)
+	q.log.Errorf("Found existing QEMU process(es) with VM name '%s':", vmName)
+	q.log.Errorf("%s", processes)
+	return fmt.Errorf(
+		"cannot start VM '%s': a QEMU process with this name is already running. Please stop the existing VM or use a different name. Process details:\n%s",
+		vmName, processes,
+	)
 }

--- a/tests/functional/framework/qemu.go
+++ b/tests/functional/framework/qemu.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1270,15 +1271,24 @@ func regexpMatch(pattern, s string) (bool, error) {
 }
 
 // pgrepRunner abstracts exec.Command so unit tests can substitute a fake.
-type pgrepRunner func(pattern string) string
+// It mirrors pgrep's contract: ("", nil) when nothing matches, a populated
+// stdout on matches, and a non-nil error when pgrep itself cannot run.
+type pgrepRunner func(pattern string) (string, error)
 
-// realPgrepRunner is the production runner: shell out to pgrep -f.
-func realPgrepRunner(pattern string) string {
+// realPgrepRunner is the production runner: shell out to pgrep -f. Exit
+// status 1 is pgrep's "no process matched" and is not an error; anything
+// else (missing binary, exit 2, signal) must surface to the caller instead
+// of silently passing the duplicate-VM check.
+func realPgrepRunner(pattern string) (string, error) {
 	out, err := exec.Command("pgrep", "-f", pattern).Output()
-	if err != nil {
-		return ""
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return "", nil
 	}
-	return string(out)
+	if err != nil {
+		return "", fmt.Errorf("pgrep -f %q: %w", pattern, err)
+	}
+	return string(out), nil
 }
 
 // checkForExistingVM checks if there's already a running QEMU process with the given VM name.
@@ -1289,13 +1299,20 @@ func (q *QEMUManager) checkForExistingVM(vmName string) error {
 
 // checkForExistingVMRun is the testable core. When pgrep finds no matches it
 // returns an empty string and we treat that as success. Any non-empty result
-// is an existing QEMU with our name and we return a duplicate-name error.
+// is an existing QEMU with our name and we return a duplicate-name error. A
+// runner error means the check itself failed and is propagated so a host
+// without pgrep fails loudly instead of racing a second VM into existence.
 func checkForExistingVMRun(
 	q *QEMUManager,
 	vmName string,
 	run pgrepRunner,
 ) error {
-	output := run(existingVMPattern(vmName))
+	output, err := run(existingVMPattern(vmName))
+	if err != nil {
+		return fmt.Errorf(
+			"cannot check for existing VM '%s': %w", vmName, err,
+		)
+	}
 	if len(output) == 0 {
 		return nil
 	}

--- a/tests/functional/framework/qemu.go
+++ b/tests/functional/framework/qemu.go
@@ -1254,8 +1254,10 @@ func isKVMEnabled() bool {
 // checkForExistingVM checks if there's already a running QEMU process with the given VM name.
 // This prevents conflicts when running tests in parallel or when a previous test didn't clean up properly.
 func (q *QEMUManager) checkForExistingVM(vmName string) error {
-	// Use pgrep to find processes matching the VM name
-	cmd := exec.Command("pgrep", "-af", vmName)
+	// Match QEMU itself and exclude pgrep's own command line from the result.
+	pattern := "[q]emu-system-x86_64.*[[:space:]]-name[[:space:]]+" +
+		regexp.QuoteMeta(vmName) + "([[:space:]]|$)"
+	cmd := exec.Command("pgrep", "-f", pattern)
 	output, err := cmd.Output()
 
 	// pgrep returns exit code 1 if no processes found, which is what we want

--- a/tests/functional/framework/qemu_test.go
+++ b/tests/functional/framework/qemu_test.go
@@ -39,7 +39,9 @@ func findPid(t *testing.T, pattern, cmdline string) bool {
 	return matched
 }
 
-func TestExistingVMPattern_DetectsRealQEMU(t *testing.T) {
+// verifies that the built pattern matches a running qemu argv for the same
+// VM name.
+func Test_ExistingVMPattern_DetectsRealQEMU(t *testing.T) {
 	const vmName = "yanet-test-vm-suite"
 	pattern := existingVMPattern(vmName)
 
@@ -50,7 +52,8 @@ func TestExistingVMPattern_DetectsRealQEMU(t *testing.T) {
 	)
 }
 
-func TestExistingVMPattern_RejectsOtherQEMU(t *testing.T) {
+// verifies that a qemu started for a different VM name never matches.
+func Test_ExistingVMPattern_RejectsOtherQEMU(t *testing.T) {
 	const vmName = "yanet-test-vm-suite"
 	pattern := existingVMPattern(vmName)
 
@@ -61,7 +64,9 @@ func TestExistingVMPattern_RejectsOtherQEMU(t *testing.T) {
 	)
 }
 
-func TestExistingVMPattern_RejectsSimilarName(t *testing.T) {
+// verifies that the trailing boundary rejects longer VM names that merely
+// contain this one.
+func Test_ExistingVMPattern_RejectsSimilarName(t *testing.T) {
 	const vmName = "yanet-test-vm-suite"
 	pattern := existingVMPattern(vmName)
 
@@ -72,7 +77,9 @@ func TestExistingVMPattern_RejectsSimilarName(t *testing.T) {
 	)
 }
 
-func TestExistingVMPattern_RejectsPgrepSelf(t *testing.T) {
+// verifies that the bracketed first token keeps pgrep from matching its
+// own argv.
+func Test_ExistingVMPattern_RejectsPgrepSelf(t *testing.T) {
 	const vmName = "yanet-test-vm-suite"
 	pattern := existingVMPattern(vmName)
 
@@ -85,7 +92,8 @@ func TestExistingVMPattern_RejectsPgrepSelf(t *testing.T) {
 	)
 }
 
-func TestCheckForExistingVMRun_EmptyOutputIsOK(t *testing.T) {
+// verifies that an empty pgrep result reads as no conflict.
+func Test_CheckForExistingVMRun_EmptyOutputIsOK(t *testing.T) {
 	q := &QEMUManager{
 		Name: "main",
 		log:  zap.NewNop().Sugar(),
@@ -98,7 +106,8 @@ func TestCheckForExistingVMRun_EmptyOutputIsOK(t *testing.T) {
 	require.NoError(t, err, "an empty pgrep result must mean no conflict")
 }
 
-func TestCheckForExistingVMRun_PopulatedOutputIsError(t *testing.T) {
+// verifies that a non-empty pgrep result fails the check naming the VM.
+func Test_CheckForExistingVMRun_PopulatedOutputIsError(t *testing.T) {
 	q := &QEMUManager{
 		Name: "main",
 		log:  zap.NewNop().Sugar(),
@@ -118,10 +127,10 @@ func TestCheckForExistingVMRun_PopulatedOutputIsError(t *testing.T) {
 	)
 }
 
-// TestCheckForExistingVMRun_RunnerErrorIsPropagated verifies that a failing
-// pgrep (missing binary on the host, unexpected exit status) surfaces as an
-// error instead of silently passing the duplicate-VM check.
-func TestCheckForExistingVMRun_RunnerErrorIsPropagated(t *testing.T) {
+// verifies that a failing pgrep (missing binary on the host, unexpected
+// exit status) surfaces as an error instead of silently passing the
+// duplicate-VM check.
+func Test_CheckForExistingVMRun_RunnerErrorIsPropagated(t *testing.T) {
 	q := &QEMUManager{
 		Name: "main",
 		log:  zap.NewNop().Sugar(),

--- a/tests/functional/framework/qemu_test.go
+++ b/tests/functional/framework/qemu_test.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -89,9 +90,11 @@ func TestCheckForExistingVMRun_EmptyOutputIsOK(t *testing.T) {
 		Name: "main",
 		log:  zap.NewNop().Sugar(),
 	}
-	err := checkForExistingVMRun(q, "yanet-test-vm-suite", func(string) string {
-		return ""
-	})
+	err := checkForExistingVMRun(
+		q, "yanet-test-vm-suite", func(string) (string, error) {
+			return "", nil
+		},
+	)
 	require.NoError(t, err, "an empty pgrep result must mean no conflict")
 }
 
@@ -103,8 +106,8 @@ func TestCheckForExistingVMRun_PopulatedOutputIsError(t *testing.T) {
 	err := checkForExistingVMRun(
 		q,
 		"yanet-test-vm-suite",
-		func(string) string {
-			return "12345 qemu-system-x86_64 -name yanet-test-vm-suite"
+		func(string) (string, error) {
+			return "12345 qemu-system-x86_64 -name yanet-test-vm-suite", nil
 		},
 	)
 	require.Error(t, err, "non-empty pgrep result must surface as an error")
@@ -112,5 +115,35 @@ func TestCheckForExistingVMRun_PopulatedOutputIsError(t *testing.T) {
 		t,
 		strings.Contains(err.Error(), "yanet-test-vm-suite"),
 		"error must mention the conflicting VM name",
+	)
+}
+
+// TestCheckForExistingVMRun_RunnerErrorIsPropagated verifies that a failing
+// pgrep (missing binary on the host, unexpected exit status) surfaces as an
+// error instead of silently passing the duplicate-VM check.
+func TestCheckForExistingVMRun_RunnerErrorIsPropagated(t *testing.T) {
+	q := &QEMUManager{
+		Name: "main",
+		log:  zap.NewNop().Sugar(),
+	}
+	err := checkForExistingVMRun(
+		q,
+		"yanet-test-vm-suite",
+		func(string) (string, error) {
+			return "", errors.New("exec: pgrep: executable file not found")
+		},
+	)
+	require.Error(
+		t, err, "a pgrep failure must not be treated as no conflict",
+	)
+	require.True(
+		t,
+		strings.Contains(err.Error(), "cannot check for existing VM"),
+		"error must state which check failed",
+	)
+	require.True(
+		t,
+		strings.Contains(err.Error(), "executable file not found"),
+		"underlying pgrep error must be wrapped, not swallowed",
 	)
 }

--- a/tests/functional/framework/qemu_test.go
+++ b/tests/functional/framework/qemu_test.go
@@ -1,0 +1,116 @@
+package framework
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// qemuCmdline returns a representative argv slice for pgrep -f to scan. The
+// fake runner pretends pgrep appended the matching PID line; the test only
+// exercises the pattern, not pgrep itself.
+func qemuCmdline(vmName string) string {
+	return "12345 qemu-system-x86_64 -name " + vmName +
+		" -smp 2 -m 1G -enable-kvm"
+}
+
+// pgrepCmdlineForSelfMatch reproduces the argv pgrep builds when invoking
+// itself, so we can verify the [q]emu-system-x86_64 opening class prevents
+// pgrep from matching its own command line.
+func pgrepCmdlineForSelfMatch(vmName string) string {
+	// The first argv element has its first byte replaced so the pattern
+	// cannot match it via the [q]emu-system-x86_64 anchor.
+	return "99999 /usr/bin/pgrep -f " +
+		"[q]emu-system-x86_64.*[[:space:]]-name[[:space:]]+" + vmName +
+		"([[:space:]]|$)"
+}
+
+// findPid reports whether pattern (a Go regexp) finds a match in cmdline.
+// We approximate pgrep's POSIX ERE matching with Go's regexp package, which
+// supports the same [[:space:]] class and basic quantifiers used by the
+// production pattern.
+func findPid(t *testing.T, pattern, cmdline string) bool {
+	t.Helper()
+	matched, err := regexpMatch(pattern, cmdline)
+	require.NoError(t, err)
+	return matched
+}
+
+func TestExistingVMPattern_DetectsRealQEMU(t *testing.T) {
+	const vmName = "yanet-test-vm-suite"
+	pattern := existingVMPattern(vmName)
+
+	require.True(
+		t,
+		findPid(t, pattern, qemuCmdline(vmName)),
+		"pattern must match a real qemu-system-x86_64 argv containing -name <vm>",
+	)
+}
+
+func TestExistingVMPattern_RejectsOtherQEMU(t *testing.T) {
+	const vmName = "yanet-test-vm-suite"
+	pattern := existingVMPattern(vmName)
+
+	require.False(
+		t,
+		findPid(t, pattern, "12345 qemu-system-x86_64 -name other-vm -smp 2"),
+		"pattern must not match a qemu running a different VM",
+	)
+}
+
+func TestExistingVMPattern_RejectsSimilarName(t *testing.T) {
+	const vmName = "yanet-test-vm-suite"
+	pattern := existingVMPattern(vmName)
+
+	require.False(
+		t,
+		findPid(t, pattern, qemuCmdline("yanet-test-vm-suite-other")),
+		"trailing boundary must stop shorter-name matches on longer names",
+	)
+}
+
+func TestExistingVMPattern_RejectsPgrepSelf(t *testing.T) {
+	const vmName = "yanet-test-vm-suite"
+	pattern := existingVMPattern(vmName)
+
+	// The [q]emu-system-x86_64 opening class defeats pgrep's own argv match.
+	// pgrep's first argv token is /usr/bin/pgrep, which never starts with 'q'.
+	require.False(
+		t,
+		findPid(t, pattern, pgrepCmdlineForSelfMatch(vmName)),
+		"pattern must not match pgrep's own argv when its command line includes the VM name",
+	)
+}
+
+func TestCheckForExistingVMRun_EmptyOutputIsOK(t *testing.T) {
+	q := &QEMUManager{
+		Name: "main",
+		log:  zap.NewNop().Sugar(),
+	}
+	err := checkForExistingVMRun(q, "yanet-test-vm-suite", func(string) string {
+		return ""
+	})
+	require.NoError(t, err, "an empty pgrep result must mean no conflict")
+}
+
+func TestCheckForExistingVMRun_PopulatedOutputIsError(t *testing.T) {
+	q := &QEMUManager{
+		Name: "main",
+		log:  zap.NewNop().Sugar(),
+	}
+	err := checkForExistingVMRun(
+		q,
+		"yanet-test-vm-suite",
+		func(string) string {
+			return "12345 qemu-system-x86_64 -name yanet-test-vm-suite"
+		},
+	)
+	require.Error(t, err, "non-empty pgrep result must surface as an error")
+	require.True(
+		t,
+		strings.Contains(err.Error(), "yanet-test-vm-suite"),
+		"error must mention the conflicting VM name",
+	)
+}

--- a/tests/functional/main/forward_test.go
+++ b/tests/functional/main/forward_test.go
@@ -3,6 +3,7 @@ package functional
 import (
 	"encoding/json"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,12 +23,13 @@ func deviceCounterValues(
 ) map[string][]uint64 {
 	t.Helper()
 
-	command := testFramework.Paths.CLI("yanet-cli-counters") +
-		" --format json --device " + device + " --kind device"
+	var command strings.Builder
+	command.WriteString(testFramework.Paths.CLI("yanet-cli-counters"))
+	command.WriteString(" --format json --device " + device + " --kind device")
 	for _, name := range names {
-		command += " --name " + name
+		command.WriteString(" --name " + name)
 	}
-	output, err := testFramework.ExecuteCommand(command)
+	output, err := testFramework.ExecuteCommand(command.String())
 	require.NoError(t, err)
 
 	var response struct {

--- a/tests/functional/main/forward_test.go
+++ b/tests/functional/main/forward_test.go
@@ -1,6 +1,7 @@
 package functional
 
 import (
+	"encoding/json"
 	"net"
 	"testing"
 	"time"
@@ -11,6 +12,70 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/yanet-platform/yanet2/tests/functional/framework"
 )
+
+// Returns selected device counters summed across worker instances.
+func deviceCounterValues(
+	t *testing.T,
+	testFramework *framework.TestFramework,
+	device string,
+	names ...string,
+) map[string][]uint64 {
+	t.Helper()
+
+	command := testFramework.Paths.CLI("yanet-cli-counters") +
+		" --format json --device " + device + " --kind device"
+	for _, name := range names {
+		command += " --name " + name
+	}
+	output, err := testFramework.ExecuteCommand(command)
+	require.NoError(t, err)
+
+	var response struct {
+		Groups []struct {
+			Counters []struct {
+				Name      string `json:"name"`
+				Instances []struct {
+					Values []uint64 `json:"values"`
+				} `json:"instances"`
+			} `json:"counters"`
+		} `json:"groups"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &response))
+
+	valuesByName := map[string][]uint64{}
+	for _, group := range response.Groups {
+		for _, counter := range group.Counters {
+			values := valuesByName[counter.Name]
+			for _, instance := range counter.Instances {
+				if len(values) < len(instance.Values) {
+					missing := len(instance.Values) - len(values)
+					values = append(values, make([]uint64, missing)...)
+				}
+				for idx, value := range instance.Values {
+					values[idx] += value
+				}
+			}
+			valuesByName[counter.Name] = values
+		}
+	}
+	for _, name := range names {
+		require.Contains(t, valuesByName, name)
+	}
+	return valuesByName
+}
+
+// Asserts an exact packet-and-byte delta for one counter.
+func requireCounterDelta(
+	t *testing.T,
+	before, after, expected []uint64,
+) {
+	t.Helper()
+	require.Len(t, before, len(expected))
+	require.Len(t, after, len(expected))
+	for idx := range expected {
+		require.Equal(t, expected[idx], after[idx]-before[idx])
+	}
+}
 
 // createICMPPacket creates a simple ICMP echo request packet for testing
 func createICMPPacket(srcIP, dstIP net.IP, payload []byte) []byte {
@@ -232,4 +297,74 @@ func testForward(t *testing.T, fw *framework.TestFramework) {
 		assert.Equal(t, 4, cntICMP, "four ICMP replies are expected")
 	})
 
+}
+
+// verifies that the YAML limit reaches live module execution.
+func Test_PacketRecircLimit_FromDataplaneConfig(t *testing.T) {
+	withBootedVM(t, func(testFramework *framework.TestFramework) {
+		const device = "01:00.0"
+		require.NoError(t, testFramework.CreateConfigFile("recirc-forward.yaml", `
+rules:
+  - target: "01:00.0"
+    mode: OUT
+    counter: recirc
+    devices:
+      - "01:00.0"
+    vlan_ranges:
+      - from: 0
+        to: 4095
+    srcs:
+      - "0.0.0.0/0"
+    dsts:
+      - "0.0.0.0/0"
+`))
+
+		paths := testFramework.Paths
+		_, err := testFramework.ExecuteCommands(
+			paths.CLI("yanet-cli-forward")+
+				" update --name=recirc --rules "+
+				"/mnt/config/recirc-forward.yaml",
+			paths.CLI("yanet-cli-function")+
+				" update --name=recirc --chains recirc:1=forward:recirc",
+			paths.CLI("yanet-cli-pipeline")+
+				" update --name=recirc --functions recirc",
+			paths.CLI("yanet-cli-device-plain")+
+				" update --name="+device+
+				" --input test:1 --output recirc:1",
+		)
+		require.NoError(t, err)
+
+		before := deviceCounterValues(
+			t, testFramework, device, "output_rx", "output_recirc_drop",
+		)
+		packet := framework.CreateTCPIPv4Packet(
+			net.ParseIP("192.0.2.1"),
+			net.ParseIP("198.51.100.1"),
+			[]byte("recirculation limit"),
+			nil,
+		)
+		input, output, err := testFramework.SendPacketAndParse(
+			0, 0, packet, 200*time.Millisecond,
+		)
+		require.Error(t, err)
+		require.NotNil(t, input)
+		require.Nil(t, output)
+
+		after := deviceCounterValues(
+			t, testFramework, device, "output_rx", "output_recirc_drop",
+		)
+		packetSize := uint64(len(packet))
+		expectedOutputPasses := uint64(testPacketRecircLimit)
+		require.Equal(
+			t,
+			expectedOutputPasses,
+			after["output_rx"][0]-before["output_rx"][0],
+		)
+		requireCounterDelta(
+			t,
+			before["output_recirc_drop"],
+			after["output_recirc_drop"],
+			[]uint64{1, packetSize},
+		)
+	})
 }

--- a/tests/functional/main/forward_test.go
+++ b/tests/functional/main/forward_test.go
@@ -302,7 +302,7 @@ func testForward(t *testing.T, fw *framework.TestFramework) {
 }
 
 // verifies that the YAML limit reaches live module execution.
-func TestPacketRecircLimit_FromDataplaneConfig(t *testing.T) {
+func Test_PacketRecircLimit_FromDataplaneConfig(t *testing.T) {
 	withBootedVM(t, func(testFramework *framework.TestFramework) {
 		const device = "01:00.0"
 		require.NoError(t, testFramework.CreateConfigFile("recirc-forward.yaml", `

--- a/tests/functional/main/forward_test.go
+++ b/tests/functional/main/forward_test.go
@@ -302,7 +302,7 @@ func testForward(t *testing.T, fw *framework.TestFramework) {
 }
 
 // verifies that the YAML limit reaches live module execution.
-func Test_PacketRecircLimit_FromDataplaneConfig(t *testing.T) {
+func TestPacketRecircLimit_FromDataplaneConfig(t *testing.T) {
 	withBootedVM(t, func(testFramework *framework.TestFramework) {
 		const device = "01:00.0"
 		require.NoError(t, testFramework.CreateConfigFile("recirc-forward.yaml", `

--- a/tests/functional/main/framework_test.go
+++ b/tests/functional/main/framework_test.go
@@ -13,6 +13,8 @@ import (
 // harness owns the baseline VM pool shared by every test in this package.
 var harness *framework.Harness
 
+const testPacketRecircLimit = uint16(5)
+
 // globalPool is the baseline VM pool. It is a convenience alias for
 // harness.Pool() used by the per-test isolation helpers below.
 var globalPool *framework.VMPool
@@ -102,7 +104,11 @@ func testMainWrapper(m *testing.M) (code int) {
 	}()
 
 	h, cleanup, err := framework.SetupHarness(framework.HarnessConfig{
-		PoolName: "main",
+		PoolName:    "main",
+		BaselineTag: "packet-recirc-limit-5",
+		Dataplane: framework.DataplaneConfig(framework.DataplaneOptions{
+			PacketRecircLimit: testPacketRecircLimit,
+		}),
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to set up functional-test harness: %v\n", err)


### PR DESCRIPTION
- Bounds packet recirculation with a configurable lineage limit and an independent stall limit.
- Count route attempts and target-device drops while keeping counters and packet metadata consistent across decapsulation and cloning.
- Preserve fixed packet sets, payload snapshots, and ownership when dataplane UT rounds are replayed.
- Add C, dataplane UT, CGO binding, clone, and functional regression coverage.
- Closes #2051.