### PR TITLE
feat(dscp)!: split prefix lists by address family on the wire

### DIFF
--- a/common/commonpb/v1/ipv4prefix.go
+++ b/common/commonpb/v1/ipv4prefix.go
@@ -33,6 +33,14 @@ func NewIPv4PrefixFromPrefix(prefix netip.Prefix) (*IPv4Prefix, error) {
 	return NewIPv4PrefixFromContiguous(net), nil
 }
 
+// NewIPv4PrefixesFromPrefixes creates IPv4Prefix messages from IPv4
+// netip.Prefix values, masking off any host bits.
+//
+// Returns an error if any prefix is invalid or not IPv4.
+func NewIPv4PrefixesFromPrefixes(prefixes []netip.Prefix) ([]*IPv4Prefix, error) {
+	return networksFromPrefixes(prefixes, NewIPv4PrefixFromPrefix)
+}
+
 // ToContiguous converts the IPv4Prefix to an xnetip IPv4 CIDR
 // block.
 //

--- a/common/commonpb/v1/ipv6prefix.go
+++ b/common/commonpb/v1/ipv6prefix.go
@@ -33,6 +33,14 @@ func NewIPv6PrefixFromPrefix(prefix netip.Prefix) (*IPv6Prefix, error) {
 	return NewIPv6PrefixFromContiguous(net), nil
 }
 
+// NewIPv6PrefixesFromPrefixes creates IPv6Prefix messages from IPv6
+// netip.Prefix values, masking off any host bits.
+//
+// Returns an error if any prefix is invalid or not IPv6.
+func NewIPv6PrefixesFromPrefixes(prefixes []netip.Prefix) ([]*IPv6Prefix, error) {
+	return networksFromPrefixes(prefixes, NewIPv6PrefixFromPrefix)
+}
+
 // ToContiguous converts the IPv6Prefix to an xnetip IPv6 CIDR
 // block.
 //

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -690,9 +690,49 @@ impl<'de> Deserialize<'de> for pb::IpPrefix {
     }
 }
 
+/// Partitions mixed-family contiguous prefixes into the family-typed
+/// prefix messages, preserving the within-family order.
+pub fn partition_prefixes(
+    prefixes: impl IntoIterator<Item = Contiguous<IpNetwork>>,
+) -> (Vec<pb::IPv4Prefix>, Vec<pb::IPv6Prefix>) {
+    let mut v4 = Vec::new();
+    let mut v6 = Vec::new();
+    for prefix in prefixes {
+        match prefix.addr() {
+            IpAddr::V4(addr) => v4.push(pb::IPv4Prefix {
+                addr: Some(pb::IPv4Address::from(addr)),
+                prefix_len: u32::from(prefix.prefix()),
+            }),
+            IpAddr::V6(addr) => v6.push(pb::IPv6Prefix {
+                addr: Some(pb::IPv6Address::from(addr)),
+                prefix_len: u32::from(prefix.prefix()),
+            }),
+        }
+    }
+
+    (v4, v6)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn partition_prefixes_splits_by_family_preserving_order() {
+        let prefixes = ["2001:db8::/32", "10.0.0.0/8", "192.0.2.0/24", "2001:db8:1::/48"]
+            .map(|prefix| Contiguous::<IpNetwork>::parse(prefix).unwrap());
+
+        let (v4, v6) = partition_prefixes(prefixes);
+
+        assert_eq!(
+            vec!["10.0.0.0/8", "192.0.2.0/24"],
+            v4.iter().map(ToString::to_string).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            vec!["2001:db8::/32", "2001:db8:1::/48"],
+            v6.iter().map(ToString::to_string).collect::<Vec<_>>()
+        );
+    }
 
     #[test]
     fn v4_round_trip() {

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -3,7 +3,7 @@ use clap_complete::{
     CompleteEnv,
     engine::{ArgValueCandidates, CompletionCandidate},
 };
-use commonpb::pb::IpPrefix;
+use commonpb::partition_prefixes;
 use dscppb::{
     AddPrefixesRequest, DscpConfig, RemovePrefixesRequest, SetDscpMarkingRequest, ShowConfigRequest,
     ShowConfigResponse, dscp_service_client::DscpServiceClient,
@@ -206,9 +206,11 @@ impl DscpService {
     }
 
     pub async fn add_prefixes(&mut self, cmd: AddPrefixesCmd) -> Result<(), Error> {
+        let (prefixes4, prefixes6) = partition_prefixes(cmd.prefix.iter().copied());
         let request = AddPrefixesRequest {
             name: cmd.config_name.clone(),
-            prefixes: cmd.prefix.iter().copied().map(IpPrefix::from).collect(),
+            prefixes4,
+            prefixes6,
         };
         log::trace!("AddPrefixesRequest: {request:?}");
         let response = self
@@ -229,9 +231,11 @@ impl DscpService {
     }
 
     pub async fn remove_prefixes(&mut self, cmd: RemovePrefixesCmd) -> Result<(), Error> {
+        let (prefixes4, prefixes6) = partition_prefixes(cmd.prefix.iter().copied());
         let request = RemovePrefixesRequest {
             name: cmd.config_name.clone(),
-            prefixes: cmd.prefix.iter().copied().map(IpPrefix::from).collect(),
+            prefixes4,
+            prefixes6,
         };
         log::trace!("RemovePrefixesRequest: {request:?}");
         let response = self
@@ -296,11 +300,16 @@ fn print_tree(response: &ShowConfigResponse) {
         }
 
         tree.begin_child("Prefixes".to_string());
-        if config.prefixes.is_empty() {
+        if config.prefixes4.is_empty() && config.prefixes6.is_empty() {
             tree.add_empty_child("(none)".to_owned());
         }
 
-        for (idx, prefix) in config.prefixes.iter().enumerate() {
+        let prefixes = config
+            .prefixes4
+            .iter()
+            .map(ToString::to_string)
+            .chain(config.prefixes6.iter().map(ToString::to_string));
+        for (idx, prefix) in prefixes.enumerate() {
             tree.add_empty_child(format!("{idx}: {prefix}"));
         }
         tree.end_child();

--- a/modules/dscp/controlplane/dscppb/v1/dscp.proto
+++ b/modules/dscp/controlplane/dscppb/v1/dscp.proto
@@ -2,7 +2,8 @@ syntax = "proto3";
 
 package modules.dscp.controlplane.dscppb.v1;
 
-import "common/commonpb/v1/ipprefix.proto";
+import "common/commonpb/v1/ipv4prefix.proto";
+import "common/commonpb/v1/ipv6prefix.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/modules/dscp/controlplane/dscppb/v1;dscppb";
 
@@ -24,7 +25,8 @@ service DscpService {
 }
 
 message Config {
-  repeated common.commonpb.v1.IPPrefix prefixes = 2;
+  repeated common.commonpb.v1.IPv4Prefix prefixes4 = 1;
+  repeated common.commonpb.v1.IPv6Prefix prefixes6 = 2;
   DscpConfig dscp_config = 3;
 }
 
@@ -51,7 +53,8 @@ message ShowConfigResponse { Config config = 1; }
 // AddPrefixesRequest adds prefixes to the input filter of the dscp module.
 message AddPrefixesRequest {
   string name = 1;
-  repeated common.commonpb.v1.IPPrefix prefixes = 2;
+  repeated common.commonpb.v1.IPv4Prefix prefixes4 = 2;
+  repeated common.commonpb.v1.IPv6Prefix prefixes6 = 3;
 }
 message AddPrefixesResponse {}
 
@@ -59,7 +62,8 @@ message AddPrefixesResponse {}
 // module.
 message RemovePrefixesRequest {
   string name = 1;
-  repeated common.commonpb.v1.IPPrefix prefixes = 2;
+  repeated common.commonpb.v1.IPv4Prefix prefixes4 = 2;
+  repeated common.commonpb.v1.IPv6Prefix prefixes6 = 3;
 }
 message RemovePrefixesResponse {}
 

--- a/modules/dscp/controlplane/service.go
+++ b/modules/dscp/controlplane/service.go
@@ -43,9 +43,14 @@ type DscpService struct {
 }
 
 type config struct {
-	Prefixes []netip.Prefix
-	Config   dscpConfig
-	Module   ModuleHandle
+	// Prefixes4 is the sorted IPv4 prefix set.
+	Prefixes4 []netip.Prefix
+	// Prefixes6 is the sorted IPv6 prefix set.
+	Prefixes6 []netip.Prefix
+	// Config is the DSCP marking configuration.
+	Config dscpConfig
+	// Module is the shared-memory handle of the published config.
+	Module ModuleHandle
 }
 
 // Free releases the module handle held by the config.
@@ -60,9 +65,10 @@ func (m *config) Free() error {
 
 func (m *config) Clone() *config {
 	return &config{
-		Prefixes: slices.Clone(m.Prefixes),
-		Config:   m.Config,
-		Module:   m.Module,
+		Prefixes4: slices.Clone(m.Prefixes4),
+		Prefixes6: slices.Clone(m.Prefixes6),
+		Config:    m.Config,
+		Module:    m.Module,
 	}
 }
 
@@ -115,13 +121,18 @@ func (m *DscpService) ShowConfig(
 		return nil, status.Error(codes.NotFound, "config not found")
 	}
 
-	prefixes, err := commonpb.NetworksFromPrefixes(config.Prefixes)
+	prefixes4, err := commonpb.NewIPv4PrefixesFromPrefixes(config.Prefixes4)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to convert prefixes: %v", err)
+	}
+	prefixes6, err := commonpb.NewIPv6PrefixesFromPrefixes(config.Prefixes6)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to convert prefixes: %v", err)
 	}
 
 	response.Config = &dscppb.Config{
-		Prefixes: prefixes,
+		Prefixes4: prefixes4,
+		Prefixes6: prefixes6,
 		DscpConfig: &dscppb.DscpConfig{
 			Flag: uint32(config.Config.Flag),
 			Mark: uint32(config.Config.Mark),
@@ -140,7 +151,11 @@ func (m *DscpService) AddPrefixes(
 	}
 
 	name := request.GetName()
-	toAdd, err := commonpb.PrefixesFromNetworks(request.GetPrefixes())
+	toAdd4, err := commonpb.PrefixesFromNetworks(request.GetPrefixes4())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
+	}
+	toAdd6, err := commonpb.PrefixesFromNetworks(request.GetPrefixes6())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
 	}
@@ -153,18 +168,25 @@ func (m *DscpService) AddPrefixes(
 		cfg = currConfig.Clone()
 	}
 
-	cfg.Prefixes = slices.Compact(
-		slices.SortedFunc(
-			slices.Values(slices.Concat(cfg.Prefixes, toAdd)),
-			comparePrefixes,
-		),
-	)
+	cfg.Prefixes4 = mergePrefixes(cfg.Prefixes4, toAdd4)
+	cfg.Prefixes6 = mergePrefixes(cfg.Prefixes6, toAdd6)
 
 	if err := m.updateModuleConfig(name, cfg); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
 	return &dscppb.AddPrefixesResponse{}, nil
+}
+
+// mergePrefixes folds new prefixes into an existing sorted set, keeping it
+// sorted and duplicate-free.
+func mergePrefixes(existing, toAdd []netip.Prefix) []netip.Prefix {
+	return slices.Compact(
+		slices.SortedFunc(
+			slices.Values(slices.Concat(existing, toAdd)),
+			comparePrefixes,
+		),
+	)
 }
 
 func comparePrefixes(first, second netip.Prefix) int {
@@ -183,7 +205,11 @@ func (m *DscpService) RemovePrefixes(
 	}
 
 	name := request.GetName()
-	toRemove, err := commonpb.PrefixesFromNetworks(request.GetPrefixes())
+	toRemove4, err := commonpb.PrefixesFromNetworks(request.GetPrefixes4())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
+	}
+	toRemove6, err := commonpb.PrefixesFromNetworks(request.GetPrefixes6())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
 	}
@@ -198,18 +224,24 @@ func (m *DscpService) RemovePrefixes(
 		cfg = currConfig.Clone()
 	}
 
-	cfg.Prefixes = slices.DeleteFunc(
-		cfg.Prefixes,
-		func(prefix netip.Prefix) bool {
-			return slices.Contains(toRemove, prefix)
-		},
-	)
+	cfg.Prefixes4 = removePrefixes(cfg.Prefixes4, toRemove4)
+	cfg.Prefixes6 = removePrefixes(cfg.Prefixes6, toRemove6)
 
 	if err := m.updateModuleConfig(name, cfg); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
 	return &dscppb.RemovePrefixesResponse{}, nil
+}
+
+// removePrefixes drops every listed prefix from an existing set.
+func removePrefixes(existing, toRemove []netip.Prefix) []netip.Prefix {
+	return slices.DeleteFunc(
+		existing,
+		func(prefix netip.Prefix) bool {
+			return slices.Contains(toRemove, prefix)
+		},
+	)
 }
 
 func (m *DscpService) SetDscpMarking(
@@ -246,7 +278,7 @@ func (m *DscpService) SetDscpMarking(
 func (m *DscpService) updateModuleConfig(name string, cfg *config) error {
 	module, err := m.backend.UpdateModule(
 		name,
-		cfg.Prefixes,
+		slices.Concat(cfg.Prefixes4, cfg.Prefixes6),
 		cfg.Config.Flag,
 		cfg.Config.Mark,
 	)
@@ -258,9 +290,10 @@ func (m *DscpService) updateModuleConfig(name string, cfg *config) error {
 	m.parkOrFree(cfg.Module)
 
 	m.configs[name] = &config{
-		Prefixes: cfg.Prefixes,
-		Config:   cfg.Config,
-		Module:   module,
+		Prefixes4: cfg.Prefixes4,
+		Prefixes6: cfg.Prefixes6,
+		Config:    cfg.Config,
+		Module:    module,
 	}
 
 	return nil

--- a/modules/dscp/controlplane/service_test.go
+++ b/modules/dscp/controlplane/service_test.go
@@ -18,22 +18,37 @@ import (
 
 var errBackendFailure = fmt.Errorf("backend failure")
 
-// mustNetworks returns structured networks for valid CIDR test inputs.
-func mustNetworks(t *testing.T, prefixes ...string) []*commonpb.IPPrefix {
+// mustPrefixes4 returns family-typed IPv4 prefix messages for valid CIDR
+// test inputs.
+func mustPrefixes4(t *testing.T, prefixes ...string) []*commonpb.IPv4Prefix {
 	t.Helper()
 
-	networks := make([]*commonpb.IPPrefix, 0, len(prefixes))
-	for _, prefix := range prefixes {
-		network, err := commonpb.NewIPPrefixFromPrefix(netip.MustParsePrefix(prefix))
-		require.NoError(t, err)
-		networks = append(networks, network)
-	}
-
+	networks, err := commonpb.NewIPv4PrefixesFromPrefixes(parsePrefixes(prefixes))
+	require.NoError(t, err)
 	return networks
 }
 
-// networkStrings returns canonical CIDR text for valid structured networks.
-func networkStrings(t *testing.T, networks []*commonpb.IPPrefix) []string {
+// mustPrefixes6 is mustPrefixes4 for IPv6 prefix messages.
+func mustPrefixes6(t *testing.T, prefixes ...string) []*commonpb.IPv6Prefix {
+	t.Helper()
+
+	networks, err := commonpb.NewIPv6PrefixesFromPrefixes(parsePrefixes(prefixes))
+	require.NoError(t, err)
+	return networks
+}
+
+// parsePrefixes parses valid CIDR test inputs.
+func parsePrefixes(prefixes []string) []netip.Prefix {
+	out := make([]netip.Prefix, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		out = append(out, netip.MustParsePrefix(prefix))
+	}
+	return out
+}
+
+// prefixStrings returns canonical CIDR text for valid prefix messages of
+// either family.
+func prefixStrings[T interface{ ToPrefix() (netip.Prefix, error) }](t *testing.T, networks []T) []string {
 	t.Helper()
 
 	prefixes := make([]string, 0, len(networks))
@@ -44,14 +59,6 @@ func networkStrings(t *testing.T, networks []*commonpb.IPPrefix) []string {
 	}
 
 	return prefixes
-}
-
-// malformedNetwork returns a network with an invalid address length.
-func malformedNetwork() *commonpb.IPPrefix {
-	return &commonpb.IPPrefix{
-		Addr:      &commonpb.IPAddress{Addr: []byte{10, 0, 0}},
-		PrefixLen: 24,
-	}
 }
 
 type mockModuleHandle struct {
@@ -117,8 +124,9 @@ func Test_DscpService_ListShowAddRemoveSetMarking(t *testing.T) {
 
 	{
 		response, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
-			Name:     "dscp0",
-			Prefixes: mustNetworks(t, "10.0.0.0/24", "2001:db8::/32"),
+			Name:      "dscp0",
+			Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
+			Prefixes6: mustPrefixes6(t, "2001:db8::/32"),
 		})
 		require.NotNil(t, response)
 		require.NoError(t, err)
@@ -136,11 +144,8 @@ func Test_DscpService_ListShowAddRemoveSetMarking(t *testing.T) {
 		require.NotNil(t, response)
 		require.NoError(t, err)
 		assert.Empty(t, response.Config.DscpConfig)
-		assert.Equal(
-			t,
-			[]string{"10.0.0.0/24", "2001:db8::/32"},
-			networkStrings(t, response.Config.Prefixes),
-		)
+		assert.Equal(t, []string{"10.0.0.0/24"}, prefixStrings(t, response.Config.Prefixes4))
+		assert.Equal(t, []string{"2001:db8::/32"}, prefixStrings(t, response.Config.Prefixes6))
 	}
 
 	{
@@ -165,8 +170,8 @@ func Test_DscpService_ListShowAddRemoveSetMarking(t *testing.T) {
 
 	{
 		response, err := service.RemovePrefixes(ctx, &dscppb.RemovePrefixesRequest{
-			Name:     "dscp0",
-			Prefixes: mustNetworks(t, "10.0.0.0/24"),
+			Name:      "dscp0",
+			Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
 		})
 		require.NotNil(t, response)
 		require.NoError(t, err)
@@ -176,11 +181,8 @@ func Test_DscpService_ListShowAddRemoveSetMarking(t *testing.T) {
 		response, err := service.ShowConfig(ctx, &dscppb.ShowConfigRequest{Name: "dscp0"})
 		require.NotNil(t, response)
 		require.NoError(t, err)
-		assert.Equal(
-			t,
-			[]string{"2001:db8::/32"},
-			networkStrings(t, response.Config.Prefixes),
-		)
+		assert.Empty(t, response.Config.Prefixes4)
+		assert.Equal(t, []string{"2001:db8::/32"}, prefixStrings(t, response.Config.Prefixes6))
 	}
 }
 
@@ -199,8 +201,8 @@ func Test_DscpService_RequestValidation(t *testing.T) {
 
 	t.Run("AddPrefixesInvalidName", func(t *testing.T) {
 		response, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
-			Name:     "",
-			Prefixes: mustNetworks(t, "10.0.0.0/24"),
+			Name:      "",
+			Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
 		})
 		require.Nil(t, response)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -208,8 +210,8 @@ func Test_DscpService_RequestValidation(t *testing.T) {
 
 	t.Run("RemovePrefixesInvalidName", func(t *testing.T) {
 		response, err := service.RemovePrefixes(ctx, &dscppb.RemovePrefixesRequest{
-			Name:     "",
-			Prefixes: mustNetworks(t, "10.0.0.0/24"),
+			Name:      "",
+			Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
 		})
 		require.Nil(t, response)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -225,8 +227,8 @@ func Test_DscpService_RequestValidation(t *testing.T) {
 
 	t.Run("AddPrefixesInvalidPrefix", func(t *testing.T) {
 		response, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
-			Name:     "dscp0",
-			Prefixes: []*commonpb.IPPrefix{malformedNetwork()},
+			Name:      "dscp0",
+			Prefixes4: []*commonpb.IPv4Prefix{{PrefixLen: 24}},
 		})
 		require.Nil(t, response)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -234,8 +236,8 @@ func Test_DscpService_RequestValidation(t *testing.T) {
 
 	t.Run("RemovePrefixesInvalidPrefix", func(t *testing.T) {
 		response, err := service.RemovePrefixes(ctx, &dscppb.RemovePrefixesRequest{
-			Name:     "dscp0",
-			Prefixes: []*commonpb.IPPrefix{malformedNetwork()},
+			Name:      "dscp0",
+			Prefixes6: []*commonpb.IPv6Prefix{{PrefixLen: 64}},
 		})
 		require.Nil(t, response)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -277,14 +279,14 @@ func Test_DscpService_NoUpdateOnFailure(t *testing.T) {
 	name := "dscp0"
 
 	_, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
-		Name:     name,
-		Prefixes: mustNetworks(t, "10.0.0.0/24"),
+		Name:      name,
+		Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
 	})
 	require.NoError(t, err)
 
 	_, err = service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
-		Name:     name,
-		Prefixes: mustNetworks(t, "20.0.0.0/24"),
+		Name:      name,
+		Prefixes4: mustPrefixes4(t, "20.0.0.0/24"),
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.Internal, status.Code(err))
@@ -292,7 +294,7 @@ func Test_DscpService_NoUpdateOnFailure(t *testing.T) {
 	response, err := service.ShowConfig(ctx, &dscppb.ShowConfigRequest{Name: name})
 	require.NotNil(t, response)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"10.0.0.0/24"}, networkStrings(t, response.Config.Prefixes))
+	assert.Equal(t, []string{"10.0.0.0/24"}, prefixStrings(t, response.Config.Prefixes4))
 }
 
 // Test_DscpService_ConcurrentAccess verifies that concurrent mutations and
@@ -312,8 +314,8 @@ func Test_DscpService_ConcurrentAccess(t *testing.T) {
 			for j := range iterations {
 				if j%3 == 0 {
 					if _, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
-						Name:     name,
-						Prefixes: mustNetworks(t, fmt.Sprintf("10.%d.%d.0/24", i, j)),
+						Name:      name,
+						Prefixes4: mustPrefixes4(t, fmt.Sprintf("10.%d.%d.0/24", i, j)),
 					}); err != nil {
 						return err
 					}
@@ -321,8 +323,8 @@ func Test_DscpService_ConcurrentAccess(t *testing.T) {
 				}
 				if j%3 == 1 {
 					if _, err := service.RemovePrefixes(ctx, &dscppb.RemovePrefixesRequest{
-						Name:     name,
-						Prefixes: mustNetworks(t, fmt.Sprintf("10.%d.%d.0/24", i, j)),
+						Name:      name,
+						Prefixes4: mustPrefixes4(t, fmt.Sprintf("10.%d.%d.0/24", i, j)),
 					}); err != nil {
 						return err
 					}


### PR DESCRIPTION
- Replace the mixed-family IPPrefix lists with family-typed commonpb.IPv4Prefix and IPv6Prefix lists across Config, AddPrefixes and RemovePrefixes.
- Keep the prefix sets per family in the service model, so the decode path no longer branches per element.
- Add per-family bulk prefix encoders to commonpb and a prefix partition helper to the Rust bindings, shared with the upcoming decap split.

Closes #2208.