### PR TITLE
feat(commonpb,balancer2)!: carry source networks in a family oneof container

### DIFF
--- a/common/commonpb/v1/ipnetwork.proto
+++ b/common/commonpb/v1/ipnetwork.proto
@@ -4,5 +4,14 @@ package common.commonpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/common/commonpb/v1;commonpb";
 
-// This file is deliberately message-less. It is kept as a placeholder
-// for upcoming network messages.
+import "common/commonpb/v1/ipv4network.proto";
+import "common/commonpb/v1/ipv6network.proto";
+
+// IPNetwork represents an IPv4 or IPv6 network with a general per-bit
+// mask. The family is structural through the oneof.
+message IPNetwork {
+  oneof network {
+    IPv4Network v4 = 1;
+    IPv6Network v6 = 2;
+  }
+}

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -513,6 +513,65 @@ impl<'de> Deserialize<'de> for pb::IPv6Network {
     }
 }
 
+impl From<IpNetwork> for pb::IpNetwork {
+    fn from(net: IpNetwork) -> Self {
+        let network = match net {
+            IpNetwork::V4(net) => pb::ip_network::Network::V4(net.into()),
+            IpNetwork::V6(net) => pb::ip_network::Network::V6(net.into()),
+        };
+        pb::IpNetwork { network: Some(network) }
+    }
+}
+
+impl TryFrom<&pb::IpNetwork> for IpNetwork {
+    type Error = Box<dyn Error>;
+
+    fn try_from(net: &pb::IpNetwork) -> Result<Self, Self::Error> {
+        match &net.network {
+            Some(pb::ip_network::Network::V4(net)) => Ok(Self::V4(Ipv4Network::try_from(net)?)),
+            Some(pb::ip_network::Network::V6(net)) => Ok(Self::V6(Ipv6Network::try_from(net)?)),
+            None => Err("invalid IP network: missing network".into()),
+        }
+    }
+}
+
+impl Display for pb::IpNetwork {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match IpNetwork::try_from(self) {
+            Ok(net) => net.fmt(f),
+            Err(..) => f.write_str("invalid"),
+        }
+    }
+}
+
+impl FromStr for pb::IpNetwork {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let net = IpNetwork::parse(s)?;
+        Ok(Self::from(net))
+    }
+}
+
+impl Serialize for pb::IpNetwork {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for pb::IpNetwork {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<Self>().map_err(de::Error::custom)
+    }
+}
+
 impl From<(IpAddr, IpAddr)> for pb::IpRange {
     fn from((start, end): (IpAddr, IpAddr)) -> Self {
         pb::IpRange {
@@ -732,6 +791,14 @@ mod test {
             vec!["2001:db8::/32", "2001:db8:1::/48"],
             v6.iter().map(ToString::to_string).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn ip_network_container_round_trips_as_string() {
+        for text in ["192.0.2.0/24", "2001:db8::/ffff:ffff:0:ffff::"] {
+            let net: pb::IpNetwork = text.parse().expect("a valid network must parse");
+            assert_eq!(text, net.to_string());
+        }
     }
 
     #[test]

--- a/modules/balancer2/cli/src/config.rs
+++ b/modules/balancer2/cli/src/config.rs
@@ -6,7 +6,7 @@ use core::{
 };
 use std::fs::File;
 
-use filterpb::pb::{IpNet, PortRange};
+use filterpb::pb::PortRange;
 use netip::IpNetwork;
 use serde::{Deserialize, Deserializer};
 use yanet_cli_balancer2::balancerpb;
@@ -229,12 +229,12 @@ impl TryFrom<VirtualService> for balancerpb::VsConfig {
 fn allowed_source(entry: AllowedSrcEntry) -> Result<balancerpb::AllowedSources, Box<dyn Error>> {
     match entry {
         AllowedSrcEntry::Simple(network) => Ok(balancerpb::AllowedSources {
-            nets: vec![IpNet::from(network)],
+            nets: vec![network.into()],
             ports: vec![],
             tag: None,
         }),
         AllowedSrcEntry::Structured { network, ports, tag } => Ok(balancerpb::AllowedSources {
-            nets: vec![IpNet::from(network)],
+            nets: vec![network.into()],
             ports: ports.iter().map(port_range).collect::<Result<_, _>>()?,
             tag,
         }),
@@ -259,7 +259,7 @@ impl From<Real> for balancerpb::RealConfig {
                 port: u32::from(real.port),
             }),
             weight: real.weight,
-            src: Some(IpNet::from(real.src)),
+            src: Some(real.src.into()),
         }
     }
 }

--- a/modules/balancer2/controlplane/balancerpb/v1/config.proto
+++ b/modules/balancer2/controlplane/balancerpb/v1/config.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package modules.balancer2.controlplane.balancerpb.v1;
 
 import "common/filterpb/v1/filter.proto";
+import "common/commonpb/v1/ipnetwork.proto";
 
 import "google/protobuf/duration.proto";
 
@@ -51,7 +52,7 @@ message VsIdentifier {
 // - If allowed_srcs contains entries: Only matching sources are permitted
 // - Multiple AllowedSrc entries are evaluated with OR logic (any match allows)
 message AllowedSources {
-  repeated common.filterpb.v1.IPNet nets = 1;
+  repeated common.commonpb.v1.IPNetwork nets = 1;
   repeated common.filterpb.v1.PortRange ports = 2;
   optional string tag = 3;
 }
@@ -83,7 +84,7 @@ message RealIdentifier {
 message RealConfig {
   RelativeRealIdentifier id = 1;
   uint32 weight = 2;
-  common.filterpb.v1.IPNet src = 3;
+  common.commonpb.v1.IPNetwork src = 3;
 }
 
 message VsFlags {


### PR DESCRIPTION
- Add the commonpb.IPNetwork message: a family oneof over the general IPv4 and IPv6 network messages.
- Replace the untyped IPNet in the balancer allowed-source lists and the real source network with it, keeping both fields mixed-family.
- Unblocks #2212; the Go binding family-safety design stays under #2188.