### PR TITLE
fix(pdump): store the prepared config only once publishing it succeeds

### DIFF
--- a/modules/pdump/controlplane/ring_test.go
+++ b/modules/pdump/controlplane/ring_test.go
@@ -1004,7 +1004,7 @@ func Test_PdumpService_SetConfig_PreservesPublishedConfigDuringReaderDrain(t *te
 		&pdumppb.ShowConfigRequest{Name: name},
 	)
 	require.NoError(t, err)
-	require.Equal(t, "new", response.Config.Filter)
+	require.Equal(t, "old", response.Config.Filter)
 	require.NoError(t, tasks.Wait())
 }
 

--- a/modules/pdump/controlplane/service.go
+++ b/modules/pdump/controlplane/service.go
@@ -186,8 +186,8 @@ func (m *PdumpService) SetConfig(
 	err := m.updateConfig(
 		name,
 		request,
-		func() error {
-			return m.updateModuleConfig(name)
+		func(config *pdumpConfig) error {
+			return m.updateModuleConfig(name, config)
 		},
 	)
 	if err != nil {
@@ -282,14 +282,13 @@ func (m *PdumpService) transferConfigParameters(
 // the previous ring have stopped and the state lock has been reacquired.
 func (m *PdumpService) updateModuleConfig(
 	name string,
+	modConfig *pdumpConfig,
 ) error {
 	if m.agent == nil {
 		return fmt.Errorf("pdump agent is required")
 	}
 
 	m.log.Debug("update config", zap.String("module", name))
-
-	modConfig := m.configs[name]
 
 	ffiConfig, err := NewModuleConfig(m.agent, name, WithModuleConfigLog(m.log))
 	if err != nil {
@@ -416,7 +415,7 @@ func (m *PdumpService) registerRingReaders(
 func (m *PdumpService) updateConfig(
 	name string,
 	request *pdumppb.SetConfigRequest,
-	publish func() error,
+	publish func(config *pdumpConfig) error,
 ) error {
 	newConfig, err := m.prepareConfig(name, request)
 	if err != nil {
@@ -427,8 +426,12 @@ func (m *PdumpService) updateConfig(
 		name,
 		fmt.Errorf("terminated by config update"),
 		func() error {
+			if err := publish(newConfig); err != nil {
+				return err
+			}
 			m.configs[name] = newConfig
-			return publish()
+
+			return nil
 		},
 	)
 }


### PR DESCRIPTION
- An update stored the prepared config before publishing it and left it there when the publish failed.
- Publishing addresses the prepared ring at the shared memory it allocates and releases that memory on failure, so the stored entry was left holding pointers into freed shared memory that a later read follows.
- Hand the prepared config to the publish rather than routing it through the map, and store it only once that succeeds, so a failed update does not take effect and no rollback is needed.
- The existing reader-drain test covers this: it now expects the previously published config to survive an update whose publish fails.

Closes #2230.
