### PR TITLE
perf(filter): batch the net6 fallback classifier lookups

### DIFF
--- a/lib/filter/query/net6.h
+++ b/lib/filter/query/net6.h
@@ -9,6 +9,7 @@
 #include <rte_mbuf.h>
 
 #include <stdint.h>
+#include <string.h>
 
 static inline void
 FILTER_ATTR_QUERY_FUNC(net6_dst)(
@@ -20,6 +21,8 @@ FILTER_ATTR_QUERY_FUNC(net6_dst)(
 
 	struct net6_classifier *c = (struct net6_classifier *)data;
 
+	uint8_t hi_keys[count][8];
+	uint8_t lo_keys[count][8];
 	uint32_t hi_values[count];
 	uint32_t lo_values[count];
 
@@ -31,23 +34,12 @@ FILTER_ATTR_QUERY_FUNC(net6_dst)(
 			packets[idx]->network_header.offset
 		);
 
-		hi_values[idx] = lpm8_lookup(
-			&c->hi, (const uint8_t *)ipv6_hdr->dst_addr
-		);
+		memcpy(hi_keys[idx], ipv6_hdr->dst_addr, 8);
+		memcpy(lo_keys[idx], ipv6_hdr->dst_addr + 8, 8);
 	}
 
-	for (uint32_t idx = 0; idx < count; ++idx) {
-		struct rte_mbuf *mbuf = packet_to_mbuf(packets[idx]);
-		struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
-			mbuf,
-			struct rte_ipv6_hdr *,
-			packets[idx]->network_header.offset
-		);
-
-		lo_values[idx] = lpm8_lookup(
-			&c->lo, (const uint8_t *)ipv6_hdr->dst_addr + 8
-		);
-	}
+	lpm8_lookup_batch(&c->hi, hi_keys[0], hi_values, count);
+	lpm8_lookup_batch(&c->lo, lo_keys[0], lo_values, count);
 
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		result[idx] = value_table_get(
@@ -66,6 +58,8 @@ FILTER_ATTR_QUERY_FUNC(net6_src)(
 
 	struct net6_classifier *c = (struct net6_classifier *)data;
 
+	uint8_t hi_keys[count][8];
+	uint8_t lo_keys[count][8];
 	uint32_t hi_values[count];
 	uint32_t lo_values[count];
 
@@ -77,23 +71,12 @@ FILTER_ATTR_QUERY_FUNC(net6_src)(
 			packets[idx]->network_header.offset
 		);
 
-		hi_values[idx] = lpm8_lookup(
-			&c->hi, (const uint8_t *)ipv6_hdr->src_addr
-		);
+		memcpy(hi_keys[idx], ipv6_hdr->src_addr, 8);
+		memcpy(lo_keys[idx], ipv6_hdr->src_addr + 8, 8);
 	}
 
-	for (uint32_t idx = 0; idx < count; ++idx) {
-		struct rte_mbuf *mbuf = packet_to_mbuf(packets[idx]);
-		struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
-			mbuf,
-			struct rte_ipv6_hdr *,
-			packets[idx]->network_header.offset
-		);
-
-		lo_values[idx] = lpm8_lookup(
-			&c->lo, (const uint8_t *)ipv6_hdr->src_addr + 8
-		);
-	}
+	lpm8_lookup_batch(&c->hi, hi_keys[0], hi_values, count);
+	lpm8_lookup_batch(&c->lo, lo_keys[0], lo_values, count);
 
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		result[idx] = value_table_get(

--- a/tests/common/lpm_test.c
+++ b/tests/common/lpm_test.c
@@ -133,6 +133,7 @@ test_lookup_batch_matches_scalar(void) {
 	uint64_t rand_state = 0x12345678;
 
 	uint8_t prefixes[300][16];
+	const int key_sizes[] = {16, 8, 4};
 	size_t counts[] = {1, 31, 32, 33, 100, 1000};
 	uint8_t *keys = malloc(1000 * 16);
 	uint32_t *results = malloc(1000 * sizeof(uint32_t));
@@ -140,7 +141,11 @@ test_lookup_batch_matches_scalar(void) {
 		goto out;
 	}
 
-	for (int key_size = 16; key_size > 0; key_size -= 12) {
+	// Covers the sizes the dataplane actually walks: 16-byte and 4-byte
+	// generic keys, and the 8-byte halves of the net6 classifiers.
+	for (size_t ks = 0; ks < sizeof(key_sizes) / sizeof(key_sizes[0]);
+	     ++ks) {
+		const int key_size = key_sizes[ks];
 		struct lpm tree;
 		if (lpm_init(&tree, &mctx, "lpm")) {
 			goto out;


### PR DESCRIPTION
- Replace the two per-packet scalar trie walks in the net6 fallback attribute functions with a single header-extraction pass and interleaved batched walks for both address halves.
- Duplicate per-packet header resolution across the two passes is gone, and the out-of-order engine now overlaps the trie chains across the batch.
- bench_net6 improves 1.5-1.6x end-to-end (19 to 29-31 Mpps on a single core, measured at 100/500/5000 rules).
- Extend the lpm batch equivalence test to cover the 8-byte key size used by the net6 classifiers.