### PR TITLE
build(operators): disable cgo for the grpc-only operators

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -134,6 +134,16 @@ if get_option('fuzzing').enabled()
   yanet_cgo_ldflags += cgo_flags
 endif
 
+# gRPC-only operators never touch shared memory and link no cgo.
+#
+# Building them with cgo disabled turns a stray import of a module control
+# plane or of the FFI bindings into a loud build failure; with cgo on it
+# would silently restore the cgo link, which meson cannot see and which
+# then fails only as an ordering-dependent "cannot find -l<lib>" error.
+# Because it snapshots the Go build environment above, it must stay
+# below the last assignment to that environment.
+yanet_go_nocgo_env = yanet_go_env + {'CGO_ENABLED': '0'}
+
 yanet_rootdir = include_directories('.')
 
 # Initialize fuzzing targets dictionary

--- a/operators/decap/meson.build
+++ b/operators/decap/meson.build
@@ -19,7 +19,7 @@ if not get_option('fuzzing').enabled()
           '-o', '@OUTPUT@',
           join_paths(meson.current_source_dir(), 'cmd', 'yanet-decap-operator'),
       ],
-      env: yanet_go_env,
+      env: yanet_go_nocgo_env,
       build_by_default: true,
       build_always_stale: true,
       depends: [

--- a/operators/pipeline/meson.build
+++ b/operators/pipeline/meson.build
@@ -3,8 +3,8 @@ install_data(
     install_dir: '/etc/yanet2',
 )
 
-# Skip pipeline-operator when fuzzing — no CGO but still gets sanitizer flags
-# that interfere with the fuzzing build.
+# Not a fuzz target, and nothing in the fuzz suite runs it, so the
+# fuzzing configuration skips it to save build time.
 if not get_option('fuzzing').enabled()
   custom_target(
       'yanet-pipeline-operator',
@@ -17,7 +17,7 @@ if not get_option('fuzzing').enabled()
           '-o', '@OUTPUT@',
           join_paths(meson.current_source_dir(), 'cmd', 'yanet-pipeline-operator'),
       ],
-      env: yanet_go_env,
+      env: yanet_go_nocgo_env,
       build_by_default: true,
       build_always_stale: true,
       depends: [

--- a/operators/route/meson.build
+++ b/operators/route/meson.build
@@ -3,8 +3,8 @@ install_data(
     install_dir: '/etc/yanet2',
 )
 
-# Skip route-operator when fuzzing — no CGO but still gets sanitizer flags
-# that interfere with the fuzzing build.
+# Not a fuzz target, and nothing in the fuzz suite runs it, so the
+# fuzzing configuration skips it to save build time.
 if not get_option('fuzzing').enabled()
   custom_target(
       'yanet-route-operator',
@@ -17,7 +17,7 @@ if not get_option('fuzzing').enabled()
           '-o', '@OUTPUT@',
           join_paths(meson.current_source_dir(), 'cmd', 'yanet-route-operator'),
       ],
-      env: yanet_go_env,
+      env: yanet_go_nocgo_env,
       build_by_default: true,
       build_always_stale: true,
       depends: [


### PR DESCRIPTION
- Follow-up to #2165 (#2083): the route operator is pure Go again, but nothing asserted it, so a stray import of a module control plane or of the FFI bindings would silently restore the cgo link that the removed meson `depends:` used to paper over, and surface only as the ordering-dependent `cannot find -lrure` failure seen in #2074.
- Build the gRPC-only operators (`decap`, `pipeline`, `route`) with `CGO_ENABLED=0` through a shared `yanet_go_nocgo_env` in the root `meson.build`, so every regular build (release, deb, sanitizer, functional) is the guard and no extra CI job is needed.
- `forward` and `bird-adapter` are untouched: they still reach `bindings/go/filter` through `common/filterpb/v1`.
- The three binaries become statically linked pure-Go executables (`go version -m` reports `CGO_ENABLED=0`); the Go resolver replaces the libc one, which is the usual shape for Go daemons.
- Verified that the guard trips: re-importing `modules/route/controlplane` into the route operator makes `meson compile yanet-route-operator` fail with `controlplane/ffi: build constraints exclude all Go files`.
- The fuzzing-skip comments of the route and pipeline operator targets are refreshed: with cgo disabled the sanitizer flags no longer reach these builds, so the skip is kept only because the fuzzing build has no use for the binaries.
