### PR TITLE
feat(acl): split filter network lists by address family on the wire

### DIFF
--- a/bindings/go/filterpbconv/v1/convert.go
+++ b/bindings/go/filterpbconv/v1/convert.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 )
 
@@ -110,6 +111,37 @@ func ToIPNet(pb *filterpb.IPNet) (filter.IPNet, error) {
 	}
 
 	return net, nil
+}
+
+// ToNet4sFromContiguous converts family-typed contiguous IPv4 network
+// messages to filter IPNets.
+func ToNet4sFromContiguous(pb []*commonpb.ContiguousIPv4Network) (filter.IPNets, error) {
+	prefixes, err := commonpb.PrefixesFromNetworks(pb)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid IPv4 network: %v", err)
+	}
+
+	return filter.Net4sFromPrefixes(prefixes)
+}
+
+// ToNet6sFromBiContiguous converts family-typed bi-contiguous IPv6 network
+// messages to filter IPNets.
+func ToNet6sFromBiContiguous(pb []*commonpb.BiContiguousIPv6Network) (filter.IPNets, error) {
+	out := make(filter.IPNets, 0, len(pb))
+
+	for idx := range pb {
+		net, err := pb[idx].ToBiContiguous()
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid IPv6 network at index %d: %v", idx, err)
+		}
+
+		out = append(out, filter.IPNet{
+			Addr: net.Network().Addr(),
+			Mask: net.Network().Mask(),
+		})
+	}
+
+	return out, nil
 }
 
 // ToPortRanges converts protobuf PortRange messages to filter PortRanges.

--- a/common/commonpb/v1/contiguousnetwork.go
+++ b/common/commonpb/v1/contiguousnetwork.go
@@ -49,33 +49,7 @@ func ParseContiguousIPNetwork(s string) (*ContiguousIPNetwork, error) {
 //
 // Returns an error if any prefix is not valid.
 func NetworksFromPrefixes(prefixes []netip.Prefix) ([]*ContiguousIPNetwork, error) {
-	networks := make([]*ContiguousIPNetwork, 0, len(prefixes))
-	for idx, prefix := range prefixes {
-		network, err := NewContiguousIPNetworkFromPrefix(prefix)
-		if err != nil {
-			return nil, fmt.Errorf("prefixes[%d]: %w", idx, err)
-		}
-		networks = append(networks, network)
-	}
-
-	return networks, nil
-}
-
-// PrefixesFromNetworks converts ContiguousIPNetwork messages to masked
-// netip.Prefix values.
-//
-// Returns an error if any network is malformed.
-func PrefixesFromNetworks(networks []*ContiguousIPNetwork) ([]netip.Prefix, error) {
-	prefixes := make([]netip.Prefix, 0, len(networks))
-	for idx, network := range networks {
-		prefix, err := network.ToPrefix()
-		if err != nil {
-			return nil, fmt.Errorf("prefixes[%d]: %w", idx, err)
-		}
-		prefixes = append(prefixes, prefix)
-	}
-
-	return prefixes, nil
+	return networksFromPrefixes(prefixes, NewContiguousIPNetworkFromPrefix)
 }
 
 // ToContiguous converts the ContiguousIPNetwork to an xnetip CIDR block.

--- a/common/commonpb/v1/ipnetwork.go
+++ b/common/commonpb/v1/ipnetwork.go
@@ -1,4 +1,42 @@
 package commonpb
 
-// This file is deliberately empty. It is kept as a placeholder for
-// upcoming network messages.
+import (
+	"fmt"
+	"net/netip"
+)
+
+// networksFromPrefixes converts netip.Prefix values to network messages
+// through the supplied per-family constructor.
+//
+// Returns an error naming the offending index if any prefix does not fit
+// the constructor's family.
+func networksFromPrefixes[T any](prefixes []netip.Prefix, newNetwork func(netip.Prefix) (T, error)) ([]T, error) {
+	networks := make([]T, 0, len(prefixes))
+	for idx, prefix := range prefixes {
+		network, err := newNetwork(prefix)
+		if err != nil {
+			return nil, fmt.Errorf("prefixes[%d]: %w", idx, err)
+		}
+		networks = append(networks, network)
+	}
+
+	return networks, nil
+}
+
+// PrefixesFromNetworks converts contiguous network messages of any one
+// message type to masked netip.Prefix values.
+//
+// Returns an error naming the offending index if any network is
+// malformed.
+func PrefixesFromNetworks[T interface{ ToPrefix() (netip.Prefix, error) }](networks []T) ([]netip.Prefix, error) {
+	prefixes := make([]netip.Prefix, 0, len(networks))
+	for idx, network := range networks {
+		prefix, err := network.ToPrefix()
+		if err != nil {
+			return nil, fmt.Errorf("prefixes[%d]: %w", idx, err)
+		}
+		prefixes = append(prefixes, prefix)
+	}
+
+	return prefixes, nil
+}

--- a/common/commonpb/v1/ipnetwork_test.go
+++ b/common/commonpb/v1/ipnetwork_test.go
@@ -1,0 +1,35 @@
+package commonpb_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+)
+
+// TestPrefixesFromNetworks_TypedNetworks asserts that a family-typed
+// network list decodes to masked netip.Prefix values.
+func TestPrefixesFromNetworks_TypedNetworks(t *testing.T) {
+	first, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("10.0.0.0/24"))
+	require.NoError(t, err)
+	second, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("10.0.1.1/24"))
+	require.NoError(t, err)
+
+	prefixes, err := commonpb.PrefixesFromNetworks([]*commonpb.ContiguousIPv4Network{first, second})
+	require.NoError(t, err)
+	require.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/24"),
+		netip.MustParsePrefix("10.0.1.0/24"),
+	}, prefixes)
+}
+
+// TestPrefixesFromNetworks_MalformedTypedNetwork asserts that a malformed
+// family-typed network is rejected with the offending index named.
+func TestPrefixesFromNetworks_MalformedTypedNetwork(t *testing.T) {
+	_, err := commonpb.PrefixesFromNetworks([]*commonpb.ContiguousIPv4Network{
+		{Addr: &commonpb.IPv4Address{Addr: 0x0a000000}, PrefixLen: 33},
+	})
+	require.ErrorContains(t, err, "prefixes[0]")
+}

--- a/common/commonpb/v1/ipv4network.go
+++ b/common/commonpb/v1/ipv4network.go
@@ -33,16 +33,6 @@ func NewContiguousIPv4NetworkFromPrefix(prefix netip.Prefix) (*ContiguousIPv4Net
 	return NewContiguousIPv4NetworkFromContiguous(net), nil
 }
 
-// ParseContiguousIPv4Network parses s as an IPv4 CIDR prefix, masking off
-// any host bits.
-func ParseContiguousIPv4Network(s string) (*ContiguousIPv4Network, error) {
-	prefix, err := netip.ParsePrefix(s)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse IP network: %w", err)
-	}
-	return NewContiguousIPv4NetworkFromPrefix(prefix)
-}
-
 // ToContiguous converts the ContiguousIPv4Network to an xnetip IPv4 CIDR
 // block.
 //
@@ -103,7 +93,11 @@ func (m *ContiguousIPv4Network) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("empty IP network is not allowed")
 	}
 
-	parsed, err := ParseContiguousIPv4Network(raw)
+	prefix, err := netip.ParsePrefix(raw)
+	if err != nil {
+		return fmt.Errorf("failed to parse IP network: %w", err)
+	}
+	parsed, err := NewContiguousIPv4NetworkFromPrefix(prefix)
 	if err != nil {
 		return err
 	}

--- a/common/commonpb/v1/ipv6network.go
+++ b/common/commonpb/v1/ipv6network.go
@@ -33,16 +33,6 @@ func NewContiguousIPv6NetworkFromPrefix(prefix netip.Prefix) (*ContiguousIPv6Net
 	return NewContiguousIPv6NetworkFromContiguous(net), nil
 }
 
-// ParseContiguousIPv6Network parses s as an IPv6 CIDR prefix, masking off
-// any host bits.
-func ParseContiguousIPv6Network(s string) (*ContiguousIPv6Network, error) {
-	prefix, err := netip.ParsePrefix(s)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse IP network: %w", err)
-	}
-	return NewContiguousIPv6NetworkFromPrefix(prefix)
-}
-
 // ToContiguous converts the ContiguousIPv6Network to an xnetip IPv6 CIDR
 // block.
 //
@@ -103,7 +93,11 @@ func (m *ContiguousIPv6Network) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("empty IP network is not allowed")
 	}
 
-	parsed, err := ParseContiguousIPv6Network(raw)
+	prefix, err := netip.ParsePrefix(raw)
+	if err != nil {
+		return fmt.Errorf("failed to parse IP network: %w", err)
+	}
+	parsed, err := NewContiguousIPv6NetworkFromPrefix(prefix)
 	if err != nil {
 		return err
 	}

--- a/modules/acl/cli/build.rs
+++ b/modules/acl/cli/build.rs
@@ -32,6 +32,24 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             ".modules.acl.controlplane.aclpb.v1.Action.kind",
             "#[serde(with = \"crate::action_kind\")]",
         )
+        // The typed network lists stay out of the YAML output while empty,
+        // so show rendering of a legacy-schema config is unchanged.
+        .field_attribute(
+            ".modules.acl.controlplane.aclpb.v1.Rule.sources4",
+            "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
+        )
+        .field_attribute(
+            ".modules.acl.controlplane.aclpb.v1.Rule.sources6",
+            "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
+        )
+        .field_attribute(
+            ".modules.acl.controlplane.aclpb.v1.Rule.destinations4",
+            "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
+        )
+        .field_attribute(
+            ".modules.acl.controlplane.aclpb.v1.Rule.destinations6",
+            "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
+        )
         .compile_protos(&["aclpb/v1/acl.proto"], &["../../..", "../controlplane"])?;
 
     Ok(())

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -681,6 +681,47 @@ mod test {
     }
 
     #[test]
+    fn test_rules_yaml_typed_network_lists_parse() {
+        let yaml = r#"
+rules:
+  - actions:
+      - kind: ACTION_KIND_PASS
+    sources4:
+      - 192.0.2.0/24
+      - 192.0.3.1/255.255.255.255
+    sources6:
+      - 2001:db8::/32
+      - "2001:db8::/ffff:ffff:ffff:0:ffff::"
+    destinations4:
+      - 0.0.0.0/0
+    destinations6:
+      - "::/::"
+"#;
+        let config: ACLConfig = serde_yaml::from_str(yaml).expect("typed network lists must parse");
+
+        let rule = &config.rules[0];
+        assert_eq!(2, rule.sources4.len());
+        assert_eq!(2, rule.sources6.len());
+        assert_eq!(1, rule.destinations4.len());
+        assert_eq!(1, rule.destinations6.len());
+    }
+
+    #[test]
+    fn test_rules_yaml_rejects_noncontiguous_v4_source() {
+        let yaml = "rules:\n  - sources4:\n      - 192.0.2.0/255.0.255.0\n";
+
+        serde_yaml::from_str::<ACLConfig>(yaml).expect_err("a non-contiguous IPv4 mask must be rejected at parse time");
+    }
+
+    #[test]
+    fn test_rules_yaml_rejects_v6_hole_within_half() {
+        let yaml = "rules:\n  - sources6:\n      - \"2001:db8::/ffff:0:ffff::\"\n";
+
+        serde_yaml::from_str::<ACLConfig>(yaml)
+            .expect_err("an IPv6 mask with a hole inside a half must be rejected at parse time");
+    }
+
+    #[test]
     fn a_tag_entry_splits_on_the_first_equals() {
         let tag = parse_tag("config=my-acl").expect("a well-formed tag must parse");
 

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package modules.acl.controlplane.aclpb.v1;
 
 import "common/filterpb/v1/filter.proto";
+import "common/commonpb/v1/bicontiguousnetwork.proto";
+import "common/commonpb/v1/ipv4network.proto";
 import "common/commonpb/v1/metric.proto";
 import "common/commonpb/v1/ipaddr.proto";
 import "common/commonpb/v1/macaddr.proto";
@@ -79,12 +81,20 @@ message Rule {
 
   repeated common.filterpb.v1.Device devices = 3;
   repeated common.filterpb.v1.VlanRange vlan_ranges = 4;
-  repeated common.filterpb.v1.IPNet srcs = 5;
-  repeated common.filterpb.v1.IPNet dsts = 6;
+  // srcs and dsts carry mixed-family networks with free-form byte
+  // masks; they remain accepted for backward compatibility and merge
+  // with the typed lists below. New clients use the typed lists, which
+  // make invalid mask shapes unrepresentable.
+  repeated common.filterpb.v1.IPNet srcs = 5 [deprecated = true];
+  repeated common.filterpb.v1.IPNet dsts = 6 [deprecated = true];
   repeated common.filterpb.v1.ProtoRange proto_ranges = 7;
   repeated common.filterpb.v1.PortRange src_port_ranges = 8;
   repeated common.filterpb.v1.PortRange dst_port_ranges = 9;
   common.filterpb.v1.Fragment fragment = 10;
+  repeated common.commonpb.v1.ContiguousIPv4Network sources4 = 11;
+  repeated common.commonpb.v1.BiContiguousIPv6Network sources6 = 12;
+  repeated common.commonpb.v1.ContiguousIPv4Network destinations4 = 13;
+  repeated common.commonpb.v1.BiContiguousIPv6Network destinations6 = 14;
 }
 
 message Action { ActionKind kind = 1; }

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -14,7 +14,10 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
 	filterpbconv "github.com/yanet-platform/yanet2/bindings/go/filterpbconv/v1"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -368,6 +371,36 @@ func labeler(fullMethod string, req any) metrics.Labels {
 	}
 }
 
+// mergedNet4s decodes the IPv4 networks a rule carries in the legacy
+// mixed-family list and the typed list, legacy entries first.
+func mergedNet4s(legacy []*filterpb.IPNet, typed []*commonpb.ContiguousIPv4Network) (filter.IPNets, error) {
+	nets, err := filterpbconv.ToNet4s(legacy)
+	if err != nil {
+		return nil, err
+	}
+	typedNets, err := filterpbconv.ToNet4sFromContiguous(typed)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(nets, typedNets...), nil
+}
+
+// mergedNet6s decodes the IPv6 networks a rule carries in the legacy
+// mixed-family list and the typed list, legacy entries first.
+func mergedNet6s(legacy []*filterpb.IPNet, typed []*commonpb.BiContiguousIPv6Network) (filter.IPNets, error) {
+	nets, err := filterpbconv.ToNet6s(legacy)
+	if err != nil {
+		return nil, err
+	}
+	typedNets, err := filterpbconv.ToNet6sFromBiContiguous(typed)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(nets, typedNets...), nil
+}
+
 func convertRules(reqRules []*aclpb.Rule) ([]cacl.AclRule, error) {
 	rules := make([]cacl.AclRule, 0, len(reqRules))
 	for _, reqRule := range reqRules {
@@ -379,19 +412,19 @@ func convertRules(reqRules []*aclpb.Rule) ([]cacl.AclRule, error) {
 		if err != nil {
 			return nil, err
 		}
-		src4s, err := filterpbconv.ToNet4s(reqRule.Srcs)
+		src4s, err := mergedNet4s(reqRule.Srcs, reqRule.Sources4)
 		if err != nil {
 			return nil, err
 		}
-		dst4s, err := filterpbconv.ToNet4s(reqRule.Dsts)
+		dst4s, err := mergedNet4s(reqRule.Dsts, reqRule.Destinations4)
 		if err != nil {
 			return nil, err
 		}
-		src6s, err := filterpbconv.ToNet6s(reqRule.Srcs)
+		src6s, err := mergedNet6s(reqRule.Srcs, reqRule.Sources6)
 		if err != nil {
 			return nil, err
 		}
-		dst6s, err := filterpbconv.ToNet6s(reqRule.Dsts)
+		dst6s, err := mergedNet6s(reqRule.Dsts, reqRule.Destinations6)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -3,6 +3,7 @@ package acl_test
 import (
 	"context"
 	"errors"
+	"net/netip"
 	"sync"
 	"testing"
 	"time"
@@ -16,7 +17,10 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/yanet-platform/xnetip"
+
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
@@ -964,6 +968,117 @@ func TestUpdateConfig_RejectsNonContiguousMask(t *testing.T) {
 	_, err := svc.UpdateConfig(t.Context(), req)
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// mustV4Network builds a ContiguousIPv4Network from a CIDR test literal.
+func mustV4Network(t *testing.T, cidr string) *commonpb.ContiguousIPv4Network {
+	t.Helper()
+
+	network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix(cidr))
+	require.NoError(t, err)
+	return network
+}
+
+// mustV6Network builds a BiContiguousIPv6Network from an xnetip test
+// literal, accepting the CIDR and address/mask forms.
+func mustV6Network(s string) *commonpb.BiContiguousIPv6Network {
+	return commonpb.NewBiContiguousIPv6NetworkFromBiContiguous(xnetip.MustParseBiContiguous(s))
+}
+
+// TestUpdateConfig_TypedNetworkLists verifies that a rule carrying only
+// typed network lists decodes into the per-family filter values.
+//
+// The IPv6 destination uses a mask with a hole exactly at the /64
+// boundary, which the CIDR form cannot express.
+func TestUpdateConfig_TypedNetworkLists(t *testing.T) {
+	backend := newFakeBackend()
+	svc := newTestService(backend)
+
+	source4 := mustV4Network(t, "192.0.2.0/24")
+	destination4 := mustV4Network(t, "198.51.100.0/24")
+	source6 := mustV6Network("2001:db8::/32")
+	destination6 := &commonpb.BiContiguousIPv6Network{
+		Addr:        commonpb.NewIPv6Address(netip.MustParseAddr("2001:db8:1::").As16()),
+		HiPrefixLen: 48,
+		LoPrefixLen: 16,
+	}
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name: "acl0",
+		Rules: []*aclpb.Rule{{
+			Actions:       []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}},
+			Sources4:      []*commonpb.ContiguousIPv4Network{source4},
+			Sources6:      []*commonpb.BiContiguousIPv6Network{source6},
+			Destinations4: []*commonpb.ContiguousIPv4Network{destination4},
+			Destinations6: []*commonpb.BiContiguousIPv6Network{destination6},
+		}},
+	})
+	require.NoError(t, err)
+
+	handles := backend.CreatedHandles()
+	require.Len(t, handles, 1)
+	rules := handles[0].Rules()
+	require.Len(t, rules, 1)
+
+	assert.Equal(t, filter.IPNets{filter.MustParseIPNet("192.0.2.0/24")}, rules[0].Src4s)
+	assert.Equal(t, filter.IPNets{filter.MustParseIPNet("2001:db8::/32")}, rules[0].Src6s)
+	assert.Equal(t, filter.IPNets{filter.MustParseIPNet("198.51.100.0/24")}, rules[0].Dst4s)
+	assert.Equal(t, filter.IPNets{{
+		Addr: netip.MustParseAddr("2001:db8:1::"),
+		Mask: netip.MustParseAddr("ffff:ffff:ffff:0:ffff::"),
+	}}, rules[0].Dst6s)
+}
+
+// TestUpdateConfig_MergesLegacyAndTypedNetworks verifies that legacy and
+// typed lists merge into one match set, legacy entries first.
+func TestUpdateConfig_MergesLegacyAndTypedNetworks(t *testing.T) {
+	backend := newFakeBackend()
+	svc := newTestService(backend)
+
+	typed := mustV4Network(t, "198.51.100.0/24")
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name: "acl0",
+		Rules: []*aclpb.Rule{{
+			Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}},
+			Srcs: []*filterpb.IPNet{{
+				Addr: []byte{192, 0, 2, 0},
+				Mask: []byte{255, 255, 255, 0},
+			}},
+			Sources4: []*commonpb.ContiguousIPv4Network{typed},
+		}},
+	})
+	require.NoError(t, err)
+
+	handles := backend.CreatedHandles()
+	require.Len(t, handles, 1)
+	rules := handles[0].Rules()
+	require.Len(t, rules, 1)
+	assert.Equal(t, filter.IPNets{
+		filter.MustParseIPNet("192.0.2.0/24"),
+		filter.MustParseIPNet("198.51.100.0/24"),
+	}, rules[0].Src4s)
+}
+
+// TestUpdateConfig_RejectsTypedV6HalfOverflow verifies that a half prefix
+// length above 64 is rejected before reaching the backend.
+func TestUpdateConfig_RejectsTypedV6HalfOverflow(t *testing.T) {
+	backend := newFakeBackend()
+	svc := newTestService(backend)
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name: "acl0",
+		Rules: []*aclpb.Rule{{
+			Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}},
+			Sources6: []*commonpb.BiContiguousIPv6Network{{
+				Addr:        commonpb.NewIPv6Address(netip.MustParseAddr("2001:db8::").As16()),
+				HiPrefixLen: 65,
+			}},
+		}},
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Equal(t, 0, backend.PublishCalls(), "backend must not be asked to publish")
 }
 
 // TestDeleteConfig_UnknownConfig verifies that DeleteConfig reports

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -15,6 +15,7 @@ import (
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/xerror"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
@@ -1139,8 +1140,9 @@ func TestACL_Counters(t *testing.T) {
 			},
 			Counter: "svc_counter",
 			Devices: []*filterpb.Device{{Name: "port0"}},
-			Srcs:    []*filterpb.IPNet{{Addr: make([]byte, 4), Mask: make([]byte, 4)}},
-			Dsts:    []*filterpb.IPNet{{Addr: make([]byte, 4), Mask: make([]byte, 4)}},
+			// 0.0.0.0/0: the zero address with a zero prefix length.
+			Sources4:      []*commonpb.ContiguousIPv4Network{{Addr: &commonpb.IPv4Address{}}},
+			Destinations4: []*commonpb.ContiguousIPv4Network{{Addr: &commonpb.IPv4Address{}}},
 			// UDP (17) with any subtype: proto in the high byte.
 			ProtoRanges:   []*filterpb.ProtoRange{{From: 17 << 8, To: 17<<8 | 0xFF}},
 			SrcPortRanges: []*filterpb.PortRange{{From: 0, To: 65535}},

--- a/modules/acl/web/SaveDiffModal.tsx
+++ b/modules/acl/web/SaveDiffModal.tsx
@@ -17,9 +17,14 @@ const ACTION_KIND_YAML_NAMES: Record<ActionKind, string> = {
 
 /** Build the serialisable object array for a set of ACL rules. Used by both YAML and JSON export. */
 export const rulesToYamlObjects = (rules: Rule[]): Array<Record<string, unknown>> => {
+    const isV6 = (cidr: string): boolean => cidr.split('/')[0].includes(':');
     return rules.map(r => {
-        const srcs = (r.srcs ?? []).map(formatIPNetItem).filter(Boolean);
-        const dsts = (r.dsts ?? []).map(formatIPNetItem).filter(Boolean);
+        const srcs = [...(r.srcs ?? []).map(formatIPNetItem).filter(Boolean), ...(r.sources4 ?? []), ...(r.sources6 ?? [])];
+        const dsts = [
+            ...(r.dsts ?? []).map(formatIPNetItem).filter(Boolean),
+            ...(r.destinations4 ?? []),
+            ...(r.destinations6 ?? []),
+        ];
         const fmtRange = (rng: { from?: number; to?: number }): { from: number; to: number } => ({
             from: rng.from ?? 0,
             to: rng.to ?? 0,
@@ -34,8 +39,14 @@ export const rulesToYamlObjects = (rules: Rule[]): Array<Record<string, unknown>
         }));
 
         const entry: Record<string, unknown> = {};
-        if (srcs.length > 0) entry['srcs'] = srcs;
-        if (dsts.length > 0) entry['dsts'] = dsts;
+        const sources4 = srcs.filter(s => !isV6(s));
+        const sources6 = srcs.filter(isV6);
+        const destinations4 = dsts.filter(d => !isV6(d));
+        const destinations6 = dsts.filter(isV6);
+        if (sources4.length > 0) entry['sources4'] = sources4;
+        if (sources6.length > 0) entry['sources6'] = sources6;
+        if (destinations4.length > 0) entry['destinations4'] = destinations4;
+        if (destinations6.length > 0) entry['destinations6'] = destinations6;
         if (src_port_ranges.length > 0) entry['src_port_ranges'] = src_port_ranges;
         if (dst_port_ranges.length > 0) entry['dst_port_ranges'] = dst_port_ranges;
         if (proto_ranges.length > 0) entry['proto_ranges'] = proto_ranges;

--- a/modules/acl/web/hooks.ts
+++ b/modules/acl/web/hooks.ts
@@ -2,7 +2,7 @@ import type { Rule, PortRange, VlanRange, ProtoRange, Action } from '@yanet/core
 import { ActionKind } from '@yanet/core/api/acl';
 import { extractBytes, formatIPNetItem, formatRange } from '@yanet/core/utils';
 import type { RuleDraft, RuleItem } from './types';
-import { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
+import { parseRangesRaw, parseProtoRangesRaw, partitionCidrsToTyped } from './parseHelpers';
 export { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
 
 /**
@@ -69,9 +69,13 @@ export const expandRule = (rule: Rule): {
 } => {
     const srcs = rule.srcs ?? [];
     const dsts = rule.dsts ?? [];
+    const sources4 = rule.sources4 ?? [];
+    const sources6 = rule.sources6 ?? [];
+    const destinations4 = rule.destinations4 ?? [];
+    const destinations6 = rule.destinations6 ?? [];
 
-    const sourceCidrs = srcs.map(formatIPNetItem).filter(Boolean);
-    const dstCidrs = dsts.map(formatIPNetItem).filter(Boolean);
+    const sourceCidrs = [...srcs.map(formatIPNetItem).filter(Boolean), ...sources4, ...sources6];
+    const dstCidrs = [...dsts.map(formatIPNetItem).filter(Boolean), ...destinations4, ...destinations6];
 
     const srcPortRanges = (rule.src_port_ranges ?? []).map(formatRange);
     const dstPortRanges = (rule.dst_port_ranges ?? []).map(formatRange);
@@ -80,16 +84,16 @@ export const expandRule = (rule: Rule): {
     const deviceNames = (rule.devices ?? []).map(d => d.name ?? '').filter(Boolean);
 
     // Per-family counts for classification (addr byte length: 4 = IPv4, 16 = IPv6).
-    let v4SrcCount = 0;
-    let v6SrcCount = 0;
+    let v4SrcCount = sources4.length;
+    let v6SrcCount = sources6.length;
     for (const net of srcs) {
         const len = extractBytes(net.addr)?.length ?? 0;
         if (len === 4) v4SrcCount++;
         else if (len === 16) v6SrcCount++;
     }
 
-    let v4DstCount = 0;
-    let v6DstCount = 0;
+    let v4DstCount = destinations4.length;
+    let v6DstCount = destinations6.length;
     for (const net of dsts) {
         const len = extractBytes(net.addr)?.length ?? 0;
         if (len === 4) v4DstCount++;
@@ -199,16 +203,20 @@ export const itemToDraft = (item: RuleItem): RuleDraft => ruleToDraft(item.rule)
 /** Convert a ProtoRange wire object to the encoded-range string "A-B". */
 export const protoRangeToStr = (r: ProtoRange): string => formatRange(r);
 
-/** Convert a RuleDraft to a wire Rule. */
+/** Convert a RuleDraft to a wire Rule, carrying networks in the typed lists. */
 export const draftToRule = (draft: RuleDraft): Rule => {
     const actions: Action[] = draft.actions.map(kind => ({ kind }));
+    const sources = partitionCidrsToTyped(draft.sourceCidrs);
+    const destinations = partitionCidrsToTyped(draft.dstCidrs);
     return {
         actions,
         counter: draft.counter || undefined,
         devices: draft.deviceNames.map(name => ({ name })),
         vlan_ranges: parseRangesRaw(draft.vlanRaw),
-        srcs: parseCidrsToIPNets(draft.sourceCidrs),
-        dsts: parseCidrsToIPNets(draft.dstCidrs),
+        sources4: sources.v4,
+        sources6: sources.v6,
+        destinations4: destinations.v4,
+        destinations6: destinations.v6,
         proto_ranges: parseProtoRangesRaw(draft.protoRaw),
         src_port_ranges: parseRangesRaw(draft.srcPortRaw),
         dst_port_ranges: parseRangesRaw(draft.dstPortRaw),

--- a/modules/acl/web/parseHelpers.ts
+++ b/modules/acl/web/parseHelpers.ts
@@ -8,7 +8,7 @@
 import type { ProtoRange } from '@yanet/core/api/acl';
 import { parseRangesRaw } from '@yanet/core/utils';
 
-export { parseCidrsToIPNets, parseRangesRaw } from '@yanet/core/utils';
+export { parseCidrsToIPNets, parseRangesRaw, partitionCidrsToTyped } from '@yanet/core/utils';
 
 /** Parse encoded proto ranges (e.g. "1536-1791") to ProtoRange wire objects. */
 export const parseProtoRangesRaw = (raw: string): ProtoRange[] => parseRangesRaw(raw) as ProtoRange[];

--- a/modules/acl/web/structuredDiff.ts
+++ b/modules/acl/web/structuredDiff.ts
@@ -53,9 +53,17 @@ const fieldValues = (rule: Rule, field: RuleField): string[] => {
         case 'counter':
             return [rule.counter ?? ''];
         case 'srcs':
-            return (rule.srcs ?? []).map(formatIPNetItem).filter(Boolean);
+            return [
+                ...(rule.srcs ?? []).map(formatIPNetItem).filter(Boolean),
+                ...(rule.sources4 ?? []),
+                ...(rule.sources6 ?? []),
+            ];
         case 'dsts':
-            return (rule.dsts ?? []).map(formatIPNetItem).filter(Boolean);
+            return [
+                ...(rule.dsts ?? []).map(formatIPNetItem).filter(Boolean),
+                ...(rule.destinations4 ?? []),
+                ...(rule.destinations6 ?? []),
+            ];
         case 'src_port_ranges':
             return (rule.src_port_ranges ?? []).map(fmtRange);
         case 'dst_port_ranges':

--- a/modules/acl/web/yamlImport.worker.ts
+++ b/modules/acl/web/yamlImport.worker.ts
@@ -11,7 +11,7 @@
 import yaml from 'js-yaml';
 import { ActionKind } from '@yanet/core/api/acl';
 import type { Rule } from '@yanet/core/api/acl';
-import { parseCidrsToIPNets } from './parseHelpers';
+import { partitionCidrsToTyped } from './parseHelpers';
 
 /** Raw shape of an action entry in the YAML schema. */
 interface YamlAction {
@@ -22,6 +22,10 @@ interface YamlAction {
 interface YamlRule {
     srcs?: unknown;
     dsts?: unknown;
+    sources4?: unknown;
+    sources6?: unknown;
+    destinations4?: unknown;
+    destinations6?: unknown;
     src_port_ranges?: unknown;
     dst_port_ranges?: unknown;
     proto_ranges?: unknown;
@@ -64,8 +68,16 @@ const convertRow = (r: unknown): Rule => {
     if (!r || typeof r !== 'object') return {};
     const row = r as YamlRule;
 
-    const srcs = parseCidrsToIPNets(parseStringArray(row.srcs));
-    const dsts = parseCidrsToIPNets(parseStringArray(row.dsts));
+    const sources = partitionCidrsToTyped([
+        ...parseStringArray(row.srcs),
+        ...parseStringArray(row.sources4),
+        ...parseStringArray(row.sources6),
+    ]);
+    const destinations = partitionCidrsToTyped([
+        ...parseStringArray(row.dsts),
+        ...parseStringArray(row.destinations4),
+        ...parseStringArray(row.destinations6),
+    ]);
 
     const src_port_ranges = rangesFromObjects(row.src_port_ranges);
     const dst_port_ranges = rangesFromObjects(row.dst_port_ranges);
@@ -90,7 +102,19 @@ const convertRow = (r: unknown): Rule => {
         })
         .filter((a): a is { kind: ActionKind } => a !== null);
 
-    return { srcs, dsts, src_port_ranges, dst_port_ranges, proto_ranges, vlan_ranges, devices, counter, actions };
+    return {
+        sources4: sources.v4,
+        sources6: sources.v6,
+        destinations4: destinations.v4,
+        destinations6: destinations.v6,
+        src_port_ranges,
+        dst_port_ranges,
+        proto_ranges,
+        vlan_ranges,
+        devices,
+        counter,
+        actions,
+    };
 };
 
 /** Convert raw rule rows in chunks, posting progress after each chunk. */

--- a/tests/functional/testdata/acl+fwstate.yaml
+++ b/tests/functional/testdata/acl+fwstate.yaml
@@ -27,7 +27,7 @@ rules:
     dst_port_ranges:
       - from: 80
         to: 80
-    dsts:
+    destinations4:
       - 192.0.3.0/255.255.255.0
     proto_ranges:
       - from: 1536
@@ -35,7 +35,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.0/255.255.255.0
     vlan_ranges: []
 
@@ -47,7 +47,7 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations4:
       - 192.0.2.0/255.255.255.0
     proto_ranges:
       - from: 1536
@@ -55,7 +55,7 @@ rules:
     src_port_ranges:
       - from: 80
         to: 80
-    srcs:
+    sources4:
       - 192.0.3.0/255.255.255.0
     vlan_ranges: []
 
@@ -67,7 +67,7 @@ rules:
     dst_port_ranges:
       - from: 80
         to: 80
-    dsts:
+    destinations4:
       - 192.0.3.0/255.255.255.0
     proto_ranges:
       - from: 4352
@@ -75,7 +75,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.0/255.255.255.0
     vlan_ranges: []
 
@@ -87,7 +87,7 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations4:
       - 192.0.2.0/255.255.255.0
     proto_ranges:
       - from: 4352
@@ -95,7 +95,7 @@ rules:
     src_port_ranges:
       - from: 80
         to: 80
-    srcs:
+    sources4:
       - 192.0.3.0/255.255.255.0
     vlan_ranges: []
 
@@ -109,7 +109,7 @@ rules:
     dst_port_ranges:
       - from: 80
         to: 80
-    dsts:
+    destinations6:
       - "2001:db8:2::/ffff:ffff:ffff::"
     proto_ranges:
       - from: 1536
@@ -117,7 +117,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources6:
       - "2001:db8:1::/ffff:ffff:ffff::"
     vlan_ranges: []
 
@@ -129,7 +129,7 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations6:
       - "2001:db8:1::/ffff:ffff:ffff::"
     proto_ranges:
       - from: 1536
@@ -137,7 +137,7 @@ rules:
     src_port_ranges:
       - from: 80
         to: 80
-    srcs:
+    sources6:
       - "2001:db8:2::/ffff:ffff:ffff::"
     vlan_ranges: []
 
@@ -152,7 +152,7 @@ rules:
     dst_port_ranges:
       - from: 9999
         to: 9999
-    dsts:
+    destinations6:
       - "ff02::1/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
     proto_ranges:
       - from: 4352
@@ -160,7 +160,7 @@ rules:
     src_port_ranges:
       - from: 9999
         to: 9999
-    srcs:
+    sources6:
       - "::/::0"
     vlan_ranges:
       - from: 0

--- a/tests/functional/testdata/acl-mbuf-leak.yaml
+++ b/tests/functional/testdata/acl-mbuf-leak.yaml
@@ -13,7 +13,7 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations4:
       - 0.0.0.0/0.0.0.0
     proto_ranges:
       - from: 4352
@@ -21,7 +21,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.30/255.255.255.255
     vlan_ranges: []
 
@@ -33,7 +33,7 @@ rules:
     dst_port_ranges:
       - from: 80
         to: 80
-    dsts:
+    destinations4:
       - 192.0.3.1/255.255.255.255
     proto_ranges:
       - from: 1536
@@ -41,7 +41,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.40/255.255.255.255
     vlan_ranges: []
 
@@ -52,7 +52,7 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations4:
       - 0.0.0.0/0.0.0.0
     proto_ranges:
       - from: 4352
@@ -60,6 +60,6 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.50/255.255.255.255
     vlan_ranges: []

--- a/tests/functional/testdata/acl.yaml
+++ b/tests/functional/testdata/acl.yaml
@@ -9,10 +9,12 @@
 #     counter: string                         # Optional counter name
 #     devices: [{name: string}]                 # List of devices (objects with a name)
 #     dst_port_ranges: [{from: N, to: M}]       # Destination port ranges
-#     dsts: [string]                            # Destination addresses (address/mask or CIDR)
+#     destinations4: [string]                   # IPv4 destination addresses (address/mask or CIDR)
+#     destinations6: [string]                   # IPv6 destination addresses (address/mask or CIDR)
 #     proto_ranges: [{from: N, to: M}]          # Protocol ranges
 #     src_port_ranges: [{from: N, to: M}]       # Source port ranges
-#     srcs: [string]                            # Source addresses (address/mask or CIDR)
+#     sources4: [string]                        # IPv4 source addresses (address/mask or CIDR)
+#     sources6: [string]                        # IPv6 source addresses (address/mask or CIDR)
 #     vlan_ranges: [{from: N, to: M}]           # VLAN ranges (0-4095)
 
 rules:
@@ -28,7 +30,7 @@ rules:
         to: 450
       - from: 600
         to: 600
-    dsts:
+    destinations4:
       - 192.0.3.1/255.255.255.255
     proto_ranges:
       - from: 4352
@@ -36,7 +38,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.2/255.255.255.255
     vlan_ranges: []
 
@@ -49,7 +51,7 @@ rules:
     dst_port_ranges:
       - from: 600
         to: 600
-    dsts:
+    destinations4:
       - 192.0.3.1/255.255.255.255
     proto_ranges:
       - from: 4352
@@ -57,7 +59,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.99/255.255.255.255
     vlan_ranges: []
 
@@ -72,7 +74,7 @@ rules:
     dst_port_ranges:
       - from: 600
         to: 600
-    dsts:
+    destinations4:
       - 192.0.3.1/255.255.255.255
     proto_ranges:
       - from: 1538
@@ -206,7 +208,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.2/255.255.255.255
     vlan_ranges: []
 
@@ -220,8 +222,9 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations4:
       - 0.0.0.0/0.0.0.0
+    destinations6:
       - "::/::"
     proto_ranges:
       - from: 1540
@@ -291,8 +294,9 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 0.0.0.0/0.0.0.0
+    sources6:
       - "::/::"
     vlan_ranges: []
 
@@ -306,7 +310,7 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations4:
       - 192.0.3.1/255.255.255.255
     proto_ranges:
       - from: 264
@@ -314,7 +318,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.2/255.255.255.255
     vlan_ranges: []
 
@@ -329,7 +333,7 @@ rules:
     dst_port_ranges:
       - from: 600
         to: 600
-    dsts:
+    destinations4:
       - 192.0.3.1/255.255.255.255
     proto_ranges:
       - from: 4352
@@ -337,7 +341,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.0/255.255.255.0
     vlan_ranges: []
 
@@ -351,8 +355,9 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations4:
       - 0.0.0.0/0.0.0.0
+    destinations6:
       - "::/::"
     proto_ranges:
       - from: 4352
@@ -360,7 +365,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.99.0/255.255.255.0
     vlan_ranges: []
 
@@ -375,7 +380,7 @@ rules:
     dst_port_ranges:
       - from: 600
         to: 600
-    dsts:
+    destinations6:
       - 2001:db8::2/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
     proto_ranges:
       - from: 1536
@@ -383,7 +388,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources6:
       - 2001:db8::1/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
     vlan_ranges: []
 
@@ -397,7 +402,7 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations6:
       - 2001:db8::2/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
     proto_ranges:
       - from: 14976
@@ -407,7 +412,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources6:
       - 2001:db8::1/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
     vlan_ranges: []
 
@@ -421,7 +426,7 @@ rules:
     dst_port_ranges:
       - from: 600
         to: 600
-    dsts:
+    destinations6:
       - 2001:db8::2/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
     proto_ranges:
       - from: 4352
@@ -429,7 +434,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources6:
       - 2001:db8::99/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
     vlan_ranges: []
 
@@ -444,8 +449,9 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations4:
       - 0.0.0.0/0.0.0.0
+    destinations6:
       - "::/::"
     proto_ranges:
       - from: 4352
@@ -453,7 +459,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.0/255.255.255.254
     vlan_ranges: []
 
@@ -466,8 +472,9 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations4:
       - 0.0.0.0/0.0.0.0
+    destinations6:
       - "::/::"
     proto_ranges:
       - from: 4352
@@ -475,7 +482,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.0/255.255.255.240
     vlan_ranges: []
 
@@ -488,8 +495,9 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations4:
       - 0.0.0.0/0.0.0.0
+    destinations6:
       - "::/::"
     proto_ranges:
       - from: 4352
@@ -497,7 +505,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.2.0/255.255.255.0
     vlan_ranges: []
 
@@ -510,8 +518,9 @@ rules:
     dst_port_ranges:
       - from: 0
         to: 65535
-    dsts:
+    destinations4:
       - 0.0.0.0/0.0.0.0
+    destinations6:
       - "::/::"
     proto_ranges:
       - from: 4352
@@ -519,7 +528,7 @@ rules:
     src_port_ranges:
       - from: 0
         to: 65535
-    srcs:
+    sources4:
       - 192.0.0.0/255.255.0.0
     vlan_ranges: []
 # # ===== DEFAULT DENY =====
@@ -529,14 +538,16 @@ rules:
 #       - {name: ""}
 #     dst_port_ranges:
 #       - {from: 0, to: 65535}
-#     dsts:
+#     destinations4:
 #       - 0.0.0.0/0.0.0.0
+#     destinations6:
 #       - '::/0'
 #     proto_ranges:
 #       - {from: 0, to: 65535}
 #     src_port_ranges:
 #       - {from: 0, to: 65535}
-#     srcs:
+#     sources4:
 #       - 0.0.0.0/0.0.0.0
+#     sources6:
 #       - '::/0'
 #     vlan_ranges: []

--- a/web/src/core/api/acl.ts
+++ b/web/src/core/api/acl.ts
@@ -52,6 +52,13 @@ export interface Rule {
     proto_ranges?: ProtoRange[];
     src_port_ranges?: PortRange[];
     dst_port_ranges?: PortRange[];
+    // Family-typed network lists (commonpb.ContiguousIPv4Network and
+    // commonpb.BiContiguousIPv6Network), serialized by the gateway as bare
+    // network strings. They merge with the legacy srcs/dsts lists.
+    sources4?: string[];
+    sources6?: string[];
+    destinations4?: string[];
+    destinations6?: string[];
 }
 
 export interface ShowConfigRequest {

--- a/web/src/core/utils/netip.test.ts
+++ b/web/src/core/utils/netip.test.ts
@@ -8,6 +8,7 @@ import {
     ipRangeSpan,
     parseCIDRPrefix,
     parseCidrsToIPNets,
+    partitionCidrsToTyped,
     parseIPToBytes,
     parseIPv6ToBytes,
     IPv4Prefix,
@@ -585,5 +586,42 @@ describe('ipRangeSpan', () => {
 
     it('returns undefined for a missing endpoint', () => {
         expect(ipRangeSpan({ start: '10.0.0.0' })).toBeUndefined();
+    });
+});
+
+describe('partitionCidrsToTyped', () => {
+    it('partitions by family and canonicalizes bare hosts to full width', () => {
+        expect(partitionCidrsToTyped(['192.0.2.0/24', '2001:db8::/32', '10.1.2.3', '::1'])).toEqual({
+            v4: ['192.0.2.0/24', '10.1.2.3/32'],
+            v6: ['2001:db8::/32', '::1/128'],
+        });
+    });
+
+    it('drops malformed entries', () => {
+        expect(partitionCidrsToTyped(['192.0.2.0/33', 'garbage', '10.0.0.0/8/9', '2001:db8::/129'])).toEqual({
+            v4: [],
+            v6: [],
+        });
+    });
+
+    it('canonicalizes a contiguous IPv4 mask form to a prefix length', () => {
+        expect(partitionCidrsToTyped(['192.0.2.0/255.255.255.0'])).toEqual({
+            v4: ['192.0.2.0/24'],
+            v6: [],
+        });
+    });
+
+    it('preserves a bi-contiguous IPv6 mask with a hole at the /64 boundary', () => {
+        expect(partitionCidrsToTyped(['2001:db8:1::/ffff:ffff:ffff:0:ffff::'])).toEqual({
+            v4: [],
+            v6: ['2001:db8:1::/ffff:ffff:ffff:0:ffff::'],
+        });
+    });
+
+    it('drops masks outside the typed mask classes', () => {
+        expect(partitionCidrsToTyped(['192.0.2.0/255.0.255.0', '2001:db8::/ffff:0:ffff::'])).toEqual({
+            v4: [],
+            v6: [],
+        });
     });
 });

--- a/web/src/core/utils/netip.ts
+++ b/web/src/core/utils/netip.ts
@@ -934,6 +934,60 @@ export const ipRangeSpan = (range: IPRangeWire | undefined): bigint | undefined 
  * width for its family (/32 for IPv4, /128 for IPv6). A token with an
  * empty or malformed mask is dropped.
  */
+/**
+ * Check if an IPv6 mask is bi-contiguous: each 64-bit half is
+ * independently all 1s followed by all 0s. A hole exactly at the /64
+ * boundary is allowed while a hole within a half is not.
+ * @param maskBytes - 16 bytes representing the mask
+ * @returns true if the mask is bi-contiguous
+ */
+export const isBiContiguousMask = (maskBytes: number[]): boolean =>
+    maskBytes.length === 16 && isContiguousMask(maskBytes.slice(0, 8)) && isContiguousMask(maskBytes.slice(8));
+
+/**
+ * Partition CIDR strings into family-typed network string lists, the wire
+ * form of the commonpb typed network messages.
+ *
+ * Prefix-length entries are canonicalized to `addr/len`, and a bare host
+ * address gains the full-width prefix for its family. An IP-shaped mask is
+ * accepted when it fits the typed message's mask class — contiguous for
+ * IPv4 (canonicalized to `addr/len`), per-half contiguous for IPv6 (kept
+ * in the address/mask form the wire accepts). Anything else is dropped,
+ * like in parseCidrsToIPNets.
+ */
+export const partitionCidrsToTyped = (cidrs: string[]): { v4: string[]; v6: string[] } => {
+    const v4: string[] = [];
+    const v6: string[] = [];
+    for (const cidr of cidrs) {
+        const parts = cidr.trim().split('/');
+        if (parts.length > 2) continue;
+        const [ipPart, maskStr] = parts;
+        const addrBytes = parseIPToBytes(ipPart);
+        if (!addrBytes) continue;
+        const isIPv4 = addrBytes.length === 4;
+        const maxPrefix = isIPv4 ? 32 : 128;
+        if (parts.length === 1) {
+            (isIPv4 ? v4 : v6).push(`${ipPart}/${maxPrefix}`);
+            continue;
+        }
+        const prefixLength = parseStrictPrefixLength(maskStr, maxPrefix);
+        if (prefixLength !== undefined) {
+            (isIPv4 ? v4 : v6).push(`${ipPart}/${prefixLength}`);
+            continue;
+        }
+        const maskBytes = parseIPToBytes(maskStr);
+        if (!maskBytes || maskBytes.length !== addrBytes.length) continue;
+        if (isIPv4) {
+            if (!isContiguousMask(maskBytes)) continue;
+            v4.push(`${ipPart}/${countPrefixLength(maskBytes)}`);
+        } else {
+            if (!isBiContiguousMask(maskBytes)) continue;
+            v6.push(`${ipPart}/${maskStr}`);
+        }
+    }
+    return { v4, v6 };
+};
+
 export const parseCidrsToIPNets = (cidrs: string[]): Array<{ addr: string; mask: string }> => {
     const results: Array<{ addr: string; mask: string }> = [];
     for (const cidr of cidrs) {


### PR DESCRIPTION
- Adds family-typed, class-typed rule network lists: `sources4`/`destinations4` carry `commonpb.ContiguousIPv4Network` and `sources6`/`destinations6` carry `commonpb.BiContiguousIPv6Network`, so a non-contiguous IPv4 mask or an IPv6 mask with a hole inside a half is unrepresentable on the wire, while a hole exactly at the /64 boundary remains expressible.
- Keeps the legacy `srcs`/`dsts` accepted and merged server-side for external clients, now marked deprecated; #2232 tracks their removal after the ACL operator migrates, so no wire break happens here.
- Migrates every in-tree client to the typed lists: the CLI ruleset YAML schema gains parse-time mask validation, the web UI writes and reads the typed lists, and the functional fixtures move to the new keys.
- Adds generic bulk prefix converters to commonpb and drops the redundant CIDR-parsing constructors in favor of netip conversions, inlining the string parse into the JSON unmarshal path.
- Closes #2205.