### PR TITLE
fix(acl): restore generic metrics

### DIFF
--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -14,6 +14,10 @@ type metricsSource interface {
 	Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error)
 }
 
+type moduleCounterReader interface {
+	ModuleCounters(dataplaneConfig *ffi.DPConfig, position ffi.ModuleReference, counterNames []string) []ffi.CounterInfo
+}
+
 // MetricsService exposes ACL module metrics over its own gRPC service.
 type MetricsService struct {
 	aclpb.UnimplementedMetricsServiceServer
@@ -46,7 +50,8 @@ func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetric
 var aclStructuralCounters = []string{
 	"acl_no_match", "acl_action_allow", "acl_action_deny", "acl_action_count",
 	"acl_action_check_state", "acl_action_create_state", "acl_action_unknown",
-	"acl_state_miss", "acl_sync_sent",
+	"acl_state_miss", "acl_sync_sent", "rx", "tx", "drop", "pending_input",
+	"pending_output",
 }
 
 // Metrics returns ACL module metrics matching tags: per-pipeline packet
@@ -107,15 +112,19 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 
 		var counters []ffi.CounterInfo
 		if read {
-			counters = dpConfig.ModuleCounters(
-				pos.Device,
-				pos.Pipeline,
-				pos.Function,
-				pos.Chain,
-				moduleType,
-				configName,
-				names,
-			)
+			if counterReader, ok := m.backend.(moduleCounterReader); ok {
+				counters = counterReader.ModuleCounters(dpConfig, pos, names)
+			} else {
+				counters = dpConfig.ModuleCounters(
+					pos.Device,
+					pos.Pipeline,
+					pos.Function,
+					pos.Chain,
+					moduleType,
+					configName,
+					names,
+				)
+			}
 		}
 
 		for _, counter := range counters {
@@ -178,6 +187,31 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 				result = append(result,
 					commonpb.NewMetricCounter("acl_sync_sent_packets", packets, baseLabels...),
 					commonpb.NewMetricCounter("acl_sync_sent_bytes", bytes, baseLabels...),
+				)
+			case "rx":
+				result = append(result,
+					commonpb.NewMetricCounter("acl_rx_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_rx_bytes", bytes, baseLabels...),
+				)
+			case "tx":
+				result = append(result,
+					commonpb.NewMetricCounter("acl_tx_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_tx_bytes", bytes, baseLabels...),
+				)
+			case "drop":
+				result = append(result,
+					commonpb.NewMetricCounter("acl_drop_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_drop_bytes", bytes, baseLabels...),
+				)
+			case "pending_input":
+				result = append(result,
+					commonpb.NewMetricCounter("acl_pending_input_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_pending_input_bytes", bytes, baseLabels...),
+				)
+			case "pending_output":
+				result = append(result,
+					commonpb.NewMetricCounter("acl_pending_output_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_pending_output_bytes", bytes, baseLabels...),
 				)
 			}
 		}

--- a/modules/acl/controlplane/metrics_test.go
+++ b/modules/acl/controlplane/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
 )
 
@@ -17,9 +18,103 @@ type spyMetricsSource struct {
 	receivedTags []*commonpb.MetricTag
 }
 
+type counterRead struct {
+	dataplaneConfig *ffi.DPConfig
+	counterNames    []string
+}
+
+type counterSpyBackend struct {
+	*fakeBackend
+
+	counterReads []counterRead
+	counters     map[string][]ffi.CounterInfo
+}
+
+// newCounterSpyBackend returns a backend that records bounded counter reads.
+func newCounterSpyBackend(
+	dataplaneConfig *ffi.DPConfig,
+	counters map[string][]ffi.CounterInfo,
+) *counterSpyBackend {
+	backend := newFakeBackend()
+	backend.dpConfig = dataplaneConfig
+	return &counterSpyBackend{fakeBackend: backend, counters: counters}
+}
+
+// ModuleCounters records the requested names before returning fixed values.
+func (m *counterSpyBackend) ModuleCounters(
+	dataplaneConfig *ffi.DPConfig,
+	position ffi.ModuleReference,
+	counterNames []string,
+) []ffi.CounterInfo {
+	m.counterReads = append(m.counterReads, counterRead{
+		dataplaneConfig: dataplaneConfig,
+		counterNames:    append([]string(nil), counterNames...),
+	})
+	return append([]ffi.CounterInfo(nil), m.counters[position.ModuleName]...)
+}
+
+// CounterReads returns the counter reads observed by the backend.
+func (m *counterSpyBackend) CounterReads() []counterRead {
+	return append([]counterRead(nil), m.counterReads...)
+}
+
 func (m *spyMetricsSource) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
 	m.receivedTags = tags
 	return m.metrics, nil
+}
+
+// verifies that an untagged scrape reads only the fixed counter set and
+// exports generic worker totals without histogram or rule metrics.
+func Test_ACLMetrics_UntaggedScrapeUsesBoundedGenericCounters(t *testing.T) {
+	_, agent := newMetricsSnapshotHarness(t)
+	dataplaneConfig := agent.DPConfig()
+	backend := newCounterSpyBackend(dataplaneConfig, map[string][]ffi.CounterInfo{
+		"acl0": {
+			{Name: "rx", Values: [][]uint64{{1, 100}, {2, 200}}},
+			{Name: "tx", Values: [][]uint64{{3, 300}, {4, 400}}},
+			{Name: "drop", Values: [][]uint64{{5, 500}, {6, 600}}},
+			{Name: "pending_input", Values: [][]uint64{{7, 700}, {8, 800}}},
+			{Name: "pending_output", Values: [][]uint64{{9, 900}, {10, 1000}}},
+			{Name: "hist_0", Values: [][]uint64{{11, 1100, 11000}}},
+			{Name: "rule_counter", Values: [][]uint64{{12, 1200}}},
+		},
+	})
+	service := acl.NewACLService(backend)
+
+	collected, err := service.Metrics()
+	require.NoError(t, err)
+
+	expectedQuery := []string{
+		"acl_no_match", "acl_action_allow", "acl_action_deny", "acl_action_count",
+		"acl_action_check_state", "acl_action_create_state", "acl_action_unknown",
+		"acl_state_miss", "acl_sync_sent", "rx", "tx", "drop", "pending_input",
+		"pending_output",
+	}
+	reads := backend.CounterReads()
+	require.Len(t, reads, 5)
+	for _, read := range reads {
+		require.Same(t, dataplaneConfig, read.dataplaneConfig)
+		require.Equal(t, expectedQuery, read.counterNames)
+	}
+
+	expectedMetrics := map[string]uint64{
+		"acl_rx_packets":             3,
+		"acl_rx_bytes":               300,
+		"acl_tx_packets":             7,
+		"acl_tx_bytes":               700,
+		"acl_drop_packets":           11,
+		"acl_drop_bytes":             1100,
+		"acl_pending_input_packets":  15,
+		"acl_pending_input_bytes":    1500,
+		"acl_pending_output_packets": 19,
+		"acl_pending_output_bytes":   1900,
+	}
+	actualMetrics := map[string]uint64{}
+	for _, metric := range collected {
+		actualMetrics[metric.GetName()] = metric.GetCounter()
+	}
+	require.Len(t, collected, len(expectedMetrics))
+	require.Equal(t, expectedMetrics, actualMetrics)
 }
 
 // TestMetricsServiceGetMetricsForwardsTags verifies that GetMetrics forwards


### PR DESCRIPTION
ACL metrics previously exposed only ACL-specific structural counters such as `acl_no_match` and `acl_action_*`. This change adds dedicated packet/byte metrics for `rx`, `tx`, `drop`, `pending_input`, and `pending_output`, while keeping histogram and per-rule counters excluded