### PR TITLE
style(commonpb): reshape the ipv4 address field comment

### DIFF
--- a/common/commonpb/v1/ipaddr.proto
+++ b/common/commonpb/v1/ipaddr.proto
@@ -25,6 +25,8 @@ message IPAddress {
 // Unlike IPAddress, the family is fixed by the type and every value is a
 // valid address: there is no malformed state to validate after decoding.
 message IPv4Address {
-  // The address as a big-endian u32 value: 10.1.2.3 is 0x0A010203.
+  // The address as a big-endian u32 value.
+  //
+  // 10.1.2.3 is 0x0a010203.
   fixed32 addr = 1;
 }

--- a/common/commonpb/v1/ipv4addr_test.go
+++ b/common/commonpb/v1/ipv4addr_test.go
@@ -23,8 +23,8 @@ func Test_NewIPv4AddressFromAddr_Valid(t *testing.T) {
 		want uint32
 	}{
 		{name: "zero address", addr: "0.0.0.0", want: 0x00000000},
-		{name: "broadcast", addr: "255.255.255.255", want: 0xFFFFFFFF},
-		{name: "asymmetric octets", addr: "10.1.2.3", want: 0x0A010203},
+		{name: "broadcast", addr: "255.255.255.255", want: 0xffffffff},
+		{name: "asymmetric octets", addr: "10.1.2.3", want: 0x0a010203},
 	}
 
 	for _, tt := range tests {
@@ -63,7 +63,7 @@ func Test_NewIPv4AddressFromAddr_RejectsNonIPv4(t *testing.T) {
 // byte becomes the most significant byte of the encoded value.
 func Test_NewIPv4Address_NetworkByteOrder(t *testing.T) {
 	ip := commonpb.NewIPv4Address([4]byte{10, 1, 2, 3})
-	require.Equal(t, uint32(0x0A010203), ip.Addr)
+	require.Equal(t, uint32(0x0a010203), ip.Addr)
 }
 
 // Test_IPv4Address_ToAddr_RoundTrip verifies that conversion to netip

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -917,7 +917,7 @@ mod test {
     #[test]
     fn test_ipv4_address_conversion_network_byte_order() {
         let addr = pb::IPv4Address::from(Ipv4Addr::new(10, 1, 2, 3));
-        assert_eq!(0x0A010203, addr.addr);
+        assert_eq!(0x0a010203, addr.addr);
         assert_eq!(Ipv4Addr::new(10, 1, 2, 3), Ipv4Addr::from(&addr));
     }
 
@@ -927,7 +927,7 @@ mod test {
     fn test_ipv4_address_wire_bytes_golden() {
         use prost::Message;
 
-        let addr = pb::IPv4Address { addr: 0x0A010203 };
+        let addr = pb::IPv4Address { addr: 0x0a010203 };
         assert_eq!(vec![0x0d, 0x03, 0x02, 0x01, 0x0a], addr.encode_to_vec());
     }
 


### PR DESCRIPTION
- Reshapes the IPv4Address field comment into the brief, blank line, example structure, matching the sibling messages.
- Lowercases the shared hex fixtures in the Go and Rust tests.
