### PR TITLE
refactor(common): decouple filterpb from the cgo filter bindings

### DIFF
--- a/bindings/go/filterpbconv/v1/convert.go
+++ b/bindings/go/filterpbconv/v1/convert.go
@@ -1,4 +1,9 @@
-package filterpb
+// Package filterpbconv translates protobuf filter messages into cgo-bound
+// filter values.
+//
+// Keeping the translation in this bridge package lets message-only consumers
+// avoid the C toolchain.
+package filterpbconv
 
 import (
 	"net/netip"
@@ -7,10 +12,11 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 )
 
 // ToDevices converts protobuf Device messages to filter Devices.
-func ToDevices(pb []*Device) (filter.Devices, error) {
+func ToDevices(pb []*filterpb.Device) (filter.Devices, error) {
 	out := make(filter.Devices, len(pb))
 	for idx := range pb {
 		out[idx] = filter.Device{
@@ -23,7 +29,7 @@ func ToDevices(pb []*Device) (filter.Devices, error) {
 
 // ToNet4s converts protobuf IPNet messages to filter IPNets, keeping only IPv4
 // entries.
-func ToNet4s(pb []*IPNet) (filter.IPNets, error) {
+func ToNet4s(pb []*filterpb.IPNet) (filter.IPNets, error) {
 	out := make(filter.IPNets, 0, len(pb))
 
 	for idx := range pb {
@@ -43,7 +49,7 @@ func ToNet4s(pb []*IPNet) (filter.IPNets, error) {
 
 // ToNet6s converts protobuf IPNet messages to filter IPNets, keeping only IPv6
 // entries.
-func ToNet6s(pb []*IPNet) (filter.IPNets, error) {
+func ToNet6s(pb []*filterpb.IPNet) (filter.IPNets, error) {
 	out := make(filter.IPNets, 0, len(pb))
 
 	for idx := range pb {
@@ -61,7 +67,9 @@ func ToNet6s(pb []*IPNet) (filter.IPNets, error) {
 	return out, nil
 }
 
-func ToIPNet(pb *IPNet) (filter.IPNet, error) {
+// ToIPNet validates the address family and mask shape before returning a
+// filter network value.
+func ToIPNet(pb *filterpb.IPNet) (filter.IPNet, error) {
 	addr, ok := netip.AddrFromSlice(pb.Addr)
 	if !ok {
 		return filter.IPNet{}, status.Error(
@@ -106,7 +114,7 @@ func ToIPNet(pb *IPNet) (filter.IPNet, error) {
 
 // ToNet4sFromPrefixes converts protobuf IPPrefix messages to filter
 // IPNets, keeping only IPv4 entries.
-func ToNet4sFromPrefixes(pb []*IPPrefix) (filter.IPNets, error) {
+func ToNet4sFromPrefixes(pb []*filterpb.IPPrefix) (filter.IPNets, error) {
 	prefixes := make([]netip.Prefix, 0, len(pb))
 
 	for _, p := range pb {
@@ -130,7 +138,7 @@ func ToNet4sFromPrefixes(pb []*IPPrefix) (filter.IPNets, error) {
 
 // ToNet6sFromPrefixes converts protobuf IPPrefix messages to filter
 // IPNets, keeping only IPv6 entries.
-func ToNet6sFromPrefixes(pb []*IPPrefix) (filter.IPNets, error) {
+func ToNet6sFromPrefixes(pb []*filterpb.IPPrefix) (filter.IPNets, error) {
 	prefixes := make([]netip.Prefix, 0, len(pb))
 
 	for _, p := range pb {
@@ -153,7 +161,7 @@ func ToNet6sFromPrefixes(pb []*IPPrefix) (filter.IPNets, error) {
 }
 
 // ToPortRanges converts protobuf PortRange messages to filter PortRanges.
-func ToPortRanges(pb []*PortRange) (filter.PortRanges, error) {
+func ToPortRanges(pb []*filterpb.PortRange) (filter.PortRanges, error) {
 	out := make(filter.PortRanges, len(pb))
 
 	for idx := range pb {
@@ -191,7 +199,7 @@ func ToPortRanges(pb []*PortRange) (filter.PortRanges, error) {
 
 // ToProtoRanges converts protobuf ProtoRange messages to filter
 // ProtoRanges.
-func ToProtoRanges(pb []*ProtoRange) (filter.ProtoRanges, error) {
+func ToProtoRanges(pb []*filterpb.ProtoRange) (filter.ProtoRanges, error) {
 	out := make(filter.ProtoRanges, len(pb))
 
 	for idx := range pb {
@@ -228,7 +236,7 @@ func ToProtoRanges(pb []*ProtoRange) (filter.ProtoRanges, error) {
 }
 
 // ToVlanRanges converts protobuf VlanRange messages to filter VlanRanges.
-func ToVlanRanges(pb []*VlanRange) (filter.VlanRanges, error) {
+func ToVlanRanges(pb []*filterpb.VlanRange) (filter.VlanRanges, error) {
 	out := make(filter.VlanRanges, len(pb))
 
 	for idx := range pb {
@@ -257,16 +265,16 @@ func ToVlanRanges(pb []*VlanRange) (filter.VlanRanges, error) {
 }
 
 // ToFragment converts protobuf Fragment message to filter Fragment.
-func ToFragment(pb *Fragment) (filter.Fragment, error) {
+func ToFragment(pb *filterpb.Fragment) (filter.Fragment, error) {
 	if pb == nil {
 		return filter.FragmentAny, nil
 	}
 	switch pb.Kind {
-	case FragmentKind_Any:
+	case filterpb.FragmentKind_Any:
 		return filter.FragmentAny, nil
-	case FragmentKind_None:
+	case filterpb.FragmentKind_None:
 		return filter.FragmentNone, nil
-	case FragmentKind_Frag:
+	case filterpb.FragmentKind_Frag:
 		return filter.FragmentFrag, nil
 	}
 

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -14,7 +14,7 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
+	filterpbconv "github.com/yanet-platform/yanet2/bindings/go/filterpbconv/v1"
 	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -404,39 +404,39 @@ func labeler(fullMethod string, req any) metrics.Labels {
 func convertRules(reqRules []*aclpb.Rule) ([]cacl.AclRule, error) {
 	rules := make([]cacl.AclRule, 0, len(reqRules))
 	for _, reqRule := range reqRules {
-		devices, err := filterpb.ToDevices(reqRule.Devices)
+		devices, err := filterpbconv.ToDevices(reqRule.Devices)
 		if err != nil {
 			return nil, err
 		}
-		vlanRanges, err := filterpb.ToVlanRanges(reqRule.VlanRanges)
+		vlanRanges, err := filterpbconv.ToVlanRanges(reqRule.VlanRanges)
 		if err != nil {
 			return nil, err
 		}
-		src4s, err := filterpb.ToNet4s(reqRule.Srcs)
+		src4s, err := filterpbconv.ToNet4s(reqRule.Srcs)
 		if err != nil {
 			return nil, err
 		}
-		dst4s, err := filterpb.ToNet4s(reqRule.Dsts)
+		dst4s, err := filterpbconv.ToNet4s(reqRule.Dsts)
 		if err != nil {
 			return nil, err
 		}
-		src6s, err := filterpb.ToNet6s(reqRule.Srcs)
+		src6s, err := filterpbconv.ToNet6s(reqRule.Srcs)
 		if err != nil {
 			return nil, err
 		}
-		dst6s, err := filterpb.ToNet6s(reqRule.Dsts)
+		dst6s, err := filterpbconv.ToNet6s(reqRule.Dsts)
 		if err != nil {
 			return nil, err
 		}
-		protoRanges, err := filterpb.ToProtoRanges(reqRule.ProtoRanges)
+		protoRanges, err := filterpbconv.ToProtoRanges(reqRule.ProtoRanges)
 		if err != nil {
 			return nil, err
 		}
-		srcPortRanges, err := filterpb.ToPortRanges(reqRule.SrcPortRanges)
+		srcPortRanges, err := filterpbconv.ToPortRanges(reqRule.SrcPortRanges)
 		if err != nil {
 			return nil, err
 		}
-		dstPortRanges, err := filterpb.ToPortRanges(reqRule.DstPortRanges)
+		dstPortRanges, err := filterpbconv.ToPortRanges(reqRule.DstPortRanges)
 		if err != nil {
 			return nil, err
 		}
@@ -444,7 +444,7 @@ func convertRules(reqRules []*aclpb.Rule) ([]cacl.AclRule, error) {
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid actions in rule: %v", err)
 		}
-		fragment, err := filterpb.ToFragment(reqRule.Fragment)
+		fragment, err := filterpbconv.ToFragment(reqRule.Fragment)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
+	filterpbconv "github.com/yanet-platform/yanet2/bindings/go/filterpbconv/v1"
 	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
 	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
@@ -149,27 +149,27 @@ func (m *ForwardService) UpdateConfig(ctx context.Context, req *forwardpb.Update
 			action.Counter = materializeCounter(action.Target)
 		}
 
-		devices, err := filterpb.ToDevices(reqRule.Devices)
+		devices, err := filterpbconv.ToDevices(reqRule.Devices)
 		if err != nil {
 			return nil, err
 		}
-		vlanRanges, err := filterpb.ToVlanRanges(reqRule.VlanRanges)
+		vlanRanges, err := filterpbconv.ToVlanRanges(reqRule.VlanRanges)
 		if err != nil {
 			return nil, err
 		}
-		src4s, err := filterpb.ToNet4s(reqRule.Srcs)
+		src4s, err := filterpbconv.ToNet4s(reqRule.Srcs)
 		if err != nil {
 			return nil, err
 		}
-		dst4s, err := filterpb.ToNet4s(reqRule.Dsts)
+		dst4s, err := filterpbconv.ToNet4s(reqRule.Dsts)
 		if err != nil {
 			return nil, err
 		}
-		src6s, err := filterpb.ToNet6s(reqRule.Srcs)
+		src6s, err := filterpbconv.ToNet6s(reqRule.Srcs)
 		if err != nil {
 			return nil, err
 		}
-		dst6s, err := filterpb.ToNet6s(reqRule.Dsts)
+		dst6s, err := filterpbconv.ToNet6s(reqRule.Dsts)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/mirror/controlplane/service.go
+++ b/modules/mirror/controlplane/service.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
+	filterpbconv "github.com/yanet-platform/yanet2/bindings/go/filterpbconv/v1"
 	"github.com/yanet-platform/yanet2/modules/mirror/bindings/go/cmirror"
 	mirrorpb "github.com/yanet-platform/yanet2/modules/mirror/controlplane/mirrorpb/v1"
 )
@@ -118,27 +118,27 @@ func (m *MirrorService) UpdateConfig(
 			return nil, status.Error(codes.InvalidArgument, "rule action is required")
 		}
 
-		devices, err := filterpb.ToDevices(reqRule.Devices)
+		devices, err := filterpbconv.ToDevices(reqRule.Devices)
 		if err != nil {
 			return nil, err
 		}
-		vlanRanges, err := filterpb.ToVlanRanges(reqRule.VlanRanges)
+		vlanRanges, err := filterpbconv.ToVlanRanges(reqRule.VlanRanges)
 		if err != nil {
 			return nil, err
 		}
-		src4s, err := filterpb.ToNet4s(reqRule.Srcs)
+		src4s, err := filterpbconv.ToNet4s(reqRule.Srcs)
 		if err != nil {
 			return nil, err
 		}
-		dst4s, err := filterpb.ToNet4s(reqRule.Dsts)
+		dst4s, err := filterpbconv.ToNet4s(reqRule.Dsts)
 		if err != nil {
 			return nil, err
 		}
-		src6s, err := filterpb.ToNet6s(reqRule.Srcs)
+		src6s, err := filterpbconv.ToNet6s(reqRule.Srcs)
 		if err != nil {
 			return nil, err
 		}
-		dst6s, err := filterpb.ToNet6s(reqRule.Dsts)
+		dst6s, err := filterpbconv.ToNet6s(reqRule.Dsts)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Move protobuf-to-filter converters into a versioned bindings bridge.
- Keep filter message consumers independent of cgo while preserving module conversion behavior.
- Allow the forward operator and BIRD adapter to build without a C toolchain.
- Closes #2168.
