### PR TITLE
refactor(shm): cp_objects ref counting and parking

### DIFF
--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -107,6 +107,14 @@ struct agent {
 	// plain and vlan devices keeps each type's entries for that type's own
 	// next construction.
 	struct cp_device *parked_devices;
+
+	// Head of this agent's list of shared objects parked after their
+	// reference count reached zero.
+	//
+	// Follows the same discipline as the device list above: an object
+	// type's construction call reclaims only matching entries, leaving
+	// other types' entries parked for their own next construction.
+	struct cp_object *parked_objects;
 };
 
 struct dp_config *

--- a/lib/controlplane/config/cp_object.c
+++ b/lib/controlplane/config/cp_object.c
@@ -4,6 +4,7 @@
 #include "lib/dataplane/config/zone.h"
 
 #include "lib/controlplane/agent/agent.h"
+#include "lib/controlplane/config/zone.h"
 
 #include <string.h>
 
@@ -64,6 +65,13 @@ cp_object_init(
 		goto err_out;
 	}
 
+	// Take the creator's reference only after construction succeeds.
+	//
+	// A failed construction leaves nothing to unbalance. This reference
+	// is never mirrored into the live-reference count: a dead creator
+	// must not hold it above zero.
+	registry_item_ref(&self->config_item);
+
 	return 0;
 
 err_out:
@@ -113,31 +121,153 @@ cp_object_registry_copy(
 	}
 
 	SET_OFFSET_OF(&new_registry->memory_context, memory_context);
+
+	// Mirror each copied item's new generation reference into its own
+	// agent.
+	//
+	// This keeps the per-agent live count tracking references from a
+	// live configuration generation rather than the creator's own hold,
+	// which a dead creator would otherwise never release.
+	for (uint64_t idx = 0; idx < new_registry->registry.capacity; ++idx) {
+		struct cp_object *object =
+			cp_object_registry_get(new_registry, idx);
+		if (object == NULL) {
+			continue;
+		}
+		struct agent *agent = ADDR_OF(&object->agent);
+		if (agent != NULL) {
+			agent->loaded_object_count += 1;
+		}
+	}
+
 	return 0;
 }
 
-static void
+void
 cp_object_registry_item_free_cb(struct registry_item *item, void *data) {
-	(void)data;
 	struct cp_object *object =
 		container_of(item, struct cp_object, config_item);
-
-	// Registry membership is not ownership: an object leaving the registry
-	// is not freed here.
-	//
-	// The object lives in its creating agent's arena and is reclaimed
-	// wholesale when the agent is reclaimed. agent_attach /
-	// agent_free_unused_agents gate that reclamation on every
-	// loaded_*_count reaching zero, so the agent is not torn down while any
-	// of its objects still holds a reference from a live generation.
 	struct agent *agent = ADDR_OF(&object->agent);
-	if (agent != NULL) {
-		agent->loaded_object_count -= 1;
+	if (agent == NULL) {
+		return;
+	}
+
+	if (ADDR_OF(&object->parked_next) != NULL) {
+		return;
+	}
+
+	struct cp_object *head = ADDR_OF(&agent->parked_objects);
+	SET_OFFSET_OF(&object->parked_next, (head != NULL) ? head : object);
+	SET_OFFSET_OF(&agent->parked_objects, object);
+	(void)data;
+}
+
+void
+cp_object_release(struct cp_object *self) {
+	struct agent *agent = ADDR_OF(&self->agent);
+	struct cp_config *cp_config =
+		(agent != NULL) ? ADDR_OF(&agent->cp_config) : NULL;
+
+	if (cp_config != NULL) {
+		cp_config_lock(cp_config);
+	}
+	registry_item_unref(
+		&self->config_item, cp_object_registry_item_free_cb, NULL
+	);
+	if (cp_config != NULL) {
+		cp_config_unlock(cp_config);
 	}
 }
 
 void
+cp_object_drain_parked(
+	struct agent *agent,
+	const char *object_type,
+	cp_object_free_handler destroy
+) {
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	cp_config_lock(cp_config);
+
+	// Splice the target type's entries into a local list, leaving the
+	// rest linked in place for their own type's next call.
+	//
+	// A spliced-out tail leaves its former predecessor pointing at itself
+	// as the new end of the list, so a parked entry's link is never null.
+	struct cp_object *owned = NULL;
+	struct cp_object *prev = NULL;
+	struct cp_object *cur = ADDR_OF(&agent->parked_objects);
+
+	while (cur != NULL) {
+		struct cp_object *raw_next = ADDR_OF(&cur->parked_next);
+		struct cp_object *next = (raw_next == cur) ? NULL : raw_next;
+
+		if (!strncmp(cur->type, object_type, sizeof(cur->type))) {
+			if (prev == NULL) {
+				SET_OFFSET_OF(&agent->parked_objects, next);
+			} else {
+				SET_OFFSET_OF(
+					&prev->parked_next,
+					(next != NULL) ? next : prev
+				);
+			}
+			SET_OFFSET_OF(&cur->parked_next, owned);
+			owned = cur;
+		} else {
+			prev = cur;
+		}
+
+		cur = next;
+	}
+
+	if (owned == NULL) {
+		cp_config_unlock(cp_config);
+		return;
+	}
+
+	// Pin the agent's arena for the destroy loop below, still under the
+	// same lock the splice above ran under, so the reclaim guard can never
+	// observe the entries detached but the pin not yet set.
+	agent->parked_teardown_count += 1;
+
+	cp_config_unlock(cp_config);
+
+	while (owned != NULL) {
+		struct cp_object *next = ADDR_OF(&owned->parked_next);
+		destroy(owned);
+		owned = next;
+	}
+
+	cp_config_lock(cp_config);
+	agent->parked_teardown_count -= 1;
+	cp_config_unlock(cp_config);
+}
+
+void
 cp_object_registry_fini(struct cp_object_registry *registry) {
+	// Mirror each remaining item's dropped generation reference into its
+	// own agent before releasing it.
+	//
+	// The callback this teardown invokes only parks each item at zero
+	// references instead of adjusting the live count itself, so this
+	// loop mirrors the drop first. The same allocation-failure guard
+	// applies as elsewhere: a registry whose backing storage never
+	// allocated reports a nonzero capacity with nothing to walk.
+	if (ADDR_OF(&registry->registry.items) != NULL) {
+		for (uint64_t idx = 0; idx < registry->registry.capacity;
+		     ++idx) {
+			struct cp_object *object =
+				cp_object_registry_get(registry, idx);
+			if (object == NULL) {
+				continue;
+			}
+			struct agent *agent = ADDR_OF(&object->agent);
+			if (agent != NULL) {
+				agent->loaded_object_count -= 1;
+			}
+		}
+	}
+
 	registry_fini(
 		&registry->registry, cp_object_registry_item_free_cb, NULL
 	);
@@ -250,11 +380,12 @@ cp_object_registry_upsert(
 		return -1;
 	}
 
-	// Count the object only on its first registry reference, mirroring the
-	// 1->0 transition at which cp_object_registry_item_free_cb decrements;
-	// a re-upsert of an already-referenced instance must not double-count.
-	uint64_t refcnt_before = new_object->config_item.refcnt;
-
+	// Mirror this upsert's generation-reference changes into each
+	// affected object's own agent.
+	//
+	// Gaining a reference through upsert only ever happens here, and
+	// losing one to a displacing upsert only ever happens here too, so
+	// the per-agent live count must track both in this one place.
 	struct cp_object_cmp_data cmp_data;
 	strtcpy(cmp_data.type, object_type, sizeof(cmp_data.type));
 	strtcpy(cmp_data.name, object_name, sizeof(cmp_data.name));
@@ -271,9 +402,15 @@ cp_object_registry_upsert(
 		return -1;
 	}
 
-	struct agent *agent = ADDR_OF(&new_object->agent);
-	if (agent != NULL && refcnt_before == 0) {
-		agent->loaded_object_count += 1;
+	struct agent *new_agent = ADDR_OF(&new_object->agent);
+	if (new_agent != NULL) {
+		new_agent->loaded_object_count += 1;
+	}
+	if (old_object != NULL) {
+		struct agent *old_agent = ADDR_OF(&old_object->agent);
+		if (old_agent != NULL) {
+			old_agent->loaded_object_count -= 1;
+		}
 	}
 
 	return 0;
@@ -285,16 +422,33 @@ cp_object_registry_delete(
 	const char *object_type,
 	const char *object_name
 ) {
+	struct cp_object *old_object =
+		cp_object_registry_lookup(registry, object_type, object_name);
+
 	struct cp_object_cmp_data cmp_data;
 	strtcpy(cmp_data.type, object_type, sizeof(cmp_data.type));
 	strtcpy(cmp_data.name, object_name, sizeof(cmp_data.name));
 
-	return registry_replace(
-		&registry->registry,
-		cp_object_registry_item_cmp,
-		&cmp_data,
-		NULL,
-		cp_object_registry_item_free_cb,
-		NULL
-	);
+	if (registry_replace(
+		    &registry->registry,
+		    cp_object_registry_item_cmp,
+		    &cmp_data,
+		    NULL,
+		    cp_object_registry_item_free_cb,
+		    NULL
+	    )) {
+		return -1;
+	}
+
+	// Mirror the generation reference this delete drops into the removed
+	// object's own agent, matching the decrement upsert performs when it
+	// displaces an entry.
+	if (old_object != NULL) {
+		struct agent *old_agent = ADDR_OF(&old_object->agent);
+		if (old_agent != NULL) {
+			old_agent->loaded_object_count -= 1;
+		}
+	}
+
+	return 0;
 }

--- a/lib/controlplane/config/cp_object.h
+++ b/lib/controlplane/config/cp_object.h
@@ -10,14 +10,20 @@
 #include "lib/errors/errors.h"
 
 struct agent;
+struct cp_object;
+
+typedef void (*cp_object_free_handler)(struct cp_object *self);
 
 /*
  * Generic, uniquely-named shared object accounted in a controlplane
  * configuration generation.
  *
- * Like cp_module/cp_device it is refcounted via registry_item and owns a
- * counter registry. Unlike them it has no dataplane handler and no device
- * binding; its purpose is to be referenced by name from other entities.
+ * Like cp_module/cp_device it is refcounted via registry_item, owns a
+ * counter registry, and takes its creator's reference at init: the last
+ * release parks it on its agent's parked list until a construction call
+ * for its own type reclaims it. Unlike them it has no dataplane handler
+ * and no device binding; its purpose is to be referenced by name from
+ * other entities.
  */
 struct cp_object {
 	struct registry_item config_item;
@@ -41,13 +47,24 @@ struct cp_object {
 
 	// Memory context for the object's own allocations.
 	struct memory_context memory_context;
+
+	// Link to the next object parked on the same agent's list, once this
+	// object's reference count reaches zero.
+	//
+	// Only the zero-transition handler sets it, and only a later reclaim
+	// for this object's own type reads it. It stays unset until that
+	// transition happens. The parked list's tail refers to itself
+	// instead of ending at null, so a parked entry's link is never null
+	// — which also marks that this object is already parked.
+	struct cp_object *parked_next;
 };
 
 // Initialize object resources: sub-context, identity, and counter registry.
 //
 // Zeroes self first, like cp_module_init. Resolves object_type against the
 // dataplane's object-type registry (failing if it is not loaded), mirroring
-// cp_module_init's module-type lookup. On failure, internally calls
+// cp_module_init's module-type lookup. On success takes the creator's
+// reference, which cp_object_release drops. On failure, internally calls
 // cp_object_fini and returns -1.
 int
 cp_object_init(
@@ -61,9 +78,57 @@ cp_object_init(
 // Tear down resources acquired by cp_object_init.
 //
 // Finalizes the sub-context last, mirroring cp_module_fini. Idempotent on
-// zero-init.
+// zero-init. Runs only from a parked-entry destructor, never on a live
+// reference: use cp_object_release for that.
 void
 cp_object_fini(struct cp_object *self);
+
+// Destroy every parked object of one type, using the caller's destructor
+// for that type.
+//
+// A different type sharing the same parked list is left in place for its
+// own next call. A parked entry already sits at reference count zero, so
+// the destructor runs directly with no further release and nothing here
+// outlives this call. An object type's construction call runs this before
+// allocating, so a recreation under memory pressure benefits from the
+// space a parked instance would free rather than failing before reaching
+// that reclaim. The caller must not hold the configuration lock.
+void
+cp_object_drain_parked(
+	struct agent *agent,
+	const char *object_type,
+	cp_object_free_handler destroy
+);
+
+// The single handler for an object reference count reaching zero, reached
+// the same way from a registry drop or an explicit release.
+//
+// Parks the object on its agent's list instead of destroying it, because
+// this generic layer does not know the object's subclass, and an agent can
+// host more than one object type at once. The object's own type-specific
+// reclaim destroys it later.
+//
+// Idempotent: once set, a parked entry's link is never null again, so a
+// duplicate transition leaves it in place instead of relinking it. Every
+// caller already holds the configuration lock, so this handler must not
+// take it itself.
+void
+cp_object_registry_item_free_cb(struct registry_item *item, void *data);
+
+// Drop the reference construction took on the caller's behalf.
+//
+// The zero-transition handler runs only when this drop is the last
+// reference, so a caller must not assume the call freed anything: a live
+// or pinned configuration generation may still hold the object. An object
+// parked here is not destroyed on the spot — the next construction call
+// for the same type reclaims it, or it is freed along with the agent's
+// arena.
+//
+// Takes the object's own agent's configuration lock itself, unlike the
+// registry-driven path to the same handler, which already runs under
+// that lock.
+void
+cp_object_release(struct cp_object *self);
 
 struct cp_object_registry {
 	struct memory_context *memory_context;

--- a/lib/controlplane/tests/cp_object_gen_test.c
+++ b/lib/controlplane/tests/cp_object_gen_test.c
@@ -142,8 +142,9 @@ test_cp_object_gen_update_and_lookup(struct yanet_shm *shm) {
 	);
 
 	// Deleting each object from the live generation drops its last
-	// reference (the prior generation is freed by the install), so the
-	// free callback decrements loaded_object_count for each.
+	// generation reference (the prior generation is freed by the
+	// install), so each delete mirrors the drop into
+	// loaded_object_count.
 	TEST_ASSERT_SUCCESS(
 		agent_delete_object(agent, "test", "lookup-1", &err),
 		"delete_object(lookup-1) failed: %s",
@@ -185,9 +186,10 @@ test_cp_object_gen_update_and_lookup(struct yanet_shm *shm) {
 // the replacement's counter registry inherits the prior object's counter
 // definitions via counter_registry_link. Delete removes the object from
 // the live generation. Across the update/replace/delete gen swaps each
-// released object's last reference drops in the registry free callback,
-// so loaded_object_count returns to zero; the arena is then returned to
-// its pre-test size by tearing each object down explicitly.
+// swap mirrors its generation-reference changes into loaded_object_count,
+// so the count returns to zero once every object retires; the arena is
+// then returned to its pre-test size by tearing each object down
+// explicitly.
 static int
 test_cp_object_gen_replace_delete(struct yanet_shm *shm) {
 	yanet_error *err = NULL;
@@ -257,8 +259,8 @@ test_cp_object_gen_replace_delete(struct yanet_shm *shm) {
 	// Replace obj1 with a fresh object of the same name: the slot index
 	// is preserved and the replacement inherits obj1's counter. obj1 is
 	// still referenced by the prior generation until that generation is
-	// freed by the install, at which point its last reference drops and
-	// the free callback decrements loaded_object_count.
+	// freed by the install; the replace and the retire each mirror their
+	// reference change into loaded_object_count and the two cancel.
 	struct cp_object *new_obj1 = (struct cp_object *)memory_balloc(
 		&agent->memory_context, sizeof(struct cp_object)
 	);

--- a/lib/controlplane/tests/cp_object_test.c
+++ b/lib/controlplane/tests/cp_object_test.c
@@ -33,8 +33,8 @@
 // Lifecycle symmetry: allocate+init then fini+reclaim, plus the zero-init
 // fini no-op. The agent arena must return to its pre-test size.
 //
-// loaded_object_count is registry-refcount-based, so init/fini do not touch
-// it and the count stays zero across a direct init/fini pair.
+// loaded_object_count tracks only generation references, so the creator's
+// own reference never touches it and init/fini leave the count at zero.
 static int
 test_cp_object_lifecycle(struct yanet_shm *shm) {
 	yanet_error *err = NULL;
@@ -101,10 +101,10 @@ test_cp_object_lifecycle(struct yanet_shm *shm) {
 // Stable name index across registry_copy, slot-preserving upsert-replace,
 // and delete+reinsert; counter continuity via counter_registry_link.
 //
-// loaded_object_count tracks registry refcounts: each upsert bumps the
-// count, the free callback (fired only when an item's refcount reaches
-// zero) decrements it. After every registry that referenced the objects
-// is finalized the count returns to zero.
+// loaded_object_count tracks generation references: each copy, upsert, and
+// delete mirrors the reference it adds or drops into the owning agent, and
+// finalizing every registry that referenced the objects returns the count
+// to zero.
 static int
 test_cp_object_index_stability(struct yanet_shm *shm) {
 	yanet_error *err = NULL;
@@ -190,8 +190,8 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 	);
 
 	// registry_copy is slot-by-slot, so indices survive into the copy.
-	// Each copied item gains a reference, so loaded_object_count is
-	// unchanged by the copy itself.
+	// Each copied item gains a generation reference, so the count rises
+	// by one per referenced object.
 	struct cp_object_registry copied;
 	TEST_ASSERT_SUCCESS(
 		cp_object_registry_copy(
@@ -202,8 +202,8 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 	);
 	TEST_ASSERT_EQUAL(
 		agent->loaded_object_count,
-		2,
-		"registry_copy must not change loaded_object_count"
+		4,
+		"registry_copy must mirror a generation reference per object"
 	);
 
 	uint64_t index;
@@ -229,9 +229,8 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 	// Replace foo in the copy: slot-preserving, and the replacement
 	// inherits the old counter definition via counter_registry_link.
 	//
-	// foo is still referenced by the original registry, so freeing its
-	// slot in the copy only drops its refcount by one (no free callback,
-	// no count decrement); foo2's upsert bumps the count.
+	// foo2 gains the copy's generation reference while foo loses it, so
+	// the two changes cancel and the count stays at four.
 	struct cp_object *foo2 = (struct cp_object *)memory_balloc(
 		&agent->memory_context, sizeof(struct cp_object)
 	);
@@ -248,8 +247,8 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 	);
 	TEST_ASSERT_EQUAL(
 		agent->loaded_object_count,
-		3,
-		"loaded_object_count must be 3 after upsert(foo2) replaces "
+		4,
+		"loaded_object_count must stay 4 after upsert(foo2) replaces "
 		"foo in one of two registries"
 	);
 	TEST_ASSERT_SUCCESS(
@@ -269,7 +268,7 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 
 	// Delete and reinsert bar in the copy: bar is still referenced by
 	// the original registry, so the delete drops only the copy's
-	// reference (no free callback). The reinserted bar2 bumps the count.
+	// generation reference. The reinserted bar2 gains one back.
 	TEST_ASSERT_SUCCESS(
 		cp_object_registry_delete(&copied, "test", "bar"),
 		"delete(bar) failed"
@@ -322,9 +321,10 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 		"registry_lookup(foo) must return the replacement"
 	);
 
-	// Finalizing both registries drops every reference: foo2 and bar2
-	// retire from the copy, foo and bar retire from the original. The
-	// free callback fires for each, returning loaded_object_count to zero.
+	// Finalizing both registries drops every generation reference: foo2
+	// and bar2 retire from the copy, foo and bar retire from the original,
+	// returning loaded_object_count to zero. The creator holds its own
+	// reference on each object, so nothing parks here yet.
 	cp_object_registry_fini(&copied);
 	cp_object_registry_fini(&registry);
 	TEST_ASSERT_EQUAL(
@@ -338,6 +338,10 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 	// objects' storage: each object lives in the agent's arena until
 	// the agent itself is reclaimed. Tear them down explicitly so the
 	// arena returns to its pre-test size.
+	cp_object_release(foo);
+	cp_object_release(bar);
+	cp_object_release(foo2);
+	cp_object_release(bar2);
 	cp_object_fini(foo);
 	memory_bfree(&agent->memory_context, foo, sizeof(*foo));
 	cp_object_fini(bar);

--- a/lib/controlplane/tests/meson.build
+++ b/lib/controlplane/tests/meson.build
@@ -190,3 +190,26 @@ parked_devices_test = executable(
 )
 
 test('parked_devices', parked_devices_test, suite: ['lib'])
+
+parked_objects_test = executable(
+  'parked_objects_test',
+  ['parked_objects_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_device_plain',
+    '-Wl,--export-dynamic-symbol=new_device_plain',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_dev_plain_api,
+    lib_fwstate_objects_dep,
+    libdpdk_dep,
+  ],
+  link_with: [lib_dev_plain_dp],
+  include_directories: yanet_rootdir,
+)
+
+test('parked_objects', parked_objects_test, suite: ['lib'])

--- a/lib/controlplane/tests/parked_objects_test.c
+++ b/lib/controlplane/tests/parked_objects_test.c
@@ -1,0 +1,314 @@
+/*
+ * Regression test for the object-parking mechanism: a construction call
+ * must reclaim only parked entries of its own type, and parking an
+ * already-parked object must not extend the list into a cycle.
+ */
+
+#include "api/agent.h"
+
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+
+#include "lib/controlplane/agent/agent.h"
+#include "lib/controlplane/config/cp_object.h"
+#include "lib/controlplane/config/zone.h"
+
+#include "objects/fwstate/api/fwstate_map_v4_object.h"
+#include "objects/fwstate/api/fwstate_map_v6_object.h"
+
+#include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/errors/errors.h"
+
+#include "lib/logging/log.h"
+
+#include <stdio.h>
+
+#define PARKED_TEST_MEMORY_LIMIT (2u * 1024u * 1024u)
+
+// Reproduces a cross-type parking scenario: releasing one object type's
+// handle while another type shares the same agent.
+//
+// In production, one control plane can own v4 and v6 fwstate-map objects
+// through a single agent. A released v4 handle parks once its last
+// reference drops, and an unrelated v6 construction must leave it parked.
+// A release no longer reclaims by itself, so whichever object each type
+// releases last here stays parked until a later construction of that same
+// type reclaims it.
+static int
+test_drain_parked_filters_by_type(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm,
+		0,
+		"parked-obj-drain-filter",
+		PARKED_TEST_MEMORY_LIMIT,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct cp_object *v4_0 =
+		fwstate_map_v4_object_config_new(agent, "m0", &err);
+	TEST_ASSERT_NOT_NULL(v4_0, "fwstate_map_v4_object_config_new failed");
+
+	// Simulate a live generation holding v4_0: a manual registry
+	// reference, exactly like an install would take.
+	struct cp_object_registry reg;
+	TEST_ASSERT_SUCCESS(
+		cp_object_registry_init(&agent->memory_context, &reg, &err),
+		"cp_object_registry_init failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_object_registry_upsert(
+			&reg, FWSTATE_MAP_V4_OBJECT_TYPE, "m0", v4_0, &err
+		),
+		"cp_object_registry_upsert failed"
+	);
+	TEST_ASSERT_EQUAL(
+		agent->loaded_object_count,
+		1,
+		"the generation reference must be mirrored into the live count"
+	);
+
+	// Release the creator's own reference, exactly as the fwstate-map
+	// control plane does on free.
+	//
+	// The generation reference above still holds v4_0 alive, so
+	// nothing parks yet.
+	fwstate_map_v4_object_config_free(v4_0);
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_objects),
+		"nothing must be parked while a generation still holds v4_0"
+	);
+
+	// Retire the generation: its last reference drops and v4_0 parks.
+	cp_object_registry_fini(&reg);
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_objects) == v4_0,
+		"v4_0 must be parked once its last reference drops"
+	);
+	TEST_ASSERT_EQUAL(
+		agent->loaded_object_count,
+		0,
+		"the live count must reach zero with the last reference"
+	);
+
+	// An unrelated v6 construction must not touch a parked v4 object.
+	struct cp_object *v6_0 =
+		fwstate_map_v6_object_config_new(agent, "m0", &err);
+	TEST_ASSERT_NOT_NULL(v6_0, "fwstate_map_v6_object_config_new failed");
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_objects) == v4_0,
+		"v6's own construction must leave a parked v4 object untouched"
+	);
+
+	// A v4 construction reaches its own type's parked list and destroys
+	// v4_0.
+	struct cp_object *v4_1 =
+		fwstate_map_v4_object_config_new(agent, "m1", &err);
+	TEST_ASSERT_NOT_NULL(v4_1, "fwstate_map_v4_object_config_new failed");
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_objects),
+		"v4's own construction must reclaim the parked v4 object"
+	);
+
+	// Steady state: exactly one live v4 and one live v6 object.
+	// Reconstructing each type below must return to this same byte count.
+	size_t checkpoint = block_allocator_free_size(&agent->block_allocator);
+
+	// Freeing the only live instance of each type parks it instead of
+	// destroying it: nothing constructs that type again yet to reclaim it.
+	fwstate_map_v4_object_config_free(v4_1);
+	fwstate_map_v6_object_config_free(v6_0);
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_objects) == v6_0,
+		"the last release of each type must park it, not destroy it"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&v6_0->parked_next) == v4_1,
+		"parking must chain onto the existing list head"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&v4_1->parked_next) == v4_1,
+		"the list tail stays self-referential"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)block_allocator_free_size(&agent->block_allocator),
+		(long)checkpoint,
+		"parking must not itself move memory"
+	);
+
+	// A later construction of each type reclaims what its own release
+	// left parked, exactly as v4_1 reclaimed v4_0 above.
+	struct cp_object *v4_2 =
+		fwstate_map_v4_object_config_new(agent, "m2", &err);
+	TEST_ASSERT_NOT_NULL(v4_2, "fwstate_map_v4_object_config_new failed");
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_objects) == v6_0,
+		"a v4 construction must reclaim only the parked v4 object"
+	);
+
+	struct cp_object *v6_1 =
+		fwstate_map_v6_object_config_new(agent, "m1", &err);
+	TEST_ASSERT_NOT_NULL(v6_1, "fwstate_map_v6_object_config_new failed");
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_objects),
+		"a v6 construction must reclaim the parked v6 object"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)block_allocator_free_size(&agent->block_allocator),
+		(long)checkpoint,
+		"replacing each type's parked predecessor must return to the "
+		"same steady state"
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+// A duplicate zero-transition on an already-parked object must not link
+// it in twice.
+//
+// A single-node list can't tell: the head is already the node itself, so
+// a duplicate push is a no-op regardless. This drives it on a two-node
+// list instead: park an older object, then a newer one on top of it,
+// then re-drive the callback on the older, tail entry. Without the
+// guard that relinks the tail in front of the head, closing the two
+// nodes into a cycle a real drain call never finishes walking.
+static int
+test_park_is_idempotent(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm,
+		0,
+		"parked-obj-park-idempotent",
+		PARKED_TEST_MEMORY_LIMIT,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct cp_object *v4_old =
+		fwstate_map_v4_object_config_new(agent, "idem-old", &err);
+	TEST_ASSERT_NOT_NULL(v4_old, "fwstate_map_v4_object_config_new failed");
+	struct cp_object *v4_new =
+		fwstate_map_v4_object_config_new(agent, "idem-new", &err);
+	TEST_ASSERT_NOT_NULL(v4_new, "fwstate_map_v4_object_config_new failed");
+
+	size_t checkpoint = block_allocator_free_size(&agent->block_allocator);
+
+	// Park the older object first, then the newer one on top of it: head
+	// v4_new, tail v4_old self-referential.
+	cp_object_registry_item_free_cb(&v4_old->config_item, NULL);
+	cp_object_registry_item_free_cb(&v4_new->config_item, NULL);
+	TEST_ASSERT(
+		ADDR_OF(&agent->parked_objects) == v4_new,
+		"the second park must move the head to v4_new"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&v4_new->parked_next) == v4_old,
+		"v4_new must link onto v4_old"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&v4_old->parked_next) == v4_old,
+		"v4_old must remain the self-referential tail"
+	);
+
+	// Drive the zero-transition callback again on the tail, the same way
+	// a lost update between two racing releases once could.
+	cp_object_registry_item_free_cb(&v4_old->config_item, NULL);
+
+	// Walk from the head with a bound past the real list length: a cyclic
+	// corruption fails this assertion instead of hanging the traversal.
+	struct cp_object *seen[8];
+	size_t seen_count = 0;
+	struct cp_object *node = ADDR_OF(&agent->parked_objects);
+	while (node != NULL && seen_count < 8) {
+		seen[seen_count++] = node;
+		struct cp_object *next = ADDR_OF(&node->parked_next);
+		node = (next == node) ? NULL : next;
+	}
+	TEST_ASSERT_EQUAL(
+		(long)seen_count,
+		2L,
+		"a duplicate zero-transition must not change the list length"
+	);
+	TEST_ASSERT(
+		seen[0] == v4_new && seen[1] == v4_old,
+		"a duplicate zero-transition must not reorder the list"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&v4_old->parked_next) == v4_old,
+		"a duplicate push must leave v4_old's own link untouched"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)block_allocator_free_size(&agent->block_allocator),
+		(long)checkpoint,
+		"parking and re-parking an already-parked object must not move "
+		"memory"
+	);
+
+	// A later v4 construction reclaims every parked entry of its own
+	// type, v4_old and v4_new alike.
+	struct cp_object *v4_next =
+		fwstate_map_v4_object_config_new(agent, "idem-next", &err);
+	TEST_ASSERT_NOT_NULL(
+		v4_next, "fwstate_map_v4_object_config_new failed"
+	);
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->parked_objects),
+		"construction must reclaim every parked object of its own type"
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	const char *port_names[] = {"01:00.0"};
+	const char *devs_to_load[] = {"plain"};
+	const char *objs_to_load[] = {
+		FWSTATE_MAP_V4_OBJECT_TYPE,
+		FWSTATE_MAP_V6_OBJECT_TYPE,
+	};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 24,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = NULL,
+		.module_count = 0,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+		.objects_to_load = objs_to_load,
+		.objects_to_load_count = 2,
+	};
+
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	if (ut == NULL) {
+		fprintf(stderr, "dataplane_ut_new failed\n");
+		return 1;
+	}
+
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	if (shm == NULL) {
+		fprintf(stderr, "dataplane_ut_shm returned NULL\n");
+		dataplane_ut_free(ut);
+		return 1;
+	}
+
+	int res = test_drain_parked_filters_by_type(shm);
+	if (res == TEST_SUCCESS) {
+		res = test_park_is_idempotent(shm);
+	}
+
+	dataplane_ut_free(ut);
+
+	return (res == TEST_SUCCESS) ? 0 : 1;
+}

--- a/objects/fwstate/api/fwstate_map_object.c
+++ b/objects/fwstate/api/fwstate_map_object.c
@@ -116,6 +116,20 @@ map_insert_layer(
 
 // --- IPv4 object -------------------------------------------------------------
 
+// Parked-entry destructor: tears the object down and returns its storage
+// to the agent arena.
+static void
+fwstate_map_v4_object_destroy(struct cp_object *cp_object) {
+	struct fwstate_map_v4_object *self = container_of(
+		cp_object, struct fwstate_map_v4_object, cp_object
+	);
+
+	struct agent *agent = ADDR_OF(&cp_object->agent);
+
+	fwstate_map_v4_object_fini(self);
+	fwstate_map_v4_object_free(self, agent);
+}
+
 struct fwstate_map_v4_object *
 fwstate_map_v4_object_new(struct agent *agent) {
 	return (struct fwstate_map_v4_object *)memory_balloc(
@@ -168,6 +182,13 @@ struct cp_object *
 fwstate_map_v4_object_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 ) {
+	// Reclaim this type's parked entries before the wrapper allocation:
+	// a parked instance can be most of the arena, so reclaiming it first
+	// can be the difference between success and failure under pressure.
+	cp_object_drain_parked(
+		agent, FWSTATE_MAP_V4_OBJECT_TYPE, fwstate_map_v4_object_destroy
+	);
+
 	struct fwstate_map_v4_object *self = fwstate_map_v4_object_new(agent);
 	if (self == NULL) {
 		yanet_error_add(
@@ -187,14 +208,7 @@ fwstate_map_v4_object_config_new(
 
 void
 fwstate_map_v4_object_config_free(struct cp_object *cp_object) {
-	struct fwstate_map_v4_object *self = container_of(
-		cp_object, struct fwstate_map_v4_object, cp_object
-	);
-
-	struct agent *agent = ADDR_OF(&cp_object->agent);
-
-	fwstate_map_v4_object_fini(self);
-	fwstate_map_v4_object_free(self, agent);
+	cp_object_release(cp_object);
 }
 
 fwtable_t *
@@ -258,6 +272,20 @@ fwstate_map_v4_object_free_stale_layers(struct fwstate_map_v4_object *self) {
 
 // --- IPv6 object -------------------------------------------------------------
 
+// Parked-entry destructor: tears the object down and returns its storage
+// to the agent arena.
+static void
+fwstate_map_v6_object_destroy(struct cp_object *cp_object) {
+	struct fwstate_map_v6_object *self = container_of(
+		cp_object, struct fwstate_map_v6_object, cp_object
+	);
+
+	struct agent *agent = ADDR_OF(&cp_object->agent);
+
+	fwstate_map_v6_object_fini(self);
+	fwstate_map_v6_object_free(self, agent);
+}
+
 struct fwstate_map_v6_object *
 fwstate_map_v6_object_new(struct agent *agent) {
 	return (struct fwstate_map_v6_object *)memory_balloc(
@@ -310,6 +338,13 @@ struct cp_object *
 fwstate_map_v6_object_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 ) {
+	// Reclaim this type's parked entries before the wrapper allocation:
+	// a parked instance can be most of the arena, so reclaiming it first
+	// can be the difference between success and failure under pressure.
+	cp_object_drain_parked(
+		agent, FWSTATE_MAP_V6_OBJECT_TYPE, fwstate_map_v6_object_destroy
+	);
+
 	struct fwstate_map_v6_object *self = fwstate_map_v6_object_new(agent);
 	if (self == NULL) {
 		yanet_error_add(
@@ -329,14 +364,7 @@ fwstate_map_v6_object_config_new(
 
 void
 fwstate_map_v6_object_config_free(struct cp_object *cp_object) {
-	struct fwstate_map_v6_object *self = container_of(
-		cp_object, struct fwstate_map_v6_object, cp_object
-	);
-
-	struct agent *agent = ADDR_OF(&cp_object->agent);
-
-	fwstate_map_v6_object_fini(self);
-	fwstate_map_v6_object_free(self, agent);
+	cp_object_release(cp_object);
 }
 
 fwtable_t *

--- a/objects/fwstate/api/fwstate_map_v4_object.h
+++ b/objects/fwstate/api/fwstate_map_v4_object.h
@@ -58,14 +58,17 @@ fwstate_map_v4_object_free(
 );
 
 // Registration convenience: allocate + init and return the cp_object
-// pointer for agent_update_objects. On failure the object is fully
-// cleaned up and NULL is returned.
+// pointer for agent_update_objects. Reclaims this type's parked entries
+// before allocating. On failure the object is fully cleaned up and NULL
+// is returned.
 struct cp_object *
 fwstate_map_v4_object_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 );
 
-// Free handler matching the cp_object destruction pattern.
+// Drop the reference construction took on the caller's behalf; the object
+// parks on its agent's list at zero references and is destroyed by the
+// next construction of its own type.
 void
 fwstate_map_v4_object_config_free(struct cp_object *cp_object);
 

--- a/objects/fwstate/api/fwstate_map_v6_object.h
+++ b/objects/fwstate/api/fwstate_map_v6_object.h
@@ -58,14 +58,17 @@ fwstate_map_v6_object_free(
 );
 
 // Registration convenience: allocate + init and return the cp_object
-// pointer for agent_update_objects. On failure the object is fully
-// cleaned up and NULL is returned.
+// pointer for agent_update_objects. Reclaims this type's parked entries
+// before allocating. On failure the object is fully cleaned up and NULL
+// is returned.
 struct cp_object *
 fwstate_map_v6_object_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 );
 
-// Free handler matching the cp_object destruction pattern.
+// Drop the reference construction took on the caller's behalf; the object
+// parks on its agent's list at zero references and is destroyed by the
+// next construction of its own type.
 void
 fwstate_map_v6_object_config_free(struct cp_object *cp_object);
 

--- a/objects/fwstate/bindings/go/cfwstate/map.go
+++ b/objects/fwstate/bindings/go/cfwstate/map.go
@@ -304,9 +304,12 @@ func (m *MapObjectConfig) FreeStaleLayers() error {
 	return nil
 }
 
-// Free releases the underlying C memory via the fwstate-map free handler.
+// Free drops the reference construction took on the caller's behalf.
 //
-// Safe to call multiple times: subsequent calls are no-ops.
+// Safe to call multiple times: subsequent calls are no-ops. The object is
+// not destroyed on the spot: once its last reference drops it parks on
+// the agent's list, and the next construction of the same object type
+// reclaims it.
 func (m *MapObjectConfig) Free() {
 	if ptr := m.asRawPtr(); ptr != nil {
 		if m.kind == KindV6 {


### PR DESCRIPTION
Unreferenced objects are parked inside owning agent