### PR TITLE
feat(commonpb): add a general ipv4 network message

### DIFF
--- a/common/commonpb/meson.build
+++ b/common/commonpb/meson.build
@@ -12,6 +12,7 @@ common_proto_files = [
     join_paths(common_proto_dir, 'v1', 'ipnetwork.proto'),
     join_paths(common_proto_dir, 'v1', 'contiguousnetwork.proto'),
     join_paths(common_proto_dir, 'v1', 'ipv4prefix.proto'),
+    join_paths(common_proto_dir, 'v1', 'ipv4network.proto'),
     join_paths(common_proto_dir, 'v1', 'ipv6prefix.proto'),
     join_paths(common_proto_dir, 'v1', 'bicontiguousnetwork.proto'),
 ]
@@ -32,6 +33,7 @@ common_protoc_gen = custom_target(
         'ipnetwork.pb.go',
         'contiguousnetwork.pb.go',
         'ipv4prefix.pb.go',
+        'ipv4network.pb.go',
         'ipv6prefix.pb.go',
         'bicontiguousnetwork.pb.go',
     ],

--- a/common/commonpb/v1/ipv4network.go
+++ b/common/commonpb/v1/ipv4network.go
@@ -1,0 +1,76 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/yanet-platform/xnetip"
+)
+
+// NewIPv4NetworkFrom4 creates an IPv4Network from an xnetip
+// network value. The inverse of ToNetwork4.
+func NewIPv4NetworkFrom4(net xnetip.Network4) *IPv4Network {
+	return &IPv4Network{
+		Addr: NewIPv4Address(net.Addr().As4()),
+		Mask: NewIPv4Address(net.Mask().As4()),
+	}
+}
+
+// ToNetwork4 converts the IPv4Network to a normalized xnetip network
+// value, rejecting an absent addr or mask. The inverse of NewIPv4NetworkFrom4.
+func (m *IPv4Network) ToNetwork4() (xnetip.Network4, error) {
+	if m.GetAddr() == nil {
+		return xnetip.Network4{}, fmt.Errorf("missing network address")
+	}
+	if m.GetMask() == nil {
+		return xnetip.Network4{}, fmt.Errorf("missing network mask")
+	}
+
+	net, err := xnetip.Network4From(m.GetAddr().ToAddr(), m.GetMask().ToAddr())
+	if err != nil {
+		return xnetip.Network4{}, fmt.Errorf("failed to build IP network: %w", err)
+	}
+	return net, nil
+}
+
+// AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
+func (m *IPv4Network) AsLogValue() any {
+	net, err := m.ToNetwork4()
+	if err != nil {
+		return "invalid"
+	}
+
+	return net.String()
+}
+
+// MarshalJSON serializes the network as a bare string: the CIDR form
+// when the mask is contiguous, the address/mask form otherwise.
+func (m *IPv4Network) MarshalJSON() ([]byte, error) {
+	net, err := m.ToNetwork4()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(net.String())
+}
+
+// UnmarshalJSON accepts a bare string in any form xnetip parsing accepts:
+// CIDR, explicit address/mask, or a bare host address.
+func (m *IPv4Network) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw == "" {
+		return fmt.Errorf("empty IP network is not allowed")
+	}
+
+	net, err := xnetip.ParseNetwork4(raw)
+	if err != nil {
+		return fmt.Errorf("failed to parse IP network: %w", err)
+	}
+
+	parsed := NewIPv4NetworkFrom4(net)
+	m.Addr = parsed.Addr
+	m.Mask = parsed.Mask
+	return nil
+}

--- a/common/commonpb/v1/ipv4network.proto
+++ b/common/commonpb/v1/ipv4network.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package common.commonpb.v1;
+
+option go_package = "github.com/yanet-platform/yanet2/common/commonpb/v1;commonpb";
+
+import "common/commonpb/v1/ipv4addr.proto";
+
+// IPv4Network represents an IPv4 network as a base address and an
+// arbitrary bitmask. Accepted mask classes are the consuming API's contract.
+message IPv4Network {
+  // Network base address, normalized by the mask on decode.
+  //
+  // MUST be present.
+  IPv4Address addr = 1;
+  // Network bitmask.
+  //
+  // MUST be present. The explicit zero mask is the match-all wildcard.
+  IPv4Address mask = 2;
+}

--- a/common/commonpb/v1/ipv4network_test.go
+++ b/common/commonpb/v1/ipv4network_test.go
@@ -1,0 +1,96 @@
+package commonpb_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/xnetip"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+)
+
+// Test_IPv4Network_RoundTrip asserts that contiguous and non-contiguous
+// masks survive the New/ToNetwork4 round trip normalized.
+func Test_IPv4Network_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+	}{
+		{name: "contiguous", network: "192.0.2.0/255.255.255.0"},
+		{name: "non-contiguous", network: "192.0.2.0/255.0.255.0"},
+		{name: "host route", network: "192.0.2.1/255.255.255.255"},
+		{name: "match all", network: "0.0.0.0/0.0.0.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			net, err := xnetip.ParseNetwork4(tt.network)
+			require.NoError(t, err)
+
+			got, err := commonpb.NewIPv4NetworkFrom4(net).ToNetwork4()
+			require.NoError(t, err)
+			require.Equal(t, net, got)
+		})
+	}
+}
+
+// Test_IPv4Network_ToNetwork4_NormalizesAddr asserts that address bits
+// outside a hand-constructed message's mask are cleared on decode.
+func Test_IPv4Network_ToNetwork4_NormalizesAddr(t *testing.T) {
+	message := &commonpb.IPv4Network{
+		Addr: commonpb.NewIPv4Address([4]byte{192, 0, 2, 1}),
+		Mask: commonpb.NewIPv4Address([4]byte{255, 255, 255, 0}),
+	}
+
+	net, err := message.ToNetwork4()
+	require.NoError(t, err)
+	require.Equal(t, "192.0.2.0/24", net.String())
+}
+
+// Test_IPv4Network_ToNetwork4_MissingAddr asserts that an absent address
+// submessage is rejected as malformed.
+func Test_IPv4Network_ToNetwork4_MissingAddr(t *testing.T) {
+	_, err := (&commonpb.IPv4Network{Mask: commonpb.NewIPv4Address([4]byte{255, 255, 255, 0})}).ToNetwork4()
+	require.Error(t, err)
+}
+
+// Test_IPv4Network_ToNetwork4_MissingMask asserts that an absent mask
+// submessage is rejected as malformed rather than treated as a wildcard.
+func Test_IPv4Network_ToNetwork4_MissingMask(t *testing.T) {
+	_, err := (&commonpb.IPv4Network{Addr: commonpb.NewIPv4Address([4]byte{192, 0, 2, 1})}).ToNetwork4()
+	require.Error(t, err)
+}
+
+// Test_IPv4Network_JSON asserts that the JSON form is a bare string: the
+// CIDR form for a contiguous mask, the address/mask form otherwise.
+func Test_IPv4Network_JSON(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		json string
+	}{
+		{name: "contiguous renders CIDR", text: "192.0.2.0/24", json: `"192.0.2.0/24"`},
+		{name: "non-contiguous renders mask", text: "192.0.2.0/255.0.255.0", json: `"192.0.2.0/255.0.255.0"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var message commonpb.IPv4Network
+			require.NoError(t, json.Unmarshal([]byte(`"`+tt.text+`"`), &message))
+
+			data, err := json.Marshal(&message)
+			require.NoError(t, err)
+			require.Equal(t, tt.json, string(data))
+		})
+	}
+}
+
+// Test_IPv4Network_JSON_Rejects asserts that empty and IPv6 inputs are
+// rejected on decode.
+func Test_IPv4Network_JSON_Rejects(t *testing.T) {
+	for _, input := range []string{`""`, `"2001:db8::/32"`, `"garbage"`} {
+		var message commonpb.IPv4Network
+		require.Error(t, json.Unmarshal([]byte(input), &message), input)
+	}
+}

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 /// Messages that gain the ordinary `Serialize`/`Deserialize` derive.
 ///
 /// The address messages, `MACAddress`, and the network messages
-/// (`ContiguousIPNetwork`, `IPv4Prefix`, `IPv6Prefix`,
+/// (`ContiguousIPNetwork`, `IPv4Prefix`, `IPv6Prefix`, `IPv4Network`,
 /// `BiContiguousIPv6Network`) are deliberately absent: `src/lib.rs`
 /// hand-writes their `Serialize`/`Deserialize` impls to go straight to
 /// and from a plain string, and prost-build's attribute paths are
@@ -38,6 +38,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipnetwork.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/contiguousnetwork.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipv4prefix.proto");
+    println!("cargo:rerun-if-changed=common/commonpb/v1/ipv4network.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipv6prefix.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/bicontiguousnetwork.proto");
 
@@ -69,6 +70,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             "common/commonpb/v1/ipnetwork.proto",
             "common/commonpb/v1/contiguousnetwork.proto",
             "common/commonpb/v1/ipv4prefix.proto",
+            "common/commonpb/v1/ipv4network.proto",
             "common/commonpb/v1/ipv6prefix.proto",
             "common/commonpb/v1/bicontiguousnetwork.proto",
         ],

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -339,6 +339,62 @@ impl<'de> Deserialize<'de> for pb::IPv4Prefix {
     }
 }
 
+impl From<Ipv4Network> for pb::IPv4Network {
+    fn from(net: Ipv4Network) -> Self {
+        pb::IPv4Network {
+            addr: Some(pb::IPv4Address::from(*net.addr())),
+            mask: Some(pb::IPv4Address::from(*net.mask())),
+        }
+    }
+}
+
+impl TryFrom<&pb::IPv4Network> for Ipv4Network {
+    type Error = Box<dyn Error>;
+
+    fn try_from(net: &pb::IPv4Network) -> Result<Self, Self::Error> {
+        let addr = net.addr.as_ref().ok_or("invalid IP network: missing address")?;
+        let mask = net.mask.as_ref().ok_or("invalid IP network: missing mask")?;
+        Ok(Ipv4Network::new(Ipv4Addr::from(addr), Ipv4Addr::from(mask)))
+    }
+}
+
+impl Display for pb::IPv4Network {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match Ipv4Network::try_from(self) {
+            Ok(net) => net.fmt(f),
+            Err(..) => f.write_str("invalid"),
+        }
+    }
+}
+
+impl FromStr for pb::IPv4Network {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let net = Ipv4Network::parse(s)?;
+        Ok(Self::from(net))
+    }
+}
+
+impl Serialize for pb::IPv4Network {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for pb::IPv4Network {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<Self>().map_err(de::Error::custom)
+    }
+}
+
 impl From<Contiguous<Ipv6Network>> for pb::IPv6Prefix {
     fn from(net: Contiguous<Ipv6Network>) -> Self {
         pb::IPv6Prefix {


### PR DESCRIPTION
- Adds `IPv4Network`: an IPv4 base address plus an arbitrary bitmask, both carried as `IPv4Address`, taking the file name freed by the #2235 rename.
- Unlike `IPv4Prefix`, any mask bit pattern is representable; the consuming API decides which mask classes it accepts, so relaxing an engine limitation later is a validation change rather than a wire migration.
- An absent addr or mask is malformed: the explicit zero mask is the match-all wildcard, so a producer that forgot a field cannot silently widen a rule.
- Go and Rust conversions go through xnetip/netip network values, normalizing address bits outside the mask; JSON is a bare string — the CIDR form for a contiguous mask, the address/mask form otherwise.
- Part of #2234; stacked on #2236 (merged).
