### PR TITLE
feat(commonpb): add a fixed-width ipv6 address message

### DIFF
--- a/common/commonpb/v1/ipaddr.proto
+++ b/common/commonpb/v1/ipaddr.proto
@@ -28,3 +28,20 @@ message IPv4Address {
   // The address as a big-endian u32 value: 10.1.2.3 is 0x0A010203.
   fixed32 addr = 1;
 }
+
+// IPv6Address represents an IPv6 host address.
+//
+// Unlike IPAddress, the family is fixed by the type and every value is a
+// valid address: there is no malformed state to validate after decoding.
+// IPv4-mapped addresses belong to this family, distinct from the same
+// address in its IPv4Address form.
+message IPv6Address {
+  // Address bytes 0-7 as a big-endian u64.
+  //
+  // For 2a02:6b8:0:1::100 this is 0x2a0206b800000001.
+  fixed64 hi = 1;
+  // Address bytes 8-15 as a big-endian u64.
+  //
+  // For 2a02:6b8:0:1::100 this is 0x0000000000000100.
+  fixed64 lo = 2;
+}

--- a/common/commonpb/v1/ipv6addr.go
+++ b/common/commonpb/v1/ipv6addr.go
@@ -1,0 +1,81 @@
+package commonpb
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net/netip"
+)
+
+// NewIPv6AddressFromAddr creates an IPv6Address from a netip.Addr value.
+//
+// The input must be an IPv6 value; the IPv4-mapped form is accepted as
+// IPv6. Zoned addresses are rejected rather than silently stripped: a
+// zone is host-local and belongs as a sibling field on the owning
+// message.
+func NewIPv6AddressFromAddr(addr netip.Addr) (*IPv6Address, error) {
+	if addr.Zone() != "" {
+		return nil, fmt.Errorf("zoned IPv6 address is not allowed: %s", addr)
+	}
+	if !addr.Is6() {
+		return nil, fmt.Errorf("not an IPv6 address: %s", addr)
+	}
+	return NewIPv6Address(addr.As16()), nil
+}
+
+// NewIPv6Address creates an IPv6Address from a 16-byte address in
+// network byte order.
+func NewIPv6Address(addr [16]byte) *IPv6Address {
+	return &IPv6Address{
+		Hi: binary.BigEndian.Uint64(addr[:8]),
+		Lo: binary.BigEndian.Uint64(addr[8:]),
+	}
+}
+
+// ToAddr converts the IPv6Address to a netip.Addr value.
+//
+// Every value is a valid address, so the conversion is total: the zero
+// message maps to the zero address. Whether an address is present at all
+// is the owning field's concern, not this message's.
+func (m *IPv6Address) ToAddr() netip.Addr {
+	var raw [16]byte
+	binary.BigEndian.PutUint64(raw[:8], m.GetHi())
+	binary.BigEndian.PutUint64(raw[8:], m.GetLo())
+	return netip.AddrFrom16(raw)
+}
+
+// AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
+func (m *IPv6Address) AsLogValue() any {
+	return m.ToAddr().String()
+}
+
+// MarshalJSON serializes the message as a bare IPv6 address string, the
+// same form the Rust side renders.
+func (m *IPv6Address) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.ToAddr().String())
+}
+
+// UnmarshalJSON accepts a bare IPv6 address string.
+func (m *IPv6Address) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw == "" {
+		return fmt.Errorf("empty IP address is not allowed")
+	}
+
+	parsed, err := netip.ParseAddr(raw)
+	if err != nil {
+		return fmt.Errorf("failed to parse IP address: %w", err)
+	}
+
+	addr, err := NewIPv6AddressFromAddr(parsed)
+	if err != nil {
+		return err
+	}
+
+	m.Hi = addr.Hi
+	m.Lo = addr.Lo
+	return nil
+}

--- a/common/commonpb/v1/ipv6addr_test.go
+++ b/common/commonpb/v1/ipv6addr_test.go
@@ -1,0 +1,241 @@
+package commonpb_test
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+)
+
+// Test_NewIPv6AddressFromAddr_Valid verifies that IPv6 input splits into
+// big-endian u64 halves along the byte 0-7 / 8-15 boundary.
+//
+// The fixture values mirror the Rust tests so a half-swap or endianness
+// defect fails identically in both languages.
+func Test_NewIPv6AddressFromAddr_Valid(t *testing.T) {
+	tests := []struct {
+		name   string
+		addr   string
+		wantHi uint64
+		wantLo uint64
+	}{
+		{name: "zero address", addr: "::", wantHi: 0, wantLo: 0},
+		{name: "loopback", addr: "::1", wantHi: 0, wantLo: 1},
+		{
+			name:   "asymmetric halves",
+			addr:   "2a02:6b8:0:1::100",
+			wantHi: 0x2a0206b800000001,
+			wantLo: 0x0000000000000100,
+		},
+		{
+			name:   "IPv4-mapped IPv6",
+			addr:   "::ffff:10.1.2.3",
+			wantHi: 0,
+			wantLo: 0x0000ffff0a010203,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip, err := commonpb.NewIPv6AddressFromAddr(netip.MustParseAddr(tt.addr))
+			require.NoError(t, err)
+			require.Equal(t, tt.wantHi, ip.Hi)
+			require.Equal(t, tt.wantLo, ip.Lo)
+		})
+	}
+}
+
+// Test_NewIPv6AddressFromAddr_RejectsNonIPv6 verifies that native IPv4
+// input, zoned addresses, and the invalid zero value return errors.
+func Test_NewIPv6AddressFromAddr_RejectsNonIPv6(t *testing.T) {
+	tests := []struct {
+		name string
+		addr netip.Addr
+	}{
+		{name: "native IPv4", addr: netip.MustParseAddr("10.1.2.3")},
+		{name: "zoned link-local", addr: netip.MustParseAddr("fe80::1%eth0")},
+		{name: "zero value", addr: netip.Addr{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := commonpb.NewIPv6AddressFromAddr(tt.addr)
+			require.Error(t, err)
+		})
+	}
+}
+
+// Test_NewIPv6Address_NetworkByteOrder verifies that the first address
+// byte becomes the most significant byte of the high half.
+func Test_NewIPv6Address_NetworkByteOrder(t *testing.T) {
+	raw := [16]byte{
+		0x2a, 0x02, 0x06, 0xb8, 0x00, 0x00, 0x00, 0x01,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+	}
+	ip := commonpb.NewIPv6Address(raw)
+	require.Equal(t, uint64(0x2a0206b800000001), ip.Hi)
+	require.Equal(t, uint64(0x0000000000000100), ip.Lo)
+}
+
+// Test_IPv6Address_ToAddr_RoundTrip verifies that conversion to netip
+// and back preserves the address exactly, mapped form included.
+func Test_IPv6Address_ToAddr_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+	}{
+		{name: "zero address", addr: "::"},
+		{name: "asymmetric halves", addr: "2a02:6b8:0:1::100"},
+		{name: "IPv4-mapped IPv6", addr: "::ffff:10.1.2.3"},
+		{name: "all ones", addr: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr := netip.MustParseAddr(tt.addr)
+			ip, err := commonpb.NewIPv6AddressFromAddr(addr)
+			require.NoError(t, err)
+			require.Equal(t, addr, ip.ToAddr())
+		})
+	}
+}
+
+// Test_IPv6Address_ToAddr_ZeroMessage verifies that the conversion is
+// total: the zero message is the zero address, not an error.
+func Test_IPv6Address_ToAddr_ZeroMessage(t *testing.T) {
+	ip := &commonpb.IPv6Address{}
+	require.Equal(t, netip.MustParseAddr("::"), ip.ToAddr())
+}
+
+// Test_IPv6Address_WireBytes verifies the two-fixed64 wire encoding
+// against a golden byte fixture.
+//
+// The fixture is shared with the Rust tests, so a half-swap or
+// endianness defect fails identically in both languages.
+func Test_IPv6Address_WireBytes(t *testing.T) {
+	ip, err := commonpb.NewIPv6AddressFromAddr(netip.MustParseAddr("2a02:6b8:0:1::100"))
+	require.NoError(t, err)
+	got, err := proto.Marshal(ip)
+	require.NoError(t, err)
+	require.Equal(t, []byte{
+		0x09, 0x01, 0x00, 0x00, 0x00, 0xb8, 0x06, 0x02, 0x2a,
+		0x11, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}, got)
+}
+
+// Test_IPv6Address_MarshalJSON verifies that the message serializes as
+// a bare IPv6 address string, the same form the Rust side emits.
+func Test_IPv6Address_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   *commonpb.IPv6Address
+		want string
+	}{
+		{
+			name: "asymmetric halves",
+			ip:   &commonpb.IPv6Address{Hi: 0x2a0206b800000001, Lo: 0x0000000000000100},
+			want: `"2a02:6b8:0:1::100"`,
+		},
+		{
+			name: "IPv4-mapped IPv6",
+			ip:   &commonpb.IPv6Address{Hi: 0, Lo: 0x0000ffff0a010203},
+			want: `"::ffff:10.1.2.3"`,
+		},
+		{
+			name: "loopback",
+			ip:   &commonpb.IPv6Address{Hi: 0, Lo: 1},
+			want: `"::1"`,
+		},
+		{
+			name: "zero message",
+			ip:   &commonpb.IPv6Address{},
+			want: `"::"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.ip)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+// Test_IPv6Address_UnmarshalJSON verifies that only bare unzoned IPv6
+// address strings are accepted, the mapped form included.
+func Test_IPv6Address_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "IPv6", input: `"2a02:6b8:0:1::100"`, want: "2a02:6b8:0:1::100"},
+		{name: "IPv4-mapped IPv6", input: `"::ffff:10.1.2.3"`, want: "::ffff:10.1.2.3"},
+		{name: "native IPv4", input: `"10.1.2.3"`, wantErr: true},
+		{name: "zoned link-local", input: `"fe80::1%eth0"`, wantErr: true},
+		{name: "empty string", input: `""`, wantErr: true},
+		{name: "malformed address", input: `"not-an-ip"`, wantErr: true},
+		{name: "object form", input: `{"hi":1,"lo":2}`, wantErr: true},
+		{name: "invalid JSON", input: `"2a02`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ip commonpb.IPv6Address
+			err := json.Unmarshal([]byte(tt.input), &ip)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, netip.MustParseAddr(tt.want), ip.ToAddr())
+		})
+	}
+}
+
+// Test_IPv6Address_JSONRoundTrip verifies that marshaling and
+// unmarshaling reproduce the original message, mapped form included.
+func Test_IPv6Address_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   *commonpb.IPv6Address
+	}{
+		{
+			name: "asymmetric halves",
+			ip:   &commonpb.IPv6Address{Hi: 0x2a0206b800000001, Lo: 0x0000000000000100},
+		},
+		{
+			name: "IPv4-mapped IPv6",
+			ip:   &commonpb.IPv6Address{Hi: 0, Lo: 0x0000ffff0a010203},
+		},
+		{
+			name: "loopback",
+			ip:   &commonpb.IPv6Address{Hi: 0, Lo: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.ip)
+			require.NoError(t, err)
+
+			var got commonpb.IPv6Address
+			require.NoError(t, json.Unmarshal(data, &got))
+			require.Equal(t, tt.ip.Hi, got.Hi)
+			require.Equal(t, tt.ip.Lo, got.Lo)
+		})
+	}
+}
+
+// Test_IPv6Address_AsLogValue verifies compact address rendering for
+// request logs.
+func Test_IPv6Address_AsLogValue(t *testing.T) {
+	ip := &commonpb.IPv6Address{Hi: 0x2a0206b800000001, Lo: 0x0000000000000100}
+	require.Equal(t, "2a02:6b8:0:1::100", ip.AsLogValue())
+}

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -2,10 +2,10 @@ use core::error::Error;
 
 /// Messages that gain the ordinary `Serialize`/`Deserialize` derive.
 ///
-/// `IPAddress`, `IPv4Address`, `MACAddress`, and `ContiguousIPNetwork` are
-/// deliberately absent: `src/lib.rs` hand-writes their
-/// `Serialize`/`Deserialize` impls to go straight to and from a plain
-/// string, and prost-build's attribute
+/// `IPAddress`, `IPv4Address`, `IPv6Address`, `MACAddress`, and
+/// `ContiguousIPNetwork` are deliberately absent: `src/lib.rs` hand-writes
+/// their `Serialize`/`Deserialize` impls to go straight to and from a
+/// plain string, and prost-build's attribute
 /// paths are additive, not subtractive -- a blanket `message_attribute(".",
 /// ...)` cannot exclude a single message, so every other message is listed
 /// here individually instead.

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -221,6 +221,56 @@ impl<'de> Deserialize<'de> for pb::IPv4Address {
     }
 }
 
+impl From<Ipv6Addr> for pb::IPv6Address {
+    fn from(addr: Ipv6Addr) -> Self {
+        let bits = addr.to_bits();
+        pb::IPv6Address {
+            hi: (bits >> 64) as u64,
+            lo: bits as u64,
+        }
+    }
+}
+
+impl From<&pb::IPv6Address> for Ipv6Addr {
+    fn from(ip: &pb::IPv6Address) -> Self {
+        Ipv6Addr::from_bits((u128::from(ip.hi) << 64) | u128::from(ip.lo))
+    }
+}
+
+impl Display for pb::IPv6Address {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        Ipv6Addr::from(self).fmt(f)
+    }
+}
+
+impl FromStr for pb::IPv6Address {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let addr = Ipv6Addr::from_str(s)?;
+        Ok(Self::from(addr))
+    }
+}
+
+impl Serialize for pb::IPv6Address {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for pb::IPv6Address {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<Self>().map_err(de::Error::custom)
+    }
+}
+
 impl From<(IpAddr, IpAddr)> for pb::IpRange {
     fn from((start, end): (IpAddr, IpAddr)) -> Self {
         pb::IpRange {
@@ -954,5 +1004,74 @@ mod test {
     #[test]
     fn test_ipv4_address_from_str_rejects_ipv4_mapped() {
         assert!("::ffff:10.1.2.3".parse::<pb::IPv4Address>().is_err());
+    }
+
+    /// Verifies that address bytes 0-7 land in the high half and bytes
+    /// 8-15 in the low half, both big-endian, in both directions.
+    ///
+    /// The fixture values mirror the Go tests so a half-swap or
+    /// endianness defect fails identically in both languages.
+    #[test]
+    fn test_ipv6_address_conversion_network_byte_order() {
+        let source = Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, 0x100);
+        let addr = pb::IPv6Address::from(source);
+        assert_eq!(0x2a0206b800000001, addr.hi);
+        assert_eq!(0x0000000000000100, addr.lo);
+        assert_eq!(source, Ipv6Addr::from(&addr));
+    }
+
+    /// Verifies the two-fixed64 wire encoding against a golden byte
+    /// fixture shared with the Go tests.
+    #[test]
+    fn test_ipv6_address_wire_bytes_golden() {
+        use prost::Message;
+
+        let addr = pb::IPv6Address {
+            hi: 0x2a0206b800000001,
+            lo: 0x0000000000000100,
+        };
+        assert_eq!(
+            vec![
+                0x09, 0x01, 0x00, 0x00, 0x00, 0xb8, 0x06, 0x02, 0x2a, 0x11, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00,
+            ],
+            addr.encode_to_vec()
+        );
+    }
+
+    #[test]
+    fn test_ipv6_address_display_boundary_values() {
+        assert_eq!("::", pb::IPv6Address { hi: 0, lo: 0 }.to_string());
+        assert_eq!(
+            "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            pb::IPv6Address { hi: u64::MAX, lo: u64::MAX }.to_string()
+        );
+    }
+
+    /// Verifies that the IPv4-mapped form stays in its mapped rendering
+    /// instead of collapsing to the bare IPv4 string.
+    #[test]
+    fn test_ipv6_address_display_keeps_ipv4_mapped_form() {
+        let addr = pb::IPv6Address { hi: 0, lo: 0x0000ffff0a010203 };
+        assert_eq!("::ffff:10.1.2.3", addr.to_string());
+    }
+
+    #[test]
+    fn test_ipv6_address_serde_string_round_trip() {
+        let addr = pb::IPv6Address::from(Ipv6Addr::new(0x2a02, 0x6b8, 0, 1, 0, 0, 0, 0x100));
+        let json = serde_json::to_string(&addr).unwrap();
+        assert_eq!(r#""2a02:6b8:0:1::100""#, json);
+        let got: pb::IPv6Address = serde_json::from_str(&json).unwrap();
+        assert_eq!(addr, got);
+    }
+
+    #[test]
+    fn test_ipv6_address_from_str_rejects_ipv4() {
+        assert!("10.1.2.3".parse::<pb::IPv6Address>().is_err());
+    }
+
+    #[test]
+    fn test_ipv6_address_from_str_rejects_zoned() {
+        assert!("fe80::1%eth0".parse::<pb::IPv6Address>().is_err());
     }
 }


### PR DESCRIPTION
- Adds an IPv6Address message carrying the address as two fixed64 halves in network byte order, so every value is a valid address with no malformed-length state.
- Adds Go helpers mirroring the IPv4 sibling: netip conversions that accept the IPv4-mapped form but reject native IPv4 and zoned input, a total conversion back, compact log rendering, and bare-string JSON.
- Adds Rust conversions, Display that keeps the IPv4-mapped rendering, FromStr, and hand-written string-form serde excluded from the derive list.
- Pins the half-split and byte-order contract with shared cross-language fixtures, including a golden wire-bytes test.

Closes #2199.
