### PR TITLE
feat(decap)!: split prefix lists by address family on the wire

### DIFF
--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -3,6 +3,7 @@ use clap_complete::{
     CompleteEnv,
     engine::{ArgValueCandidates, CompletionCandidate},
 };
+use commonpb::partition_prefixes;
 use decappb::{
     ListConfigsRequest, ShowConfigRequest, ShowConfigResponse, UpdateConfigRequest,
     decap_service_client::DecapServiceClient,
@@ -159,7 +160,7 @@ impl DecapService {
         output::data(
             || &response,
             || {
-                if response.prefixes.is_empty() {
+                if response.prefixes4.is_empty() && response.prefixes6.is_empty() {
                     output::empty_with_hint(
                         format_args!("No decap prefixes found for '{}'.", cmd.config_name),
                         format_args!("create one with 'yanet-cli-decap update --name <name> --prefixes <cidr>'"),
@@ -175,9 +176,11 @@ impl DecapService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Error> {
+        let (prefixes4, prefixes6) = partition_prefixes(cmd.prefixes);
         let request = UpdateConfigRequest {
             name: cmd.config_name.clone(),
-            prefixes: cmd.prefixes.into_iter().map(Into::into).collect(),
+            prefixes4,
+            prefixes6,
         };
         log::trace!("update config request: {request:?}");
         let response = self
@@ -198,7 +201,12 @@ impl DecapService {
 fn print_tree(resp: &ShowConfigResponse) {
     let mut tree = TreeBuilder::new("Decap Prefixes".to_string());
 
-    for (idx, prefix) in resp.prefixes.iter().enumerate() {
+    let prefixes = resp
+        .prefixes4
+        .iter()
+        .map(ToString::to_string)
+        .chain(resp.prefixes6.iter().map(ToString::to_string));
+    for (idx, prefix) in prefixes.enumerate() {
         tree.add_empty_child(format!("{idx}: {prefix}"));
     }
 

--- a/modules/decap/controlplane/decappb/v1/decap.proto
+++ b/modules/decap/controlplane/decappb/v1/decap.proto
@@ -2,7 +2,8 @@ syntax = "proto3";
 
 package modules.decap.controlplane.decappb.v1;
 
-import "common/commonpb/v1/ipprefix.proto";
+import "common/commonpb/v1/ipv4prefix.proto";
+import "common/commonpb/v1/ipv6prefix.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1;decappb";
 
@@ -28,12 +29,16 @@ message ListConfigsResponse { repeated string configs = 1; }
 message ShowConfigRequest { string name = 1; }
 
 // ShowConfigResponse contains the configuration details of the decap module.
-message ShowConfigResponse { repeated common.commonpb.v1.IPPrefix prefixes = 1; }
+message ShowConfigResponse {
+  repeated common.commonpb.v1.IPv4Prefix prefixes4 = 1;
+  repeated common.commonpb.v1.IPv6Prefix prefixes6 = 2;
+}
 
 // UpdateConfigRequest carries the full desired prefix set for the named config.
 message UpdateConfigRequest {
   string name = 1;
-  repeated common.commonpb.v1.IPPrefix prefixes = 2;
+  repeated common.commonpb.v1.IPv4Prefix prefixes4 = 2;
+  repeated common.commonpb.v1.IPv6Prefix prefixes6 = 3;
 }
 
 // UpdateConfigResponse is the response to an UpdateConfig call.

--- a/modules/decap/controlplane/service.go
+++ b/modules/decap/controlplane/service.go
@@ -35,8 +35,12 @@ type Backend interface {
 }
 
 type config struct {
-	Prefixes []netip.Prefix
-	Module   ModuleHandle
+	// Prefixes4 is the sorted IPv4 prefix set.
+	Prefixes4 []netip.Prefix
+	// Prefixes6 is the sorted IPv6 prefix set.
+	Prefixes6 []netip.Prefix
+	// Module is the shared-memory handle of the published config.
+	Module ModuleHandle
 }
 
 // Free releases the module handle held by the config.
@@ -107,12 +111,16 @@ func (m *DecapService) ShowConfig(
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
 
-	prefixes, err := commonpb.NetworksFromPrefixes(entry.Prefixes)
+	prefixes4, err := commonpb.NewIPv4PrefixesFromPrefixes(entry.Prefixes4)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to convert prefixes: %v", err)
+	}
+	prefixes6, err := commonpb.NewIPv6PrefixesFromPrefixes(entry.Prefixes6)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to convert prefixes: %v", err)
 	}
 
-	return &decappb.ShowConfigResponse{Prefixes: prefixes}, nil
+	return &decappb.ShowConfigResponse{Prefixes4: prefixes4, Prefixes6: prefixes6}, nil
 }
 
 // UpdateConfig atomically replaces the whole prefix set of the named config.
@@ -125,22 +133,22 @@ func (m *DecapService) UpdateConfig(
 		return nil, errConfigNameRequired
 	}
 
-	prefixes, err := commonpb.PrefixesFromNetworks(req.GetPrefixes())
+	prefixes4, err := commonpb.PrefixesFromNetworks(req.GetPrefixes4())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
+	}
+	prefixes6, err := commonpb.PrefixesFromNetworks(req.GetPrefixes6())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
 	}
 
-	prefixes = slices.Compact(
-		slices.SortedFunc(
-			slices.Values(prefixes),
-			comparePrefixes,
-		),
-	)
-
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	cfg := &config{Prefixes: prefixes}
+	cfg := &config{
+		Prefixes4: normalizePrefixes(prefixes4),
+		Prefixes6: normalizePrefixes(prefixes6),
+	}
 	if err := m.updateConfig(name, cfg); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
@@ -155,12 +163,22 @@ func comparePrefixes(first, second netip.Prefix) int {
 	)
 }
 
+// normalizePrefixes sorts a prefix set and drops duplicates.
+func normalizePrefixes(prefixes []netip.Prefix) []netip.Prefix {
+	return slices.Compact(
+		slices.SortedFunc(
+			slices.Values(prefixes),
+			comparePrefixes,
+		),
+	)
+}
+
 // updateConfig calls the backend to publish cfg, retries this service's
 // deferred handles (the publish retired the generations that were
 // holding them), frees or defers the old module handle, and stores the
 // new config. The caller must hold m.mu.
 func (m *DecapService) updateConfig(name string, cfg *config) error {
-	mod, err := m.backend.UpdateModule(name, cfg.Prefixes)
+	mod, err := m.backend.UpdateModule(name, slices.Concat(cfg.Prefixes4, cfg.Prefixes6))
 	if err != nil {
 		return fmt.Errorf("failed to update module config %q: %w", name, err)
 	}
@@ -172,8 +190,9 @@ func (m *DecapService) updateConfig(name string, cfg *config) error {
 	}
 
 	m.configs[name] = &config{
-		Prefixes: cfg.Prefixes,
-		Module:   mod,
+		Prefixes4: cfg.Prefixes4,
+		Prefixes6: cfg.Prefixes6,
+		Module:    mod,
 	}
 
 	return nil

--- a/modules/decap/controlplane/service_test.go
+++ b/modules/decap/controlplane/service_test.go
@@ -18,18 +18,35 @@ import (
 	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
 
-func mustNetworks(t *testing.T, cidrs ...string) []*commonpb.IPPrefix {
+// mustPrefixes4 returns family-typed IPv4 prefix messages for valid CIDR
+// test inputs.
+func mustPrefixes4(t *testing.T, cidrs ...string) []*commonpb.IPv4Prefix {
 	t.Helper()
-	networks := make([]*commonpb.IPPrefix, 0, len(cidrs))
-	for _, cidr := range cidrs {
-		network, err := commonpb.NewIPPrefixFromPrefix(netip.MustParsePrefix(cidr))
-		require.NoError(t, err)
-		networks = append(networks, network)
-	}
+	networks, err := commonpb.NewIPv4PrefixesFromPrefixes(parsePrefixes(cidrs))
+	require.NoError(t, err)
 	return networks
 }
 
-func networkStrings(t *testing.T, networks []*commonpb.IPPrefix) []string {
+// mustPrefixes6 is mustPrefixes4 for IPv6 prefix messages.
+func mustPrefixes6(t *testing.T, cidrs ...string) []*commonpb.IPv6Prefix {
+	t.Helper()
+	networks, err := commonpb.NewIPv6PrefixesFromPrefixes(parsePrefixes(cidrs))
+	require.NoError(t, err)
+	return networks
+}
+
+// parsePrefixes parses valid CIDR test inputs.
+func parsePrefixes(cidrs []string) []netip.Prefix {
+	out := make([]netip.Prefix, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		out = append(out, netip.MustParsePrefix(cidr))
+	}
+	return out
+}
+
+// prefixStrings returns canonical CIDR text for valid prefix messages of
+// either family.
+func prefixStrings[T interface{ ToPrefix() (netip.Prefix, error) }](t *testing.T, networks []T) []string {
 	t.Helper()
 	strs := make([]string, 0, len(networks))
 	for _, network := range networks {
@@ -82,8 +99,9 @@ func Test_DecapService_UpdateAndShow(t *testing.T) {
 	prefix := "10.0.0.0/24"
 
 	resp, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
-		Name:     "decap0",
-		Prefixes: mustNetworks(t, prefix),
+		Name:      "decap0",
+		Prefixes4: mustPrefixes4(t, prefix),
+		Prefixes6: mustPrefixes6(t, "2001:db8::/32"),
 	})
 	require.NotNil(t, resp)
 	require.NoError(t, err)
@@ -91,30 +109,33 @@ func Test_DecapService_UpdateAndShow(t *testing.T) {
 	show, err := svc.ShowConfig(t.Context(), &decappb.ShowConfigRequest{Name: "decap0"})
 	require.NotNil(t, show)
 	require.NoError(t, err)
-	require.Len(t, show.Prefixes, 1)
-	require.Equal(t, []byte{10, 0, 0, 0}, show.Prefixes[0].GetAddr().GetAddr())
-	require.Equal(t, uint32(24), show.Prefixes[0].GetPrefixLen())
+	require.Len(t, show.Prefixes4, 1)
+	require.Equal(t, uint32(0x0a000000), show.Prefixes4[0].GetAddr().GetAddr())
+	require.Equal(t, uint32(24), show.Prefixes4[0].GetPrefixLen())
+	require.Equal(t, []string{"2001:db8::/32"}, prefixStrings(t, show.Prefixes6))
 }
 
 func Test_DecapService_UpdateFullyReplaces(t *testing.T) {
 	svc := newTestService(t)
 
 	_, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
-		Name:     "decap0",
-		Prefixes: mustNetworks(t, "10.0.0.0/24", "10.0.1.0/24"),
+		Name:      "decap0",
+		Prefixes4: mustPrefixes4(t, "10.0.0.0/24", "10.0.1.0/24"),
+		Prefixes6: mustPrefixes6(t, "2001:db8::/32"),
 	})
 	require.NoError(t, err)
 
 	_, err = svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
-		Name:     "decap0",
-		Prefixes: mustNetworks(t, "192.168.0.0/16"),
+		Name:      "decap0",
+		Prefixes4: mustPrefixes4(t, "192.168.0.0/16"),
 	})
 	require.NoError(t, err)
 
 	show, err := svc.ShowConfig(t.Context(), &decappb.ShowConfigRequest{Name: "decap0"})
 	require.NotNil(t, show)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]string{"192.168.0.0/16"}, networkStrings(t, show.Prefixes)))
+	require.Empty(t, cmp.Diff([]string{"192.168.0.0/16"}, prefixStrings(t, show.Prefixes4)))
+	require.Empty(t, show.Prefixes6)
 }
 
 func Test_DecapService_ListUpdateList(t *testing.T) {
@@ -127,8 +148,8 @@ func Test_DecapService_ListUpdateList(t *testing.T) {
 	assert.Empty(t, list.Configs)
 
 	_, err = svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
-		Name:     "decap0",
-		Prefixes: mustNetworks(t, "10.0.0.0/24"),
+		Name:      "decap0",
+		Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
 	})
 	require.NoError(t, err)
 
@@ -144,8 +165,8 @@ func Test_DecapService_EmptyConfigName(t *testing.T) {
 
 	t.Run("UpdateConfig", func(t *testing.T) {
 		resp, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
-			Name:     "",
-			Prefixes: mustNetworks(t, "10.0.0.0/24"),
+			Name:      "",
+			Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
 		})
 		require.Nil(t, resp)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -161,20 +182,27 @@ func Test_DecapService_EmptyConfigName(t *testing.T) {
 func Test_DecapService_InvalidPrefix(t *testing.T) {
 	tests := []struct {
 		name    string
-		network *commonpb.IPPrefix
+		request *decappb.UpdateConfigRequest
 	}{
 		{
-			name: "address length is neither 4 nor 16 bytes",
-			network: &commonpb.IPPrefix{
-				Addr:      &commonpb.IPAddress{Addr: []byte{10, 0, 0}},
-				PrefixLen: 24,
+			name: "missing IPv4 address",
+			request: &decappb.UpdateConfigRequest{
+				Name:      "decap0",
+				Prefixes4: []*commonpb.IPv4Prefix{{PrefixLen: 24}},
 			},
 		},
 		{
-			name: "prefix length exceeds address bit length",
-			network: &commonpb.IPPrefix{
-				Addr:      &commonpb.IPAddress{Addr: []byte{10, 0, 0, 0}},
-				PrefixLen: 33,
+			name: "IPv4 prefix length exceeds address bit length",
+			request: &decappb.UpdateConfigRequest{
+				Name:      "decap0",
+				Prefixes4: []*commonpb.IPv4Prefix{{Addr: &commonpb.IPv4Address{Addr: 0x0a000000}, PrefixLen: 33}},
+			},
+		},
+		{
+			name: "IPv6 prefix length exceeds address bit length",
+			request: &decappb.UpdateConfigRequest{
+				Name:      "decap0",
+				Prefixes6: []*commonpb.IPv6Prefix{{Addr: &commonpb.IPv6Address{}, PrefixLen: 129}},
 			},
 		},
 	}
@@ -183,10 +211,7 @@ func Test_DecapService_InvalidPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := newTestService(t)
 
-			resp, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
-				Name:     "decap0",
-				Prefixes: []*commonpb.IPPrefix{tt.network},
-			})
+			resp, err := svc.UpdateConfig(t.Context(), tt.request)
 			require.Nil(t, resp)
 			require.Equal(t, codes.InvalidArgument, status.Code(err))
 
@@ -203,14 +228,14 @@ func Test_DecapService_UpdateFailureAtomic(t *testing.T) {
 	name := "decap0"
 
 	_, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
-		Name:     name,
-		Prefixes: mustNetworks(t, "10.0.0.0/24"),
+		Name:      name,
+		Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
 	})
 	require.NoError(t, err)
 
 	_, err = svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
-		Name:     name,
-		Prefixes: mustNetworks(t, "10.0.1.0/24"),
+		Name:      name,
+		Prefixes4: mustPrefixes4(t, "10.0.1.0/24"),
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.Internal, status.Code(err))
@@ -218,7 +243,7 @@ func Test_DecapService_UpdateFailureAtomic(t *testing.T) {
 	show, err := svc.ShowConfig(ctx, &decappb.ShowConfigRequest{Name: name})
 	require.NotNil(t, show)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]string{"10.0.0.0/24"}, networkStrings(t, show.Prefixes)))
+	require.Empty(t, cmp.Diff([]string{"10.0.0.0/24"}, prefixStrings(t, show.Prefixes4)))
 }
 
 func Test_DecapService_DeduplicatePrefixes(t *testing.T) {
@@ -226,15 +251,15 @@ func Test_DecapService_DeduplicatePrefixes(t *testing.T) {
 	prefix := "10.0.0.0/24"
 
 	_, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
-		Name:     "decap0",
-		Prefixes: mustNetworks(t, prefix, prefix, prefix),
+		Name:      "decap0",
+		Prefixes4: mustPrefixes4(t, prefix, prefix, prefix),
 	})
 	require.NoError(t, err)
 
 	show, err := svc.ShowConfig(t.Context(), &decappb.ShowConfigRequest{Name: "decap0"})
 	require.NotNil(t, show)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]string{prefix}, networkStrings(t, show.Prefixes)))
+	require.Empty(t, cmp.Diff([]string{prefix}, prefixStrings(t, show.Prefixes4)))
 }
 
 func Test_DecapService_ConcurrentAccess(t *testing.T) {
@@ -243,7 +268,7 @@ func Test_DecapService_ConcurrentAccess(t *testing.T) {
 	const goroutines = 10
 	const iterations = 100
 
-	networks := mustNetworks(t, "10.0.0.0/24")
+	networks := mustPrefixes4(t, "10.0.0.0/24")
 
 	g, ctx := errgroup.WithContext(t.Context())
 
@@ -252,8 +277,8 @@ func Test_DecapService_ConcurrentAccess(t *testing.T) {
 			for jdx := range iterations {
 				name := fmt.Sprintf("config-%d-%d", idx, jdx)
 				_, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
-					Name:     name,
-					Prefixes: networks,
+					Name:      name,
+					Prefixes4: networks,
 				})
 				if err != nil {
 					return err

--- a/modules/decap/web/PrefixYamlIO.tsx
+++ b/modules/decap/web/PrefixYamlIO.tsx
@@ -19,7 +19,7 @@ const PrefixYamlIO: React.FC<PrefixYamlIOProps> = ({ configName, rows, onImport,
         itemLabel="prefixes"
         downloadPrefix={`decap-${configName}`}
         toastPrefix="prefix-yaml"
-        importPlaceholder={`config: ${configName}\nprefixes:\n  - 10.0.0.0/8\n  - 2a02:6b8::/32`}
+        importPlaceholder={`config: ${configName}\nprefixes4:\n  - 10.0.0.0/8\nprefixes6:\n  - 2a02:6b8::/32`}
         exportYaml={() => rowsToYaml(configName, rows)}
         parseImport={yamlToRows}
         disabled={disabled}

--- a/modules/decap/web/usePrefixDraft.test.ts
+++ b/modules/decap/web/usePrefixDraft.test.ts
@@ -29,7 +29,8 @@ describe('usePrefixDraft load', () => {
 
     it('produces one row per wire element and keeps the prefix string as row identity', async () => {
         showConfig.mockResolvedValue({
-            prefixes: [{ network: '10.0.0.0/8' }, { network: '2001:db8::/32' }],
+            prefixes4: ['10.0.0.0/8'],
+            prefixes6: ['2001:db8::/32'],
         });
 
         const { result } = renderHook(() => usePrefixDraft());
@@ -56,11 +57,11 @@ describe('usePrefixDraft commitConfig', () => {
     beforeEach(() => {
         showConfig.mockReset();
         updateConfig.mockReset();
-        showConfig.mockResolvedValue({ prefixes: [] });
+        showConfig.mockResolvedValue({ prefixes4: [], prefixes6: [] });
         updateConfig.mockResolvedValue({});
     });
 
-    it('sends exactly one object-shaped wire element per draft row, in order, dropping none', async () => {
+    it('sends every draft row as a bare string in its family list, dropping none', async () => {
         const { result } = renderHook(() => usePrefixDraft());
         await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -87,10 +88,7 @@ describe('usePrefixDraft commitConfig', () => {
         expect(updateConfig).toHaveBeenCalledTimes(1);
         const sent = updateConfig.mock.calls[0][0];
         expect(sent.name).toBe('decap0');
-        expect(sent.prefixes).toEqual([
-            { network: '10.0.0.0/8' },
-            { network: '' },
-            { network: 'not-a-cidr' },
-        ]);
+        expect(sent.prefixes4).toEqual(['10.0.0.0/8', '', 'not-a-cidr']);
+        expect(sent.prefixes6).toEqual([]);
     });
 });

--- a/modules/decap/web/usePrefixDraft.ts
+++ b/modules/decap/web/usePrefixDraft.ts
@@ -21,10 +21,9 @@ export const usePrefixDraft = (): UsePrefixDraftResult => {
         const configNames = await inventoryConfigNames('decap');
         return loadKnownConfigs(configNames, async (name): Promise<{ name: string; rows: PrefixRowItem[] }> => {
             const resp = await API.decap.showConfig({ name });
-            const rows: PrefixRowItem[] = (resp.prefixes ?? []).map((net) => {
-                const p = net.network ?? '';
-                return { id: p, prefix: p };
-            });
+            const rows: PrefixRowItem[] = [...(resp.prefixes4 ?? []), ...(resp.prefixes6 ?? [])].map(
+                (p) => ({ id: p, prefix: p }),
+            );
             return { name, rows };
         }, { onDropped: warnConfigsUnknown('decap-configs-unknown', 'decap') });
     }, []);
@@ -33,8 +32,12 @@ export const usePrefixDraft = (): UsePrefixDraftResult => {
         configName: string,
         draftRows: PrefixRowItem[],
     ): Promise<void> => {
-        const prefixes = draftRows.map((r) => ({ network: r.prefix }));
-        await API.decap.updateConfig({ name: configName, prefixes });
+        const prefixes = draftRows.map((r) => r.prefix);
+        await API.decap.updateConfig({
+            name: configName,
+            prefixes4: prefixes.filter((p) => !p.includes(':')),
+            prefixes6: prefixes.filter((p) => p.includes(':')),
+        });
     }, []);
 
     return useDraft<PrefixRowItem>({

--- a/modules/decap/web/yaml.ts
+++ b/modules/decap/web/yaml.ts
@@ -3,29 +3,53 @@ import type { PrefixRowItem } from './types';
 
 interface DecapYamlDoc {
     config: string;
-    prefixes: string[];
+    prefixes4: string[];
+    prefixes6: string[];
 }
+
+/** Partition prefix rows into the family-typed lists the schema carries. */
+const partitionRows = (rows: PrefixRowItem[]): { prefixes4: string[]; prefixes6: string[] } => {
+    const prefixes = rows.map((r) => r.prefix);
+    return {
+        prefixes4: prefixes.filter((p) => !p.includes(':')),
+        prefixes6: prefixes.filter((p) => p.includes(':')),
+    };
+};
 
 /** Serialize prefix rows for the active config to YAML. */
 export const rowsToYaml = (configName: string, rows: PrefixRowItem[]): string => {
-    const doc: DecapYamlDoc = {
-        config: configName,
-        prefixes: rows.map((r) => r.prefix),
-    };
+    const doc: DecapYamlDoc = { config: configName, ...partitionRows(rows) };
     return dumpYamlDoc(doc);
 };
 
 /** Serialize prefix rows (without config wrapper) to YAML for diff display. */
-export const rowsToDiffYaml = (rows: PrefixRowItem[]): string => {
-    const doc = { prefixes: rows.map((r) => r.prefix) };
-    return dumpYamlDoc(doc);
-};
+export const rowsToDiffYaml = (rows: PrefixRowItem[]): string => dumpYamlDoc(partitionRows(rows));
 
 /**
- * Parse YAML (either { config, prefixes } or just { prefixes }) into prefix rows.
- * Returns the parsed rows. Throws with a descriptive message on failure.
+ * Parse YAML with family-typed `prefixes4`/`prefixes6` lists (with or
+ * without the `config` wrapper) into prefix rows, IPv4 entries first.
+ * Either list may be omitted, but not both. Throws with a descriptive
+ * message on failure.
  */
-export const yamlToRows = (text: string): PrefixRowItem[] =>
-    parseYamlList<PrefixRowItem>(text, 'prefixes', (p) => ({
-        prefix: typeof p === 'string' ? p : '',
-    }));
+export const yamlToRows = (text: string): PrefixRowItem[] => {
+    const parse = (key: 'prefixes4' | 'prefixes6'): PrefixRowItem[] =>
+        parseYamlList<PrefixRowItem>(text, key, (p) => ({
+            prefix: typeof p === 'string' ? p : '',
+        }));
+
+    const tryParse = (key: 'prefixes4' | 'prefixes6'): PrefixRowItem[] | null => {
+        try {
+            return parse(key);
+        } catch {
+            return null;
+        }
+    };
+
+    const v4 = tryParse('prefixes4');
+    const v6 = tryParse('prefixes6');
+    if (v4 === null && v6 === null) {
+        // Surface the real parse error for the canonical key.
+        return parse('prefixes4');
+    }
+    return [...(v4 ?? []), ...(v6 ?? [])];
+};

--- a/operators/decap/etc/yanet/decap.d/default.yaml
+++ b/operators/decap/etc/yanet/decap.d/default.yaml
@@ -1,3 +1,4 @@
-prefixes: []
+prefixes4: []
 # - 10.0.0.0/8
+prefixes6: []
 # - 2000::/3

--- a/operators/decap/internal/operator/actuator_gateway.go
+++ b/operators/decap/internal/operator/actuator_gateway.go
@@ -85,8 +85,9 @@ func (m *GatewayActuator) Apply(ctx context.Context, state State) error {
 
 	for _, mc := range state.Modules {
 		_, e := m.decap.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
-			Name:     mc.Name,
-			Prefixes: mc.Prefixes,
+			Name:      mc.Name,
+			Prefixes4: mc.Prefixes4,
+			Prefixes6: mc.Prefixes6,
 		})
 		if e != nil {
 			err = errors.Join(err, fmt.Errorf(

--- a/operators/decap/internal/operator/operator.go
+++ b/operators/decap/internal/operator/operator.go
@@ -31,13 +31,14 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 
 	modules := make([]ModuleConfig, 0, len(cfg.Functions))
 	for _, fn := range cfg.Functions {
-		prefixes, err := LoadDecapPrefixes(fn.PrefixesFile.Unwrap())
+		prefixes4, prefixes6, err := LoadDecapPrefixes(fn.PrefixesFile.Unwrap())
 		if err != nil {
 			return nil, fmt.Errorf("failed to load prefixes file %q: %w", fn.PrefixesFile.Unwrap(), err)
 		}
 		modules = append(modules, ModuleConfig{
-			Name:     fn.Module.Unwrap(),
-			Prefixes: prefixes,
+			Name:      fn.Module.Unwrap(),
+			Prefixes4: prefixes4,
+			Prefixes6: prefixes6,
 		})
 	}
 

--- a/operators/decap/internal/operator/prefixes.go
+++ b/operators/decap/internal/operator/prefixes.go
@@ -12,37 +12,52 @@ import (
 
 // yamlPrefixFile is the top-level YAML structure for a decap prefixes file.
 type yamlPrefixFile struct {
-	Prefixes []string `yaml:"prefixes"`
+	// Prefixes4 is the IPv4 CIDR list.
+	Prefixes4 []string `yaml:"prefixes4"`
+	// Prefixes6 is the IPv6 CIDR list.
+	Prefixes6 []string `yaml:"prefixes6"`
 }
 
-// LoadDecapPrefixes reads a YAML file of the shape:
+// LoadDecapPrefixes reads a YAML file with family-typed prefixes4 and
+// prefixes6 CIDR lists, mirroring the wire schema.
 //
-//	prefixes:
-//	  - 10.0.0.0/8
-//	  - 2000::/3
-//
-// Each entry is parsed as a CIDR prefix and masked, failing fast on
-// malformed input.
-func LoadDecapPrefixes(path string) ([]*commonpb.IPPrefix, error) {
+// Each entry is parsed as a CIDR prefix of its list's family and masked,
+// failing fast on malformed or wrong-family input. An IPv4-mapped IPv6
+// prefix belongs to prefixes6.
+func LoadDecapPrefixes(path string) ([]*commonpb.IPv4Prefix, []*commonpb.IPv6Prefix, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read prefixes file %q: %w", path, err)
+		return nil, nil, fmt.Errorf("failed to read prefixes file %q: %w", path, err)
 	}
 
 	var file yamlPrefixFile
 	if err := yaml.Unmarshal(data, &file); err != nil {
-		return nil, fmt.Errorf("failed to parse prefixes file %q: %w", path, err)
+		return nil, nil, fmt.Errorf("failed to parse prefixes file %q: %w", path, err)
 	}
 
-	out := make([]*commonpb.IPPrefix, 0, len(file.Prefixes))
-	for idx, s := range file.Prefixes {
+	v4, err := parsePrefixes(file.Prefixes4, "prefixes4", commonpb.NewIPv4PrefixFromPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	v6, err := parsePrefixes(file.Prefixes6, "prefixes6", commonpb.NewIPv6PrefixFromPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	return v4, v6, nil
+}
+
+// parsePrefixes decodes one family-typed CIDR list through the family's
+// message constructor, which rejects a wrong-family entry.
+func parsePrefixes[T any](cidrs []string, key string, newPrefix func(netip.Prefix) (T, error)) ([]T, error) {
+	out := make([]T, 0, len(cidrs))
+	for idx, s := range cidrs {
 		prefix, err := netip.ParsePrefix(s)
 		if err != nil {
-			return nil, fmt.Errorf("prefixes[%d]: %w", idx, err)
+			return nil, fmt.Errorf("%s[%d]: %w", key, idx, err)
 		}
-		network, err := commonpb.NewIPPrefixFromPrefix(prefix)
+		network, err := newPrefix(prefix)
 		if err != nil {
-			return nil, fmt.Errorf("prefixes[%d]: %w", idx, err)
+			return nil, fmt.Errorf("%s[%d]: %w", key, idx, err)
 		}
 		out = append(out, network)
 	}

--- a/operators/decap/internal/operator/prefixes_test.go
+++ b/operators/decap/internal/operator/prefixes_test.go
@@ -1,0 +1,39 @@
+package operator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/operators/decap/internal/operator"
+)
+
+// TestLoadDecapPrefixes_FamilyTypedLists verifies that the family-typed
+// lists load into their matching message lists, order preserved.
+func TestLoadDecapPrefixes_FamilyTypedLists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "prefixes.yaml")
+	data := "prefixes4:\n  - 10.0.0.0/8\n  - 192.0.2.0/24\nprefixes6:\n  - 2001:db8::/32\n"
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o644))
+
+	v4, v6, err := operator.LoadDecapPrefixes(path)
+	require.NoError(t, err)
+
+	require.Len(t, v4, 2)
+	require.Equal(t, "10.0.0.0/8", v4[0].AsLogValue())
+	require.Equal(t, "192.0.2.0/24", v4[1].AsLogValue())
+	require.Len(t, v6, 1)
+	require.Equal(t, "2001:db8::/32", v6[0].AsLogValue())
+}
+
+// TestLoadDecapPrefixes_RejectsWrongFamilyEntry verifies that an entry in
+// the wrong family's list fails the whole load instead of being dropped.
+func TestLoadDecapPrefixes_RejectsWrongFamilyEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "prefixes.yaml")
+	data := "prefixes4:\n  - 2001:db8::/32\n"
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o644))
+
+	_, _, err := operator.LoadDecapPrefixes(path)
+	require.ErrorContains(t, err, "prefixes4[0]")
+}

--- a/operators/decap/internal/operator/source.go
+++ b/operators/decap/internal/operator/source.go
@@ -11,8 +11,10 @@ import (
 type ModuleConfig struct {
 	// Name is the decap module config name.
 	Name string
-	// Prefixes is the desired tunnel prefix set.
-	Prefixes []*commonpb.IPPrefix
+	// Prefixes4 is the desired IPv4 tunnel prefix set.
+	Prefixes4 []*commonpb.IPv4Prefix
+	// Prefixes6 is the desired IPv6 tunnel prefix set.
+	Prefixes6 []*commonpb.IPv6Prefix
 }
 
 // State is the desired payload pushed by each reconcile pass.

--- a/web/src/core/api/decap.ts
+++ b/web/src/core/api/decap.ts
@@ -1,17 +1,20 @@
 import { createService, type CallOptions } from './client';
-import type { IPPrefix } from '../utils/netip';
 
 export interface ShowConfigRequest {
     name?: string;
 }
 
+// The prefix lists are family-typed (commonpb.IPv4Prefix and
+// commonpb.IPv6Prefix), serialized by the gateway as bare CIDR strings.
 export interface ShowConfigResponse {
-    prefixes?: IPPrefix[];
+    prefixes4?: string[];
+    prefixes6?: string[];
 }
 
 export interface DecapUpdateConfigRequest {
     name?: string;
-    prefixes?: IPPrefix[];
+    prefixes4?: string[];
+    prefixes6?: string[];
 }
 
 export interface DecapUpdateConfigResponse { }


### PR DESCRIPTION
- Replace the mixed-family IPPrefix lists with family-typed commonpb.IPv4Prefix and IPv6Prefix lists in ShowConfig and UpdateConfig.
- Keep the prefix sets per family in the service model, so the decode path no longer branches per element.
- Switch the operator prefixes file and the web YAML schema to the same family-typed prefixes4 and prefixes6 lists, with no compatibility for the mixed key.
- Carry decap prefixes in the web as bare CIDR strings, dropping the network object wrapper from this surface.

Closes #2209.