### PR TITLE
feat(commonpb): add a fixed-width ipv4 address message

### DIFF
--- a/common/commonpb/v1/ipaddr.proto
+++ b/common/commonpb/v1/ipaddr.proto
@@ -19,3 +19,12 @@ message IPAddress {
   // Reserved for zone.
   reserved 2;
 }
+
+// IPv4Address represents an IPv4 host address.
+//
+// Unlike IPAddress, the family is fixed by the type and every value is a
+// valid address: there is no malformed state to validate after decoding.
+message IPv4Address {
+  // The address as a big-endian u32 value: 10.1.2.3 is 0x0A010203.
+  fixed32 addr = 1;
+}

--- a/common/commonpb/v1/ipv4addr.go
+++ b/common/commonpb/v1/ipv4addr.go
@@ -1,0 +1,76 @@
+package commonpb
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net/netip"
+)
+
+// NewIPv4AddressFromAddr creates an IPv4Address from a netip.Addr value.
+//
+// The input must be a native IPv4 value: IPv6 input is rejected,
+// including the IPv4-mapped form, which belongs to the IPv6 family on
+// the wire. Callers holding a mapped address unmap it first.
+func NewIPv4AddressFromAddr(addr netip.Addr) (*IPv4Address, error) {
+	if !addr.Is4() {
+		return nil, fmt.Errorf("not an IPv4 address: %s", addr)
+	}
+	return NewIPv4Address(addr.As4()), nil
+}
+
+// NewIPv4Address creates an IPv4Address from a 4-byte address in network
+// byte order.
+func NewIPv4Address(addr [4]byte) *IPv4Address {
+	return &IPv4Address{Addr: binary.BigEndian.Uint32(addr[:])}
+}
+
+// ToAddr converts the IPv4Address to a netip.Addr value.
+//
+// Every value is a valid address, so the conversion is total: the zero
+// message maps to the zero address. Whether an address is present at all
+// is the owning field's concern, not this message's.
+func (m *IPv4Address) ToAddr() netip.Addr {
+	var raw [4]byte
+	binary.BigEndian.PutUint32(raw[:], m.GetAddr())
+	return netip.AddrFrom4(raw)
+}
+
+// AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
+func (m *IPv4Address) AsLogValue() any {
+	return m.ToAddr().String()
+}
+
+// MarshalJSON serializes the message as a bare dotted-quad address
+// string.
+//
+// Unlike the mixed message's object form, there is no wrapping: the
+// value is the same bare string the Rust side renders, so both
+// languages share one JSON encoding.
+func (m *IPv4Address) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.ToAddr().String())
+}
+
+// UnmarshalJSON accepts a bare native IPv4 address string.
+func (m *IPv4Address) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw == "" {
+		return fmt.Errorf("empty IP address is not allowed")
+	}
+
+	parsed, err := netip.ParseAddr(raw)
+	if err != nil {
+		return fmt.Errorf("failed to parse IP address: %w", err)
+	}
+
+	addr, err := NewIPv4AddressFromAddr(parsed)
+	if err != nil {
+		return err
+	}
+
+	m.Addr = addr.Addr
+	return nil
+}

--- a/common/commonpb/v1/ipv4addr_test.go
+++ b/common/commonpb/v1/ipv4addr_test.go
@@ -1,0 +1,189 @@
+package commonpb_test
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+)
+
+// Test_NewIPv4AddressFromAddr_Valid verifies that native IPv4 input is
+// encoded as a big-endian u32.
+//
+// The fixture values mirror the Rust tests so a byte-order defect fails
+// identically in both languages.
+func Test_NewIPv4AddressFromAddr_Valid(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want uint32
+	}{
+		{name: "zero address", addr: "0.0.0.0", want: 0x00000000},
+		{name: "broadcast", addr: "255.255.255.255", want: 0xFFFFFFFF},
+		{name: "asymmetric octets", addr: "10.1.2.3", want: 0x0A010203},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip, err := commonpb.NewIPv4AddressFromAddr(netip.MustParseAddr(tt.addr))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, ip.Addr)
+		})
+	}
+}
+
+// Test_NewIPv4AddressFromAddr_RejectsNonIPv4 verifies that IPv6 input
+// and the invalid zero value return errors instead of being truncated.
+//
+// The IPv4-mapped form counts as IPv6 here: on the wire it belongs to
+// the IPv6 family.
+func Test_NewIPv4AddressFromAddr_RejectsNonIPv4(t *testing.T) {
+	tests := []struct {
+		name string
+		addr netip.Addr
+	}{
+		{name: "IPv6", addr: netip.MustParseAddr("2001:db8::1")},
+		{name: "IPv4-mapped IPv6", addr: netip.MustParseAddr("::ffff:10.1.2.3")},
+		{name: "zero value", addr: netip.Addr{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := commonpb.NewIPv4AddressFromAddr(tt.addr)
+			require.Error(t, err)
+		})
+	}
+}
+
+// Test_NewIPv4Address_NetworkByteOrder verifies that the first address
+// byte becomes the most significant byte of the encoded value.
+func Test_NewIPv4Address_NetworkByteOrder(t *testing.T) {
+	ip := commonpb.NewIPv4Address([4]byte{10, 1, 2, 3})
+	require.Equal(t, uint32(0x0A010203), ip.Addr)
+}
+
+// Test_IPv4Address_ToAddr_RoundTrip verifies that conversion to netip
+// and back preserves the address exactly.
+func Test_IPv4Address_ToAddr_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+	}{
+		{name: "zero address", addr: "0.0.0.0"},
+		{name: "broadcast", addr: "255.255.255.255"},
+		{name: "asymmetric octets", addr: "10.1.2.3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr := netip.MustParseAddr(tt.addr)
+			ip, err := commonpb.NewIPv4AddressFromAddr(addr)
+			require.NoError(t, err)
+			require.Equal(t, addr, ip.ToAddr())
+		})
+	}
+}
+
+// Test_IPv4Address_ToAddr_ZeroMessage verifies that the conversion is
+// total: the zero message is the zero address, not an error.
+func Test_IPv4Address_ToAddr_ZeroMessage(t *testing.T) {
+	ip := &commonpb.IPv4Address{}
+	require.Equal(t, netip.MustParseAddr("0.0.0.0"), ip.ToAddr())
+}
+
+// Test_IPv4Address_WireBytes verifies the fixed32 wire encoding against
+// a golden byte fixture.
+//
+// The fixture is shared with the Rust tests, so an endianness defect
+// fails identically in both languages.
+func Test_IPv4Address_WireBytes(t *testing.T) {
+	ip := commonpb.NewIPv4Address([4]byte{10, 1, 2, 3})
+	got, err := proto.Marshal(ip)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x0d, 0x03, 0x02, 0x01, 0x0a}, got)
+}
+
+// Test_IPv4Address_MarshalJSON verifies that the message serializes as
+// a bare dotted-quad string, the same form the Rust side emits.
+func Test_IPv4Address_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   *commonpb.IPv4Address
+		want string
+	}{
+		{
+			name: "asymmetric octets",
+			ip:   commonpb.NewIPv4Address([4]byte{10, 1, 2, 3}),
+			want: `"10.1.2.3"`,
+		},
+		{
+			name: "zero message",
+			ip:   &commonpb.IPv4Address{},
+			want: `"0.0.0.0"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.ip)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+// Test_IPv4Address_UnmarshalJSON verifies that only bare native IPv4
+// address strings are accepted.
+func Test_IPv4Address_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "IPv4", input: `"10.1.2.3"`, want: "10.1.2.3"},
+		{name: "IPv6", input: `"2001:db8::1"`, wantErr: true},
+		{name: "IPv4-mapped IPv6", input: `"::ffff:10.1.2.3"`, wantErr: true},
+		{name: "empty string", input: `""`, wantErr: true},
+		{name: "malformed address", input: `"not-an-ip"`, wantErr: true},
+		{name: "object form", input: `{"addr":"10.1.2.3"}`, wantErr: true},
+		{name: "invalid JSON", input: `"10.1`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ip commonpb.IPv4Address
+			err := json.Unmarshal([]byte(tt.input), &ip)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, netip.MustParseAddr(tt.want), ip.ToAddr())
+		})
+	}
+}
+
+// Test_IPv4Address_JSONRoundTrip verifies that marshaling and
+// unmarshaling reproduce the original message.
+func Test_IPv4Address_JSONRoundTrip(t *testing.T) {
+	original := commonpb.NewIPv4Address([4]byte{255, 255, 255, 255})
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var got commonpb.IPv4Address
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, original.Addr, got.Addr)
+}
+
+// Test_IPv4Address_AsLogValue verifies compact address rendering for
+// request logs.
+func Test_IPv4Address_AsLogValue(t *testing.T) {
+	ip := commonpb.NewIPv4Address([4]byte{10, 1, 2, 3})
+	require.Equal(t, "10.1.2.3", ip.AsLogValue())
+}

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -2,9 +2,10 @@ use core::error::Error;
 
 /// Messages that gain the ordinary `Serialize`/`Deserialize` derive.
 ///
-/// `IPAddress`, `MACAddress`, and `ContiguousIPNetwork` are deliberately
-/// absent: `src/lib.rs` hand-writes their `Serialize`/`Deserialize` impls to
-/// go straight to and from a plain string, and prost-build's attribute
+/// `IPAddress`, `IPv4Address`, `MACAddress`, and `ContiguousIPNetwork` are
+/// deliberately absent: `src/lib.rs` hand-writes their
+/// `Serialize`/`Deserialize` impls to go straight to and from a plain
+/// string, and prost-build's attribute
 /// paths are additive, not subtractive -- a blanket `message_attribute(".",
 /// ...)` cannot exclude a single message, so every other message is listed
 /// here individually instead.

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -175,6 +175,52 @@ impl<'de> Deserialize<'de> for pb::IpAddress {
     }
 }
 
+impl From<Ipv4Addr> for pb::IPv4Address {
+    fn from(addr: Ipv4Addr) -> Self {
+        pb::IPv4Address { addr: addr.to_bits() }
+    }
+}
+
+impl From<&pb::IPv4Address> for Ipv4Addr {
+    fn from(ip: &pb::IPv4Address) -> Self {
+        Ipv4Addr::from_bits(ip.addr)
+    }
+}
+
+impl Display for pb::IPv4Address {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        Ipv4Addr::from(self).fmt(f)
+    }
+}
+
+impl FromStr for pb::IPv4Address {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let addr = Ipv4Addr::from_str(s)?;
+        Ok(Self::from(addr))
+    }
+}
+
+impl Serialize for pb::IPv4Address {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for pb::IPv4Address {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<Self>().map_err(de::Error::custom)
+    }
+}
+
 impl From<(IpAddr, IpAddr)> for pb::IpRange {
     fn from((start, end): (IpAddr, IpAddr)) -> Self {
         pb::IpRange {
@@ -861,5 +907,52 @@ mod test {
         let json = serde_json::to_string(&malformed).unwrap();
         assert_eq!(r#""invalid""#, json);
         assert!(serde_json::from_str::<pb::ContiguousIpNetwork>(&json).is_err());
+    }
+
+    /// Verifies that the first address octet lands in the most
+    /// significant byte of the encoded value, in both directions.
+    ///
+    /// The fixture values mirror the Go tests so a byte-order defect
+    /// fails identically in both languages.
+    #[test]
+    fn test_ipv4_address_conversion_network_byte_order() {
+        let addr = pb::IPv4Address::from(Ipv4Addr::new(10, 1, 2, 3));
+        assert_eq!(0x0A010203, addr.addr);
+        assert_eq!(Ipv4Addr::new(10, 1, 2, 3), Ipv4Addr::from(&addr));
+    }
+
+    /// Verifies the fixed32 wire encoding against a golden byte fixture
+    /// shared with the Go tests.
+    #[test]
+    fn test_ipv4_address_wire_bytes_golden() {
+        use prost::Message;
+
+        let addr = pb::IPv4Address { addr: 0x0A010203 };
+        assert_eq!(vec![0x0d, 0x03, 0x02, 0x01, 0x0a], addr.encode_to_vec());
+    }
+
+    #[test]
+    fn test_ipv4_address_display_boundary_values() {
+        assert_eq!("0.0.0.0", pb::IPv4Address { addr: 0 }.to_string());
+        assert_eq!("255.255.255.255", pb::IPv4Address { addr: u32::MAX }.to_string());
+    }
+
+    #[test]
+    fn test_ipv4_address_serde_string_round_trip() {
+        let addr = pb::IPv4Address::from(Ipv4Addr::new(10, 1, 2, 3));
+        let json = serde_json::to_string(&addr).unwrap();
+        assert_eq!(r#""10.1.2.3""#, json);
+        let got: pb::IPv4Address = serde_json::from_str(&json).unwrap();
+        assert_eq!(addr, got);
+    }
+
+    #[test]
+    fn test_ipv4_address_from_str_rejects_ipv6() {
+        assert!("2001:db8::1".parse::<pb::IPv4Address>().is_err());
+    }
+
+    #[test]
+    fn test_ipv4_address_from_str_rejects_ipv4_mapped() {
+        assert!("::ffff:10.1.2.3".parse::<pb::IPv4Address>().is_err());
     }
 }


### PR DESCRIPTION
- Adds an IPv4Address message carrying the address as one fixed32 in network byte order, so every value is a valid address with no malformed-length state.
- Adds Go helpers mirroring the mixed-family message surface: netip conversions that reject IPv6 and IPv4-mapped input, a total conversion back, compact log rendering, and dotted-quad JSON.
- Adds Rust conversions, Display, FromStr, and hand-written string-form serde excluded from the derive list.
- Pins the byte-order contract with shared cross-language fixtures, including a golden wire-bytes test.

Closes #2198.
