### PR TITLE
refactor(route-mpls,filterpb)!: migrate rule prefixes to the contiguous network container

### DIFF
--- a/common/filterpb/v1/filter.proto
+++ b/common/filterpb/v1/filter.proto
@@ -11,11 +11,6 @@ message VlanRange {
   uint32 to = 2;
 }
 
-message IPPrefix {
-  bytes addr = 1;
-  uint32 length = 2;
-}
-
 message IPNet {
   bytes addr = 1;
   bytes mask = 2;

--- a/common/rust/filterpb/build.rs
+++ b/common/rust/filterpb/build.rs
@@ -1,13 +1,11 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    let serialize = "#[derive(serde::Serialize)]";
     let serialize_deserialize = "#[derive(serde::Serialize, serde::Deserialize)]";
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
-        .message_attribute(".common.filterpb.v1.IPPrefix", serialize)
         .message_attribute(".common.filterpb.v1.Device", serialize_deserialize)
         .message_attribute(".common.filterpb.v1.PortRange", serialize_deserialize)
         .message_attribute(".common.filterpb.v1.ProtoRange", serialize_deserialize)

--- a/modules/route-mpls/cli/build.rs
+++ b/modules/route-mpls/cli/build.rs
@@ -1,7 +1,7 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../../../common/filterpb/v1/filter.proto");
+    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/contiguousnetwork.proto");
     println!("cargo:rerun-if-changed=../../../common/commonpb/v1/ipaddr.proto");
     println!("cargo:rerun-if-changed=../controlplane/routemplspb/v1/routempls.proto");
 
@@ -9,16 +9,9 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .extern_path(".common.filterpb.v1", "crate::filterpb")
         .message_attribute(".", "#[derive(Serialize)]")
         .enum_attribute(".", "#[derive(serde::Serialize)]")
         .compile_protos(&["routemplspb/v1/routempls.proto"], &["../../..", "../controlplane"])?;
-
-    tonic_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["common/filterpb/v1/filter.proto"], &["../../.."])?;
 
     Ok(())
 }

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -1,13 +1,6 @@
 //! CLI for YANET "route-mpls" module.
 
-use core::{net::IpAddr, ops::Deref};
-
-#[allow(clippy::std_instead_of_core, non_snake_case)]
-pub mod filterpb {
-    use serde::Serialize;
-
-    tonic::include_proto!("common.filterpb.v1");
-}
+use core::net::IpAddr;
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod routemplspb {
@@ -127,25 +120,6 @@ pub struct RouteWithdrawCmd {
     /// The MPLS Label to encapsulate packets into.
     #[arg(long = "label")]
     pub mpls_label: u32,
-}
-
-impl TryFrom<Contiguous<IpNetwork>> for filterpb::IpPrefix {
-    type Error = Box<dyn core::error::Error>;
-
-    fn try_from(net: Contiguous<IpNetwork>) -> Result<Self, Self::Error> {
-        let length = net.prefix() as u32;
-
-        match net.deref() {
-            IpNetwork::V4(net) => {
-                let addr = net.addr().octets().to_vec();
-                Ok(filterpb::IpPrefix { addr, length })
-            }
-            IpNetwork::V6(net) => {
-                let addr = net.addr().octets().to_vec();
-                Ok(filterpb::IpPrefix { addr, length })
-            }
-        }
-    }
 }
 
 /// The fully-qualified gRPC service name used in error messages.
@@ -310,10 +284,7 @@ impl RouteMplsService {
             name: cmd.config_name.clone(),
             updates: vec![UpdateEvent {
                 event: Some(Event::Update(Rule {
-                    prefix: Some(
-                        filterpb::IpPrefix::try_from(cmd.prefix)
-                            .map_err(|e| self.service.invalid("update", e.to_string()))?,
-                    ),
+                    prefix: Some(cmd.prefix.into()),
                     nexthop: Some(NextHop {
                         kind: routemplspb::ActionKind::Tunnel.into(),
                         label: cmd.mpls_label,
@@ -342,10 +313,7 @@ impl RouteMplsService {
             name: cmd.config_name.clone(),
             updates: vec![UpdateEvent {
                 event: Some(Event::Withdraw(Rule {
-                    prefix: Some(
-                        filterpb::IpPrefix::try_from(cmd.prefix)
-                            .map_err(|e| self.service.invalid("withdraw", e.to_string()))?,
-                    ),
+                    prefix: Some(cmd.prefix.into()),
                     nexthop: Some(NextHop {
                         kind: routemplspb::ActionKind::Tunnel.into(),
                         label: cmd.mpls_label,

--- a/modules/route-mpls/controlplane/routemplspb/v1/routempls.proto
+++ b/modules/route-mpls/controlplane/routemplspb/v1/routempls.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package modules.route_mpls.controlplane.routemplspb.v1;
 
+import "common/commonpb/v1/contiguousnetwork.proto";
 import "common/commonpb/v1/ipaddr.proto";
-import "common/filterpb/v1/filter.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1;routemplspb";
 
@@ -50,7 +50,7 @@ message ShowConfigResponse {
 }
 
 message Rule {
-  common.filterpb.v1.IPPrefix prefix = 1;
+  common.commonpb.v1.ContiguousIPNetwork prefix = 1;
   NextHop nexthop = 2;
 }
 

--- a/modules/route-mpls/controlplane/service.go
+++ b/modules/route-mpls/controlplane/service.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
-	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/maptrie"
 	"github.com/yanet-platform/yanet2/modules/route-mpls/bindings/go/croutempls"
 	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1"
@@ -235,12 +234,13 @@ func (m *RouteMPLSService) ShowConfig(
 	rules := make([]*routemplspb.Rule, 0)
 	for _, prefixes := range config.Prefixes {
 		for prefix, nexthops := range prefixes {
+			network, err := commonpb.NewContiguousIPNetworkFromPrefix(prefix)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to encode prefix %q: %v", prefix, err)
+			}
 			for _, nexthop := range nexthops.NextHops {
 				rules = append(rules, &routemplspb.Rule{
-					Prefix: &filterpb.IPPrefix{
-						Addr:   prefix.Addr().AsSlice(),
-						Length: uint32(prefix.Bits()),
-					},
+					Prefix: network,
 					Nexthop: &routemplspb.NextHop{
 						Label:         nexthop.MPLSLabel,
 						SourceIp:      commonpb.NewIPAddressFromAddr(nexthop.Source),
@@ -302,7 +302,7 @@ func (m *RouteMPLSService) CreateConfig(
 	prefixes := maptrie.NewMapTrie[netip.Prefix, netip.Addr, NextHopList](0)
 
 	for _, rule := range req.Rules {
-		prefix, err := makePrefix(rule.Prefix)
+		prefix, err := rule.GetPrefix().ToPrefix()
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
 		}
@@ -375,7 +375,7 @@ func (m *RouteMPLSService) UpdateConfig(
 
 	for _, update := range req.Updates {
 		if u := update.GetUpdate(); u != nil {
-			prefix, err := makePrefix(u.Prefix)
+			prefix, err := u.GetPrefix().ToPrefix()
 			if err != nil {
 				return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
 			}
@@ -400,7 +400,7 @@ func (m *RouteMPLSService) UpdateConfig(
 		}
 
 		if w := update.GetWithdraw(); w != nil {
-			prefix, err := makePrefix(w.Prefix)
+			prefix, err := w.GetPrefix().ToPrefix()
 			if err != nil {
 				return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
 			}
@@ -431,14 +431,6 @@ func (m *RouteMPLSService) UpdateConfig(
 	m.configs[name] = config
 
 	return &routemplspb.UpdateConfigResponse{}, nil
-}
-
-func makePrefix(prefix *filterpb.IPPrefix) (netip.Prefix, error) {
-	addr, ok := netip.AddrFromSlice(prefix.Addr)
-	if !ok {
-		return netip.Prefix{}, fmt.Errorf("invalid address length")
-	}
-	return netip.PrefixFrom(addr, int(prefix.Length)), nil
 }
 
 func makeNextHop(nexthop *routemplspb.NextHop) (NextHop, error) {

--- a/modules/route-mpls/controlplane/service_test.go
+++ b/modules/route-mpls/controlplane/service_test.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
-	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/modules/route-mpls/bindings/go/croutempls"
 	routemplspb "github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1"
 )
@@ -60,14 +59,11 @@ func newTestService(t *testing.T) *RouteMPLSService {
 func makeRule(t *testing.T, cidr string, dst string, label uint32) *routemplspb.Rule {
 	t.Helper()
 
-	p := netip.MustParsePrefix(cidr)
-	addrBytes := p.Addr().AsSlice()
+	prefix, err := commonpb.ParseContiguousIPNetwork(cidr)
+	require.NoError(t, err)
 
 	return &routemplspb.Rule{
-		Prefix: &filterpb.IPPrefix{
-			Addr:   addrBytes,
-			Length: uint32(p.Bits()),
-		},
+		Prefix: prefix,
 		Nexthop: &routemplspb.NextHop{
 			Label:         label,
 			SourceIp:      commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.0.2.1")),
@@ -101,6 +97,38 @@ func Test_RouteMPLSService_CreateConfig_EmptyName(t *testing.T) {
 		Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
 	})
 	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Test_RouteMPLSService_CreateConfig_InvalidPrefix verifies that a rule whose
+// prefix length exceeds the address family's bit width is rejected.
+func Test_RouteMPLSService_CreateConfig_InvalidPrefix(t *testing.T) {
+	service := newTestService(t)
+
+	rule := makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)
+	rule.Prefix.PrefixLen = 33
+
+	response, err := service.CreateConfig(t.Context(), &routemplspb.CreateConfigRequest{
+		Name:  "mpls0",
+		Rules: []*routemplspb.Rule{rule},
+	})
+	require.Nil(t, response)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Test_RouteMPLSService_CreateConfig_MissingPrefix verifies that a rule
+// carrying no prefix message is rejected rather than treated as a default.
+func Test_RouteMPLSService_CreateConfig_MissingPrefix(t *testing.T) {
+	service := newTestService(t)
+
+	rule := makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)
+	rule.Prefix = nil
+
+	response, err := service.CreateConfig(t.Context(), &routemplspb.CreateConfigRequest{
+		Name:  "mpls0",
+		Rules: []*routemplspb.Rule{rule},
+	})
+	require.Nil(t, response)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 

--- a/operators/bird-adapter/internal/rib/routes.go
+++ b/operators/bird-adapter/internal/rib/routes.go
@@ -5,7 +5,6 @@ import (
 	"net/netip"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
-	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1"
 	routepb "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
 )
@@ -146,7 +145,11 @@ func ToPBRoute(route *Route) (*routepb.Route, error) {
 	}, nil
 }
 
-func ToPBMPLSRoute(route *Route, source netip.Addr) *routemplspb.Rule {
+// ToPBMPLSRoute converts an adapter Route to the wire MPLS rule.
+//
+// Returns an error if the route carries an invalid prefix, which the
+// structured wire message cannot represent.
+func ToPBMPLSRoute(route *Route, source netip.Addr) (*routemplspb.Rule, error) {
 	weight := uint64(1)
 	for _, community := range route.LargeCommunities {
 		if community.ASN == 13238 && community.Function == 1 {
@@ -164,11 +167,14 @@ func ToPBMPLSRoute(route *Route, source netip.Addr) *routemplspb.Rule {
 	if len(route.MplsLabelStack) > 0 {
 		label = route.MplsLabelStack[0]
 	}
+
+	prefix, err := commonpb.NewContiguousIPNetworkFromPrefix(route.Prefix)
+	if err != nil {
+		return nil, fmt.Errorf("invalid prefix %q: %w", route.Prefix, err)
+	}
+
 	return &routemplspb.Rule{
-		Prefix: &filterpb.IPPrefix{
-			Addr:   route.Prefix.Addr().AsSlice(),
-			Length: uint32(route.Prefix.Bits()),
-		},
+		Prefix: prefix,
 		Nexthop: &routemplspb.NextHop{
 			Kind:          routemplspb.ActionKind_ACTION_KIND_TUNNEL,
 			Label:         label,
@@ -179,5 +185,5 @@ func ToPBMPLSRoute(route *Route, source netip.Addr) *routemplspb.Rule {
 
 			Counter: fmt.Sprintf("%s/%s/%d", route.Prefix.String(), destination.String(), label),
 		},
-	}
+	}, nil
 }

--- a/operators/bird-adapter/service.go
+++ b/operators/bird-adapter/service.go
@@ -423,12 +423,20 @@ func (m *AdapterService) processBirdImport(
 					if update.Prefix.Addr().Is6() {
 						source = mplsV6Src
 					}
+					rule, err := rib.ToPBMPLSRoute(&update, source)
+					if err != nil {
+						clientLog.Debug("mpls route cannot be converted to protobuf, skip",
+							zap.String("prefix", update.Prefix.String()),
+							zap.Error(err),
+						)
+						continue
+					}
 					if update.ToRemove {
 						mplsUpdates = append(
 							mplsUpdates,
 							&routemplspb.UpdateEvent{
 								Event: &routemplspb.UpdateEvent_Withdraw{
-									Withdraw: rib.ToPBMPLSRoute(&update, source),
+									Withdraw: rule,
 								},
 							},
 						)
@@ -437,7 +445,7 @@ func (m *AdapterService) processBirdImport(
 							mplsUpdates,
 							&routemplspb.UpdateEvent{
 								Event: &routemplspb.UpdateEvent_Update{
-									Update: rib.ToPBMPLSRoute(&update, source),
+									Update: rule,
 								},
 							},
 						)


### PR DESCRIPTION
- Retypes `Rule.prefix` in place to `common.commonpb.v1.ContiguousIPNetwork`, keeping the field number, and removes the now-unconsumed `filterpb.IPPrefix` message.
- Decodes prefixes through the container's `ToPrefix`, which rejects a missing address and an out-of-range prefix length and masks host bits, with tests for both invalid shapes.
- Makes `ToPBMPLSRoute` return an error for a prefix the structured message cannot represent, logged and skipped by the BIRD import loop the same way as `ToPBRoute`.
- Replaces the route-mpls CLI's hand-rolled prefix conversion with the commonpb `From` impl, so structured output renders the prefix as a bare CIDR string.
- The wire break is accepted under #2197 and follows the #2220/#2221 precedent: `buf breaking` flags the field retype and the message removal, and no `breaking.ignore` entries are added.
- Closes #1949.