### PR TITLE
feat(commonpb): add a general ipv6 network message

### DIFF
--- a/common/commonpb/meson.build
+++ b/common/commonpb/meson.build
@@ -13,6 +13,7 @@ common_proto_files = [
     join_paths(common_proto_dir, 'v1', 'contiguousnetwork.proto'),
     join_paths(common_proto_dir, 'v1', 'ipv4prefix.proto'),
     join_paths(common_proto_dir, 'v1', 'ipv4network.proto'),
+    join_paths(common_proto_dir, 'v1', 'ipv6network.proto'),
     join_paths(common_proto_dir, 'v1', 'ipv6prefix.proto'),
     join_paths(common_proto_dir, 'v1', 'bicontiguousnetwork.proto'),
 ]
@@ -34,6 +35,7 @@ common_protoc_gen = custom_target(
         'contiguousnetwork.pb.go',
         'ipv4prefix.pb.go',
         'ipv4network.pb.go',
+        'ipv6network.pb.go',
         'ipv6prefix.pb.go',
         'bicontiguousnetwork.pb.go',
     ],

--- a/common/commonpb/v1/ipv6network.go
+++ b/common/commonpb/v1/ipv6network.go
@@ -1,0 +1,76 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/yanet-platform/xnetip"
+)
+
+// NewIPv6NetworkFrom6 creates an IPv6Network from an xnetip
+// network value. The inverse of ToNetwork6.
+func NewIPv6NetworkFrom6(net xnetip.Network6) *IPv6Network {
+	return &IPv6Network{
+		Addr: NewIPv6Address(net.Addr().As16()),
+		Mask: NewIPv6Address(net.Mask().As16()),
+	}
+}
+
+// ToNetwork6 converts the IPv6Network to a normalized xnetip network
+// value, rejecting an absent addr or mask. The inverse of NewIPv6NetworkFrom6.
+func (m *IPv6Network) ToNetwork6() (xnetip.Network6, error) {
+	if m.GetAddr() == nil {
+		return xnetip.Network6{}, fmt.Errorf("missing network address")
+	}
+	if m.GetMask() == nil {
+		return xnetip.Network6{}, fmt.Errorf("missing network mask")
+	}
+
+	net, err := xnetip.Network6From(m.GetAddr().ToAddr(), m.GetMask().ToAddr())
+	if err != nil {
+		return xnetip.Network6{}, fmt.Errorf("failed to build IP network: %w", err)
+	}
+	return net, nil
+}
+
+// AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
+func (m *IPv6Network) AsLogValue() any {
+	net, err := m.ToNetwork6()
+	if err != nil {
+		return "invalid"
+	}
+
+	return net.String()
+}
+
+// MarshalJSON serializes the network as a bare string: the CIDR form
+// when the mask is contiguous, the address/mask form otherwise.
+func (m *IPv6Network) MarshalJSON() ([]byte, error) {
+	net, err := m.ToNetwork6()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(net.String())
+}
+
+// UnmarshalJSON accepts a bare string in any form xnetip parsing accepts:
+// CIDR, explicit address/mask, or a bare host address.
+func (m *IPv6Network) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw == "" {
+		return fmt.Errorf("empty IP network is not allowed")
+	}
+
+	net, err := xnetip.ParseNetwork6(raw)
+	if err != nil {
+		return fmt.Errorf("failed to parse IP network: %w", err)
+	}
+
+	parsed := NewIPv6NetworkFrom6(net)
+	m.Addr = parsed.Addr
+	m.Mask = parsed.Mask
+	return nil
+}

--- a/common/commonpb/v1/ipv6network.proto
+++ b/common/commonpb/v1/ipv6network.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package common.commonpb.v1;
+
+option go_package = "github.com/yanet-platform/yanet2/common/commonpb/v1;commonpb";
+
+import "common/commonpb/v1/ipv6addr.proto";
+
+// IPv6Network represents an IPv6 network as a base address and an
+// arbitrary bitmask. Accepted mask classes are the consuming API's contract.
+message IPv6Network {
+  // Network base address, normalized by the mask on decode.
+  //
+  // MUST be present.
+  IPv6Address addr = 1;
+  // Network bitmask.
+  //
+  // MUST be present. The explicit zero mask is the match-all wildcard.
+  IPv6Address mask = 2;
+}

--- a/common/commonpb/v1/ipv6network_test.go
+++ b/common/commonpb/v1/ipv6network_test.go
@@ -1,0 +1,88 @@
+package commonpb_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/xnetip"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+)
+
+// Test_IPv6Network_RoundTrip asserts that contiguous, bi-contiguous, and
+// hole-inside-a-half masks all survive the New/ToNetwork6 round trip.
+func Test_IPv6Network_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+	}{
+		{name: "contiguous", network: "2001:db8::/32"},
+		{name: "bi-contiguous", network: "2001:db8:1::/ffff:ffff:ffff:0:ffff::"},
+		{name: "hole inside a half", network: "2001:db8::/ffff:0:ffff::"},
+		{name: "host route", network: "2001:db8::1/128"},
+		{name: "match all", network: "::/::"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			net, err := xnetip.ParseNetwork6(tt.network)
+			require.NoError(t, err)
+
+			got, err := commonpb.NewIPv6NetworkFrom6(net).ToNetwork6()
+			require.NoError(t, err)
+			require.Equal(t, net, got)
+		})
+	}
+}
+
+// Test_IPv6Network_ToNetwork6_MissingMask asserts that an absent mask
+// submessage is rejected as malformed rather than treated as a wildcard.
+func Test_IPv6Network_ToNetwork6_MissingMask(t *testing.T) {
+	message := &commonpb.IPv6Network{
+		Addr: commonpb.NewIPv6Address([16]byte{0x20, 0x01, 0x0d, 0xb8}),
+	}
+
+	_, err := message.ToNetwork6()
+	require.Error(t, err)
+}
+
+// Test_IPv6Network_ToNetwork6_MissingAddr asserts that an absent address
+// submessage is rejected as malformed.
+func Test_IPv6Network_ToNetwork6_MissingAddr(t *testing.T) {
+	_, err := (&commonpb.IPv6Network{}).ToNetwork6()
+	require.Error(t, err)
+}
+
+// Test_IPv6Network_JSON asserts that the JSON form is a bare string: the
+// CIDR form for a contiguous mask, the address/mask form otherwise.
+func Test_IPv6Network_JSON(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		json string
+	}{
+		{name: "contiguous renders CIDR", text: "2001:db8::/32", json: `"2001:db8::/32"`},
+		{name: "bi-contiguous renders mask", text: "2001:db8:1::/ffff:ffff:ffff:0:ffff::", json: `"2001:db8:1::/ffff:ffff:ffff:0:ffff::"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var message commonpb.IPv6Network
+			require.NoError(t, json.Unmarshal([]byte(`"`+tt.text+`"`), &message))
+
+			data, err := json.Marshal(&message)
+			require.NoError(t, err)
+			require.Equal(t, tt.json, string(data))
+		})
+	}
+}
+
+// Test_IPv6Network_JSON_Rejects asserts that empty and IPv4 inputs are
+// rejected on decode.
+func Test_IPv6Network_JSON_Rejects(t *testing.T) {
+	for _, input := range []string{`""`, `"192.0.2.0/24"`, `"garbage"`} {
+		var message commonpb.IPv6Network
+		require.Error(t, json.Unmarshal([]byte(input), &message), input)
+	}
+}

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -4,9 +4,9 @@ use core::error::Error;
 ///
 /// The address messages, `MACAddress`, and the network messages
 /// (`ContiguousIPNetwork`, `IPv4Prefix`, `IPv6Prefix`, `IPv4Network`,
-/// `BiContiguousIPv6Network`) are deliberately absent: `src/lib.rs`
-/// hand-writes their `Serialize`/`Deserialize` impls to go straight to
-/// and from a plain string, and prost-build's attribute paths are
+/// `IPv6Network`, `BiContiguousIPv6Network`) are deliberately absent:
+/// `src/lib.rs` hand-writes their `Serialize`/`Deserialize` impls to go
+/// straight to and from a plain string, and prost-build's attribute paths are
 /// additive, not
 /// subtractive -- a blanket `message_attribute(".", ...)` cannot exclude
 /// a single message, so every other message is listed here individually
@@ -39,6 +39,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=common/commonpb/v1/contiguousnetwork.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipv4prefix.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipv4network.proto");
+    println!("cargo:rerun-if-changed=common/commonpb/v1/ipv6network.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipv6prefix.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/bicontiguousnetwork.proto");
 
@@ -71,6 +72,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             "common/commonpb/v1/contiguousnetwork.proto",
             "common/commonpb/v1/ipv4prefix.proto",
             "common/commonpb/v1/ipv4network.proto",
+            "common/commonpb/v1/ipv6network.proto",
             "common/commonpb/v1/ipv6prefix.proto",
             "common/commonpb/v1/bicontiguousnetwork.proto",
         ],

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -460,6 +460,62 @@ impl<'de> Deserialize<'de> for pb::IPv6Prefix {
     }
 }
 
+impl From<Ipv6Network> for pb::IPv6Network {
+    fn from(net: Ipv6Network) -> Self {
+        pb::IPv6Network {
+            addr: Some(pb::IPv6Address::from(*net.addr())),
+            mask: Some(pb::IPv6Address::from(*net.mask())),
+        }
+    }
+}
+
+impl TryFrom<&pb::IPv6Network> for Ipv6Network {
+    type Error = Box<dyn Error>;
+
+    fn try_from(net: &pb::IPv6Network) -> Result<Self, Self::Error> {
+        let addr = net.addr.as_ref().ok_or("invalid IP network: missing address")?;
+        let mask = net.mask.as_ref().ok_or("invalid IP network: missing mask")?;
+        Ok(Ipv6Network::new(Ipv6Addr::from(addr), Ipv6Addr::from(mask)))
+    }
+}
+
+impl Display for pb::IPv6Network {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match Ipv6Network::try_from(self) {
+            Ok(net) => net.fmt(f),
+            Err(..) => f.write_str("invalid"),
+        }
+    }
+}
+
+impl FromStr for pb::IPv6Network {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let net = Ipv6Network::parse(s)?;
+        Ok(Self::from(net))
+    }
+}
+
+impl Serialize for pb::IPv6Network {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for pb::IPv6Network {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<Self>().map_err(de::Error::custom)
+    }
+}
+
 impl From<BiContiguous<Ipv6Network>> for pb::BiContiguousIPv6Network {
     fn from(net: BiContiguous<Ipv6Network>) -> Self {
         let mask = net.mask().to_bits();


### PR DESCRIPTION
- Adds `IPv6Network`: an IPv6 base address plus an arbitrary bitmask carried as an `IPv6Address`, taking the file name freed by the #2235 rename.
- Unlike `IPv6Prefix` and the bi-contiguous class, any mask bit pattern is representable — a hole inside a 64-bit half included; the consuming API decides which mask classes it accepts.
- Go and Rust conversions go through xnetip/netip network values, normalizing address bits outside the mask; an absent mask is the zero mask, mirroring `IPv4Network`; JSON is a bare string — the CIDR form for a contiguous mask, the address/mask form otherwise.
- Part of #2234; stacked on #2237.
