### PR TITLE
fix(ci): pin rust builds to the msrv

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -131,7 +131,7 @@ jobs:
           apt-get update
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
 
       # Only the cargo home is cached. Debuild runs the clean target first,
       # which removes the target directory, so an entry holding it would be

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -29,7 +29,7 @@ jobs:
             || true
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
 
       # Only the cargo home is cached. Debuild removes the target directory
       # before the build starts, so an entry holding it would be wasted.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,9 +157,7 @@ jobs:
           packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@1.88.0
 
       # A cache written on a pull-request ref is readable only from that
       # same pull request, so only main writes this one.

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -49,9 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@1.88.0
       - name: Cache cargo registry and target directory
         uses: Swatinem/rust-cache@v2.9.2
         with:


### PR DESCRIPTION
- Pins non-Clippy Rust CI jobs to Rust 1.88.0, matching the declared MSRV.
- Keeps Clippy on 1.97.1 and rustfmt on nightly.