### PR TITLE
refactor(route): decouple the route operator from controlplane/ffi

### DIFF
--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -1,14 +1,12 @@
 package route
 
 import (
-	"bytes"
-	"cmp"
 	"fmt"
-	"net"
 
 	"github.com/yanet-platform/yanet2/common/go/bitset"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/route/bindings/go/croute"
+	"github.com/yanet-platform/yanet2/modules/route/controlplane/hwroute"
 	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 )
 
@@ -216,37 +214,12 @@ func (m *backend) counters(
 	return views
 }
 
-// HardwareRoute represents a route in the Layer 2 (L2) networking stack.
+// HardwareRoute is the dataplane's Layer 2 forwarding identity.
 //
-// This is the dataplane's forwarding identity: two nexthops agreeing on
-// these three fields share one route slot regardless of what else the
-// request says about them (e.g. counter name). Keying UpdateModule's dedup
-// map on more would split one physical neighbour across slots, skewing ECMP.
-type HardwareRoute struct {
-	// SourceMAC is the MAC address of the local interface that observed
-	// the neighbour.
-	SourceMAC [6]byte
-	// DestinationMAC is the MAC address of the next hop.
-	DestinationMAC [6]byte
-	// Device is the interface name.
-	Device string
-}
-
-func (m HardwareRoute) String() string {
-	return fmt.Sprintf("%s -> %s", net.HardwareAddr(m.SourceMAC[:]), net.HardwareAddr(m.DestinationMAC[:]))
-}
-
-// Compare compares two hardware routes lexicographically for deterministic sorting.
-func (m HardwareRoute) Compare(other HardwareRoute) int {
-	if c := bytes.Compare(m.SourceMAC[:], other.SourceMAC[:]); c != 0 {
-		return c
-	}
-	if c := bytes.Compare(m.DestinationMAC[:], other.DestinationMAC[:]); c != 0 {
-		return c
-	}
-
-	return cmp.Compare(m.Device, other.Device)
-}
+// The type lives in the leaf hwroute package so that consumers needing only
+// the identity, such as the route operator, do not link the cgo shared-memory
+// stack behind this package; the alias keeps this package's public API intact.
+type HardwareRoute = hwroute.HardwareRoute
 
 func newHardwareRoute(nh *routepb.FIBNexthop) (HardwareRoute, error) {
 	src := nh.GetSrcMac()

--- a/modules/route/controlplane/hwroute/hwroute.go
+++ b/modules/route/controlplane/hwroute/hwroute.go
@@ -1,0 +1,51 @@
+// Package hwroute holds the route module's Layer 2 forwarding identity.
+//
+// It is a leaf package that depends on the standard library only, so that
+// consumers that need just the identity type — the route operator, which
+// talks to the gateway over gRPC and never touches shared memory — do not
+// pull the cgo shared-memory stack behind the route control plane into
+// their link.
+package hwroute
+
+import (
+	"bytes"
+	"cmp"
+	"fmt"
+	"net"
+)
+
+// HardwareRoute represents a route in the Layer 2 (L2) networking stack.
+//
+// This is the dataplane's forwarding identity: two nexthops agreeing on
+// these three fields share one route slot regardless of what else the
+// request says about them (e.g. counter name). Keying the route module's
+// nexthop dedup on more would split one physical neighbour across slots,
+// skewing ECMP.
+type HardwareRoute struct {
+	// SourceMAC is the MAC address of the local interface that observed
+	// the neighbour.
+	SourceMAC [6]byte
+	// DestinationMAC is the MAC address of the next hop.
+	DestinationMAC [6]byte
+	// Device is the interface name.
+	Device string
+}
+
+// String renders the route as "<source MAC> -> <destination MAC>"; the
+// device is left out.
+func (m HardwareRoute) String() string {
+	return fmt.Sprintf("%s -> %s", net.HardwareAddr(m.SourceMAC[:]), net.HardwareAddr(m.DestinationMAC[:]))
+}
+
+// Compare compares two hardware routes lexicographically for deterministic
+// sorting.
+func (m HardwareRoute) Compare(other HardwareRoute) int {
+	if c := bytes.Compare(m.SourceMAC[:], other.SourceMAC[:]); c != 0 {
+		return c
+	}
+	if c := bytes.Compare(m.DestinationMAC[:], other.DestinationMAC[:]); c != 0 {
+		return c
+	}
+
+	return cmp.Compare(m.Device, other.Device)
+}

--- a/operators/route/internal/discovery/neigh/entry.go
+++ b/operators/route/internal/discovery/neigh/entry.go
@@ -4,7 +4,7 @@ import (
 	"net/netip"
 	"time"
 
-	route "github.com/yanet-platform/yanet2/modules/route/controlplane"
+	"github.com/yanet-platform/yanet2/modules/route/controlplane/hwroute"
 )
 
 // NeighbourEntry stores information about a neighbor with resolved hardware
@@ -29,4 +29,9 @@ type NeighbourEntry struct {
 	Priority uint32
 }
 
-type HardwareRoute = route.HardwareRoute
+// HardwareRoute is the dataplane's Layer 2 forwarding identity carried by
+// a neighbour entry.
+//
+// It aliases the route module's leaf type so that both sides share one
+// definition without the operator linking the route control plane.
+type HardwareRoute = hwroute.HardwareRoute

--- a/operators/route/meson.build
+++ b/operators/route/meson.build
@@ -27,15 +27,7 @@ if not get_option('fuzzing').enabled()
           route_protoc_gen,
           common_readiness_protoc_gen,
           route_operator_readiness_protoc_gen,
-
-          # cgo linker deps, which meson cannot see: a cgo link line is a
-          # plain string to it. The operator reaches controlplane/ffi for
-          # one type in modules/route/controlplane and nothing else, so
-          # moving that type to a leaf package leaves it pure Go and
-          # retires this entry.
-          lib_agent_counters,
-          lib_counter_pattern,
-      ] + librure_targets,
+      ],
       install: true,
       install_dir: get_option('bindir'),
   )


### PR DESCRIPTION
- `yanet-route-operator` only talks to the gateway over gRPC, yet it linked the whole cgo shared-memory stack because its neighbour entry aliased `route.HardwareRoute` out of `modules/route/controlplane`, which imports `controlplane/ffi`.
- Move the hardware route identity (the struct plus `String` and `Compare`, stdlib only) into the leaf package `modules/route/controlplane/hwroute` and leave `type HardwareRoute = hwroute.HardwareRoute` in the route control plane, so the module's public API and its internal uses are unchanged; `newHardwareRoute` stays where it is.
- Point the operator's neighbour entry at the leaf package: `go list -deps` of the operator no longer contains `controlplane/ffi` or `modules/route/bindings/go/croute`, and `CGO_ENABLED=0 go build ./operators/route/cmd/yanet-route-operator` succeeds.
- Drop the hand-maintained cgo linker `depends:` entries (`lib_agent_counters`, `lib_counter_pattern`, `librure_targets`) and their comment from the operator's meson target.
- Closes #2083.
