### PR TITLE
refactor(acl): serve per-rule counter metrics from their own method

### DIFF
--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -16,6 +16,8 @@ pub enum ModeCmd {
     Show(ShowCmd),
     /// Show ACL metrics
     Metrics(MetricsCmd),
+    /// Show per-rule ACL counter metrics
+    MetricsRules(MetricsRulesCmd),
     /// Show per-rule ACL counters
     RuleCounters(RuleCountersCmd),
 }
@@ -107,6 +109,17 @@ pub struct MetricsCmd {
     /// Show only metrics matching this category
     #[arg(long, short, value_enum)]
     pub name: Option<MetricName>,
+}
+
+#[derive(Debug, Clone, Parser, Default)]
+pub struct MetricsRulesCmd {
+    /// Server-side tag filter, e.g. --tag config=my-acl --tag counter=rule_.*
+    ///
+    /// The counter tag selects rule counters by pattern, in Rust regex syntax.
+    /// Every other tag matches a label exactly, except an empty value which
+    /// requires the label to be absent and `*` which requires it present.
+    #[arg(long = "tag", short = 't', value_name = "NAME=VALUE")]
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone, Parser, Default)]

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -5,7 +5,7 @@ use aclpb::{
     DeleteConfigRequest, GetRulesCountersRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     acl_service_client::AclServiceClient, metrics_service_client::MetricsServiceClient,
 };
-use args::{DeleteCmd, MetricsCmd, ModeCmd, RuleCountersCmd, ShowCmd, UpdateCmd};
+use args::{DeleteCmd, MetricsCmd, MetricsRulesCmd, ModeCmd, RuleCountersCmd, ShowCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
 use serde::{Deserialize, Serialize};
@@ -563,6 +563,40 @@ impl ACLService {
 
         Ok(())
     }
+
+    pub async fn metrics_rules(&mut self, cmd: MetricsRulesCmd) -> Result<(), Error> {
+        let tags = cmd
+            .tags
+            .iter()
+            .map(|entry| parse_tag(entry))
+            .collect::<Result<Vec<_>, String>>()
+            .map_err(|message| Error::invalid_argument("metrics-rules", self.metrics.endpoint(), message))?;
+
+        let response = self
+            .metrics
+            .client()
+            .get_metrics_rules(GetMetricsRequest { tags })
+            .await
+            .map_err(self.metrics.status("metrics-rules"))?
+            .into_inner();
+
+        let metrics = response.metrics;
+
+        output::data(
+            || &metrics,
+            || {
+                if metrics.is_empty() {
+                    output::empty(format_args!("No ACL rule metrics found."));
+                    return;
+                }
+
+                let metrics: Vec<Metric> = metrics.iter().cloned().map(Metric::from_proto).collect();
+                print_metrics_table(&metrics)
+            },
+        );
+
+        Ok(())
+    }
 }
 
 /// Parses a `NAME=VALUE` tag entry into a [`MetricTag`].
@@ -588,6 +622,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::Update(cmd) => service.update_config(cmd).await,
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
         ModeCmd::Metrics(cmd) => service.metrics(cmd).await,
+        ModeCmd::MetricsRules(cmd) => service.metrics_rules(cmd).await,
         ModeCmd::RuleCounters(cmd) => service.rule_counters(cmd).await,
     }
 }

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -26,8 +26,10 @@ service ACLService {
 
 // MetricsService exposes ACL module metrics.
 service MetricsService {
-  // GetMetrics returns a snapshot of ACL module metrics.
+  // GetMetrics returns a snapshot of ACL module metrics, excluding per-rule counters.
   rpc GetMetrics(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
+  // GetMetricsRules returns the per-rule counter metrics GetMetrics leaves out.
+  rpc GetMetricsRules(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
 }
 
 message UpdateConfigRequest {

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -3,6 +3,9 @@ package acl
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -12,6 +15,7 @@ import (
 // metricsSource provides the module's metrics, filtered by tags.
 type metricsSource interface {
 	Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error)
+	RuleMetrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error)
 }
 
 // MetricsService exposes ACL module metrics over its own gRPC service.
@@ -37,6 +41,16 @@ func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetric
 	return &commonpb.GetMetricsResponse{Metrics: all}, nil
 }
 
+// GetMetricsRules returns the per-rule counter metrics GetMetrics leaves out.
+func (m *MetricsService) GetMetricsRules(ctx context.Context, req *commonpb.GetMetricsRequest) (*commonpb.GetMetricsResponse, error) {
+	all, err := m.source.RuleMetrics(req.GetTags()...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &commonpb.GetMetricsResponse{Metrics: all}, nil
+}
+
 // aclStructuralCounters lists the fixed ACL counters whose metrics carry no
 // "counter" label.
 //
@@ -52,9 +66,9 @@ var aclStructuralCounters = []string{
 // Metrics returns ACL module metrics matching tags: per-pipeline packet
 // counters, ACL compilation info, and gRPC call metrics.
 //
-// Per-rule counters are served by GetRulesCounters, not here. Counter
-// metrics are omitted when all worker values are zero to reduce output
-// noise.
+// Per-rule counters are served by RuleMetrics and GetRulesCounters, not
+// here. Counter metrics are omitted when all worker values are zero to
+// reduce output noise.
 //
 // Labels:
 //   - config:        ACL config name (all counter metrics)
@@ -75,6 +89,112 @@ func (m *ACLService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, e
 		all = append(all, m.metrics.Collect()...)
 	}
 	return metrics.Filter(all, tags), nil
+}
+
+// RuleMetrics returns ACL per-rule counter metrics matching tags: one
+// packets and one bytes counter for every rule counter.
+//
+// These are the counters Metrics leaves out, read from the runtime-kind
+// storages it never touches. Counter metrics are omitted when all worker
+// values are zero to reduce output noise.
+//
+// The counter tag selects rule counters by pattern, since the dataplane
+// read applies it as one. Every other tag is an exact label match.
+//
+// Labels:
+//   - config:    ACL config name
+//   - device:    dataplane device name
+//   - pipeline:  pipeline name
+//   - function:  pipeline function name
+//   - chain:     pipeline chain name
+//   - counter:   rule counter name
+func (m *ACLService) RuleMetrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
+	all, err := m.collectRuleMetrics(tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return metrics.Filter(all, tagsExceptCounter(tags)), nil
+}
+
+func tagsExceptCounter(tags []*commonpb.MetricTag) []*commonpb.MetricTag {
+	kept := make([]*commonpb.MetricTag, 0, len(tags))
+	for _, tag := range tags {
+		if tag.GetName() == "counter" {
+			continue
+		}
+
+		kept = append(kept, tag)
+	}
+
+	return kept
+}
+
+func (m *ACLService) collectRuleMetrics(tags []*commonpb.MetricTag) ([]*commonpb.Metric, error) {
+	dpConfig := m.backend.DPConfig()
+	if dpConfig == nil {
+		return []*commonpb.Metric{}, nil
+	}
+
+	names, read := metrics.Query(tags, metrics.WithUnknownEntryCounters())
+	if !read {
+		return []*commonpb.Metric{}, nil
+	}
+
+	result := make([]*commonpb.Metric, 0)
+	for pos := range dpConfig.AllModulePositions(moduleType) {
+		groups, err := dpConfig.CountersByTags([]ffi.CounterTag{
+			{Key: "device", Value: pos.Device},
+			{Key: "pipeline", Value: pos.Pipeline},
+			{Key: "function", Value: pos.Function},
+			{Key: "chain", Value: pos.Chain},
+			{Key: "module_type", Value: moduleType},
+			{Key: "module_name", Value: pos.ModuleName},
+			{Key: "kind", Value: "runtime"},
+		}, names)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal,
+				"failed to read rule counters of config %q: %v",
+				pos.ModuleName,
+				err,
+			)
+		}
+
+		for _, group := range groups {
+			for _, counter := range group.Counters {
+				var packets, bytes uint64
+				for _, workerVals := range counter.Values {
+					if len(workerVals) > 0 {
+						packets += workerVals[0]
+					}
+					if len(workerVals) > 1 {
+						bytes += workerVals[1]
+					}
+				}
+
+				if packets == 0 && bytes == 0 {
+					continue
+				}
+
+				labels := []*commonpb.Label{
+					{Name: "config", Value: pos.ModuleName},
+					{Name: "device", Value: pos.Device},
+					{Name: "pipeline", Value: pos.Pipeline},
+					{Name: "function", Value: pos.Function},
+					{Name: "chain", Value: pos.Chain},
+					{Name: "counter", Value: counter.Name},
+				}
+
+				result = append(result,
+					commonpb.NewMetricCounter("acl_rule_packets", packets, labels...),
+					commonpb.NewMetricCounter("acl_rule_bytes", bytes, labels...),
+				)
+			}
+		}
+	}
+
+	return result, nil
 }
 
 func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*commonpb.Metric, error) {

--- a/modules/acl/controlplane/metrics_test.go
+++ b/modules/acl/controlplane/metrics_test.go
@@ -12,14 +12,21 @@ import (
 // spyMetricsSource records the tags it receives and returns a fixed slice
 // of metrics for MetricsService wiring tests.
 type spyMetricsSource struct {
-	metrics []*commonpb.Metric
+	metrics     []*commonpb.Metric
+	ruleMetrics []*commonpb.Metric
 
-	receivedTags []*commonpb.MetricTag
+	receivedTags     []*commonpb.MetricTag
+	receivedRuleTags []*commonpb.MetricTag
 }
 
 func (m *spyMetricsSource) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
 	m.receivedTags = tags
 	return m.metrics, nil
+}
+
+func (m *spyMetricsSource) RuleMetrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
+	m.receivedRuleTags = tags
+	return m.ruleMetrics, nil
 }
 
 // TestMetricsServiceGetMetricsForwardsTags verifies that GetMetrics forwards
@@ -59,4 +66,34 @@ func TestMetricsServiceGetMetricsForwardsTags(t *testing.T) {
 			require.Equal(t, metrics, response.GetMetrics())
 		})
 	}
+}
+
+// TestMetricsServiceGetMetricsRulesUsesRuleSource verifies that
+// GetMetricsRules forwards its tags to the rule source and returns what that
+// source produces, keeping the two reads apart.
+func TestMetricsServiceGetMetricsRulesUsesRuleSource(t *testing.T) {
+	structural := []*commonpb.Metric{
+		{
+			Name:  "acl_action_allow_packets",
+			Value: &commonpb.Metric_Counter{Counter: 42},
+		},
+	}
+	rules := []*commonpb.Metric{
+		{
+			Name:  "acl_rule_packets",
+			Value: &commonpb.Metric_Counter{Counter: 7},
+		},
+	}
+
+	tags := []*commonpb.MetricTag{{Name: "counter", Value: "svc_counter"}}
+
+	source := &spyMetricsSource{metrics: structural, ruleMetrics: rules}
+	service := acl.NewMetricsService(source)
+
+	response, err := service.GetMetricsRules(t.Context(), &commonpb.GetMetricsRequest{Tags: tags})
+
+	require.NoError(t, err)
+	require.Equal(t, tags, source.receivedRuleTags)
+	require.Nil(t, source.receivedTags)
+	require.Equal(t, rules, response.GetMetrics())
 }

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -15,6 +15,7 @@ import (
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/xerror"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
@@ -1214,6 +1215,61 @@ func TestACL_Counters(t *testing.T) {
 		require.NotContains(t, metricNames, "acl_rule_packets")
 		require.NotContains(t, metricNames, "acl_rule_bytes")
 		require.Contains(t, metricNames, "acl_action_allow_packets")
+
+		ruleMetrics, err := svc.RuleMetrics()
+		require.NoError(t, err)
+
+		byName := make(map[string]*commonpb.Metric, len(ruleMetrics))
+		for _, metric := range ruleMetrics {
+			byName[metric.GetName()] = metric
+			require.NotContains(t, metric.GetName(), "acl_action_")
+		}
+
+		rulePackets, ok := byName["acl_rule_packets"]
+		require.True(t, ok, "rule metrics must carry acl_rule_packets")
+		require.Equal(t, uint64(3), rulePackets.GetCounter())
+
+		ruleBytes, ok := byName["acl_rule_bytes"]
+		require.True(t, ok, "rule metrics must carry acl_rule_bytes")
+		require.Equal(t, 3*pktSize, ruleBytes.GetCounter())
+
+		labels := make(map[string]string, len(rulePackets.GetLabels()))
+		for _, label := range rulePackets.GetLabels() {
+			labels[label.GetName()] = label.GetValue()
+		}
+		require.Equal(t, "svc_counter", labels["counter"])
+		require.Equal(t, "test", labels["config"])
+		require.Equal(t, "port0", labels["device"])
+
+		ruleMetricNames := func(tags ...*commonpb.MetricTag) []string {
+			t.Helper()
+
+			got, err := svc.RuleMetrics(tags...)
+			require.NoError(t, err)
+
+			names := make([]string, 0, len(got))
+			for _, metric := range got {
+				names = append(names, metric.GetName())
+			}
+
+			return names
+		}
+
+		require.Contains(t,
+			ruleMetricNames(&commonpb.MetricTag{Name: "counter", Value: "svc_.*"}),
+			"acl_rule_packets",
+			"a counter pattern must reach the dataplane read and survive filtering",
+		)
+		require.Contains(t,
+			ruleMetricNames(&commonpb.MetricTag{Name: "counter", Value: "svc_counter"}),
+			"acl_rule_packets",
+		)
+		require.Empty(t, ruleMetricNames(&commonpb.MetricTag{Name: "counter", Value: "no_such_.*"}))
+		require.Contains(t,
+			ruleMetricNames(&commonpb.MetricTag{Name: "config", Value: "test"}),
+			"acl_rule_packets",
+		)
+		require.Empty(t, ruleMetricNames(&commonpb.MetricTag{Name: "config", Value: "other"}))
 
 		_, err = svc.GetRulesCounters(t.Context(), &aclpb.GetRulesCountersRequest{Name: "missing"})
 		require.Equal(t, codes.NotFound, status.Code(err))


### PR DESCRIPTION
Per-rule ACL counters moved into runtime registries and lost their acl_rule_* metrics, leaving GetRulesCounters as the only way to read them and nothing scrapeable alongside the module's other metrics.

GetMetricsRules now returns acl_rule_packets and acl_rule_bytes for every rule counter, labelled with the config, the position and the counter name. It reads the runtime-kind storages GetMetrics never touches, so GetMetrics keeps returning the predefined counters alone and needed no change.

The counter tag selects rule counters by pattern: the tagged counter read applies it, so it is not re-applied afterwards as an exact label match, which would discard everything a pattern selected. Every other tag stays an exact label match. GetRulesCounters is unchanged and keeps serving the same counters in its own shape.