### PR TITLE
feat(commonpb): add a bi-contiguous network message

### DIFF
--- a/common/commonpb/v1/bicontiguousnetwork.go
+++ b/common/commonpb/v1/bicontiguousnetwork.go
@@ -1,0 +1,122 @@
+package commonpb
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net/netip"
+
+	"github.com/yanet-platform/xnetip"
+)
+
+// NewBiContiguousIPv6NetworkFromBiContiguous creates a
+// BiContiguousIPv6Network from an xnetip bi-contiguous network.
+//
+// The conversion is total: the network is masked by its own invariant.
+// The inverse of ToBiContiguous.
+func NewBiContiguousIPv6NetworkFromBiContiguous(net xnetip.BiContiguous) *BiContiguousIPv6Network {
+	return &BiContiguousIPv6Network{
+		Addr:        NewIPv6Address(net.Network().Addr().As16()),
+		HiPrefixLen: uint32(net.HighPrefixLen()),
+		LoPrefixLen: uint32(net.LowPrefixLen()),
+	}
+}
+
+// ParseBiContiguousIPv6Network parses s as an IPv6 network whose two
+// 64-bit mask halves are independently contiguous.
+//
+// Host bits are masked off. The CIDR form, the explicit address/mask
+// form, and a bare address promoted to a host route are all accepted.
+// A mask with a hole inside either half is rejected, as is an IPv4
+// input.
+func ParseBiContiguousIPv6Network(s string) (*BiContiguousIPv6Network, error) {
+	net, err := xnetip.ParseBiContiguous(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse IP network: %w", err)
+	}
+	return NewBiContiguousIPv6NetworkFromBiContiguous(net), nil
+}
+
+// ToBiContiguous converts the BiContiguousIPv6Network to an xnetip
+// bi-contiguous network.
+//
+// Returns an error if addr is absent or either half's prefix length
+// exceeds 64. Every in-range length pair is a valid mask, so no mask
+// shape is ever rejected. The returned network is masked, so host bits
+// never leak out even if the message was constructed by hand. The
+// inverse of NewBiContiguousIPv6NetworkFromBiContiguous.
+func (m *BiContiguousIPv6Network) ToBiContiguous() (xnetip.BiContiguous, error) {
+	if m.GetAddr() == nil {
+		return xnetip.BiContiguous{}, fmt.Errorf("missing network address")
+	}
+	if m.GetHiPrefixLen() > 64 || m.GetLoPrefixLen() > 64 {
+		return xnetip.BiContiguous{}, fmt.Errorf(
+			"invalid prefix lengths %d/%d: each half must not exceed 64",
+			m.GetHiPrefixLen(), m.GetLoPrefixLen(),
+		)
+	}
+
+	var mask [16]byte
+	binary.BigEndian.PutUint64(mask[:8], leadingOnes64(int(m.GetHiPrefixLen())))
+	binary.BigEndian.PutUint64(mask[8:], leadingOnes64(int(m.GetLoPrefixLen())))
+
+	net, err := xnetip.BiContiguousFrom(m.GetAddr().ToAddr(), netip.AddrFrom16(mask))
+	if err != nil {
+		return xnetip.BiContiguous{}, fmt.Errorf("failed to build IP network: %w", err)
+	}
+	return net, nil
+}
+
+// leadingOnes64 returns the 64-bit mask half holding a leading run of
+// length one bits.
+//
+// The caller guarantees length is within 0 through 64. A shift by the
+// full width is well defined in Go and yields the zero mask.
+func leadingOnes64(length int) uint64 {
+	return ^uint64(0) << (64 - length)
+}
+
+// AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
+func (m *BiContiguousIPv6Network) AsLogValue() any {
+	net, err := m.ToBiContiguous()
+	if err != nil {
+		return "invalid"
+	}
+
+	return net.String()
+}
+
+// MarshalJSON serializes the network as a bare string, the same form
+// the Rust side renders.
+//
+// The CIDR form appears when the mask is globally contiguous, the
+// address/mask form otherwise.
+func (m *BiContiguousIPv6Network) MarshalJSON() ([]byte, error) {
+	net, err := m.ToBiContiguous()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(net.String())
+}
+
+// UnmarshalJSON accepts a bare string in any form
+// ParseBiContiguousIPv6Network accepts.
+func (m *BiContiguousIPv6Network) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw == "" {
+		return fmt.Errorf("empty IP network is not allowed")
+	}
+
+	parsed, err := ParseBiContiguousIPv6Network(raw)
+	if err != nil {
+		return err
+	}
+
+	m.Addr = parsed.Addr
+	m.HiPrefixLen = parsed.HiPrefixLen
+	m.LoPrefixLen = parsed.LoPrefixLen
+	return nil
+}

--- a/common/commonpb/v1/bicontiguousnetwork_test.go
+++ b/common/commonpb/v1/bicontiguousnetwork_test.go
@@ -1,0 +1,401 @@
+package commonpb_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yanet-platform/xnetip"
+	"google.golang.org/protobuf/proto"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+)
+
+// Test_NewBiContiguousIPv6NetworkFromBiContiguous_Valid verifies that
+// networks encode as the address plus one run length per mask half.
+//
+// The fixture values mirror the Rust tests so an encoding defect fails
+// identically in both languages.
+func Test_NewBiContiguousIPv6NetworkFromBiContiguous_Valid(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+		wantHi  uint64
+		wantLo  uint64
+		wantHL  uint32
+		wantLL  uint32
+	}{
+		{name: "default route", network: "::/0"},
+		{
+			name:    "globally contiguous subnet",
+			network: "2001:db8::/32",
+			wantHi:  0x20010db800000000,
+			wantHL:  32,
+		},
+		{
+			name:    "host route",
+			network: "2001:db8::1/128",
+			wantHi:  0x20010db800000000,
+			wantLo:  1,
+			wantHL:  64,
+			wantLL:  64,
+		},
+		{
+			name:    "hole at the /64 boundary",
+			network: "2001:db8:ff00::1:2:0:0/ffff:ffff:ff00:0:ffff:ffff:0:0",
+			wantHi:  0x20010db8ff000000,
+			wantLo:  0x0001000200000000,
+			wantHL:  40,
+			wantLL:  32,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network := commonpb.NewBiContiguousIPv6NetworkFromBiContiguous(
+				xnetip.MustParseBiContiguous(tt.network),
+			)
+			require.Equal(t, tt.wantHi, network.Addr.Hi)
+			require.Equal(t, tt.wantLo, network.Addr.Lo)
+			require.Equal(t, tt.wantHL, network.HiPrefixLen)
+			require.Equal(t, tt.wantLL, network.LoPrefixLen)
+		})
+	}
+}
+
+// Test_NewBiContiguousIPv6NetworkFromBiContiguous_ZeroValue verifies
+// that the zero network converts totally to the wildcard message.
+func Test_NewBiContiguousIPv6NetworkFromBiContiguous_ZeroValue(t *testing.T) {
+	network := commonpb.NewBiContiguousIPv6NetworkFromBiContiguous(xnetip.BiContiguous{})
+	require.NotNil(t, network.Addr)
+	require.Equal(t, uint64(0), network.Addr.Hi)
+	require.Equal(t, uint64(0), network.Addr.Lo)
+	require.Equal(t, uint32(0), network.HiPrefixLen)
+	require.Equal(t, uint32(0), network.LoPrefixLen)
+}
+
+// Test_BiContiguousIPv6Network_ToBiContiguous_RoundTrip verifies that
+// conversion to the domain type and back preserves the network exactly.
+func Test_BiContiguousIPv6Network_ToBiContiguous_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+		want    string
+	}{
+		{name: "default route", network: "::/0", want: "::/0"},
+		{name: "globally contiguous subnet", network: "2001:db8::/32", want: "2001:db8::/32"},
+		{name: "host route", network: "2001:db8::1/128", want: "2001:db8::1/128"},
+		{
+			name:    "hole at the /64 boundary",
+			network: "2001:db8:ff00::1:2:0:0/ffff:ffff:ff00:0:ffff:ffff:0:0",
+			want:    "2001:db8:ff00:0:1:2::/ffff:ffff:ff00:0:ffff:ffff::",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network, err := commonpb.ParseBiContiguousIPv6Network(tt.network)
+			require.NoError(t, err)
+			got, err := network.ToBiContiguous()
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got.String())
+		})
+	}
+}
+
+// Test_BiContiguousIPv6Network_AllPrefixPairs_RoundTrip verifies that
+// every length pair from 0 through 64 survives the round trip.
+//
+// This is the class bijectivity the encoding is chosen for: no pair in
+// range is invalid, and nothing outside the class is expressible.
+func Test_BiContiguousIPv6Network_AllPrefixPairs_RoundTrip(t *testing.T) {
+	allOnes := &commonpb.IPv6Address{Hi: ^uint64(0), Lo: ^uint64(0)}
+	for hiLen := range uint32(65) {
+		for loLen := range uint32(65) {
+			network := &commonpb.BiContiguousIPv6Network{
+				Addr:        allOnes,
+				HiPrefixLen: hiLen,
+				LoPrefixLen: loLen,
+			}
+			net, err := network.ToBiContiguous()
+			require.NoError(t, err)
+			back := commonpb.NewBiContiguousIPv6NetworkFromBiContiguous(net)
+			require.Equal(t, hiLen, back.HiPrefixLen)
+			require.Equal(t, loLen, back.LoPrefixLen)
+		}
+	}
+}
+
+// Test_BiContiguousIPv6Network_ToBiContiguous_MasksHostBits verifies
+// that bits outside the mask decode to the masked network.
+func Test_BiContiguousIPv6Network_ToBiContiguous_MasksHostBits(t *testing.T) {
+	network := &commonpb.BiContiguousIPv6Network{
+		Addr:        &commonpb.IPv6Address{Hi: 0x20010db8ffffffff, Lo: ^uint64(0)},
+		HiPrefixLen: 32,
+		LoPrefixLen: 16,
+	}
+	got, err := network.ToBiContiguous()
+	require.NoError(t, err)
+	require.Equal(t, "2001:db8:0:0:ffff::/ffff:ffff:0:0:ffff::", got.String())
+}
+
+// Test_BiContiguousIPv6Network_ToBiContiguous_Rejects verifies that an
+// absent address and an out-of-range half length return errors.
+func Test_BiContiguousIPv6Network_ToBiContiguous_Rejects(t *testing.T) {
+	validAddr := &commonpb.IPv6Address{Hi: 0x20010db800000000}
+	tests := []struct {
+		name    string
+		network *commonpb.BiContiguousIPv6Network
+	}{
+		{
+			name:    "absent addr",
+			network: &commonpb.BiContiguousIPv6Network{HiPrefixLen: 32},
+		},
+		{
+			name: "high length above 64",
+			network: &commonpb.BiContiguousIPv6Network{
+				Addr:        validAddr,
+				HiPrefixLen: 65,
+			},
+		},
+		{
+			name: "low length above 64",
+			network: &commonpb.BiContiguousIPv6Network{
+				Addr:        validAddr,
+				LoPrefixLen: 65,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.network.ToBiContiguous()
+			require.Error(t, err)
+		})
+	}
+}
+
+// Test_BiContiguousIPv6Network_WireRoundTrip verifies golden wire bytes
+// shared with the Rust tests and that decode reproduces the network.
+//
+// The wildcard is not an empty message: the present-but-zero address
+// encodes as two bytes, and decode relies on that presence to tell the
+// wildcard from a malformed message.
+func Test_BiContiguousIPv6Network_WireRoundTrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		network   string
+		wantBytes []byte
+	}{
+		{
+			name:      "default route",
+			network:   "::/0",
+			wantBytes: []byte{0x0a, 0x00},
+		},
+		{
+			name:    "hole at the /64 boundary",
+			network: "2001:db8:ff00::1:2:0:0/ffff:ffff:ff00:0:ffff:ffff:0:0",
+			wantBytes: []byte{
+				0x0a, 0x12,
+				0x09, 0x00, 0x00, 0x00, 0xff, 0xb8, 0x0d, 0x01, 0x20,
+				0x11, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0x00,
+				0x10, 0x28,
+				0x18, 0x20,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original, err := commonpb.ParseBiContiguousIPv6Network(tt.network)
+			require.NoError(t, err)
+
+			data, err := proto.Marshal(original)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantBytes, data)
+
+			var got commonpb.BiContiguousIPv6Network
+			require.NoError(t, proto.Unmarshal(data, &got))
+			net, err := got.ToBiContiguous()
+			require.NoError(t, err)
+			want, err := original.ToBiContiguous()
+			require.NoError(t, err)
+			require.Equal(t, want, net)
+		})
+	}
+}
+
+// Test_ParseBiContiguousIPv6Network_AcceptedForms verifies that the
+// CIDR, explicit mask, and bare host forms parse canonically.
+func Test_ParseBiContiguousIPv6Network_AcceptedForms(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "CIDR form", input: "2001:db8::/32", want: "2001:db8::/32"},
+		{
+			name:  "explicit mask form",
+			input: "2001:db8:ff00::1:2:0:0/ffff:ffff:ff00:0:ffff:ffff:0:0",
+			want:  "2001:db8:ff00:0:1:2::/ffff:ffff:ff00:0:ffff:ffff::",
+		},
+		{name: "bare address is a host route", input: "2001:db8::1", want: "2001:db8::1/128"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network, err := commonpb.ParseBiContiguousIPv6Network(tt.input)
+			require.NoError(t, err)
+			net, err := network.ToBiContiguous()
+			require.NoError(t, err)
+			require.Equal(t, tt.want, net.String())
+		})
+	}
+}
+
+// Test_ParseBiContiguousIPv6Network_Invalid verifies that masks with an
+// interior hole, IPv4 input, and junk are rejected.
+func Test_ParseBiContiguousIPv6Network_Invalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "interior hole in the high half", input: "2001:db8::/ffff:0:ffff::"},
+		{
+			name:  "interior hole in the low half",
+			input: "2001:db8::/ffff:ffff:ffff:ffff:ffff:0:ffff:0",
+		},
+		{name: "IPv4 CIDR", input: "10.0.0.0/24"},
+		{name: "not a network", input: "not-a-net"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := commonpb.ParseBiContiguousIPv6Network(tt.input)
+			require.Error(t, err)
+		})
+	}
+}
+
+// Test_BiContiguousIPv6Network_MarshalJSON verifies that the network
+// serializes as a bare string, the same form the Rust side emits.
+//
+// The CIDR form appears when the mask is globally contiguous, the
+// address/mask form otherwise.
+func Test_BiContiguousIPv6Network_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+		want    string
+	}{
+		{
+			name:    "globally contiguous subnet",
+			network: "2001:db8::/32",
+			want:    `"2001:db8::/32"`,
+		},
+		{
+			name:    "hole at the /64 boundary",
+			network: "2001:db8:ff00::1:2:0:0/ffff:ffff:ff00:0:ffff:ffff:0:0",
+			want:    `"2001:db8:ff00:0:1:2::/ffff:ffff:ff00:0:ffff:ffff::"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network, err := commonpb.ParseBiContiguousIPv6Network(tt.network)
+			require.NoError(t, err)
+			got, err := json.Marshal(network)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+// Test_BiContiguousIPv6Network_MarshalJSON_RejectsAbsentAddr verifies
+// that a malformed message fails to serialize.
+func Test_BiContiguousIPv6Network_MarshalJSON_RejectsAbsentAddr(t *testing.T) {
+	network := &commonpb.BiContiguousIPv6Network{HiPrefixLen: 32}
+	_, err := json.Marshal(network)
+	require.Error(t, err)
+}
+
+// Test_BiContiguousIPv6Network_UnmarshalJSON verifies that bare strings
+// in every accepted parse form are decoded and the rest are rejected.
+func Test_BiContiguousIPv6Network_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "CIDR form", input: `"2001:db8::/32"`, want: "2001:db8::/32"},
+		{
+			name:  "explicit mask form",
+			input: `"2001:db8:ff00::1:2:0:0/ffff:ffff:ff00:0:ffff:ffff:0:0"`,
+			want:  "2001:db8:ff00:0:1:2::/ffff:ffff:ff00:0:ffff:ffff::",
+		},
+		{name: "interior hole", input: `"2001:db8::/ffff:0:ffff::"`, wantErr: true},
+		{name: "IPv4 CIDR", input: `"10.0.0.0/24"`, wantErr: true},
+		{name: "empty string", input: `""`, wantErr: true},
+		{name: "object form", input: `{"network":"2001:db8::/32"}`, wantErr: true},
+		{name: "invalid JSON", input: `"2001`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var network commonpb.BiContiguousIPv6Network
+			err := json.Unmarshal([]byte(tt.input), &network)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			net, err := network.ToBiContiguous()
+			require.NoError(t, err)
+			require.Equal(t, tt.want, net.String())
+		})
+	}
+}
+
+// Test_BiContiguousIPv6Network_JSONRoundTrip verifies that marshaling
+// and unmarshaling reproduce the original message for both text forms.
+func Test_BiContiguousIPv6Network_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+	}{
+		{name: "globally contiguous subnet", network: "2001:db8::/32"},
+		{
+			name:    "hole at the /64 boundary",
+			network: "2001:db8:ff00::1:2:0:0/ffff:ffff:ff00:0:ffff:ffff:0:0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original, err := commonpb.ParseBiContiguousIPv6Network(tt.network)
+			require.NoError(t, err)
+
+			data, err := json.Marshal(original)
+			require.NoError(t, err)
+
+			var got commonpb.BiContiguousIPv6Network
+			require.NoError(t, json.Unmarshal(data, &got))
+			require.Equal(t, original.Addr.Hi, got.Addr.Hi)
+			require.Equal(t, original.Addr.Lo, got.Addr.Lo)
+			require.Equal(t, original.HiPrefixLen, got.HiPrefixLen)
+			require.Equal(t, original.LoPrefixLen, got.LoPrefixLen)
+		})
+	}
+}
+
+// Test_BiContiguousIPv6Network_AsLogValue verifies compact rendering for
+// request logs and the invalid fallback for a malformed message.
+func Test_BiContiguousIPv6Network_AsLogValue(t *testing.T) {
+	network, err := commonpb.ParseBiContiguousIPv6Network("2001:db8::/32")
+	require.NoError(t, err)
+	require.Equal(t, "2001:db8::/32", network.AsLogValue())
+
+	malformed := &commonpb.BiContiguousIPv6Network{HiPrefixLen: 32}
+	require.Equal(t, "invalid", malformed.AsLogValue())
+}

--- a/common/commonpb/v1/ipnetwork.proto
+++ b/common/commonpb/v1/ipnetwork.proto
@@ -55,3 +55,29 @@ message ContiguousIPv6Network {
   // MUST be <= 128.
   uint32 prefix_len = 2;
 }
+
+// BiContiguousIPv6Network represents an IPv6 network whose two 64-bit
+// mask halves are independently contiguous.
+//
+// This is the filter compiler's valid IPv6 class: each mask half is a
+// leading run of one bits, so a hole exactly at the /64 boundary is
+// expressible while a mask with a hole inside either half is
+// unrepresentable. Globally contiguous CIDR masks are the subset with
+// hi_prefix_len 64 or lo_prefix_len 0. An absent message means no
+// network. The wildcard ::/0 is the explicit all-zero encoding, and an
+// absent addr is the only malformed state.
+message BiContiguousIPv6Network {
+  // Network base address.
+  //
+  // MUST be present. Address bits not covered by the two half-masks are
+  // masked off on decode, so producers need not normalize.
+  IPv6Address addr = 1;
+  // Leading-ones run length of the high 64-bit mask half.
+  //
+  // MUST be <= 64.
+  uint32 hi_prefix_len = 2;
+  // Leading-ones run length of the low 64-bit mask half.
+  //
+  // MUST be <= 64.
+  uint32 lo_prefix_len = 3;
+}

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -3,10 +3,11 @@ use core::error::Error;
 /// Messages that gain the ordinary `Serialize`/`Deserialize` derive.
 ///
 /// The address messages, `MACAddress`, and the network messages
-/// (`ContiguousIPNetwork`, `ContiguousIPv4Network`, `ContiguousIPv6Network`)
-/// are deliberately absent: `src/lib.rs` hand-writes their
-/// `Serialize`/`Deserialize` impls to go straight to and from a plain
-/// string, and prost-build's attribute paths are additive, not
+/// (`ContiguousIPNetwork`, `ContiguousIPv4Network`, `ContiguousIPv6Network`,
+/// `BiContiguousIPv6Network`) are deliberately absent: `src/lib.rs`
+/// hand-writes their `Serialize`/`Deserialize` impls to go straight to
+/// and from a plain string, and prost-build's attribute paths are
+/// additive, not
 /// subtractive -- a blanket `message_attribute(".", ...)` cannot exclude
 /// a single message, so every other message is listed here individually
 /// instead.

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -5,7 +5,10 @@ use core::{
     str::FromStr,
 };
 
-use netip::{Contiguous, IpNetwork, Ipv4Network, Ipv6Network, MacAddr, ipv4_range_to_networks, ipv6_range_to_networks};
+use netip::{
+    BiContiguous, Contiguous, IpNetwork, Ipv4Network, Ipv6Network, MacAddr, ipv4_range_to_networks,
+    ipv6_range_to_networks,
+};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 #[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
@@ -392,6 +395,82 @@ impl Serialize for pb::ContiguousIPv6Network {
 }
 
 impl<'de> Deserialize<'de> for pb::ContiguousIPv6Network {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<Self>().map_err(de::Error::custom)
+    }
+}
+
+impl From<BiContiguous<Ipv6Network>> for pb::BiContiguousIPv6Network {
+    fn from(net: BiContiguous<Ipv6Network>) -> Self {
+        let mask = net.mask().to_bits();
+        pb::BiContiguousIPv6Network {
+            addr: Some(pb::IPv6Address::from(*net.addr())),
+            hi_prefix_len: ((mask >> 64) as u64).leading_ones(),
+            lo_prefix_len: (mask as u64).leading_ones(),
+        }
+    }
+}
+
+impl TryFrom<&pb::BiContiguousIPv6Network> for BiContiguous<Ipv6Network> {
+    type Error = Box<dyn Error>;
+
+    /// Masks address bits outside the two half-masks rather than
+    /// rejecting them.
+    fn try_from(net: &pb::BiContiguousIPv6Network) -> Result<Self, Self::Error> {
+        let addr = net.addr.as_ref().ok_or("invalid IP network: missing address")?;
+        if net.hi_prefix_len > 64 || net.lo_prefix_len > 64 {
+            return Err(format!(
+                "invalid prefix lengths {}/{}: each half must not exceed 64",
+                net.hi_prefix_len, net.lo_prefix_len
+            )
+            .into());
+        }
+
+        let mask = (u128::from(u64::MAX.unbounded_shl(64 - net.hi_prefix_len)) << 64)
+            | u128::from(u64::MAX.unbounded_shl(64 - net.lo_prefix_len));
+        let network = Ipv6Network::new(Ipv6Addr::from(addr), Ipv6Addr::from_bits(mask));
+        BiContiguous::try_from(network).map_err(|e| format!("failed to build IP network: {e}").into())
+    }
+}
+
+impl Display for pb::BiContiguousIPv6Network {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match BiContiguous::<Ipv6Network>::try_from(self) {
+            Ok(net) => net.fmt(f),
+            Err(..) => f.write_str("invalid"),
+        }
+    }
+}
+
+impl FromStr for pb::BiContiguousIPv6Network {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let net = BiContiguous::<Ipv6Network>::parse(s)?;
+        Ok(Self::from(net))
+    }
+}
+
+impl Serialize for pb::BiContiguousIPv6Network {
+    /// Serializes as the string `Display` renders: the CIDR form when
+    /// the mask is globally contiguous, the address/mask form otherwise.
+    ///
+    /// A message with an absent address renders as the literal
+    /// `"invalid"`, which is not itself a parseable network and so
+    /// deliberately does not deserialize back.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for pb::BiContiguousIPv6Network {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -1426,5 +1505,157 @@ mod test {
             ],
             msg.encode_to_vec()
         );
+    }
+
+    /// Verifies typed construction from a bi-contiguous network and the
+    /// decode back, with fixtures mirrored in the Go tests.
+    #[test]
+    fn test_bicontiguous_ipv6_network_conversion_round_trip() {
+        let net = BiContiguous::<Ipv6Network>::parse("2001:db8:ff00::1:2:0:0/ffff:ffff:ff00:0:ffff:ffff:0:0").unwrap();
+        let msg = pb::BiContiguousIPv6Network::from(net);
+        assert_eq!(
+            Some(pb::IPv6Address {
+                hi: 0x20010db8ff000000,
+                lo: 0x0001000200000000
+            }),
+            msg.addr
+        );
+        assert_eq!(40, msg.hi_prefix_len);
+        assert_eq!(32, msg.lo_prefix_len);
+        assert_eq!(net, BiContiguous::<Ipv6Network>::try_from(&msg).unwrap());
+    }
+
+    /// Verifies the nested wire encoding against a golden byte fixture
+    /// shared with the Go tests.
+    #[test]
+    fn test_bicontiguous_ipv6_network_wire_bytes_golden() {
+        use prost::Message;
+
+        let msg = pb::BiContiguousIPv6Network {
+            addr: Some(pb::IPv6Address {
+                hi: 0x20010db8ff000000,
+                lo: 0x0001000200000000,
+            }),
+            hi_prefix_len: 40,
+            lo_prefix_len: 32,
+        };
+        assert_eq!(
+            vec![
+                0x0a, 0x12, 0x09, 0x00, 0x00, 0x00, 0xff, 0xb8, 0x0d, 0x01, 0x20, 0x11, 0x00, 0x00, 0x00, 0x00, 0x02,
+                0x00, 0x01, 0x00, 0x10, 0x28, 0x18, 0x20,
+            ],
+            msg.encode_to_vec()
+        );
+    }
+
+    /// The wildcard is not an empty message: the present-but-zero
+    /// address encodes as two bytes, and decode relies on that presence
+    /// to tell the wildcard from a malformed message.
+    #[test]
+    fn test_bicontiguous_ipv6_network_wire_bytes_zero_value_golden() {
+        use prost::Message;
+
+        let msg = pb::BiContiguousIPv6Network {
+            addr: Some(pb::IPv6Address { hi: 0, lo: 0 }),
+            hi_prefix_len: 0,
+            lo_prefix_len: 0,
+        };
+        assert_eq!(vec![0x0a, 0x00], msg.encode_to_vec());
+    }
+
+    #[test]
+    fn test_bicontiguous_ipv6_network_try_from_masks_host_bits() {
+        let msg = pb::BiContiguousIPv6Network {
+            addr: Some(pb::IPv6Address { hi: 0x20010db8ffffffff, lo: u64::MAX }),
+            hi_prefix_len: 32,
+            lo_prefix_len: 16,
+        };
+        let expected = BiContiguous::<Ipv6Network>::parse("2001:db8:0:0:ffff::/ffff:ffff:0:0:ffff::").unwrap();
+        assert_eq!(expected, BiContiguous::<Ipv6Network>::try_from(&msg).unwrap());
+    }
+
+    #[test]
+    fn test_bicontiguous_ipv6_network_try_from_rejects_absent_addr() {
+        let malformed = pb::BiContiguousIPv6Network {
+            addr: None,
+            hi_prefix_len: 32,
+            lo_prefix_len: 0,
+        };
+        assert!(BiContiguous::<Ipv6Network>::try_from(&malformed).is_err());
+    }
+
+    #[test]
+    fn test_bicontiguous_ipv6_network_try_from_rejects_half_overflow() {
+        let addr = Some(pb::IPv6Address { hi: 0x20010db800000000, lo: 0 });
+        let high = pb::BiContiguousIPv6Network {
+            addr,
+            hi_prefix_len: 65,
+            lo_prefix_len: 0,
+        };
+        assert!(BiContiguous::<Ipv6Network>::try_from(&high).is_err());
+
+        let low = pb::BiContiguousIPv6Network {
+            addr,
+            hi_prefix_len: 0,
+            lo_prefix_len: 65,
+        };
+        assert!(BiContiguous::<Ipv6Network>::try_from(&low).is_err());
+    }
+
+    #[test]
+    fn test_bicontiguous_ipv6_network_serde_string_round_trip() {
+        let msg = pb::BiContiguousIPv6Network::from(
+            BiContiguous::<Ipv6Network>::parse("2001:db8:ff00::1:2:0:0/ffff:ffff:ff00:0:ffff:ffff:0:0").unwrap(),
+        );
+        let json = serde_json::to_string(&msg).unwrap();
+        assert_eq!(r#""2001:db8:ff00:0:1:2::/ffff:ffff:ff00:0:ffff:ffff::""#, json);
+        let got: pb::BiContiguousIPv6Network = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, got);
+    }
+
+    /// The `"invalid"` literal an absent address serializes to is not
+    /// itself a parseable network, so deserializing it back is a
+    /// deliberate error rather than a silently reconstructed message.
+    #[test]
+    fn test_bicontiguous_ipv6_network_serde_invalid_does_not_deserialize() {
+        let malformed = pb::BiContiguousIPv6Network {
+            addr: None,
+            hi_prefix_len: 32,
+            lo_prefix_len: 0,
+        };
+        let json = serde_json::to_string(&malformed).unwrap();
+        assert_eq!(r#""invalid""#, json);
+        assert!(serde_json::from_str::<pb::BiContiguousIPv6Network>(&json).is_err());
+    }
+
+    #[test]
+    fn test_bicontiguous_ipv6_network_from_str_accepts_cidr_form() {
+        let got: pb::BiContiguousIPv6Network = "2001:db8::/32".parse().unwrap();
+        assert_eq!(Some(pb::IPv6Address { hi: 0x20010db800000000, lo: 0 }), got.addr);
+        assert_eq!(32, got.hi_prefix_len);
+        assert_eq!(0, got.lo_prefix_len);
+    }
+
+    #[test]
+    fn test_bicontiguous_ipv6_network_from_str_rejects_high_half_hole() {
+        assert!(
+            "2001:db8::/ffff:0:ffff::"
+                .parse::<pb::BiContiguousIPv6Network>()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_bicontiguous_ipv6_network_from_str_rejects_low_half_hole() {
+        assert!(
+            "2001:db8::/ffff:ffff:ffff:ffff:ffff:0:ffff:0"
+                .parse::<pb::BiContiguousIPv6Network>()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_bicontiguous_ipv6_network_from_str_rejects_ipv4() {
+        assert!("10.0.0.0/24".parse::<pb::BiContiguousIPv6Network>().is_err());
     }
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/krl v0.0.0-20250403164848-fcf8101b2f53
 	github.com/vishvananda/netlink v1.3.1
-	github.com/yanet-platform/xnetip v0.1.0
+	github.com/yanet-platform/xnetip v0.1.1
 	go.uber.org/zap v1.28.0
 	golang.org/x/crypto v0.48.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/yanet-platform/xnetip v0.1.0 h1:SVPO12Uh1EcVAnLxSLsb8TU9usTRcp9nx1afQdYRglo=
 github.com/yanet-platform/xnetip v0.1.0/go.mod h1:ijlIrlZrBRL0+r4MATXqfKCfQK9Ze8Y68G7bn41Vluc=
+github.com/yanet-platform/xnetip v0.1.1 h1:hrJ8SQiTwkVOxhHloIpvON6V+/4n9IqtHSJQJ94rmLk=
+github.com/yanet-platform/xnetip v0.1.1/go.mod h1:ijlIrlZrBRL0+r4MATXqfKCfQK9Ze8Y68G7bn41Vluc=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.39.0 h1:8yPrr/S0ND9QEfTfdP9V+SiwT4E0G7Y5MO7p85nis48=


### PR DESCRIPTION
- Adds a BiContiguousIPv6Network message encoding the filter compiler's IPv6 class as the typed address plus one leading-ones run length per 64-bit mask half.
- Every in-range length pair is a valid mask and a mask with an interior hole is unrepresentable, so the mask-shape validation disappears from the wire boundary.
- Address bits outside the half-masks are masked off on decode, consistently with the contiguous siblings.
- Adds Go helpers over the xnetip bi-contiguous domain type, bumping xnetip to v0.1.1, which introduces the type on top of an otherwise behavior-preserving refactor.
- Adds Rust conversions, Display, FromStr, and string-form serde over the netip bi-contiguous wrapper.
- Pins the encoding with shared cross-language fixtures: an exhaustive per-half length-pair round trip, boundary-hole golden wire bytes, and the wildcard presence invariant.

Closes #2183.
