### PR TITLE
fix(dataplane): initialize the worker counter registry once per instance

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -37,6 +37,7 @@
 #include "lib/dataplane/config/topology.h"
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/packet/packet.h"
+#include "lib/dataplane/worker/counters.h"
 #include "lib/logging/log.h"
 
 #include <unistd.h>
@@ -785,6 +786,25 @@ dataplane_init(
 
 		dp_config->instance_idx = instance_idx;
 		dp_config->instance_count = dataplane->instance_count;
+
+		if (counter_registry_init(
+			    &dp_config->worker_counters,
+			    &dp_config->memory_context,
+			    0
+		    )) {
+			LOG(ERROR,
+			    "failed to initialize worker counter registry for "
+			    "instance %u",
+			    instance_idx);
+			return -1;
+		}
+		if (worker_counters_register(dp_config)) {
+			LOG(ERROR,
+			    "failed to register worker counters for instance "
+			    "%u",
+			    instance_idx);
+			return -1;
+		}
 
 		struct cp_config *cp_config = instance->cp_config;
 		if (dp_counter_storage_init(

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -504,15 +504,6 @@ dataplane_worker_init(
 	// Initialize zero rx connections
 	worker->write_ctx.rx_pipe_count = 0;
 
-	// Prepare counter registry
-	counter_registry_init(
-		&dp_config->worker_counters, &dp_config->memory_context, 0
-	);
-
-	if (worker_counters_register(dp_config)) {
-		return -1;
-	}
-
 	return 0;
 
 error_mempool:


### PR DESCRIPTION
- The worker counter registry lives in the instance config and is shared by every worker of that instance, but each worker initialised it again and re-registered the same nine counters.
- Re-initialising a registry resets its name array and string index without freeing them, so an instance with N workers left N-1 name arrays of 2432 bytes, plus N-1 string indexes, stranded in the instance arena for the lifetime of the process.
- Registration now happens once per instance, right before the counter storages are spawned, and the result of the initialisation is checked instead of discarded.
- Registering a counter that is already known returns its existing index, so the registry still holds the same nine counters in the same order and startup behaviour is unchanged.
- Closes #2161.
