### PR TITLE
feat(forward)!: split filter network lists by address family on the wire

### DIFF
--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -9,11 +9,12 @@ use clap_complete::{
     CompleteEnv,
     engine::{ArgValueCandidates, CompletionCandidate},
 };
+use commonpb::pb::{IPv4Network, IPv6Network};
 use forwardpb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     forward_service_client::ForwardServiceClient,
 };
-use netip::{Contiguous, IpNetwork};
+use netip::IpNetwork;
 use serde::{Deserialize, Serialize, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
@@ -157,6 +158,9 @@ impl TryFrom<ForwardRule> for forwardpb::Rule {
             ModeKind::Unknown(mode) => return Err(format!("unknown forward mode {mode}").into()),
         };
 
+        let (sources4, sources6) = partition_nets(forward_rule.srcs)?;
+        let (destinations4, destinations6) = partition_nets(forward_rule.dsts)?;
+
         Ok(Self {
             action: Some(forwardpb::Action {
                 target: forward_rule.target,
@@ -165,18 +169,36 @@ impl TryFrom<ForwardRule> for forwardpb::Rule {
             }),
             devices: forward_rule.devices.into_iter().map(|m| m.into()).collect(),
             vlan_ranges: forward_rule.vlan_ranges.into_iter().map(Into::into).collect(),
-            srcs: forward_rule
-                .srcs
-                .into_iter()
-                .map(|n| Contiguous::<IpNetwork>::parse(&n).map(filterpb::pb::IpNet::from))
-                .collect::<Result<Vec<_>, _>>()?,
-            dsts: forward_rule
-                .dsts
-                .into_iter()
-                .map(|n| Contiguous::<IpNetwork>::parse(&n).map(filterpb::pb::IpNet::from))
-                .collect::<Result<Vec<_>, _>>()?,
+            sources4,
+            sources6,
+            destinations4,
+            destinations6,
         })
     }
+}
+
+/// Partitions a mixed-family network list into the family-typed wire
+/// messages, preserving the within-family order.
+fn partition_nets(nets: Vec<String>) -> Result<(Vec<IPv4Network>, Vec<IPv6Network>), Box<dyn core::error::Error>> {
+    let mut v4 = Vec::new();
+    let mut v6 = Vec::new();
+    for net in nets {
+        match IpNetwork::parse(&net)? {
+            IpNetwork::V4(net) => v4.push(net.into()),
+            IpNetwork::V6(net) => v6.push(net.into()),
+        }
+    }
+
+    Ok((v4, v6))
+}
+
+/// Renders the family-typed wire lists back into one mixed list, IPv4
+/// entries first.
+fn render_nets(v4: Vec<IPv4Network>, v6: Vec<IPv6Network>) -> Vec<String> {
+    v4.into_iter()
+        .map(|net| net.to_string())
+        .chain(v6.into_iter().map(|net| net.to_string()))
+        .collect()
 }
 
 impl TryFrom<forwardpb::Rule> for ForwardRule {
@@ -197,8 +219,8 @@ impl TryFrom<forwardpb::Rule> for ForwardRule {
             counter: action.counter,
             devices: rule.devices.into_iter().map(|d| d.name).collect(),
             vlan_ranges: rule.vlan_ranges.into_iter().map(VlanRange::from).collect(),
-            srcs: rule.srcs.into_iter().map(|n| n.to_string()).collect(),
-            dsts: rule.dsts.into_iter().map(|n| n.to_string()).collect(),
+            srcs: render_nets(rule.sources4, rule.sources6),
+            dsts: render_nets(rule.destinations4, rule.destinations6),
         })
     }
 }
@@ -209,11 +231,15 @@ impl TryFrom<forwardpb::Rule> for ForwardRule {
 /// and an empty counter as an empty string, and none of them is optional on
 /// `update` either.
 ///
-/// A network renders from the address and mask actually stored, so
-/// re-applying shown output normalises an address that carries host bits
-/// outside its mask. A stored IPv6 network's mask may have a hole at the
-/// `/64` boundary. Such a network renders in expanded-mask form, and
-/// `update` rejects it because it requires a contiguous mask.
+/// The `srcs` and `dsts` lists are mixed-family in the file but travel
+/// family-split on the wire, so `show` renders IPv4 entries before IPv6
+/// entries and only within-family order survives a round trip. A network
+/// parses in CIDR or address/mask form, normalising an address that
+/// carries host bits outside its mask. Any parseable mask is sent as-is,
+/// and the server enforces the filter compiler's mask classes: contiguous
+/// for IPv4, bi-contiguous for IPv6. A stored IPv6 mask with its hole
+/// exactly at the `/64` boundary renders in expanded-mask form and
+/// round-trips through `update`.
 ///
 /// A `counter` left empty on `update` is not stored empty: the server
 /// materialises it to `to_<target>` before storing, bounded to whatever
@@ -419,10 +445,12 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 mod test {
     use super::*;
 
-    fn ip_net(cidr: &str) -> filterpb::pb::IpNet {
-        Contiguous::<IpNetwork>::parse(cidr)
-            .expect("valid cidr in test fixture")
-            .into()
+    fn v4_net(net: &str) -> IPv4Network {
+        net.parse().expect("valid IPv4 network in test fixture")
+    }
+
+    fn v6_net(net: &str) -> IPv6Network {
+        net.parse().expect("valid IPv6 network in test fixture")
     }
 
     fn sample_rules() -> Vec<forwardpb::Rule> {
@@ -441,8 +469,10 @@ mod test {
                     filterpb::pb::VlanRange { from: 0, to: 100 },
                     filterpb::pb::VlanRange { from: 200, to: 300 },
                 ],
-                srcs: vec![ip_net("192.0.2.0/24"), ip_net("2001:db8::/32")],
-                dsts: vec![ip_net("203.0.113.0/24"), ip_net("2001:db8:1::/48")],
+                sources4: vec![v4_net("192.0.2.0/24")],
+                sources6: vec![v6_net("2001:db8::/32")],
+                destinations4: vec![v4_net("203.0.113.0/24")],
+                destinations6: vec![v6_net("2001:db8:1::/48")],
             },
             forwardpb::Rule {
                 action: Some(forwardpb::Action {
@@ -452,8 +482,10 @@ mod test {
                 }),
                 devices: vec![],
                 vlan_ranges: vec![],
-                srcs: vec![],
-                dsts: vec![],
+                sources4: vec![],
+                sources6: vec![],
+                destinations4: vec![],
+                destinations6: vec![],
             },
             forwardpb::Rule {
                 action: Some(forwardpb::Action {
@@ -463,8 +495,10 @@ mod test {
                 }),
                 devices: vec![filterpb::pb::Device { name: "eth2".to_string() }],
                 vlan_ranges: vec![filterpb::pb::VlanRange { from: 10, to: 20 }],
-                srcs: vec![ip_net("10.0.0.0/8")],
-                dsts: vec![ip_net("10.1.0.0/16")],
+                sources4: vec![v4_net("10.0.0.0/8")],
+                sources6: vec![],
+                destinations4: vec![v4_net("10.1.0.0/16")],
+                destinations6: vec![],
             },
         ]
     }
@@ -541,6 +575,55 @@ rules:
     }
 
     #[test]
+    fn mixed_family_networks_partition_by_family_preserving_order() {
+        let yaml = r#"
+rules:
+  - target: "t"
+    mode: "NONE"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs:
+      - 2001:db8::/32
+      - 192.0.2.0/24
+      - 10.0.0.0/8
+    dsts: []
+"#;
+
+        let config: ForwardConfig = serde_yaml::from_str(yaml).expect("mixed families must parse");
+        let rules: Vec<forwardpb::Rule> = config.try_into().expect("mixed families must convert");
+
+        assert_eq!(vec![v4_net("192.0.2.0/24"), v4_net("10.0.0.0/8")], rules[0].sources4);
+        assert_eq!(vec![v6_net("2001:db8::/32")], rules[0].sources6);
+    }
+
+    #[test]
+    fn a_bi_contiguous_v6_mask_round_trips_through_the_rule_file() {
+        let rule = forwardpb::Rule {
+            action: Some(forwardpb::Action {
+                target: "t".to_string(),
+                mode: forwardpb::ForwardMode::None as i32,
+                counter: "c".to_string(),
+            }),
+            devices: vec![],
+            vlan_ranges: vec![],
+            sources4: vec![],
+            // The mask hole sits exactly at the /64 boundary, which the
+            // filter compiler accepts.
+            sources6: vec![v6_net("2001:db8::/ffff:ffff:ffff:0:ffff::")],
+            destinations4: vec![],
+            destinations6: vec![],
+        };
+
+        let config = ForwardConfig::try_from(vec![rule.clone()]).expect("a bi-contiguous v6 network must render");
+        let yaml = serde_yaml::to_string(&config).expect("forward config must serialize");
+        let parsed: ForwardConfig = serde_yaml::from_str(&yaml).expect("forward config must deserialize");
+        let rebuilt: Vec<forwardpb::Rule> = parsed.try_into().expect("forward config must convert back");
+
+        assert_eq!(vec![rule], rebuilt);
+    }
+
+    #[test]
     fn an_unrecognised_mode_number_is_shown_but_rejected_by_update() {
         let rule = forwardpb::Rule {
             action: Some(forwardpb::Action {
@@ -550,8 +633,10 @@ rules:
             }),
             devices: vec![],
             vlan_ranges: vec![],
-            srcs: vec![],
-            dsts: vec![],
+            sources4: vec![],
+            sources6: vec![],
+            destinations4: vec![],
+            destinations6: vec![],
         };
 
         let config = ForwardConfig::try_from(vec![rule]).expect("an unrecognised mode must not blank the show");

--- a/modules/forward/controlplane/forwardpb/v1/forward.proto
+++ b/modules/forward/controlplane/forwardpb/v1/forward.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package modules.forward.controlplane.forwardpb.v1;
 
 import "common/filterpb/v1/filter.proto";
+import "common/commonpb/v1/ipv4network.proto";
+import "common/commonpb/v1/ipv6network.proto";
 import "common/commonpb/v1/metric.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1;forwardpb";
@@ -59,8 +61,10 @@ message Rule {
 
   repeated common.filterpb.v1.Device devices = 2;
   repeated common.filterpb.v1.VlanRange vlan_ranges = 3;
-  repeated common.filterpb.v1.IPNet srcs = 4;
-  repeated common.filterpb.v1.IPNet dsts = 5;
+  repeated common.commonpb.v1.IPv4Network sources4 = 4;
+  repeated common.commonpb.v1.IPv6Network sources6 = 5;
+  repeated common.commonpb.v1.IPv4Network destinations4 = 6;
+  repeated common.commonpb.v1.IPv6Network destinations6 = 7;
 }
 
 message Action {

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -166,19 +166,19 @@ func (m *ForwardService) UpdateConfig(ctx context.Context, req *forwardpb.Update
 		if err != nil {
 			return nil, err
 		}
-		src4s, err := filterpbconv.ToNet4s(reqRule.Srcs)
+		src4s, err := filterpbconv.ToNet4sFromNetworks(reqRule.Sources4)
 		if err != nil {
 			return nil, err
 		}
-		dst4s, err := filterpbconv.ToNet4s(reqRule.Dsts)
+		dst4s, err := filterpbconv.ToNet4sFromNetworks(reqRule.Destinations4)
 		if err != nil {
 			return nil, err
 		}
-		src6s, err := filterpbconv.ToNet6s(reqRule.Srcs)
+		src6s, err := filterpbconv.ToNet6sFromNetworks(reqRule.Sources6)
 		if err != nil {
 			return nil, err
 		}
-		dst6s, err := filterpbconv.ToNet6s(reqRule.Dsts)
+		dst6s, err := filterpbconv.ToNet6sFromNetworks(reqRule.Destinations6)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/forward/controlplane/service_test.go
+++ b/modules/forward/controlplane/service_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/yanet-platform/xnetip"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
 	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
@@ -294,6 +295,119 @@ func TestUpdateConfigMaterializesEmptyCounterUTF8Boundary(t *testing.T) {
 
 	_, err = proto.Marshal(response)
 	require.NoError(t, err, "ShowConfigResponse carrying the materialised counter must marshal")
+}
+
+// v4net builds an IPv4Network message from xnetip network text, in any
+// form xnetip parsing accepts: CIDR or an explicit address/mask.
+func v4net(s string) *commonpb.IPv4Network {
+	return commonpb.NewIPv4NetworkFrom4(xnetip.MustParseNetwork4(s))
+}
+
+// v6net builds an IPv6Network message the same way.
+func v6net(s string) *commonpb.IPv6Network {
+	return commonpb.NewIPv6NetworkFrom6(xnetip.MustParseNetwork6(s))
+}
+
+// TestUpdateConfigRejectsOutOfClassMasks verifies that UpdateConfig
+// enforces the filter compiler's mask classes on the network lists.
+//
+// A non-contiguous IPv4 mask and an IPv6 mask with a hole inside a
+// 64-bit half are both rejected.
+func TestUpdateConfigRejectsOutOfClassMasks(t *testing.T) {
+	tests := []struct {
+		name string
+		rule *forwardpb.Rule
+	}{
+		{
+			name: "non-contiguous IPv4 source mask",
+			rule: &forwardpb.Rule{
+				Action:   &forwardpb.Action{Target: "device0"},
+				Sources4: []*commonpb.IPv4Network{v4net("192.0.2.0/255.0.255.0")},
+			},
+		},
+		{
+			name: "IPv6 destination mask with a hole inside a half",
+			rule: &forwardpb.Rule{
+				Action:        &forwardpb.Action{Target: "device0"},
+				Destinations6: []*commonpb.IPv6Network{v6net("2001:db8::/ffff:0:ffff::")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := forward.NewForwardService(&mockBackend{})
+
+			_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+				Name:  "config",
+				Rules: []*forwardpb.Rule{tt.rule},
+			})
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// TestUpdateConfigAcceptsV6MaskHoleAtHalfBoundary verifies that an IPv6
+// mask with its hole exactly at the /64 boundary reaches the backend.
+func TestUpdateConfigAcceptsV6MaskHoleAtHalfBoundary(t *testing.T) {
+	backend := &recordingBackend{}
+	svc := forward.NewForwardService(backend)
+
+	const network = "2001:db8::/ffff:ffff:ffff:0:ffff::"
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*forwardpb.Rule{
+			{
+				Action:   &forwardpb.Action{Target: "device0"},
+				Sources6: []*commonpb.IPv6Network{v6net(network)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.rules, 1)
+	require.Equal(t, []xnetip.BiContiguous{xnetip.MustParseBiContiguous(network)}, backend.rules[0].Src6s)
+}
+
+// TestUpdateConfigPreservesWithinFamilyNetworkOrder verifies that the
+// networks of every family-typed list reach the backend in request order.
+func TestUpdateConfigPreservesWithinFamilyNetworkOrder(t *testing.T) {
+	backend := &recordingBackend{}
+	svc := forward.NewForwardService(backend)
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*forwardpb.Rule{
+			{
+				Action:        &forwardpb.Action{Target: "device0"},
+				Sources4:      []*commonpb.IPv4Network{v4net("192.0.2.0/24"), v4net("10.0.0.0/8")},
+				Sources6:      []*commonpb.IPv6Network{v6net("2001:db8:1::/48"), v6net("2001:db8::/32")},
+				Destinations4: []*commonpb.IPv4Network{v4net("203.0.113.0/24"), v4net("198.51.100.0/24")},
+				Destinations6: []*commonpb.IPv6Network{v6net("2001:db8:2::/48"), v6net("2001:db8:3::/48")},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.rules, 1)
+	rule := backend.rules[0]
+	require.Equal(t, []xnetip.Contiguous[xnetip.Network4]{
+		xnetip.MustParseContiguous4("192.0.2.0/24"),
+		xnetip.MustParseContiguous4("10.0.0.0/8"),
+	}, rule.Src4s)
+	require.Equal(t, []xnetip.BiContiguous{
+		xnetip.MustParseBiContiguous("2001:db8:1::/48"),
+		xnetip.MustParseBiContiguous("2001:db8::/32"),
+	}, rule.Src6s)
+	require.Equal(t, []xnetip.Contiguous[xnetip.Network4]{
+		xnetip.MustParseContiguous4("203.0.113.0/24"),
+		xnetip.MustParseContiguous4("198.51.100.0/24"),
+	}, rule.Dst4s)
+	require.Equal(t, []xnetip.BiContiguous{
+		xnetip.MustParseBiContiguous("2001:db8:2::/48"),
+		xnetip.MustParseBiContiguous("2001:db8:3::/48"),
+	}, rule.Dst6s)
 }
 
 // TestMetricsExactTagNeverReadsForeignCounter verifies that an exact

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/yanet-platform/xnetip"
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
-	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/xerror"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -374,11 +374,11 @@ func TestForward_EmptyCounterMaterializesToTarget(t *testing.T) {
 					Target: "port1",
 					Mode:   forwardpb.ForwardMode_OUT,
 				},
-				Srcs: []*filterpb.IPNet{
-					{Addr: []byte{0, 0, 0, 0}, Mask: []byte{0, 0, 0, 0}},
+				Sources4: []*commonpb.IPv4Network{
+					commonpb.NewIPv4NetworkFrom4(xnetip.MustParseNetwork4("0.0.0.0/0")),
 				},
-				Dsts: []*filterpb.IPNet{
-					{Addr: []byte{10, 0, 0, 0}, Mask: []byte{255, 255, 255, 0}},
+				Destinations4: []*commonpb.IPv4Network{
+					commonpb.NewIPv4NetworkFrom4(xnetip.MustParseNetwork4("10.0.0.0/24")),
 				},
 			},
 		},

--- a/modules/forward/web/SaveDiffModal.tsx
+++ b/modules/forward/web/SaveDiffModal.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import type { Rule } from '@yanet/core/api/forward';
 import { ForwardMode, FORWARD_MODE_LABELS } from '@yanet/core/api/forward';
-import { formatIPNetItem, dumpYamlDoc } from '@yanet/core/utils';
+import { dumpYamlDoc } from '@yanet/core/utils';
 import { SaveDiffModal as SharedSaveDiffModal } from '@yanet/core/components';
 import { effectiveCounterName } from './hooks';
 
@@ -15,8 +15,8 @@ import { effectiveCounterName } from './hooks';
 export const rulesToDiffYaml = (rules: Rule[], showEffectiveCounter = false): string => {
     const yamlRules = rules.map((r) => {
         const devices = (r.devices ?? []).map(d => d.name ?? '').filter(Boolean);
-        const srcs = (r.srcs ?? []).map(formatIPNetItem).filter(Boolean);
-        const dsts = (r.dsts ?? []).map(formatIPNetItem).filter(Boolean);
+        const srcs = [...(r.sources4 ?? []), ...(r.sources6 ?? [])];
+        const dsts = [...(r.destinations4 ?? []), ...(r.destinations6 ?? [])];
         const vlan_ranges = (r.vlan_ranges ?? []).map(vr => ({
             from: vr.from ?? 0,
             to: vr.to ?? 0,

--- a/modules/forward/web/YamlIO.tsx
+++ b/modules/forward/web/YamlIO.tsx
@@ -3,7 +3,7 @@ import yaml from 'js-yaml';
 import type { Rule } from '@yanet/core/api/forward';
 import { ForwardMode } from '@yanet/core/api/forward';
 import { toaster } from '@yanet/core/utils';
-import { parseCidrsToIPNets } from '@yanet/core/utils';
+import { partitionCidrsToTyped } from '@yanet/core/utils';
 import { rulesToDiffYaml } from './SaveDiffModal';
 import YamlIOModal from '@yanet/core/components/YamlIOModal';
 
@@ -82,16 +82,24 @@ export const parseYamlToRules = (text: string): Rule[] => {
         });
 
         const srcsRaw = Array.isArray(row.srcs) ? row.srcs : [];
-        const srcs = parseCidrsToIPNets(
+        const sources = partitionCidrsToTyped(
             (srcsRaw as unknown[]).filter((s): s is string => typeof s === 'string'),
         );
 
         const dstsRaw = Array.isArray(row.dsts) ? row.dsts : [];
-        const dsts = parseCidrsToIPNets(
+        const destinations = partitionCidrsToTyped(
             (dstsRaw as unknown[]).filter((s): s is string => typeof s === 'string'),
         );
 
-        return { action: { target, mode, counter }, devices, vlan_ranges, srcs, dsts };
+        return {
+            action: { target, mode, counter },
+            devices,
+            vlan_ranges,
+            sources4: sources.v4,
+            sources6: sources.v6,
+            destinations4: destinations.v4,
+            destinations6: destinations.v6,
+        };
     });
 
     return rules;

--- a/modules/forward/web/hooks.ts
+++ b/modules/forward/web/hooks.ts
@@ -1,6 +1,6 @@
 import type { Rule, VlanRange } from '@yanet/core/api/forward';
 import { ForwardMode } from '@yanet/core/api/forward';
-import { formatIPNetItem, formatRange, parseCidrsToIPNets, parseRangesRaw } from '@yanet/core/utils';
+import { formatRange, parseRangesRaw, partitionCidrsToTyped } from '@yanet/core/utils';
 import type { RuleItem, RuleDraft } from './types';
 
 /** Format VlanRange array to a display string. */
@@ -35,8 +35,8 @@ export const rulesToNgItems = (rules: Rule[]): RuleItem[] => {
         const deviceNames = (rule.devices || []).map((d) => d.name || '').filter(Boolean);
         const vlansDisplay = formatVlanRanges(rule.vlan_ranges);
         const isAllVlans = computeIsAllVlans(rule.vlan_ranges);
-        const sourceCidrs = (rule.srcs || []).map(formatIPNetItem).filter(Boolean);
-        const dstCidrs = (rule.dsts || []).map(formatIPNetItem).filter(Boolean);
+        const sourceCidrs = [...(rule.sources4 || []), ...(rule.sources6 || [])];
+        const dstCidrs = [...(rule.destinations4 || []), ...(rule.destinations6 || [])];
         const mode = rule.action?.mode ?? ForwardMode.NONE;
 
         return {
@@ -57,18 +57,24 @@ export const rulesToNgItems = (rules: Rule[]): RuleItem[] => {
     });
 };
 
-/** Convert a RuleDraft to a Rule for the API. */
-export const draftToRule = (draft: RuleDraft): Rule => ({
-    action: {
-        target: draft.target,
-        mode: draft.mode,
-        counter: draft.counter || undefined,
-    },
-    devices: draft.deviceNames.map((name) => ({ name })),
-    vlan_ranges: parseRangesRaw(draft.vlansRaw),
-    srcs: parseCidrsToIPNets(draft.sourceCidrs),
-    dsts: parseCidrsToIPNets(draft.dstCidrs),
-});
+/** Convert a RuleDraft to a Rule for the API, carrying networks in the family-typed lists. */
+export const draftToRule = (draft: RuleDraft): Rule => {
+    const sources = partitionCidrsToTyped(draft.sourceCidrs);
+    const destinations = partitionCidrsToTyped(draft.dstCidrs);
+    return {
+        action: {
+            target: draft.target,
+            mode: draft.mode,
+            counter: draft.counter || undefined,
+        },
+        devices: draft.deviceNames.map((name) => ({ name })),
+        vlan_ranges: parseRangesRaw(draft.vlansRaw),
+        sources4: sources.v4,
+        sources6: sources.v6,
+        destinations4: destinations.v4,
+        destinations6: destinations.v6,
+    };
+};
 
 /** Convert a RuleItem back to a RuleDraft for editing. */
 export const itemToDraft = (item: RuleItem): RuleDraft => ({

--- a/operators/forward/internal/operator/rules.go
+++ b/operators/forward/internal/operator/rules.go
@@ -2,12 +2,13 @@ package operator
 
 import (
 	"fmt"
-	"net"
 	"net/netip"
 	"os"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/yanet-platform/xnetip"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
@@ -96,12 +97,12 @@ func convertRule(r yamlForwardRule) (*forwardpb.Rule, error) {
 		vlanRanges[idx] = &filterpb.VlanRange{From: vr.From, To: vr.To}
 	}
 
-	srcs, err := convertCIDRs(r.Srcs)
+	sources4, sources6, err := convertCIDRs(r.Srcs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse src: %w", err)
 	}
 
-	dsts, err := convertCIDRs(r.Dsts)
+	destinations4, destinations6, err := convertCIDRs(r.Dsts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse dst: %w", err)
 	}
@@ -112,10 +113,12 @@ func convertRule(r yamlForwardRule) (*forwardpb.Rule, error) {
 			Mode:    mode,
 			Counter: r.Counter,
 		},
-		Devices:    devices,
-		VlanRanges: vlanRanges,
-		Srcs:       srcs,
-		Dsts:       dsts,
+		Devices:       devices,
+		VlanRanges:    vlanRanges,
+		Sources4:      sources4,
+		Sources6:      sources6,
+		Destinations4: destinations4,
+		Destinations6: destinations6,
 	}, nil
 }
 
@@ -133,20 +136,32 @@ func convertMode(m yamlModeKind) (forwardpb.ForwardMode, error) {
 	}
 }
 
-// convertCIDRs parses a slice of CIDR strings into filterpb.IPNet values.
-func convertCIDRs(cidrs []string) ([]*filterpb.IPNet, error) {
-	out := make([]*filterpb.IPNet, 0, len(cidrs))
+// convertCIDRs parses a slice of CIDR strings into family-typed network
+// messages, preserving the within-family order of the input.
+//
+// An IPv4-mapped IPv6 address counts as IPv6, as it did when the family
+// was derived from the address byte length.
+func convertCIDRs(cidrs []string) ([]*commonpb.IPv4Network, []*commonpb.IPv6Network, error) {
+	var v4 []*commonpb.IPv4Network
+	var v6 []*commonpb.IPv6Network
 	for _, s := range cidrs {
 		prefix, err := netip.ParsePrefix(s)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse CIDR %q: %w", s, err)
+			return nil, nil, fmt.Errorf("failed to parse CIDR %q: %w", s, err)
 		}
-		addr := prefix.Masked().Addr().AsSlice()
-		mask := net.CIDRMask(prefix.Bits(), len(addr)*8)
-		out = append(out, &filterpb.IPNet{
-			Addr: addr,
-			Mask: mask,
-		})
+		if prefix.Addr().Is4() {
+			net, ok := xnetip.Network4FromPrefix(prefix)
+			if !ok {
+				return nil, nil, fmt.Errorf("invalid CIDR %q", s)
+			}
+			v4 = append(v4, commonpb.NewIPv4NetworkFrom4(net))
+			continue
+		}
+		net, ok := xnetip.Network6FromPrefix(prefix)
+		if !ok {
+			return nil, nil, fmt.Errorf("invalid CIDR %q", s)
+		}
+		v6 = append(v6, commonpb.NewIPv6NetworkFrom6(net))
 	}
-	return out, nil
+	return v4, v6, nil
 }

--- a/operators/forward/internal/operator/rules_test.go
+++ b/operators/forward/internal/operator/rules_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 	"github.com/yanet-platform/yanet2/operators/forward/internal/operator"
 )
@@ -47,4 +48,71 @@ func TestLoadForwardRules_Mode(t *testing.T) {
 			require.Equal(t, tt.want, rules[0].Action.Mode)
 		})
 	}
+}
+
+// TestLoadForwardRules_NetworkFamilySplit verifies that mixed srcs/dsts
+// CIDR lists split into the family-typed proto lists, order preserved.
+func TestLoadForwardRules_NetworkFamilySplit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rules.yaml")
+	data := `rules:
+  - target: fn:test
+    mode: NONE
+    counter: cnt
+    srcs:
+      - 2001:db8::/32
+      - 192.0.2.0/24
+      - 10.0.0.0/8
+      - 2001:db8:1::/48
+    dsts:
+      - 203.0.113.0/24
+`
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o644))
+
+	rules, err := operator.LoadForwardRules(path)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+
+	rule := rules[0]
+	require.Equal(t, []string{"192.0.2.0/24", "10.0.0.0/8"}, networks4ToStrings(t, rule.Sources4))
+	require.Equal(t, []string{"2001:db8::/32", "2001:db8:1::/48"}, networks6ToStrings(t, rule.Sources6))
+	require.Equal(t, []string{"203.0.113.0/24"}, networks4ToStrings(t, rule.Destinations4))
+	require.Empty(t, rule.Destinations6)
+}
+
+// TestLoadForwardRules_RejectsMalformedCIDR verifies that a rule file
+// carrying an unparseable network fails to load instead of dropping it.
+func TestLoadForwardRules_RejectsMalformedCIDR(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rules.yaml")
+	data := "rules:\n  - target: fn:test\n    mode: NONE\n    counter: cnt\n    srcs:\n      - 192.0.2.0/33\n"
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o644))
+
+	_, err := operator.LoadForwardRules(path)
+	require.Error(t, err)
+}
+
+// networks4ToStrings renders IPv4Network messages in their canonical text
+// form for comparison.
+func networks4ToStrings(t *testing.T, nets []*commonpb.IPv4Network) []string {
+	t.Helper()
+
+	out := make([]string, len(nets))
+	for idx, net := range nets {
+		parsed, err := net.ToNetwork4()
+		require.NoError(t, err)
+		out[idx] = parsed.String()
+	}
+	return out
+}
+
+// networks6ToStrings is networks4ToStrings for IPv6Network messages.
+func networks6ToStrings(t *testing.T, nets []*commonpb.IPv6Network) []string {
+	t.Helper()
+
+	out := make([]string, len(nets))
+	for idx, net := range nets {
+		parsed, err := net.ToNetwork6()
+		require.NoError(t, err)
+		out[idx] = parsed.String()
+	}
+	return out
 }

--- a/web/src/core/api/forward.ts
+++ b/web/src/core/api/forward.ts
@@ -2,8 +2,8 @@ import { createService, type CallOptions } from './client';
 
 // Forward types based on forwardpb/forward.proto
 
-import type { Device, VlanRange, IPNet, ListConfigsResponse } from './shared';
-export type { Device, VlanRange, IPNet, ListConfigsResponse };
+import type { Device, VlanRange, ListConfigsResponse } from './shared';
+export type { Device, VlanRange, ListConfigsResponse };
 
 export enum ForwardMode {
     NONE = 0,
@@ -27,8 +27,13 @@ export interface Rule {
     action?: Action;
     devices?: Device[];
     vlan_ranges?: VlanRange[];
-    srcs?: IPNet[];
-    dsts?: IPNet[];
+    // Family-typed network lists (commonpb.IPv4Network and
+    // commonpb.IPv6Network), serialized by the gateway as bare network
+    // strings.
+    sources4?: string[];
+    sources6?: string[];
+    destinations4?: string[];
+    destinations6?: string[];
 }
 
 // Request/Response types


### PR DESCRIPTION
- Replace the mixed-family IPNet rule lists with family-typed commonpb.IPv4Network and IPv6Network lists, named as in the ACL rules.
- Enforce the filter compiler mask classes in the service decode instead of re-discovering the family from byte length.
- Keep the CLI, operator and web rule surfaces mixed-family, partitioning by family at the protobuf boundary.

Closes #2206.