### PR TITLE
feat(xcfg): override config values from the environment

### DIFF
--- a/common/go/xcfg/env.go
+++ b/common/go/xcfg/env.go
@@ -1,0 +1,1099 @@
+package xcfg
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultEnvPrefix is the prefix every environment override carries.
+const DefaultEnvPrefix = "YANET_"
+
+// maxEnvDepth bounds the type walk so a self-referential config type cannot
+// recurse forever while names are generated.
+const maxEnvDepth = 32
+
+var durationType = reflect.TypeFor[time.Duration]()
+
+// envTyped is implemented by a wrapper that stores its value in an unexported
+// field, such as NonEmptyString or NonZero[T], so the env walk can see the
+// type actually being configured instead of stopping at the wrapper.
+//
+// The wrapped type decides two things the wrapper itself cannot answer:
+// whether the path is a leaf, and whether the value must be emitted as a
+// quoted string.
+type envTyped interface {
+	EnvType() reflect.Type
+}
+
+// envValued exposes a wrapper's current value to the environment overlay.
+//
+// The value is used only when an absent sequence must retain destination
+// defaults before one of its elements is overridden.
+type envValued interface {
+	EnvValue() reflect.Value
+}
+
+type envExplicitlySet interface {
+	EnvIsSet() bool
+}
+
+type defaultPruneResult uint8
+
+const (
+	defaultKept defaultPruneResult = iota
+	defaultOmitted
+	defaultRejected
+)
+
+type envMaterialization struct {
+	Node  *yaml.Node
+	Value reflect.Value
+}
+
+type envApplyState struct {
+	Names            map[string]string
+	Touched          map[*yaml.Node]struct{}
+	Detached         map[*yaml.Node]struct{}
+	Materializations []envMaterialization
+	Changed          bool
+}
+
+// applyEnv overlays environment variables onto the YAML document and returns
+// the re-encoded document.
+//
+// Overriding the document rather than the decoded struct is what keeps the
+// wrappers honest: every value still arrives through the type's own
+// UnmarshalYAML, so NonEmptyString still rejects an empty string and
+// Required still counts as explicitly set. Writing the fields by reflection
+// would reach past those unexported fields and skip their validation
+// entirely.
+//
+// The variable name for a field is generated from the destination type, never
+// parsed out of the environment, so a key that itself contains an underscore
+// (http_endpoint) cannot be split at the wrong place.
+//
+// Returns buf unchanged when no variable applies, leaving the reported error
+// lines pointing at the user's own file.
+func applyEnv(buf []byte, dst any, prefix string, env map[string]string) ([]byte, error) {
+	t := reflect.TypeOf(dst)
+	if t == nil {
+		return nil, fmt.Errorf("environment overrides require a non-nil destination")
+	}
+	if len(env) == 0 {
+		return buf, nil
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(buf, &doc); err != nil {
+		return nil, err
+	}
+
+	root := documentRoot(&doc)
+	state := &envApplyState{
+		Names:    map[string]string{},
+		Touched:  map[*yaml.Node]struct{}{},
+		Detached: map[*yaml.Node]struct{}{},
+	}
+
+	if err := envApplyNode(
+		root,
+		t,
+		reflect.ValueOf(dst),
+		prefix,
+		"",
+		env,
+		state,
+		0,
+	); err != nil {
+		return nil, err
+	}
+	for _, materialization := range state.Materializations {
+		if pruneUnsetRequiredDefaults(
+			materialization.Node,
+			materialization.Value,
+			state.Touched,
+		) == defaultRejected {
+			return nil, fmt.Errorf("cannot materialize defaults containing an unset required value")
+		}
+	}
+	if !state.Changed {
+		return buf, nil
+	}
+	if err := expandDetachedAliases(root, state.Detached); err != nil {
+		return nil, err
+	}
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-encode config with environment overrides: %w", err)
+	}
+
+	return out, nil
+}
+
+// environ returns the variables carrying prefix, keyed by full name.
+func environ(prefix string) map[string]string {
+	env := map[string]string{}
+	for _, entry := range os.Environ() {
+		name, value, found := strings.Cut(entry, "=")
+		if !found || !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		env[name] = value
+	}
+
+	return env
+}
+
+// documentRoot returns the document's root node, seeding an empty mapping for
+// an empty document so an override can still create the first key.
+func documentRoot(doc *yaml.Node) *yaml.Node {
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0]
+	}
+
+	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	*doc = yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+
+	return root
+}
+
+// envApplyNode walks t alongside node, writing every variable that names a
+// path within it.
+//
+// envName is the variable name for the current path and path is its dotted
+// config equivalent, kept only to report a collision in the terms the config
+// file uses.
+func envApplyNode(
+	node *yaml.Node,
+	t reflect.Type,
+	value reflect.Value,
+	envName string,
+	path string,
+	env map[string]string,
+	state *envApplyState,
+	depth int,
+) error {
+	if depth > maxEnvDepth {
+		return fmt.Errorf("config type nests deeper than %d levels at %q", maxEnvDepth, path)
+	}
+
+	wrappedValue := envValueIsWrapped(value)
+	value = envUnwrapValue(value)
+	t = envUnwrap(t)
+	if value.IsValid() && value.Type() != t {
+		value = reflect.Value{}
+	}
+	// yaml.Node holds an arbitrary raw YAML value. Its exported implementation
+	// fields are not part of the destination schema, so environment overrides
+	// cannot address them.
+	if t == yamlNodeType {
+		return nil
+	}
+
+	_, yamlExact := env[envName]
+	if yamlExact && envDecodesYAML(t) && envNamesBelow(env, envName) {
+		return fmt.Errorf("environment variable %s conflicts with a nested override", envName)
+	}
+	if (yamlExact && envDecodesYAML(t)) || envIsLeaf(t) {
+		value, ok := env[envName]
+		if !ok {
+			return nil
+		}
+		// Two distinct config paths folding onto one variable would make
+		// the override silently ambiguous, so it is rejected instead.
+		if previous, seen := state.Names[envName]; seen && previous != path {
+			return fmt.Errorf(
+				"environment variable %s maps to both %q and %q", envName, previous, path,
+			)
+		}
+		state.Names[envName] = path
+
+		setEnvScalar(node, t, value)
+		state.Touched[node] = struct{}{}
+		state.Changed = true
+
+		return nil
+	}
+
+	switch t.Kind() {
+	case reflect.Struct:
+		if wrappedValue && isAbsentNode(node) {
+			if err := materializeDefaults(node, value, yaml.MappingNode, state); err != nil {
+				return err
+			}
+		}
+		return envApplyStruct(node, t, value, envName, path, env, state, depth)
+	case reflect.Slice, reflect.Array:
+		return envApplySequence(node, t, value, envName, path, env, state, depth)
+	default:
+		// A map has no fixed key set to generate names from, so its
+		// entries stay file-only.
+		return nil
+	}
+}
+
+func envApplyStruct(
+	node *yaml.Node,
+	t reflect.Type,
+	value reflect.Value,
+	envName string,
+	path string,
+	env map[string]string,
+	state *envApplyState,
+	depth int,
+) error {
+	for idx := range t.NumField() {
+		f := t.Field(idx)
+		if !f.IsExported() {
+			continue
+		}
+
+		tag := f.Tag.Get("yaml")
+		if tag == "-" {
+			continue
+		}
+
+		// An inline struct's fields live at the parent's level in both
+		// the document and the variable name.
+		if isInlineTag(tag) {
+			ft := f.Type
+			for ft.Kind() == reflect.Pointer {
+				ft = ft.Elem()
+			}
+			if ft.Kind() == reflect.Map {
+				continue
+			}
+			if err := envApplyNode(
+				node,
+				f.Type,
+				envStructField(value, idx),
+				envName,
+				path,
+				env,
+				state,
+				depth+1,
+			); err != nil {
+				return err
+			}
+			continue
+		}
+
+		key := envKeyName(f)
+		childEnv := envJoin(envName, envSegment(key))
+		// Descending only where a variable names a leaf keeps the
+		// document free of empty mappings that would decode as null and
+		// wipe a default.
+		if !envWrites(f.Type, childEnv, env, depth+1) {
+			continue
+		}
+
+		// A node of an incompatible shape is left for the decoder to
+		// reject, so an override cannot turn a malformed file into a
+		// valid one.
+		if !ensureMapping(node, state) {
+			return nil
+		}
+		child := mappingChild(node, key, state)
+
+		childPath := key
+		if path != "" {
+			childPath = path + "." + key
+		}
+		if err := envApplyNode(
+			child,
+			f.Type,
+			envStructField(value, idx),
+			childEnv,
+			childPath,
+			env,
+			state,
+			depth+1,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func envApplySequence(
+	node *yaml.Node,
+	t reflect.Type,
+	value reflect.Value,
+	envName string,
+	path string,
+	env map[string]string,
+	state *envApplyState,
+	depth int,
+) error {
+	indices := envIndices(env, envName)
+	// An index a fixed array has no element for names nothing in the
+	// destination type, the same as a variable that matches no field at
+	// all. Appending it would grow the sequence past the array's length
+	// and make yaml.v3 reject an otherwise valid file.
+	indices = envIndicesInRange(indices, t)
+	// An index counts only when a variable names a leaf inside that
+	// element. A name that merely looks like an index would otherwise
+	// append an element no leaf ever fills, which decodes as null.
+	indices = slices.DeleteFunc(indices, func(idx int) bool {
+		return !envWrites(t.Elem(), envJoin(envName, strconv.Itoa(idx)), env, depth+1)
+	})
+	if len(indices) == 0 {
+		return nil
+	}
+
+	wasAbsent := isAbsentNode(node)
+	if wasAbsent {
+		if err := materializeDefaults(node, value, yaml.SequenceNode, state); err != nil {
+			return err
+		}
+	}
+	// A node of an incompatible shape is left for the decoder to reject,
+	// so an override cannot turn a malformed file into a valid one.
+	if !ensureSequence(node, state) {
+		return nil
+	}
+	existing := len(node.Content)
+	highest := indices[len(indices)-1]
+
+	// An element past the end of the file's list is only well defined when
+	// every index up to it is supplied; otherwise the gap would decode as a
+	// null element.
+	for idx := existing; idx <= highest; idx++ {
+		if !slices.Contains(indices, idx) {
+			return fmt.Errorf(
+				"%s is missing: overriding %s requires every index up to it",
+				envJoin(envName, strconv.Itoa(idx)),
+				envJoin(envName, strconv.Itoa(highest)),
+			)
+		}
+		node.Content = append(node.Content, &yaml.Node{})
+	}
+
+	for _, idx := range indices {
+		elemEnv := envJoin(envName, strconv.Itoa(idx))
+		elemPath := fmt.Sprintf("%s[%d]", path, idx)
+		if err := envApplyNode(
+			node.Content[idx],
+			t.Elem(),
+			envSequenceElement(value, idx),
+			elemEnv,
+			elemPath,
+			env,
+			state,
+			depth+1,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// materializeDefaults seeds an absent container from the destination.
+//
+// Decode may receive a config whose defaults already populate a sequence. A
+// generated sequence must start from those elements so overriding one index
+// does not erase sibling fields, later elements, or reject a later index as a
+// gap. A struct behind a value wrapper needs the same treatment because its
+// decoder replaces the whole wrapped value rather than updating it in place.
+func materializeDefaults(
+	node *yaml.Node,
+	value reflect.Value,
+	kind yaml.Kind,
+	state *envApplyState,
+) error {
+	if !value.IsValid() || !value.CanInterface() {
+		return nil
+	}
+
+	buf, err := yaml.Marshal(value.Interface())
+	if err != nil {
+		return fmt.Errorf("failed to encode defaults for environment overrides: %w", err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(buf, &doc); err != nil {
+		return fmt.Errorf("failed to decode defaults for environment overrides: %w", err)
+	}
+	root := documentRoot(&doc)
+	if root.Kind == kind {
+		materialized := copyNode(root)
+		materialized.Anchor = node.Anchor
+		*node = *materialized
+		markDetachedTree(node, state.Detached)
+		state.Materializations = append(state.Materializations, envMaterialization{
+			Node:  node,
+			Value: value,
+		})
+	}
+
+	return nil
+}
+
+// pruneUnsetRequiredDefaults keeps explicit-presence validation intact.
+//
+// A YAML round-trip would otherwise serialize an unset required wrapper as
+// its zero value and decode it back as explicitly supplied. Mapping fields can
+// be omitted; a positional or wrapper-nested value cannot be represented
+// without changing its meaning, so materialization rejects it.
+func pruneUnsetRequiredDefaults(
+	node *yaml.Node,
+	value reflect.Value,
+	touched map[*yaml.Node]struct{},
+) defaultPruneResult {
+	for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
+		if value.IsNil() {
+			return defaultKept
+		}
+		value = value.Elem()
+	}
+	if !value.IsValid() || !value.CanInterface() {
+		return defaultKept
+	}
+	if explicit, ok := value.Interface().(envExplicitlySet); ok && !explicit.EnvIsSet() {
+		if !envNodeTouched(node, touched) {
+			return defaultOmitted
+		}
+	}
+	if wrapper, ok := value.Interface().(envValued); ok {
+		switch pruneUnsetRequiredDefaults(node, wrapper.EnvValue(), touched) {
+		case defaultOmitted, defaultRejected:
+			return defaultRejected
+		}
+		return defaultKept
+	}
+
+	switch value.Kind() {
+	case reflect.Struct:
+		if node.Kind != yaml.MappingNode {
+			return defaultKept
+		}
+		valueType := value.Type()
+		for fieldIdx := range valueType.NumField() {
+			field := valueType.Field(fieldIdx)
+			if !field.IsExported() || field.Tag.Get("yaml") == "-" {
+				continue
+			}
+			if isInlineTag(field.Tag.Get("yaml")) {
+				if pruneUnsetRequiredDefaults(node, value.Field(fieldIdx), touched) != defaultKept {
+					return defaultRejected
+				}
+				continue
+			}
+
+			key := envKeyName(field)
+			for nodeIdx := 0; nodeIdx+1 < len(node.Content); nodeIdx += 2 {
+				if mappingKeyName(node.Content[nodeIdx]) != key {
+					continue
+				}
+				switch pruneUnsetRequiredDefaults(
+					node.Content[nodeIdx+1],
+					value.Field(fieldIdx),
+					touched,
+				) {
+				case defaultOmitted:
+					node.Content = slices.Delete(node.Content, nodeIdx, nodeIdx+2)
+				case defaultRejected:
+					return defaultRejected
+				}
+				break
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		if node.Kind != yaml.SequenceNode {
+			return defaultKept
+		}
+		for idx := range min(value.Len(), len(node.Content)) {
+			if pruneUnsetRequiredDefaults(node.Content[idx], value.Index(idx), touched) != defaultKept {
+				return defaultRejected
+			}
+		}
+	}
+
+	return defaultKept
+}
+
+func envNodeTouched(node *yaml.Node, touched map[*yaml.Node]struct{}) bool {
+	if _, ok := touched[node]; ok {
+		return true
+	}
+	for _, child := range node.Content {
+		if envNodeTouched(child, touched) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func envValueIsWrapped(value reflect.Value) bool {
+	for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
+		if value.IsNil() {
+			return false
+		}
+		value = value.Elem()
+	}
+	if !value.IsValid() || !value.CanInterface() {
+		return false
+	}
+
+	_, ok := value.Interface().(envValued)
+	return ok
+}
+
+func envUnwrapValue(value reflect.Value) reflect.Value {
+	for range maxEnvDepth {
+		for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
+			if value.IsNil() {
+				return reflect.Value{}
+			}
+			value = value.Elem()
+		}
+		if !value.IsValid() || !value.CanInterface() {
+			return value
+		}
+
+		wrapper, ok := value.Interface().(envValued)
+		if !ok {
+			return value
+		}
+		value = wrapper.EnvValue()
+	}
+
+	return value
+}
+
+func envStructField(value reflect.Value, idx int) reflect.Value {
+	if !value.IsValid() || value.Kind() != reflect.Struct {
+		return reflect.Value{}
+	}
+
+	return value.Field(idx)
+}
+
+func envSequenceElement(value reflect.Value, idx int) reflect.Value {
+	if !value.IsValid() || value.Kind() != reflect.Slice && value.Kind() != reflect.Array || idx >= value.Len() {
+		return reflect.Value{}
+	}
+
+	return value.Index(idx)
+}
+
+// envIndicesInRange drops the indices a fixed array has no element for.
+// A slice grows to fit, so every index stays.
+func envIndicesInRange(indices []int, t reflect.Type) []int {
+	if t.Kind() != reflect.Array {
+		return indices
+	}
+
+	return slices.DeleteFunc(indices, func(idx int) bool {
+		return idx >= t.Len()
+	})
+}
+
+// envIndices returns the sorted element indices addressed under envName.
+func envIndices(env map[string]string, envName string) []int {
+	prefix := envChildPrefix(envName)
+
+	var indices []int
+	for name := range env {
+		rest, found := strings.CutPrefix(name, prefix)
+		if !found {
+			continue
+		}
+
+		digits, _, _ := strings.Cut(rest, "_")
+		idx, err := strconv.Atoi(digits)
+		if err != nil || idx < 0 {
+			continue
+		}
+		if !slices.Contains(indices, idx) {
+			indices = append(indices, idx)
+		}
+	}
+	slices.Sort(indices)
+
+	return indices
+}
+
+// envWrites reports whether any variable names a leaf inside t.
+//
+// A variable is matched against the names t itself generates, never against a
+// string prefix. Two sibling keys where one is a prefix of the other are the
+// reason: YANET_GATEWAY_DEVICES_0 belongs to gateway_devices, yet it opens
+// with every character of the name gateway generates. Descending on that
+// resemblance would materialise gateway as an empty mapping that no leaf ever
+// fills, which decodes as null and wipes the whole subtree's defaults — and
+// with it the config, since a null key is rejected. The same holds for a
+// variable that names nothing in the type at all.
+//
+// A container whose name no variable continues is answered without looking
+// at its fields. That is what bounds the cost on a self-referential type: a
+// branching one, Node{Left, Right *Node}, would otherwise be enumerated along
+// both arms down to the depth bound, which is 2^maxEnvDepth calls.
+//
+// Past the depth bound the generated names run out before a self-referential
+// type does, so the same question is all that is left: a variable that
+// continues the current name lets the applying walk reach the bound and
+// report the path it gave up on, while an unrelated one leaves the type
+// alone.
+func envWrites(t reflect.Type, envName string, env map[string]string, depth int) bool {
+	if depth > maxEnvDepth {
+		_, exact := env[envName]
+		return exact || envNamesBelow(env, envName)
+	}
+
+	t = envUnwrap(t)
+	if t == yamlNodeType {
+		return false
+	}
+	if envDecodesYAML(t) {
+		if _, ok := env[envName]; ok {
+			return true
+		}
+	}
+
+	if envIsLeaf(t) {
+		_, ok := env[envName]
+		return ok
+	}
+
+	// Every name a container generates extends the current one, so with
+	// no variable below it none of its fields can match. Answering here
+	// keeps a branching self-referential type — Node{Left, Right *Node} —
+	// from being enumerated to the depth bound along both arms, which
+	// costs 2^maxEnvDepth calls and never terminates in practice.
+	if !envNamesBelow(env, envName) {
+		return false
+	}
+
+	switch t.Kind() {
+	case reflect.Struct:
+		for idx := range t.NumField() {
+			f := t.Field(idx)
+			if !f.IsExported() {
+				continue
+			}
+
+			tag := f.Tag.Get("yaml")
+			if tag == "-" {
+				continue
+			}
+
+			if isInlineTag(tag) {
+				ft := f.Type
+				for ft.Kind() == reflect.Pointer {
+					ft = ft.Elem()
+				}
+				if ft.Kind() == reflect.Map {
+					continue
+				}
+				if envWrites(f.Type, envName, env, depth+1) {
+					return true
+				}
+				continue
+			}
+
+			childEnv := envJoin(envName, envSegment(envKeyName(f)))
+			if envWrites(f.Type, childEnv, env, depth+1) {
+				return true
+			}
+		}
+
+		return false
+	case reflect.Slice, reflect.Array:
+		// The bound a fixed array puts on its indices holds here too:
+		// an index it has no element for names nothing in the type, so
+		// reporting a match would materialise a sequence node the
+		// applying walk then declines to fill.
+		for _, idx := range envIndicesInRange(envIndices(env, envName), t) {
+			if envWrites(t.Elem(), envJoin(envName, strconv.Itoa(idx)), env, depth+1) {
+				return true
+			}
+		}
+
+		return false
+	default:
+		// A map has no fixed key set to generate names from.
+		return false
+	}
+}
+
+// envNamesBelow reports whether any variable continues envName, naming
+// something nested below the path it stands for.
+func envNamesBelow(env map[string]string, envName string) bool {
+	prefix := envChildPrefix(envName)
+	for name := range env {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// envKeyName returns the YAML key a field decodes from, matching yaml.v3's own
+// default of lowercasing an untagged field name.
+func envKeyName(f reflect.StructField) string {
+	name, _, _ := strings.Cut(f.Tag.Get("yaml"), ",")
+	if name == "" {
+		name = strings.ToLower(f.Name)
+	}
+
+	return name
+}
+
+// envJoin appends one segment to a variable name.
+//
+// An empty base is the unprefixed namespace WithEnvPrefix("") asks for, where
+// a top-level key is named NAME rather than _NAME.
+func envJoin(envName, segment string) string {
+	if envName == "" {
+		return segment
+	}
+	if strings.HasSuffix(envName, "_") {
+		return envName + segment
+	}
+
+	return envName + "_" + segment
+}
+
+// envChildPrefix returns the string every variable naming something below
+// envName starts with. Under an empty base that is every variable collected.
+func envChildPrefix(envName string) string {
+	if envName == "" {
+		return ""
+	}
+	if strings.HasSuffix(envName, "_") {
+		return envName
+	}
+
+	return envName + "_"
+}
+
+// envSegment renders one config key as a variable name segment.
+func envSegment(key string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return unicode.ToUpper(r)
+		}
+		return '_'
+	}, key)
+}
+
+// envUnwrap resolves a pointer or value wrapper to the type actually being
+// configured.
+func envUnwrap(t reflect.Type) reflect.Type {
+	for range maxEnvDepth {
+		for t.Kind() == reflect.Pointer {
+			t = t.Elem()
+		}
+
+		wrapper, ok := reflect.New(t).Interface().(envTyped)
+		if !ok {
+			return t
+		}
+
+		inner := wrapper.EnvType()
+		if inner == nil || inner == t {
+			return t
+		}
+		t = inner
+	}
+
+	return t
+}
+
+// envIsLeaf reports whether t takes a single scalar value rather than being
+// walked into.
+func envIsLeaf(t reflect.Type) bool {
+	if t == durationType || envDecodesText(t) {
+		return true
+	}
+
+	switch t.Kind() {
+	case reflect.Struct:
+		// A custom decoder with no exported schema fields takes one scalar.
+		// A decoder with exported fields may still own a mapping, so exact
+		// parent variables are handled separately while nested names walk
+		// those fields.
+		return isOpaqueToWalk(t)
+	case reflect.Slice, reflect.Array, reflect.Map:
+		return false
+	default:
+		return true
+	}
+}
+
+// envDecodesText reports whether t parses itself from a string.
+func envDecodesText(t reflect.Type) bool {
+	return reflect.PointerTo(t).Implements(textUnmarshalerType)
+}
+
+func envDecodesYAML(t reflect.Type) bool {
+	return t.Kind() == reflect.Struct && reflect.PointerTo(t).Implements(yamlUnmarshalerType)
+}
+
+// setEnvScalar replaces node with the value read from the environment.
+//
+// The tag is chosen from the destination type because YAML would otherwise
+// resolve the most common value in this config — an endpoint such as
+// "[::1]:8080" — as a flow sequence, while quoting every value would break a
+// numeric field that cannot accept a string.
+//
+// An anchor the node defines is carried over, since the document's aliases
+// resolve to this very node and dropping it would leave every one of them
+// dangling. The packaged control plane config relies on this: memory_path
+// defines an anchor that a dozen module entries alias.
+func setEnvScalar(node *yaml.Node, t reflect.Type, value string) {
+	*node = yaml.Node{Kind: yaml.ScalarNode, Value: value, Anchor: node.Anchor}
+
+	if t.Kind() == reflect.String || t == durationType || envDecodesText(t) {
+		node.Tag = "!!str"
+		node.Style = yaml.DoubleQuotedStyle
+	}
+}
+
+// ensureMapping turns an absent node into an empty mapping, keeping any
+// anchor the document binds to it, and reports whether the node can hold
+// one.
+//
+// A node the file already fills with something else is left untouched: the
+// document is malformed for this destination type, and rewriting it would
+// let an override that names one field paper over the whole broken value,
+// turning an error into a silent success.
+func ensureMapping(node *yaml.Node, state *envApplyState) bool {
+	resolveForWrite(node, state)
+	if node.Kind == yaml.MappingNode {
+		return true
+	}
+	if !isAbsentNode(node) {
+		return false
+	}
+
+	*node = yaml.Node{Kind: yaml.MappingNode, Tag: "!!map", Anchor: node.Anchor}
+
+	return true
+}
+
+// ensureSequence turns an absent node into an empty sequence, keeping any
+// anchor the document binds to it, and reports whether the node can hold
+// one. A node of another shape is left for the decoder to reject, as in
+// ensureMapping.
+func ensureSequence(node *yaml.Node, state *envApplyState) bool {
+	resolveForWrite(node, state)
+	if node.Kind == yaml.SequenceNode {
+		return true
+	}
+	if !isAbsentNode(node) {
+		return false
+	}
+
+	*node = yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq", Anchor: node.Anchor}
+
+	return true
+}
+
+// isAbsentNode reports whether the node carries no value from the file, so
+// materialising a container in its place invents nothing the user wrote.
+//
+// A zero node is a key the document never had; an explicit null is a key
+// written with no value, which a container override is allowed to fill.
+func isAbsentNode(node *yaml.Node) bool {
+	return node.Kind == 0 || node.Tag == "!!null"
+}
+
+// resolveForWrite replaces an alias with a copy of its target so an override
+// cannot leak into every other user of the same anchor.
+func resolveForWrite(node *yaml.Node, state *envApplyState) {
+	if node.Kind != yaml.AliasNode || node.Alias == nil {
+		return
+	}
+
+	*node = *copyNode(node.Alias)
+	markDetachedTree(node, state.Detached)
+}
+
+// copyNode deep-copies a node without sharing internal aliases.
+//
+// Internal alias targets are rewired to copied nodes. Before encoding, those
+// aliases are expanded from the final copied values, avoiding duplicate anchor
+// names while preserving overrides made after the copy. External aliases keep
+// pointing at their original anchors.
+func copyNode(node *yaml.Node) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	copies := map[*yaml.Node]*yaml.Node{}
+	out := copyNodeTree(node, copies)
+	rewireCopiedAliases(node, out, copies)
+
+	return out
+}
+
+func copyNodeTree(node *yaml.Node, copies map[*yaml.Node]*yaml.Node) *yaml.Node {
+	out := *node
+	out.Anchor = ""
+	out.Content = nil
+	copies[node] = &out
+	for _, child := range node.Content {
+		out.Content = append(out.Content, copyNodeTree(child, copies))
+	}
+
+	return &out
+}
+
+func rewireCopiedAliases(original, copied *yaml.Node, copies map[*yaml.Node]*yaml.Node) {
+	if original.Kind == yaml.AliasNode && original.Alias != nil {
+		if target, ok := copies[original.Alias]; ok {
+			copied.Alias = target
+		}
+	}
+	for idx := range min(len(original.Content), len(copied.Content)) {
+		rewireCopiedAliases(original.Content[idx], copied.Content[idx], copies)
+	}
+}
+
+func markDetachedTree(node *yaml.Node, detached map[*yaml.Node]struct{}) {
+	detached[node] = struct{}{}
+	for _, child := range node.Content {
+		markDetachedTree(child, detached)
+	}
+}
+
+func expandDetachedAliases(node *yaml.Node, detached map[*yaml.Node]struct{}) error {
+	if node.Kind == yaml.AliasNode && node.Alias != nil {
+		if _, ok := detached[node.Alias]; ok {
+			expanded, err := copyExpandedNode(node.Alias, detached, 0)
+			if err != nil {
+				return err
+			}
+			*node = *expanded
+			return nil
+		}
+	}
+	for _, child := range node.Content {
+		if err := expandDetachedAliases(child, detached); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyExpandedNode(node *yaml.Node, detached map[*yaml.Node]struct{}, depth int) (*yaml.Node, error) {
+	if depth > maxEnvDepth {
+		return nil, fmt.Errorf("environment override alias expansion exceeds %d levels", maxEnvDepth)
+	}
+	if node.Kind == yaml.AliasNode && node.Alias != nil {
+		if _, ok := detached[node.Alias]; ok {
+			return copyExpandedNode(node.Alias, detached, depth+1)
+		}
+	}
+
+	out := *node
+	out.Anchor = ""
+	out.Content = nil
+	for _, child := range node.Content {
+		copied, err := copyExpandedNode(child, detached, depth)
+		if err != nil {
+			return nil, err
+		}
+		out.Content = append(out.Content, copied)
+	}
+
+	return &out, nil
+}
+
+// mappingChild returns the value node stored under key, appending one when
+// the document does not have that key yet.
+//
+// A key the mapping holds only through a "<<" merge is materialised as a
+// direct key carrying a copy of the inherited value. A direct key overrides
+// what the merge supplies, so writing into a fresh empty node would shadow
+// the merged mapping whole, dropping every other field it carries.
+func mappingChild(node *yaml.Node, key string, state *envApplyState) *yaml.Node {
+	for idx := 0; idx+1 < len(node.Content); idx += 2 {
+		if mappingKeyName(node.Content[idx]) == key {
+			return node.Content[idx+1]
+		}
+	}
+
+	value := &yaml.Node{}
+	if inherited := mergedValue(node, key, 0); inherited != nil {
+		value = copyNode(inherited)
+		markDetachedTree(value, state.Detached)
+	}
+	node.Content = append(
+		node.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		value,
+	)
+
+	return value
+}
+
+// mergedValue returns the value a "<<" merge key supplies for key, or nil
+// when the mapping inherits no such key.
+func mergedValue(node *yaml.Node, key string, depth int) *yaml.Node {
+	if depth > maxEnvDepth {
+		return nil
+	}
+
+	for idx := 0; idx+1 < len(node.Content); idx += 2 {
+		if isMergeKey(node.Content[idx]) {
+			return mergedSourceValue(node.Content[idx+1], key, depth)
+		}
+	}
+
+	return nil
+}
+
+// mergedSourceValue resolves one merge source, which is a mapping, an alias
+// to one, or a sequence of those. The first source holding the key wins, as
+// it does when yaml.v3 applies the merge itself.
+func mergedSourceValue(node *yaml.Node, key string, depth int) *yaml.Node {
+	if node == nil || depth > maxEnvDepth {
+		return nil
+	}
+
+	if node.Kind == yaml.AliasNode {
+		if node.Alias == nil {
+			return nil
+		}
+		node = node.Alias
+	}
+
+	if node.Kind == yaml.SequenceNode {
+		for _, item := range node.Content {
+			if value := mergedSourceValue(item, key, depth+1); value != nil {
+				return value
+			}
+		}
+
+		return nil
+	}
+
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for idx := 0; idx+1 < len(node.Content); idx += 2 {
+		if mappingKeyName(node.Content[idx]) == key {
+			return node.Content[idx+1]
+		}
+	}
+
+	// A merged mapping may itself inherit the key from a further merge.
+	return mergedValue(node, key, depth+1)
+}

--- a/common/go/xcfg/env_test.go
+++ b/common/go/xcfg/env_test.go
@@ -1,0 +1,1539 @@
+package xcfg_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"gopkg.in/yaml.v3"
+)
+
+// envOverrides puts env in the process environment for the duration of the
+// test and enables the overlay, so a test states the variables it relies on
+// and nothing else.
+func envOverrides(t *testing.T, env map[string]string) xcfg.Option {
+	t.Helper()
+	for _, entry := range os.Environ() {
+		name, value, found := strings.Cut(entry, "=")
+		if !found || !strings.HasPrefix(name, xcfg.DefaultEnvPrefix) {
+			continue
+		}
+		require.NoError(t, os.Unsetenv(name))
+		t.Cleanup(func() {
+			require.NoError(t, os.Setenv(name, value))
+		})
+	}
+	for name, value := range env {
+		t.Setenv(name, value)
+	}
+
+	return xcfg.WithEnv()
+}
+
+func Test_Env_OverridesScalar(t *testing.T) {
+	type Config struct {
+		Name xcfg.NonEmptyString `yaml:"name"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_NAME": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Name.Unwrap())
+}
+
+func Test_Env_OverridesNestedField(t *testing.T) {
+	type Server struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Server Server `yaml:"server"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("server:\n  endpoint: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_SERVER_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Server.Endpoint.Unwrap())
+}
+
+// A key that itself contains an underscore must not be split at the wrong
+// place: the name is generated from the type, never parsed out of the
+// environment.
+func Test_Env_KeyWithUnderscoreNotSplit(t *testing.T) {
+	type Server struct {
+		HTTPEndpoint xcfg.NonEmptyString `yaml:"http_endpoint"`
+	}
+	type Config struct {
+		Server Server `yaml:"server"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("server:\n  http_endpoint: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_SERVER_HTTP_ENDPOINT": ":8080"}),
+	))
+	require.Equal(t, ":8080", cfg.Server.HTTPEndpoint.Unwrap())
+}
+
+// An endpoint is the most common value in this config and would resolve as a
+// YAML flow sequence if it were emitted untagged.
+func Test_Env_EndpointNotParsedAsSequence(t *testing.T) {
+	type Config struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("endpoint: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_ENDPOINT": "[::1]:8080"}),
+	))
+	require.Equal(t, "[::1]:8080", cfg.Endpoint.Unwrap())
+}
+
+func Test_Env_EndpointIntoPlainString(t *testing.T) {
+	type Config struct {
+		Endpoint string `yaml:"endpoint"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("endpoint: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_ENDPOINT": "[::1]:0"}),
+	))
+	require.Equal(t, "[::1]:0", cfg.Endpoint)
+}
+
+// A value that arrives from the environment goes through the destination
+// type's own decoding, so it is validated exactly like one written in the
+// file.
+func Test_Env_RejectsEmptyNonEmptyString(t *testing.T) {
+	type Config struct {
+		Name xcfg.NonEmptyString `yaml:"name"`
+	}
+
+	var cfg Config
+	require.Error(t, xcfg.Decode(
+		[]byte("name: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_NAME": ""}),
+	))
+}
+
+func Test_Env_CreatesAbsentKey(t *testing.T) {
+	type Config struct {
+		Name xcfg.NonEmptyString `yaml:"name"`
+		Path xcfg.NonEmptyString `yaml:"path"`
+	}
+
+	cfg := Config{Path: xcfg.MustNonEmptyString("/default")}
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_NAME": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Name.Unwrap())
+	require.Equal(t, "/default", cfg.Path.Unwrap())
+}
+
+func Test_Env_EmptyDocument(t *testing.T) {
+	type Config struct {
+		Name xcfg.NonEmptyString `yaml:"name"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		nil,
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_NAME": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Name.Unwrap())
+}
+
+func Test_Env_PreservesDefaultsWhenNoVariable(t *testing.T) {
+	type Config struct {
+		Name xcfg.NonEmptyString `yaml:"name"`
+		Path xcfg.NonEmptyString `yaml:"path"`
+	}
+
+	cfg := Config{Path: xcfg.MustNonEmptyString("/default")}
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{}),
+	))
+	require.Equal(t, "from-file", cfg.Name.Unwrap())
+	require.Equal(t, "/default", cfg.Path.Unwrap())
+}
+
+func Test_Env_UnrelatedVariableIgnored(t *testing.T) {
+	type Config struct {
+		Name xcfg.NonEmptyString `yaml:"name"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_NOT_A_FIELD": "x"}),
+	))
+	require.Equal(t, "from-file", cfg.Name.Unwrap())
+}
+
+// Case-specific environment setup is isolated from matching variables already
+// present in the test process.
+func Test_Env_InheritedVariableCleared(t *testing.T) {
+	type Config struct {
+		Name string `yaml:"name"`
+		Path string `yaml:"path"`
+	}
+
+	t.Setenv("YANET_PATH", "inherited")
+	cfg := Config{Path: "default"}
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_NAME": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Name)
+	require.Equal(t, "default", cfg.Path)
+}
+
+// Leaving the document untouched when nothing applies is what keeps reported
+// error lines pointing at the user's own file.
+func Test_Env_ErrorLineFollowsFileWithoutMatch(t *testing.T) {
+	type Config struct {
+		Name    string `yaml:"name"`
+		Workers int    `yaml:"workers"`
+	}
+
+	var cfg Config
+	err := xcfg.Decode(
+		[]byte("# a comment\n\nname: foo\nworkers: not-a-number\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_NOT_A_FIELD": "x"}),
+	)
+	require.ErrorContains(t, err, "line 4")
+}
+
+func Test_Env_OverridesNumeric(t *testing.T) {
+	type Config struct {
+		Workers xcfg.NonZero[uint16] `yaml:"workers"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("workers: 1"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_WORKERS": "4"}),
+	))
+	require.Equal(t, uint16(4), cfg.Workers.Unwrap())
+}
+
+func Test_Env_RejectsZeroNonZero(t *testing.T) {
+	type Config struct {
+		Workers xcfg.NonZero[uint16] `yaml:"workers"`
+	}
+
+	var cfg Config
+	require.Error(t, xcfg.Decode(
+		[]byte("workers: 1"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_WORKERS": "0"}),
+	))
+}
+
+func Test_Env_OverridesBool(t *testing.T) {
+	type Config struct {
+		Debug bool `yaml:"debug"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("debug: false"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_DEBUG": "true"}),
+	))
+	require.True(t, cfg.Debug)
+}
+
+func Test_Env_OverridesDuration(t *testing.T) {
+	type Config struct {
+		Timeout time.Duration `yaml:"timeout"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("timeout: 1s"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_TIMEOUT": "1500ms"}),
+	))
+	require.Equal(t, 1500*time.Millisecond, cfg.Timeout)
+}
+
+func Test_Env_MaterializesAbsentOptional(t *testing.T) {
+	type Inner struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Server xcfg.Optional[Inner] `yaml:"server"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_SERVER_ENDPOINT": "from-env"}),
+	))
+	require.NotNil(t, cfg.Server.Unwrap())
+	require.Equal(t, "from-env", cfg.Server.Unwrap().Endpoint.Unwrap())
+}
+
+func Test_Env_LeavesOptionalAbsent(t *testing.T) {
+	type Inner struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Name   xcfg.NonEmptyString  `yaml:"name"`
+		Server xcfg.Optional[Inner] `yaml:"server"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_NAME": "from-env"}),
+	))
+	require.Nil(t, cfg.Server.Unwrap())
+}
+
+func Test_Env_SetsRequired(t *testing.T) {
+	type Config struct {
+		Name xcfg.Required[string] `yaml:"name"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_NAME": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Name.Unwrap())
+}
+
+func Test_Env_OverridesSequenceElement(t *testing.T) {
+	type Gateway struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateways []Gateway `yaml:"gateways"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("gateways:\n  - endpoint: a\n  - endpoint: b\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_1_ENDPOINT": "[::1]:8080"}),
+	))
+	require.Len(t, cfg.Gateways, 2)
+	require.Equal(t, "a", cfg.Gateways[0].Endpoint.Unwrap())
+	require.Equal(t, "[::1]:8080", cfg.Gateways[1].Endpoint.Unwrap())
+}
+
+func Test_Env_AppendsSequenceElement(t *testing.T) {
+	type Gateway struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateways []Gateway `yaml:"gateways"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("gateways:\n  - endpoint: a\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_1_ENDPOINT": "b"}),
+	))
+	require.Len(t, cfg.Gateways, 2)
+	require.Equal(t, "a", cfg.Gateways[0].Endpoint.Unwrap())
+	require.Equal(t, "b", cfg.Gateways[1].Endpoint.Unwrap())
+}
+
+func Test_Env_SequenceGapRejected(t *testing.T) {
+	type Gateway struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateways []Gateway `yaml:"gateways"`
+	}
+
+	var cfg Config
+	err := xcfg.Decode(
+		[]byte("gateways: []\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_2_ENDPOINT": "c"}),
+	)
+	require.ErrorContains(t, err, "YANET_GATEWAYS_0")
+}
+
+func Test_Env_SequenceOfScalars(t *testing.T) {
+	type Config struct {
+		Names []string `yaml:"names"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("names:\n  - a\n"),
+		&cfg,
+		envOverrides(t, map[string]string{
+			"YANET_NAMES_0": "x",
+			"YANET_NAMES_1": "y",
+		}),
+	))
+	require.Equal(t, []string{"x", "y"}, cfg.Names)
+}
+
+// Two config paths folding onto one variable would make the override
+// silently ambiguous.
+func Test_Env_CollisionRejected(t *testing.T) {
+	type HTTP struct {
+		Endpoint string `yaml:"endpoint"`
+	}
+	type Config struct {
+		HTTPEndpoint string `yaml:"http_endpoint"`
+		HTTP         HTTP   `yaml:"http"`
+	}
+
+	var cfg Config
+	err := xcfg.Decode(
+		[]byte("{}"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_HTTP_ENDPOINT": "x"}),
+	)
+	require.ErrorContains(t, err, "maps to both")
+}
+
+func Test_Env_InlineStruct(t *testing.T) {
+	type Common struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Common `yaml:",inline"`
+		Name   xcfg.NonEmptyString `yaml:"name"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: n\nendpoint: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Endpoint.Unwrap())
+	require.Equal(t, "n", cfg.Name.Unwrap())
+}
+
+func Test_Env_SkipsIgnoredField(t *testing.T) {
+	type Config struct {
+		Name   string `yaml:"name"`
+		Hidden string `yaml:"-"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_HIDDEN": "x"}),
+	))
+	require.Empty(t, cfg.Hidden)
+}
+
+// A field with no explicit tag name is keyed by its lowercased Go name,
+// matching yaml.v3's own default key resolution.
+func Test_Env_UntaggedFieldUsesLowercasedName(t *testing.T) {
+	type Config struct {
+		Endpoint string
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("endpoint: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Endpoint)
+}
+
+// A map has no fixed key set to generate names from, so its entries stay
+// file-only rather than being silently half-addressable.
+func Test_Env_MapEntriesStayFileOnly(t *testing.T) {
+	type Config struct {
+		Labels map[string]string `yaml:"labels"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("labels:\n  a: from-file\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_LABELS_A": "from-env"}),
+	))
+	require.Equal(t, map[string]string{"a": "from-file"}, cfg.Labels)
+}
+
+// A sibling key that is a prefix of another sibling key must not be
+// descended into: YANET_GATEWAY_DEVICES_A belongs to gateway_devices, yet it
+// opens with every character of the name gateway generates. Materialising
+// gateway as an empty mapping would decode as null and wipe its defaults.
+func Test_Env_PrefixSiblingKeyNotDescended(t *testing.T) {
+	type Gateway struct {
+		Endpoint string `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateway        Gateway           `yaml:"gateway"`
+		GatewayDevices map[string]string `yaml:"gateway_devices"`
+	}
+
+	cfg := Config{Gateway: Gateway{Endpoint: "default"}}
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAY_DEVICES_A": "x"}),
+	))
+	require.Equal(t, "default", cfg.Gateway.Endpoint)
+}
+
+// Skipping a prefix sibling must not swallow a genuine collision: when the
+// longer key's own name is also the name a nested leaf generates, the two
+// really are ambiguous and the override stays rejected.
+func Test_Env_PrefixSiblingStillCollides(t *testing.T) {
+	type Table struct {
+		Name string `yaml:"name"`
+	}
+	type Config struct {
+		Table     Table  `yaml:"table"`
+		TableName string `yaml:"table_name"`
+	}
+
+	var cfg Config
+	err := xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_TABLE_NAME": "from-env"}),
+	)
+	require.ErrorContains(t, err, "maps to both")
+}
+
+// A variable that names nothing in the type must leave the document alone
+// rather than seed an empty mapping the file never had.
+func Test_Env_StrayVariableLeavesDefaults(t *testing.T) {
+	type Server struct {
+		Endpoint string `yaml:"endpoint"`
+	}
+	type Config struct {
+		Server Server `yaml:"server"`
+	}
+
+	cfg := Config{Server: Server{Endpoint: "default"}}
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_SERVER_BOGUS": "x"}),
+	))
+	require.Equal(t, "default", cfg.Server.Endpoint)
+}
+
+// A sequence index is honoured only when a variable names a leaf inside that
+// element; a name that merely looks like an index must not append an element
+// no leaf ever fills.
+func Test_Env_StrayIndexNotAppended(t *testing.T) {
+	type Gateway struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateways []Gateway `yaml:"gateways"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("gateways:\n  - endpoint: a\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_1_BOGUS": "x"}),
+	))
+	require.Len(t, cfg.Gateways, 1)
+	require.Equal(t, "a", cfg.Gateways[0].Endpoint.Unwrap())
+}
+
+func Test_Env_OverridesThroughPointer(t *testing.T) {
+	type Inner struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Server *Inner `yaml:"server"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("server:\n  endpoint: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_SERVER_ENDPOINT": "from-env"}),
+	))
+	require.NotNil(t, cfg.Server)
+	require.Equal(t, "from-env", cfg.Server.Endpoint.Unwrap())
+}
+
+// Overriding through an alias must not leak into every other user of the
+// same anchor.
+func Test_Env_AliasNotLeaked(t *testing.T) {
+	type Inner struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		A Inner `yaml:"a"`
+		B Inner `yaml:"b"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("a: &shared\n  endpoint: shared\nb: *shared\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_B_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, "shared", cfg.A.Endpoint.Unwrap())
+	require.Equal(t, "from-env", cfg.B.Endpoint.Unwrap())
+}
+
+// Detaching an aliased container keeps aliases inside the copied subtree
+// connected to copied anchors rather than the original subtree.
+func Test_Env_AliasCopyKeepsInternalAliases(t *testing.T) {
+	type Inner struct {
+		Endpoint string `yaml:"endpoint"`
+		Mirror   string `yaml:"mirror"`
+	}
+	type Config struct {
+		Dummy   string `yaml:"dummy"`
+		A       Inner  `yaml:"a"`
+		B       Inner  `yaml:"b"`
+		Outside string `yaml:"outside"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("dummy: &endpoint_env_copy_1 external\n"+
+			"a: &shared\n  endpoint: &endpoint old\n  mirror: *endpoint\n"+
+			"b: *shared\noutside: *endpoint_env_copy_1\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_B_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, "external", cfg.Dummy)
+	require.Equal(t, Inner{Endpoint: "old", Mirror: "old"}, cfg.A)
+	require.Equal(t, Inner{Endpoint: "from-env", Mirror: "from-env"}, cfg.B)
+	require.Equal(t, "external", cfg.Outside)
+}
+
+// Overriding a scalar that defines an anchor must keep the anchor, or every
+// alias to it is left dangling. The packaged control plane config does this
+// with memory_path.
+func Test_Env_AnchoredScalarKeepsAliases(t *testing.T) {
+	type Module struct {
+		MemoryPath string `yaml:"memory_path"`
+	}
+	type Config struct {
+		MemoryPath string   `yaml:"memory_path"`
+		Modules    []Module `yaml:"modules"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("memory_path: &memory_path /dev/hugepages/yanet\n"+
+			"modules:\n"+
+			"  - memory_path: *memory_path\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_MEMORY_PATH": "/dev/hugepages/other"}),
+	))
+	require.Equal(t, "/dev/hugepages/other", cfg.MemoryPath)
+	require.Len(t, cfg.Modules, 1)
+	require.Equal(t, "/dev/hugepages/other", cfg.Modules[0].MemoryPath)
+}
+
+// Materialising defaults into an anchored null container must keep aliases to
+// that container valid and pointed at the overlaid value.
+func Test_Env_MaterializedContainerKeepsAliases(t *testing.T) {
+	type Gateway struct {
+		Endpoint string `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateways []Gateway `yaml:"gateways"`
+		Mirror   []Gateway `yaml:"mirror"`
+	}
+
+	cfg := Config{Gateways: []Gateway{{Endpoint: "from-default"}}}
+	require.NoError(t, xcfg.Decode(
+		[]byte("gateways: &gateways\nmirror: *gateways\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_0_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, []Gateway{{Endpoint: "from-env"}}, cfg.Gateways)
+	require.Equal(t, []Gateway{{Endpoint: "from-env"}}, cfg.Mirror)
+}
+
+// A key held only through a "<<" merge must keep the rest of what it
+// inherits when one of its children is overridden.
+func Test_Env_MergedKeyKeepsInheritedFields(t *testing.T) {
+	type Server struct {
+		Endpoint string `yaml:"endpoint"`
+		Timeout  string `yaml:"timeout"`
+	}
+	type Config struct {
+		Server Server `yaml:"server"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("defaults: &defaults\n"+
+			"  server:\n"+
+			"    endpoint: from-file\n"+
+			"    timeout: 5s\n"+
+			"<<: *defaults\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_SERVER_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Server.Endpoint)
+	require.Equal(t, "5s", cfg.Server.Timeout)
+}
+
+// An override lands under the same scrutiny as a key written in the file.
+func Test_Env_OverrideIsKnownKey(t *testing.T) {
+	type Config struct {
+		Name string `yaml:"name"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file"),
+		&cfg,
+		xcfg.WithKnownFields(),
+		envOverrides(t, map[string]string{"YANET_NAME": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Name)
+}
+
+func Test_Env_KnownFieldsStillRejectsUnknownKey(t *testing.T) {
+	type Config struct {
+		Name string `yaml:"name"`
+	}
+
+	var cfg Config
+	require.Error(t, xcfg.Decode(
+		[]byte("name: from-file\nnope: x\n"),
+		&cfg,
+		xcfg.WithKnownFields(),
+		envOverrides(t, map[string]string{"YANET_NAME": "from-env"}),
+	))
+}
+
+// Only the prefixed namespace is consulted.
+func Test_Env_ReadsProcessEnvironment(t *testing.T) {
+	type Config struct {
+		Name xcfg.NonEmptyString `yaml:"name"`
+	}
+
+	t.Setenv("YANET_NAME", "from-env")
+	t.Setenv("UNRELATED_NAME", "ignored")
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode([]byte("name: from-file"), &cfg, xcfg.WithEnv()))
+	require.Equal(t, "from-env", cfg.Name.Unwrap())
+}
+
+func Test_Env_DisabledWithoutOption(t *testing.T) {
+	type Config struct {
+		Name xcfg.NonEmptyString `yaml:"name"`
+	}
+
+	t.Setenv("YANET_NAME", "from-env")
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode([]byte("name: from-file"), &cfg))
+	require.Equal(t, "from-file", cfg.Name.Unwrap())
+}
+
+func Test_Env_CustomPrefix(t *testing.T) {
+	type Config struct {
+		Name xcfg.NonEmptyString `yaml:"name"`
+	}
+
+	t.Setenv("YANET_NAME", "shared-namespace")
+	t.Setenv("ANNOUNCER_NAME", "from-env")
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file"),
+		&cfg,
+		xcfg.WithEnvPrefix("ANNOUNCER_"),
+	))
+	require.Equal(t, "from-env", cfg.Name.Unwrap())
+}
+
+// An underscore-only prefix remains a literal prefix rather than selecting
+// the unprefixed namespace.
+func Test_Env_UnderscorePrefix(t *testing.T) {
+	type Config struct {
+		Name string `yaml:"name"`
+	}
+
+	t.Setenv("_NAME", "from-env")
+	t.Setenv("NAME", "unprefixed")
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file"),
+		&cfg,
+		xcfg.WithEnvPrefix("_"),
+	))
+	require.Equal(t, "from-env", cfg.Name)
+}
+
+// Letters outside ASCII remain letters in environment names and are
+// upper-cased instead of being folded into the separator character.
+func Test_Env_UnicodeKeyUppercased(t *testing.T) {
+	type Config struct {
+		City string `yaml:"münchen"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("münchen: from-file"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_MÜNCHEN": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.City)
+}
+
+func Test_Env_LoadConfigAppliesOverride(t *testing.T) {
+	type Config struct {
+		Name xcfg.NonEmptyString `yaml:"name"`
+	}
+
+	path := t.TempDir() + "/config.yaml"
+	require.NoError(t, os.WriteFile(path, []byte("name: from-file"), 0o600))
+
+	t.Setenv("YANET_NAME", "from-env")
+
+	cfg, err := xcfg.LoadConfig[Config](path, xcfg.WithEnv())
+	require.NoError(t, err)
+	require.Equal(t, "from-env", cfg.Name.Unwrap())
+}
+
+func Test_Env_RejectsMalformedDocument(t *testing.T) {
+	type Config struct {
+		Name string `yaml:"name"`
+	}
+
+	var cfg Config
+	require.Error(t, xcfg.Decode(
+		[]byte("name: [unclosed\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_NAME": "from-env"}),
+	))
+}
+
+// Enabling the environment overlay must not turn an invalid nil destination
+// into a reflection panic.
+func Test_Env_NilDestinationRejected(t *testing.T) {
+	err := xcfg.Decode(
+		[]byte("{}\n"),
+		nil,
+		envOverrides(t, map[string]string{"YANET_NAME": "from-env"}),
+	)
+	require.Error(t, err)
+}
+
+// A nil destination is rejected even when no matching process variable makes
+// the overlay walk the destination type.
+func Test_Env_NilDestinationRejectedWithoutVariables(t *testing.T) {
+	err := xcfg.Decode([]byte("{}\n"), nil, envOverrides(t, map[string]string{}))
+	require.Error(t, err)
+}
+
+// A self-referential type must not send the name walk into infinite
+// recursion. The variable names a path deeper than the walk will follow, so
+// the walk gives up and says where.
+func Test_Env_BoundsRecursion(t *testing.T) {
+	type Node struct {
+		Name string `yaml:"name"`
+		Next *Node  `yaml:"next"`
+	}
+
+	deep := "YANET" + strings.Repeat("_NEXT", 34)
+
+	var cfg Node
+	err := xcfg.Decode(
+		[]byte("name: root"),
+		&cfg,
+		envOverrides(t, map[string]string{deep + "_NAME": "x"}),
+	)
+	require.ErrorContains(t, err, "nests deeper than")
+}
+
+// An exact leaf match one level past the bound must reach the applying walk
+// and report that bound rather than being mistaken for an unrelated variable.
+func Test_Env_ExactLeafPastDepthLimitRejected(t *testing.T) {
+	type Node struct {
+		Name string `yaml:"name"`
+		Next *Node  `yaml:"next"`
+	}
+
+	deep := "YANET" + strings.Repeat("_NEXT", 32)
+
+	var cfg Node
+	err := xcfg.Decode(
+		[]byte("name: root"),
+		&cfg,
+		envOverrides(t, map[string]string{deep + "_NAME": "x"}),
+	)
+	require.ErrorContains(t, err, "nests deeper than")
+}
+
+// A variable that names nothing must not push a self-referential type into
+// that bound: the type could go on forever, but no variable asks it to.
+func Test_Env_StrayVariableOnRecursiveType(t *testing.T) {
+	type Node struct {
+		Name string `yaml:"name"`
+		Next *Node  `yaml:"next"`
+	}
+
+	var cfg Node
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: root"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_UNUSED": "x"}),
+	))
+	require.Equal(t, "root", cfg.Name)
+	require.Nil(t, cfg.Next)
+}
+
+// A string field must receive the value verbatim, including the values YAML
+// would otherwise resolve to a bool, a number or null. The emitter quotes
+// some forms on its own, so these are the ones that actually depend on the
+// destination type being consulted.
+func Test_Env_StringKeepsYAMLHostileValues(t *testing.T) {
+	type Config struct {
+		V string `yaml:"v"`
+	}
+
+	for _, value := range []string{
+		"null", "~", "true", "false", "yes", "no", "on", "off",
+		"0x10", "007", "1e5", ".inf", ".nan", "12:30", "-", "",
+	} {
+		t.Run(value, func(t *testing.T) {
+			var cfg Config
+			require.NoError(t, xcfg.Decode(
+				[]byte("v: placeholder"),
+				&cfg,
+				envOverrides(t, map[string]string{"YANET_V": value}),
+			))
+			require.Equal(t, value, cfg.V)
+		})
+	}
+}
+
+// The same values must survive the wrapper, which reports the type it
+// configures through EnvType.
+func Test_Env_NonEmptyStringKeepsYAMLHostileValues(t *testing.T) {
+	type Config struct {
+		V xcfg.NonEmptyString `yaml:"v"`
+	}
+
+	for _, value := range []string{"null", "true", "yes", "0x10", "12:30", "[::1]:8080"} {
+		t.Run(value, func(t *testing.T) {
+			var cfg Config
+			require.NoError(t, xcfg.Decode(
+				[]byte("v: placeholder"),
+				&cfg,
+				envOverrides(t, map[string]string{"YANET_V": value}),
+			))
+			require.Equal(t, value, cfg.V.Unwrap())
+		})
+	}
+}
+
+// A numeric field must not be handed a quoted scalar, which it could not
+// decode.
+func Test_Env_NumericNotQuoted(t *testing.T) {
+	type Config struct {
+		Workers int `yaml:"workers"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("workers: 1"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_WORKERS": "4"}),
+	))
+	require.Equal(t, 4, cfg.Workers)
+}
+
+// An override that the destination type cannot decode must be reported
+// rather than silently ignored.
+func Test_Env_RejectsUndecodableValue(t *testing.T) {
+	type Config struct {
+		Workers int `yaml:"workers"`
+	}
+
+	var cfg Config
+	require.Error(t, xcfg.Decode(
+		[]byte("workers: 1"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_WORKERS": "not-a-number"}),
+	))
+}
+
+// branchingNode is self-referential through two fields, so a walk that
+// enumerates its fields before deciding a variable is unrelated costs
+// 2^depth calls rather than the linear cost a single link would hide.
+type branchingNode struct {
+	Left  *branchingNode `yaml:"left"`
+	Right *branchingNode `yaml:"right"`
+	Name  string         `yaml:"name"`
+}
+
+type exportedScalar struct {
+	Value int
+}
+
+func (m *exportedScalar) UnmarshalYAML(node *yaml.Node) error {
+	return node.Decode(&m.Value)
+}
+
+type exportedMapping struct {
+	Name string `yaml:"name"`
+}
+
+func (m *exportedMapping) UnmarshalYAML(node *yaml.Node) error {
+	type plain exportedMapping
+	return node.Decode((*plain)(m))
+}
+
+// A custom scalar decoder owns its YAML representation even when its Go type
+// has exported implementation fields.
+func Test_Env_CustomYAMLScalarWithExportedFieldOverridden(t *testing.T) {
+	type Config struct {
+		Port exportedScalar `yaml:"port"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("port: 1\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_PORT": "2"}),
+	))
+	require.Equal(t, 2, cfg.Port.Value)
+}
+
+// A mapping-backed custom decoder retains nested field overrides when no
+// exact parent variable is supplied.
+func Test_Env_CustomYAMLMappingWithExportedFieldOverridden(t *testing.T) {
+	type Config struct {
+		Function exportedMapping `yaml:"function"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("function:\n  name: from-file\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_FUNCTION_NAME": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Function.Name)
+}
+
+// A variable that names nothing must be answered without expanding a
+// branching self-referential type. The assertion is the test terminating:
+// before the prune this ran past any timeout.
+func Test_Env_StrayVariableOnBranchingRecursiveType(t *testing.T) {
+	type Config struct {
+		Root branchingNode `yaml:"root"`
+		Name string        `yaml:"name"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file\nroot:\n  name: root\n"),
+		&cfg,
+		envOverrides(t, map[string]string{
+			"YANET_NAME":   "from-env",
+			"YANET_UNUSED": "x",
+		}),
+	))
+	require.Equal(t, "from-env", cfg.Name)
+	require.Equal(t, "root", cfg.Root.Name)
+	require.Nil(t, cfg.Root.Left)
+	require.Nil(t, cfg.Root.Right)
+}
+
+// A parent the file fills with a scalar cannot hold the key an override
+// names. Rewriting it would let the override hide a malformed file, so the
+// document is left for the decoder to reject.
+func Test_Env_MalformedMappingParentStillRejected(t *testing.T) {
+	type Server struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Server Server `yaml:"server"`
+	}
+
+	var cfg Config
+	err := xcfg.Decode(
+		[]byte("server: broken\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_SERVER_ENDPOINT": "from-env"}),
+	)
+	require.ErrorContains(t, err, "cannot unmarshal")
+}
+
+// The same holds for a sequence destination the file fills with a scalar.
+func Test_Env_MalformedSequenceParentStillRejected(t *testing.T) {
+	type Gateway struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateways []Gateway `yaml:"gateways"`
+	}
+
+	var cfg Config
+	err := xcfg.Decode(
+		[]byte("gateways: broken\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_0_ENDPOINT": "from-env"}),
+	)
+	require.ErrorContains(t, err, "cannot unmarshal")
+}
+
+// An explicit null is a key written with no value, which an override is
+// still allowed to fill.
+func Test_Env_FillsExplicitNullParent(t *testing.T) {
+	type Server struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Server Server `yaml:"server"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("server:\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_SERVER_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Server.Endpoint.Unwrap())
+}
+
+// A key written as an alias resolves to the same key an override names, so
+// the existing entry must be found rather than a second one appended: the
+// duplicate would decode as the whole mapping and drop its other fields.
+func Test_Env_AliasedMappingKeyResolved(t *testing.T) {
+	type Server struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+		Timeout  xcfg.NonEmptyString `yaml:"timeout"`
+	}
+	type Config struct {
+		Key    xcfg.NonEmptyString `yaml:"key"`
+		Server Server              `yaml:"server"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("key: &key server\n*key: {endpoint: old, timeout: 5s}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_SERVER_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, "from-env", cfg.Server.Endpoint.Unwrap())
+	require.Equal(t, "5s", cfg.Server.Timeout.Unwrap())
+}
+
+// An index a fixed array has no element for names nothing in the
+// destination type, so it is ignored rather than appended: growing the
+// sequence would make yaml reject an otherwise valid file on its length.
+func Test_Env_ArrayIndexPastEndIgnored(t *testing.T) {
+	type Gateway struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateways [2]Gateway `yaml:"gateways"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("gateways:\n  - endpoint: a\n  - endpoint: b\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_2_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, "a", cfg.Gateways[0].Endpoint.Unwrap())
+	require.Equal(t, "b", cfg.Gateways[1].Endpoint.Unwrap())
+}
+
+// An index the array does have is still overridden.
+func Test_Env_ArrayIndexInRangeOverridden(t *testing.T) {
+	type Gateway struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateways [2]Gateway `yaml:"gateways"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("gateways:\n  - endpoint: a\n  - endpoint: b\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_1_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, "a", cfg.Gateways[0].Endpoint.Unwrap())
+	require.Equal(t, "from-env", cfg.Gateways[1].Endpoint.Unwrap())
+}
+
+// An out-of-range array index names nothing in the type, so it must not
+// materialise the parent an unrelated override causes to be written out.
+// Materialising it would decode as null and wipe the parent's own defaults —
+// here, leave a required field unset.
+func Test_Env_ArrayIndexPastEndKeepsParentAbsent(t *testing.T) {
+	type Gateway struct {
+		Endpoint string `yaml:"endpoint"`
+	}
+	type Server struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+		Gateways [2]Gateway          `yaml:"gateways"`
+	}
+	type Config struct {
+		Name   string  `yaml:"name"`
+		Server *Server `yaml:"server"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file\n"),
+		&cfg,
+		envOverrides(t, map[string]string{
+			"YANET_NAME":                       "from-env",
+			"YANET_SERVER_GATEWAYS_2_ENDPOINT": "stray",
+		}),
+	))
+	require.Equal(t, "from-env", cfg.Name)
+	require.Nil(t, cfg.Server)
+}
+
+// An empty prefix asks for the unprefixed namespace, where a top-level key is
+// named NAME rather than _NAME.
+func Test_Env_EmptyPrefix(t *testing.T) {
+	type Server struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Name   string `yaml:"name"`
+		Server Server `yaml:"server"`
+	}
+
+	t.Setenv("NAME", "from-env")
+	t.Setenv("SERVER_ENDPOINT", "endpoint-from-env")
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file\nserver:\n  endpoint: endpoint-from-file\n"),
+		&cfg,
+		xcfg.WithEnvPrefix(""),
+	))
+	require.Equal(t, "from-env", cfg.Name)
+	require.Equal(t, "endpoint-from-env", cfg.Server.Endpoint.Unwrap())
+}
+
+// yaml.Node stores arbitrary raw YAML. Its exported implementation fields are
+// not schema fields and must remain file-only.
+func Test_Env_YAMLNodeStaysFileOnly(t *testing.T) {
+	type Config struct {
+		Name string    `yaml:"name"`
+		Raw  yaml.Node `yaml:"raw"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("name: from-file\nraw:\n  original: kept\n"),
+		&cfg,
+		envOverrides(t, map[string]string{
+			"YANET_NAME":      "from-env",
+			"YANET_RAW_VALUE": "injected",
+		}),
+	))
+	require.Equal(t, "from-env", cfg.Name)
+	require.Equal(t, yaml.MappingNode, cfg.Raw.Kind)
+	require.Len(t, cfg.Raw.Content, 2)
+	require.Equal(t, "original", cfg.Raw.Content[0].Value)
+	require.Equal(t, "kept", cfg.Raw.Content[1].Value)
+}
+
+// An absent fixed array starts from its destination value so a partial
+// override retains every untouched element and still has its declared length.
+func Test_Env_AbsentArrayPreservesDefaults(t *testing.T) {
+	type Gateway struct {
+		Endpoint string `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateways [2]Gateway `yaml:"gateways"`
+	}
+
+	cfg := Config{Gateways: [2]Gateway{{Endpoint: "first"}, {Endpoint: "second"}}}
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_1_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, [2]Gateway{{Endpoint: "first"}, {Endpoint: "from-env"}}, cfg.Gateways)
+}
+
+// Supplying every element gives an absent fixed array its exact length and is
+// therefore still supported.
+func Test_Env_AbsentArrayFullyOverridden(t *testing.T) {
+	type Gateway struct {
+		Endpoint string `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateways [2]Gateway `yaml:"gateways"`
+	}
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{
+			"YANET_GATEWAYS_0_ENDPOINT": "a",
+			"YANET_GATEWAYS_1_ENDPOINT": "b",
+		}),
+	))
+	require.Equal(t, "a", cfg.Gateways[0].Endpoint)
+	require.Equal(t, "b", cfg.Gateways[1].Endpoint)
+}
+
+// An override into an absent defaulted slice starts from the destination's
+// current elements, preserving untouched elements and sibling defaults.
+func Test_Env_AbsentSlicePreservesDefaults(t *testing.T) {
+	type Gateway struct {
+		Endpoint string `yaml:"endpoint"`
+		Timeout  string `yaml:"timeout"`
+	}
+	type Config struct {
+		Gateways []Gateway `yaml:"gateways"`
+	}
+
+	cfg := Config{Gateways: []Gateway{
+		{Endpoint: "first", Timeout: "1s"},
+		{Endpoint: "second", Timeout: "2s"},
+	}}
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_1_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, []Gateway{
+		{Endpoint: "first", Timeout: "1s"},
+		{Endpoint: "from-env", Timeout: "2s"},
+	}, cfg.Gateways)
+}
+
+// A present wrapper does not hide the destination slice whose defaults must
+// seed an absent sequence before one element is overridden.
+func Test_Env_OptionalSlicePreservesDefaults(t *testing.T) {
+	type Gateway struct {
+		Endpoint string `yaml:"endpoint"`
+		Timeout  string `yaml:"timeout"`
+	}
+	type Config struct {
+		Gateways xcfg.Optional[[]Gateway] `yaml:"gateways"`
+	}
+
+	cfg := Config{Gateways: xcfg.NewOptional([]Gateway{
+		{Endpoint: "first", Timeout: "1s"},
+		{Endpoint: "second", Timeout: "2s"},
+	})}
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_1_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, []Gateway{
+		{Endpoint: "first", Timeout: "1s"},
+		{Endpoint: "from-env", Timeout: "2s"},
+	}, *cfg.Gateways.Unwrap())
+}
+
+// A required wrapper likewise preserves its existing sequence while the
+// environment explicitly supplies the overridden child.
+func Test_Env_RequiredSlicePreservesDefaults(t *testing.T) {
+	type Gateway struct {
+		Endpoint string `yaml:"endpoint"`
+		Timeout  string `yaml:"timeout"`
+	}
+	type Config struct {
+		Gateways xcfg.Required[[]Gateway] `yaml:"gateways"`
+	}
+
+	cfg := Config{Gateways: xcfg.NewRequired([]Gateway{
+		{Endpoint: "first", Timeout: "1s"},
+		{Endpoint: "second", Timeout: "2s"},
+	})}
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_1_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, []Gateway{
+		{Endpoint: "first", Timeout: "1s"},
+		{Endpoint: "from-env", Timeout: "2s"},
+	}, cfg.Gateways.Unwrap())
+}
+
+// A value wrapper around a struct retains sibling defaults when an override
+// materialises the otherwise absent mapping.
+func Test_Env_RequiredStructPreservesDefaults(t *testing.T) {
+	type Server struct {
+		Endpoint string `yaml:"endpoint"`
+		Timeout  string `yaml:"timeout"`
+	}
+	type Config struct {
+		Server xcfg.Required[Server] `yaml:"server"`
+	}
+
+	cfg := Config{Server: xcfg.NewRequired(Server{Endpoint: "old", Timeout: "5s"})}
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_SERVER_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, Server{Endpoint: "from-env", Timeout: "5s"}, cfg.Server.Unwrap())
+}
+
+// Materialising sequence defaults must not turn an unset required sibling
+// into an explicitly supplied zero value.
+func Test_Env_SequenceDefaultsKeepRequiredUnset(t *testing.T) {
+	type Gateway struct {
+		Endpoint   string             `yaml:"endpoint"`
+		InstanceID xcfg.Required[int] `yaml:"instance_id"`
+	}
+	type Config struct {
+		Gateways []Gateway `yaml:"gateways"`
+	}
+
+	cfg := Config{Gateways: []Gateway{{Endpoint: "from-default"}}}
+	err := xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_0_ENDPOINT": "from-env"}),
+	)
+	require.ErrorContains(t, err, "value must be set explicitly")
+}
+
+// An exact environment value may satisfy an unset required element that was
+// present only in a destination-defaulted sequence.
+func Test_Env_SequenceDefaultRequiredElementOverridden(t *testing.T) {
+	type Config struct {
+		Values []xcfg.Required[int] `yaml:"values"`
+	}
+
+	cfg := Config{Values: make([]xcfg.Required[int], 1)}
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_VALUES_0": "3"}),
+	))
+	require.Equal(t, 3, cfg.Values[0].Unwrap())
+}
+
+// Explicit-presence state is checked through every wrapper layer when
+// sequence defaults are materialised.
+func Test_Env_SequenceDefaultsKeepNestedRequiredUnset(t *testing.T) {
+	type Gateway struct {
+		Endpoint   string                            `yaml:"endpoint"`
+		InstanceID xcfg.Optional[xcfg.Required[int]] `yaml:"instance_id"`
+	}
+	type Config struct {
+		Gateways []Gateway `yaml:"gateways"`
+	}
+
+	cfg := Config{Gateways: []Gateway{{
+		Endpoint:   "from-default",
+		InstanceID: xcfg.NewOptional(xcfg.Required[int]{}),
+	}}}
+	err := xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_GATEWAYS_0_ENDPOINT": "from-env"}),
+	)
+	require.ErrorContains(t, err, "unset required")
+}
+
+// Supplying one descendant of an unset required struct does not mark its own
+// untouched required descendants as explicitly supplied.
+func Test_Env_SequenceDefaultsKeepRequiredDescendantUnset(t *testing.T) {
+	type Inner struct {
+		Name string             `yaml:"name"`
+		ID   xcfg.Required[int] `yaml:"id"`
+	}
+	type Config struct {
+		Values []xcfg.Optional[xcfg.Required[Inner]] `yaml:"values"`
+	}
+
+	cfg := Config{Values: []xcfg.Optional[xcfg.Required[Inner]]{
+		xcfg.NewOptional(xcfg.Required[Inner]{}),
+	}}
+	err := xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_VALUES_0_NAME": "from-env"}),
+	)
+	require.Error(t, err)
+}
+
+// An already present optional struct is preserved from its current value
+// rather than recreated from only the overridden child.
+func Test_Env_OptionalStructPreservesDefaults(t *testing.T) {
+	type Server struct {
+		Endpoint string `yaml:"endpoint"`
+		Timeout  string `yaml:"timeout"`
+	}
+	type Config struct {
+		Server xcfg.Optional[Server] `yaml:"server"`
+	}
+
+	cfg := Config{Server: xcfg.NewOptional(Server{Endpoint: "old", Timeout: "5s"})}
+	require.NoError(t, xcfg.Decode(
+		[]byte("{}\n"),
+		&cfg,
+		envOverrides(t, map[string]string{"YANET_SERVER_ENDPOINT": "from-env"}),
+	))
+	require.Equal(t, Server{Endpoint: "from-env", Timeout: "5s"}, *cfg.Server.Unwrap())
+}
+
+// An empty prefix names a sequence element without a leading underscore too.
+func Test_Env_EmptyPrefixSequenceElement(t *testing.T) {
+	type Gateway struct {
+		Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	}
+	type Config struct {
+		Gateways []Gateway `yaml:"gateways"`
+	}
+
+	t.Setenv("GATEWAYS_0_ENDPOINT", "from-env")
+
+	var cfg Config
+	require.NoError(t, xcfg.Decode(
+		[]byte("gateways:\n  - endpoint: from-file\n"),
+		&cfg,
+		xcfg.WithEnvPrefix(""),
+	))
+	require.Equal(t, "from-env", cfg.Gateways[0].Endpoint.Unwrap())
+}

--- a/common/go/xcfg/load.go
+++ b/common/go/xcfg/load.go
@@ -33,11 +33,14 @@ type Option func(*options)
 
 type options struct {
 	KnownFields bool
+	Env         bool
+	EnvPrefix   string
 }
 
 func newOptions() *options {
 	return &options{
 		KnownFields: false,
+		EnvPrefix:   DefaultEnvPrefix,
 	}
 }
 
@@ -52,6 +55,39 @@ func newOptions() *options {
 func WithKnownFields() Option {
 	return func(o *options) {
 		o.KnownFields = true
+	}
+}
+
+// WithEnv lets an environment variable override the value a key holds in the
+// document.
+//
+// A variable is named after the path its key sits at, prefixed with
+// DefaultEnvPrefix, upper-cased, with every separator replaced by an
+// underscore: server.endpoint reads YANET_SERVER_ENDPOINT and
+// gateways[0].endpoint reads YANET_GATEWAYS_0_ENDPOINT. A list element beyond
+// the ones the file defines is appended, so a deployment can add a gateway
+// without shipping a different file, and dropping one is a matter of not
+// naming it rather than blanking it out.
+//
+// An override is applied to the document before it is decoded, so the value
+// still passes through the destination type's own decoding and validation: an
+// empty NonEmptyString is rejected whether it came from the file or the
+// environment.
+func WithEnv() Option {
+	return func(o *options) {
+		o.Env = true
+	}
+}
+
+// WithEnvPrefix overrides the prefix WithEnv expects, for a binary that must
+// not read the shared YANET_ namespace.
+//
+// An empty prefix asks for the unprefixed namespace, where server.endpoint
+// reads SERVER_ENDPOINT.
+func WithEnvPrefix(prefix string) Option {
+	return func(o *options) {
+		o.Env = true
+		o.EnvPrefix = prefix
 	}
 }
 
@@ -87,10 +123,29 @@ func Decode(buf []byte, dst any, options ...Option) error {
 	for _, o := range options {
 		o(opts)
 	}
+	dstType := reflect.TypeOf(dst)
+	if dstType == nil {
+		return fmt.Errorf("destination must not be nil")
+	}
+
+	if opts.Env {
+		// Applied before the known-keys walk so an override lands under
+		// the same scrutiny as a key written in the file.
+		overlaid, err := applyEnv(
+			buf,
+			dst,
+			opts.EnvPrefix,
+			environ(opts.EnvPrefix),
+		)
+		if err != nil {
+			return err
+		}
+		buf = overlaid
+	}
 
 	collected, complete, err := walkDocument(
 		buf,
-		reflect.TypeOf(dst),
+		dstType,
 		maxAliasExpansionWork,
 	)
 	if err != nil {
@@ -112,7 +167,7 @@ func Decode(buf []byte, dst any, options ...Option) error {
 		}
 		decoded = true
 
-		collected, _, err = walkDocument(buf, reflect.TypeOf(dst), 0)
+		collected, _, err = walkDocument(buf, dstType, 0)
 		if err != nil {
 			return err
 		}

--- a/common/go/xcfg/nonempty.go
+++ b/common/go/xcfg/nonempty.go
@@ -3,6 +3,7 @@ package xcfg
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 )
@@ -52,6 +53,20 @@ func (m NonEmptyString) Validate() error {
 // String implements fmt.Stringer.
 func (m NonEmptyString) String() string {
 	return m.v
+}
+
+// EnvType implements envTyped, telling the environment overlay in env.go that
+// this wrapper configures a plain string, so an override is emitted as a
+// quoted scalar rather than resolved as YAML. Without it an endpoint such as
+// "[::1]:8080" would be read as a flow sequence.
+func (m NonEmptyString) EnvType() reflect.Type {
+	return reflect.TypeFor[string]()
+}
+
+// EnvValue implements envValued, exposing the current wrapped default to the
+// environment overlay.
+func (m NonEmptyString) EnvValue() reflect.Value {
+	return reflect.ValueOf(m.v)
 }
 
 // MarshalYAML implements yaml.Marshaler.

--- a/common/go/xcfg/nonzero.go
+++ b/common/go/xcfg/nonzero.go
@@ -3,6 +3,7 @@ package xcfg
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 )
@@ -46,6 +47,18 @@ func (m NonZero[T]) Unwrap() T {
 // String implements fmt.Stringer.
 func (m NonZero[T]) String() string {
 	return fmt.Sprint(m.v)
+}
+
+// EnvType implements envTyped, letting the environment overlay in env.go
+// configure the wrapped value instead of treating the wrapper as opaque.
+func (m NonZero[T]) EnvType() reflect.Type {
+	return reflect.TypeFor[T]()
+}
+
+// EnvValue implements envValued, exposing the current wrapped default to the
+// environment overlay.
+func (m NonZero[T]) EnvValue() reflect.Value {
+	return reflect.ValueOf(m.v)
 }
 
 // Validate checks that the value is not zero.

--- a/common/go/xcfg/optional.go
+++ b/common/go/xcfg/optional.go
@@ -70,6 +70,25 @@ func (m Optional[T]) WalkType() reflect.Type {
 	return reflect.TypeFor[T]()
 }
 
+// EnvType implements envTyped, letting the environment overlay in env.go
+// address the wrapped value's own fields.
+//
+// An override materialises the optional value: naming a key under an absent
+// Optional makes it present, since the overlay writes the key into the
+// document and UnmarshalYAML then seeds T with its Default.
+func (m Optional[T]) EnvType() reflect.Type {
+	return reflect.TypeFor[T]()
+}
+
+// EnvValue implements envValued, exposing a present wrapped default to the
+// environment overlay.
+func (m Optional[T]) EnvValue() reflect.Value {
+	if m.v == nil {
+		return reflect.Value{}
+	}
+	return reflect.ValueOf(m.v).Elem()
+}
+
 // Elem implements validatableElem, letting validate in load.go recurse into
 // the wrapped value's own fields under Optional's own dotted path.
 //

--- a/common/go/xcfg/required.go
+++ b/common/go/xcfg/required.go
@@ -3,6 +3,7 @@ package xcfg
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 )
@@ -28,6 +29,29 @@ func (m Required[T]) Unwrap() T {
 // String implements fmt.Stringer.
 func (m Required[T]) String() string {
 	return fmt.Sprint(m.v)
+}
+
+// EnvType implements envTyped, so a required value may be supplied from the
+// environment. The override goes through UnmarshalYAML like any other value,
+// which is what marks it explicitly set.
+func (m Required[T]) EnvType() reflect.Type {
+	return reflect.TypeFor[T]()
+}
+
+// EnvValue implements envValued, exposing the current wrapped default to the
+// environment overlay.
+func (m Required[T]) EnvValue() reflect.Value {
+	return reflect.ValueOf(m.v)
+}
+
+// EnvIsSet reports whether the wrapped value was supplied explicitly.
+func (m Required[T]) EnvIsSet() bool {
+	return m.set
+}
+
+// Elem exposes the wrapped value for recursive validation.
+func (m *Required[T]) Elem() reflect.Value {
+	return reflect.ValueOf(&m.v).Elem()
 }
 
 // Validate checks that the value was set explicitly.


### PR DESCRIPTION
A config value could only come from the file, so deploying the same image to several hosts meant shipping a different file to each one just to change an endpoint or an instance id.

Add WithEnv, which lets an environment variable override the value a key holds in the document. A variable is named after the path its key sits at, prefixed with YANET_, upper-cased, with every separator replaced by an underscore: server.endpoint reads YANET_SERVER_ENDPOINT and gateways[0].endpoint reads YANET_GATEWAYS_0_ENDPOINT. WithEnvPrefix serves a binary that must not read the shared namespace.

The override is applied to the YAML document before it is decoded rather than written onto the struct by reflection, so every value still arrives through the destination type's own UnmarshalYAML: an empty NonEmptyString is rejected whether it came from the file or the environment, and a Required set this way still counts as explicitly set. The wrappers report the type they configure through the new envTyped interface, which also decides whether a value is emitted as a quoted scalar -- without it an endpoint such as "[::1]:8080" would be read as a flow sequence.

The variable name is generated from the destination type and never parsed out of the environment, so a key that itself contains an underscore (http_endpoint) cannot be split at the wrong place. Two paths folding onto one name are rejected rather than left silently ambiguous. A map stays file-only, having no fixed key set to generate names from, and a sequence element past the end of the file's list is appended only when every index up to it is supplied, so a gap cannot decode as a null element.

The walk descends into a field only where a variable names a leaf the type actually generates, matched against those names rather than against a string prefix. Two sibling keys where one extends the other are the reason: YANET_GATEWAY_DEVICES_A belongs to gateway_devices, yet it opens with every character of the name gateway generates. Descending on that resemblance would materialise gateway as an empty mapping no leaf ever fills, which decodes as null and wipes the subtree's defaults -- and with it the config, since a null key is rejected. A variable naming nothing in the type, or an index whose element holds no named leaf, is likewise left alone.