### PR TITLE
docs(controlplane): state the generation install contract

### DIFF
--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -209,6 +209,14 @@ cp_config_gen_release(
 	}
 }
 
+// Publishes a fully built configuration generation and retires the one it
+// replaces.
+//
+// Failure is reported only by steps that run before publication, which
+// leaves the configuration in use untouched and the generation being
+// installed unobserved by any worker, so the caller may reclaim it.
+// Success is reported only once every worker has taken the new generation,
+// so the replaced one is executed nowhere and is safe to reclaim.
 static inline int
 cp_config_gen_install(
 	struct dp_config *dp_config,


### PR DESCRIPTION
- Document the contract of the configuration generation install path in both directions: failure is only ever reported by steps that run before publication, and success only once every worker has taken the new generation.
- Both halves are what callers reclaim memory on: a failed call is followed by freeing the generation that was being installed, a successful one by retiring the generation it replaced, so a failure reported after publication would turn either cleanup into a use-after-free of the live configuration.
- Fixes the contract in place instead of adding an epoch barrier: bounding the acknowledgement wait stays possible, but the bound may not be surfaced as a failure from this call.
- Comment-only change, no behaviour difference.

Closes #1887.
