### PR TITLE
perf(pipeline): speed up chain and pipeline hash demux

### DIFF
--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -2,9 +2,79 @@
 
 #include <string.h>
 
+#include "common/numutils.h"
+
 // cp_config and cp_config_gen
 #include "lib/controlplane/config/zone.h"
 #include "lib/errors/errors.h"
+
+// Minimum power-of-two routing table size once any destination is enabled.
+//
+// A table barely larger than the weight sum rounds small ratios coarsely
+// (three equal chains need four slots), while the floor keeps configured
+// ratios accurate and still fits a single small allocation.
+#define ROUTING_TABLE_MIN_SLOTS 64
+
+// Distribute a power-of-two routing table's padding slots over its enabled
+// destinations in proportion to their weights.
+//
+// Largest remainder: every enabled destination first receives its floored
+// share of the padding, then the few still-unassigned slots go one each to
+// the destinations with the largest fractional remainders. Zero-weight
+// destinations never receive a slot, so a disabled destination stays
+// unroutable, and configured ratios survive the power-of-two rounding as
+// closely as slot counts allow.
+//
+// The weight array is scratch: awarded leftover slots zero their entry, so
+// the repeat scans skip them. The leftover count is always below the number
+// of enabled destinations (the fractional parts sum to the leftover and
+// each is below one), so the scans never run out of candidates while slots
+// remain. Products are computed at 128 bits because a weight can approach
+// the table size, which may approach 2^63.
+static void
+routing_table_pad(
+	uint64_t *map,
+	uint64_t map_size,
+	uint64_t weight_sum,
+	uint64_t *weights,
+	uint64_t count
+) {
+	const uint64_t pad = map_size - weight_sum;
+
+	uint64_t pos = weight_sum;
+	for (uint64_t idx = 0; idx < count; ++idx) {
+		const uint64_t share =
+			(uint64_t)(((unsigned __int128)weights[idx] * pad) /
+				   weight_sum);
+		for (uint64_t n = 0; n < share; ++n) {
+			map[pos] = idx;
+			++pos;
+		}
+	}
+
+	while (pos < map_size) {
+		uint64_t best = count;
+		uint64_t best_rem = 0;
+		for (uint64_t idx = 0; idx < count; ++idx) {
+			if (weights[idx] == 0) {
+				continue;
+			}
+
+			const uint64_t rem =
+				(uint64_t)(((unsigned __int128)weights[idx] *
+					    pad) %
+					   weight_sum);
+			if (rem > best_rem) {
+				best = idx;
+				best_rem = rem;
+			}
+		}
+
+		weights[best] = 0;
+		map[pos] = best;
+		++pos;
+	}
+}
 
 static void
 module_ectx_free(
@@ -689,10 +759,33 @@ function_ectx_free(
 		counter_storage_free(counter_storage);
 	}
 
-	size_t ectx_size =
-		sizeof(struct function_ectx) +
-		sizeof(struct chain_ectx *) * function_ectx->chain_map_size;
+	size_t ectx_size = sizeof(struct function_ectx) +
+			   sizeof(uint64_t) * function_ectx->chain_map_size;
 	memory_bfree(memory_context, function_ectx, ectx_size);
+}
+
+// Size a function's chain routing table, padded up to a power of two.
+//
+// A power-of-two table size lets packet selection mask the flow hash
+// instead of dividing it. A fully disabled function keeps the table size
+// at zero; the padding itself is spread by the shared largest-remainder
+// distributor, which never routes traffic to a zero-weight chain.
+static uint64_t
+function_ectx_chain_map_size(const struct cp_function *cp_function) {
+	uint64_t weight_sum = 0;
+	for (uint64_t idx = 0; idx < cp_function->chain_count; ++idx) {
+		weight_sum += cp_function->chains[idx].weight;
+	}
+
+	if (weight_sum == 0) {
+		return 0;
+	}
+
+	if (weight_sum < ROUTING_TABLE_MIN_SLOTS) {
+		return ROUTING_TABLE_MIN_SLOTS;
+	}
+
+	return next_power_of_two(weight_sum);
 }
 
 static struct function_ectx *
@@ -709,13 +802,11 @@ function_ectx_create(
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
-	uint64_t weight_sum = 0;
-	for (uint64_t idx = 0; idx < cp_function->chain_count; ++idx) {
-		weight_sum += cp_function->chains[idx].weight;
-	}
+	const uint64_t chain_map_size =
+		function_ectx_chain_map_size(cp_function);
 
 	size_t ectx_size = sizeof(struct function_ectx) +
-			   sizeof(struct chain_ectx *) * weight_sum;
+			   sizeof(uint64_t) * chain_map_size;
 
 	struct function_ectx *function_ectx = (struct function_ectx *)
 		memory_balloc(memory_context, ectx_size);
@@ -730,7 +821,7 @@ function_ectx_create(
 
 	memset(function_ectx, 0, ectx_size);
 	SET_OFFSET_OF(&function_ectx->cp_function, cp_function);
-	function_ectx->chain_map_size = weight_sum;
+	function_ectx->chain_map_size = chain_map_size;
 
 	struct chain_ectx **chains = (struct chain_ectx **)memory_balloc(
 		memory_context,
@@ -854,11 +945,47 @@ function_ectx_create(
 		for (uint64_t weight_idx = 0;
 		     weight_idx < cp_function->chains[idx].weight;
 		     ++weight_idx) {
-			SET_OFFSET_OF(
-				function_ectx->chain_map + pos, chain_ectx
-			);
+			function_ectx->chain_map[pos] = idx;
 			++pos;
 		}
+	}
+
+	// Scratch weights for the largest-remainder padding distributor; a
+	// fully disabled function has no padding to distribute.
+	if (function_ectx->chain_map_size > 0) {
+		uint64_t weight_sum = 0;
+		for (uint64_t idx = 0; idx < cp_function->chain_count; ++idx) {
+			weight_sum += cp_function->chains[idx].weight;
+		}
+
+		uint64_t *weights = (uint64_t *)memory_balloc(
+			memory_context,
+			sizeof(uint64_t) * cp_function->chain_count
+		);
+		if (weights == NULL) {
+			yanet_error_add(
+				err,
+				"failed to allocate memory for chain weights "
+				"in function '%s'",
+				cp_function->name
+			);
+			goto error;
+		}
+		for (uint64_t idx = 0; idx < cp_function->chain_count; ++idx) {
+			weights[idx] = cp_function->chains[idx].weight;
+		}
+		routing_table_pad(
+			function_ectx->chain_map,
+			function_ectx->chain_map_size,
+			weight_sum,
+			weights,
+			cp_function->chain_count
+		);
+		memory_bfree(
+			memory_context,
+			weights,
+			sizeof(uint64_t) * cp_function->chain_count
+		);
 	}
 
 	return function_ectx;
@@ -1074,9 +1201,9 @@ device_entry_ectx_free(
 		);
 	}
 
-	size_t ectx_size = sizeof(struct device_entry_ectx) +
-			   sizeof(struct pipeline_ectx *) *
-				   device_entry_ectx->pipeline_map_size;
+	size_t ectx_size =
+		sizeof(struct device_entry_ectx) +
+		sizeof(uint64_t) * device_entry_ectx->pipeline_map_size;
 
 	memory_bfree(memory_context, device_entry_ectx, ectx_size);
 }
@@ -1100,8 +1227,21 @@ device_entry_ectx_create(
 		weight_sum += cp_device_entry->pipelines[idx].weight;
 	}
 
+	// Same power-of-two padding as the function chain table: masking the
+	// flow hash replaces a division, the largest-remainder distributor
+	// keeps disabled pipelines at zero slots, and a fully disabled entry
+	// keeps the table size at zero.
+	uint64_t pipeline_map_size = 0;
+	if (weight_sum > 0) {
+		if (weight_sum < ROUTING_TABLE_MIN_SLOTS) {
+			pipeline_map_size = ROUTING_TABLE_MIN_SLOTS;
+		} else {
+			pipeline_map_size = next_power_of_two(weight_sum);
+		}
+	}
+
 	size_t ectx_size = sizeof(struct device_entry_ectx) +
-			   sizeof(struct pipeline_ectx *) * weight_sum;
+			   sizeof(uint64_t) * pipeline_map_size;
 
 	struct device_entry_ectx *device_entry_ectx =
 		(struct device_entry_ectx *)memory_balloc(
@@ -1186,7 +1326,7 @@ device_entry_ectx_create(
 		       device_entry_ectx->pipeline_count);
 	SET_OFFSET_OF(&device_entry_ectx->pipelines, pipelines);
 
-	device_entry_ectx->pipeline_map_size = weight_sum;
+	device_entry_ectx->pipeline_map_size = pipeline_map_size;
 	uint64_t pos = 0;
 	for (uint64_t idx = 0; idx < cp_device_entry->pipeline_count; ++idx) {
 		struct cp_pipeline *cp_pipeline = cp_config_gen_lookup_pipeline(
@@ -1221,6 +1361,34 @@ device_entry_ectx_create(
 			device_entry_ectx->pipeline_map[pos] = idx;
 			++pos;
 		}
+	}
+
+	// Scratch weights for the largest-remainder padding distributor; a
+	// fully disabled entry has no padding to distribute.
+	if (device_entry_ectx->pipeline_map_size > 0) {
+		uint64_t *weights = (uint64_t *)memory_balloc(
+			memory_context,
+			sizeof(uint64_t) * cp_device_entry->pipeline_count
+		);
+		if (weights == NULL) {
+			goto error;
+		}
+		for (uint64_t idx = 0; idx < cp_device_entry->pipeline_count;
+		     ++idx) {
+			weights[idx] = cp_device_entry->pipelines[idx].weight;
+		}
+		routing_table_pad(
+			device_entry_ectx->pipeline_map,
+			device_entry_ectx->pipeline_map_size,
+			weight_sum,
+			weights,
+			cp_device_entry->pipeline_count
+		);
+		memory_bfree(
+			memory_context,
+			weights,
+			sizeof(uint64_t) * cp_device_entry->pipeline_count
+		);
 	}
 
 	return device_entry_ectx;

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -129,8 +129,11 @@ struct function_ectx {
 	struct counter_storage *counter_storage;
 	uint64_t chain_count;
 	struct chain_ectx **chains;
+	// Size of the routing table below; always a power of two so packet
+	// selection masks the flow hash instead of dividing it.
 	uint64_t chain_map_size;
-	struct chain_ectx *chain_map[];
+	// Destination indices into the chains array, replicated by weight.
+	uint64_t chain_map[];
 };
 
 struct pipeline_ectx {

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -11,7 +11,76 @@
 #include "lib/dataplane/packet/packet.h"
 #include "lib/dataplane/time/tsc.h"
 
+#include <stdbool.h>
+#include <string.h>
+
 #include <rte_cycles.h>
+#include <rte_prefetch.h>
+
+// Number of leading hash-demux destinations whose list tails are held in
+// local storage during one demux pass.
+#define DEMUX_TAIL_CACHE 16
+
+// One destination's locally built packet list.
+//
+// Appending each packet straight to its destination's shared schedule list
+// reloads the list tail and the packet/byte tallies from shared state for
+// every packet. A demux pass instead links packets through these locally
+// held tails, prefetching the next packet while it runs, and splices each
+// finished list into its destination once. Destinations beyond the cache
+// are appended directly.
+struct demux_list {
+	struct packet *head;
+	struct packet **tail;
+	uint64_t count;
+	uint64_t bytes;
+};
+
+static inline void
+demux_list_add(struct demux_list *demux, struct packet *packet) {
+	if (demux->head == NULL) {
+		demux->head = packet;
+	} else {
+		*demux->tail = packet;
+	}
+	demux->tail = &packet->next;
+	demux->count += 1;
+	demux->bytes += packet->data_len;
+}
+
+// Splice a locally built list into a schedule's input list.
+static inline void
+demux_list_splice_input(
+	struct packet_front *schedule, const struct demux_list *demux
+) {
+	*demux->tail = NULL;
+
+	struct packet_list list = {
+		.first = demux->head,
+		.last = demux->tail,
+	};
+	packet_list_concat(&schedule->input, &list);
+
+	schedule->input_count += demux->count;
+	schedule->input_bytes += demux->bytes;
+}
+
+// Splice a locally built list into a schedule's output list.
+static inline void
+demux_list_splice_output(
+	struct packet_front *schedule, const struct demux_list *demux
+) {
+	*demux->tail = NULL;
+
+	struct packet_list list = {
+		.first = demux->head,
+		.last = demux->tail,
+	};
+	packet_list_concat(&schedule->output, &list);
+
+	schedule->output_count += demux->count;
+	schedule->output_bytes += demux->bytes;
+}
 
 static inline void
 counter_add_packets_bytes(
@@ -206,31 +275,56 @@ function_ectx_run_single_chain(
 
 // Demultiplex packets across the function's chains by hash.
 //
-// Each chain is processed on its own packet front and the results are merged
-// back into the caller's front.
+// The routing table is a power of two, so selection masks the flow hash
+// instead of dividing it. Each chain is processed on its own packet front
+// and the results are merged back into the caller's front.
 static void
 function_ectx_run_chains(
 	struct dp_worker *dp_worker,
 	struct function_ectx *function_ectx,
 	struct packet_front *packet_front
 ) {
-	struct packet *packet = packet_list_pop(&packet_front->output);
-	while (packet != NULL) {
-		uint64_t map_idx = packet->hash % function_ectx->chain_map_size;
+	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
+	const uint64_t map_mask = function_ectx->chain_map_size - 1;
 
-		struct chain_ectx *chain_ectx =
-			ADDR_OF(function_ectx->chain_map + map_idx);
-		packet_front_input(&chain_ectx->schedule, packet);
+	struct demux_list lists[DEMUX_TAIL_CACHE];
 
-		packet = packet_list_pop(&packet_front->output);
+	struct packet *packet = packet_list_first(&packet_front->output);
+	bool lists_live = packet != NULL;
+	if (lists_live) {
+		memset(lists, 0, sizeof(lists));
 	}
+
+	while (packet != NULL) {
+		struct packet *next = packet->next;
+		rte_prefetch0(next);
+
+		uint64_t chain_idx =
+			function_ectx->chain_map[packet->hash & map_mask];
+
+		if (chain_idx < DEMUX_TAIL_CACHE) {
+			demux_list_add(&lists[chain_idx], packet);
+		} else {
+			struct chain_ectx *chain_ectx =
+				ADDR_OF(chains + chain_idx);
+			packet_front_input(&chain_ectx->schedule, packet);
+		}
+
+		packet = next;
+	}
+	packet_list_init(&packet_front->output);
 	packet_front->output_count = 0;
 	packet_front->output_bytes = 0;
 
-	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
-
 	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
 		struct chain_ectx *chain_ectx = ADDR_OF(chains + idx);
+
+		if (lists_live && idx < DEMUX_TAIL_CACHE &&
+		    lists[idx].head != NULL) {
+			demux_list_splice_input(
+				&chain_ectx->schedule, &lists[idx]
+			);
+		}
 
 		chain_ectx_process(
 			dp_worker, chain_ectx, &chain_ectx->schedule
@@ -388,8 +482,9 @@ device_entry_ectx_dispatch_single(
 
 // Demultiplex the handler output across the entry's pipelines by hash.
 //
-// Each pipeline is processed on its own packet front and the results are merged
-// back into the caller's front.
+// The routing table is a power of two, so selection masks the flow hash
+// instead of dividing it. Each pipeline is processed on its own packet
+// front and the results are merged back into the caller's front.
 static inline void
 device_entry_ectx_dispatch_many(
 	struct dp_worker *dp_worker,
@@ -397,24 +492,46 @@ device_entry_ectx_dispatch_many(
 	struct packet_front *packet_front
 ) {
 	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
+	const uint64_t map_mask = entry_ectx->pipeline_map_size - 1;
 
-	struct packet *packet = packet_list_pop(&packet_front->output);
-	while (packet != NULL) {
-		uint64_t pipeline_idx =
-			entry_ectx->pipeline_map
-				[packet->hash % entry_ectx->pipeline_map_size];
+	struct demux_list lists[DEMUX_TAIL_CACHE];
 
-		struct pipeline_ectx *pipeline_ectx =
-			ADDR_OF(pipelines + pipeline_idx);
-		packet_front_output(&pipeline_ectx->schedule, packet);
-
-		packet = packet_list_pop(&packet_front->output);
+	struct packet *packet = packet_list_first(&packet_front->output);
+	bool lists_live = packet != NULL;
+	if (lists_live) {
+		memset(lists, 0, sizeof(lists));
 	}
+
+	while (packet != NULL) {
+		struct packet *next = packet->next;
+		rte_prefetch0(next);
+
+		uint64_t pipeline_idx =
+			entry_ectx->pipeline_map[packet->hash & map_mask];
+
+		if (pipeline_idx < DEMUX_TAIL_CACHE) {
+			demux_list_add(&lists[pipeline_idx], packet);
+		} else {
+			struct pipeline_ectx *pipeline_ectx =
+				ADDR_OF(pipelines + pipeline_idx);
+			packet_front_output(&pipeline_ectx->schedule, packet);
+		}
+
+		packet = next;
+	}
+	packet_list_init(&packet_front->output);
 	packet_front->output_count = 0;
 	packet_front->output_bytes = 0;
 
 	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
 		struct pipeline_ectx *pipeline_ectx = ADDR_OF(pipelines + idx);
+
+		if (lists_live && idx < DEMUX_TAIL_CACHE &&
+		    lists[idx].head != NULL) {
+			demux_list_splice_output(
+				&pipeline_ectx->schedule, &lists[idx]
+			);
+		}
 
 		pipeline_ectx_process(
 			dp_worker, pipeline_ectx, &pipeline_ectx->schedule

--- a/tests/pipeline/dispatch_test.go
+++ b/tests/pipeline/dispatch_test.go
@@ -17,9 +17,17 @@
 //
 //  4. The single-pipeline fast path delivers the whole batch to the one bound
 //     pipeline intact.
+//
+//  5. Power-of-two padding of the chain and pipeline routing tables never
+//     routes traffic to a zero-weight destination, and the demux delivers
+//     every packet to exactly one enabled destination.
+//
+//  6. Destinations whose index falls outside the demux local-tail cache are
+//     still routed correctly through the direct-append fallback.
 package pipeline_test
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -410,4 +418,412 @@ func TestEmptyPipelineDeviceDropsAllPackets(t *testing.T) {
 		"device entry with no pipeline must not forward any packet")
 	require.Len(t, result.Drop, packetCount,
 		"device entry with no pipeline must drop all packets")
+}
+
+// dispatchFlowPacket builds an Ethernet/IPv4/UDP packet whose source address
+// varies with the flow index, so a batch of them carries distinct flow hashes
+// and spreads across a hash demux instead of piling onto one destination.
+func dispatchFlowPacket(t *testing.T, flowIdx int) gopacket.Packet {
+	t.Helper()
+
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip4 := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    net.ParseIP(fmt.Sprintf("192.0.2.%d", 10+flowIdx)),
+		DstIP:    net.ParseIP("10.0.0.1"),
+	}
+	udp := layers.UDP{SrcPort: 12345, DstPort: 80}
+	require.NoError(t, udp.SetNetworkLayerForChecksum(&ip4))
+	return xpacket.LayersToPacket(t, &eth, &ip4, &udp)
+}
+
+// dispatchFlowPackets builds a batch of packets with distinct flow hashes.
+func dispatchFlowPackets(t *testing.T, count int) []gopacket.Packet {
+	t.Helper()
+
+	pkts := make([]gopacket.Packet, count)
+	for idx := range count {
+		pkts[idx] = dispatchFlowPacket(t, idx)
+	}
+	return pkts
+}
+
+// publishTwoRuleACLBackend creates a harness with one allow-all and one
+// deny-all ACL module published under the given names.
+func publishTwoRuleACLBackend(
+	t *testing.T,
+	agentName, allowName, denyName string,
+	extraModules ...string,
+) (*dataplaneut.Harness, *ffi.Agent) {
+	t.Helper()
+
+	h, agent, backend := setupACLBackend(t, agentName, extraModules...)
+	publishMatchAllACL(t, backend, allowName, cacl.ActionAllow)
+	publishMatchAllACL(t, backend, denyName, cacl.ActionDeny)
+	return h, agent
+}
+
+// verifies that padding the chain routing table to a power of two never
+// leaks traffic to a zero-weight chain, and that the demux hands every packet
+// to exactly one enabled chain.
+//
+// The weights 2/0/1 sum to 3, so the table is padded well past their sum;
+// the deny chain holds zero slots by construction, so any packet reaching it
+// would show up as a drop. All packets must survive to the egress.
+func Test_FunctionDemux_PaddedWeights_KeepZeroWeightChainIsolated(t *testing.T) {
+	const (
+		allowACL = "pw-allow"
+		denyACL  = "pw-deny"
+		fn       = "pw-fn"
+		fwdName  = "pw-fwd"
+	)
+
+	h, agent := publishTwoRuleACLBackend(t, "pw-test", allowACL, denyACL, "forward")
+
+	forwardBackend := forward.NewBackend(agent)
+	rule := cforward.ForwardRule{
+		Target:  "port0",
+		Mode:    cforward.ModeOut,
+		Counter: fwdName,
+		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:   filter.IPNets{filter.MustParseIPNet("10.0.0.0/8")},
+	}
+	handle, err := forwardBackend.UpdateModule(
+		fwdName, []cforward.ForwardRule{rule},
+	)
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+
+	// The allow chains forward their packets to the output stage; the
+	// input entry itself never transmits, so reaching egress proves the
+	// packet traversed a chain intact.
+	allowModules := []ffi.ChainModuleConfig{
+		{Type: "acl", Name: allowACL},
+		{Type: "forward", Name: fwdName},
+	}
+
+	// Three chains with weights 2/0/1: two allow chains around a disabled
+	// deny chain.
+	chains := []ffi.FunctionChainConfig{
+		{
+			Weight: 2,
+			Chain: ffi.ChainConfig{
+				Name:    fn + "-a",
+				Modules: allowModules,
+			},
+		},
+		{
+			Weight: 0,
+			Chain: ffi.ChainConfig{
+				Name:    fn + "-b",
+				Modules: []ffi.ChainModuleConfig{{Type: "acl", Name: denyACL}},
+			},
+		},
+		{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name:    fn + "-c",
+				Modules: allowModules,
+			},
+		},
+	}
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name:   fn,
+		Chains: chains,
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      fn,
+		Functions: []string{fn},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: fn, Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+
+	const packetCount = 16
+	result, err := h.HandlePackets(dispatchFlowPackets(t, packetCount)...)
+	require.NoError(t, err)
+	require.Len(t, result.Output, packetCount,
+		"every packet must reach egress through one of the enabled chains")
+	require.Empty(t, result.Drop,
+		"the zero-weight deny chain must never receive a packet")
+
+	counters := h.SharedMemory().DPConfig(0).FunctionCounters("port0", fn, fn)
+	byName := dataplaneut.SingleValueCounters(counters)
+	require.Equal(t, uint64(packetCount), byName["input"],
+		"the function must see every packet exactly once")
+}
+
+// verifies that a chain whose index falls outside the demux local-tail cache
+// still receives its packets through the direct-append fallback.
+//
+// Sixteen zero-weight deny chains push the one enabled allow chain to index
+// 16, beyond the cached destinations. The single enabled chain holds the
+// only routing slot, so every packet must reach it and survive to egress.
+func Test_FunctionDemux_TailCacheOverflow_RoutesThroughDirectAppend(t *testing.T) {
+	const (
+		allowACL   = "bc-allow"
+		denyACL    = "bc-deny"
+		fn         = "bc-fn"
+		fwdName    = "bc-fwd"
+		chainCount = 17
+		allowIdx   = chainCount - 1
+	)
+
+	h, agent := publishTwoRuleACLBackend(t, "bc-test", allowACL, denyACL, "forward")
+
+	forwardBackend := forward.NewBackend(agent)
+	rule := cforward.ForwardRule{
+		Target:  "port0",
+		Mode:    cforward.ModeOut,
+		Counter: fwdName,
+		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:   filter.IPNets{filter.MustParseIPNet("10.0.0.0/8")},
+	}
+	handle, err := forwardBackend.UpdateModule(
+		fwdName, []cforward.ForwardRule{rule},
+	)
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+
+	// The enabled chain forwards to the output stage; the input entry
+	// itself never transmits.
+	allowModules := []ffi.ChainModuleConfig{
+		{Type: "acl", Name: allowACL},
+		{Type: "forward", Name: fwdName},
+	}
+
+	chains := make([]ffi.FunctionChainConfig, 0, chainCount)
+	for idx := range chainCount {
+		weight := uint64(0)
+		modules := []ffi.ChainModuleConfig{{Type: "acl", Name: denyACL}}
+		if idx == allowIdx {
+			weight = 1
+			modules = allowModules
+		}
+		chains = append(chains, ffi.FunctionChainConfig{
+			Weight: weight,
+			Chain: ffi.ChainConfig{
+				Name:    fmt.Sprintf("%s-%d", fn, idx),
+				Modules: modules,
+			},
+		})
+	}
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name:   fn,
+		Chains: chains,
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      fn,
+		Functions: []string{fn},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: fn, Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+
+	const packetCount = 8
+	result, err := h.HandlePackets(dispatchFlowPackets(t, packetCount)...)
+	require.NoError(t, err)
+	require.Len(t, result.Output, packetCount,
+		"every packet must reach the single enabled chain past the tail cache")
+	require.Empty(t, result.Drop,
+		"no packet may leak to a zero-weight chain while routing past the cache")
+}
+
+// verifies that padding the device-entry pipeline routing table to a power
+// of two never leaks traffic to a zero-weight pipeline, and that every packet
+// reaches exactly one enabled pipeline.
+//
+// The input entry binds three pipelines with weights 2/0/1; the deny
+// pipeline holds zero slots by construction, so a leak would surface as a
+// drop while the two forward pipelines carry everything to egress.
+func Test_DeviceEntryDemux_PaddedWeights_KeepZeroWeightPipelineIsolated(t *testing.T) {
+	const (
+		allowACL = "pp-allow"
+		denyACL  = "pp-deny"
+		allowFn  = "pp-allow-fn"
+		denyFn   = "pp-deny-fn"
+		fwdName  = "pp-fwd"
+	)
+
+	h, agent := publishTwoRuleACLBackend(t, "pp-test", allowACL, denyACL, "forward")
+
+	forwardBackend := forward.NewBackend(agent)
+	rule := cforward.ForwardRule{
+		Target:  "port0",
+		Mode:    cforward.ModeOut,
+		Counter: fwdName,
+		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:   filter.IPNets{filter.MustParseIPNet("10.0.0.0/8")},
+	}
+	handle, err := forwardBackend.UpdateModule(
+		fwdName, []cforward.ForwardRule{rule},
+	)
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+
+	// The allow pipeline forwards matching traffic to the output stage;
+	// the deny pipeline drops everything it receives.
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: allowFn,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name: allowFn + "-chain",
+				Modules: []ffi.ChainModuleConfig{
+					{Type: "acl", Name: allowACL},
+					{Type: "forward", Name: fwdName},
+				},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: denyFn,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name:    denyFn + "-chain",
+				Modules: []ffi.ChainModuleConfig{{Type: "acl", Name: denyACL}},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "pp-allow-a",
+		Functions: []string{allowFn},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "pp-deny",
+		Functions: []string{denyFn},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "pp-allow-c",
+		Functions: []string{allowFn},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name: "port0",
+		Input: []ffi.DevicePipelineConfig{
+			{Name: "pp-allow-a", Weight: 2},
+			{Name: "pp-deny", Weight: 0},
+			{Name: "pp-allow-c", Weight: 1},
+		},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+
+	const packetCount = 16
+	result, err := h.HandlePackets(dispatchFlowPackets(t, packetCount)...)
+	require.NoError(t, err)
+	require.Len(t, result.Output, packetCount,
+		"every packet must reach egress through one of the enabled pipelines")
+	require.Empty(t, result.Drop,
+		"the zero-weight deny pipeline must never receive a packet")
+}
+
+// verifies that a pipeline whose index falls outside the demux local-tail
+// cache still receives its packets through the direct-append fallback.
+//
+// Sixteen zero-weight deny pipelines push the one enabled forward pipeline
+// to index 16, beyond the cached destinations. The single enabled pipeline
+// holds the only routing slot, so every packet must survive to egress.
+func Test_DeviceEntryDemux_TailCacheOverflow_RoutesThroughDirectAppend(t *testing.T) {
+	const (
+		allowACL      = "bp-allow"
+		denyACL       = "bp-deny"
+		allowFn       = "bp-allow-fn"
+		denyFn        = "bp-deny-fn"
+		fwdName       = "bp-fwd"
+		pipelineCount = 17
+		allowIdx      = pipelineCount - 1
+	)
+
+	h, agent := publishTwoRuleACLBackend(t, "bp-test", allowACL, denyACL, "forward")
+
+	forwardBackend := forward.NewBackend(agent)
+	rule := cforward.ForwardRule{
+		Target:  "port0",
+		Mode:    cforward.ModeOut,
+		Counter: fwdName,
+		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:   filter.IPNets{filter.MustParseIPNet("10.0.0.0/8")},
+	}
+	handle, err := forwardBackend.UpdateModule(
+		fwdName, []cforward.ForwardRule{rule},
+	)
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: allowFn,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name: allowFn + "-chain",
+				Modules: []ffi.ChainModuleConfig{
+					{Type: "acl", Name: allowACL},
+					{Type: "forward", Name: fwdName},
+				},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: denyFn,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name:    denyFn + "-chain",
+				Modules: []ffi.ChainModuleConfig{{Type: "acl", Name: denyACL}},
+			},
+		}},
+	}))
+
+	input := make([]ffi.DevicePipelineConfig, 0, pipelineCount)
+	for idx := range pipelineCount {
+		if idx == allowIdx {
+			input = append(input, ffi.DevicePipelineConfig{
+				Name:   "bp-allow",
+				Weight: 1,
+			})
+			continue
+		}
+		name := fmt.Sprintf("bp-deny-%d", idx)
+		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+			Name:      name,
+			Functions: []string{denyFn},
+		}))
+		input = append(input, ffi.DevicePipelineConfig{
+			Name:   name,
+			Weight: 0,
+		})
+	}
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "bp-allow",
+		Functions: []string{allowFn},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  input,
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+
+	const packetCount = 8
+	result, err := h.HandlePackets(dispatchFlowPackets(t, packetCount)...)
+	require.NoError(t, err)
+	require.Len(t, result.Output, packetCount,
+		"every packet must reach the single enabled pipeline past the tail cache")
+	require.Empty(t, result.Drop,
+		"no packet may leak to a zero-weight pipeline while routing past the cache")
 }


### PR DESCRIPTION
- Pad the weighted chain and pipeline routing tables to a power of two so per-packet selection masks the flow hash instead of dividing it; the padding is spread by largest-remainder allocation so configured weight ratios survive the rounding and zero-weight destinations stay unroutable.
- Build each destination's packet list through locally cached tails during the demux pass and splice it once afterwards, instead of reloading the shared list state and tallies for every packet; destinations past a small cache append directly.
- Prefetch the next packet descriptor while walking the demux source list.
- The chain table now stores destination indices, matching the pipeline table.
- Extend the dispatch regression suite with deterministic tests for the padded weights, the zero-weight isolation under padding, and the direct-append fallback beyond the tail cache, on both demux levels.