### PR TITLE
fix(controlplane,operator): default backends to ephemeral ports

### DIFF
--- a/controlplane/etc/yanet/controlplane.d/default.yaml
+++ b/controlplane/etc/yanet/controlplane.d/default.yaml
@@ -64,60 +64,48 @@ modules:
     memory_path: *memory_path
     # Memory requirements for a single FIB-push transaction.
     memory_requirements: 16MB
-    endpoint: "[::1]:0"
   route-mpls:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
-    endpoint: "[::1]:0"
   decap:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
-    endpoint: "[::1]:0"
   dscp:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
-    endpoint: "[::1]:0"
   forward:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
-    endpoint: "[::1]:0"
   mirror:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
-    endpoint: "[::1]:0"
   nat64:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
-    endpoint: "[::1]:0"
   pdump:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
-    endpoint: "[::1]:0"
   acl:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 8GB
-    endpoint: "[::1]:0"
   blackhole:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 4MB
-    endpoint: "[::1]:0"
 devices:
   plain:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
-    endpoint: "[::1]:0"
   vlan:
     instance_id: 0
     memory_path: *memory_path
     memory_requirements: 16MB
-    endpoint: "[::1]:0"

--- a/controlplane/yncp/cfg_test.go
+++ b/controlplane/yncp/cfg_test.go
@@ -46,6 +46,35 @@ func Test_ShippedDefaultConfig_LoadsIntendedEnabledSet(t *testing.T) {
 	require.Equal(t, uint32(0), cfg.Gateway.InstanceID.Unwrap())
 }
 
+// Test_ShippedDefaultConfig_OmittedBackendEndpointsUseEphemeralPorts verifies
+// that omitted backend endpoints inherit loopback port-zero defaults.
+func Test_ShippedDefaultConfig_OmittedBackendEndpointsUseEphemeralPorts(t *testing.T) {
+	config, err := xcfg.LoadConfig[yncp.Config](
+		"../etc/yanet/controlplane.d/default.yaml",
+	)
+	require.NoError(t, err)
+
+	endpoints := map[string]string{
+		"route module":      config.Modules.Route.Unwrap().Endpoint.Unwrap(),
+		"route MPLS module": config.Modules.RouteMPLS.Unwrap().Endpoint.Unwrap(),
+		"decap module":      config.Modules.Decap.Unwrap().Endpoint.Unwrap(),
+		"DSCP module":       config.Modules.DSCP.Unwrap().Endpoint.Unwrap(),
+		"forward module":    config.Modules.Forward.Unwrap().Endpoint.Unwrap(),
+		"mirror module":     config.Modules.Mirror.Unwrap().Endpoint.Unwrap(),
+		"NAT64 module":      config.Modules.NAT64.Unwrap().Endpoint.Unwrap(),
+		"pdump module":      config.Modules.Pdump.Unwrap().Endpoint.Unwrap(),
+		"ACL module":        config.Modules.ACL.Unwrap().Endpoint.Unwrap(),
+		"blackhole module":  config.Modules.Blackhole.Unwrap().Endpoint.Unwrap(),
+		"plain device":      config.Devices.Plain.Unwrap().Endpoint.Unwrap(),
+		"VLAN device":       config.Devices.Vlan.Unwrap().Endpoint.Unwrap(),
+	}
+	for name, endpoint := range endpoints {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, "[::1]:0", endpoint)
+		})
+	}
+}
+
 // Test_ModuleWithoutInstanceID_FailsValidation asserts that a listed module
 // omitting instance_id fails with a dotted path naming that module.
 func Test_ModuleWithoutInstanceID_FailsValidation(t *testing.T) {

--- a/operators/decap/etc/yanet/yanet-decap-operator-default.yaml
+++ b/operators/decap/etc/yanet/yanet-decap-operator-default.yaml
@@ -1,9 +1,6 @@
 logging:
   level: info
 
-server:
-  endpoint: "[::1]:50004"
-
 gateways:
   - name: numa0
     endpoint: "[::1]:8080"

--- a/operators/decap/internal/operator/cfg.go
+++ b/operators/decap/internal/operator/cfg.go
@@ -76,7 +76,7 @@ func DefaultConfig() *Config {
 			Level: zapcore.InfoLevel,
 		},
 		Server: operator.GRPCServerConfig{
-			Endpoint: xcfg.MustNonEmptyString("[::1]:50004"),
+			Endpoint: xcfg.MustNonEmptyString("[::1]:0"),
 		},
 		Reconcile: operator.ReconcileConfig{
 			Interval:       xcfg.MustNonZero(operator.DefaultReconcileInterval),

--- a/operators/decap/internal/operator/cfg_test.go
+++ b/operators/decap/internal/operator/cfg_test.go
@@ -29,9 +29,14 @@ func Test_ShippedPrefixesDefault_NoUnknownKeys(t *testing.T) {
 	require.NoError(t, xcfg.CheckKnownKeys[yamlPrefixFile](data))
 }
 
-func TestDefaultConfig_ServerEndpoint(t *testing.T) {
-	cfg := DefaultConfig()
-	require.Equal(t, "[::1]:50004", cfg.Server.Endpoint.Unwrap())
+// Test_ShippedDefaultConfig_OmittedServerEndpointUsesEphemeralPort verifies
+// that the shipped file inherits the loopback port-zero listener endpoint.
+func Test_ShippedDefaultConfig_OmittedServerEndpointUsesEphemeralPort(t *testing.T) {
+	config, err := xcfg.LoadConfig[Config](
+		"../../etc/yanet/yanet-decap-operator-default.yaml",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "[::1]:0", config.Server.Endpoint.Unwrap())
 }
 
 func TestFunctionConfig_IgnorePdump_DefaultsTrue(t *testing.T) {

--- a/operators/forward/etc/yanet/yanet-forward-operator-default.yaml
+++ b/operators/forward/etc/yanet/yanet-forward-operator-default.yaml
@@ -1,9 +1,6 @@
 logging:
   level: info
 
-server:
-  endpoint: "[::1]:50003"
-
 gateways:
   - name: numa0
     endpoint: "[::1]:8080"

--- a/operators/forward/internal/operator/cfg.go
+++ b/operators/forward/internal/operator/cfg.go
@@ -75,7 +75,7 @@ func DefaultConfig() *Config {
 			Level: zapcore.InfoLevel,
 		},
 		Server: operator.GRPCServerConfig{
-			Endpoint: xcfg.MustNonEmptyString("[::1]:50003"),
+			Endpoint: xcfg.MustNonEmptyString("[::1]:0"),
 		},
 		Reconcile: operator.ReconcileConfig{
 			Interval:       xcfg.MustNonZero(operator.DefaultReconcileInterval),

--- a/operators/forward/internal/operator/cfg_test.go
+++ b/operators/forward/internal/operator/cfg_test.go
@@ -18,6 +18,16 @@ func Test_ShippedDefaultConfig_NoUnknownKeys(t *testing.T) {
 	require.NoError(t, xcfg.CheckKnownKeys[Config](data))
 }
 
+// Test_ShippedDefaultConfig_OmittedServerEndpointUsesEphemeralPort verifies
+// that the shipped file inherits the loopback port-zero listener endpoint.
+func Test_ShippedDefaultConfig_OmittedServerEndpointUsesEphemeralPort(t *testing.T) {
+	config, err := xcfg.LoadConfig[Config](
+		"../../etc/yanet/yanet-forward-operator-default.yaml",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "[::1]:0", config.Server.Endpoint.Unwrap())
+}
+
 // Test_ShippedRulesDefault_NoUnknownKeys guards the shipped forward rules
 // files against a key that matches no field in yamlForwardConfig.
 func Test_ShippedRulesDefault_NoUnknownKeys(t *testing.T) {

--- a/operators/pipeline/etc/yanet/yanet-pipeline-operator-default.yaml
+++ b/operators/pipeline/etc/yanet/yanet-pipeline-operator-default.yaml
@@ -1,9 +1,6 @@
 logging:
   level: debug
 
-server:
-  endpoint: "[::1]:50001"
-
 gateways:
   - name: numa0
     endpoint: "[::1]:8080"

--- a/operators/pipeline/internal/operator/cfg.go
+++ b/operators/pipeline/internal/operator/cfg.go
@@ -45,7 +45,7 @@ func DefaultConfig() *Config {
 			Level: zapcore.InfoLevel,
 		},
 		Server: operator.GRPCServerConfig{
-			Endpoint: xcfg.MustNonEmptyString("localhost:50001"),
+			Endpoint: xcfg.MustNonEmptyString("[::1]:0"),
 		},
 		Reconcile: operator.ReconcileConfig{
 			Interval:       xcfg.MustNonZero(operator.DefaultReconcileInterval),

--- a/operators/pipeline/internal/operator/cfg_test.go
+++ b/operators/pipeline/internal/operator/cfg_test.go
@@ -17,3 +17,13 @@ func Test_ShippedDefaultConfig_NoUnknownKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, xcfg.CheckKnownKeys[operator.Config](data))
 }
+
+// Test_ShippedDefaultConfig_OmittedServerEndpointUsesEphemeralPort verifies
+// that the shipped file inherits the loopback port-zero listener endpoint.
+func Test_ShippedDefaultConfig_OmittedServerEndpointUsesEphemeralPort(t *testing.T) {
+	config, err := xcfg.LoadConfig[operator.Config](
+		"../../etc/yanet/yanet-pipeline-operator-default.yaml",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "[::1]:0", config.Server.Endpoint.Unwrap())
+}

--- a/operators/route/etc/yanet/yanet-route-operator-default.yaml
+++ b/operators/route/etc/yanet/yanet-route-operator-default.yaml
@@ -4,10 +4,6 @@
 logging:
   level: debug
 
-# gRPC server exposed by the operator.
-server:
-  endpoint: "[::1]:50002"
-
 # One entry per dataplane instance (typically one per NUMA node).
 gateways:
   - name: numa0

--- a/operators/route/internal/operator/cfg.go
+++ b/operators/route/internal/operator/cfg.go
@@ -114,7 +114,7 @@ func DefaultConfig() *Config {
 			Level: zapcore.InfoLevel,
 		},
 		Server: operator.GRPCServerConfig{
-			Endpoint: xcfg.MustNonEmptyString("localhost:50002"),
+			Endpoint: xcfg.MustNonEmptyString("[::1]:0"),
 		},
 		Reconcile: operator.ReconcileConfig{
 			Interval:       xcfg.MustNonZero(operator.DefaultReconcileInterval),

--- a/operators/route/internal/operator/cfg_test.go
+++ b/operators/route/internal/operator/cfg_test.go
@@ -17,3 +17,13 @@ func Test_ShippedDefaultConfig_NoUnknownKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, xcfg.CheckKnownKeys[operator.Config](data))
 }
+
+// Test_ShippedDefaultConfig_OmittedServerEndpointUsesEphemeralPort verifies
+// that the shipped file inherits the loopback port-zero listener endpoint.
+func Test_ShippedDefaultConfig_OmittedServerEndpointUsesEphemeralPort(t *testing.T) {
+	config, err := xcfg.LoadConfig[operator.Config](
+		"../../etc/yanet/yanet-route-operator-default.yaml",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "[::1]:0", config.Server.Endpoint.Unwrap())
+}


### PR DESCRIPTION
- Default self-registering operator listeners to kernel-assigned loopback ports.
- Remove redundant backend endpoint keys from shipped control-plane and operator configurations.
- Verify omitted module, device, and operator endpoints inherit `[::1]:0`.

Closes #2156.