### PR TITLE
feat(bird-adapter)!: carry family-typed mpls source addresses on the wire

### DIFF
--- a/operators/bird-adapter/adapterpb/v1/bird_import.proto
+++ b/operators/bird-adapter/adapterpb/v1/bird_import.proto
@@ -22,9 +22,13 @@ message SetupConfigRequest {
   string name = 1;
   ImportConfig config = 2;
   // IPv4 source address for MPLS routes.
-  common.commonpb.v1.IPAddress source_v4 = 3;
+  //
+  // MUST be present.
+  common.commonpb.v1.IPv4Address source_v4 = 3;
   // IPv6 source address for MPLS routes.
-  common.commonpb.v1.IPAddress source_v6 = 4;
+  //
+  // MUST be present.
+  common.commonpb.v1.IPv6Address source_v6 = 4;
 }
 
 message SetupConfigResponse {}

--- a/operators/bird-adapter/cmd/yanet-bird-adapter/client.go
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/client.go
@@ -79,16 +79,23 @@ func runClient() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse --source-v4: %w", err)
 	}
-	if !addrV4.Is4() {
-		return fmt.Errorf("--source-v4 must be an IPv4 address, got %q", clientCmdArgs.SourceV4)
+	sourceV4, err := commonpb.NewIPv4AddressFromAddr(addrV4)
+	if err != nil {
+		return fmt.Errorf("invalid --source-v4: %w", err)
 	}
 
 	addrV6, err := netip.ParseAddr(clientCmdArgs.SourceV6)
 	if err != nil {
 		return fmt.Errorf("failed to parse --source-v6: %w", err)
 	}
-	if !addrV6.Is6() || addrV6.Is4In6() {
-		return fmt.Errorf("--source-v6 must be an IPv6 address, got %q", clientCmdArgs.SourceV6)
+	// The wire type counts the IPv4-mapped form as IPv6, but the server
+	// requires a pure IPv6 source; reject it before the round trip.
+	if addrV6.Is4In6() {
+		return fmt.Errorf("--source-v6 must be a pure IPv6 address, got %q", clientCmdArgs.SourceV6)
+	}
+	sourceV6, err := commonpb.NewIPv6AddressFromAddr(addrV6)
+	if err != nil {
+		return fmt.Errorf("invalid --source-v6: %w", err)
 	}
 
 	// Load server config to get the adapter address
@@ -124,8 +131,8 @@ func runClient() error {
 
 	req := &adapterpb.SetupConfigRequest{
 		Name:     clientCmdArgs.ConfigName,
-		SourceV4: commonpb.NewIPAddressFromAddr(addrV4),
-		SourceV6: commonpb.NewIPAddressFromAddr(addrV6),
+		SourceV4: sourceV4,
+		SourceV6: sourceV6,
 		Config: &adapterpb.ImportConfig{
 			Sockets:  clientCmdArgs.Sockets,
 			LogLevel: logLevel,

--- a/operators/bird-adapter/service.go
+++ b/operators/bird-adapter/service.go
@@ -135,14 +135,16 @@ func (m *AdapterService) SetupConfig(
 		return nil, fmt.Errorf("no import config provided")
 	}
 
-	mplsV4Src, err := req.GetSourceV4().ToAddr()
-	if err != nil {
-		return nil, fmt.Errorf("invalid v4 source (bytes=%x): %w", req.GetSourceV4().GetAddr(), err)
+	// The typed sources decode totally: an omitted field is otherwise
+	// indistinguishable from the zero address, so check presence here.
+	if req.GetSourceV4() == nil {
+		return nil, fmt.Errorf("no v4 source address provided")
 	}
-	mplsV6Src, err := req.GetSourceV6().ToAddr()
-	if err != nil {
-		return nil, fmt.Errorf("invalid v6 source (bytes=%x): %w", req.GetSourceV6().GetAddr(), err)
+	if req.GetSourceV6() == nil {
+		return nil, fmt.Errorf("no v6 source address provided")
 	}
+	mplsV4Src := req.GetSourceV4().ToAddr()
+	mplsV6Src := req.GetSourceV6().ToAddr()
 
 	cfg := bird.DefaultConfig()
 	req.GetConfig().ToConfig(cfg)

--- a/operators/bird-adapter/service_test.go
+++ b/operators/bird-adapter/service_test.go
@@ -4,6 +4,8 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	bird_adapter "github.com/yanet-platform/yanet2/operators/bird-adapter"
 	adapterpb "github.com/yanet-platform/yanet2/operators/bird-adapter/adapterpb/v1"
@@ -16,12 +18,68 @@ func TestAdapterService_SetupConfig_RejectsMissingConfig(t *testing.T) {
 
 	req := &adapterpb.SetupConfigRequest{
 		Name:     "test",
-		SourceV4: commonpb.NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.1")),
-		SourceV6: commonpb.NewIPAddressFromAddr(netip.MustParseAddr("2001:db8::1")),
+		SourceV4: commonpb.NewIPv4Address(netip.MustParseAddr("10.0.0.1").As4()),
+		SourceV6: commonpb.NewIPv6Address(netip.MustParseAddr("2001:db8::1").As16()),
 	}
 
 	_, err := svc.SetupConfig(t.Context(), req)
 	if err == nil {
 		t.Fatal("expected an error for a request with no import config, got nil")
+	}
+}
+
+// TestAdapterService_SetupConfig_RejectsMissingSource asserts that omitting
+// either source address fails on the presence check specifically.
+//
+// Every case errors eventually — the route operator endpoint is unreachable —
+// so the assertions pin down whether the presence check itself fired.
+func TestAdapterService_SetupConfig_RejectsMissingSource(t *testing.T) {
+	validV4 := commonpb.NewIPv4Address(netip.MustParseAddr("10.0.0.1").As4())
+	validV6 := commonpb.NewIPv6Address(netip.MustParseAddr("2001:db8::1").As16())
+
+	tests := []struct {
+		name      string
+		sourceV4  *commonpb.IPv4Address
+		sourceV6  *commonpb.IPv6Address
+		wantError string
+	}{
+		{
+			name:      "missing v4 source",
+			sourceV6:  validV6,
+			wantError: "no v4 source address provided",
+		},
+		{
+			name:      "missing v6 source",
+			sourceV4:  validV4,
+			wantError: "no v6 source address provided",
+		},
+		{
+			name:     "both sources present pass the presence checks",
+			sourceV4: validV4,
+			sourceV6: validV6,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := bird_adapter.NewAdapterService("127.0.0.1:0")
+
+			req := &adapterpb.SetupConfigRequest{
+				Name:     "test",
+				SourceV4: tc.sourceV4,
+				SourceV6: tc.sourceV6,
+				Config: &adapterpb.ImportConfig{
+					Sockets: []string{"/nonexistent.sock"},
+				},
+			}
+
+			_, err := svc.SetupConfig(t.Context(), req)
+			require.Error(t, err)
+			if tc.wantError != "" {
+				require.ErrorContains(t, err, tc.wantError)
+				return
+			}
+			require.NotContains(t, err.Error(), "source address provided")
+		})
 	}
 }


### PR DESCRIPTION
- Retype the MPLS source address fields to the family-fixed messages, making a wrong-family value unrepresentable on the wire.
- Replace the decode-time byte checks with explicit presence checks, since the typed messages decode totally.
- Construct the request in the Go client through the family-typed helpers.
- The buf breaking check is expected red: the wire break is deliberate under the parent epic and shipped without an ignore entry.

Closes #2204.