### PR TITLE
chore(agents): allow explicit admin review overrides

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -21,7 +21,8 @@ Land a verified, reviewer-approved change on `main`. Invoking this skill is the 
 - No destructive git on a dirty tree (`reset --hard`, `checkout`, `restore`, `stash`); recovery recipes are in `references/branching-and-recovery.md`.
 - Subjects: `<type>(<scope>): <brief>` (see `AGENTS.md` → Commits & PRs); the PR title is the same; body = capitalized, period-ended, high-level bullets, `Closes #<n>.` when applicable, no `## Summary`, no test plan, no AI footers.
 - One logical change = one PR; out-of-scope prerequisites ship first in their own PR.
-- Never merge with an unaddressed review finding, a red check (a proven flake is still red — fix or rerun it first), `reviewDecision: REVIEW_REQUIRED`, or a PR tied to a `needs-architect` issue (stop, leave it open, report).
+- Never merge with an unaddressed review finding, a red check (a proven flake is still red — fix or rerun it first), or a PR tied to a `needs-architect` issue (stop, leave it open, report).
+- `reviewDecision: REVIEW_REQUIRED` blocks a normal merge; bypass it with `--admin` only when a repository administrator explicitly requests that override.
 - Never delete a branch until `gh pr view --json state` says `MERGED`.
 
 ## Phases
@@ -32,7 +33,7 @@ Land a verified, reviewer-approved change on `main`. Invoking this skill is the 
 3. **Commit.** Conventional subject, high-level body, no footers; `make lint-commit` must pass (the `commit-msg` hook runs it).
 4. **Push & PR.** `git push -u origin <branch>`; `gh pr create --title "<subject>" --body "<bullets>"` (add `--draft` if the user asked); pushes touching `.github/workflows/` need the git token's `workflow` scope — ask the user if refused.
 5. **CI & review.** `gh pr checks <n> --watch`; on a failure attributable to the change → fix, gates, re-review, `git commit --amend` or a fixup, force-with-lease; on a flake → compare the same workflow on latest `origin/main` runs, then `gh run rerun <id> --failed`. Read every review thread (`gh api repos/{owner}/{repo}/pulls/<n>/comments`, `gh pr view --comments`) and PR-level review; Codex may post findings as an issue comment with no review. Fix or answer each; after any push to a reviewed PR post `@codex review`; resolve addressed threads (`gh api graphql` `resolveReviewThread`).
-6. **Merge** (only if authorized). Check the `needs-architect` label on every issue the body names (`gh issue view <n> --json labels`, both repos). Single commit → `gh pr merge <n> --squash`; deliberately structured multi-commit → `--rebase`; review fixups → `--squash --subject "<type>(<scope>): <title> (#n)" --body ""` (never GitHub's default squash body). Blocked by a ruleset → `--admin` with the same strategy, and say why. Behind main → rebase (never merge main in), gates, re-review, force-with-lease, back to 5.
+6. **Merge** (only if authorized). Check the `needs-architect` label on every issue the body names (`gh issue view <n> --json labels`, both repos). Single commit → `gh pr merge <n> --squash`; deliberately structured multi-commit → `--rebase`; review fixups → `--squash --subject "<type>(<scope>): <title> (#n)" --body ""` (never GitHub's default squash body). Blocked by a ruleset → `--admin` only after an explicit administrator request, with the same strategy, and say why. Behind main → rebase (never merge main in), gates, re-review, force-with-lease, back to 5.
 7. **Cleanup.** After `MERGED`: `git worktree remove <path>`, `git branch -D <branch>` (squash/rebase leaves it unmerged locally), `git push origin --delete <branch>` if GitHub did not; update the primary `main` only if it is clean and on `main`.
 
 ## Report


### PR DESCRIPTION
- Keep required GitHub review as the default while allowing a repository administrator to explicitly request an administrative override.
- Preserve blockers for unresolved findings, failed checks, and work tied to a needs-architect issue.