### PR TITLE
feat(commonpb): add a family-typed contiguous ipv4 network message

### DIFF
--- a/common/commonpb/v1/ipnetwork.proto
+++ b/common/commonpb/v1/ipnetwork.proto
@@ -21,3 +21,20 @@ message ContiguousIPNetwork {
   // MUST be <= 32 for a 4-byte addr and <= 128 for a 16-byte addr.
   uint32 prefix_len = 2;
 }
+
+// ContiguousIPv4Network represents an IPv4 CIDR prefix.
+//
+// Unlike ContiguousIPNetwork, the family is fixed by the type: the
+// address cannot carry IPv6, and an absent addr is the only malformed
+// state.
+message ContiguousIPv4Network {
+  // Network base address.
+  //
+  // MUST be present. Host bits below prefix_len are masked off on
+  // decode, so producers need not normalize.
+  IPv4Address addr = 1;
+  // Prefix length, in bits.
+  //
+  // MUST be <= 32.
+  uint32 prefix_len = 2;
+}

--- a/common/commonpb/v1/ipv4network.go
+++ b/common/commonpb/v1/ipv4network.go
@@ -1,0 +1,114 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/netip"
+
+	"github.com/yanet-platform/xnetip"
+)
+
+// NewContiguousIPv4NetworkFromContiguous creates a ContiguousIPv4Network
+// from an xnetip IPv4 CIDR block.
+//
+// The conversion is total: the block is masked by its own invariant. The
+// inverse of ToContiguous.
+func NewContiguousIPv4NetworkFromContiguous(net xnetip.Contiguous[xnetip.Network4]) *ContiguousIPv4Network {
+	return &ContiguousIPv4Network{
+		Addr:      NewIPv4Address(net.Network().Addr().As4()),
+		PrefixLen: uint32(net.PrefixLen()),
+	}
+}
+
+// NewContiguousIPv4NetworkFromPrefix creates a ContiguousIPv4Network from
+// a netip.Prefix value, masking off any host bits.
+//
+// Returns an error if prefix is not a valid IPv4 prefix; the IPv4-mapped
+// form counts as IPv6 here, consistently with IPv4Address.
+func NewContiguousIPv4NetworkFromPrefix(prefix netip.Prefix) (*ContiguousIPv4Network, error) {
+	net, ok := xnetip.ContiguousFromPrefix4(prefix)
+	if !ok {
+		return nil, fmt.Errorf("not a valid IPv4 prefix: %s", prefix)
+	}
+	return NewContiguousIPv4NetworkFromContiguous(net), nil
+}
+
+// ParseContiguousIPv4Network parses s as an IPv4 CIDR prefix, masking off
+// any host bits.
+func ParseContiguousIPv4Network(s string) (*ContiguousIPv4Network, error) {
+	prefix, err := netip.ParsePrefix(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse IP network: %w", err)
+	}
+	return NewContiguousIPv4NetworkFromPrefix(prefix)
+}
+
+// ToContiguous converts the ContiguousIPv4Network to an xnetip IPv4 CIDR
+// block.
+//
+// Returns an error if addr is absent or prefix_len exceeds 32; the
+// latter wraps xnetip.ErrCIDROverflow. The returned block is masked, so
+// host bits never leak out even if the message was constructed by hand.
+// The inverse of NewContiguousIPv4NetworkFromContiguous.
+func (m *ContiguousIPv4Network) ToContiguous() (xnetip.Contiguous[xnetip.Network4], error) {
+	if m.GetAddr() == nil {
+		return xnetip.Contiguous[xnetip.Network4]{}, fmt.Errorf("missing network address")
+	}
+	net, err := xnetip.ContiguousFromCIDR4(m.GetAddr().ToAddr(), int(m.GetPrefixLen()))
+	if err != nil {
+		return xnetip.Contiguous[xnetip.Network4]{}, fmt.Errorf("failed to build IP network: %w", err)
+	}
+	return net, nil
+}
+
+// ToPrefix converts the ContiguousIPv4Network back to a masked
+// netip.Prefix value.
+//
+// Returns an error exactly when ToContiguous does.
+func (m *ContiguousIPv4Network) ToPrefix() (netip.Prefix, error) {
+	net, err := m.ToContiguous()
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+	return net.Prefix(), nil
+}
+
+// AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
+func (m *ContiguousIPv4Network) AsLogValue() any {
+	prefix, err := m.ToPrefix()
+	if err != nil {
+		return "invalid"
+	}
+
+	return prefix.String()
+}
+
+// MarshalJSON serializes the network as a bare CIDR string, the same
+// form the Rust side renders.
+func (m *ContiguousIPv4Network) MarshalJSON() ([]byte, error) {
+	prefix, err := m.ToPrefix()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(prefix.String())
+}
+
+// UnmarshalJSON accepts a bare IPv4 CIDR string.
+func (m *ContiguousIPv4Network) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw == "" {
+		return fmt.Errorf("empty IP network is not allowed")
+	}
+
+	parsed, err := ParseContiguousIPv4Network(raw)
+	if err != nil {
+		return err
+	}
+
+	m.Addr = parsed.Addr
+	m.PrefixLen = parsed.PrefixLen
+	return nil
+}

--- a/common/commonpb/v1/ipv4network_test.go
+++ b/common/commonpb/v1/ipv4network_test.go
@@ -1,0 +1,268 @@
+package commonpb_test
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yanet-platform/xnetip"
+	"google.golang.org/protobuf/proto"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+)
+
+// Test_NewContiguousIPv4NetworkFromPrefix_Valid verifies that IPv4
+// prefixes are encoded with the typed address and their length.
+//
+// The fixture values mirror the Rust tests so an encoding defect fails
+// identically in both languages.
+func Test_NewContiguousIPv4NetworkFromPrefix_Valid(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		wantAddr uint32
+		wantLen  uint32
+	}{
+		{name: "default route", prefix: "0.0.0.0/0", wantAddr: 0, wantLen: 0},
+		{name: "private eight", prefix: "10.0.0.0/8", wantAddr: 0x0a000000, wantLen: 8},
+		{name: "host route", prefix: "10.1.2.3/32", wantAddr: 0x0a010203, wantLen: 32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix(tt.prefix))
+			require.NoError(t, err)
+			require.Equal(t, tt.wantAddr, network.Addr.Addr)
+			require.Equal(t, tt.wantLen, network.PrefixLen)
+		})
+	}
+}
+
+// Test_NewContiguousIPv4NetworkFromPrefix_MasksHostBits verifies that
+// host bits below the prefix length are cleared at construction.
+func Test_NewContiguousIPv4NetworkFromPrefix_MasksHostBits(t *testing.T) {
+	network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("10.1.2.3/24"))
+	require.NoError(t, err)
+	require.Equal(t, uint32(0x0a010200), network.Addr.Addr)
+	require.Equal(t, uint32(24), network.PrefixLen)
+}
+
+// Test_NewContiguousIPv4NetworkFromPrefix_RejectsNonIPv4 verifies that
+// non-IPv4 prefixes and the invalid zero value return errors.
+//
+// The IPv4-mapped form counts as IPv6 here, consistently with the typed
+// address message.
+func Test_NewContiguousIPv4NetworkFromPrefix_RejectsNonIPv4(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix netip.Prefix
+	}{
+		{name: "IPv6", prefix: netip.MustParsePrefix("2a02:6b8::/32")},
+		{name: "IPv4-mapped IPv6", prefix: netip.MustParsePrefix("::ffff:10.0.0.0/104")},
+		{name: "zero value", prefix: netip.Prefix{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := commonpb.NewContiguousIPv4NetworkFromPrefix(tt.prefix)
+			require.Error(t, err)
+		})
+	}
+}
+
+// Test_ContiguousIPv4Network_ToPrefix_RoundTrip verifies that conversion
+// to netip and back preserves the network exactly.
+func Test_ContiguousIPv4Network_ToPrefix_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+	}{
+		{name: "default route", prefix: "0.0.0.0/0"},
+		{name: "private eight", prefix: "10.0.0.0/8"},
+		{name: "subnet", prefix: "192.168.1.0/24"},
+		{name: "host route", prefix: "10.1.2.3/32"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefix := netip.MustParsePrefix(tt.prefix)
+			network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(prefix)
+			require.NoError(t, err)
+			got, err := network.ToPrefix()
+			require.NoError(t, err)
+			require.Equal(t, prefix, got)
+		})
+	}
+}
+
+// Test_ContiguousIPv4Network_ToPrefix_MasksHostBits verifies that a
+// hand-built message with host bits set decodes to the masked network.
+func Test_ContiguousIPv4Network_ToPrefix_MasksHostBits(t *testing.T) {
+	network := &commonpb.ContiguousIPv4Network{
+		Addr:      &commonpb.IPv4Address{Addr: 0x0a010203},
+		PrefixLen: 24,
+	}
+	got, err := network.ToPrefix()
+	require.NoError(t, err)
+	require.Equal(t, netip.MustParsePrefix("10.1.2.0/24"), got)
+}
+
+// Test_ContiguousIPv4Network_ToPrefix_Rejects verifies that an absent
+// address and an out-of-range prefix length return errors.
+func Test_ContiguousIPv4Network_ToPrefix_Rejects(t *testing.T) {
+	tests := []struct {
+		name    string
+		network *commonpb.ContiguousIPv4Network
+	}{
+		{
+			name:    "absent addr",
+			network: &commonpb.ContiguousIPv4Network{PrefixLen: 24},
+		},
+		{
+			name: "prefix length above 32",
+			network: &commonpb.ContiguousIPv4Network{
+				Addr:      &commonpb.IPv4Address{Addr: 0x0a000000},
+				PrefixLen: 33,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.network.ToPrefix()
+			require.Error(t, err)
+		})
+	}
+}
+
+// Test_NewContiguousIPv4NetworkFromContiguous_ZeroValue verifies that
+// the zero CIDR block converts totally to the default route message.
+func Test_NewContiguousIPv4NetworkFromContiguous_ZeroValue(t *testing.T) {
+	network := commonpb.NewContiguousIPv4NetworkFromContiguous(xnetip.Contiguous[xnetip.Network4]{})
+	require.NotNil(t, network.Addr)
+	require.Equal(t, uint32(0), network.Addr.Addr)
+	require.Equal(t, uint32(0), network.PrefixLen)
+}
+
+// Test_ContiguousIPv4Network_WireRoundTrip verifies golden wire bytes
+// shared with the Rust tests and that decode reproduces the network.
+//
+// The default route is not an empty message: the present-but-zero
+// address encodes as two bytes, and decode relies on that presence to
+// tell the default route from a malformed message.
+func Test_ContiguousIPv4Network_WireRoundTrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    string
+		wantBytes []byte
+	}{
+		{
+			name:      "default route",
+			prefix:    "0.0.0.0/0",
+			wantBytes: []byte{0x0a, 0x00},
+		},
+		{
+			name:      "host route",
+			prefix:    "10.1.2.3/32",
+			wantBytes: []byte{0x0a, 0x05, 0x0d, 0x03, 0x02, 0x01, 0x0a, 0x10, 0x20},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix(tt.prefix))
+			require.NoError(t, err)
+
+			data, err := proto.Marshal(original)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantBytes, data)
+
+			var got commonpb.ContiguousIPv4Network
+			require.NoError(t, proto.Unmarshal(data, &got))
+			prefix, err := got.ToPrefix()
+			require.NoError(t, err)
+			require.Equal(t, netip.MustParsePrefix(tt.prefix), prefix)
+		})
+	}
+}
+
+// Test_ContiguousIPv4Network_MarshalJSON verifies that the network
+// serializes as a bare CIDR string, the same form the Rust side emits.
+func Test_ContiguousIPv4Network_MarshalJSON(t *testing.T) {
+	network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("10.1.2.0/24"))
+	require.NoError(t, err)
+	got, err := json.Marshal(network)
+	require.NoError(t, err)
+	require.Equal(t, `"10.1.2.0/24"`, string(got))
+}
+
+// Test_ContiguousIPv4Network_MarshalJSON_RejectsAbsentAddr verifies that
+// a malformed message fails to serialize instead of inventing a network.
+func Test_ContiguousIPv4Network_MarshalJSON_RejectsAbsentAddr(t *testing.T) {
+	network := &commonpb.ContiguousIPv4Network{PrefixLen: 24}
+	_, err := json.Marshal(network)
+	require.Error(t, err)
+}
+
+// Test_ContiguousIPv4Network_UnmarshalJSON verifies that only bare IPv4
+// CIDR strings are accepted, with host bits masked off.
+func Test_ContiguousIPv4Network_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "subnet", input: `"10.1.2.0/24"`, want: "10.1.2.0/24"},
+		{name: "unmasked host bits", input: `"10.1.2.3/24"`, want: "10.1.2.0/24"},
+		{name: "IPv6", input: `"2a02:6b8::/32"`, wantErr: true},
+		{name: "IPv4-mapped IPv6", input: `"::ffff:10.0.0.0/104"`, wantErr: true},
+		{name: "bare address", input: `"10.1.2.3"`, wantErr: true},
+		{name: "empty string", input: `""`, wantErr: true},
+		{name: "malformed network", input: `"not-a-network"`, wantErr: true},
+		{name: "object form", input: `{"network":"10.1.2.0/24"}`, wantErr: true},
+		{name: "invalid JSON", input: `"10.1`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var network commonpb.ContiguousIPv4Network
+			err := json.Unmarshal([]byte(tt.input), &network)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			got, err := network.ToPrefix()
+			require.NoError(t, err)
+			require.Equal(t, netip.MustParsePrefix(tt.want), got)
+		})
+	}
+}
+
+// Test_ContiguousIPv4Network_JSONRoundTrip verifies that marshaling and
+// unmarshaling reproduce the original message.
+func Test_ContiguousIPv4Network_JSONRoundTrip(t *testing.T) {
+	original, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("192.168.1.0/24"))
+	require.NoError(t, err)
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var got commonpb.ContiguousIPv4Network
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, original.Addr.Addr, got.Addr.Addr)
+	require.Equal(t, original.PrefixLen, got.PrefixLen)
+}
+
+// Test_ContiguousIPv4Network_AsLogValue verifies compact CIDR rendering
+// for request logs and the invalid fallback for a malformed message.
+func Test_ContiguousIPv4Network_AsLogValue(t *testing.T) {
+	network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("10.1.2.0/24"))
+	require.NoError(t, err)
+	require.Equal(t, "10.1.2.0/24", network.AsLogValue())
+
+	malformed := &commonpb.ContiguousIPv4Network{PrefixLen: 24}
+	require.Equal(t, "invalid", malformed.AsLogValue())
+}

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -5,7 +5,7 @@ use core::{
     str::FromStr,
 };
 
-use netip::{Contiguous, IpNetwork, MacAddr, ipv4_range_to_networks, ipv6_range_to_networks};
+use netip::{Contiguous, IpNetwork, Ipv4Network, MacAddr, ipv4_range_to_networks, ipv6_range_to_networks};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 #[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
@@ -262,6 +262,71 @@ impl Serialize for pb::IPv6Address {
 }
 
 impl<'de> Deserialize<'de> for pb::IPv6Address {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<Self>().map_err(de::Error::custom)
+    }
+}
+
+impl From<Contiguous<Ipv4Network>> for pb::ContiguousIPv4Network {
+    fn from(net: Contiguous<Ipv4Network>) -> Self {
+        pb::ContiguousIPv4Network {
+            addr: Some(pb::IPv4Address::from(*net.addr())),
+            prefix_len: u32::from(net.prefix()),
+        }
+    }
+}
+
+impl TryFrom<&pb::ContiguousIPv4Network> for Contiguous<Ipv4Network> {
+    type Error = Box<dyn Error>;
+
+    /// Masks host bits to `prefix_len` rather than rejecting them.
+    fn try_from(net: &pb::ContiguousIPv4Network) -> Result<Self, Self::Error> {
+        let addr = net.addr.as_ref().ok_or("invalid IP network: missing address")?;
+        let addr = Ipv4Addr::from(addr);
+        let prefix_len =
+            u8::try_from(net.prefix_len).map_err(|_| format!("invalid prefix length {}", net.prefix_len))?;
+        Contiguous::<Ipv4Network>::try_from((addr, prefix_len))
+            .map_err(|e| format!("invalid prefix length {prefix_len}: {e}").into())
+    }
+}
+
+impl Display for pb::ContiguousIPv4Network {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match Contiguous::<Ipv4Network>::try_from(self) {
+            Ok(net) => net.fmt(f),
+            Err(..) => f.write_str("invalid"),
+        }
+    }
+}
+
+impl FromStr for pb::ContiguousIPv4Network {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let net = Contiguous::<Ipv4Network>::parse(s)?;
+        Ok(Self::from(net))
+    }
+}
+
+impl Serialize for pb::ContiguousIPv4Network {
+    /// Serializes as the CIDR string `Display` renders.
+    ///
+    /// A message with an absent address renders as the literal
+    /// `"invalid"`, which is not itself a parseable network and so
+    /// deliberately does not deserialize back.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for pb::ContiguousIPv4Network {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -1073,5 +1138,103 @@ mod test {
     #[test]
     fn test_ipv6_address_from_str_rejects_zoned() {
         assert!("fe80::1%eth0".parse::<pb::IPv6Address>().is_err());
+    }
+
+    /// Verifies typed construction from a CIDR block and the decode back,
+    /// with fixtures mirrored in the Go tests.
+    #[test]
+    fn test_contiguous_ipv4_network_conversion_round_trip() {
+        let net = Contiguous::<Ipv4Network>::parse("10.1.2.0/24").unwrap();
+        let msg = pb::ContiguousIPv4Network::from(net);
+        assert_eq!(Some(pb::IPv4Address { addr: 0x0a010200 }), msg.addr);
+        assert_eq!(24, msg.prefix_len);
+        assert_eq!(net, Contiguous::<Ipv4Network>::try_from(&msg).unwrap());
+    }
+
+    /// Verifies the nested wire encoding against a golden byte fixture
+    /// shared with the Go tests.
+    #[test]
+    fn test_contiguous_ipv4_network_wire_bytes_golden() {
+        use prost::Message;
+
+        let msg = pb::ContiguousIPv4Network {
+            addr: Some(pb::IPv4Address { addr: 0x0a010203 }),
+            prefix_len: 32,
+        };
+        assert_eq!(
+            vec![0x0a, 0x05, 0x0d, 0x03, 0x02, 0x01, 0x0a, 0x10, 0x20],
+            msg.encode_to_vec()
+        );
+    }
+
+    #[test]
+    fn test_contiguous_ipv4_network_try_from_masks_host_bits() {
+        let msg = pb::ContiguousIPv4Network {
+            addr: Some(pb::IPv4Address { addr: 0x0a010203 }),
+            prefix_len: 24,
+        };
+        let expected = Contiguous::<Ipv4Network>::parse("10.1.2.0/24").unwrap();
+        assert_eq!(expected, Contiguous::<Ipv4Network>::try_from(&msg).unwrap());
+    }
+
+    #[test]
+    fn test_contiguous_ipv4_network_try_from_rejects_absent_addr() {
+        let malformed = pb::ContiguousIPv4Network { addr: None, prefix_len: 24 };
+        assert!(Contiguous::<Ipv4Network>::try_from(&malformed).is_err());
+    }
+
+    #[test]
+    fn test_contiguous_ipv4_network_try_from_rejects_prefix_overflow() {
+        let malformed = pb::ContiguousIPv4Network {
+            addr: Some(pb::IPv4Address { addr: 0x0a000000 }),
+            prefix_len: 33,
+        };
+        assert!(Contiguous::<Ipv4Network>::try_from(&malformed).is_err());
+    }
+
+    #[test]
+    fn test_contiguous_ipv4_network_serde_string_round_trip() {
+        let msg = pb::ContiguousIPv4Network::from(Contiguous::<Ipv4Network>::parse("10.0.0.0/8").unwrap());
+        let json = serde_json::to_string(&msg).unwrap();
+        assert_eq!(r#""10.0.0.0/8""#, json);
+        let got: pb::ContiguousIPv4Network = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, got);
+    }
+
+    /// The `"invalid"` literal an absent address serializes to is not
+    /// itself a parseable network, so deserializing it back is a
+    /// deliberate error rather than a silently reconstructed message.
+    #[test]
+    fn test_contiguous_ipv4_network_serde_invalid_does_not_deserialize() {
+        let malformed = pb::ContiguousIPv4Network { addr: None, prefix_len: 24 };
+        let json = serde_json::to_string(&malformed).unwrap();
+        assert_eq!(r#""invalid""#, json);
+        assert!(serde_json::from_str::<pb::ContiguousIPv4Network>(&json).is_err());
+    }
+
+    #[test]
+    fn test_contiguous_ipv4_network_from_str_masks_host_bits() {
+        let got: pb::ContiguousIPv4Network = "10.1.2.3/24".parse().unwrap();
+        assert_eq!(Some(pb::IPv4Address { addr: 0x0a010200 }), got.addr);
+        assert_eq!(24, got.prefix_len);
+    }
+
+    #[test]
+    fn test_contiguous_ipv4_network_from_str_rejects_ipv6() {
+        assert!("2a02:6b8::/32".parse::<pb::ContiguousIPv4Network>().is_err());
+    }
+
+    /// The default route is not an empty message: the present-but-zero
+    /// address encodes as two bytes, and decode relies on that presence
+    /// to tell the default route from a malformed message.
+    #[test]
+    fn test_contiguous_ipv4_network_wire_bytes_zero_value_golden() {
+        use prost::Message;
+
+        let msg = pb::ContiguousIPv4Network {
+            addr: Some(pb::IPv4Address { addr: 0 }),
+            prefix_len: 0,
+        };
+        assert_eq!(vec![0x0a, 0x00], msg.encode_to_vec());
     }
 }


### PR DESCRIPTION
- Adds a ContiguousIPv4Network message pairing the typed IPv4 address with a prefix length bounded by 32, so the family is structural on the wire.
- Host bits below the prefix are masked off on decode rather than rejected, consistently with the mixed message's helpers.
- Adds Go helpers over the family-typed xnetip CIDR block with CIDR-only parsing and bare-CIDR-string JSON.
- Adds Rust conversions, Display, FromStr, and string-form serde mirroring the mixed network message in typed form.
- Pins the nested wire encoding and the masking behavior with shared cross-language fixtures.

Closes #2200.
