### PR TITLE
feat(nat64)!: carry family-typed host addresses on the wire

### DIFF
--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -5,7 +5,6 @@ use clap_complete::{
     engine::{ArgValueCandidates, CompletionCandidate},
     CompleteEnv,
 };
-use commonpb::pb::IpAddress;
 use nat64pb::{
     nat64_service_client::Nat64ServiceClient, AddMappingRequest, AddPrefixRequest, ListConfigsRequest,
     RemoveMappingRequest, RemovePrefixRequest, SetDropUnknownRequest, SetMtuRequest, ShowConfigRequest,
@@ -333,8 +332,8 @@ impl NAT64Service {
     pub async fn add_mapping(&mut self, cmd: AddMappingCmd) -> Result<(), Error> {
         let request = AddMappingRequest {
             name: cmd.config_name.clone(),
-            ipv4: Some(IpAddress { addr: cmd.ipv4.octets().to_vec() }),
-            ipv6: Some(IpAddress { addr: cmd.ipv6.octets().to_vec() }),
+            ipv4: Some(cmd.ipv4.into()),
+            ipv6: Some(cmd.ipv6.into()),
             prefix_index: cmd.prefix_index,
         };
         log::debug!("AddMappingRequest: {request:?}");
@@ -358,7 +357,7 @@ impl NAT64Service {
     pub async fn remove_mapping(&mut self, cmd: RemoveMappingCmd) -> Result<(), Error> {
         let request = RemoveMappingRequest {
             name: cmd.config_name.clone(),
-            ipv4: Some(IpAddress { addr: cmd.ipv4.octets().to_vec() }),
+            ipv4: Some(cmd.ipv4.into()),
         };
         log::debug!("RemoveMappingRequest: {request:?}");
         self.service

--- a/modules/nat64/controlplane/nat64pb/v1/nat64.proto
+++ b/modules/nat64/controlplane/nat64pb/v1/nat64.proto
@@ -54,9 +54,9 @@ message Prefix {
 
 // Mapping represents an IPv4-IPv6 address mapping
 message Mapping {
-  common.commonpb.v1.IPAddress ipv4 = 1; // IPv4 host address
-  common.commonpb.v1.IPAddress ipv6 = 2; // IPv6 host address
-  uint32 prefix_index = 3;               // Index of the used prefix
+  common.commonpb.v1.IPv4Address ipv4 = 1; // IPv4 host address
+  common.commonpb.v1.IPv6Address ipv6 = 2; // IPv6 host address
+  uint32 prefix_index = 3;                 // Index of the used prefix
 }
 
 // Config represents configuration for a single dataplane instance
@@ -90,9 +90,9 @@ message RemovePrefixResponse {}
 // AddMappingRequest specifies an IPv4-IPv6 mapping to add
 message AddMappingRequest {
   string name = 1;
-  common.commonpb.v1.IPAddress ipv4 = 2; // IPv4 host address
-  common.commonpb.v1.IPAddress ipv6 = 3; // IPv6 host address
-  uint32 prefix_index = 4;               // Index of the used prefix
+  common.commonpb.v1.IPv4Address ipv4 = 2; // IPv4 host address
+  common.commonpb.v1.IPv6Address ipv6 = 3; // IPv6 host address
+  uint32 prefix_index = 4;                 // Index of the used prefix
 }
 
 message AddMappingResponse {}
@@ -100,7 +100,7 @@ message AddMappingResponse {}
 // RemoveMappingRequest specifies an IPv4-IPv6 mapping to remove
 message RemoveMappingRequest {
   string name = 1;
-  common.commonpb.v1.IPAddress ipv4 = 2; // IPv4 host address to remove mapping for
+  common.commonpb.v1.IPv4Address ipv4 = 2; // IPv4 host address to remove mapping for
 }
 
 message RemoveMappingResponse {}

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -176,8 +176,8 @@ func (m *NAT64Service) ShowConfig(ctx context.Context, req *nat64pb.ShowConfigRe
 
 	for _, mapping := range cfg.Mappings {
 		response.Config.Mappings = append(response.Config.Mappings, &nat64pb.Mapping{
-			Ipv4:        commonpb.NewIPAddressFromAddr(mapping.IPv4),
-			Ipv6:        commonpb.NewIPAddressFromAddr(mapping.IPv6),
+			Ipv4:        commonpb.NewIPv4Address(mapping.IPv4.As4()),
+			Ipv6:        commonpb.NewIPv6Address(mapping.IPv6.As16()),
 			PrefixIndex: mapping.PrefixIndex,
 		})
 	}
@@ -248,18 +248,15 @@ func (m *NAT64Service) RemovePrefix(ctx context.Context, req *nat64pb.RemovePref
 }
 
 func (m *NAT64Service) AddMapping(ctx context.Context, req *nat64pb.AddMappingRequest) (*nat64pb.AddMappingResponse, error) {
-	ipv4, err := req.GetIpv4().ToAddr()
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid ipv4 (bytes=%x): %v", req.GetIpv4().GetAddr(), err)
+	if req.GetIpv4() == nil {
+		return nil, status.Error(codes.InvalidArgument, "ipv4 address is required")
 	}
-	if !ipv4.Is4() {
-		return nil, status.Errorf(codes.InvalidArgument, "ipv4 %q is not an IPv4 address", ipv4)
+	if req.GetIpv6() == nil {
+		return nil, status.Error(codes.InvalidArgument, "ipv6 address is required")
 	}
-	ipv6, err := req.GetIpv6().ToAddr()
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid ipv6 (bytes=%x): %v", req.GetIpv6().GetAddr(), err)
-	}
-	if !ipv6.Is6() || ipv6.Is4In6() {
+	ipv4 := req.GetIpv4().ToAddr()
+	ipv6 := req.GetIpv6().ToAddr()
+	if ipv6.Is4In6() {
 		return nil, status.Errorf(codes.InvalidArgument, "ipv6 %q is not a pure IPv6 address", ipv6)
 	}
 
@@ -294,13 +291,10 @@ func (m *NAT64Service) AddMapping(ctx context.Context, req *nat64pb.AddMappingRe
 }
 
 func (m *NAT64Service) RemoveMapping(ctx context.Context, req *nat64pb.RemoveMappingRequest) (*nat64pb.RemoveMappingResponse, error) {
-	ipv4, err := req.GetIpv4().ToAddr()
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid ipv4 (bytes=%x): %v", req.GetIpv4().GetAddr(), err)
+	if req.GetIpv4() == nil {
+		return nil, status.Error(codes.InvalidArgument, "ipv4 address is required")
 	}
-	if !ipv4.Is4() {
-		return nil, status.Errorf(codes.InvalidArgument, "ipv4 %q is not an IPv4 address", ipv4)
-	}
+	ipv4 := req.GetIpv4().ToAddr()
 
 	name := req.GetName()
 	if name == "" {

--- a/modules/nat64/controlplane/service_test.go
+++ b/modules/nat64/controlplane/service_test.go
@@ -59,8 +59,8 @@ func Test_NAT64Service_AddShowRemove(t *testing.T) {
 	require.False(t, backend.handles[1].freed)
 	_, err = service.AddMapping(ctx, &nat64pb.AddMappingRequest{
 		Name:        "nat64-0",
-		Ipv4:        commonpb.NewIPAddressFromAddr(ipv4),
-		Ipv6:        commonpb.NewIPAddressFromAddr(ipv6),
+		Ipv4:        commonpb.NewIPv4Address(ipv4.As4()),
+		Ipv6:        commonpb.NewIPv6Address(ipv6.As16()),
 		PrefixIndex: 1,
 	})
 	require.NoError(t, err)
@@ -84,7 +84,7 @@ func Test_NAT64Service_AddShowRemove(t *testing.T) {
 
 	_, err = service.RemoveMapping(ctx, &nat64pb.RemoveMappingRequest{
 		Name: "nat64-0",
-		Ipv4: commonpb.NewIPAddressFromAddr(ipv4),
+		Ipv4: commonpb.NewIPv4Address(ipv4.As4()),
 	})
 	require.NoError(t, err)
 
@@ -187,4 +187,37 @@ func Test_NAT64Service_InvalidMTU(t *testing.T) {
 	})
 	require.Nil(t, resp)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Test_NAT64Service_MappingAddressInvalid verifies missing and
+// IPv4-mapped mapping addresses are rejected.
+func Test_NAT64Service_MappingAddressInvalid(t *testing.T) {
+	backend := &mockBackend{}
+	service := NewNAT64Service(backend)
+	ctx := t.Context()
+
+	// A valid prefix keeps the prefix-index guard out of the way, so an
+	// InvalidArgument below can come only from the address checks.
+	_, err := service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{
+		Name:   "nat64-0",
+		Prefix: []byte{0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	})
+	require.NoError(t, err)
+
+	ipv4 := commonpb.NewIPv4Address(netip.MustParseAddr("192.0.2.1").As4())
+	ipv6 := commonpb.NewIPv6Address(netip.MustParseAddr("2001:db8::1").As16())
+	mapped := commonpb.NewIPv6Address(netip.MustParseAddr("::ffff:192.0.2.1").As16())
+
+	_, err = service.AddMapping(ctx, &nat64pb.AddMappingRequest{Name: "nat64-0", Ipv6: ipv6})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	_, err = service.AddMapping(ctx, &nat64pb.AddMappingRequest{Name: "nat64-0", Ipv4: ipv4})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	_, err = service.AddMapping(ctx, &nat64pb.AddMappingRequest{Name: "nat64-0", Ipv4: ipv4, Ipv6: mapped})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	_, err = service.RemoveMapping(ctx, &nat64pb.RemoveMappingRequest{Name: "nat64-0"})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	// Only the prefix update reached the backend: no mapping landed.
+	require.Len(t, backend.configs, 1)
+	require.Empty(t, backend.configs[0].Mappings)
 }

--- a/modules/nat64/tests/functional/nat64_test.go
+++ b/modules/nat64/tests/functional/nat64_test.go
@@ -111,8 +111,8 @@ func mustAddMapping(t *testing.T, svc *nat64.NAT64Service, name string, ip4, ip6
 	t.Helper()
 	_, err := svc.AddMapping(t.Context(), &nat64pb.AddMappingRequest{
 		Name:        name,
-		Ipv4:        commonpb.NewIPAddressFromAddr(netip.MustParseAddr(ip4)),
-		Ipv6:        commonpb.NewIPAddressFromAddr(netip.MustParseAddr(ip6)),
+		Ipv4:        commonpb.NewIPv4Address(netip.MustParseAddr(ip4).As4()),
+		Ipv6:        commonpb.NewIPv6Address(netip.MustParseAddr(ip6).As16()),
 		PrefixIndex: prefixIdx,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
- Retype the nat64 mapping fields from the mixed `IPAddress` to the fixed-width `commonpb.IPv4Address`/`IPv6Address` messages, making the address family structural on the wire.
- Drop the byte-length family validation from the Go service; presence checks and the IPv4-mapped rejection remain.
- Build the CLI requests through the typed conversions; rendering and the JSON shape are unchanged.
- The wire break is deliberate under the typed-address epic; the buf breaking gate is expected to stay red, no ignore entry is added.

Closes #2202.