### PR TITLE
refactor(commonpb)!: rename the contiguous network messages to prefix messages

### DIFF
--- a/bindings/go/filterpbconv/v1/convert.go
+++ b/bindings/go/filterpbconv/v1/convert.go
@@ -115,7 +115,7 @@ func ToIPNet(pb *filterpb.IPNet) (filter.IPNet, error) {
 
 // ToNet4sFromContiguous converts family-typed contiguous IPv4 network
 // messages to filter IPNets.
-func ToNet4sFromContiguous(pb []*commonpb.ContiguousIPv4Network) (filter.IPNets, error) {
+func ToNet4sFromContiguous(pb []*commonpb.IPv4Prefix) (filter.IPNets, error) {
 	prefixes, err := commonpb.PrefixesFromNetworks(pb)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid IPv4 network: %v", err)

--- a/common/commonpb/meson.build
+++ b/common/commonpb/meson.build
@@ -11,8 +11,8 @@ common_proto_files = [
     join_paths(common_proto_dir, 'v1', 'iprange.proto'),
     join_paths(common_proto_dir, 'v1', 'ipnetwork.proto'),
     join_paths(common_proto_dir, 'v1', 'contiguousnetwork.proto'),
-    join_paths(common_proto_dir, 'v1', 'ipv4network.proto'),
-    join_paths(common_proto_dir, 'v1', 'ipv6network.proto'),
+    join_paths(common_proto_dir, 'v1', 'ipv4prefix.proto'),
+    join_paths(common_proto_dir, 'v1', 'ipv6prefix.proto'),
     join_paths(common_proto_dir, 'v1', 'bicontiguousnetwork.proto'),
 ]
 
@@ -31,8 +31,8 @@ common_protoc_gen = custom_target(
         'iprange.pb.go',
         'ipnetwork.pb.go',
         'contiguousnetwork.pb.go',
-        'ipv4network.pb.go',
-        'ipv6network.pb.go',
+        'ipv4prefix.pb.go',
+        'ipv6prefix.pb.go',
         'bicontiguousnetwork.pb.go',
     ],
     input: common_proto_files,

--- a/common/commonpb/v1/ipnetwork_test.go
+++ b/common/commonpb/v1/ipnetwork_test.go
@@ -12,12 +12,12 @@ import (
 // TestPrefixesFromNetworks_TypedNetworks asserts that a family-typed
 // network list decodes to masked netip.Prefix values.
 func TestPrefixesFromNetworks_TypedNetworks(t *testing.T) {
-	first, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("10.0.0.0/24"))
+	first, err := commonpb.NewIPv4PrefixFromPrefix(netip.MustParsePrefix("10.0.0.0/24"))
 	require.NoError(t, err)
-	second, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("10.0.1.1/24"))
+	second, err := commonpb.NewIPv4PrefixFromPrefix(netip.MustParsePrefix("10.0.1.1/24"))
 	require.NoError(t, err)
 
-	prefixes, err := commonpb.PrefixesFromNetworks([]*commonpb.ContiguousIPv4Network{first, second})
+	prefixes, err := commonpb.PrefixesFromNetworks([]*commonpb.IPv4Prefix{first, second})
 	require.NoError(t, err)
 	require.Equal(t, []netip.Prefix{
 		netip.MustParsePrefix("10.0.0.0/24"),
@@ -28,7 +28,7 @@ func TestPrefixesFromNetworks_TypedNetworks(t *testing.T) {
 // TestPrefixesFromNetworks_MalformedTypedNetwork asserts that a malformed
 // family-typed network is rejected with the offending index named.
 func TestPrefixesFromNetworks_MalformedTypedNetwork(t *testing.T) {
-	_, err := commonpb.PrefixesFromNetworks([]*commonpb.ContiguousIPv4Network{
+	_, err := commonpb.PrefixesFromNetworks([]*commonpb.IPv4Prefix{
 		{Addr: &commonpb.IPv4Address{Addr: 0x0a000000}, PrefixLen: 33},
 	})
 	require.ErrorContains(t, err, "prefixes[0]")

--- a/common/commonpb/v1/ipv4prefix.go
+++ b/common/commonpb/v1/ipv4prefix.go
@@ -8,39 +8,39 @@ import (
 	"github.com/yanet-platform/xnetip"
 )
 
-// NewContiguousIPv4NetworkFromContiguous creates a ContiguousIPv4Network
+// NewIPv4PrefixFromContiguous creates a IPv4Prefix
 // from an xnetip IPv4 CIDR block.
 //
 // The conversion is total: the block is masked by its own invariant. The
 // inverse of ToContiguous.
-func NewContiguousIPv4NetworkFromContiguous(net xnetip.Contiguous[xnetip.Network4]) *ContiguousIPv4Network {
-	return &ContiguousIPv4Network{
+func NewIPv4PrefixFromContiguous(net xnetip.Contiguous[xnetip.Network4]) *IPv4Prefix {
+	return &IPv4Prefix{
 		Addr:      NewIPv4Address(net.Network().Addr().As4()),
 		PrefixLen: uint32(net.PrefixLen()),
 	}
 }
 
-// NewContiguousIPv4NetworkFromPrefix creates a ContiguousIPv4Network from
+// NewIPv4PrefixFromPrefix creates a IPv4Prefix from
 // a netip.Prefix value, masking off any host bits.
 //
 // Returns an error if prefix is not a valid IPv4 prefix; the IPv4-mapped
 // form counts as IPv6 here, consistently with IPv4Address.
-func NewContiguousIPv4NetworkFromPrefix(prefix netip.Prefix) (*ContiguousIPv4Network, error) {
+func NewIPv4PrefixFromPrefix(prefix netip.Prefix) (*IPv4Prefix, error) {
 	net, ok := xnetip.ContiguousFromPrefix4(prefix)
 	if !ok {
 		return nil, fmt.Errorf("not a valid IPv4 prefix: %s", prefix)
 	}
-	return NewContiguousIPv4NetworkFromContiguous(net), nil
+	return NewIPv4PrefixFromContiguous(net), nil
 }
 
-// ToContiguous converts the ContiguousIPv4Network to an xnetip IPv4 CIDR
+// ToContiguous converts the IPv4Prefix to an xnetip IPv4 CIDR
 // block.
 //
 // Returns an error if addr is absent or prefix_len exceeds 32; the
 // latter wraps xnetip.ErrCIDROverflow. The returned block is masked, so
 // host bits never leak out even if the message was constructed by hand.
-// The inverse of NewContiguousIPv4NetworkFromContiguous.
-func (m *ContiguousIPv4Network) ToContiguous() (xnetip.Contiguous[xnetip.Network4], error) {
+// The inverse of NewIPv4PrefixFromContiguous.
+func (m *IPv4Prefix) ToContiguous() (xnetip.Contiguous[xnetip.Network4], error) {
 	if m.GetAddr() == nil {
 		return xnetip.Contiguous[xnetip.Network4]{}, fmt.Errorf("missing network address")
 	}
@@ -51,11 +51,11 @@ func (m *ContiguousIPv4Network) ToContiguous() (xnetip.Contiguous[xnetip.Network
 	return net, nil
 }
 
-// ToPrefix converts the ContiguousIPv4Network back to a masked
+// ToPrefix converts the IPv4Prefix back to a masked
 // netip.Prefix value.
 //
 // Returns an error exactly when ToContiguous does.
-func (m *ContiguousIPv4Network) ToPrefix() (netip.Prefix, error) {
+func (m *IPv4Prefix) ToPrefix() (netip.Prefix, error) {
 	net, err := m.ToContiguous()
 	if err != nil {
 		return netip.Prefix{}, err
@@ -64,7 +64,7 @@ func (m *ContiguousIPv4Network) ToPrefix() (netip.Prefix, error) {
 }
 
 // AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
-func (m *ContiguousIPv4Network) AsLogValue() any {
+func (m *IPv4Prefix) AsLogValue() any {
 	prefix, err := m.ToPrefix()
 	if err != nil {
 		return "invalid"
@@ -75,7 +75,7 @@ func (m *ContiguousIPv4Network) AsLogValue() any {
 
 // MarshalJSON serializes the network as a bare CIDR string, the same
 // form the Rust side renders.
-func (m *ContiguousIPv4Network) MarshalJSON() ([]byte, error) {
+func (m *IPv4Prefix) MarshalJSON() ([]byte, error) {
 	prefix, err := m.ToPrefix()
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func (m *ContiguousIPv4Network) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON accepts a bare IPv4 CIDR string.
-func (m *ContiguousIPv4Network) UnmarshalJSON(data []byte) error {
+func (m *IPv4Prefix) UnmarshalJSON(data []byte) error {
 	var raw string
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -97,7 +97,7 @@ func (m *ContiguousIPv4Network) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse IP network: %w", err)
 	}
-	parsed, err := NewContiguousIPv4NetworkFromPrefix(prefix)
+	parsed, err := NewIPv4PrefixFromPrefix(prefix)
 	if err != nil {
 		return err
 	}

--- a/common/commonpb/v1/ipv4prefix.proto
+++ b/common/commonpb/v1/ipv4prefix.proto
@@ -4,21 +4,21 @@ package common.commonpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/common/commonpb/v1;commonpb";
 
-import "common/commonpb/v1/ipv6addr.proto";
+import "common/commonpb/v1/ipv4addr.proto";
 
-// ContiguousIPv6Network represents an IPv6 CIDR prefix.
+// IPv4Prefix represents an IPv4 CIDR prefix.
 //
 // Unlike ContiguousIPNetwork, the family is fixed by the type: the
-// address cannot carry IPv4, and an absent addr is the only malformed
+// address cannot carry IPv6, and an absent addr is the only malformed
 // state.
-message ContiguousIPv6Network {
+message IPv4Prefix {
   // Network base address.
   //
   // MUST be present. Host bits below prefix_len are masked off on
   // decode, so producers need not normalize.
-  IPv6Address addr = 1;
+  IPv4Address addr = 1;
   // Prefix length, in bits.
   //
-  // MUST be <= 128.
+  // MUST be <= 32.
   uint32 prefix_len = 2;
 }

--- a/common/commonpb/v1/ipv4prefix_test.go
+++ b/common/commonpb/v1/ipv4prefix_test.go
@@ -12,12 +12,12 @@ import (
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 )
 
-// Test_NewContiguousIPv4NetworkFromPrefix_Valid verifies that IPv4
+// Test_NewIPv4PrefixFromPrefix_Valid verifies that IPv4
 // prefixes are encoded with the typed address and their length.
 //
 // The fixture values mirror the Rust tests so an encoding defect fails
 // identically in both languages.
-func Test_NewContiguousIPv4NetworkFromPrefix_Valid(t *testing.T) {
+func Test_NewIPv4PrefixFromPrefix_Valid(t *testing.T) {
 	tests := []struct {
 		name     string
 		prefix   string
@@ -31,7 +31,7 @@ func Test_NewContiguousIPv4NetworkFromPrefix_Valid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix(tt.prefix))
+			network, err := commonpb.NewIPv4PrefixFromPrefix(netip.MustParsePrefix(tt.prefix))
 			require.NoError(t, err)
 			require.Equal(t, tt.wantAddr, network.Addr.Addr)
 			require.Equal(t, tt.wantLen, network.PrefixLen)
@@ -39,21 +39,21 @@ func Test_NewContiguousIPv4NetworkFromPrefix_Valid(t *testing.T) {
 	}
 }
 
-// Test_NewContiguousIPv4NetworkFromPrefix_MasksHostBits verifies that
+// Test_NewIPv4PrefixFromPrefix_MasksHostBits verifies that
 // host bits below the prefix length are cleared at construction.
-func Test_NewContiguousIPv4NetworkFromPrefix_MasksHostBits(t *testing.T) {
-	network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("10.1.2.3/24"))
+func Test_NewIPv4PrefixFromPrefix_MasksHostBits(t *testing.T) {
+	network, err := commonpb.NewIPv4PrefixFromPrefix(netip.MustParsePrefix("10.1.2.3/24"))
 	require.NoError(t, err)
 	require.Equal(t, uint32(0x0a010200), network.Addr.Addr)
 	require.Equal(t, uint32(24), network.PrefixLen)
 }
 
-// Test_NewContiguousIPv4NetworkFromPrefix_RejectsNonIPv4 verifies that
+// Test_NewIPv4PrefixFromPrefix_RejectsNonIPv4 verifies that
 // non-IPv4 prefixes and the invalid zero value return errors.
 //
 // The IPv4-mapped form counts as IPv6 here, consistently with the typed
 // address message.
-func Test_NewContiguousIPv4NetworkFromPrefix_RejectsNonIPv4(t *testing.T) {
+func Test_NewIPv4PrefixFromPrefix_RejectsNonIPv4(t *testing.T) {
 	tests := []struct {
 		name   string
 		prefix netip.Prefix
@@ -65,15 +65,15 @@ func Test_NewContiguousIPv4NetworkFromPrefix_RejectsNonIPv4(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := commonpb.NewContiguousIPv4NetworkFromPrefix(tt.prefix)
+			_, err := commonpb.NewIPv4PrefixFromPrefix(tt.prefix)
 			require.Error(t, err)
 		})
 	}
 }
 
-// Test_ContiguousIPv4Network_ToPrefix_RoundTrip verifies that conversion
+// Test_IPv4Prefix_ToPrefix_RoundTrip verifies that conversion
 // to netip and back preserves the network exactly.
-func Test_ContiguousIPv4Network_ToPrefix_RoundTrip(t *testing.T) {
+func Test_IPv4Prefix_ToPrefix_RoundTrip(t *testing.T) {
 	tests := []struct {
 		name   string
 		prefix string
@@ -87,7 +87,7 @@ func Test_ContiguousIPv4Network_ToPrefix_RoundTrip(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			prefix := netip.MustParsePrefix(tt.prefix)
-			network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(prefix)
+			network, err := commonpb.NewIPv4PrefixFromPrefix(prefix)
 			require.NoError(t, err)
 			got, err := network.ToPrefix()
 			require.NoError(t, err)
@@ -96,10 +96,10 @@ func Test_ContiguousIPv4Network_ToPrefix_RoundTrip(t *testing.T) {
 	}
 }
 
-// Test_ContiguousIPv4Network_ToPrefix_MasksHostBits verifies that a
+// Test_IPv4Prefix_ToPrefix_MasksHostBits verifies that a
 // hand-built message with host bits set decodes to the masked network.
-func Test_ContiguousIPv4Network_ToPrefix_MasksHostBits(t *testing.T) {
-	network := &commonpb.ContiguousIPv4Network{
+func Test_IPv4Prefix_ToPrefix_MasksHostBits(t *testing.T) {
+	network := &commonpb.IPv4Prefix{
 		Addr:      &commonpb.IPv4Address{Addr: 0x0a010203},
 		PrefixLen: 24,
 	}
@@ -108,20 +108,20 @@ func Test_ContiguousIPv4Network_ToPrefix_MasksHostBits(t *testing.T) {
 	require.Equal(t, netip.MustParsePrefix("10.1.2.0/24"), got)
 }
 
-// Test_ContiguousIPv4Network_ToPrefix_Rejects verifies that an absent
+// Test_IPv4Prefix_ToPrefix_Rejects verifies that an absent
 // address and an out-of-range prefix length return errors.
-func Test_ContiguousIPv4Network_ToPrefix_Rejects(t *testing.T) {
+func Test_IPv4Prefix_ToPrefix_Rejects(t *testing.T) {
 	tests := []struct {
 		name    string
-		network *commonpb.ContiguousIPv4Network
+		network *commonpb.IPv4Prefix
 	}{
 		{
 			name:    "absent addr",
-			network: &commonpb.ContiguousIPv4Network{PrefixLen: 24},
+			network: &commonpb.IPv4Prefix{PrefixLen: 24},
 		},
 		{
 			name: "prefix length above 32",
-			network: &commonpb.ContiguousIPv4Network{
+			network: &commonpb.IPv4Prefix{
 				Addr:      &commonpb.IPv4Address{Addr: 0x0a000000},
 				PrefixLen: 33,
 			},
@@ -136,22 +136,22 @@ func Test_ContiguousIPv4Network_ToPrefix_Rejects(t *testing.T) {
 	}
 }
 
-// Test_NewContiguousIPv4NetworkFromContiguous_ZeroValue verifies that
+// Test_NewIPv4PrefixFromContiguous_ZeroValue verifies that
 // the zero CIDR block converts totally to the default route message.
-func Test_NewContiguousIPv4NetworkFromContiguous_ZeroValue(t *testing.T) {
-	network := commonpb.NewContiguousIPv4NetworkFromContiguous(xnetip.Contiguous[xnetip.Network4]{})
+func Test_NewIPv4PrefixFromContiguous_ZeroValue(t *testing.T) {
+	network := commonpb.NewIPv4PrefixFromContiguous(xnetip.Contiguous[xnetip.Network4]{})
 	require.NotNil(t, network.Addr)
 	require.Equal(t, uint32(0), network.Addr.Addr)
 	require.Equal(t, uint32(0), network.PrefixLen)
 }
 
-// Test_ContiguousIPv4Network_WireRoundTrip verifies golden wire bytes
+// Test_IPv4Prefix_WireRoundTrip verifies golden wire bytes
 // shared with the Rust tests and that decode reproduces the network.
 //
 // The default route is not an empty message: the present-but-zero
 // address encodes as two bytes, and decode relies on that presence to
 // tell the default route from a malformed message.
-func Test_ContiguousIPv4Network_WireRoundTrip(t *testing.T) {
+func Test_IPv4Prefix_WireRoundTrip(t *testing.T) {
 	tests := []struct {
 		name      string
 		prefix    string
@@ -171,14 +171,14 @@ func Test_ContiguousIPv4Network_WireRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			original, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix(tt.prefix))
+			original, err := commonpb.NewIPv4PrefixFromPrefix(netip.MustParsePrefix(tt.prefix))
 			require.NoError(t, err)
 
 			data, err := proto.Marshal(original)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantBytes, data)
 
-			var got commonpb.ContiguousIPv4Network
+			var got commonpb.IPv4Prefix
 			require.NoError(t, proto.Unmarshal(data, &got))
 			prefix, err := got.ToPrefix()
 			require.NoError(t, err)
@@ -187,27 +187,27 @@ func Test_ContiguousIPv4Network_WireRoundTrip(t *testing.T) {
 	}
 }
 
-// Test_ContiguousIPv4Network_MarshalJSON verifies that the network
+// Test_IPv4Prefix_MarshalJSON verifies that the network
 // serializes as a bare CIDR string, the same form the Rust side emits.
-func Test_ContiguousIPv4Network_MarshalJSON(t *testing.T) {
-	network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("10.1.2.0/24"))
+func Test_IPv4Prefix_MarshalJSON(t *testing.T) {
+	network, err := commonpb.NewIPv4PrefixFromPrefix(netip.MustParsePrefix("10.1.2.0/24"))
 	require.NoError(t, err)
 	got, err := json.Marshal(network)
 	require.NoError(t, err)
 	require.Equal(t, `"10.1.2.0/24"`, string(got))
 }
 
-// Test_ContiguousIPv4Network_MarshalJSON_RejectsAbsentAddr verifies that
+// Test_IPv4Prefix_MarshalJSON_RejectsAbsentAddr verifies that
 // a malformed message fails to serialize instead of inventing a network.
-func Test_ContiguousIPv4Network_MarshalJSON_RejectsAbsentAddr(t *testing.T) {
-	network := &commonpb.ContiguousIPv4Network{PrefixLen: 24}
+func Test_IPv4Prefix_MarshalJSON_RejectsAbsentAddr(t *testing.T) {
+	network := &commonpb.IPv4Prefix{PrefixLen: 24}
 	_, err := json.Marshal(network)
 	require.Error(t, err)
 }
 
-// Test_ContiguousIPv4Network_UnmarshalJSON verifies that only bare IPv4
+// Test_IPv4Prefix_UnmarshalJSON verifies that only bare IPv4
 // CIDR strings are accepted, with host bits masked off.
-func Test_ContiguousIPv4Network_UnmarshalJSON(t *testing.T) {
+func Test_IPv4Prefix_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -227,7 +227,7 @@ func Test_ContiguousIPv4Network_UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var network commonpb.ContiguousIPv4Network
+			var network commonpb.IPv4Prefix
 			err := json.Unmarshal([]byte(tt.input), &network)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -241,28 +241,28 @@ func Test_ContiguousIPv4Network_UnmarshalJSON(t *testing.T) {
 	}
 }
 
-// Test_ContiguousIPv4Network_JSONRoundTrip verifies that marshaling and
+// Test_IPv4Prefix_JSONRoundTrip verifies that marshaling and
 // unmarshaling reproduce the original message.
-func Test_ContiguousIPv4Network_JSONRoundTrip(t *testing.T) {
-	original, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("192.168.1.0/24"))
+func Test_IPv4Prefix_JSONRoundTrip(t *testing.T) {
+	original, err := commonpb.NewIPv4PrefixFromPrefix(netip.MustParsePrefix("192.168.1.0/24"))
 	require.NoError(t, err)
 
 	data, err := json.Marshal(original)
 	require.NoError(t, err)
 
-	var got commonpb.ContiguousIPv4Network
+	var got commonpb.IPv4Prefix
 	require.NoError(t, json.Unmarshal(data, &got))
 	require.Equal(t, original.Addr.Addr, got.Addr.Addr)
 	require.Equal(t, original.PrefixLen, got.PrefixLen)
 }
 
-// Test_ContiguousIPv4Network_AsLogValue verifies compact CIDR rendering
+// Test_IPv4Prefix_AsLogValue verifies compact CIDR rendering
 // for request logs and the invalid fallback for a malformed message.
-func Test_ContiguousIPv4Network_AsLogValue(t *testing.T) {
-	network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix("10.1.2.0/24"))
+func Test_IPv4Prefix_AsLogValue(t *testing.T) {
+	network, err := commonpb.NewIPv4PrefixFromPrefix(netip.MustParsePrefix("10.1.2.0/24"))
 	require.NoError(t, err)
 	require.Equal(t, "10.1.2.0/24", network.AsLogValue())
 
-	malformed := &commonpb.ContiguousIPv4Network{PrefixLen: 24}
+	malformed := &commonpb.IPv4Prefix{PrefixLen: 24}
 	require.Equal(t, "invalid", malformed.AsLogValue())
 }

--- a/common/commonpb/v1/ipv6prefix.go
+++ b/common/commonpb/v1/ipv6prefix.go
@@ -8,39 +8,39 @@ import (
 	"github.com/yanet-platform/xnetip"
 )
 
-// NewContiguousIPv6NetworkFromContiguous creates a ContiguousIPv6Network
+// NewIPv6PrefixFromContiguous creates a IPv6Prefix
 // from an xnetip IPv6 CIDR block.
 //
 // The conversion is total: the block is masked by its own invariant. The
 // inverse of ToContiguous.
-func NewContiguousIPv6NetworkFromContiguous(net xnetip.Contiguous[xnetip.Network6]) *ContiguousIPv6Network {
-	return &ContiguousIPv6Network{
+func NewIPv6PrefixFromContiguous(net xnetip.Contiguous[xnetip.Network6]) *IPv6Prefix {
+	return &IPv6Prefix{
 		Addr:      NewIPv6Address(net.Network().Addr().As16()),
 		PrefixLen: uint32(net.PrefixLen()),
 	}
 }
 
-// NewContiguousIPv6NetworkFromPrefix creates a ContiguousIPv6Network from
+// NewIPv6PrefixFromPrefix creates a IPv6Prefix from
 // a netip.Prefix value, masking off any host bits.
 //
 // Returns an error if prefix is not a valid IPv6 prefix; the IPv4-mapped
 // form counts as IPv6 here, consistently with IPv6Address.
-func NewContiguousIPv6NetworkFromPrefix(prefix netip.Prefix) (*ContiguousIPv6Network, error) {
+func NewIPv6PrefixFromPrefix(prefix netip.Prefix) (*IPv6Prefix, error) {
 	net, ok := xnetip.ContiguousFromPrefix6(prefix)
 	if !ok {
 		return nil, fmt.Errorf("not a valid IPv6 prefix: %s", prefix)
 	}
-	return NewContiguousIPv6NetworkFromContiguous(net), nil
+	return NewIPv6PrefixFromContiguous(net), nil
 }
 
-// ToContiguous converts the ContiguousIPv6Network to an xnetip IPv6 CIDR
+// ToContiguous converts the IPv6Prefix to an xnetip IPv6 CIDR
 // block.
 //
 // Returns an error if addr is absent or prefix_len exceeds 128; the
 // latter wraps xnetip.ErrCIDROverflow. The returned block is masked, so
 // host bits never leak out even if the message was constructed by hand.
-// The inverse of NewContiguousIPv6NetworkFromContiguous.
-func (m *ContiguousIPv6Network) ToContiguous() (xnetip.Contiguous[xnetip.Network6], error) {
+// The inverse of NewIPv6PrefixFromContiguous.
+func (m *IPv6Prefix) ToContiguous() (xnetip.Contiguous[xnetip.Network6], error) {
 	if m.GetAddr() == nil {
 		return xnetip.Contiguous[xnetip.Network6]{}, fmt.Errorf("missing network address")
 	}
@@ -51,11 +51,11 @@ func (m *ContiguousIPv6Network) ToContiguous() (xnetip.Contiguous[xnetip.Network
 	return net, nil
 }
 
-// ToPrefix converts the ContiguousIPv6Network back to a masked
+// ToPrefix converts the IPv6Prefix back to a masked
 // netip.Prefix value.
 //
 // Returns an error exactly when ToContiguous does.
-func (m *ContiguousIPv6Network) ToPrefix() (netip.Prefix, error) {
+func (m *IPv6Prefix) ToPrefix() (netip.Prefix, error) {
 	net, err := m.ToContiguous()
 	if err != nil {
 		return netip.Prefix{}, err
@@ -64,7 +64,7 @@ func (m *ContiguousIPv6Network) ToPrefix() (netip.Prefix, error) {
 }
 
 // AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
-func (m *ContiguousIPv6Network) AsLogValue() any {
+func (m *IPv6Prefix) AsLogValue() any {
 	prefix, err := m.ToPrefix()
 	if err != nil {
 		return "invalid"
@@ -75,7 +75,7 @@ func (m *ContiguousIPv6Network) AsLogValue() any {
 
 // MarshalJSON serializes the network as a bare CIDR string, the same
 // form the Rust side renders.
-func (m *ContiguousIPv6Network) MarshalJSON() ([]byte, error) {
+func (m *IPv6Prefix) MarshalJSON() ([]byte, error) {
 	prefix, err := m.ToPrefix()
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func (m *ContiguousIPv6Network) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON accepts a bare IPv6 CIDR string.
-func (m *ContiguousIPv6Network) UnmarshalJSON(data []byte) error {
+func (m *IPv6Prefix) UnmarshalJSON(data []byte) error {
 	var raw string
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -97,7 +97,7 @@ func (m *ContiguousIPv6Network) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse IP network: %w", err)
 	}
-	parsed, err := NewContiguousIPv6NetworkFromPrefix(prefix)
+	parsed, err := NewIPv6PrefixFromPrefix(prefix)
 	if err != nil {
 		return err
 	}

--- a/common/commonpb/v1/ipv6prefix.proto
+++ b/common/commonpb/v1/ipv6prefix.proto
@@ -4,21 +4,21 @@ package common.commonpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/common/commonpb/v1;commonpb";
 
-import "common/commonpb/v1/ipv4addr.proto";
+import "common/commonpb/v1/ipv6addr.proto";
 
-// ContiguousIPv4Network represents an IPv4 CIDR prefix.
+// IPv6Prefix represents an IPv6 CIDR prefix.
 //
 // Unlike ContiguousIPNetwork, the family is fixed by the type: the
-// address cannot carry IPv6, and an absent addr is the only malformed
+// address cannot carry IPv4, and an absent addr is the only malformed
 // state.
-message ContiguousIPv4Network {
+message IPv6Prefix {
   // Network base address.
   //
   // MUST be present. Host bits below prefix_len are masked off on
   // decode, so producers need not normalize.
-  IPv4Address addr = 1;
+  IPv6Address addr = 1;
   // Prefix length, in bits.
   //
-  // MUST be <= 32.
+  // MUST be <= 128.
   uint32 prefix_len = 2;
 }

--- a/common/commonpb/v1/ipv6prefix_test.go
+++ b/common/commonpb/v1/ipv6prefix_test.go
@@ -12,12 +12,12 @@ import (
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 )
 
-// Test_NewContiguousIPv6NetworkFromPrefix_Valid verifies that IPv6
+// Test_NewIPv6PrefixFromPrefix_Valid verifies that IPv6
 // prefixes are encoded with the typed address halves and their length.
 //
 // The fixture values mirror the Rust tests so an encoding defect fails
 // identically in both languages.
-func Test_NewContiguousIPv6NetworkFromPrefix_Valid(t *testing.T) {
+func Test_NewIPv6PrefixFromPrefix_Valid(t *testing.T) {
 	tests := []struct {
 		name    string
 		prefix  string
@@ -51,7 +51,7 @@ func Test_NewContiguousIPv6NetworkFromPrefix_Valid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			network, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix(tt.prefix))
+			network, err := commonpb.NewIPv6PrefixFromPrefix(netip.MustParsePrefix(tt.prefix))
 			require.NoError(t, err)
 			require.Equal(t, tt.wantHi, network.Addr.Hi)
 			require.Equal(t, tt.wantLo, network.Addr.Lo)
@@ -60,19 +60,19 @@ func Test_NewContiguousIPv6NetworkFromPrefix_Valid(t *testing.T) {
 	}
 }
 
-// Test_NewContiguousIPv6NetworkFromPrefix_MasksHostBits verifies that
+// Test_NewIPv6PrefixFromPrefix_MasksHostBits verifies that
 // host bits below the prefix length are cleared at construction.
-func Test_NewContiguousIPv6NetworkFromPrefix_MasksHostBits(t *testing.T) {
-	network, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix("2a02:6b8:0:1::100/64"))
+func Test_NewIPv6PrefixFromPrefix_MasksHostBits(t *testing.T) {
+	network, err := commonpb.NewIPv6PrefixFromPrefix(netip.MustParsePrefix("2a02:6b8:0:1::100/64"))
 	require.NoError(t, err)
 	require.Equal(t, uint64(0x2a0206b800000001), network.Addr.Hi)
 	require.Equal(t, uint64(0), network.Addr.Lo)
 	require.Equal(t, uint32(64), network.PrefixLen)
 }
 
-// Test_NewContiguousIPv6NetworkFromPrefix_RejectsNonIPv6 verifies that
+// Test_NewIPv6PrefixFromPrefix_RejectsNonIPv6 verifies that
 // IPv4 prefixes and the invalid zero value return errors.
-func Test_NewContiguousIPv6NetworkFromPrefix_RejectsNonIPv6(t *testing.T) {
+func Test_NewIPv6PrefixFromPrefix_RejectsNonIPv6(t *testing.T) {
 	tests := []struct {
 		name   string
 		prefix netip.Prefix
@@ -83,25 +83,25 @@ func Test_NewContiguousIPv6NetworkFromPrefix_RejectsNonIPv6(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := commonpb.NewContiguousIPv6NetworkFromPrefix(tt.prefix)
+			_, err := commonpb.NewIPv6PrefixFromPrefix(tt.prefix)
 			require.Error(t, err)
 		})
 	}
 }
 
-// Test_NewContiguousIPv6NetworkFromContiguous_ZeroValue verifies that
+// Test_NewIPv6PrefixFromContiguous_ZeroValue verifies that
 // the zero CIDR block converts totally to the default route message.
-func Test_NewContiguousIPv6NetworkFromContiguous_ZeroValue(t *testing.T) {
-	network := commonpb.NewContiguousIPv6NetworkFromContiguous(xnetip.Contiguous[xnetip.Network6]{})
+func Test_NewIPv6PrefixFromContiguous_ZeroValue(t *testing.T) {
+	network := commonpb.NewIPv6PrefixFromContiguous(xnetip.Contiguous[xnetip.Network6]{})
 	require.NotNil(t, network.Addr)
 	require.Equal(t, uint64(0), network.Addr.Hi)
 	require.Equal(t, uint64(0), network.Addr.Lo)
 	require.Equal(t, uint32(0), network.PrefixLen)
 }
 
-// Test_ContiguousIPv6Network_ToPrefix_RoundTrip verifies that conversion
+// Test_IPv6Prefix_ToPrefix_RoundTrip verifies that conversion
 // to netip and back preserves the network exactly, mapped form included.
-func Test_ContiguousIPv6Network_ToPrefix_RoundTrip(t *testing.T) {
+func Test_IPv6Prefix_ToPrefix_RoundTrip(t *testing.T) {
 	tests := []struct {
 		name   string
 		prefix string
@@ -115,7 +115,7 @@ func Test_ContiguousIPv6Network_ToPrefix_RoundTrip(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			prefix := netip.MustParsePrefix(tt.prefix)
-			network, err := commonpb.NewContiguousIPv6NetworkFromPrefix(prefix)
+			network, err := commonpb.NewIPv6PrefixFromPrefix(prefix)
 			require.NoError(t, err)
 			got, err := network.ToPrefix()
 			require.NoError(t, err)
@@ -124,10 +124,10 @@ func Test_ContiguousIPv6Network_ToPrefix_RoundTrip(t *testing.T) {
 	}
 }
 
-// Test_ContiguousIPv6Network_ToPrefix_MasksHostBits verifies that a
+// Test_IPv6Prefix_ToPrefix_MasksHostBits verifies that a
 // hand-built message with host bits set decodes to the masked network.
-func Test_ContiguousIPv6Network_ToPrefix_MasksHostBits(t *testing.T) {
-	network := &commonpb.ContiguousIPv6Network{
+func Test_IPv6Prefix_ToPrefix_MasksHostBits(t *testing.T) {
+	network := &commonpb.IPv6Prefix{
 		Addr:      &commonpb.IPv6Address{Hi: 0x2a0206b800000001, Lo: 0x0000000000000100},
 		PrefixLen: 64,
 	}
@@ -136,20 +136,20 @@ func Test_ContiguousIPv6Network_ToPrefix_MasksHostBits(t *testing.T) {
 	require.Equal(t, netip.MustParsePrefix("2a02:6b8:0:1::/64"), got)
 }
 
-// Test_ContiguousIPv6Network_ToPrefix_Rejects verifies that an absent
+// Test_IPv6Prefix_ToPrefix_Rejects verifies that an absent
 // address and an out-of-range prefix length return errors.
-func Test_ContiguousIPv6Network_ToPrefix_Rejects(t *testing.T) {
+func Test_IPv6Prefix_ToPrefix_Rejects(t *testing.T) {
 	tests := []struct {
 		name    string
-		network *commonpb.ContiguousIPv6Network
+		network *commonpb.IPv6Prefix
 	}{
 		{
 			name:    "absent addr",
-			network: &commonpb.ContiguousIPv6Network{PrefixLen: 64},
+			network: &commonpb.IPv6Prefix{PrefixLen: 64},
 		},
 		{
 			name: "prefix length above 128",
-			network: &commonpb.ContiguousIPv6Network{
+			network: &commonpb.IPv6Prefix{
 				Addr:      &commonpb.IPv6Address{Hi: 0x2a0206b800000000},
 				PrefixLen: 129,
 			},
@@ -164,7 +164,7 @@ func Test_ContiguousIPv6Network_ToPrefix_Rejects(t *testing.T) {
 	}
 }
 
-// Test_ContiguousIPv6Network_WireRoundTrip verifies golden wire bytes
+// Test_IPv6Prefix_WireRoundTrip verifies golden wire bytes
 // shared with the Rust tests and that decode reproduces the network.
 //
 // The default route is not an empty message: the present-but-zero
@@ -172,7 +172,7 @@ func Test_ContiguousIPv6Network_ToPrefix_Rejects(t *testing.T) {
 // tell the default route from a malformed message. A half-zero address
 // omits that half inside the nested message and decodes back
 // losslessly.
-func Test_ContiguousIPv6Network_WireRoundTrip(t *testing.T) {
+func Test_IPv6Prefix_WireRoundTrip(t *testing.T) {
 	tests := []struct {
 		name      string
 		prefix    string
@@ -215,14 +215,14 @@ func Test_ContiguousIPv6Network_WireRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			original, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix(tt.prefix))
+			original, err := commonpb.NewIPv6PrefixFromPrefix(netip.MustParsePrefix(tt.prefix))
 			require.NoError(t, err)
 
 			data, err := proto.Marshal(original)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantBytes, data)
 
-			var got commonpb.ContiguousIPv6Network
+			var got commonpb.IPv6Prefix
 			require.NoError(t, proto.Unmarshal(data, &got))
 			prefix, err := got.ToPrefix()
 			require.NoError(t, err)
@@ -231,27 +231,27 @@ func Test_ContiguousIPv6Network_WireRoundTrip(t *testing.T) {
 	}
 }
 
-// Test_ContiguousIPv6Network_MarshalJSON verifies that the network
+// Test_IPv6Prefix_MarshalJSON verifies that the network
 // serializes as a bare CIDR string, the same form the Rust side emits.
-func Test_ContiguousIPv6Network_MarshalJSON(t *testing.T) {
-	network, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix("2a02:6b8::/32"))
+func Test_IPv6Prefix_MarshalJSON(t *testing.T) {
+	network, err := commonpb.NewIPv6PrefixFromPrefix(netip.MustParsePrefix("2a02:6b8::/32"))
 	require.NoError(t, err)
 	got, err := json.Marshal(network)
 	require.NoError(t, err)
 	require.Equal(t, `"2a02:6b8::/32"`, string(got))
 }
 
-// Test_ContiguousIPv6Network_MarshalJSON_RejectsAbsentAddr verifies that
+// Test_IPv6Prefix_MarshalJSON_RejectsAbsentAddr verifies that
 // a malformed message fails to serialize instead of inventing a network.
-func Test_ContiguousIPv6Network_MarshalJSON_RejectsAbsentAddr(t *testing.T) {
-	network := &commonpb.ContiguousIPv6Network{PrefixLen: 64}
+func Test_IPv6Prefix_MarshalJSON_RejectsAbsentAddr(t *testing.T) {
+	network := &commonpb.IPv6Prefix{PrefixLen: 64}
 	_, err := json.Marshal(network)
 	require.Error(t, err)
 }
 
-// Test_ContiguousIPv6Network_UnmarshalJSON verifies that only bare IPv6
+// Test_IPv6Prefix_UnmarshalJSON verifies that only bare IPv6
 // CIDR strings are accepted, with host bits masked off.
-func Test_ContiguousIPv6Network_UnmarshalJSON(t *testing.T) {
+func Test_IPv6Prefix_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -271,7 +271,7 @@ func Test_ContiguousIPv6Network_UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var network commonpb.ContiguousIPv6Network
+			var network commonpb.IPv6Prefix
 			err := json.Unmarshal([]byte(tt.input), &network)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -285,29 +285,29 @@ func Test_ContiguousIPv6Network_UnmarshalJSON(t *testing.T) {
 	}
 }
 
-// Test_ContiguousIPv6Network_JSONRoundTrip verifies that marshaling and
+// Test_IPv6Prefix_JSONRoundTrip verifies that marshaling and
 // unmarshaling reproduce the original message.
-func Test_ContiguousIPv6Network_JSONRoundTrip(t *testing.T) {
-	original, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix("2a02:6b8:0:1::/64"))
+func Test_IPv6Prefix_JSONRoundTrip(t *testing.T) {
+	original, err := commonpb.NewIPv6PrefixFromPrefix(netip.MustParsePrefix("2a02:6b8:0:1::/64"))
 	require.NoError(t, err)
 
 	data, err := json.Marshal(original)
 	require.NoError(t, err)
 
-	var got commonpb.ContiguousIPv6Network
+	var got commonpb.IPv6Prefix
 	require.NoError(t, json.Unmarshal(data, &got))
 	require.Equal(t, original.Addr.Hi, got.Addr.Hi)
 	require.Equal(t, original.Addr.Lo, got.Addr.Lo)
 	require.Equal(t, original.PrefixLen, got.PrefixLen)
 }
 
-// Test_ContiguousIPv6Network_AsLogValue verifies compact CIDR rendering
+// Test_IPv6Prefix_AsLogValue verifies compact CIDR rendering
 // for request logs and the invalid fallback for a malformed message.
-func Test_ContiguousIPv6Network_AsLogValue(t *testing.T) {
-	network, err := commonpb.NewContiguousIPv6NetworkFromPrefix(netip.MustParsePrefix("2a02:6b8::/32"))
+func Test_IPv6Prefix_AsLogValue(t *testing.T) {
+	network, err := commonpb.NewIPv6PrefixFromPrefix(netip.MustParsePrefix("2a02:6b8::/32"))
 	require.NoError(t, err)
 	require.Equal(t, "2a02:6b8::/32", network.AsLogValue())
 
-	malformed := &commonpb.ContiguousIPv6Network{PrefixLen: 64}
+	malformed := &commonpb.IPv6Prefix{PrefixLen: 64}
 	require.Equal(t, "invalid", malformed.AsLogValue())
 }

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 /// Messages that gain the ordinary `Serialize`/`Deserialize` derive.
 ///
 /// The address messages, `MACAddress`, and the network messages
-/// (`ContiguousIPNetwork`, `ContiguousIPv4Network`, `ContiguousIPv6Network`,
+/// (`ContiguousIPNetwork`, `IPv4Prefix`, `IPv6Prefix`,
 /// `BiContiguousIPv6Network`) are deliberately absent: `src/lib.rs`
 /// hand-writes their `Serialize`/`Deserialize` impls to go straight to
 /// and from a plain string, and prost-build's attribute paths are
@@ -37,8 +37,8 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=common/commonpb/v1/iprange.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipnetwork.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/contiguousnetwork.proto");
-    println!("cargo:rerun-if-changed=common/commonpb/v1/ipv4network.proto");
-    println!("cargo:rerun-if-changed=common/commonpb/v1/ipv6network.proto");
+    println!("cargo:rerun-if-changed=common/commonpb/v1/ipv4prefix.proto");
+    println!("cargo:rerun-if-changed=common/commonpb/v1/ipv6prefix.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/bicontiguousnetwork.proto");
 
     let mut config = tonic_build::configure()
@@ -68,8 +68,8 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             "common/commonpb/v1/iprange.proto",
             "common/commonpb/v1/ipnetwork.proto",
             "common/commonpb/v1/contiguousnetwork.proto",
-            "common/commonpb/v1/ipv4network.proto",
-            "common/commonpb/v1/ipv6network.proto",
+            "common/commonpb/v1/ipv4prefix.proto",
+            "common/commonpb/v1/ipv6prefix.proto",
             "common/commonpb/v1/bicontiguousnetwork.proto",
         ],
         &["../../.."],

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -274,20 +274,20 @@ impl<'de> Deserialize<'de> for pb::IPv6Address {
     }
 }
 
-impl From<Contiguous<Ipv4Network>> for pb::ContiguousIPv4Network {
+impl From<Contiguous<Ipv4Network>> for pb::IPv4Prefix {
     fn from(net: Contiguous<Ipv4Network>) -> Self {
-        pb::ContiguousIPv4Network {
+        pb::IPv4Prefix {
             addr: Some(pb::IPv4Address::from(*net.addr())),
             prefix_len: u32::from(net.prefix()),
         }
     }
 }
 
-impl TryFrom<&pb::ContiguousIPv4Network> for Contiguous<Ipv4Network> {
+impl TryFrom<&pb::IPv4Prefix> for Contiguous<Ipv4Network> {
     type Error = Box<dyn Error>;
 
     /// Masks host bits to `prefix_len` rather than rejecting them.
-    fn try_from(net: &pb::ContiguousIPv4Network) -> Result<Self, Self::Error> {
+    fn try_from(net: &pb::IPv4Prefix) -> Result<Self, Self::Error> {
         let addr = net.addr.as_ref().ok_or("invalid IP network: missing address")?;
         let addr = Ipv4Addr::from(addr);
         let prefix_len =
@@ -297,7 +297,7 @@ impl TryFrom<&pb::ContiguousIPv4Network> for Contiguous<Ipv4Network> {
     }
 }
 
-impl Display for pb::ContiguousIPv4Network {
+impl Display for pb::IPv4Prefix {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match Contiguous::<Ipv4Network>::try_from(self) {
             Ok(net) => net.fmt(f),
@@ -306,7 +306,7 @@ impl Display for pb::ContiguousIPv4Network {
     }
 }
 
-impl FromStr for pb::ContiguousIPv4Network {
+impl FromStr for pb::IPv4Prefix {
     type Err = Box<dyn Error>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -315,7 +315,7 @@ impl FromStr for pb::ContiguousIPv4Network {
     }
 }
 
-impl Serialize for pb::ContiguousIPv4Network {
+impl Serialize for pb::IPv4Prefix {
     /// Serializes as the CIDR string `Display` renders.
     ///
     /// A message with an absent address renders as the literal
@@ -329,7 +329,7 @@ impl Serialize for pb::ContiguousIPv4Network {
     }
 }
 
-impl<'de> Deserialize<'de> for pb::ContiguousIPv4Network {
+impl<'de> Deserialize<'de> for pb::IPv4Prefix {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -339,20 +339,20 @@ impl<'de> Deserialize<'de> for pb::ContiguousIPv4Network {
     }
 }
 
-impl From<Contiguous<Ipv6Network>> for pb::ContiguousIPv6Network {
+impl From<Contiguous<Ipv6Network>> for pb::IPv6Prefix {
     fn from(net: Contiguous<Ipv6Network>) -> Self {
-        pb::ContiguousIPv6Network {
+        pb::IPv6Prefix {
             addr: Some(pb::IPv6Address::from(*net.addr())),
             prefix_len: u32::from(net.prefix()),
         }
     }
 }
 
-impl TryFrom<&pb::ContiguousIPv6Network> for Contiguous<Ipv6Network> {
+impl TryFrom<&pb::IPv6Prefix> for Contiguous<Ipv6Network> {
     type Error = Box<dyn Error>;
 
     /// Masks host bits to `prefix_len` rather than rejecting them.
-    fn try_from(net: &pb::ContiguousIPv6Network) -> Result<Self, Self::Error> {
+    fn try_from(net: &pb::IPv6Prefix) -> Result<Self, Self::Error> {
         let addr = net.addr.as_ref().ok_or("invalid IP network: missing address")?;
         let addr = Ipv6Addr::from(addr);
         let prefix_len =
@@ -362,7 +362,7 @@ impl TryFrom<&pb::ContiguousIPv6Network> for Contiguous<Ipv6Network> {
     }
 }
 
-impl Display for pb::ContiguousIPv6Network {
+impl Display for pb::IPv6Prefix {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match Contiguous::<Ipv6Network>::try_from(self) {
             Ok(net) => net.fmt(f),
@@ -371,7 +371,7 @@ impl Display for pb::ContiguousIPv6Network {
     }
 }
 
-impl FromStr for pb::ContiguousIPv6Network {
+impl FromStr for pb::IPv6Prefix {
     type Err = Box<dyn Error>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -380,7 +380,7 @@ impl FromStr for pb::ContiguousIPv6Network {
     }
 }
 
-impl Serialize for pb::ContiguousIPv6Network {
+impl Serialize for pb::IPv6Prefix {
     /// Serializes as the CIDR string `Display` renders.
     ///
     /// A message with an absent address renders as the literal
@@ -394,7 +394,7 @@ impl Serialize for pb::ContiguousIPv6Network {
     }
 }
 
-impl<'de> Deserialize<'de> for pb::ContiguousIPv6Network {
+impl<'de> Deserialize<'de> for pb::IPv6Prefix {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -1289,7 +1289,7 @@ mod test {
     #[test]
     fn test_contiguous_ipv4_network_conversion_round_trip() {
         let net = Contiguous::<Ipv4Network>::parse("10.1.2.0/24").unwrap();
-        let msg = pb::ContiguousIPv4Network::from(net);
+        let msg = pb::IPv4Prefix::from(net);
         assert_eq!(Some(pb::IPv4Address { addr: 0x0a010200 }), msg.addr);
         assert_eq!(24, msg.prefix_len);
         assert_eq!(net, Contiguous::<Ipv4Network>::try_from(&msg).unwrap());
@@ -1301,7 +1301,7 @@ mod test {
     fn test_contiguous_ipv4_network_wire_bytes_golden() {
         use prost::Message;
 
-        let msg = pb::ContiguousIPv4Network {
+        let msg = pb::IPv4Prefix {
             addr: Some(pb::IPv4Address { addr: 0x0a010203 }),
             prefix_len: 32,
         };
@@ -1313,7 +1313,7 @@ mod test {
 
     #[test]
     fn test_contiguous_ipv4_network_try_from_masks_host_bits() {
-        let msg = pb::ContiguousIPv4Network {
+        let msg = pb::IPv4Prefix {
             addr: Some(pb::IPv4Address { addr: 0x0a010203 }),
             prefix_len: 24,
         };
@@ -1323,13 +1323,13 @@ mod test {
 
     #[test]
     fn test_contiguous_ipv4_network_try_from_rejects_absent_addr() {
-        let malformed = pb::ContiguousIPv4Network { addr: None, prefix_len: 24 };
+        let malformed = pb::IPv4Prefix { addr: None, prefix_len: 24 };
         assert!(Contiguous::<Ipv4Network>::try_from(&malformed).is_err());
     }
 
     #[test]
     fn test_contiguous_ipv4_network_try_from_rejects_prefix_overflow() {
-        let malformed = pb::ContiguousIPv4Network {
+        let malformed = pb::IPv4Prefix {
             addr: Some(pb::IPv4Address { addr: 0x0a000000 }),
             prefix_len: 33,
         };
@@ -1338,10 +1338,10 @@ mod test {
 
     #[test]
     fn test_contiguous_ipv4_network_serde_string_round_trip() {
-        let msg = pb::ContiguousIPv4Network::from(Contiguous::<Ipv4Network>::parse("10.0.0.0/8").unwrap());
+        let msg = pb::IPv4Prefix::from(Contiguous::<Ipv4Network>::parse("10.0.0.0/8").unwrap());
         let json = serde_json::to_string(&msg).unwrap();
         assert_eq!(r#""10.0.0.0/8""#, json);
-        let got: pb::ContiguousIPv4Network = serde_json::from_str(&json).unwrap();
+        let got: pb::IPv4Prefix = serde_json::from_str(&json).unwrap();
         assert_eq!(msg, got);
     }
 
@@ -1350,22 +1350,22 @@ mod test {
     /// deliberate error rather than a silently reconstructed message.
     #[test]
     fn test_contiguous_ipv4_network_serde_invalid_does_not_deserialize() {
-        let malformed = pb::ContiguousIPv4Network { addr: None, prefix_len: 24 };
+        let malformed = pb::IPv4Prefix { addr: None, prefix_len: 24 };
         let json = serde_json::to_string(&malformed).unwrap();
         assert_eq!(r#""invalid""#, json);
-        assert!(serde_json::from_str::<pb::ContiguousIPv4Network>(&json).is_err());
+        assert!(serde_json::from_str::<pb::IPv4Prefix>(&json).is_err());
     }
 
     #[test]
     fn test_contiguous_ipv4_network_from_str_masks_host_bits() {
-        let got: pb::ContiguousIPv4Network = "10.1.2.3/24".parse().unwrap();
+        let got: pb::IPv4Prefix = "10.1.2.3/24".parse().unwrap();
         assert_eq!(Some(pb::IPv4Address { addr: 0x0a010200 }), got.addr);
         assert_eq!(24, got.prefix_len);
     }
 
     #[test]
     fn test_contiguous_ipv4_network_from_str_rejects_ipv6() {
-        assert!("2a02:6b8::/32".parse::<pb::ContiguousIPv4Network>().is_err());
+        assert!("2a02:6b8::/32".parse::<pb::IPv4Prefix>().is_err());
     }
 
     /// The default route is not an empty message: the present-but-zero
@@ -1375,7 +1375,7 @@ mod test {
     fn test_contiguous_ipv4_network_wire_bytes_zero_value_golden() {
         use prost::Message;
 
-        let msg = pb::ContiguousIPv4Network {
+        let msg = pb::IPv4Prefix {
             addr: Some(pb::IPv4Address { addr: 0 }),
             prefix_len: 0,
         };
@@ -1387,7 +1387,7 @@ mod test {
     #[test]
     fn test_contiguous_ipv6_network_conversion_round_trip() {
         let net = Contiguous::<Ipv6Network>::parse("2a02:6b8::/32").unwrap();
-        let msg = pb::ContiguousIPv6Network::from(net);
+        let msg = pb::IPv6Prefix::from(net);
         assert_eq!(Some(pb::IPv6Address { hi: 0x2a0206b800000000, lo: 0 }), msg.addr);
         assert_eq!(32, msg.prefix_len);
         assert_eq!(net, Contiguous::<Ipv6Network>::try_from(&msg).unwrap());
@@ -1399,7 +1399,7 @@ mod test {
     fn test_contiguous_ipv6_network_wire_bytes_golden() {
         use prost::Message;
 
-        let msg = pb::ContiguousIPv6Network {
+        let msg = pb::IPv6Prefix {
             addr: Some(pb::IPv6Address {
                 hi: 0x2a0206b800000001,
                 lo: 0x0000000000000100,
@@ -1422,7 +1422,7 @@ mod test {
     fn test_contiguous_ipv6_network_wire_bytes_zero_value_golden() {
         use prost::Message;
 
-        let msg = pb::ContiguousIPv6Network {
+        let msg = pb::IPv6Prefix {
             addr: Some(pb::IPv6Address { hi: 0, lo: 0 }),
             prefix_len: 0,
         };
@@ -1431,7 +1431,7 @@ mod test {
 
     #[test]
     fn test_contiguous_ipv6_network_try_from_masks_host_bits() {
-        let msg = pb::ContiguousIPv6Network {
+        let msg = pb::IPv6Prefix {
             addr: Some(pb::IPv6Address {
                 hi: 0x2a0206b800000001,
                 lo: 0x0000000000000100,
@@ -1444,13 +1444,13 @@ mod test {
 
     #[test]
     fn test_contiguous_ipv6_network_try_from_rejects_absent_addr() {
-        let malformed = pb::ContiguousIPv6Network { addr: None, prefix_len: 64 };
+        let malformed = pb::IPv6Prefix { addr: None, prefix_len: 64 };
         assert!(Contiguous::<Ipv6Network>::try_from(&malformed).is_err());
     }
 
     #[test]
     fn test_contiguous_ipv6_network_try_from_rejects_prefix_overflow() {
-        let malformed = pb::ContiguousIPv6Network {
+        let malformed = pb::IPv6Prefix {
             addr: Some(pb::IPv6Address { hi: 0x2a0206b800000000, lo: 0 }),
             prefix_len: 129,
         };
@@ -1459,10 +1459,10 @@ mod test {
 
     #[test]
     fn test_contiguous_ipv6_network_serde_string_round_trip() {
-        let msg = pb::ContiguousIPv6Network::from(Contiguous::<Ipv6Network>::parse("2a02:6b8::/32").unwrap());
+        let msg = pb::IPv6Prefix::from(Contiguous::<Ipv6Network>::parse("2a02:6b8::/32").unwrap());
         let json = serde_json::to_string(&msg).unwrap();
         assert_eq!(r#""2a02:6b8::/32""#, json);
-        let got: pb::ContiguousIPv6Network = serde_json::from_str(&json).unwrap();
+        let got: pb::IPv6Prefix = serde_json::from_str(&json).unwrap();
         assert_eq!(msg, got);
     }
 
@@ -1471,22 +1471,22 @@ mod test {
     /// deliberate error rather than a silently reconstructed message.
     #[test]
     fn test_contiguous_ipv6_network_serde_invalid_does_not_deserialize() {
-        let malformed = pb::ContiguousIPv6Network { addr: None, prefix_len: 64 };
+        let malformed = pb::IPv6Prefix { addr: None, prefix_len: 64 };
         let json = serde_json::to_string(&malformed).unwrap();
         assert_eq!(r#""invalid""#, json);
-        assert!(serde_json::from_str::<pb::ContiguousIPv6Network>(&json).is_err());
+        assert!(serde_json::from_str::<pb::IPv6Prefix>(&json).is_err());
     }
 
     #[test]
     fn test_contiguous_ipv6_network_from_str_masks_host_bits() {
-        let got: pb::ContiguousIPv6Network = "2a02:6b8:0:1::100/64".parse().unwrap();
+        let got: pb::IPv6Prefix = "2a02:6b8:0:1::100/64".parse().unwrap();
         assert_eq!(Some(pb::IPv6Address { hi: 0x2a0206b800000001, lo: 0 }), got.addr);
         assert_eq!(64, got.prefix_len);
     }
 
     #[test]
     fn test_contiguous_ipv6_network_from_str_rejects_ipv4() {
-        assert!("10.0.0.0/8".parse::<pb::ContiguousIPv6Network>().is_err());
+        assert!("10.0.0.0/8".parse::<pb::IPv6Prefix>().is_err());
     }
 
     /// A half-zero address omits that half inside the nested message;
@@ -1495,7 +1495,7 @@ mod test {
     fn test_contiguous_ipv6_network_wire_bytes_hi_only_golden() {
         use prost::Message;
 
-        let msg = pb::ContiguousIPv6Network {
+        let msg = pb::IPv6Prefix {
             addr: Some(pb::IPv6Address { hi: 0x2a0206b800000000, lo: 0 }),
             prefix_len: 32,
         };

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -4,7 +4,7 @@ package modules.acl.controlplane.aclpb.v1;
 
 import "common/filterpb/v1/filter.proto";
 import "common/commonpb/v1/bicontiguousnetwork.proto";
-import "common/commonpb/v1/ipv4network.proto";
+import "common/commonpb/v1/ipv4prefix.proto";
 import "common/commonpb/v1/metric.proto";
 import "common/commonpb/v1/ipaddr.proto";
 import "common/commonpb/v1/macaddr.proto";
@@ -91,9 +91,9 @@ message Rule {
   repeated common.filterpb.v1.PortRange src_port_ranges = 8;
   repeated common.filterpb.v1.PortRange dst_port_ranges = 9;
   common.filterpb.v1.Fragment fragment = 10;
-  repeated common.commonpb.v1.ContiguousIPv4Network sources4 = 11;
+  repeated common.commonpb.v1.IPv4Prefix sources4 = 11;
   repeated common.commonpb.v1.BiContiguousIPv6Network sources6 = 12;
-  repeated common.commonpb.v1.ContiguousIPv4Network destinations4 = 13;
+  repeated common.commonpb.v1.IPv4Prefix destinations4 = 13;
   repeated common.commonpb.v1.BiContiguousIPv6Network destinations6 = 14;
 }
 

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -373,7 +373,7 @@ func labeler(fullMethod string, req any) metrics.Labels {
 
 // mergedNet4s decodes the IPv4 networks a rule carries in the legacy
 // mixed-family list and the typed list, legacy entries first.
-func mergedNet4s(legacy []*filterpb.IPNet, typed []*commonpb.ContiguousIPv4Network) (filter.IPNets, error) {
+func mergedNet4s(legacy []*filterpb.IPNet, typed []*commonpb.IPv4Prefix) (filter.IPNets, error) {
 	nets, err := filterpbconv.ToNet4s(legacy)
 	if err != nil {
 		return nil, err

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -970,11 +970,11 @@ func TestUpdateConfig_RejectsNonContiguousMask(t *testing.T) {
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
-// mustV4Network builds a ContiguousIPv4Network from a CIDR test literal.
-func mustV4Network(t *testing.T, cidr string) *commonpb.ContiguousIPv4Network {
+// mustV4Network builds a IPv4Prefix from a CIDR test literal.
+func mustV4Network(t *testing.T, cidr string) *commonpb.IPv4Prefix {
 	t.Helper()
 
-	network, err := commonpb.NewContiguousIPv4NetworkFromPrefix(netip.MustParsePrefix(cidr))
+	network, err := commonpb.NewIPv4PrefixFromPrefix(netip.MustParsePrefix(cidr))
 	require.NoError(t, err)
 	return network
 }
@@ -1007,9 +1007,9 @@ func TestUpdateConfig_TypedNetworkLists(t *testing.T) {
 		Name: "acl0",
 		Rules: []*aclpb.Rule{{
 			Actions:       []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}},
-			Sources4:      []*commonpb.ContiguousIPv4Network{source4},
+			Sources4:      []*commonpb.IPv4Prefix{source4},
 			Sources6:      []*commonpb.BiContiguousIPv6Network{source6},
-			Destinations4: []*commonpb.ContiguousIPv4Network{destination4},
+			Destinations4: []*commonpb.IPv4Prefix{destination4},
 			Destinations6: []*commonpb.BiContiguousIPv6Network{destination6},
 		}},
 	})
@@ -1045,7 +1045,7 @@ func TestUpdateConfig_MergesLegacyAndTypedNetworks(t *testing.T) {
 				Addr: []byte{192, 0, 2, 0},
 				Mask: []byte{255, 255, 255, 0},
 			}},
-			Sources4: []*commonpb.ContiguousIPv4Network{typed},
+			Sources4: []*commonpb.IPv4Prefix{typed},
 		}},
 	})
 	require.NoError(t, err)

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -1141,8 +1141,8 @@ func TestACL_Counters(t *testing.T) {
 			Counter: "svc_counter",
 			Devices: []*filterpb.Device{{Name: "port0"}},
 			// 0.0.0.0/0: the zero address with a zero prefix length.
-			Sources4:      []*commonpb.ContiguousIPv4Network{{Addr: &commonpb.IPv4Address{}}},
-			Destinations4: []*commonpb.ContiguousIPv4Network{{Addr: &commonpb.IPv4Address{}}},
+			Sources4:      []*commonpb.IPv4Prefix{{Addr: &commonpb.IPv4Address{}}},
+			Destinations4: []*commonpb.IPv4Prefix{{Addr: &commonpb.IPv4Address{}}},
 			// UDP (17) with any subtype: proto in the high byte.
 			ProtoRanges:   []*filterpb.ProtoRange{{From: 17 << 8, To: 17<<8 | 0xFF}},
 			SrcPortRanges: []*filterpb.PortRange{{From: 0, To: 65535}},

--- a/web/src/core/api/acl.ts
+++ b/web/src/core/api/acl.ts
@@ -52,7 +52,7 @@ export interface Rule {
     proto_ranges?: ProtoRange[];
     src_port_ranges?: PortRange[];
     dst_port_ranges?: PortRange[];
-    // Family-typed network lists (commonpb.ContiguousIPv4Network and
+    // Family-typed network lists (commonpb.IPv4Prefix and
     // commonpb.BiContiguousIPv6Network), serialized by the gateway as bare
     // network strings. They merge with the legacy srcs/dsts lists.
     sources4?: string[];


### PR DESCRIPTION
- Renames `ContiguousIPv4Network`/`ContiguousIPv6Network` to `IPv4Prefix`/`IPv6Prefix`: the messages carry `addr + prefix_len`, so the name states the domain concept instead of a mask-class property, matching the netip vocabulary.
- Renames the per-message proto/Go files and the Go/Rust helpers accordingly; the freed `ipv4network`/`ipv6network` names go to the general mask-typed messages of #2234.
- A message rename is invisible on the binary wire and in the bare-string JSON, so this is a generated-API break only; `buf breaking` reports the expected delete-plus-add pair for the two messages, following the #2197 posture of no ignore entries.
- `BiContiguousIPv6Network` is deliberately untouched: it is removed under #2234 once acl leaves it.
- Closes #2235.