### PR TITLE
fix(acl): scope grpc metrics to own services

### DIFF
--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -7,15 +7,13 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
-	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
 )
 
 const (
-	moduleType  = "acl"
-	agentName   = moduleType
-	serviceName = "modules.acl.controlplane.aclpb.v1.ACLService"
+	moduleType = "acl"
+	agentName  = moduleType
 )
 
 // ModuleOption configures the ACLModule constructor.
@@ -55,7 +53,7 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 		o(opts)
 	}
 
-	log := opts.Log.With(zap.String("module", serviceName))
+	log := opts.Log.With(zap.String("module", ACLServiceName))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
@@ -78,9 +76,7 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 	aclService := NewACLService(
 		NewBackend(agent),
 		WithLog(log),
-		WithMetrics(grpcmetrics.NewFactory(
-			grpcmetrics.WithLabeler(labeler),
-		)),
+		WithMetrics(NewMetricsFactory()),
 	)
 
 	metricsService := NewMetricsService(aclService)
@@ -104,8 +100,8 @@ func (m *ACLModule) Endpoint() string {
 
 func (m *ACLModule) ServicesNames() []string {
 	return []string{
-		serviceName,
-		aclpb.MetricsService_ServiceDesc.ServiceName,
+		ACLServiceName,
+		ACLMetricsServiceName,
 	}
 }
 

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -100,18 +100,22 @@ var (
 // NewMetricsFactory returns a [grpcmetrics.Factory] pre-bound to this module's
 // own labeler and service filter, applying any extra options (e.g. custom
 // histogram buckets) supplied by the caller.
+//
+// The labeler and the service filter are applied after the extra options,
+// so a caller cannot override the module's scoping. Any retention provider
+// passed here is ignored: the service injects its own at construction time.
 func NewMetricsFactory(extra ...grpcmetrics.Option) grpcmetrics.Factory {
 	opts := make([]grpcmetrics.Option, 0, len(extra)+2)
-	opts = append(opts, grpcmetrics.WithLabeler(labeler))
-
-	// Scope the collector to this module's own services.
-	opts = append(opts, grpcmetrics.WithServiceFilter(
-		func(service string) bool {
-			return service == ACLServiceName ||
-				service == ACLMetricsServiceName
-		},
-	))
 	opts = append(opts, extra...)
+	opts = append(opts,
+		grpcmetrics.WithLabeler(labeler),
+		grpcmetrics.WithServiceFilter(
+			func(service string) bool {
+				return service == ACLServiceName ||
+					service == ACLMetricsServiceName
+			},
+		),
+	)
 	return grpcmetrics.NewFactory(opts...)
 }
 

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -78,11 +78,41 @@ func WithLog(log *zap.Logger) Option {
 
 // WithMetrics sets the gRPC metrics factory.
 //
-// When unset, no metrics are collected.
+// When unset, no metrics are collected. Use [NewMetricsFactory] to build a
+// factory scoped to this module's services.
 func WithMetrics(factory grpcmetrics.Factory) Option {
 	return func(o *options) {
 		o.Metrics = factory
 	}
+}
+
+// ACLServiceName and ACLMetricsServiceName are the fully-qualified gRPC
+// service names exposed by this module, derived from the generated service
+// descriptors so they cannot drift from the proto definitions.
+//
+// They are used to scope the module's [grpcmetrics.ServerMetrics] to its own
+// services when several modules share a single [grpc.Server].
+var (
+	ACLServiceName        = aclpb.ACLService_ServiceDesc.ServiceName
+	ACLMetricsServiceName = aclpb.MetricsService_ServiceDesc.ServiceName
+)
+
+// NewMetricsFactory returns a [grpcmetrics.Factory] pre-bound to this module's
+// own labeler and service filter, applying any extra options (e.g. custom
+// histogram buckets) supplied by the caller.
+func NewMetricsFactory(extra ...grpcmetrics.Option) grpcmetrics.Factory {
+	opts := make([]grpcmetrics.Option, 0, len(extra)+2)
+	opts = append(opts, grpcmetrics.WithLabeler(labeler))
+
+	// Scope the collector to this module's own services.
+	opts = append(opts, grpcmetrics.WithServiceFilter(
+		func(service string) bool {
+			return service == ACLServiceName ||
+				service == ACLMetricsServiceName
+		},
+	))
+	opts = append(opts, extra...)
+	return grpcmetrics.NewFactory(opts...)
 }
 
 type aclConfig struct {

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -1204,6 +1204,49 @@ func TestMetrics_DoesNotWaitForUpdateConfig(t *testing.T) {
 	}
 }
 
+// Test_NewMetricsFactory_ScopesToOwnServices verifies that the module's
+// metrics factory records only the services the ACL module registers, so a
+// foreign service sharing the module server records no series.
+func Test_NewMetricsFactory_ScopesToOwnServices(t *testing.T) {
+	svc := acl.NewACLService(newFakeBackend(), acl.WithMetrics(acl.NewMetricsFactory()))
+
+	okHandler := func(context.Context, any) (any, error) {
+		return &aclpb.ListConfigsResponse{}, nil
+	}
+	// The requests carry no config label so the service's retention keeps the
+	// recorded series.
+	for _, fullMethod := range []string{
+		"/" + acl.ACLServiceName + "/ListConfigs",
+		"/" + acl.ACLMetricsServiceName + "/GetMetrics",
+		"/modules.fwstate.controlplane.fwstatepb.v1.FWStateService/ShowConfig",
+		"/modules.fwstate.controlplane.fwstatepb.v1.MetricsService/GetMetrics",
+	} {
+		_, err := svc.UnaryServerInterceptor()(
+			t.Context(),
+			&aclpb.ListConfigsRequest{},
+			&grpc.UnaryServerInfo{FullMethod: fullMethod},
+			okHandler,
+		)
+		require.NoError(t, err)
+	}
+
+	collected, err := svc.Metrics()
+	require.NoError(t, err)
+
+	services := map[string]struct{}{}
+	for _, metric := range collected {
+		for _, label := range metric.GetLabels() {
+			if label.GetName() == "grpc_service" {
+				services[label.GetValue()] = struct{}{}
+			}
+		}
+	}
+	assert.Equal(t, map[string]struct{}{
+		acl.ACLServiceName:        {},
+		acl.ACLMetricsServiceName: {},
+	}, services)
+}
+
 func TestMetricsSnapshotTracksConfigLifecycle(t *testing.T) {
 	_, agent := newMetricsSnapshotHarness(t)
 	backend := newBlockingDPConfigBackend(agent.DPConfig())


### PR DESCRIPTION
- Introduce acl.NewMetricsFactory() pre-binding the module's labeler and a service filter admitting only the ACL and ACL Metrics service names, mirroring the fwstate module's factory pattern.
- Derive the service-name constants from the generated descriptors and use them in the module wiring, replacing the hand-written FQN string.
- Cover the scoping with a regression test asserting foreign services sharing the module server record no series.

Refs #1743.