### PR TITLE
feat(commonpb): add a family-typed contiguous ipv6 network message

### DIFF
--- a/common/commonpb/v1/ipnetwork.proto
+++ b/common/commonpb/v1/ipnetwork.proto
@@ -38,3 +38,20 @@ message ContiguousIPv4Network {
   // MUST be <= 32.
   uint32 prefix_len = 2;
 }
+
+// ContiguousIPv6Network represents an IPv6 CIDR prefix.
+//
+// Unlike ContiguousIPNetwork, the family is fixed by the type: the
+// address cannot carry IPv4, and an absent addr is the only malformed
+// state.
+message ContiguousIPv6Network {
+  // Network base address.
+  //
+  // MUST be present. Host bits below prefix_len are masked off on
+  // decode, so producers need not normalize.
+  IPv6Address addr = 1;
+  // Prefix length, in bits.
+  //
+  // MUST be <= 128.
+  uint32 prefix_len = 2;
+}

--- a/common/commonpb/v1/ipv6network.go
+++ b/common/commonpb/v1/ipv6network.go
@@ -1,0 +1,114 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/netip"
+
+	"github.com/yanet-platform/xnetip"
+)
+
+// NewContiguousIPv6NetworkFromContiguous creates a ContiguousIPv6Network
+// from an xnetip IPv6 CIDR block.
+//
+// The conversion is total: the block is masked by its own invariant. The
+// inverse of ToContiguous.
+func NewContiguousIPv6NetworkFromContiguous(net xnetip.Contiguous[xnetip.Network6]) *ContiguousIPv6Network {
+	return &ContiguousIPv6Network{
+		Addr:      NewIPv6Address(net.Network().Addr().As16()),
+		PrefixLen: uint32(net.PrefixLen()),
+	}
+}
+
+// NewContiguousIPv6NetworkFromPrefix creates a ContiguousIPv6Network from
+// a netip.Prefix value, masking off any host bits.
+//
+// Returns an error if prefix is not a valid IPv6 prefix; the IPv4-mapped
+// form counts as IPv6 here, consistently with IPv6Address.
+func NewContiguousIPv6NetworkFromPrefix(prefix netip.Prefix) (*ContiguousIPv6Network, error) {
+	net, ok := xnetip.ContiguousFromPrefix6(prefix)
+	if !ok {
+		return nil, fmt.Errorf("not a valid IPv6 prefix: %s", prefix)
+	}
+	return NewContiguousIPv6NetworkFromContiguous(net), nil
+}
+
+// ParseContiguousIPv6Network parses s as an IPv6 CIDR prefix, masking off
+// any host bits.
+func ParseContiguousIPv6Network(s string) (*ContiguousIPv6Network, error) {
+	prefix, err := netip.ParsePrefix(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse IP network: %w", err)
+	}
+	return NewContiguousIPv6NetworkFromPrefix(prefix)
+}
+
+// ToContiguous converts the ContiguousIPv6Network to an xnetip IPv6 CIDR
+// block.
+//
+// Returns an error if addr is absent or prefix_len exceeds 128; the
+// latter wraps xnetip.ErrCIDROverflow. The returned block is masked, so
+// host bits never leak out even if the message was constructed by hand.
+// The inverse of NewContiguousIPv6NetworkFromContiguous.
+func (m *ContiguousIPv6Network) ToContiguous() (xnetip.Contiguous[xnetip.Network6], error) {
+	if m.GetAddr() == nil {
+		return xnetip.Contiguous[xnetip.Network6]{}, fmt.Errorf("missing network address")
+	}
+	net, err := xnetip.ContiguousFromCIDR6(m.GetAddr().ToAddr(), int(m.GetPrefixLen()))
+	if err != nil {
+		return xnetip.Contiguous[xnetip.Network6]{}, fmt.Errorf("failed to build IP network: %w", err)
+	}
+	return net, nil
+}
+
+// ToPrefix converts the ContiguousIPv6Network back to a masked
+// netip.Prefix value.
+//
+// Returns an error exactly when ToContiguous does.
+func (m *ContiguousIPv6Network) ToPrefix() (netip.Prefix, error) {
+	net, err := m.ToContiguous()
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+	return net.Prefix(), nil
+}
+
+// AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
+func (m *ContiguousIPv6Network) AsLogValue() any {
+	prefix, err := m.ToPrefix()
+	if err != nil {
+		return "invalid"
+	}
+
+	return prefix.String()
+}
+
+// MarshalJSON serializes the network as a bare CIDR string, the same
+// form the Rust side renders.
+func (m *ContiguousIPv6Network) MarshalJSON() ([]byte, error) {
+	prefix, err := m.ToPrefix()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(prefix.String())
+}
+
+// UnmarshalJSON accepts a bare IPv6 CIDR string.
+func (m *ContiguousIPv6Network) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw == "" {
+		return fmt.Errorf("empty IP network is not allowed")
+	}
+
+	parsed, err := ParseContiguousIPv6Network(raw)
+	if err != nil {
+		return err
+	}
+
+	m.Addr = parsed.Addr
+	m.PrefixLen = parsed.PrefixLen
+	return nil
+}

--- a/common/commonpb/v1/ipv6network_test.go
+++ b/common/commonpb/v1/ipv6network_test.go
@@ -1,0 +1,313 @@
+package commonpb_test
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yanet-platform/xnetip"
+	"google.golang.org/protobuf/proto"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+)
+
+// Test_NewContiguousIPv6NetworkFromPrefix_Valid verifies that IPv6
+// prefixes are encoded with the typed address halves and their length.
+//
+// The fixture values mirror the Rust tests so an encoding defect fails
+// identically in both languages.
+func Test_NewContiguousIPv6NetworkFromPrefix_Valid(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefix  string
+		wantHi  uint64
+		wantLo  uint64
+		wantLen uint32
+	}{
+		{name: "default route", prefix: "::/0", wantHi: 0, wantLo: 0, wantLen: 0},
+		{
+			name:    "global unicast",
+			prefix:  "2a02:6b8::/32",
+			wantHi:  0x2a0206b800000000,
+			wantLo:  0,
+			wantLen: 32,
+		},
+		{
+			name:    "host route",
+			prefix:  "2a02:6b8:0:1::100/128",
+			wantHi:  0x2a0206b800000001,
+			wantLo:  0x0000000000000100,
+			wantLen: 128,
+		},
+		{
+			name:    "IPv4-mapped IPv6",
+			prefix:  "::ffff:10.0.0.0/104",
+			wantHi:  0,
+			wantLo:  0x0000ffff0a000000,
+			wantLen: 104,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix(tt.prefix))
+			require.NoError(t, err)
+			require.Equal(t, tt.wantHi, network.Addr.Hi)
+			require.Equal(t, tt.wantLo, network.Addr.Lo)
+			require.Equal(t, tt.wantLen, network.PrefixLen)
+		})
+	}
+}
+
+// Test_NewContiguousIPv6NetworkFromPrefix_MasksHostBits verifies that
+// host bits below the prefix length are cleared at construction.
+func Test_NewContiguousIPv6NetworkFromPrefix_MasksHostBits(t *testing.T) {
+	network, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix("2a02:6b8:0:1::100/64"))
+	require.NoError(t, err)
+	require.Equal(t, uint64(0x2a0206b800000001), network.Addr.Hi)
+	require.Equal(t, uint64(0), network.Addr.Lo)
+	require.Equal(t, uint32(64), network.PrefixLen)
+}
+
+// Test_NewContiguousIPv6NetworkFromPrefix_RejectsNonIPv6 verifies that
+// IPv4 prefixes and the invalid zero value return errors.
+func Test_NewContiguousIPv6NetworkFromPrefix_RejectsNonIPv6(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix netip.Prefix
+	}{
+		{name: "IPv4", prefix: netip.MustParsePrefix("10.0.0.0/8")},
+		{name: "zero value", prefix: netip.Prefix{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := commonpb.NewContiguousIPv6NetworkFromPrefix(tt.prefix)
+			require.Error(t, err)
+		})
+	}
+}
+
+// Test_NewContiguousIPv6NetworkFromContiguous_ZeroValue verifies that
+// the zero CIDR block converts totally to the default route message.
+func Test_NewContiguousIPv6NetworkFromContiguous_ZeroValue(t *testing.T) {
+	network := commonpb.NewContiguousIPv6NetworkFromContiguous(xnetip.Contiguous[xnetip.Network6]{})
+	require.NotNil(t, network.Addr)
+	require.Equal(t, uint64(0), network.Addr.Hi)
+	require.Equal(t, uint64(0), network.Addr.Lo)
+	require.Equal(t, uint32(0), network.PrefixLen)
+}
+
+// Test_ContiguousIPv6Network_ToPrefix_RoundTrip verifies that conversion
+// to netip and back preserves the network exactly, mapped form included.
+func Test_ContiguousIPv6Network_ToPrefix_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+	}{
+		{name: "default route", prefix: "::/0"},
+		{name: "global unicast", prefix: "2a02:6b8::/32"},
+		{name: "host route", prefix: "::1/128"},
+		{name: "IPv4-mapped IPv6", prefix: "::ffff:10.0.0.0/104"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefix := netip.MustParsePrefix(tt.prefix)
+			network, err := commonpb.NewContiguousIPv6NetworkFromPrefix(prefix)
+			require.NoError(t, err)
+			got, err := network.ToPrefix()
+			require.NoError(t, err)
+			require.Equal(t, prefix, got)
+		})
+	}
+}
+
+// Test_ContiguousIPv6Network_ToPrefix_MasksHostBits verifies that a
+// hand-built message with host bits set decodes to the masked network.
+func Test_ContiguousIPv6Network_ToPrefix_MasksHostBits(t *testing.T) {
+	network := &commonpb.ContiguousIPv6Network{
+		Addr:      &commonpb.IPv6Address{Hi: 0x2a0206b800000001, Lo: 0x0000000000000100},
+		PrefixLen: 64,
+	}
+	got, err := network.ToPrefix()
+	require.NoError(t, err)
+	require.Equal(t, netip.MustParsePrefix("2a02:6b8:0:1::/64"), got)
+}
+
+// Test_ContiguousIPv6Network_ToPrefix_Rejects verifies that an absent
+// address and an out-of-range prefix length return errors.
+func Test_ContiguousIPv6Network_ToPrefix_Rejects(t *testing.T) {
+	tests := []struct {
+		name    string
+		network *commonpb.ContiguousIPv6Network
+	}{
+		{
+			name:    "absent addr",
+			network: &commonpb.ContiguousIPv6Network{PrefixLen: 64},
+		},
+		{
+			name: "prefix length above 128",
+			network: &commonpb.ContiguousIPv6Network{
+				Addr:      &commonpb.IPv6Address{Hi: 0x2a0206b800000000},
+				PrefixLen: 129,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.network.ToPrefix()
+			require.Error(t, err)
+		})
+	}
+}
+
+// Test_ContiguousIPv6Network_WireRoundTrip verifies golden wire bytes
+// shared with the Rust tests and that decode reproduces the network.
+//
+// The default route is not an empty message: the present-but-zero
+// address encodes as two bytes, and decode relies on that presence to
+// tell the default route from a malformed message. A half-zero address
+// omits that half inside the nested message and decodes back
+// losslessly.
+func Test_ContiguousIPv6Network_WireRoundTrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    string
+		wantBytes []byte
+	}{
+		{
+			name:      "default route",
+			prefix:    "::/0",
+			wantBytes: []byte{0x0a, 0x00},
+		},
+		{
+			name:   "global unicast",
+			prefix: "2a02:6b8::/32",
+			wantBytes: []byte{
+				0x0a, 0x09,
+				0x09, 0x00, 0x00, 0x00, 0x00, 0xb8, 0x06, 0x02, 0x2a,
+				0x10, 0x20,
+			},
+		},
+		{
+			name:   "sixty-four boundary",
+			prefix: "2a02:6b8:0:1::/64",
+			wantBytes: []byte{
+				0x0a, 0x09,
+				0x09, 0x01, 0x00, 0x00, 0x00, 0xb8, 0x06, 0x02, 0x2a,
+				0x10, 0x40,
+			},
+		},
+		{
+			name:   "host route",
+			prefix: "2a02:6b8:0:1::100/128",
+			wantBytes: []byte{
+				0x0a, 0x12,
+				0x09, 0x01, 0x00, 0x00, 0x00, 0xb8, 0x06, 0x02, 0x2a,
+				0x11, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x10, 0x80, 0x01,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix(tt.prefix))
+			require.NoError(t, err)
+
+			data, err := proto.Marshal(original)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantBytes, data)
+
+			var got commonpb.ContiguousIPv6Network
+			require.NoError(t, proto.Unmarshal(data, &got))
+			prefix, err := got.ToPrefix()
+			require.NoError(t, err)
+			require.Equal(t, netip.MustParsePrefix(tt.prefix), prefix)
+		})
+	}
+}
+
+// Test_ContiguousIPv6Network_MarshalJSON verifies that the network
+// serializes as a bare CIDR string, the same form the Rust side emits.
+func Test_ContiguousIPv6Network_MarshalJSON(t *testing.T) {
+	network, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix("2a02:6b8::/32"))
+	require.NoError(t, err)
+	got, err := json.Marshal(network)
+	require.NoError(t, err)
+	require.Equal(t, `"2a02:6b8::/32"`, string(got))
+}
+
+// Test_ContiguousIPv6Network_MarshalJSON_RejectsAbsentAddr verifies that
+// a malformed message fails to serialize instead of inventing a network.
+func Test_ContiguousIPv6Network_MarshalJSON_RejectsAbsentAddr(t *testing.T) {
+	network := &commonpb.ContiguousIPv6Network{PrefixLen: 64}
+	_, err := json.Marshal(network)
+	require.Error(t, err)
+}
+
+// Test_ContiguousIPv6Network_UnmarshalJSON verifies that only bare IPv6
+// CIDR strings are accepted, with host bits masked off.
+func Test_ContiguousIPv6Network_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "global unicast", input: `"2a02:6b8::/32"`, want: "2a02:6b8::/32"},
+		{name: "unmasked host bits", input: `"2a02:6b8:0:1::100/64"`, want: "2a02:6b8:0:1::/64"},
+		{name: "IPv4-mapped IPv6", input: `"::ffff:10.0.0.0/104"`, want: "::ffff:10.0.0.0/104"},
+		{name: "IPv4", input: `"10.0.0.0/8"`, wantErr: true},
+		{name: "bare address", input: `"2a02:6b8::1"`, wantErr: true},
+		{name: "empty string", input: `""`, wantErr: true},
+		{name: "malformed network", input: `"not-a-network"`, wantErr: true},
+		{name: "object form", input: `{"network":"2a02:6b8::/32"}`, wantErr: true},
+		{name: "invalid JSON", input: `"2a02`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var network commonpb.ContiguousIPv6Network
+			err := json.Unmarshal([]byte(tt.input), &network)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			got, err := network.ToPrefix()
+			require.NoError(t, err)
+			require.Equal(t, netip.MustParsePrefix(tt.want), got)
+		})
+	}
+}
+
+// Test_ContiguousIPv6Network_JSONRoundTrip verifies that marshaling and
+// unmarshaling reproduce the original message.
+func Test_ContiguousIPv6Network_JSONRoundTrip(t *testing.T) {
+	original, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix("2a02:6b8:0:1::/64"))
+	require.NoError(t, err)
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var got commonpb.ContiguousIPv6Network
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, original.Addr.Hi, got.Addr.Hi)
+	require.Equal(t, original.Addr.Lo, got.Addr.Lo)
+	require.Equal(t, original.PrefixLen, got.PrefixLen)
+}
+
+// Test_ContiguousIPv6Network_AsLogValue verifies compact CIDR rendering
+// for request logs and the invalid fallback for a malformed message.
+func Test_ContiguousIPv6Network_AsLogValue(t *testing.T) {
+	network, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix("2a02:6b8::/32"))
+	require.NoError(t, err)
+	require.Equal(t, "2a02:6b8::/32", network.AsLogValue())
+
+	malformed := &commonpb.ContiguousIPv6Network{PrefixLen: 64}
+	require.Equal(t, "invalid", malformed.AsLogValue())
+}

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -2,13 +2,14 @@ use core::error::Error;
 
 /// Messages that gain the ordinary `Serialize`/`Deserialize` derive.
 ///
-/// `IPAddress`, `IPv4Address`, `IPv6Address`, `MACAddress`, and
-/// `ContiguousIPNetwork` are deliberately absent: `src/lib.rs` hand-writes
-/// their `Serialize`/`Deserialize` impls to go straight to and from a
-/// plain string, and prost-build's attribute
-/// paths are additive, not subtractive -- a blanket `message_attribute(".",
-/// ...)` cannot exclude a single message, so every other message is listed
-/// here individually instead.
+/// The address messages, `MACAddress`, and the network messages
+/// (`ContiguousIPNetwork`, `ContiguousIPv4Network`, `ContiguousIPv6Network`)
+/// are deliberately absent: `src/lib.rs` hand-writes their
+/// `Serialize`/`Deserialize` impls to go straight to and from a plain
+/// string, and prost-build's attribute paths are additive, not
+/// subtractive -- a blanket `message_attribute(".", ...)` cannot exclude
+/// a single message, so every other message is listed here individually
+/// instead.
 const SERDE_MESSAGES: &[&str] = &[
     ".common.commonpb.v1.ModuleId",
     ".common.commonpb.v1.FunctionId",

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -5,7 +5,7 @@ use core::{
     str::FromStr,
 };
 
-use netip::{Contiguous, IpNetwork, Ipv4Network, MacAddr, ipv4_range_to_networks, ipv6_range_to_networks};
+use netip::{Contiguous, IpNetwork, Ipv4Network, Ipv6Network, MacAddr, ipv4_range_to_networks, ipv6_range_to_networks};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 #[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
@@ -327,6 +327,71 @@ impl Serialize for pb::ContiguousIPv4Network {
 }
 
 impl<'de> Deserialize<'de> for pb::ContiguousIPv4Network {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<Self>().map_err(de::Error::custom)
+    }
+}
+
+impl From<Contiguous<Ipv6Network>> for pb::ContiguousIPv6Network {
+    fn from(net: Contiguous<Ipv6Network>) -> Self {
+        pb::ContiguousIPv6Network {
+            addr: Some(pb::IPv6Address::from(*net.addr())),
+            prefix_len: u32::from(net.prefix()),
+        }
+    }
+}
+
+impl TryFrom<&pb::ContiguousIPv6Network> for Contiguous<Ipv6Network> {
+    type Error = Box<dyn Error>;
+
+    /// Masks host bits to `prefix_len` rather than rejecting them.
+    fn try_from(net: &pb::ContiguousIPv6Network) -> Result<Self, Self::Error> {
+        let addr = net.addr.as_ref().ok_or("invalid IP network: missing address")?;
+        let addr = Ipv6Addr::from(addr);
+        let prefix_len =
+            u8::try_from(net.prefix_len).map_err(|_| format!("invalid prefix length {}", net.prefix_len))?;
+        Contiguous::<Ipv6Network>::try_from((addr, prefix_len))
+            .map_err(|e| format!("invalid prefix length {prefix_len}: {e}").into())
+    }
+}
+
+impl Display for pb::ContiguousIPv6Network {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match Contiguous::<Ipv6Network>::try_from(self) {
+            Ok(net) => net.fmt(f),
+            Err(..) => f.write_str("invalid"),
+        }
+    }
+}
+
+impl FromStr for pb::ContiguousIPv6Network {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let net = Contiguous::<Ipv6Network>::parse(s)?;
+        Ok(Self::from(net))
+    }
+}
+
+impl Serialize for pb::ContiguousIPv6Network {
+    /// Serializes as the CIDR string `Display` renders.
+    ///
+    /// A message with an absent address renders as the literal
+    /// `"invalid"`, which is not itself a parseable network and so
+    /// deliberately does not deserialize back.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for pb::ContiguousIPv6Network {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -1236,5 +1301,130 @@ mod test {
             prefix_len: 0,
         };
         assert_eq!(vec![0x0a, 0x00], msg.encode_to_vec());
+    }
+
+    /// Verifies typed construction from a CIDR block and the decode back,
+    /// with fixtures mirrored in the Go tests.
+    #[test]
+    fn test_contiguous_ipv6_network_conversion_round_trip() {
+        let net = Contiguous::<Ipv6Network>::parse("2a02:6b8::/32").unwrap();
+        let msg = pb::ContiguousIPv6Network::from(net);
+        assert_eq!(Some(pb::IPv6Address { hi: 0x2a0206b800000000, lo: 0 }), msg.addr);
+        assert_eq!(32, msg.prefix_len);
+        assert_eq!(net, Contiguous::<Ipv6Network>::try_from(&msg).unwrap());
+    }
+
+    /// Verifies the nested wire encoding against a golden byte fixture
+    /// shared with the Go tests.
+    #[test]
+    fn test_contiguous_ipv6_network_wire_bytes_golden() {
+        use prost::Message;
+
+        let msg = pb::ContiguousIPv6Network {
+            addr: Some(pb::IPv6Address {
+                hi: 0x2a0206b800000001,
+                lo: 0x0000000000000100,
+            }),
+            prefix_len: 128,
+        };
+        assert_eq!(
+            vec![
+                0x0a, 0x12, 0x09, 0x01, 0x00, 0x00, 0x00, 0xb8, 0x06, 0x02, 0x2a, 0x11, 0x00, 0x01, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x10, 0x80, 0x01,
+            ],
+            msg.encode_to_vec()
+        );
+    }
+
+    /// The default route is not an empty message: the present-but-zero
+    /// address encodes as two bytes, and decode relies on that presence
+    /// to tell the default route from a malformed message.
+    #[test]
+    fn test_contiguous_ipv6_network_wire_bytes_zero_value_golden() {
+        use prost::Message;
+
+        let msg = pb::ContiguousIPv6Network {
+            addr: Some(pb::IPv6Address { hi: 0, lo: 0 }),
+            prefix_len: 0,
+        };
+        assert_eq!(vec![0x0a, 0x00], msg.encode_to_vec());
+    }
+
+    #[test]
+    fn test_contiguous_ipv6_network_try_from_masks_host_bits() {
+        let msg = pb::ContiguousIPv6Network {
+            addr: Some(pb::IPv6Address {
+                hi: 0x2a0206b800000001,
+                lo: 0x0000000000000100,
+            }),
+            prefix_len: 64,
+        };
+        let expected = Contiguous::<Ipv6Network>::parse("2a02:6b8:0:1::/64").unwrap();
+        assert_eq!(expected, Contiguous::<Ipv6Network>::try_from(&msg).unwrap());
+    }
+
+    #[test]
+    fn test_contiguous_ipv6_network_try_from_rejects_absent_addr() {
+        let malformed = pb::ContiguousIPv6Network { addr: None, prefix_len: 64 };
+        assert!(Contiguous::<Ipv6Network>::try_from(&malformed).is_err());
+    }
+
+    #[test]
+    fn test_contiguous_ipv6_network_try_from_rejects_prefix_overflow() {
+        let malformed = pb::ContiguousIPv6Network {
+            addr: Some(pb::IPv6Address { hi: 0x2a0206b800000000, lo: 0 }),
+            prefix_len: 129,
+        };
+        assert!(Contiguous::<Ipv6Network>::try_from(&malformed).is_err());
+    }
+
+    #[test]
+    fn test_contiguous_ipv6_network_serde_string_round_trip() {
+        let msg = pb::ContiguousIPv6Network::from(Contiguous::<Ipv6Network>::parse("2a02:6b8::/32").unwrap());
+        let json = serde_json::to_string(&msg).unwrap();
+        assert_eq!(r#""2a02:6b8::/32""#, json);
+        let got: pb::ContiguousIPv6Network = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, got);
+    }
+
+    /// The `"invalid"` literal an absent address serializes to is not
+    /// itself a parseable network, so deserializing it back is a
+    /// deliberate error rather than a silently reconstructed message.
+    #[test]
+    fn test_contiguous_ipv6_network_serde_invalid_does_not_deserialize() {
+        let malformed = pb::ContiguousIPv6Network { addr: None, prefix_len: 64 };
+        let json = serde_json::to_string(&malformed).unwrap();
+        assert_eq!(r#""invalid""#, json);
+        assert!(serde_json::from_str::<pb::ContiguousIPv6Network>(&json).is_err());
+    }
+
+    #[test]
+    fn test_contiguous_ipv6_network_from_str_masks_host_bits() {
+        let got: pb::ContiguousIPv6Network = "2a02:6b8:0:1::100/64".parse().unwrap();
+        assert_eq!(Some(pb::IPv6Address { hi: 0x2a0206b800000001, lo: 0 }), got.addr);
+        assert_eq!(64, got.prefix_len);
+    }
+
+    #[test]
+    fn test_contiguous_ipv6_network_from_str_rejects_ipv4() {
+        assert!("10.0.0.0/8".parse::<pb::ContiguousIPv6Network>().is_err());
+    }
+
+    /// A half-zero address omits that half inside the nested message;
+    /// the fixture pins the hi-only shape shared with the Go tests.
+    #[test]
+    fn test_contiguous_ipv6_network_wire_bytes_hi_only_golden() {
+        use prost::Message;
+
+        let msg = pb::ContiguousIPv6Network {
+            addr: Some(pb::IPv6Address { hi: 0x2a0206b800000000, lo: 0 }),
+            prefix_len: 32,
+        };
+        assert_eq!(
+            vec![
+                0x0a, 0x09, 0x09, 0x00, 0x00, 0x00, 0x00, 0xb8, 0x06, 0x02, 0x2a, 0x10, 0x20
+            ],
+            msg.encode_to_vec()
+        );
     }
 }


### PR DESCRIPTION
- Adds a ContiguousIPv6Network message pairing the typed IPv6 address with a prefix length bounded by 128, so the family is structural on the wire.
- Host bits below the prefix are masked off on decode rather than rejected, consistently with the IPv4 sibling.
- Adds Go helpers over the family-typed xnetip CIDR block with CIDR-only parsing and bare-CIDR-string JSON.
- Adds Rust conversions, Display, FromStr, and string-form serde mirroring the IPv4 sibling.
- Pins the nested wire encoding, the default-route presence invariant, and the masking behavior with shared cross-language fixtures.

Closes #2201.
