### PR TITLE
fix(ci): keep clippy checks reproducible

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -71,9 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.1
         with:
-          toolchain: stable
           components: clippy
       - name: Cache cargo registry and target directory
         uses: Swatinem/rust-cache@v2.9.2


### PR DESCRIPTION
- Pins the Clippy job to Rust 1.97.1, the last known-green toolchain.
- Prevents stable toolchain releases from changing lint results without an explicit workflow update.