### PR TITLE
feat(mirror)!: split filter network lists by address family on the wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,7 +3422,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "colored",
- "netip",
  "prost",
  "prost-types",
  "ptree",
@@ -3432,6 +3431,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
  "yanet-filterpb",
 ]
 

--- a/modules/mirror/cli/Cargo.toml
+++ b/modules/mirror/cli/Cargo.toml
@@ -11,8 +11,8 @@ workspace = true
 
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}
+commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
-netip = "0.3"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 colored = "3"

--- a/modules/mirror/cli/build.rs
+++ b/modules/mirror/cli/build.rs
@@ -6,6 +6,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
+        .extern_path(".common.commonpb.v1", "::commonpb::pb")
         .extern_path(".common.filterpb.v1", "::filterpb::pb")
         .message_attribute(".", "#[derive(Serialize)]")
         .compile_protos(&["mirrorpb/v1/mirror.proto"], &["../../..", "../controlplane"])?;

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -9,11 +9,11 @@ use clap_complete::{
     CompleteEnv,
     engine::{ArgValueCandidates, CompletionCandidate},
 };
+use commonpb::pb::{IPv4Network, IPv6Network};
 use mirrorpb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     mirror_service_client::MirrorServiceClient,
 };
-use netip::{Contiguous, IpNetwork};
 use serde::{Deserialize, Serialize, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
@@ -142,8 +142,10 @@ struct MirrorRule {
     counter: String,
     devices: Vec<String>,
     vlan_ranges: Vec<VlanRange>,
-    srcs: Vec<String>,
-    dsts: Vec<String>,
+    sources4: Vec<IPv4Network>,
+    sources6: Vec<IPv6Network>,
+    destinations4: Vec<IPv4Network>,
+    destinations6: Vec<IPv6Network>,
 }
 
 impl TryFrom<MirrorRule> for mirrorpb::Rule {
@@ -165,16 +167,10 @@ impl TryFrom<MirrorRule> for mirrorpb::Rule {
             }),
             devices: mirror_rule.devices.into_iter().map(|m| m.into()).collect(),
             vlan_ranges: mirror_rule.vlan_ranges.into_iter().map(Into::into).collect(),
-            srcs: mirror_rule
-                .srcs
-                .into_iter()
-                .map(|n| Contiguous::<IpNetwork>::parse(&n).map(filterpb::pb::IpNet::from))
-                .collect::<Result<Vec<_>, _>>()?,
-            dsts: mirror_rule
-                .dsts
-                .into_iter()
-                .map(|n| Contiguous::<IpNetwork>::parse(&n).map(filterpb::pb::IpNet::from))
-                .collect::<Result<Vec<_>, _>>()?,
+            sources4: mirror_rule.sources4,
+            sources6: mirror_rule.sources6,
+            destinations4: mirror_rule.destinations4,
+            destinations6: mirror_rule.destinations6,
         })
     }
 }
@@ -197,21 +193,14 @@ impl TryFrom<mirrorpb::Rule> for MirrorRule {
             counter: action.counter,
             devices: rule.devices.into_iter().map(|d| d.name).collect(),
             vlan_ranges: rule.vlan_ranges.into_iter().map(VlanRange::from).collect(),
-            srcs: rule.srcs.into_iter().map(|n| n.to_string()).collect(),
-            dsts: rule.dsts.into_iter().map(|n| n.to_string()).collect(),
+            sources4: rule.sources4,
+            sources6: rule.sources6,
+            destinations4: rule.destinations4,
+            destinations6: rule.destinations6,
         })
     }
 }
 
-/// A mirror module configuration as read from or written to a rule file.
-///
-/// Every rule field is always emitted, including an empty sequence as `[]`
-/// and an empty counter as an empty string, and none of them is optional on
-/// `update` either. A network renders from the address and mask actually
-/// stored, so re-applying shown output normalises an address that carries
-/// host bits outside its mask. A stored IPv6 network's mask may have a hole
-/// at the `/64` boundary. Such a network renders in expanded-mask form, and
-/// `update` rejects it because it requires a contiguous mask.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MirrorConfig {
     rules: Vec<MirrorRule>,
@@ -410,10 +399,12 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 mod test {
     use super::*;
 
-    fn ip_net(cidr: &str) -> filterpb::pb::IpNet {
-        Contiguous::<IpNetwork>::parse(cidr)
-            .expect("valid cidr in test fixture")
-            .into()
+    fn v4_net(net: &str) -> IPv4Network {
+        net.parse().expect("valid IPv4 network in test fixture")
+    }
+
+    fn v6_net(net: &str) -> IPv6Network {
+        net.parse().expect("valid IPv6 network in test fixture")
     }
 
     fn sample_rules() -> Vec<mirrorpb::Rule> {
@@ -432,8 +423,10 @@ mod test {
                     filterpb::pb::VlanRange { from: 0, to: 100 },
                     filterpb::pb::VlanRange { from: 200, to: 300 },
                 ],
-                srcs: vec![ip_net("192.0.2.0/24"), ip_net("2001:db8::/32")],
-                dsts: vec![ip_net("203.0.113.0/24"), ip_net("2001:db8:1::/48")],
+                sources4: vec![v4_net("192.0.2.0/24")],
+                sources6: vec![v6_net("2001:db8::/32")],
+                destinations4: vec![v4_net("203.0.113.0/24")],
+                destinations6: vec![v6_net("2001:db8:1::/48")],
             },
             mirrorpb::Rule {
                 action: Some(mirrorpb::Action {
@@ -443,8 +436,10 @@ mod test {
                 }),
                 devices: vec![],
                 vlan_ranges: vec![],
-                srcs: vec![],
-                dsts: vec![],
+                sources4: vec![],
+                sources6: vec![],
+                destinations4: vec![],
+                destinations6: vec![],
             },
             mirrorpb::Rule {
                 action: Some(mirrorpb::Action {
@@ -454,8 +449,10 @@ mod test {
                 }),
                 devices: vec![filterpb::pb::Device { name: "eth2".to_string() }],
                 vlan_ranges: vec![filterpb::pb::VlanRange { from: 10, to: 20 }],
-                srcs: vec![ip_net("10.0.0.0/8")],
-                dsts: vec![ip_net("10.1.0.0/16")],
+                sources4: vec![v4_net("10.0.0.0/8")],
+                sources6: vec![],
+                destinations4: vec![v4_net("10.1.0.0/16")],
+                destinations6: vec![],
             },
         ]
     }
@@ -481,22 +478,28 @@ rules:
     counter: ""
     devices: []
     vlan_ranges: []
-    srcs: []
-    dsts: []
+    sources4: []
+    sources6: []
+    destinations4: []
+    destinations6: []
   - target: "t2"
     mode: "IN"
     counter: ""
     devices: []
     vlan_ranges: []
-    srcs: []
-    dsts: []
+    sources4: []
+    sources6: []
+    destinations4: []
+    destinations6: []
   - target: "t3"
     mode: "OUT"
     counter: ""
     devices: []
     vlan_ranges: []
-    srcs: []
-    dsts: []
+    sources4: []
+    sources6: []
+    destinations4: []
+    destinations6: []
 "#;
         let legacy = r#"
 rules:
@@ -505,22 +508,28 @@ rules:
     counter: ""
     devices: []
     vlan_ranges: []
-    srcs: []
-    dsts: []
+    sources4: []
+    sources6: []
+    destinations4: []
+    destinations6: []
   - target: "t2"
     mode: "In"
     counter: ""
     devices: []
     vlan_ranges: []
-    srcs: []
-    dsts: []
+    sources4: []
+    sources6: []
+    destinations4: []
+    destinations6: []
   - target: "t3"
     mode: "Out"
     counter: ""
     devices: []
     vlan_ranges: []
-    srcs: []
-    dsts: []
+    sources4: []
+    sources6: []
+    destinations4: []
+    destinations6: []
 "#;
 
         for yaml in [uppercase, legacy] {
@@ -529,6 +538,32 @@ rules:
             assert!(matches!(config.rules[1].mode, ModeKind::In));
             assert!(matches!(config.rules[2].mode, ModeKind::Out));
         }
+    }
+
+    #[test]
+    fn a_bi_contiguous_v6_mask_round_trips_through_the_rule_file() {
+        let rule = mirrorpb::Rule {
+            action: Some(mirrorpb::Action {
+                target: "t".to_string(),
+                mode: mirrorpb::MirrorMode::None as i32,
+                counter: "c".to_string(),
+            }),
+            devices: vec![],
+            vlan_ranges: vec![],
+            sources4: vec![],
+            // The mask hole sits exactly at the /64 boundary, which the
+            // filter compiler accepts.
+            sources6: vec![v6_net("2001:db8::/ffff:ffff:ffff:0:ffff::")],
+            destinations4: vec![],
+            destinations6: vec![],
+        };
+
+        let config = MirrorConfig::try_from(vec![rule.clone()]).expect("a bi-contiguous v6 network must render");
+        let yaml = serde_yaml::to_string(&config).expect("mirror config must serialize");
+        let parsed: MirrorConfig = serde_yaml::from_str(&yaml).expect("mirror config must deserialize");
+        let rebuilt: Vec<mirrorpb::Rule> = parsed.try_into().expect("mirror config must convert back");
+
+        assert_eq!(vec![rule], rebuilt);
     }
 
     #[test]
@@ -541,8 +576,10 @@ rules:
             }),
             devices: vec![],
             vlan_ranges: vec![],
-            srcs: vec![],
-            dsts: vec![],
+            sources4: vec![],
+            sources6: vec![],
+            destinations4: vec![],
+            destinations6: vec![],
         };
 
         let config = MirrorConfig::try_from(vec![rule]).expect("an unrecognised mode must not blank the show");

--- a/modules/mirror/controlplane/mirrorpb/v1/mirror.proto
+++ b/modules/mirror/controlplane/mirrorpb/v1/mirror.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package modules.mirror.controlplane.mirrorpb.v1;
 
 import "common/filterpb/v1/filter.proto";
+import "common/commonpb/v1/ipv4network.proto";
+import "common/commonpb/v1/ipv6network.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/modules/mirror/controlplane/mirrorpb/v1;mirrorpb";
 
@@ -47,8 +49,10 @@ message Rule {
 
   repeated common.filterpb.v1.Device devices = 2;
   repeated common.filterpb.v1.VlanRange vlan_ranges = 3;
-  repeated common.filterpb.v1.IPNet srcs = 4;
-  repeated common.filterpb.v1.IPNet dsts = 5;
+  repeated common.commonpb.v1.IPv4Network sources4 = 4;
+  repeated common.commonpb.v1.IPv6Network sources6 = 5;
+  repeated common.commonpb.v1.IPv4Network destinations4 = 6;
+  repeated common.commonpb.v1.IPv6Network destinations6 = 7;
 }
 
 message Action {

--- a/modules/mirror/controlplane/service.go
+++ b/modules/mirror/controlplane/service.go
@@ -135,19 +135,19 @@ func (m *MirrorService) UpdateConfig(
 		if err != nil {
 			return nil, err
 		}
-		src4s, err := filterpbconv.ToNet4s(reqRule.Srcs)
+		src4s, err := filterpbconv.ToNet4sFromNetworks(reqRule.Sources4)
 		if err != nil {
 			return nil, err
 		}
-		dst4s, err := filterpbconv.ToNet4s(reqRule.Dsts)
+		dst4s, err := filterpbconv.ToNet4sFromNetworks(reqRule.Destinations4)
 		if err != nil {
 			return nil, err
 		}
-		src6s, err := filterpbconv.ToNet6s(reqRule.Srcs)
+		src6s, err := filterpbconv.ToNet6sFromNetworks(reqRule.Sources6)
 		if err != nil {
 			return nil, err
 		}
-		dst6s, err := filterpbconv.ToNet6s(reqRule.Dsts)
+		dst6s, err := filterpbconv.ToNet6sFromNetworks(reqRule.Destinations6)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/mirror/controlplane/service_test.go
+++ b/modules/mirror/controlplane/service_test.go
@@ -10,6 +10,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/yanet-platform/xnetip"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/modules/mirror/bindings/go/cmirror"
 	mirror "github.com/yanet-platform/yanet2/modules/mirror/controlplane"
 	mirrorpb "github.com/yanet-platform/yanet2/modules/mirror/controlplane/mirrorpb/v1"
@@ -48,6 +50,33 @@ func (m *nilHandleBackend) UpdateModule(
 	rules []cmirror.MirrorRule,
 ) (mirror.ModuleHandle, error) {
 	return nil, nil
+}
+
+// recordingBackend captures the rules handed to UpdateModule so a test can
+// inspect what the service sends to shared memory.
+type recordingBackend struct {
+	mockBackend
+
+	rules []cmirror.MirrorRule
+}
+
+func (m *recordingBackend) UpdateModule(
+	name string,
+	rules []cmirror.MirrorRule,
+) (mirror.ModuleHandle, error) {
+	m.rules = rules
+	return &mockModuleHandle{}, nil
+}
+
+// v4net builds an IPv4Network message from xnetip network text, in any
+// form xnetip parsing accepts: CIDR or an explicit address/mask.
+func v4net(s string) *commonpb.IPv4Network {
+	return commonpb.NewIPv4NetworkFrom4(xnetip.MustParseNetwork4(s))
+}
+
+// v6net builds an IPv6Network message the same way.
+func v6net(s string) *commonpb.IPv6Network {
+	return commonpb.NewIPv6NetworkFrom6(xnetip.MustParseNetwork6(s))
 }
 
 // TestShowConfigUnknownConfig verifies that ShowConfig reports NotFound for
@@ -91,6 +120,108 @@ func TestUpdateConfigReplacesConfigWithoutHandle(t *testing.T) {
 
 	_, err = svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{Name: "config"})
 	require.NoError(t, err)
+}
+
+// TestUpdateConfigRejectsOutOfClassMasks verifies that UpdateConfig
+// enforces the filter compiler's mask classes on the network lists.
+//
+// A non-contiguous IPv4 mask and an IPv6 mask with a hole inside a
+// 64-bit half are both rejected.
+func TestUpdateConfigRejectsOutOfClassMasks(t *testing.T) {
+	tests := []struct {
+		name string
+		rule *mirrorpb.Rule
+	}{
+		{
+			name: "non-contiguous IPv4 source mask",
+			rule: &mirrorpb.Rule{
+				Action:   &mirrorpb.Action{Target: "device0"},
+				Sources4: []*commonpb.IPv4Network{v4net("192.0.2.0/255.0.255.0")},
+			},
+		},
+		{
+			name: "IPv6 destination mask with a hole inside a half",
+			rule: &mirrorpb.Rule{
+				Action:        &mirrorpb.Action{Target: "device0"},
+				Destinations6: []*commonpb.IPv6Network{v6net("2001:db8::/ffff:0:ffff::")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := mirror.NewMirrorService(&mockBackend{})
+
+			_, err := svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{
+				Name:  "config",
+				Rules: []*mirrorpb.Rule{tt.rule},
+			})
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// TestUpdateConfigAcceptsV6MaskHoleAtHalfBoundary verifies that an IPv6
+// mask with its hole exactly at the /64 boundary reaches the backend.
+func TestUpdateConfigAcceptsV6MaskHoleAtHalfBoundary(t *testing.T) {
+	backend := &recordingBackend{}
+	svc := mirror.NewMirrorService(backend)
+
+	const network = "2001:db8::/ffff:ffff:ffff:0:ffff::"
+
+	_, err := svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*mirrorpb.Rule{
+			{
+				Action:   &mirrorpb.Action{Target: "device0"},
+				Sources6: []*commonpb.IPv6Network{v6net(network)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.rules, 1)
+	require.Equal(t, []xnetip.BiContiguous{xnetip.MustParseBiContiguous(network)}, backend.rules[0].Src6s)
+}
+
+// TestUpdateConfigPreservesWithinFamilyNetworkOrder verifies that the
+// networks of every family-typed list reach the backend in request order.
+func TestUpdateConfigPreservesWithinFamilyNetworkOrder(t *testing.T) {
+	backend := &recordingBackend{}
+	svc := mirror.NewMirrorService(backend)
+
+	_, err := svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*mirrorpb.Rule{
+			{
+				Action:        &mirrorpb.Action{Target: "device0"},
+				Sources4:      []*commonpb.IPv4Network{v4net("192.0.2.0/24"), v4net("10.0.0.0/8")},
+				Sources6:      []*commonpb.IPv6Network{v6net("2001:db8:1::/48"), v6net("2001:db8::/32")},
+				Destinations4: []*commonpb.IPv4Network{v4net("203.0.113.0/24"), v4net("198.51.100.0/24")},
+				Destinations6: []*commonpb.IPv6Network{v6net("2001:db8:2::/48"), v6net("2001:db8:3::/48")},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.rules, 1)
+	rule := backend.rules[0]
+	require.Equal(t, []xnetip.Contiguous[xnetip.Network4]{
+		xnetip.MustParseContiguous4("192.0.2.0/24"),
+		xnetip.MustParseContiguous4("10.0.0.0/8"),
+	}, rule.Src4s)
+	require.Equal(t, []xnetip.BiContiguous{
+		xnetip.MustParseBiContiguous("2001:db8:1::/48"),
+		xnetip.MustParseBiContiguous("2001:db8::/32"),
+	}, rule.Src6s)
+	require.Equal(t, []xnetip.Contiguous[xnetip.Network4]{
+		xnetip.MustParseContiguous4("203.0.113.0/24"),
+		xnetip.MustParseContiguous4("198.51.100.0/24"),
+	}, rule.Dst4s)
+	require.Equal(t, []xnetip.BiContiguous{
+		xnetip.MustParseBiContiguous("2001:db8:2::/48"),
+		xnetip.MustParseBiContiguous("2001:db8:3::/48"),
+	}, rule.Dst6s)
 }
 
 // Run with: go test -race


### PR DESCRIPTION
- Replace the mixed-family IPNet rule lists with family-typed commonpb.IPv4Network and IPv6Network lists, named as in the ACL and forward rules.
- Enforce the filter compiler mask classes in the service decode instead of re-discovering the family from byte length.
- Switch the CLI rule-file schema to the same family-split lists, with no compatibility for the mixed srcs and dsts keys.

Closes #2207.