### PR TITLE
feat(commonpb,route)!: switch the ip prefix container to a family oneof

### DIFF
--- a/common/commonpb/v1/ipprefix.go
+++ b/common/commonpb/v1/ipprefix.go
@@ -4,77 +4,55 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/netip"
-
-	"github.com/yanet-platform/xnetip"
 )
 
-// NewIPPrefixFromContiguous creates a IPPrefix from
-// an xnetip CIDR block.
+// NewIPPrefixFromPrefix creates an IPPrefix from a netip.Prefix value,
+// masking off any host bits.
 //
-// The conversion is total: the block is masked by its own invariant, so
-// the message carries the base address in the block's family width (four
-// bytes for IPv4, sixteen for IPv6) and the prefix length verbatim. The
-// inverse of ToContiguous.
-func NewIPPrefixFromContiguous(net xnetip.Contiguous[xnetip.Network]) *IPPrefix {
-	return &IPPrefix{
-		Addr:      NewIPAddressFromAddr(net.Network().Addr()),
-		PrefixLen: uint32(net.PrefixLen()),
-	}
-}
-
-// NewIPPrefixFromPrefix creates a IPPrefix from a
-// netip.Prefix value, masking off any host bits.
-//
+// The set oneof branch follows the address family. An IPv4-mapped IPv6
+// address counts as IPv6, consistently with the family-typed messages.
 // Returns an error if prefix is not valid.
 func NewIPPrefixFromPrefix(prefix netip.Prefix) (*IPPrefix, error) {
-	net, ok := xnetip.ContiguousFromPrefix(prefix)
-	if !ok {
-		return nil, fmt.Errorf("invalid prefix")
+	switch {
+	case prefix.Addr().Is4():
+		v4, err := NewIPv4PrefixFromPrefix(prefix)
+		if err != nil {
+			return nil, err
+		}
+		return &IPPrefix{Prefix: &IPPrefix_V4{V4: v4}}, nil
+	case prefix.Addr().Is6():
+		v6, err := NewIPv6PrefixFromPrefix(prefix)
+		if err != nil {
+			return nil, err
+		}
+		return &IPPrefix{Prefix: &IPPrefix_V6{V6: v6}}, nil
+	default:
+		return nil, fmt.Errorf("not a valid IP prefix: %s", prefix)
 	}
-	return NewIPPrefixFromContiguous(net), nil
-}
-
-// NetworksFromPrefixes creates IPPrefix messages from netip.Prefix
-// values, masking off any host bits.
-//
-// Returns an error if any prefix is not valid.
-func NetworksFromPrefixes(prefixes []netip.Prefix) ([]*IPPrefix, error) {
-	return networksFromPrefixes(prefixes, NewIPPrefixFromPrefix)
-}
-
-// ToContiguous converts the IPPrefix to an xnetip CIDR block.
-//
-// Returns an error if addr is missing or malformed, or if prefix_len
-// exceeds the address family's bit length; the latter wraps
-// xnetip.ErrCIDROverflow. The returned block is masked, so host bits never
-// leak out even if the message was constructed by hand, and the family
-// follows the address width: a sixteen-byte IPv4-mapped address stays
-// IPv6, consistently with IPAddress. The inverse of
-// NewIPPrefixFromContiguous.
-func (m *IPPrefix) ToContiguous() (xnetip.Contiguous[xnetip.Network], error) {
-	addr, err := m.GetAddr().ToAddr()
-	if err != nil {
-		return xnetip.Contiguous[xnetip.Network]{}, fmt.Errorf("failed to parse network address: %w", err)
-	}
-	net, err := xnetip.ContiguousFromCIDR(addr, int(m.GetPrefixLen()))
-	if err != nil {
-		return xnetip.Contiguous[xnetip.Network]{}, fmt.Errorf("failed to build IP network: %w", err)
-	}
-	return net, nil
 }
 
 // ToPrefix converts the IPPrefix back to a netip.Prefix value.
 //
-// Returns an error if addr is malformed or if prefix_len exceeds the
-// address family's bit length, exactly when ToContiguous does. The returned
-// prefix is masked, so host bits never leak out even if the message was
-// constructed by hand.
+// Returns an error if the oneof is unset or the set branch is malformed.
+// The returned prefix is masked, so host bits never leak out even if the
+// message was constructed by hand.
 func (m *IPPrefix) ToPrefix() (netip.Prefix, error) {
-	net, err := m.ToContiguous()
-	if err != nil {
-		return netip.Prefix{}, err
+	switch prefix := m.GetPrefix().(type) {
+	case *IPPrefix_V4:
+		net, err := prefix.V4.ToContiguous()
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		return net.Prefix(), nil
+	case *IPPrefix_V6:
+		net, err := prefix.V6.ToContiguous()
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		return net.Prefix(), nil
+	default:
+		return netip.Prefix{}, fmt.Errorf("missing network prefix")
 	}
-	return net.Prefix(), nil
 }
 
 // AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
@@ -87,34 +65,28 @@ func (m *IPPrefix) AsLogValue() any {
 	return prefix.String()
 }
 
-// ipPrefixJSON is the JSON wire shape shared by MarshalJSON and
-// UnmarshalJSON.
-type ipPrefixJSON struct {
-	// Network is the CIDR string.
-	Network string `json:"network"`
-}
-
-// MarshalJSON serializes the network as a human-readable CIDR string.
+// MarshalJSON serializes the prefix as a bare CIDR string, identically to
+// the family-typed prefix messages.
 func (m *IPPrefix) MarshalJSON() ([]byte, error) {
 	prefix, err := m.ToPrefix()
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(ipPrefixJSON{Network: prefix.String()})
+	return json.Marshal(prefix.String())
 }
 
-// UnmarshalJSON accepts the network as a CIDR string under the "network"
-// key.
+// UnmarshalJSON accepts a bare CIDR string, inferring the family from the
+// text.
 func (m *IPPrefix) UnmarshalJSON(data []byte) error {
-	var raw ipPrefixJSON
+	var raw string
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	if raw.Network == "" {
+	if raw == "" {
 		return fmt.Errorf("empty IP network is not allowed")
 	}
 
-	prefix, err := netip.ParsePrefix(raw.Network)
+	prefix, err := netip.ParsePrefix(raw)
 	if err != nil {
 		return fmt.Errorf("failed to parse IP network: %w", err)
 	}
@@ -123,7 +95,6 @@ func (m *IPPrefix) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	m.Addr = parsed.Addr
-	m.PrefixLen = parsed.PrefixLen
+	m.Prefix = parsed.Prefix
 	return nil
 }

--- a/common/commonpb/v1/ipprefix.proto
+++ b/common/commonpb/v1/ipprefix.proto
@@ -4,19 +4,14 @@ package common.commonpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/common/commonpb/v1;commonpb";
 
-import "common/commonpb/v1/ipaddr.proto";
+import "common/commonpb/v1/ipv4prefix.proto";
+import "common/commonpb/v1/ipv6prefix.proto";
 
-// IPPrefix represents an IPv4 or IPv6 CIDR prefix.
-//
-// The mask is a prefix length rather than a general per-bit mask. Family
-// is determined by the length of addr, consistently with IPAddress.
+// IPPrefix represents an IPv4 or IPv6 CIDR prefix. The family is
+// structural through the oneof.
 message IPPrefix {
-  // Masked network base address.
-  //
-  // Host bits below prefix_len MUST be zero.
-  IPAddress addr = 1;
-  // Prefix length, in bits.
-  //
-  // MUST be <= 32 for a 4-byte addr and <= 128 for a 16-byte addr.
-  uint32 prefix_len = 2;
+  oneof prefix {
+    IPv4Prefix v4 = 1;
+    IPv6Prefix v6 = 2;
+  }
 }

--- a/common/commonpb/v1/ipprefix_test.go
+++ b/common/commonpb/v1/ipprefix_test.go
@@ -5,146 +5,42 @@ import (
 	"net/netip"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/yanet-platform/xnetip"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 )
 
-// TestIPPrefix_ToPrefix_RoundTrip asserts that a prefix that is
-// already masked survives a New/ToPrefix round trip for both families.
+// TestIPPrefix_ToPrefix_RoundTrip verifies that both families survive the
+// construction and decode round trip, with host bits masked off.
 func TestIPPrefix_ToPrefix_RoundTrip(t *testing.T) {
 	tests := []struct {
 		name   string
-		prefix netip.Prefix
+		input  string
+		want   string
+		wantV4 bool
 	}{
-		{name: "IPv4", prefix: netip.MustParsePrefix("10.0.0.0/24")},
-		{name: "IPv4 host route", prefix: netip.MustParsePrefix("10.0.0.1/32")},
-		{name: "IPv4 default route", prefix: netip.MustParsePrefix("0.0.0.0/0")},
-		{name: "IPv6", prefix: netip.MustParsePrefix("2001:db8::/32")},
-		{name: "IPv6 host route", prefix: netip.MustParsePrefix("2001:db8::1/128")},
-		{name: "IPv6 default route", prefix: netip.MustParsePrefix("::/0")},
+		{name: "IPv4", input: "10.0.0.1/24", want: "10.0.0.0/24", wantV4: true},
+		{name: "IPv6", input: "2001:db8::1/32", want: "2001:db8::/32"},
+		{name: "IPv4-mapped IPv6 stays IPv6", input: "::ffff:10.0.0.1/120", want: "::ffff:10.0.0.0/120"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m, err := commonpb.NewIPPrefixFromPrefix(tt.prefix)
+			m, err := commonpb.NewIPPrefixFromPrefix(netip.MustParsePrefix(tt.input))
 			require.NoError(t, err)
+
+			require.Equal(t, tt.wantV4, m.GetV4() != nil)
+			require.Equal(t, !tt.wantV4, m.GetV6() != nil)
+
 			got, err := m.ToPrefix()
 			require.NoError(t, err)
-			require.Equal(t, tt.prefix, got)
+			require.Equal(t, netip.MustParsePrefix(tt.want), got)
 		})
 	}
 }
 
-// TestIPPrefix_HostBitsNormalized asserts that construction
-// and decoding both mask host bits below prefix_len.
-//
-// The normalization is documented behavior of both directions, not an
-// accident of one. It checks the raw wire bytes (m.GetAddr().GetAddr())
-// directly rather than only round-tripping through ToPrefix, because
-// ToPrefix masks on the way out too: a constructor that forgot to mask
-// would still pass a ToPrefix-only assertion.
-func TestIPPrefix_HostBitsNormalized(t *testing.T) {
-	tests := []struct {
-		name      string
-		input     string
-		wantIn    string
-		wantBytes []byte
-	}{
-		{name: "IPv4", input: "10.0.0.1/24", wantIn: "10.0.0.0/24", wantBytes: []byte{10, 0, 0, 0}},
-		{
-			name:      "IPv6",
-			input:     "2001:db8::1/32",
-			wantIn:    "2001:db8::/32",
-			wantBytes: []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			in := netip.MustParsePrefix(tt.input)
-			want := netip.MustParsePrefix(tt.wantIn)
-
-			m, err := commonpb.NewIPPrefixFromPrefix(in)
-			require.NoError(t, err)
-			require.Equal(t, tt.wantBytes, m.GetAddr().GetAddr())
-			got, err := m.ToPrefix()
-			require.NoError(t, err)
-			require.Equal(t, want, got)
-		})
-	}
-
-	decodeTests := []struct {
-		name      string
-		addr      []byte
-		prefixLen uint32
-		wantIn    string
-	}{
-		{name: "IPv4 hand-built", addr: []byte{10, 0, 0, 1}, prefixLen: 24, wantIn: "10.0.0.0/24"},
-		{
-			name:      "IPv6 hand-built",
-			addr:      []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
-			prefixLen: 32,
-			wantIn:    "2001:db8::/32",
-		},
-	}
-
-	for _, tt := range decodeTests {
-		t.Run(tt.name, func(t *testing.T) {
-			want := netip.MustParsePrefix(tt.wantIn)
-			m := &commonpb.IPPrefix{
-				Addr:      &commonpb.IPAddress{Addr: tt.addr},
-				PrefixLen: tt.prefixLen,
-			}
-			got, err := m.ToPrefix()
-			require.NoError(t, err)
-			require.Equal(t, want, got)
-		})
-	}
-}
-
-// TestIPPrefix_ToPrefix_PrefixLenOverflow asserts that a
-// prefix_len exceeding the family's bit length is rejected.
-//
-// The rejection is the contract: an overflowing length must not be
-// silently truncated or wrapped.
-func TestIPPrefix_ToPrefix_PrefixLenOverflow(t *testing.T) {
-	tests := []struct {
-		name      string
-		addr      []byte
-		prefixLen uint32
-	}{
-		{name: "IPv4 overflow", addr: []byte{10, 0, 0, 0}, prefixLen: 33},
-		{name: "IPv6 overflow", addr: make([]byte, 16), prefixLen: 129},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m := &commonpb.IPPrefix{
-				Addr:      &commonpb.IPAddress{Addr: tt.addr},
-				PrefixLen: tt.prefixLen,
-			}
-			_, err := m.ToPrefix()
-			require.Error(t, err)
-		})
-	}
-}
-
-// TestIPPrefix_ToPrefix_MalformedAddr asserts that an addr byte
-// length other than 4 or 16 is rejected.
-func TestIPPrefix_ToPrefix_MalformedAddr(t *testing.T) {
-	m := &commonpb.IPPrefix{
-		Addr:      &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5}},
-		PrefixLen: 24,
-	}
-	_, err := m.ToPrefix()
-	require.Error(t, err)
-}
-
-// TestNewIPPrefixFromPrefix_Invalid asserts that an invalid
-// prefix is rejected at construction time.
+// TestNewIPPrefixFromPrefix_Invalid asserts that an invalid prefix is
+// rejected at construction.
 //
 // Failing at construction is the contract: an invalid input must not
 // produce a message that only fails later.
@@ -153,351 +49,70 @@ func TestNewIPPrefixFromPrefix_Invalid(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestIPPrefix_SliceConversions verifies that slice conversion
-// masks host bits and preserves IPv4 and IPv6 prefixes in both directions.
-func TestIPPrefix_SliceConversions(t *testing.T) {
-	prefixes := []netip.Prefix{
-		netip.MustParsePrefix("10.0.0.1/24"),
-		netip.MustParsePrefix("2001:db8::1/32"),
-	}
-	want := []netip.Prefix{
-		netip.MustParsePrefix("10.0.0.0/24"),
-		netip.MustParsePrefix("2001:db8::/32"),
-	}
-
-	networks, err := commonpb.NetworksFromPrefixes(prefixes)
-	require.NoError(t, err)
-
-	got, err := commonpb.PrefixesFromNetworks(networks)
-	require.NoError(t, err)
-	require.Equal(t, want, got)
-}
-
-// TestIPPrefix_SliceConversions_Invalid verifies that conversion
-// errors identify the failing prefix position.
-func TestIPPrefix_SliceConversions_Invalid(t *testing.T) {
-	_, err := commonpb.NetworksFromPrefixes([]netip.Prefix{{}})
-	require.ErrorContains(t, err, "prefixes[0]")
-
-	_, err = commonpb.PrefixesFromNetworks([]*commonpb.IPPrefix{{
-		Addr: &commonpb.IPAddress{Addr: []byte{10, 0, 0}},
-	}})
-	require.ErrorContains(t, err, "prefixes[0]")
-}
-
-// TestIPPrefix_AsLogValue asserts the log-friendly string form,
-// including the "invalid" fallback for an undecodable message.
-func TestIPPrefix_AsLogValue(t *testing.T) {
-	ipv4, err := commonpb.NewIPPrefixFromPrefix(netip.MustParsePrefix("10.0.0.0/24"))
-	require.NoError(t, err)
-	ipv6, err := commonpb.NewIPPrefixFromPrefix(netip.MustParsePrefix("2001:db8::/32"))
-	require.NoError(t, err)
-
+// TestIPPrefix_ToPrefix_Malformed verifies that an unset oneof and a
+// malformed branch decode to an error rather than a zero prefix.
+func TestIPPrefix_ToPrefix_Malformed(t *testing.T) {
 	tests := []struct {
 		name string
 		m    *commonpb.IPPrefix
-		want string
 	}{
-		{name: "IPv4", m: ipv4, want: "10.0.0.0/24"},
-		{name: "IPv6", m: ipv6, want: "2001:db8::/32"},
+		{name: "unset oneof", m: &commonpb.IPPrefix{}},
 		{
-			name: "invalid",
-			m:    &commonpb.IPPrefix{Addr: &commonpb.IPAddress{Addr: []byte{1, 2, 3}}},
-			want: "invalid",
+			name: "IPv4 branch with missing address",
+			m:    &commonpb.IPPrefix{Prefix: &commonpb.IPPrefix_V4{V4: &commonpb.IPv4Prefix{PrefixLen: 24}}},
+		},
+		{
+			name: "IPv6 branch with overflowing prefix length",
+			m: &commonpb.IPPrefix{
+				Prefix: &commonpb.IPPrefix_V6{V6: &commonpb.IPv6Prefix{Addr: &commonpb.IPv6Address{}, PrefixLen: 129}},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.m.AsLogValue())
+			_, err := tt.m.ToPrefix()
+			require.Error(t, err)
+			require.Equal(t, "invalid", tt.m.AsLogValue())
 		})
 	}
 }
 
-// TestIPPrefix_JSONRoundTrip asserts marshal/unmarshal round
-// trips through the "network" CIDR string for both families.
+// TestIPPrefix_AsLogValue verifies the compact log rendering.
+func TestIPPrefix_AsLogValue(t *testing.T) {
+	m, err := commonpb.NewIPPrefixFromPrefix(netip.MustParsePrefix("10.0.0.0/24"))
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.0/24", m.AsLogValue())
+}
+
+// TestIPPrefix_JSONRoundTrip verifies that JSON is a bare CIDR string in
+// both directions, identically to the family-typed prefix messages.
 func TestIPPrefix_JSONRoundTrip(t *testing.T) {
-	tests := []struct {
-		name   string
-		prefix netip.Prefix
-		want   string
-	}{
-		{name: "IPv4", prefix: netip.MustParsePrefix("10.0.0.0/24"), want: `{"network":"10.0.0.0/24"}`},
-		{name: "IPv6", prefix: netip.MustParsePrefix("2001:db8::/32"), want: `{"network":"2001:db8::/32"}`},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			original, err := commonpb.NewIPPrefixFromPrefix(tt.prefix)
+	for _, cidr := range []string{"10.0.0.0/24", "2001:db8::/32"} {
+		t.Run(cidr, func(t *testing.T) {
+			m, err := commonpb.NewIPPrefixFromPrefix(netip.MustParsePrefix(cidr))
 			require.NoError(t, err)
 
-			data, err := json.Marshal(original)
+			data, err := json.Marshal(m)
 			require.NoError(t, err)
-			require.Equal(t, tt.want, string(data))
+			require.Equal(t, `"`+cidr+`"`, string(data))
 
-			var got commonpb.IPPrefix
-			require.NoError(t, json.Unmarshal(data, &got))
-			require.Equal(t, tt.prefix.Addr().AsSlice(), got.GetAddr().GetAddr())
-
-			gotPrefix, err := got.ToPrefix()
+			var decoded commonpb.IPPrefix
+			require.NoError(t, json.Unmarshal(data, &decoded))
+			got, err := decoded.ToPrefix()
 			require.NoError(t, err)
-			require.Equal(t, tt.prefix, gotPrefix)
+			require.Equal(t, netip.MustParsePrefix(cidr), got)
 		})
 	}
 }
 
-// TestIPPrefix_UnmarshalJSON_Errors asserts that an empty or
-// malformed "network" value is rejected.
+// TestIPPrefix_UnmarshalJSON_Errors verifies that malformed JSON input is
+// rejected.
 func TestIPPrefix_UnmarshalJSON_Errors(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-	}{
-		{name: "empty string", input: `{"network":""}`},
-		{name: "malformed CIDR", input: `{"network":"not-a-cidr"}`},
-		{name: "invalid JSON", input: `{"network":`},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var m commonpb.IPPrefix
-			err := json.Unmarshal([]byte(tt.input), &m)
-			require.Error(t, err)
-		})
-	}
-}
-
-// Test_IPPrefix_ToContiguous_RoundTrip verifies that a CIDR block
-// of either family round-trips normalized, with a family-width wire address.
-func Test_IPPrefix_ToContiguous_RoundTrip(t *testing.T) {
-	tests := []struct {
-		name      string
-		net       xnetip.Contiguous[xnetip.Network]
-		wantBytes []byte
-		wantBits  uint32
-	}{
-		{
-			name:      "IPv4 default route",
-			net:       xnetip.MustParseContiguous("0.0.0.0/0"),
-			wantBytes: []byte{0, 0, 0, 0},
-			wantBits:  0,
-		},
-		{
-			name:      "IPv4 subnet",
-			net:       xnetip.MustParseContiguous("10.0.0.0/24"),
-			wantBytes: []byte{10, 0, 0, 0},
-			wantBits:  24,
-		},
-		{
-			name:      "IPv4 host route",
-			net:       xnetip.MustParseContiguous("10.0.0.1/32"),
-			wantBytes: []byte{10, 0, 0, 1},
-			wantBits:  32,
-		},
-		{
-			name:      "IPv6 default route",
-			net:       xnetip.MustParseContiguous("::/0"),
-			wantBytes: make([]byte, 16),
-			wantBits:  0,
-		},
-		{
-			name:      "zero block is the IPv6 default route",
-			net:       xnetip.Contiguous[xnetip.Network]{},
-			wantBytes: make([]byte, 16),
-			wantBits:  0,
-		},
-		{
-			name:      "IPv6 subnet",
-			net:       xnetip.MustParseContiguous("2001:db8::/32"),
-			wantBytes: []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			wantBits:  32,
-		},
-		{
-			name:      "IPv6 host route",
-			net:       xnetip.MustParseContiguous("2001:db8::1/128"),
-			wantBytes: []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
-			wantBits:  128,
-		},
-		{
-			name:      "IPv4-mapped IPv6 stays sixteen bytes",
-			net:       xnetip.MustParseContiguous("::ffff:10.0.0.0/120"),
-			wantBytes: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 10, 0, 0, 0},
-			wantBits:  120,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m := commonpb.NewIPPrefixFromContiguous(tt.net)
-			require.Equal(t, tt.wantBytes, m.GetAddr().GetAddr())
-			require.Equal(t, tt.wantBits, m.GetPrefixLen())
-
-			got, err := m.ToContiguous()
-			require.NoError(t, err)
-			require.Equal(t, tt.net, got)
-		})
-	}
-}
-
-// Test_IPPrefix_ToContiguous_HostBitsNormalized verifies that a
-// hand-built message with host bits set decodes to the masked block.
-func Test_IPPrefix_ToContiguous_HostBitsNormalized(t *testing.T) {
-	tests := []struct {
-		name      string
-		addr      []byte
-		prefixLen uint32
-		want      string
-	}{
-		{name: "IPv4", addr: []byte{10, 0, 0, 1}, prefixLen: 24, want: "10.0.0.0/24"},
-		{
-			name:      "IPv6",
-			addr:      []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
-			prefixLen: 32,
-			want:      "2001:db8::/32",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m := &commonpb.IPPrefix{
-				Addr:      &commonpb.IPAddress{Addr: tt.addr},
-				PrefixLen: tt.prefixLen,
-			}
-			got, err := m.ToContiguous()
-			require.NoError(t, err)
-			require.Equal(t, xnetip.MustParseContiguous(tt.want), got)
-		})
-	}
-}
-
-// Test_IPPrefix_ToContiguous_Errors verifies that a bad address or
-// an overlong prefix length is rejected, never decoded to the zero block.
-func Test_IPPrefix_ToContiguous_Errors(t *testing.T) {
-	tests := []struct {
-		name      string
-		m         *commonpb.IPPrefix
-		wantErrIs error
-	}{
-		{name: "zero message", m: &commonpb.IPPrefix{}},
-		{name: "nil address", m: &commonpb.IPPrefix{PrefixLen: 24}},
-		{
-			name: "empty address",
-			m: &commonpb.IPPrefix{
-				Addr:      &commonpb.IPAddress{},
-				PrefixLen: 24,
-			},
-		},
-		{
-			name: "three byte address",
-			m: &commonpb.IPPrefix{
-				Addr:      &commonpb.IPAddress{Addr: []byte{10, 0, 0}},
-				PrefixLen: 24,
-			},
-		},
-		{
-			name: "five byte address",
-			m: &commonpb.IPPrefix{
-				Addr:      &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5}},
-				PrefixLen: 24,
-			},
-		},
-		{
-			name: "IPv4 prefix length above 32",
-			m: &commonpb.IPPrefix{
-				Addr:      &commonpb.IPAddress{Addr: []byte{10, 0, 0, 0}},
-				PrefixLen: 33,
-			},
-			wantErrIs: xnetip.ErrCIDROverflow,
-		},
-		{
-			name: "IPv6 prefix length above 128",
-			m: &commonpb.IPPrefix{
-				Addr:      &commonpb.IPAddress{Addr: make([]byte, 16)},
-				PrefixLen: 129,
-			},
-			wantErrIs: xnetip.ErrCIDROverflow,
-		},
-		{
-			name: "IPv4 prefix length at uint32 maximum",
-			m: &commonpb.IPPrefix{
-				Addr:      &commonpb.IPAddress{Addr: []byte{10, 0, 0, 0}},
-				PrefixLen: ^uint32(0),
-			},
-			wantErrIs: xnetip.ErrCIDROverflow,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.m.ToContiguous()
-			require.Error(t, err)
-			if tt.wantErrIs != nil {
-				require.ErrorIs(t, err, tt.wantErrIs)
-			}
-			require.Equal(t, xnetip.Contiguous[xnetip.Network]{}, got)
-		})
-	}
-}
-
-// Test_IPPrefix_ToContiguous_FamilyExtraction verifies that the
-// decoded block unwraps into the family of its wire address width only.
-func Test_IPPrefix_ToContiguous_FamilyExtraction(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		wantIPv4 bool
-	}{
-		{name: "IPv4 message unwraps to Network4", input: "10.0.0.0/24", wantIPv4: true},
-		{name: "IPv6 message unwraps to Network6", input: "2001:db8::/32", wantIPv4: false},
-		{
-			name:     "IPv4-mapped IPv6 message unwraps to Network6",
-			input:    "::ffff:10.0.0.0/120",
-			wantIPv4: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m, err := commonpb.NewIPPrefixFromPrefix(netip.MustParsePrefix(tt.input))
-			require.NoError(t, err)
-			net, err := m.ToContiguous()
-			require.NoError(t, err)
-			want := netip.MustParsePrefix(tt.input)
-
-			net4, ok4 := xnetip.ContiguousIPv4(net)
-			net6, ok6 := xnetip.ContiguousIPv6(net)
-			require.Equal(t, tt.wantIPv4, ok4)
-			require.Equal(t, !tt.wantIPv4, ok6)
-			if tt.wantIPv4 {
-				require.Equal(t, want, net4.Prefix())
-			} else {
-				require.Equal(t, want, net6.Prefix())
-			}
-		})
-	}
-}
-
-// Test_IPPrefix_ToPrefix_MatchesToContiguous verifies that the
-// prefix view and the block view of one message name the same network.
-func Test_IPPrefix_ToPrefix_MatchesToContiguous(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-	}{
-		{name: "IPv4", input: "10.0.0.1/24"},
-		{name: "IPv6", input: "2001:db8::1/32"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m, err := commonpb.NewIPPrefixFromPrefix(netip.MustParsePrefix(tt.input))
-			require.NoError(t, err)
-
-			prefix, err := m.ToPrefix()
-			require.NoError(t, err)
-			net, err := m.ToContiguous()
-			require.NoError(t, err)
-			require.Equal(t, prefix, net.Prefix())
+	for _, input := range []string{`""`, `"not-a-cidr"`, `"10.0.0.0"`, `{"network": "10.0.0.0/24"}`} {
+		t.Run(input, func(t *testing.T) {
+			var decoded commonpb.IPPrefix
+			require.Error(t, json.Unmarshal([]byte(input), &decoded))
 		})
 	}
 }

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -635,8 +635,7 @@ impl pb::IpRange {
 impl From<Contiguous<IpNetwork>> for pb::IpPrefix {
     fn from(net: Contiguous<IpNetwork>) -> Self {
         pb::IpPrefix {
-            addr: Some(pb::IpAddress::from(net.addr())),
-            prefix_len: u32::from(net.prefix()),
+            prefix: Some((net.addr(), net.prefix()).into()),
         }
     }
 }
@@ -649,25 +648,53 @@ impl TryFrom<IpNetwork> for pb::IpPrefix {
     fn try_from(net: IpNetwork) -> Result<Self, Self::Error> {
         let prefix = net.prefix().ok_or("invalid IP network: mask is not contiguous")?;
         Ok(pb::IpPrefix {
-            addr: Some(pb::IpAddress::from(net.addr())),
-            prefix_len: u32::from(prefix),
+            prefix: Some((net.addr(), prefix).into()),
         })
     }
 }
 
-/// Decodes the address and prefix length a `IpPrefix` carries.
-///
-/// Shared by both network conversions below so the wire validation lives in
-/// one place and the two decode paths cannot drift apart.
-fn decode_ip_network(net: &pb::IpPrefix) -> Result<(IpAddr, u8), Box<dyn Error>> {
-    let addr = net.addr.as_ref().ok_or("invalid IP network: missing address")?;
-    let addr = IpAddr::try_from(addr)?;
-    let prefix_len: u8 = net
-        .prefix_len
-        .try_into()
-        .map_err(|_| format!("invalid prefix length {}: exceeds 255", net.prefix_len))?;
+impl From<(IpAddr, u8)> for pb::ip_prefix::Prefix {
+    /// Encodes an address and prefix length into the family branch the
+    /// oneof carries.
+    fn from((addr, prefix_len): (IpAddr, u8)) -> Self {
+        match addr {
+            IpAddr::V4(addr) => Self::V4(pb::IPv4Prefix {
+                addr: Some(pb::IPv4Address::from(addr)),
+                prefix_len: u32::from(prefix_len),
+            }),
+            IpAddr::V6(addr) => Self::V6(pb::IPv6Prefix {
+                addr: Some(pb::IPv6Address::from(addr)),
+                prefix_len: u32::from(prefix_len),
+            }),
+        }
+    }
+}
 
-    Ok((addr, prefix_len))
+impl TryFrom<&pb::IpPrefix> for (IpAddr, u8) {
+    type Error = Box<dyn Error>;
+
+    /// Decodes the address and prefix length the container carries.
+    ///
+    /// Shared by both network conversions below so the wire validation
+    /// lives in one place and the two decode paths cannot drift apart.
+    fn try_from(net: &pb::IpPrefix) -> Result<Self, Self::Error> {
+        let (addr, prefix_len) = match &net.prefix {
+            Some(pb::ip_prefix::Prefix::V4(prefix)) => {
+                let addr = prefix.addr.as_ref().ok_or("invalid IP network: missing address")?;
+                (IpAddr::V4(Ipv4Addr::from(addr)), prefix.prefix_len)
+            }
+            Some(pb::ip_prefix::Prefix::V6(prefix)) => {
+                let addr = prefix.addr.as_ref().ok_or("invalid IP network: missing address")?;
+                (IpAddr::V6(Ipv6Addr::from(addr)), prefix.prefix_len)
+            }
+            None => return Err("invalid IP network: missing prefix".into()),
+        };
+        let prefix_len: u8 = prefix_len
+            .try_into()
+            .map_err(|_| format!("invalid prefix length {prefix_len}: exceeds 255"))?;
+
+        Ok((addr, prefix_len))
+    }
 }
 
 impl TryFrom<&pb::IpPrefix> for IpNetwork {
@@ -675,7 +702,7 @@ impl TryFrom<&pb::IpPrefix> for IpNetwork {
 
     /// Masks host bits to `prefix_len` rather than rejecting them.
     fn try_from(net: &pb::IpPrefix) -> Result<Self, Self::Error> {
-        let (addr, prefix_len) = decode_ip_network(net)?;
+        let (addr, prefix_len) = <(IpAddr, u8)>::try_from(net)?;
 
         let result = match addr {
             IpAddr::V4(v4) => IpNetwork::try_from((v4, prefix_len)),
@@ -693,7 +720,7 @@ impl TryFrom<&pb::IpPrefix> for Contiguous<IpNetwork> {
     /// A mask built from a prefix length is contiguous by construction, so
     /// this never has to reject a non-contiguous mask.
     fn try_from(net: &pb::IpPrefix) -> Result<Self, Self::Error> {
-        let (addr, prefix_len) = decode_ip_network(net)?;
+        let (addr, prefix_len) = <(IpAddr, u8)>::try_from(net)?;
 
         Contiguous::<IpNetwork>::try_from((addr, prefix_len))
             .map_err(|e| format!("invalid prefix length {prefix_len}: {e}").into())
@@ -1105,7 +1132,7 @@ mod test {
     fn contiguous_ip_network_v4_round_trip() {
         let net = Contiguous::<IpNetwork>::parse("10.0.0.0/24").unwrap();
         let msg = pb::IpPrefix::from(net);
-        assert_eq!(24, msg.prefix_len);
+        assert!(matches!(&msg.prefix, Some(pb::ip_prefix::Prefix::V4(prefix)) if prefix.prefix_len == 24));
         let got = IpNetwork::try_from(&msg).unwrap();
         assert_eq!(*net, got);
     }
@@ -1114,13 +1141,13 @@ mod test {
     fn contiguous_ip_network_v6_round_trip() {
         let net = Contiguous::<IpNetwork>::parse("2001:db8::/32").unwrap();
         let msg = pb::IpPrefix::from(net);
-        assert_eq!(32, msg.prefix_len);
+        assert!(matches!(&msg.prefix, Some(pb::ip_prefix::Prefix::V6(prefix)) if prefix.prefix_len == 32));
         let got = IpNetwork::try_from(&msg).unwrap();
         assert_eq!(*net, got);
     }
 
     /// The `Contiguous<IpNetwork>` decode accepts exactly what the bare
-    /// `IpNetwork` one does, since both go through `decode_ip_network`, and
+    /// `IpNetwork` one does, since both go through the shared tuple decode, and
     /// keeps the contiguity guarantee in the type.
     #[test]
     fn contiguous_ip_network_contiguous_round_trip() {
@@ -1137,26 +1164,23 @@ mod test {
     #[test]
     fn contiguous_ip_network_contiguous_try_from_masks_host_bits() {
         let msg = pb::IpPrefix {
-            addr: Some(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))),
-            prefix_len: 24,
+            prefix: Some((IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 24).into()),
         };
         let got = Contiguous::<IpNetwork>::try_from(&msg).unwrap();
         assert_eq!(Contiguous::<IpNetwork>::parse("10.0.0.0/24").unwrap(), got);
     }
 
     /// Both decodes reject the same malformed messages, since the shared
-    /// `decode_ip_network` is what rejects them.
+    /// tuple decode is what rejects them.
     #[test]
     fn contiguous_ip_network_contiguous_try_from_rejects_malformed() {
         let malformed = [
-            pb::IpPrefix { addr: None, prefix_len: 24 },
+            pb::IpPrefix { prefix: None },
             pb::IpPrefix {
-                addr: Some(pb::IpAddress { addr: vec![10, 0, 0] }),
-                prefix_len: 24,
+                prefix: Some(pb::ip_prefix::Prefix::V4(pb::IPv4Prefix { addr: None, prefix_len: 24 })),
             },
             pb::IpPrefix {
-                addr: Some(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)))),
-                prefix_len: 33,
+                prefix: Some((IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 33).into()),
             },
         ];
 
@@ -1171,8 +1195,11 @@ mod test {
     #[test]
     fn contiguous_ip_network_masks_host_bits() {
         let msg: pb::IpPrefix = "10.0.0.1/24".parse().unwrap();
-        assert_eq!(vec![10, 0, 0, 0], msg.addr.as_ref().unwrap().addr);
-        assert_eq!(24, msg.prefix_len);
+        let Some(pb::ip_prefix::Prefix::V4(prefix)) = &msg.prefix else {
+            panic!("expected the IPv4 branch, got {:?}", msg.prefix);
+        };
+        assert_eq!(0x0a000000, prefix.addr.as_ref().unwrap().addr);
+        assert_eq!(24, prefix.prefix_len);
     }
 
     /// Mirrors [`contiguous_ip_network_masks_host_bits`] on the decode side:
@@ -1181,8 +1208,7 @@ mod test {
     #[test]
     fn contiguous_ip_network_try_from_masks_host_bits_v4() {
         let msg = pb::IpPrefix {
-            addr: Some(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))),
-            prefix_len: 24,
+            prefix: Some((IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 24).into()),
         };
         let got = IpNetwork::try_from(&msg).unwrap();
         assert_eq!(IpNetwork::parse("10.0.0.0/24").unwrap(), got);
@@ -1191,10 +1217,7 @@ mod test {
     #[test]
     fn contiguous_ip_network_try_from_masks_host_bits_v6() {
         let msg = pb::IpPrefix {
-            addr: Some(pb::IpAddress::from(IpAddr::V6(Ipv6Addr::new(
-                0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
-            )))),
-            prefix_len: 32,
+            prefix: Some((IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)), 32).into()),
         };
         let got = IpNetwork::try_from(&msg).unwrap();
         assert_eq!(IpNetwork::parse("2001:db8::/32").unwrap(), got);
@@ -1210,20 +1233,21 @@ mod test {
     fn contiguous_ip_network_try_from_accepts_contiguous_mask() {
         let net = IpNetwork::parse("192.168.0.0/255.255.255.0").unwrap();
         let msg = pb::IpPrefix::try_from(net).unwrap();
-        assert_eq!(24, msg.prefix_len);
+        assert!(matches!(&msg.prefix, Some(pb::ip_prefix::Prefix::V4(prefix)) if prefix.prefix_len == 24));
     }
 
     #[test]
     fn contiguous_ip_network_rejects_missing_addr() {
-        let msg = pb::IpPrefix { addr: None, prefix_len: 24 };
+        let msg = pb::IpPrefix {
+            prefix: Some(pb::ip_prefix::Prefix::V4(pb::IPv4Prefix { addr: None, prefix_len: 24 })),
+        };
         assert!(IpNetwork::try_from(&msg).is_err());
     }
 
     #[test]
-    fn contiguous_ip_network_rejects_malformed_addr_length() {
+    fn contiguous_ip_network_rejects_v6_prefix_len_overflow() {
         let msg = pb::IpPrefix {
-            addr: Some(pb::IpAddress { addr: vec![0u8; 5] }),
-            prefix_len: 8,
+            prefix: Some((IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0)), 129).into()),
         };
         assert!(IpNetwork::try_from(&msg).is_err());
     }
@@ -1231,8 +1255,7 @@ mod test {
     #[test]
     fn contiguous_ip_network_rejects_out_of_range_prefix_len_v4() {
         let msg = pb::IpPrefix {
-            addr: Some(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)))),
-            prefix_len: 33,
+            prefix: Some((IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 33).into()),
         };
         assert!(IpNetwork::try_from(&msg).is_err());
     }
@@ -1240,10 +1263,7 @@ mod test {
     #[test]
     fn contiguous_ip_network_rejects_out_of_range_prefix_len_v6() {
         let msg = pb::IpPrefix {
-            addr: Some(pb::IpAddress::from(IpAddr::V6(Ipv6Addr::new(
-                0x2001, 0xdb8, 0, 0, 0, 0, 0, 0,
-            )))),
-            prefix_len: 129,
+            prefix: Some((IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0)), 129).into()),
         };
         assert!(IpNetwork::try_from(&msg).is_err());
     }
@@ -1253,9 +1273,13 @@ mod test {
     /// decode `256` as `/0` and `288` as `/32` instead of rejecting them.
     #[test]
     fn contiguous_ip_network_rejects_prefix_len_that_truncates_into_range() {
-        let addr = Some(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0))));
         for prefix_len in [256, 288] {
-            let msg = pb::IpPrefix { addr: addr.clone(), prefix_len };
+            let msg = pb::IpPrefix {
+                prefix: Some(pb::ip_prefix::Prefix::V4(pb::IPv4Prefix {
+                    addr: Some(pb::IPv4Address::from(Ipv4Addr::new(10, 0, 0, 0))),
+                    prefix_len,
+                })),
+            };
             assert!(
                 IpNetwork::try_from(&msg).is_err(),
                 "expected error for prefix_len {prefix_len}"
@@ -1272,7 +1296,7 @@ mod test {
 
     #[test]
     fn contiguous_ip_network_display_invalid() {
-        let msg = pb::IpPrefix { addr: None, prefix_len: 24 };
+        let msg = pb::IpPrefix { prefix: None };
         assert_eq!("invalid", msg.to_string());
     }
 
@@ -1301,7 +1325,7 @@ mod test {
     /// deliberate error rather than a silently reconstructed message.
     #[test]
     fn serde_contiguous_ip_network_invalid_does_not_deserialize() {
-        let malformed = pb::IpPrefix { addr: None, prefix_len: 24 };
+        let malformed = pb::IpPrefix { prefix: None };
         let json = serde_json::to_string(&malformed).unwrap();
         assert_eq!(r#""invalid""#, json);
         assert!(serde_json::from_str::<pb::IpPrefix>(&json).is_err());

--- a/modules/route-mpls/controlplane/service_test.go
+++ b/modules/route-mpls/controlplane/service_test.go
@@ -108,7 +108,7 @@ func Test_RouteMPLSService_CreateConfig_InvalidPrefix(t *testing.T) {
 	service := newTestService(t)
 
 	rule := makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)
-	rule.Prefix.PrefixLen = 33
+	rule.Prefix.GetV4().PrefixLen = 33
 
 	response, err := service.CreateConfig(t.Context(), &routemplspb.CreateConfigRequest{
 		Name:  "mpls0",

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -754,21 +754,25 @@ mod test {
     }
 
     /// A prefix the server sends as a message that cannot be decoded --
-    /// missing, wrong `addr` length, or a prefix length past the family
-    /// bound -- converts into a `RouteEntry` carrying the malformed marker,
-    /// instead of aborting the process.
+    /// missing, an unset or address-less branch, or a prefix length past
+    /// the family bound -- converts into a `RouteEntry` carrying the
+    /// malformed marker, instead of aborting the process.
     #[test]
     fn route_entry_from_malformed_prefix_does_not_panic() {
         let malformed = [
             None,
-            Some(IpPrefix { addr: None, prefix_len: 8 }),
+            Some(IpPrefix { prefix: None }),
             Some(IpPrefix {
-                addr: Some(commonpb::pb::IpAddress { addr: vec![10, 0, 0] }),
-                prefix_len: 8,
+                prefix: Some(commonpb::pb::ip_prefix::Prefix::V4(commonpb::pb::IPv4Prefix {
+                    addr: None,
+                    prefix_len: 8,
+                })),
             }),
             Some(IpPrefix {
-                addr: Some(commonpb::pb::IpAddress { addr: vec![10, 0, 0, 0] }),
-                prefix_len: 33,
+                prefix: Some(commonpb::pb::ip_prefix::Prefix::V4(commonpb::pb::IPv4Prefix {
+                    addr: Some(commonpb::pb::IPv4Address { addr: 0x0a000000 }),
+                    prefix_len: 33,
+                })),
             }),
         ];
 
@@ -795,17 +799,19 @@ mod test {
     /// one ECMP group.
     #[test]
     fn route_entry_malformed_prefixes_stay_distinct() {
-        let entry_of = |addr: Vec<u8>| {
+        let entry_of = |addr: u32| {
             RouteEntry::from(operatorpb::Route {
                 prefix: Some(IpPrefix {
-                    addr: Some(commonpb::pb::IpAddress { addr }),
-                    prefix_len: 8,
+                    prefix: Some(commonpb::pb::ip_prefix::Prefix::V4(commonpb::pb::IPv4Prefix {
+                        addr: Some(commonpb::pb::IPv4Address { addr }),
+                        prefix_len: 33,
+                    })),
                 }),
                 ..Default::default()
             })
         };
 
-        assert_ne!(entry_of(vec![10, 0, 0]).prefix.0, entry_of(vec![10, 0]).prefix.0);
+        assert_ne!(entry_of(1).prefix.0, entry_of(2).prefix.0);
     }
 
     /// Two best routes sharing a prefix are marked with ECMP size 2; a prefix

--- a/operators/route/internal/operator/service_route_test.go
+++ b/operators/route/internal/operator/service_route_test.go
@@ -190,16 +190,20 @@ func TestInsertRoute_MalformedPrefix_InvalidArgument(t *testing.T) {
 			prefix: nil,
 		},
 		{
-			name:   "missing addr",
-			prefix: &commonpb.IPPrefix{PrefixLen: 24},
+			name:   "unset oneof",
+			prefix: &commonpb.IPPrefix{},
 		},
 		{
-			name:   "addr of invalid length",
-			prefix: &commonpb.IPPrefix{Addr: &commonpb.IPAddress{Addr: []byte{10, 0, 0}}, PrefixLen: 24},
+			name: "missing addr",
+			prefix: &commonpb.IPPrefix{
+				Prefix: &commonpb.IPPrefix_V4{V4: &commonpb.IPv4Prefix{PrefixLen: 24}},
+			},
 		},
 		{
-			name:   "prefix length beyond address family",
-			prefix: &commonpb.IPPrefix{Addr: &commonpb.IPAddress{Addr: []byte{10, 0, 0, 0}}, PrefixLen: 33},
+			name: "prefix length beyond address family",
+			prefix: &commonpb.IPPrefix{
+				Prefix: &commonpb.IPPrefix_V4{V4: &commonpb.IPv4Prefix{Addr: &commonpb.IPv4Address{Addr: 0x0a000000}, PrefixLen: 33}},
+			},
 		},
 	}
 
@@ -232,7 +236,9 @@ func TestInsertRoute_HostBitsAreMasked(t *testing.T) {
 	_, err := svc.InsertRoute(t.Context(), &operatorpb.InsertRouteRequest{
 		Name: "route0",
 		// 10.0.0.7/24 with host bits deliberately left set.
-		Prefix:       &commonpb.IPPrefix{Addr: &commonpb.IPAddress{Addr: []byte{10, 0, 0, 7}}, PrefixLen: 24},
+		Prefix: &commonpb.IPPrefix{
+			Prefix: &commonpb.IPPrefix_V4{V4: &commonpb.IPv4Prefix{Addr: &commonpb.IPv4Address{Addr: 0x0a000007}, PrefixLen: 24}},
+		},
 		NexthopAddrs: []*commonpb.IPAddress{commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.168.1.1"))},
 		SourceId:     operatorpb.RouteSourceID_ROUTE_SOURCE_ID_STATIC,
 	})

--- a/operators/route/web/LookupDrawer.tsx
+++ b/operators/route/web/LookupDrawer.tsx
@@ -67,7 +67,7 @@ const LookupDrawer: React.FC<LookupDrawerProps> = ({
                 ip_addr: ipAddr,
             });
             setResult({
-                prefix: res.prefix?.network ?? '',
+                prefix: res.prefix ?? '',
                 routes: res.routes ?? [],
             });
         } catch (err) {

--- a/operators/route/web/RouteDrawer.tsx
+++ b/operators/route/web/RouteDrawer.tsx
@@ -58,7 +58,7 @@ const RouteDrawer: React.FC<RouteDrawerProps> = ({
             setDoFlush(false);
             setSubmitting(false);
         }
-    }, [open, mode, route?.prefix?.network, route?.next_hop]);
+    }, [open, mode, route?.prefix, route?.next_hop]);
 
     const nexthopErrors = nexthopRows.map((row) => validateNexthop(row.value));
     const prefixError = validatePrefix(prefix);

--- a/operators/route/web/RoutePage.tsx
+++ b/operators/route/web/RoutePage.tsx
@@ -14,7 +14,7 @@ import { useRIB } from './useRIB';
 import { RIBTable } from './RIBTable';
 import RouteDrawer from './RouteDrawer';
 import LookupDrawer from './LookupDrawer';
-import { getRouteId, sortComparators, planRouteSubmit, groupByPrefix, filterByFamily, routePrefix, toWirePrefix } from './utils';
+import { getRouteId, sortComparators, planRouteSubmit, groupByPrefix, filterByFamily, routePrefix } from './utils';
 import type { RouteSortState, RouteSortableColumn, IPFamily } from './types';
 import { FamilyFilter } from '@yanet/core/components/VirtualTable';
 import '@yanet/core/styles/chrome.scss';
@@ -165,7 +165,7 @@ const RoutePage: React.FC = () => {
                 if (op.type === 'delete') {
                     await API.route.deleteRoute({
                         name: currentConfig,
-                        prefix: toWirePrefix(op.prefix),
+                        prefix: op.prefix,
                         nexthop_addrs: [op.nexthop],
                         do_flush: false,
                         source_id: RouteSourceID.STATIC,
@@ -173,7 +173,7 @@ const RoutePage: React.FC = () => {
                 } else {
                     await API.route.insertRoute({
                         name: currentConfig,
-                        prefix: toWirePrefix(op.prefix),
+                        prefix: op.prefix,
                         nexthop_addrs: op.nexthops,
                         do_flush: op.doFlush,
                         source_id: RouteSourceID.STATIC,
@@ -198,7 +198,7 @@ const RoutePage: React.FC = () => {
         try {
             await API.route.deleteRoute({
                 name: currentConfig,
-                prefix: toWirePrefix(prefix),
+                prefix,
                 nexthop_addrs: [route.next_hop],
                 do_flush: true,
                 source_id: RouteSourceID.STATIC,
@@ -247,7 +247,7 @@ const RoutePage: React.FC = () => {
             try {
                 await API.route.deleteRoute({
                     name: currentConfig,
-                    prefix: toWirePrefix(prefix),
+                    prefix,
                     nexthop_addrs: [route.next_hop],
                     do_flush: true,
                     source_id: RouteSourceID.STATIC,

--- a/operators/route/web/utils.test.ts
+++ b/operators/route/web/utils.test.ts
@@ -1,23 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { planRouteSubmit, validatePrefix, validateNexthop, sortComparators, prefixIPFamily, groupByPrefix, filterByFamily, bestPathReason, getRouteId, routePrefix, toWirePrefix } from './utils';
-import { stringToIPAddress, type IPPrefix } from '@yanet/core/utils/netip';
+import { planRouteSubmit, validatePrefix, validateNexthop, sortComparators, prefixIPFamily, groupByPrefix, filterByFamily, bestPathReason, getRouteId, routePrefix } from './utils';
+import { stringToIPAddress } from '@yanet/core/utils/netip';
 import type { Route } from '@yanet/core/api/routes';
 
 /** Builds the wire prefix message a server response carries. */
-const net = (cidr: string): IPPrefix => ({ network: cidr });
+const net = (cidr: string): string => cidr;
 
 describe('routePrefix', () => {
-    it('reads the CIDR string out of the wire message', () => {
+    it('reads the bare CIDR string off the wire', () => {
         expect(routePrefix({ prefix: net('10.0.0.0/8') })).toBe('10.0.0.0/8');
+        expect(routePrefix({ prefix: '2001:db8::/32' })).toBe('2001:db8::/32');
     });
 
     it('yields an empty string when the server sent no prefix', () => {
         expect(routePrefix({})).toBe('');
-        expect(routePrefix({ prefix: {} })).toBe('');
-    });
-
-    it('round-trips through toWirePrefix', () => {
-        expect(routePrefix({ prefix: toWirePrefix('2001:db8::/32') })).toBe('2001:db8::/32');
     });
 });
 

--- a/operators/route/web/utils.ts
+++ b/operators/route/web/utils.ts
@@ -1,16 +1,13 @@
 import type { Route } from '@yanet/core/api/routes';
 import { parseCIDRPrefix, parseIPAddress, CIDRParseError, IPParseError } from '@yanet/core/utils';
-import { ipAddressToString, type IPPrefix, type IPAddressWire } from '@yanet/core/utils/netip';
+import { ipAddressToString, type IPAddressWire } from '@yanet/core/utils/netip';
 import type { RouteSortableColumn, IPFamily } from './types';
 
 /** Reads a route's destination prefix as a CIDR string.
  *
- * Empty when the server sent no prefix — the page keeps prefixes as strings
- * everywhere below this boundary. */
-export const routePrefix = (route: Route): string => route.prefix?.network ?? '';
-
-/** Wraps a CIDR string into the wire prefix message. */
-export const toWirePrefix = (prefix: string): IPPrefix => ({ network: prefix });
+ * Empty when the server sent no prefix — the wire carries the prefix as a
+ * bare CIDR string. */
+export const routePrefix = (route: Route): string => route.prefix ?? '';
 
 export interface RouteSubmitParams {
     prefix: string;

--- a/web/src/core/api/routes.ts
+++ b/web/src/core/api/routes.ts
@@ -1,6 +1,6 @@
 import { createService, type CallOptions } from './client';
 import type { MACAddress } from './neighbours';
-import type { IPPrefix, IPAddressWire, IPRangeWire } from '../utils/netip';
+import type { IPAddressWire, IPRangeWire } from '../utils/netip';
 
 // Route types
 
@@ -17,7 +17,8 @@ export interface LargeCommunity {
 }
 
 export interface Route {
-    prefix?: IPPrefix;
+    // commonpb.IPPrefix, serialized by the gateway as a bare CIDR string.
+    prefix?: string;
     next_hop?: IPAddressWire;
     peer?: IPAddressWire;
     route_distinguisher?: string | number; // uint64
@@ -46,7 +47,8 @@ export interface ShowRoutesResponse {
 
 export interface InsertRouteRequest {
     name?: string;
-    prefix?: IPPrefix;
+    // commonpb.IPPrefix, serialized by the gateway as a bare CIDR string.
+    prefix?: string;
     nexthop_addrs?: IPAddressWire[];
     do_flush?: boolean;
     source_id?: RouteSourceID;
@@ -57,7 +59,8 @@ export interface InsertRouteResponse {
 
 export interface DeleteRouteRequest {
     name?: string;
-    prefix?: IPPrefix;
+    // commonpb.IPPrefix, serialized by the gateway as a bare CIDR string.
+    prefix?: string;
     nexthop_addrs?: IPAddressWire[];
     do_flush?: boolean;
     source_id?: RouteSourceID;
@@ -107,7 +110,8 @@ export interface LookupRouteRequest {
 }
 
 export interface LookupRouteResponse {
-    prefix?: IPPrefix;
+    // commonpb.IPPrefix, serialized by the gateway as a bare CIDR string.
+    prefix?: string;
     routes?: Route[];
 }
 

--- a/web/src/core/utils/netip.ts
+++ b/web/src/core/utils/netip.ts
@@ -750,11 +750,6 @@ export type IPAddressWire = {
     addr?: string | number[] | Uint8Array;
 };
 
-// Wire-format shape of commonpb.IPPrefix from the gRPC-JSON gateway: {network: "10.0.0.0/8"}.
-export type IPPrefix = {
-    network?: string;
-};
-
 // Wire-format shape of an IP range as returned by the gRPC-JSON gateway.
 // Both endpoints are plain IP strings — Go's IPRange.MarshalJSON flattens
 // the nested IPAddress shape into top-level strings rather than nesting


### PR DESCRIPTION
- Replace the length-discriminated addr and prefix_len pair inside commonpb.IPPrefix with a family oneof over the IPv4Prefix and IPv6Prefix messages.
- Serialize the container JSON as a bare CIDR string, identically to the family-typed messages and the Rust side, dropping the network object wrapper.
- Keep the Go and Rust helper surfaces, so the route operator, route-mpls and BIRD import flows are unchanged apart from the wire.

Closes #2210.
Closes #2243.