### PR TITLE
feat(readiness): give scopes a per-scope observation interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,6 +3653,7 @@ dependencies = [
  "prost",
  "prost-types",
  "serde",
+ "serde_json",
  "tonic",
  "tonic-build",
 ]

--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -435,6 +435,17 @@ pub fn paint_dim(text: &str) -> String {
     text.truecolor(127, 127, 127).to_string()
 }
 
+/// Returns `true` if the installed backend serializes rather than renders.
+///
+/// Answers the inverse of [`data`]'s split: code that renders outside a
+/// `data` closure — a periodic timer in a long-running watch loop, say —
+/// can check whether free-form output is wanted at all instead of relying
+/// on a side effect such as [`is_colored`], which folds in `NO_COLOR` and
+/// stderr's TTY-ness and would misclassify a piped human run.
+pub fn serializes() -> bool {
+    current().serializes()
+}
+
 /// Returns `true` if the current locale advertises UTF-8 encoding.
 fn is_utf8_locale() -> bool {
     for var in ["LC_ALL", "LC_CTYPE", "LANG"] {

--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -435,17 +435,6 @@ pub fn paint_dim(text: &str) -> String {
     text.truecolor(127, 127, 127).to_string()
 }
 
-/// Returns `true` if the installed backend serializes rather than renders.
-///
-/// Answers the inverse of [`data`]'s split: code that renders outside a
-/// `data` closure — a periodic timer in a long-running watch loop, say —
-/// can check whether free-form output is wanted at all instead of relying
-/// on a side effect such as [`is_colored`], which folds in `NO_COLOR` and
-/// stderr's TTY-ness and would misclassify a piped human run.
-pub fn serializes() -> bool {
-    current().serializes()
-}
-
 /// Returns `true` if the current locale advertises UTF-8 encoding.
 fn is_utf8_locale() -> bool {
     for var in ["LC_ALL", "LC_CTYPE", "LANG"] {

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -10,7 +10,6 @@ use clap_complete::{
 use colored::Colorize;
 use readinesspb::pb::{ReadyRequest, ReadyResponse, Scope, State};
 use serde::Serialize;
-use tokio::sync::mpsc;
 use ync::{
     client::{self, Connection, ConnectionArgs},
     completion,
@@ -195,15 +194,7 @@ async fn run_service(cmd: &Cmd, connection: &Connection, name: &str) -> Result<b
 /// Run a single unary `Ready` call and return whether all scopes are ready.
 async fn run_once(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool, Error> {
     let response: ReadyResponse = connection
-        .invoke_unary(
-            "ready",
-            name,
-            "Ready",
-            ReadyRequest {
-                scopes: cmd.scopes.clone(),
-                include_observation_updates: false,
-            },
-        )
+        .invoke_unary("ready", name, "Ready", ReadyRequest { scopes: cmd.scopes.clone() })
         .await?;
 
     let returned_names: std::collections::HashSet<&str> =
@@ -243,181 +234,72 @@ async fn run_once(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool
     Ok(all_ready)
 }
 
-/// One item forwarded from the stream task to the watch loop: a `Watch`
-/// response, or the terminal outcome once the stream ends.
-enum StreamItem {
-    Message(ReadyResponse),
-    Done(Result<(), Error>),
-}
-
 /// Stream readiness updates via `Watch` until the server closes the connection.
 ///
 /// The first message is a full snapshot of all selected scopes and renders
 /// the status block; each subsequent message carries only the scopes that
-/// changed and renders one append-only log line per scope. Between messages
-/// a staleness ticker re-evaluates every tracked scope, so a heartbeat that
-/// stops while the stream stays open still surfaces as a `stale for …`
-/// line rather than leaving a dead scope reading as live. Returns the
-/// stream's own outcome on close.
+/// changed and renders one append-only log line per scope. Returns `Ok(())`
+/// on clean stream close.
 async fn run_watch(cmd: &Cmd, name: &str) -> Result<(), Error> {
     let mut snapshot: BTreeMap<(String, String), Scope> = BTreeMap::new();
-    let mut stale_flags: BTreeMap<(String, String), bool> = BTreeMap::new();
     let mut name_width: Option<usize> = None;
 
-    // The stream runs in its own task, forwarding each response, because
-    // the staleness ticker must interleave with messages rather than wait
-    // for the next one — a silent-but-open stream is exactly the case it
-    // exists for. The request opts into observation updates so heartbeats
-    // reach the staleness tracker instead of only state changes.
-    let (sender, mut receiver) = mpsc::unbounded_channel::<StreamItem>();
-    let connection_args = cmd.connection.clone();
-    let scopes_filter = cmd.scopes.clone();
-    let service = name.to_owned();
-    let stream = tokio::spawn(async move {
-        let outcome = client::invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
-            &connection_args,
-            "ready",
-            &service,
-            "Watch",
-            ReadyRequest {
-                scopes: scopes_filter,
-                include_observation_updates: true,
-            },
-            |resp: ReadyResponse| {
-                let _ = sender.send(StreamItem::Message(resp));
-            },
-        )
-        .await;
-
-        let _ = sender.send(StreamItem::Done(outcome));
-    });
-
-    let mut ticker = tokio::time::interval(render::STALENESS_TICK);
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-    let outcome = loop {
-        tokio::select! {
-            item = receiver.recv() => match item {
-                Some(StreamItem::Message(resp)) => {
-                    render_watch_message(
-                        cmd,
-                        name,
-                        &resp,
-                        &mut snapshot,
-                        &mut stale_flags,
-                        &mut name_width,
-                    );
-                }
-                // The sender lives only inside the stream task, so a closed
-                // channel means the task ended without reporting — a panic.
-                // Awaiting the handle surfaces it instead of ending a
-                // monitoring command with a success exit code. Returning
-                // here also detaches the already-finished task, so the
-                // loop-exit abort below stays unreachable for this path.
-                None => {
-                    return match stream.await {
-                        Ok(()) => Ok(()),
-                        Err(join) => Err(Error::new(
-                            ErrorKind::Unavailable,
-                            "ready",
-                            &cmd.connection.endpoint,
-                            format!("watch stream task failed: {join}"),
-                        )),
-                    };
-                }
-                Some(StreamItem::Done(outcome)) => break outcome,
-            },
-            _ = ticker.tick() => {
-                render_staleness_flips(&snapshot, &mut stale_flags, cmd.stale_multiple);
-            }
-        }
-    };
-
-    stream.abort();
-    outcome
-}
-
-/// Renders one `Watch` message: the first renders the status block, each
-/// later one renders a transition line per changed scope, and both record
-/// the scopes into `snapshot`. `stale_flags` is seeded on the first
-/// message — the block already shows the initial staleness tags.
-fn render_watch_message(
-    cmd: &Cmd,
-    name: &str,
-    resp: &ReadyResponse,
-    snapshot: &mut BTreeMap<(String, String), Scope>,
-    stale_flags: &mut BTreeMap<(String, String), bool>,
-    name_width: &mut Option<usize>,
-) {
-    output::data(
-        || &resp.scopes,
-        || {
-            if resp.scopes.is_empty() {
-                output::empty(format_args!("No scopes found for {name}."));
-                return;
-            }
-
-            let mut scopes = resp.scopes.clone();
-            scopes.sort_by(|a, b| a.name.cmp(&b.name));
-
-            match name_width {
-                None => {
-                    let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
-                    *name_width = Some(width);
-
-                    for scope in &scopes {
-                        snapshot.insert((name.to_owned(), scope.name.clone()), scope.clone());
+    client::invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
+        &cmd.connection,
+        "ready",
+        name,
+        "Watch",
+        ReadyRequest { scopes: cmd.scopes.clone() },
+        |resp| {
+            output::data(
+                || &resp.scopes,
+                || {
+                    if resp.scopes.is_empty() {
+                        output::empty(format_args!("No scopes found for {name}."));
+                        return;
                     }
 
-                    // One clock reading for both the rendered tags and the
-                    // seeded verdicts, so a threshold crossed during the
-                    // render neither hides the first stale line nor
-                    // immediately duplicates it.
-                    let now = SystemTime::now();
-                    render::print_status_block(name, &scopes, width, cmd.stale_multiple, now, true);
+                    let mut scopes = resp.scopes.clone();
+                    scopes.sort_by(|a, b| a.name.cmp(&b.name));
 
-                    // Seed the verdicts the ticker flips against, dropping
-                    // the seed call's own flips: the block just showed them.
-                    let _ = render::staleness_flips(snapshot, stale_flags, now, cmd.stale_multiple);
-                }
-                Some(width) => {
-                    let width = *width;
-                    for scope in &scopes {
-                        let transition = render::record_transition(snapshot, name, scope);
+                    match name_width {
+                        None => {
+                            let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
+                            name_width = Some(width);
 
-                        if transition != render::Transition::Unchanged {
-                            render::print_transition_line(render::ServiceColumn::None, scope, width, transition);
+                            for scope in &scopes {
+                                snapshot.insert((name.to_owned(), scope.name.clone()), scope.clone());
+                            }
+
+                            render::print_status_block(
+                                name,
+                                &scopes,
+                                width,
+                                cmd.stale_multiple,
+                                SystemTime::now(),
+                                true,
+                            );
+                        }
+                        Some(width) => {
+                            for scope in &scopes {
+                                let transition = render::record_transition(&mut snapshot, name, scope);
+
+                                if transition != render::Transition::Unchanged {
+                                    render::print_transition_line(
+                                        render::ServiceColumn::None,
+                                        scope,
+                                        width,
+                                        transition,
+                                    );
+                                }
+                            }
                         }
                     }
-
-                    // A message refreshes the observations it carries, so
-                    // its scopes may have just gone fresh again.
-                    render_staleness_flips(snapshot, stale_flags, cmd.stale_multiple);
-                }
-            }
+                },
+            );
         },
-    );
-}
-
-/// Renders every staleness flip against `snapshot`, in human output only.
-///
-/// A serializing backend sees no staleness lines: the verdict is derived
-/// from the `observed_at` and `expected_observation_interval` fields every
-/// message already carries, and re-deriving it here would multiply the
-/// wire's event vocabulary for no new information.
-fn render_staleness_flips(
-    snapshot: &BTreeMap<(String, String), Scope>,
-    stale_flags: &mut BTreeMap<(String, String), bool>,
-    stale_multiple: u32,
-) {
-    if output::serializes() {
-        return;
-    }
-
-    let flips = render::staleness_flips(snapshot, stale_flags, SystemTime::now(), stale_multiple);
-    for ((_, scope_name), staleness) in flips {
-        render::print_staleness_line(render::ServiceColumn::None, scope_name.as_str(), 0, &staleness);
-    }
+    )
+    .await
 }
 
 /// Probes every discovered readiness service over one shared connection.
@@ -470,10 +352,7 @@ async fn run_aggregate(cmd: Cmd) -> Result<bool, Error> {
 
 /// Probes one service's `Ready` over the shared connection.
 async fn probe(connection: &Connection, service: String) -> ServiceReport {
-    let request = ReadyRequest {
-        scopes: Vec::new(),
-        include_observation_updates: false,
-    };
+    let request = ReadyRequest { scopes: Vec::new() };
 
     match connection
         .invoke_unary::<_, ReadyResponse>("ready", &service, "Ready", request)
@@ -710,5 +589,28 @@ mod test {
     #[test]
     fn all_flag_conflicts_with_a_named_service() {
         assert!(Cmd::try_parse_from(["yanet-cli-ready", "--all", "route"]).is_err());
+    }
+
+    #[test]
+    fn test_cmd_stale_multiple_defaults_to_three() {
+        let cmd = Cmd::try_parse_from(["yanet-cli-ready"]).expect("default command must parse");
+
+        assert_eq!(3, cmd.stale_multiple);
+    }
+
+    #[test]
+    fn test_cmd_stale_multiple_accepts_override() {
+        let cmd =
+            Cmd::try_parse_from(["yanet-cli-ready", "--stale-multiple", "7"]).expect("staleness multiplier must parse");
+
+        assert_eq!(7, cmd.stale_multiple);
+    }
+
+    #[test]
+    fn test_cmd_stale_multiple_accepts_zero() {
+        let cmd = Cmd::try_parse_from(["yanet-cli-ready", "--stale-multiple", "0"])
+            .expect("zero staleness multiplier must parse");
+
+        assert_eq!(0, cmd.stale_multiple);
     }
 }

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -1,7 +1,6 @@
 //! Generic readiness probe CLI.
 
-use core::time::Duration;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::SystemTime};
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::{
@@ -11,6 +10,7 @@ use clap_complete::{
 use colored::Colorize;
 use readinesspb::pb::{ReadyRequest, ReadyResponse, Scope, State};
 use serde::Serialize;
+use tokio::sync::mpsc;
 use ync::{
     client::{self, Connection, ConnectionArgs},
     completion,
@@ -81,18 +81,16 @@ pub struct Cmd {
     /// naming the service it belongs to.
     #[arg(long, default_value_t = false)]
     pub watch: bool,
-    /// Minimum time since a scope was last observed before flagging it
-    /// `stale` in human output.
+    /// Multiple of a scope's nominal observation interval past which the
+    /// scope is flagged `stale` in human output.
     ///
-    /// Readiness sources heartbeat on their own, differing cadences — e.g.
-    /// reconcile actuators every 30s, the bird RIB sampler every 1s, and the
-    /// slowest in-tree one, the route operator's neighbour monitor, every
-    /// 5m. Since the CLI cannot know a given scope's expected interval, the
-    /// default is deliberately generous, roughly 3x the slowest known
-    /// heartbeat. Accepts humantime durations (e.g. `30s`, `5m`). `0`
-    /// disables the tag.
-    #[arg(long, default_value = "15m", value_parser = parse_duration)]
-    pub stale_after: Duration,
+    /// Each scope publishes how often its source nominally re-observes it;
+    /// the flag scales that per-scope contract into a staleness threshold,
+    /// so a 5m-cadence neighbour monitor and a 1s RIB sampler are judged by
+    /// their own cadences. Scopes without an observation contract are never
+    /// flagged. `0` disables the tag.
+    #[arg(long, default_value_t = 3)]
+    pub stale_multiple: u32,
 }
 
 impl Cmd {
@@ -115,11 +113,6 @@ struct ServiceReport {
     service: String,
     scopes: Vec<Scope>,
     error: Option<String>,
-}
-
-/// Parses a CLI duration flag via `humantime`.
-fn parse_duration(value: &str) -> Result<Duration, String> {
-    humantime::parse_duration(value).map_err(|err| err.to_string())
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -202,7 +195,15 @@ async fn run_service(cmd: &Cmd, connection: &Connection, name: &str) -> Result<b
 /// Run a single unary `Ready` call and return whether all scopes are ready.
 async fn run_once(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool, Error> {
     let response: ReadyResponse = connection
-        .invoke_unary("ready", name, "Ready", ReadyRequest { scopes: cmd.scopes.clone() })
+        .invoke_unary(
+            "ready",
+            name,
+            "Ready",
+            ReadyRequest {
+                scopes: cmd.scopes.clone(),
+                include_observation_updates: false,
+            },
+        )
         .await?;
 
     let returned_names: std::collections::HashSet<&str> =
@@ -232,7 +233,7 @@ async fn run_once(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool
 
             if !scopes.is_empty() {
                 let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
-                render::print_status_block(name, &scopes, width, cmd.stale_after, false);
+                render::print_status_block(name, &scopes, width, cmd.stale_multiple, SystemTime::now(), false);
             }
 
             print_missing(&missing);
@@ -242,65 +243,181 @@ async fn run_once(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool
     Ok(all_ready)
 }
 
+/// One item forwarded from the stream task to the watch loop: a `Watch`
+/// response, or the terminal outcome once the stream ends.
+enum StreamItem {
+    Message(ReadyResponse),
+    Done(Result<(), Error>),
+}
+
 /// Stream readiness updates via `Watch` until the server closes the connection.
 ///
 /// The first message is a full snapshot of all selected scopes and renders
 /// the status block; each subsequent message carries only the scopes that
-/// changed and renders one append-only log line per scope. Returns `Ok(())`
-/// on clean stream close.
+/// changed and renders one append-only log line per scope. Between messages
+/// a staleness ticker re-evaluates every tracked scope, so a heartbeat that
+/// stops while the stream stays open still surfaces as a `stale for …`
+/// line rather than leaving a dead scope reading as live. Returns the
+/// stream's own outcome on close.
 async fn run_watch(cmd: &Cmd, name: &str) -> Result<(), Error> {
     let mut snapshot: BTreeMap<(String, String), Scope> = BTreeMap::new();
+    let mut stale_flags: BTreeMap<(String, String), bool> = BTreeMap::new();
     let mut name_width: Option<usize> = None;
 
-    client::invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
-        &cmd.connection,
-        "ready",
-        name,
-        "Watch",
-        ReadyRequest { scopes: cmd.scopes.clone() },
-        |resp| {
-            output::data(
-                || &resp.scopes,
-                || {
-                    if resp.scopes.is_empty() {
-                        output::empty(format_args!("No scopes found for {name}."));
-                        return;
+    // The stream runs in its own task, forwarding each response, because
+    // the staleness ticker must interleave with messages rather than wait
+    // for the next one — a silent-but-open stream is exactly the case it
+    // exists for. The request opts into observation updates so heartbeats
+    // reach the staleness tracker instead of only state changes.
+    let (sender, mut receiver) = mpsc::unbounded_channel::<StreamItem>();
+    let connection_args = cmd.connection.clone();
+    let scopes_filter = cmd.scopes.clone();
+    let service = name.to_owned();
+    let stream = tokio::spawn(async move {
+        let outcome = client::invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
+            &connection_args,
+            "ready",
+            &service,
+            "Watch",
+            ReadyRequest {
+                scopes: scopes_filter,
+                include_observation_updates: true,
+            },
+            |resp: ReadyResponse| {
+                let _ = sender.send(StreamItem::Message(resp));
+            },
+        )
+        .await;
+
+        let _ = sender.send(StreamItem::Done(outcome));
+    });
+
+    let mut ticker = tokio::time::interval(render::STALENESS_TICK);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    let outcome = loop {
+        tokio::select! {
+            item = receiver.recv() => match item {
+                Some(StreamItem::Message(resp)) => {
+                    render_watch_message(
+                        cmd,
+                        name,
+                        &resp,
+                        &mut snapshot,
+                        &mut stale_flags,
+                        &mut name_width,
+                    );
+                }
+                // The sender lives only inside the stream task, so a closed
+                // channel means the task ended without reporting — a panic.
+                // Awaiting the handle surfaces it instead of ending a
+                // monitoring command with a success exit code. Returning
+                // here also detaches the already-finished task, so the
+                // loop-exit abort below stays unreachable for this path.
+                None => {
+                    return match stream.await {
+                        Ok(()) => Ok(()),
+                        Err(join) => Err(Error::new(
+                            ErrorKind::Unavailable,
+                            "ready",
+                            &cmd.connection.endpoint,
+                            format!("watch stream task failed: {join}"),
+                        )),
+                    };
+                }
+                Some(StreamItem::Done(outcome)) => break outcome,
+            },
+            _ = ticker.tick() => {
+                render_staleness_flips(&snapshot, &mut stale_flags, cmd.stale_multiple);
+            }
+        }
+    };
+
+    stream.abort();
+    outcome
+}
+
+/// Renders one `Watch` message: the first renders the status block, each
+/// later one renders a transition line per changed scope, and both record
+/// the scopes into `snapshot`. `stale_flags` is seeded on the first
+/// message — the block already shows the initial staleness tags.
+fn render_watch_message(
+    cmd: &Cmd,
+    name: &str,
+    resp: &ReadyResponse,
+    snapshot: &mut BTreeMap<(String, String), Scope>,
+    stale_flags: &mut BTreeMap<(String, String), bool>,
+    name_width: &mut Option<usize>,
+) {
+    output::data(
+        || &resp.scopes,
+        || {
+            if resp.scopes.is_empty() {
+                output::empty(format_args!("No scopes found for {name}."));
+                return;
+            }
+
+            let mut scopes = resp.scopes.clone();
+            scopes.sort_by(|a, b| a.name.cmp(&b.name));
+
+            match name_width {
+                None => {
+                    let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
+                    *name_width = Some(width);
+
+                    for scope in &scopes {
+                        snapshot.insert((name.to_owned(), scope.name.clone()), scope.clone());
                     }
 
-                    let mut scopes = resp.scopes.clone();
-                    scopes.sort_by(|a, b| a.name.cmp(&b.name));
+                    // One clock reading for both the rendered tags and the
+                    // seeded verdicts, so a threshold crossed during the
+                    // render neither hides the first stale line nor
+                    // immediately duplicates it.
+                    let now = SystemTime::now();
+                    render::print_status_block(name, &scopes, width, cmd.stale_multiple, now, true);
 
-                    match name_width {
-                        None => {
-                            let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
-                            name_width = Some(width);
+                    // Seed the verdicts the ticker flips against, dropping
+                    // the seed call's own flips: the block just showed them.
+                    let _ = render::staleness_flips(snapshot, stale_flags, now, cmd.stale_multiple);
+                }
+                Some(width) => {
+                    let width = *width;
+                    for scope in &scopes {
+                        let transition = render::record_transition(snapshot, name, scope);
 
-                            for scope in &scopes {
-                                snapshot.insert((name.to_owned(), scope.name.clone()), scope.clone());
-                            }
-
-                            render::print_status_block(name, &scopes, width, cmd.stale_after, true);
-                        }
-                        Some(width) => {
-                            for scope in &scopes {
-                                let transition = render::record_transition(&mut snapshot, name, scope);
-
-                                if transition != render::Transition::Unchanged {
-                                    render::print_transition_line(
-                                        render::ServiceColumn::None,
-                                        scope,
-                                        width,
-                                        transition,
-                                    );
-                                }
-                            }
+                        if transition != render::Transition::Unchanged {
+                            render::print_transition_line(render::ServiceColumn::None, scope, width, transition);
                         }
                     }
-                },
-            );
+
+                    // A message refreshes the observations it carries, so
+                    // its scopes may have just gone fresh again.
+                    render_staleness_flips(snapshot, stale_flags, cmd.stale_multiple);
+                }
+            }
         },
-    )
-    .await
+    );
+}
+
+/// Renders every staleness flip against `snapshot`, in human output only.
+///
+/// A serializing backend sees no staleness lines: the verdict is derived
+/// from the `observed_at` and `expected_observation_interval` fields every
+/// message already carries, and re-deriving it here would multiply the
+/// wire's event vocabulary for no new information.
+fn render_staleness_flips(
+    snapshot: &BTreeMap<(String, String), Scope>,
+    stale_flags: &mut BTreeMap<(String, String), bool>,
+    stale_multiple: u32,
+) {
+    if output::serializes() {
+        return;
+    }
+
+    let flips = render::staleness_flips(snapshot, stale_flags, SystemTime::now(), stale_multiple);
+    for ((_, scope_name), staleness) in flips {
+        render::print_staleness_line(render::ServiceColumn::None, scope_name.as_str(), 0, &staleness);
+    }
 }
 
 /// Probes every discovered readiness service over one shared connection.
@@ -334,13 +451,16 @@ async fn run_aggregate(cmd: Cmd) -> Result<bool, Error> {
 
             let scopes = reports.iter().flat_map(|report| report.scopes.iter());
             let width = render::name_width(scopes.map(|scope| scope.name.as_str()));
+            // One clock reading for every block, so staleness tags across
+            // services are computed against the same instant.
+            let now = SystemTime::now();
 
             for (idx, report) in reports.iter().enumerate() {
                 if idx > 0 {
                     println!();
                 }
 
-                print_report(report, width, cmd.stale_after);
+                print_report(report, width, cmd.stale_multiple, now);
             }
         },
     );
@@ -350,7 +470,10 @@ async fn run_aggregate(cmd: Cmd) -> Result<bool, Error> {
 
 /// Probes one service's `Ready` over the shared connection.
 async fn probe(connection: &Connection, service: String) -> ServiceReport {
-    let request = ReadyRequest { scopes: Vec::new() };
+    let request = ReadyRequest {
+        scopes: Vec::new(),
+        include_observation_updates: false,
+    };
 
     match connection
         .invoke_unary::<_, ReadyResponse>("ready", &service, "Ready", request)
@@ -388,10 +511,10 @@ fn is_ready(scope: &Scope) -> bool {
 }
 
 /// Renders one service's block of the aggregate probe.
-fn print_report(report: &ServiceReport, name_width: usize, stale_after: Duration) {
+fn print_report(report: &ServiceReport, name_width: usize, stale_multiple: u32, now: SystemTime) {
     match &report.error {
         Some(message) => print_service_error(&report.service, message),
-        None => render::print_status_block(&report.service, &report.scopes, name_width, stale_after, false),
+        None => render::print_status_block(&report.service, &report.scopes, name_width, stale_multiple, now, false),
     }
 }
 
@@ -503,6 +626,7 @@ mod test {
             reasons: Vec::new(),
             observed_at: None,
             last_transition_time: None,
+            expected_observation_interval: None,
         }
     }
 

--- a/cli/modules/ready/src/render/age.rs
+++ b/cli/modules/ready/src/render/age.rs
@@ -3,94 +3,173 @@
 use core::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use prost_types::Timestamp;
+use prost_types::{Duration as ProstDuration, Timestamp};
 
 /// Returns whether a scope's staleness tag should be shown.
 ///
-/// True only when the scope has been re-observed since its last transition
-/// and that observation is older than `stale_after`. A scope set once and
-/// never re-observed is never stale; `stale_after == Duration::ZERO`
-/// disables the tag unconditionally.
+/// A scope with an observation contract goes stale once the time since its
+/// last observation exceeds the contract multiplied by `multiple`. A scope
+/// without a contract has no natural heartbeat and is never judged stale.
 pub fn is_stale(
     observed_at: Option<&Timestamp>,
-    last_transition_time: Option<&Timestamp>,
+    expected_interval: Option<&ProstDuration>,
     now: SystemTime,
-    stale_after: Duration,
+    multiple: u32,
 ) -> bool {
-    if stale_after.is_zero() {
-        return false;
-    }
-
-    let (Some(observed_at), Some(last_transition_time)) = (observed_at, last_transition_time) else {
+    let Some(expected_interval) = expected_interval else {
         return false;
     };
 
-    if (observed_at.seconds, observed_at.nanos) <= (last_transition_time.seconds, last_transition_time.nanos) {
+    let Some(observed_at) = observed_at else {
+        return false;
+    };
+
+    let threshold = observation_threshold(expected_interval, multiple);
+    if threshold.is_zero() {
         return false;
     }
 
-    let now_secs = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-    let observed_secs = observed_at.seconds.max(0) as u64;
-    let age = Duration::from_secs(now_secs.saturating_sub(observed_secs));
+    // Full nanosecond timestamps on both sides: a threshold can land
+    // between two whole seconds, so truncating either timestamp to seconds
+    // could push an age across it early. The clock's u128 nanoseconds
+    // saturate into i128 rather than truncating, so the arithmetic stays
+    // valid past u64's nanosecond horizon.
+    let now_nanos = i128::try_from(now.duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos()).unwrap_or(i128::MAX);
+    let observed_nanos = i128::from(observed_at.seconds)
+        .saturating_mul(1_000_000_000)
+        .saturating_add(i128::from(observed_at.nanos));
+    let age_nanos = now_nanos.saturating_sub(observed_nanos).max(0);
+    let age = Duration::from_nanos(u64::try_from(age_nanos).unwrap_or(u64::MAX));
 
-    age > stale_after
+    age > threshold
+}
+
+/// Converts an observation contract and its multiplier into the staleness
+/// threshold.
+///
+/// A contract that resolves to a non-positive span yields a zero threshold,
+/// which `is_stale` treats as "never stale".
+fn observation_threshold(expected_interval: &ProstDuration, multiple: u32) -> Duration {
+    let seconds = expected_interval.seconds;
+    let nanos = expected_interval.nanos;
+    if seconds < 0 || nanos < 0 {
+        return Duration::ZERO;
+    }
+
+    // Exact integer arithmetic in nanoseconds with saturation: no rounding
+    // and no overflow for any realistic contract and multiplier.
+    let total_nanos = (seconds as i128)
+        .saturating_mul(1_000_000_000)
+        .saturating_add(i128::from(nanos));
+    let threshold_nanos = total_nanos.saturating_mul(i128::from(multiple));
+    if threshold_nanos <= 0 || threshold_nanos > u64::MAX as i128 {
+        return Duration::ZERO;
+    }
+
+    Duration::from_nanos(threshold_nanos as u64)
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
 
-    #[test]
-    fn is_stale_disabled_when_stale_after_zero() {
-        let now = SystemTime::now();
-        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
-        let old = Timestamp { seconds: now_secs - 10_000, nanos: 0 };
-        let recent = Timestamp { seconds: now_secs, nanos: 0 };
+    fn timestamp(seconds_ago: i64, now_secs: i64) -> Timestamp {
+        Timestamp {
+            seconds: now_secs - seconds_ago,
+            nanos: 0,
+        }
+    }
 
-        assert!(!is_stale(Some(&old), Some(&recent), now, Duration::ZERO));
+    fn interval(seconds: i64) -> ProstDuration {
+        ProstDuration { seconds, nanos: 0 }
     }
 
     #[test]
-    fn is_stale_never_for_set_once_scope() {
+    fn test_is_stale_true_past_multiplied_contract() {
         let now = SystemTime::now();
         let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
-        let ts = Timestamp { seconds: now_secs - 10_000, nanos: 0 };
+        let observed = timestamp(601, now_secs);
 
-        assert!(!is_stale(Some(&ts), Some(&ts), now, Duration::from_secs(60)));
+        // 300s contract, multiplier 2: the observation is past 600s.
+        assert!(is_stale(Some(&observed), Some(&interval(300)), now, 2));
     }
 
     #[test]
-    fn is_stale_true_past_threshold() {
+    fn test_is_stale_false_within_multiplied_contract() {
         let now = SystemTime::now();
         let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
-        let transition = Timestamp { seconds: now_secs - 10_000, nanos: 0 };
-        let observed = Timestamp { seconds: now_secs - 120, nanos: 0 };
+        let observed = timestamp(599, now_secs);
 
-        assert!(is_stale(
-            Some(&observed),
-            Some(&transition),
-            now,
-            Duration::from_secs(60)
-        ));
+        assert!(!is_stale(Some(&observed), Some(&interval(300)), now, 2));
     }
 
     #[test]
-    fn is_stale_false_within_threshold() {
+    fn test_is_stale_uses_own_contract_per_scope() {
         let now = SystemTime::now();
         let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
-        let transition = Timestamp { seconds: now_secs - 10_000, nanos: 0 };
-        let observed = Timestamp { seconds: now_secs - 10, nanos: 0 };
+        let observed = timestamp(130, now_secs);
 
+        // The same age crosses a 30s contract at 4x but stays within a 5m
+        // contract — the tag follows the scope's own cadence, not a global
+        // constant.
+        assert!(is_stale(Some(&observed), Some(&interval(30)), now, 4));
+        assert!(!is_stale(Some(&observed), Some(&interval(300)), now, 4));
+    }
+
+    #[test]
+    fn test_is_stale_honors_sub_second_precision() {
+        // A fixed epoch-based clock, so the test controls the nanosecond
+        // offset of `now` instead of inheriting `SystemTime::now`'s.
+        let now = UNIX_EPOCH + Duration::new(10_000, 0);
+
+        // Contract 1s, multiplier 2: the threshold is exactly 2s. An age of
+        // 1.9s stays below it and an age of 2.1s crosses it — truncating
+        // either timestamp to whole seconds would read both as 2s or 3s and
+        // blur the boundary.
+        let within = Timestamp { seconds: 9_998, nanos: 100_000_000 };
+        let beyond = Timestamp { seconds: 9_997, nanos: 900_000_000 };
+
+        assert!(!is_stale(Some(&within), Some(&interval(1)), now, 2));
+        assert!(is_stale(Some(&beyond), Some(&interval(1)), now, 2));
+    }
+
+    #[test]
+    fn test_is_stale_never_without_contract() {
+        let now = SystemTime::now();
+        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let observed = timestamp(10_000, now_secs);
+
+        // A set-once scope publishes no contract and is never stale.
+        assert!(!is_stale(Some(&observed), None, now, 3));
+    }
+
+    #[test]
+    fn test_is_stale_false_when_observation_missing() {
+        assert!(!is_stale(None, Some(&interval(30)), SystemTime::now(), 3));
+    }
+
+    #[test]
+    fn test_is_stale_disabled_when_multiple_zero() {
+        let now = SystemTime::now();
+        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let observed = timestamp(10_000, now_secs);
+
+        assert!(!is_stale(Some(&observed), Some(&interval(30)), now, 0));
+    }
+
+    #[test]
+    fn test_is_stale_disabled_for_non_positive_contract() {
+        let now = SystemTime::now();
+        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let observed = timestamp(10_000, now_secs);
+
+        // A zero or negative contract is the wire form of "no contract".
+        assert!(!is_stale(Some(&observed), Some(&interval(0)), now, 3));
         assert!(!is_stale(
             Some(&observed),
-            Some(&transition),
+            Some(&ProstDuration { seconds: -5, nanos: 0 }),
             now,
-            Duration::from_secs(60)
+            3
         ));
-    }
-
-    #[test]
-    fn is_stale_false_when_timestamps_missing() {
-        assert!(!is_stale(None, None, SystemTime::now(), Duration::from_secs(60)));
     }
 }

--- a/cli/modules/ready/src/render/age.rs
+++ b/cli/modules/ready/src/render/age.rs
@@ -73,10 +73,15 @@ fn observation_threshold(expected_interval: &ProstDuration, multiple: u32) -> Du
 mod test {
     use super::*;
 
-    fn timestamp(seconds_ago: i64, now_secs: i64) -> Timestamp {
+    fn now() -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(10_000)
+    }
+
+    fn observed_at(age: Duration) -> Timestamp {
+        let observed = now().duration_since(UNIX_EPOCH).unwrap() - age;
         Timestamp {
-            seconds: now_secs - seconds_ago,
-            nanos: 0,
+            seconds: observed.as_secs() as i64,
+            nanos: observed.subsec_nanos() as i32,
         }
     }
 
@@ -85,91 +90,47 @@ mod test {
     }
 
     #[test]
-    fn test_is_stale_true_past_multiplied_contract() {
-        let now = SystemTime::now();
-        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
-        let observed = timestamp(601, now_secs);
+    fn test_is_stale_requires_age_strictly_past_exact_boundary() {
+        let boundary = observed_at(Duration::from_secs(600));
+        let past = observed_at(Duration::from_nanos(600_000_000_001));
 
-        // 300s contract, multiplier 2: the observation is past 600s.
-        assert!(is_stale(Some(&observed), Some(&interval(300)), now, 2));
+        assert!(!is_stale(Some(&boundary), Some(&interval(300)), now(), 2));
+        assert!(is_stale(Some(&past), Some(&interval(300)), now(), 2));
     }
 
     #[test]
-    fn test_is_stale_false_within_multiplied_contract() {
-        let now = SystemTime::now();
-        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
-        let observed = timestamp(599, now_secs);
+    fn test_is_stale_uses_distinct_interval_per_scope() {
+        let observed = observed_at(Duration::from_secs(130));
 
-        assert!(!is_stale(Some(&observed), Some(&interval(300)), now, 2));
+        assert!(is_stale(Some(&observed), Some(&interval(30)), now(), 4));
+        assert!(!is_stale(Some(&observed), Some(&interval(300)), now(), 4));
     }
 
     #[test]
-    fn test_is_stale_uses_own_contract_per_scope() {
-        let now = SystemTime::now();
-        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
-        let observed = timestamp(130, now_secs);
+    fn test_is_stale_false_without_observation_contract() {
+        let observed = observed_at(Duration::from_secs(1_000));
 
-        // The same age crosses a 30s contract at 4x but stays within a 5m
-        // contract — the tag follows the scope's own cadence, not a global
-        // constant.
-        assert!(is_stale(Some(&observed), Some(&interval(30)), now, 4));
-        assert!(!is_stale(Some(&observed), Some(&interval(300)), now, 4));
+        assert!(!is_stale(Some(&observed), None, now(), 3));
     }
 
     #[test]
-    fn test_is_stale_honors_sub_second_precision() {
-        // A fixed epoch-based clock, so the test controls the nanosecond
-        // offset of `now` instead of inheriting `SystemTime::now`'s.
-        let now = UNIX_EPOCH + Duration::new(10_000, 0);
-
-        // Contract 1s, multiplier 2: the threshold is exactly 2s. An age of
-        // 1.9s stays below it and an age of 2.1s crosses it — truncating
-        // either timestamp to whole seconds would read both as 2s or 3s and
-        // blur the boundary.
-        let within = Timestamp { seconds: 9_998, nanos: 100_000_000 };
-        let beyond = Timestamp { seconds: 9_997, nanos: 900_000_000 };
-
-        assert!(!is_stale(Some(&within), Some(&interval(1)), now, 2));
-        assert!(is_stale(Some(&beyond), Some(&interval(1)), now, 2));
+    fn test_is_stale_false_without_observation() {
+        assert!(!is_stale(None, Some(&interval(30)), now(), 3));
     }
 
     #[test]
-    fn test_is_stale_never_without_contract() {
-        let now = SystemTime::now();
-        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
-        let observed = timestamp(10_000, now_secs);
+    fn test_is_stale_false_when_multiplier_is_zero() {
+        let observed = observed_at(Duration::from_secs(1_000));
 
-        // A set-once scope publishes no contract and is never stale.
-        assert!(!is_stale(Some(&observed), None, now, 3));
+        assert!(!is_stale(Some(&observed), Some(&interval(30)), now(), 0));
     }
 
     #[test]
-    fn test_is_stale_false_when_observation_missing() {
-        assert!(!is_stale(None, Some(&interval(30)), SystemTime::now(), 3));
-    }
+    fn test_is_stale_preserves_nanosecond_timestamp_precision() {
+        let within = observed_at(Duration::from_nanos(1_999_999_999));
+        let past = observed_at(Duration::from_nanos(2_000_000_001));
 
-    #[test]
-    fn test_is_stale_disabled_when_multiple_zero() {
-        let now = SystemTime::now();
-        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
-        let observed = timestamp(10_000, now_secs);
-
-        assert!(!is_stale(Some(&observed), Some(&interval(30)), now, 0));
-    }
-
-    #[test]
-    fn test_is_stale_disabled_for_non_positive_contract() {
-        let now = SystemTime::now();
-        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
-        let observed = timestamp(10_000, now_secs);
-
-        // A zero or negative contract is the wire form of "no contract".
-        assert!(!is_stale(Some(&observed), Some(&interval(0)), now, 3));
-        assert!(!is_stale(
-            Some(&observed),
-            Some(&ProstDuration { seconds: -5, nanos: 0 }),
-            now,
-            3
-        ));
+        assert!(!is_stale(Some(&within), Some(&interval(1)), now(), 2));
+        assert!(is_stale(Some(&past), Some(&interval(1)), now(), 2));
     }
 }

--- a/cli/modules/ready/src/render/age.rs
+++ b/cli/modules/ready/src/render/age.rs
@@ -8,8 +8,8 @@ use prost_types::{Duration as ProstDuration, Timestamp};
 /// Returns whether a scope's staleness tag should be shown.
 ///
 /// A scope with an observation contract goes stale once the time since its
-/// last observation exceeds the contract multiplied by `multiple`. A scope
-/// without a contract has no natural heartbeat and is never judged stale.
+/// last observation exceeds the contract times the configured multiplier. A
+/// scope without a contract has no natural heartbeat and is never judged stale.
 pub fn is_stale(
     observed_at: Option<&Timestamp>,
     expected_interval: Option<&ProstDuration>,
@@ -29,11 +29,12 @@ pub fn is_stale(
         return false;
     }
 
-    // Full nanosecond timestamps on both sides: a threshold can land
-    // between two whole seconds, so truncating either timestamp to seconds
-    // could push an age across it early. The clock's u128 nanoseconds
-    // saturate into i128 rather than truncating, so the arithmetic stays
-    // valid past u64's nanosecond horizon.
+    // Preserve subsecond precision so thresholds between whole seconds are
+    // not crossed early.
+    //
+    // The clock's nanosecond count saturates into the signed arithmetic range
+    // rather than truncating, so calculations remain valid past the unsigned
+    // 64-bit nanosecond horizon.
     let now_nanos = i128::try_from(now.duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos()).unwrap_or(i128::MAX);
     let observed_nanos = i128::from(observed_at.seconds)
         .saturating_mul(1_000_000_000)
@@ -44,11 +45,7 @@ pub fn is_stale(
     age > threshold
 }
 
-/// Converts an observation contract and its multiplier into the staleness
-/// threshold.
-///
-/// A contract that resolves to a non-positive span yields a zero threshold,
-/// which `is_stale` treats as "never stale".
+/// A non-positive observation contract disables staleness detection.
 fn observation_threshold(expected_interval: &ProstDuration, multiple: u32) -> Duration {
     let seconds = expected_interval.seconds;
     let nanos = expected_interval.nanos;
@@ -56,8 +53,8 @@ fn observation_threshold(expected_interval: &ProstDuration, multiple: u32) -> Du
         return Duration::ZERO;
     }
 
-    // Exact integer arithmetic in nanoseconds with saturation: no rounding
-    // and no overflow for any realistic contract and multiplier.
+    // Saturating nanosecond arithmetic avoids rounding and overflow for any
+    // realistic contract and multiplier.
     let total_nanos = (seconds as i128)
         .saturating_mul(1_000_000_000)
         .saturating_add(i128::from(nanos));
@@ -73,10 +70,12 @@ fn observation_threshold(expected_interval: &ProstDuration, multiple: u32) -> Du
 mod test {
     use super::*;
 
+    // Returns a fixed reference time for deterministic age calculations.
     fn now() -> SystemTime {
         UNIX_EPOCH + Duration::from_secs(10_000)
     }
 
+    // Returns a timestamp at the requested age before the reference time.
     fn observed_at(age: Duration) -> Timestamp {
         let observed = now().duration_since(UNIX_EPOCH).unwrap() - age;
         Timestamp {
@@ -85,6 +84,7 @@ mod test {
         }
     }
 
+    // Returns a whole-second observation contract.
     fn interval(seconds: i64) -> ProstDuration {
         ProstDuration { seconds, nanos: 0 }
     }

--- a/cli/modules/ready/src/render/mod.rs
+++ b/cli/modules/ready/src/render/mod.rs
@@ -9,7 +9,6 @@ mod age;
 mod layout;
 mod watch;
 
-use core::time::Duration;
 use std::time::SystemTime;
 
 use colored::Colorize;
@@ -21,19 +20,9 @@ pub use self::{
     layout::name_width,
     watch::{
         Membership, ServiceColumn, Transition, print_lifecycle_line, print_lost_line, print_membership_line,
-        print_staleness_line, print_transition_line, record_transition, staleness_flips,
+        print_transition_line, record_transition,
     },
 };
-
-/// How often a `--watch` loop re-evaluates every tracked scope's
-/// staleness.
-///
-/// A stopped heartbeat produces no stream message to react to, so
-/// staleness crossings are found by polling. One second is fine enough to
-/// flag a scope within one missed observation of the finest in-tree
-/// contract (the RIB sampler's 1s) yet coarse enough to add no perceptible
-/// load: the evaluation is a map walk over the merged snapshot.
-pub const STALENESS_TICK: Duration = Duration::from_secs(1);
 
 /// Fixed width of the state label cell (`len("NOT_READY")`).
 const STATE_WIDTH: usize = 9;
@@ -92,13 +81,11 @@ impl Symbols {
 
 /// Renders the full one-shot status block for `scopes` to stdout.
 ///
-/// Renders the full one-shot status block for `scopes` to stdout.
-///
 /// `name_width` must be computed once via [`name_width`] and held constant
 /// across the render — recomputing it per row would make the column jitter.
-/// `now` is supplied by the caller so the staleness tags shown here and the
-/// verdicts a watch loop seeds from the same render agree on one point in
-/// time. The header line is `{name}{dash}{summary}`; `watching` appends a
+/// `now` is supplied by the caller so every scope in a snapshot is judged
+/// against one point in time. The header line is `{name}{dash}{summary}`;
+/// `watching` appends a
 /// `watching` suffix to that summary and, once the block is printed, adds
 /// one trailing blank line to separate it from the `--watch` transition log
 /// that follows.

--- a/cli/modules/ready/src/render/mod.rs
+++ b/cli/modules/ready/src/render/mod.rs
@@ -83,8 +83,8 @@ impl Symbols {
 ///
 /// `name_width` must be computed once via [`name_width`] and held constant
 /// across the render — recomputing it per row would make the column jitter.
-/// `now` is supplied by the caller so every scope in a snapshot is judged
-/// against one point in time. The header line is `{name}{dash}{summary}`;
+/// Every scope in a snapshot is judged against one point in time. The header
+/// line is `{name}{dash}{summary}`;
 /// `watching` appends a
 /// `watching` suffix to that summary and, once the block is printed, adds
 /// one trailing blank line to separate it from the `--watch` transition log

--- a/cli/modules/ready/src/render/mod.rs
+++ b/cli/modules/ready/src/render/mod.rs
@@ -21,9 +21,19 @@ pub use self::{
     layout::name_width,
     watch::{
         Membership, ServiceColumn, Transition, print_lifecycle_line, print_lost_line, print_membership_line,
-        print_transition_line, record_transition,
+        print_staleness_line, print_transition_line, record_transition, staleness_flips,
     },
 };
+
+/// How often a `--watch` loop re-evaluates every tracked scope's
+/// staleness.
+///
+/// A stopped heartbeat produces no stream message to react to, so
+/// staleness crossings are found by polling. One second is fine enough to
+/// flag a scope within one missed observation of the finest in-tree
+/// contract (the RIB sampler's 1s) yet coarse enough to add no perceptible
+/// load: the evaluation is a map walk over the merged snapshot.
+pub const STALENESS_TICK: Duration = Duration::from_secs(1);
 
 /// Fixed width of the state label cell (`len("NOT_READY")`).
 const STATE_WIDTH: usize = 9;
@@ -82,14 +92,24 @@ impl Symbols {
 
 /// Renders the full one-shot status block for `scopes` to stdout.
 ///
+/// Renders the full one-shot status block for `scopes` to stdout.
+///
 /// `name_width` must be computed once via [`name_width`] and held constant
 /// across the render — recomputing it per row would make the column jitter.
-/// The header line is `{name}{dash}{summary}`; `watching` appends a
+/// `now` is supplied by the caller so the staleness tags shown here and the
+/// verdicts a watch loop seeds from the same render agree on one point in
+/// time. The header line is `{name}{dash}{summary}`; `watching` appends a
 /// `watching` suffix to that summary and, once the block is printed, adds
 /// one trailing blank line to separate it from the `--watch` transition log
 /// that follows.
-pub fn print_status_block(name: &str, scopes: &[Scope], name_width: usize, stale_after: Duration, watching: bool) {
-    let now = SystemTime::now();
+pub fn print_status_block(
+    name: &str,
+    scopes: &[Scope],
+    name_width: usize,
+    stale_multiple: u32,
+    now: SystemTime,
+    watching: bool,
+) {
     let colored = output::is_colored();
     let symbols = Symbols::new(colored);
     let wrap_width = display::terminal_width();
@@ -109,7 +129,7 @@ pub fn print_status_block(name: &str, scopes: &[Scope], name_width: usize, stale
     println!("{name}{}{summary}", symbols.dash);
 
     for scope in scopes {
-        print_scope_row(scope, name_width, stale_after, now, colored, wrap_width);
+        print_scope_row(scope, name_width, stale_multiple, now, colored, wrap_width);
     }
 
     if watching {
@@ -168,7 +188,7 @@ pub fn print_all_ready_line() {
 fn print_scope_row(
     scope: &Scope,
     name_width: usize,
-    stale_after: Duration,
+    stale_multiple: u32,
     now: SystemTime,
     colored: bool,
     wrap_width: Option<usize>,
@@ -183,9 +203,9 @@ fn print_scope_row(
 
     if is_stale(
         scope.observed_at.as_ref(),
-        scope.last_transition_time.as_ref(),
+        scope.expected_observation_interval.as_ref(),
         now,
-        stale_after,
+        stale_multiple,
     ) {
         let stale_age = humanfmt::format_age(scope.observed_at.as_ref(), now).unwrap_or_default();
         let tag = format!("stale {stale_age}");

--- a/cli/modules/ready/src/render/watch.rs
+++ b/cli/modules/ready/src/render/watch.rs
@@ -4,14 +4,14 @@
 //! registry membership line renderer used by its re-discovery sweep.
 
 use core::time::Duration;
-use std::{collections::BTreeMap, time::SystemTime};
+use std::collections::BTreeMap;
 
 use chrono::Local;
 use colored::Colorize;
 use readinesspb::pb::{Scope, State};
-use ync::{display, humanfmt, output};
+use ync::{display, output};
 
-use super::{StateStyle, Symbols, age::is_stale, dim, layout::normalize_whitespace};
+use super::{StateStyle, Symbols, dim, layout::normalize_whitespace};
 
 /// Gap between the transition line's prefix and the reason text that follows
 /// it on the same line.
@@ -393,102 +393,6 @@ pub fn print_membership_line(alias: &str, alias_width: usize, membership: Member
     println!();
 }
 
-/// One direction of a per-scope staleness verdict flip.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Staleness {
-    /// The scope crossed its per-scope threshold; `age` is the
-    /// preformatted time since its last observation.
-    Stale { age: String },
-    /// A fresh observation arrived and cleared a previous stale flag.
-    Fresh,
-}
-
-/// Recomputes every snapshot scope's staleness against the tracked
-/// verdicts and returns the flips, in snapshot order.
-///
-/// `flagged` holds the last verdict per `(service, scope name)` key. A key
-/// seen for the first time is recorded, and a first sighting that is
-/// already stale reports one `Stale` flip: a scope can enter the snapshot
-/// mid-stream with a long-dead observation (a service picked up by the
-/// re-discovery sweep, a scope first appearing between heartbeats), and
-/// staying silent would swallow the only chance to warn. A first sighting
-/// that is fresh stays silent — the absence of a warning is not news. A
-/// watch loop that renders a startup snapshot seeds the map by calling
-/// this once against it and discarding the result, since the block already
-/// shows the tags. Flips are returned rather than printed so the caller
-/// can gate them on the output format and supply its own service column.
-pub fn staleness_flips(
-    snapshot: &BTreeMap<(String, String), Scope>,
-    flagged: &mut BTreeMap<(String, String), bool>,
-    now: SystemTime,
-    multiple: u32,
-) -> Vec<((String, String), Staleness)> {
-    let mut flips = Vec::new();
-
-    for (key, scope) in snapshot {
-        let stale = is_stale(
-            scope.observed_at.as_ref(),
-            scope.expected_observation_interval.as_ref(),
-            now,
-            multiple,
-        );
-
-        match flagged.get(key) {
-            Some(&was) if was != stale => {
-                flagged.insert(key.clone(), stale);
-                if stale {
-                    let age = humanfmt::format_age(scope.observed_at.as_ref(), now).unwrap_or_default();
-                    flips.push((key.clone(), Staleness::Stale { age }));
-                } else {
-                    flips.push((key.clone(), Staleness::Fresh));
-                }
-            }
-            Some(_) => {}
-            None => {
-                flagged.insert(key.clone(), stale);
-                if stale {
-                    let age = humanfmt::format_age(scope.observed_at.as_ref(), now).unwrap_or_default();
-                    flips.push((key.clone(), Staleness::Stale { age }));
-                }
-            }
-        }
-    }
-
-    flips
-}
-
-/// Prints one append-only log line for a `--watch` staleness flip.
-///
-/// Shares the lifecycle line's dim `[!]` shape — a staleness flip is
-/// neither a readiness transition nor transport chatter, but a warning
-/// about aging data — except the verdict itself: `stale for {age}` carries
-/// the same amber as the one-shot block's stale tag, while `fresh again`
-/// stays dim, matching how the block treats a recovered scope as unworthy
-/// of a tag at all. `scope_name` must already be padded to `name_width` by
-/// the caller when it renders a column.
-pub fn print_staleness_line(service: ServiceColumn, scope_name: &str, name_width: usize, staleness: &Staleness) {
-    let colored = output::is_colored();
-    let timestamp = Local::now().format("%H:%M:%S").to_string();
-    let mark = if colored { "[!]" } else { "[--]" };
-    let name = format!("{scope_name:<name_width$}");
-
-    let prefix = format!("{timestamp}  {mark} {}{name} ", service.cell());
-    print!("{}", dim(&prefix, colored));
-
-    match staleness {
-        Staleness::Stale { age } => {
-            let tag = format!("stale for {age}");
-            if colored {
-                let (r, g, b) = super::STALE_TAG_COLOR;
-                println!("{}", tag.truecolor(r, g, b));
-            } else {
-                println!("{tag}");
-            }
-        }
-        Staleness::Fresh => println!("{}", dim("fresh again", colored)),
-    }
-}
-
 #[cfg(test)]
 mod test {
     use readinesspb::pb::Reason;
@@ -514,119 +418,6 @@ mod test {
             }],
             ..scope(name, state)
         }
-    }
-
-    /// Builds a snapshot map with `observed_at` set to `age` before a fixed
-    /// `now`, plus the given freshness contract.
-    fn aged_snapshot(
-        name: &str,
-        age: Duration,
-        expected_interval: Duration,
-        now: SystemTime,
-    ) -> BTreeMap<(String, String), Scope> {
-        let seconds_back = age.as_secs() as i64;
-        let mut entry = scope(name, State::Ready);
-        entry.observed_at = Some(prost_types::Timestamp {
-            seconds: (now.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as i64) - seconds_back,
-            nanos: 0,
-        });
-        entry.expected_observation_interval = Some(prost_types::Duration {
-            seconds: expected_interval.as_secs() as i64,
-            nanos: 0,
-        });
-
-        BTreeMap::from([(("svc".to_owned(), name.to_owned()), entry)])
-    }
-
-    /// verifies that a first fresh sighting records its verdict silently,
-    /// so seeding a watch loop never echoes the block's own tags as events.
-    #[test]
-    fn test_staleness_flips_first_fresh_sighting_is_silent() {
-        let now = SystemTime::UNIX_EPOCH + Duration::new(10_000, 0);
-        // 10s contract at 3x: a 20s-old observation is still fresh.
-        let snapshot = aged_snapshot("rib", Duration::from_secs(20), Duration::from_secs(10), now);
-        let mut flagged = BTreeMap::new();
-
-        let flips = staleness_flips(&snapshot, &mut flagged, now, 3);
-
-        assert!(flips.is_empty());
-        assert_eq!(
-            &false,
-            flagged
-                .get(&("svc".to_owned(), "rib".to_owned()))
-                .expect("verdict recorded")
-        );
-    }
-
-    /// verifies that a first sighting that is already stale reports exactly
-    /// one `Stale` flip, so a mid-stream newcomer whose observation died
-    /// before it ever appeared still warns.
-    #[test]
-    fn test_staleness_flips_first_stale_sighting_reports_once() {
-        let now = SystemTime::UNIX_EPOCH + Duration::new(10_000, 0);
-        // 10s contract at 3x: a 40s-old observation is already stale.
-        let snapshot = aged_snapshot("rib", Duration::from_secs(40), Duration::from_secs(10), now);
-        let mut flagged = BTreeMap::new();
-
-        let flips = staleness_flips(&snapshot, &mut flagged, now, 3);
-
-        assert_eq!(1, flips.len());
-        assert!(matches!(&flips[0].1, Staleness::Stale { .. }));
-
-        // The second evaluation of the same dead observation is not news.
-        let flips = staleness_flips(&snapshot, &mut flagged, now, 3);
-        assert!(flips.is_empty());
-    }
-
-    /// verifies that a crossing threshold between evaluations flips the
-    /// verdict to stale, and a later fresh observation flips it back.
-    #[test]
-    fn test_staleness_flips_emit_on_crossing_and_recovery() {
-        let start = SystemTime::UNIX_EPOCH + Duration::new(10_000, 0);
-        // 10s contract at 3x: stale past 30s.
-        let mut snapshot = aged_snapshot("rib", Duration::from_secs(20), Duration::from_secs(10), start);
-        let mut flagged = BTreeMap::new();
-
-        staleness_flips(&snapshot, &mut flagged, start, 3);
-
-        // Twenty seconds later the observation is 40s old: crossed.
-        let later = start + Duration::from_secs(20);
-        let flips = staleness_flips(&snapshot, &mut flagged, later, 3);
-
-        assert_eq!(1, flips.len());
-        assert!(matches!(&flips[0].1, Staleness::Stale { .. }));
-
-        // A fresh message arrives: the observation moves to now.
-        let fresh = start + Duration::from_secs(21);
-        snapshot
-            .get_mut(&("svc".to_owned(), "rib".to_owned()))
-            .expect("scope present")
-            .observed_at = Some(prost_types::Timestamp {
-            seconds: (fresh.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as i64),
-            nanos: 0,
-        });
-        let flips = staleness_flips(&snapshot, &mut flagged, fresh, 3);
-
-        assert_eq!(1, flips.len());
-        assert_eq!(Staleness::Fresh, flips[0].1);
-    }
-
-    /// verifies that a scope without a freshness contract never flips, so
-    /// set-once scopes stay unflagged across ticks.
-    #[test]
-    fn test_staleness_flips_never_for_contractless_scope() {
-        let now = SystemTime::UNIX_EPOCH + Duration::new(10_000, 0);
-        let mut snapshot = aged_snapshot("gateway", Duration::from_secs(20), Duration::from_secs(10), now);
-        snapshot
-            .get_mut(&("svc".to_owned(), "gateway".to_owned()))
-            .expect("scope present")
-            .expected_observation_interval = None;
-        let mut flagged = BTreeMap::new();
-
-        staleness_flips(&snapshot, &mut flagged, now, 3);
-        let flips = staleness_flips(&snapshot, &mut flagged, now + Duration::from_secs(600), 3);
-
-        assert!(flips.is_empty());
     }
 
     /// Drops every ANSI SGR escape (`ESC [ … m`) from `text`, leaving the

--- a/cli/modules/ready/src/render/watch.rs
+++ b/cli/modules/ready/src/render/watch.rs
@@ -4,14 +4,14 @@
 //! registry membership line renderer used by its re-discovery sweep.
 
 use core::time::Duration;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::SystemTime};
 
 use chrono::Local;
 use colored::Colorize;
 use readinesspb::pb::{Scope, State};
-use ync::{display, output};
+use ync::{display, humanfmt, output};
 
-use super::{StateStyle, Symbols, dim, layout::normalize_whitespace};
+use super::{StateStyle, Symbols, age::is_stale, dim, layout::normalize_whitespace};
 
 /// Gap between the transition line's prefix and the reason text that follows
 /// it on the same line.
@@ -393,6 +393,102 @@ pub fn print_membership_line(alias: &str, alias_width: usize, membership: Member
     println!();
 }
 
+/// One direction of a per-scope staleness verdict flip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Staleness {
+    /// The scope crossed its per-scope threshold; `age` is the
+    /// preformatted time since its last observation.
+    Stale { age: String },
+    /// A fresh observation arrived and cleared a previous stale flag.
+    Fresh,
+}
+
+/// Recomputes every snapshot scope's staleness against the tracked
+/// verdicts and returns the flips, in snapshot order.
+///
+/// `flagged` holds the last verdict per `(service, scope name)` key. A key
+/// seen for the first time is recorded, and a first sighting that is
+/// already stale reports one `Stale` flip: a scope can enter the snapshot
+/// mid-stream with a long-dead observation (a service picked up by the
+/// re-discovery sweep, a scope first appearing between heartbeats), and
+/// staying silent would swallow the only chance to warn. A first sighting
+/// that is fresh stays silent — the absence of a warning is not news. A
+/// watch loop that renders a startup snapshot seeds the map by calling
+/// this once against it and discarding the result, since the block already
+/// shows the tags. Flips are returned rather than printed so the caller
+/// can gate them on the output format and supply its own service column.
+pub fn staleness_flips(
+    snapshot: &BTreeMap<(String, String), Scope>,
+    flagged: &mut BTreeMap<(String, String), bool>,
+    now: SystemTime,
+    multiple: u32,
+) -> Vec<((String, String), Staleness)> {
+    let mut flips = Vec::new();
+
+    for (key, scope) in snapshot {
+        let stale = is_stale(
+            scope.observed_at.as_ref(),
+            scope.expected_observation_interval.as_ref(),
+            now,
+            multiple,
+        );
+
+        match flagged.get(key) {
+            Some(&was) if was != stale => {
+                flagged.insert(key.clone(), stale);
+                if stale {
+                    let age = humanfmt::format_age(scope.observed_at.as_ref(), now).unwrap_or_default();
+                    flips.push((key.clone(), Staleness::Stale { age }));
+                } else {
+                    flips.push((key.clone(), Staleness::Fresh));
+                }
+            }
+            Some(_) => {}
+            None => {
+                flagged.insert(key.clone(), stale);
+                if stale {
+                    let age = humanfmt::format_age(scope.observed_at.as_ref(), now).unwrap_or_default();
+                    flips.push((key.clone(), Staleness::Stale { age }));
+                }
+            }
+        }
+    }
+
+    flips
+}
+
+/// Prints one append-only log line for a `--watch` staleness flip.
+///
+/// Shares the lifecycle line's dim `[!]` shape — a staleness flip is
+/// neither a readiness transition nor transport chatter, but a warning
+/// about aging data — except the verdict itself: `stale for {age}` carries
+/// the same amber as the one-shot block's stale tag, while `fresh again`
+/// stays dim, matching how the block treats a recovered scope as unworthy
+/// of a tag at all. `scope_name` must already be padded to `name_width` by
+/// the caller when it renders a column.
+pub fn print_staleness_line(service: ServiceColumn, scope_name: &str, name_width: usize, staleness: &Staleness) {
+    let colored = output::is_colored();
+    let timestamp = Local::now().format("%H:%M:%S").to_string();
+    let mark = if colored { "[!]" } else { "[--]" };
+    let name = format!("{scope_name:<name_width$}");
+
+    let prefix = format!("{timestamp}  {mark} {}{name} ", service.cell());
+    print!("{}", dim(&prefix, colored));
+
+    match staleness {
+        Staleness::Stale { age } => {
+            let tag = format!("stale for {age}");
+            if colored {
+                let (r, g, b) = super::STALE_TAG_COLOR;
+                println!("{}", tag.truecolor(r, g, b));
+            } else {
+                println!("{tag}");
+            }
+        }
+        Staleness::Fresh => println!("{}", dim("fresh again", colored)),
+    }
+}
+
 #[cfg(test)]
 mod test {
     use readinesspb::pb::Reason;
@@ -406,6 +502,7 @@ mod test {
             reasons: Vec::new(),
             observed_at: None,
             last_transition_time: None,
+            expected_observation_interval: None,
         }
     }
 
@@ -417,6 +514,119 @@ mod test {
             }],
             ..scope(name, state)
         }
+    }
+
+    /// Builds a snapshot map with `observed_at` set to `age` before a fixed
+    /// `now`, plus the given freshness contract.
+    fn aged_snapshot(
+        name: &str,
+        age: Duration,
+        expected_interval: Duration,
+        now: SystemTime,
+    ) -> BTreeMap<(String, String), Scope> {
+        let seconds_back = age.as_secs() as i64;
+        let mut entry = scope(name, State::Ready);
+        entry.observed_at = Some(prost_types::Timestamp {
+            seconds: (now.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as i64) - seconds_back,
+            nanos: 0,
+        });
+        entry.expected_observation_interval = Some(prost_types::Duration {
+            seconds: expected_interval.as_secs() as i64,
+            nanos: 0,
+        });
+
+        BTreeMap::from([(("svc".to_owned(), name.to_owned()), entry)])
+    }
+
+    /// verifies that a first fresh sighting records its verdict silently,
+    /// so seeding a watch loop never echoes the block's own tags as events.
+    #[test]
+    fn test_staleness_flips_first_fresh_sighting_is_silent() {
+        let now = SystemTime::UNIX_EPOCH + Duration::new(10_000, 0);
+        // 10s contract at 3x: a 20s-old observation is still fresh.
+        let snapshot = aged_snapshot("rib", Duration::from_secs(20), Duration::from_secs(10), now);
+        let mut flagged = BTreeMap::new();
+
+        let flips = staleness_flips(&snapshot, &mut flagged, now, 3);
+
+        assert!(flips.is_empty());
+        assert_eq!(
+            &false,
+            flagged
+                .get(&("svc".to_owned(), "rib".to_owned()))
+                .expect("verdict recorded")
+        );
+    }
+
+    /// verifies that a first sighting that is already stale reports exactly
+    /// one `Stale` flip, so a mid-stream newcomer whose observation died
+    /// before it ever appeared still warns.
+    #[test]
+    fn test_staleness_flips_first_stale_sighting_reports_once() {
+        let now = SystemTime::UNIX_EPOCH + Duration::new(10_000, 0);
+        // 10s contract at 3x: a 40s-old observation is already stale.
+        let snapshot = aged_snapshot("rib", Duration::from_secs(40), Duration::from_secs(10), now);
+        let mut flagged = BTreeMap::new();
+
+        let flips = staleness_flips(&snapshot, &mut flagged, now, 3);
+
+        assert_eq!(1, flips.len());
+        assert!(matches!(&flips[0].1, Staleness::Stale { .. }));
+
+        // The second evaluation of the same dead observation is not news.
+        let flips = staleness_flips(&snapshot, &mut flagged, now, 3);
+        assert!(flips.is_empty());
+    }
+
+    /// verifies that a crossing threshold between evaluations flips the
+    /// verdict to stale, and a later fresh observation flips it back.
+    #[test]
+    fn test_staleness_flips_emit_on_crossing_and_recovery() {
+        let start = SystemTime::UNIX_EPOCH + Duration::new(10_000, 0);
+        // 10s contract at 3x: stale past 30s.
+        let mut snapshot = aged_snapshot("rib", Duration::from_secs(20), Duration::from_secs(10), start);
+        let mut flagged = BTreeMap::new();
+
+        staleness_flips(&snapshot, &mut flagged, start, 3);
+
+        // Twenty seconds later the observation is 40s old: crossed.
+        let later = start + Duration::from_secs(20);
+        let flips = staleness_flips(&snapshot, &mut flagged, later, 3);
+
+        assert_eq!(1, flips.len());
+        assert!(matches!(&flips[0].1, Staleness::Stale { .. }));
+
+        // A fresh message arrives: the observation moves to now.
+        let fresh = start + Duration::from_secs(21);
+        snapshot
+            .get_mut(&("svc".to_owned(), "rib".to_owned()))
+            .expect("scope present")
+            .observed_at = Some(prost_types::Timestamp {
+            seconds: (fresh.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as i64),
+            nanos: 0,
+        });
+        let flips = staleness_flips(&snapshot, &mut flagged, fresh, 3);
+
+        assert_eq!(1, flips.len());
+        assert_eq!(Staleness::Fresh, flips[0].1);
+    }
+
+    /// verifies that a scope without a freshness contract never flips, so
+    /// set-once scopes stay unflagged across ticks.
+    #[test]
+    fn test_staleness_flips_never_for_contractless_scope() {
+        let now = SystemTime::UNIX_EPOCH + Duration::new(10_000, 0);
+        let mut snapshot = aged_snapshot("gateway", Duration::from_secs(20), Duration::from_secs(10), now);
+        snapshot
+            .get_mut(&("svc".to_owned(), "gateway".to_owned()))
+            .expect("scope present")
+            .expected_observation_interval = None;
+        let mut flagged = BTreeMap::new();
+
+        staleness_flips(&snapshot, &mut flagged, now, 3);
+        let flips = staleness_flips(&snapshot, &mut flagged, now + Duration::from_secs(600), 3);
+
+        assert!(flips.is_empty());
     }
 
     /// Drops every ANSI SGR escape (`ESC [ … m`) from `text`, leaving the

--- a/cli/modules/ready/src/watch.rs
+++ b/cli/modules/ready/src/watch.rs
@@ -98,7 +98,6 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
     };
 
     let mut aggregate = Aggregate::seed(&reports);
-    let mut stale_flags: BTreeMap<(String, String), bool> = BTreeMap::new();
 
     output::data(
         || &snapshot_payload,
@@ -106,9 +105,6 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
             if reports.is_empty() {
                 output::empty(format_args!("No readiness services registered."));
             } else {
-                // One clock reading for every block and for the seeded
-                // verdicts, so the tags shown here and the first flip the
-                // ticker could report agree on one point in time.
                 let now = SystemTime::now();
                 for (idx, report) in reports.iter().enumerate() {
                     if idx > 0 {
@@ -117,11 +113,6 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
 
                     print_report(report, scope_width, cmd.stale_multiple, now);
                 }
-
-                // Seed the verdicts the ticker and message paths flip
-                // against; the blocks above just showed the tags, so the
-                // seed call's own flips are dropped.
-                let _ = render::staleness_flips(&aggregate.snapshot, &mut stale_flags, now, cmd.stale_multiple);
             }
 
             render::print_watching_line();
@@ -143,169 +134,16 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
         supervisors.insert(service.clone(), handle.abort_handle());
     }
 
-    // The render loop resolves a staleness flip's service key to its alias
-    // for the service column. It maintains its own alias map kept in
-    // lockstep with membership events rather than a shared reference: the
-    // re-discovery task owns the original and never rewrites an alias a
-    // running supervisor already holds, while every assignment it makes is
-    // announced in the membership event itself, so this copy never serves
-    // a missing or stale alias for a rediscovered service.
-    let mut alias_index = aliases.clone();
-
     tokio::spawn(rediscover(connection.clone(), supervisors, aliases, sender.clone()));
 
     drop(sender);
 
-    let mut ticker = tokio::time::interval(render::STALENESS_TICK);
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-    loop {
-        tokio::select! {
-            event = receiver.recv() => {
-                let Some(event) = event else { break };
-
-                // An initial message is authoritative for its service, so
-                // the render loop must also forget the service's scopes the
-                // snapshot no longer lists — they disappeared while the
-                // stream was down.
-                let mut initial_scopes: Option<(String, Vec<Scope>)> = None;
-                let carried_scopes = match &event {
-                    Event::Service { service, data: EventData::Message { scopes, initial }, .. } => {
-                        if *initial {
-                            initial_scopes = Some((service.clone(), scopes.clone()));
-                        }
-                        true
-                    }
-                    _ => false,
-                };
-                let membership_delta = match &event {
-                    Event::Membership { discovered, departed } => {
-                        Some((discovered.clone(), departed.clone()))
-                    }
-                    _ => None,
-                };
-
-                if let Some((discovered, _)) = &membership_delta {
-                    for (service, alias) in discovered {
-                        alias_index.insert(service.clone(), alias.clone());
-                    }
-                }
-
-                // An authoritative snapshot must shape the aggregate before
-                // the one readiness recompute render_event performs: forgetting
-                // absent scopes after it would leave a stale crossing (an old
-                // all-ready set with a now-empty snapshot) uncorrected.
-                if let Some((service, present)) = &initial_scopes {
-                    forget_absent_scopes(&mut aggregate.snapshot, &mut stale_flags, service, present);
-                }
-
-                grow_widths(&event, &mut scope_width, &mut alias_width);
-                render_event(event, &mut aggregate, scope_width, alias_width);
-
-                if let Some((_, departed)) = &membership_delta {
-                    for (service, _) in departed {
-                        forget_service(&mut stale_flags, &mut alias_index, service);
-                    }
-                }
-
-                // A message refreshes the observations it carries, so its
-                // scopes may have just gone fresh again; scopes it did not
-                // carry keep their verdicts until the next tick.
-                if carried_scopes {
-                    render_staleness_flips(
-                        &aggregate.snapshot,
-                        &mut stale_flags,
-                        cmd.stale_multiple,
-                        &alias_index,
-                        alias_width,
-                        scope_width,
-                    );
-                }
-            }
-            _ = ticker.tick() => {
-                render_staleness_flips(
-                    &aggregate.snapshot,
-                    &mut stale_flags,
-                    cmd.stale_multiple,
-                    &alias_index,
-                    alias_width,
-                    scope_width,
-                );
-            }
-        }
+    while let Some(event) = receiver.recv().await {
+        grow_widths(&event, &mut scope_width, &mut alias_width);
+        render_event(event, &mut aggregate, scope_width, alias_width);
     }
 
     Ok(true)
-}
-
-/// Drops a departed service's staleness verdicts and alias.
-///
-/// The aggregate snapshot already forgot the service's scopes, so their
-/// verdicts must go too: a later re-registration re-evaluates them from
-/// scratch instead of flipping against the departed era's verdict — which
-/// would print a spurious `fresh again` or swallow a warranted `stale` —
-/// and the verdict map does not grow without bound across the watch's
-/// lifetime. The alias goes with it, since the re-discovery task reassigns
-/// it independently of this copy.
-fn forget_service(
-    stale_flags: &mut BTreeMap<(String, String), bool>,
-    alias_index: &mut BTreeMap<String, String>,
-    service: &str,
-) {
-    stale_flags.retain(|(known, _), _| known != service);
-    alias_index.remove(service);
-}
-
-/// Drops a service's snapshot scopes that its authoritative initial message
-/// no longer lists, together with their staleness verdicts.
-///
-/// An initial `Watch` message after a (re)connect is the server's full and
-/// current truth: a scope it omits no longer exists, so keeping it in the
-/// snapshot would leave it influencing the readiness aggregate and letting
-/// the ticker later print a stale line for a scope that is simply gone.
-/// The present set is taken from the message itself, never derived from the
-/// snapshot, which by definition still holds the scopes in question.
-fn forget_absent_scopes(
-    snapshot: &mut BTreeMap<(String, String), Scope>,
-    stale_flags: &mut BTreeMap<(String, String), bool>,
-    service: &str,
-    present: &[Scope],
-) {
-    let present: HashSet<&str> = present.iter().map(|scope| scope.name.as_str()).collect();
-
-    snapshot.retain(|(known, scope), _| known != service || present.contains(scope.as_str()));
-    stale_flags.retain(|(known, scope), _| known != service || present.contains(scope.as_str()));
-}
-
-/// Renders every staleness flip against the aggregate snapshot, in human
-/// output only — see the single-service watch's own copy for why a
-/// serializing backend sees none.
-fn render_staleness_flips(
-    snapshot: &BTreeMap<(String, String), Scope>,
-    stale_flags: &mut BTreeMap<(String, String), bool>,
-    stale_multiple: u32,
-    aliases: &BTreeMap<String, String>,
-    alias_width: usize,
-    scope_width: usize,
-) {
-    if output::serializes() {
-        return;
-    }
-
-    let flips = render::staleness_flips(snapshot, stale_flags, SystemTime::now(), stale_multiple);
-    for ((service, scope_name), staleness) in flips {
-        let alias = aliases
-            .get(service.as_str())
-            .map(String::as_str)
-            .unwrap_or(service.as_str());
-
-        render::print_staleness_line(
-            render::ServiceColumn::Named { alias, width: alias_width },
-            scope_name.as_str(),
-            scope_width,
-            &staleness,
-        );
-    }
 }
 
 /// Grows `scope_width` and `alias_width` to fit every name `event` carries,
@@ -325,7 +163,7 @@ fn grow_widths(event: &Event, scope_width: &mut usize, alias_width: &mut usize) 
         Event::Service { alias, data, .. } => {
             *alias_width = render::name_width([alias.as_str()]).max(*alias_width);
 
-            if let EventData::Message { scopes, .. } = data {
+            if let EventData::Message(scopes) = data {
                 let names = scopes.iter().map(|scope| scope.name.as_str());
                 *scope_width = render::name_width(names).max(*scope_width);
             }
@@ -392,12 +230,9 @@ enum Event {
 /// string: the human renderer composes them into one line at render time,
 /// and the serialized payload's `error` is `cause` alone.
 enum EventData {
-    /// A `Watch` message arrived. The server's contract makes the first
-    /// message after a stream opens a full snapshot of every scope, so
-    /// `initial` marks it: the render loop treats it as authoritative
-    /// and replaces the service's scopes wholesale rather than diffing
-    /// against pre-disconnect state.
-    Message { scopes: Vec<Scope>, initial: bool },
+    /// A `Watch` message arrived, carrying the scopes it changed (or, for
+    /// the first message after a stream opens, the full snapshot).
+    Message(Vec<Scope>),
     /// The stream (re)established after a previous disconnect.
     Reattached,
     /// The stream ended or errored; the supervisor is retrying after
@@ -452,12 +287,6 @@ struct EventPayload<'a> {
     service: &'a str,
     event: EventKind,
     scopes: &'a [Scope],
-    /// Present (as `true`) only when this message is the full snapshot that
-    /// opens a stream attempt, so a JSON consumer can treat the scopes as
-    /// authoritative without inferring it from the preceding `reattached`
-    /// line.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    snapshot: bool,
     error: Option<&'a str>,
 }
 
@@ -478,11 +307,11 @@ struct MembershipPayload<'a> {
 }
 
 impl Event {
-    fn message(service: &str, alias: &str, scopes: Vec<Scope>, initial: bool) -> Self {
+    fn message(service: &str, alias: &str, scopes: Vec<Scope>) -> Self {
         Self::Service {
             service: service.to_owned(),
             alias: alias.to_owned(),
-            data: EventData::Message { scopes, initial },
+            data: EventData::Message(scopes),
         }
     }
 
@@ -583,19 +412,13 @@ async fn supervise(connection: Arc<Connection>, service: String, alias: String, 
 
     loop {
         let mut opened_this_attempt = false;
-        let mut snapshot_seen = false;
 
         let result = connection
             .invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
                 "ready",
                 &service,
                 "Watch",
-                // Opt into observation updates so heartbeats reach the
-                // staleness tracker instead of only state changes.
-                ReadyRequest {
-                    scopes: Vec::new(),
-                    include_observation_updates: true,
-                },
+                ReadyRequest { scopes: Vec::new() },
                 |resp: ReadyResponse| {
                     if !opened_this_attempt {
                         opened_this_attempt = true;
@@ -606,11 +429,7 @@ async fn supervise(connection: Arc<Connection>, service: String, alias: String, 
                         }
                     }
 
-                    // The first message of every attempt is the server's
-                    // full snapshot; later ones carry only what changed.
-                    let initial = !snapshot_seen;
-                    snapshot_seen = true;
-                    let _ = sender.send(Event::message(&service, &alias, resp.scopes, initial));
+                    let _ = sender.send(Event::message(&service, &alias, resp.scopes));
                 },
             )
             .await;
@@ -999,12 +818,11 @@ impl Aggregate {
 fn render_event(event: Event, aggregate: &mut Aggregate, scope_width: usize, alias_width: usize) {
     match event {
         Event::Service { service, alias, data } => match data {
-            EventData::Message { scopes, initial } => {
+            EventData::Message(scopes) => {
                 let payload = EventPayload {
                     service: &service,
                     event: EventKind::Message,
                     scopes: &scopes,
-                    snapshot: initial,
                     error: None,
                 };
 
@@ -1040,7 +858,6 @@ fn render_event(event: Event, aggregate: &mut Aggregate, scope_width: usize, ali
                     service: &service,
                     event: EventKind::Reattached,
                     scopes: &[],
-                    snapshot: false,
                     error: None,
                 };
 
@@ -1056,7 +873,6 @@ fn render_event(event: Event, aggregate: &mut Aggregate, scope_width: usize, ali
                     service: &service,
                     event: EventKind::Lost,
                     scopes: &[],
-                    snapshot: false,
                     error: Some(&cause),
                 };
 
@@ -1137,7 +953,7 @@ mod test {
         let event = Event::Service {
             service: "svc".to_owned(),
             alias: "x".repeat(16),
-            data: EventData::Message { scopes: Vec::new(), initial: false },
+            data: EventData::Message(Vec::new()),
         };
         grow_widths(&event, &mut scope_width, &mut alias_width);
 
@@ -1147,7 +963,7 @@ mod test {
         let shorter = Event::Service {
             service: "svc2".to_owned(),
             alias: "a".to_owned(),
-            data: EventData::Message { scopes: Vec::new(), initial: false },
+            data: EventData::Message(Vec::new()),
         };
         grow_widths(&shorter, &mut scope_width, &mut alias_width);
 
@@ -1162,7 +978,7 @@ mod test {
         let event = Event::Service {
             service: "svc".to_owned(),
             alias: "x".repeat(100),
-            data: EventData::Message { scopes: Vec::new(), initial: false },
+            data: EventData::Message(Vec::new()),
         };
         grow_widths(&event, &mut scope_width, &mut alias_width);
 
@@ -1177,10 +993,7 @@ mod test {
         let event = Event::Service {
             service: "svc".to_owned(),
             alias: "svc".to_owned(),
-            data: EventData::Message {
-                scopes: vec![scope(&"x".repeat(20), State::Ready)],
-                initial: false,
-            },
+            data: EventData::Message(vec![scope(&"x".repeat(20), State::Ready)]),
         };
         grow_widths(&event, &mut scope_width, &mut alias_width);
 
@@ -1570,75 +1383,5 @@ mod test {
 
         let departed = vec![("b".to_owned(), "b".to_owned())];
         assert!(aggregate.apply_membership(&[], &departed));
-    }
-
-    /// verifies that forgetting a departed service drops its staleness
-    /// verdicts and alias while a sibling service's survive untouched.
-    #[test]
-    fn test_forget_service_drops_verdicts_and_alias_for_that_service_only() {
-        let mut stale_flags = BTreeMap::from([
-            (("a".to_owned(), "rib".to_owned()), true),
-            (("b".to_owned(), "rib".to_owned()), false),
-        ]);
-        let mut alias_index = BTreeMap::from([
-            ("a".to_owned(), "route".to_owned()),
-            ("b".to_owned(), "forward".to_owned()),
-        ]);
-
-        forget_service(&mut stale_flags, &mut alias_index, "b");
-
-        assert!(!stale_flags.contains_key(&("b".to_owned(), "rib".to_owned())));
-        assert!(!alias_index.contains_key("b"));
-        assert_eq!(Some(&true), stale_flags.get(&("a".to_owned(), "rib".to_owned())));
-        assert_eq!(Some(&"route".to_owned()), alias_index.get("a"));
-    }
-
-    /// verifies that an authoritative initial message drops the service's
-    /// scopes it no longer lists — together with their staleness verdicts —
-    /// while keeping the ones it does list and every sibling's scopes.
-    #[test]
-    fn test_forget_absent_scopes_drops_only_unlisted_scopes_of_that_service() {
-        let mut snapshot = BTreeMap::from([
-            (("a".to_owned(), "rib".to_owned()), scope("rib", State::Ready)),
-            (("a".to_owned(), "fib".to_owned()), scope("fib", State::Ready)),
-            (("b".to_owned(), "rib".to_owned()), scope("rib", State::Ready)),
-        ]);
-        let mut stale_flags = BTreeMap::from([
-            (("a".to_owned(), "rib".to_owned()), false),
-            (("a".to_owned(), "fib".to_owned()), true),
-            (("b".to_owned(), "rib".to_owned()), false),
-        ]);
-
-        // The reconnect snapshot lists only "rib" for service "a": "fib"
-        // disappeared while the stream was down.
-        let present = vec![scope("rib", State::Ready)];
-        forget_absent_scopes(&mut snapshot, &mut stale_flags, "a", &present);
-
-        assert!(snapshot.contains_key(&("a".to_owned(), "rib".to_owned())));
-        assert!(!snapshot.contains_key(&("a".to_owned(), "fib".to_owned())));
-        assert!(snapshot.contains_key(&("b".to_owned(), "rib".to_owned())));
-        assert!(!stale_flags.contains_key(&("a".to_owned(), "fib".to_owned())));
-        assert_eq!(Some(&false), stale_flags.get(&("a".to_owned(), "rib".to_owned())));
-    }
-
-    /// verifies that an empty authoritative snapshot wipes the service's
-    /// every scope, and that the readiness recompute performed on the
-    /// resulting aggregate reports no crossing — an empty snapshot must not
-    /// read as "all subsystems are ready".
-    #[test]
-    fn test_forget_absent_scopes_empty_snapshot_leaves_no_crossing() {
-        let reports = vec![report("a", vec![scope("rib", State::Ready)])];
-        let mut aggregate = Aggregate::seed(&reports);
-        assert!(aggregate.all_ready);
-
-        let mut stale_flags = BTreeMap::from([(("a".to_owned(), "rib".to_owned()), false)]);
-        let present: Vec<Scope> = Vec::new();
-
-        forget_absent_scopes(&mut aggregate.snapshot, &mut stale_flags, "a", &present);
-
-        assert!(aggregate.snapshot.is_empty());
-        assert!(stale_flags.is_empty());
-        assert!(!aggregate.refresh(), "an emptied snapshot must not cross into ready");
-        assert!(!aggregate.all_ready);
     }
 }

--- a/cli/modules/ready/src/watch.rs
+++ b/cli/modules/ready/src/watch.rs
@@ -13,6 +13,7 @@ use core::time::Duration;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
+    time::SystemTime,
 };
 
 use readinesspb::pb::{ReadyRequest, ReadyResponse, Scope};
@@ -97,6 +98,7 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
     };
 
     let mut aggregate = Aggregate::seed(&reports);
+    let mut stale_flags: BTreeMap<(String, String), bool> = BTreeMap::new();
 
     output::data(
         || &snapshot_payload,
@@ -104,13 +106,22 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
             if reports.is_empty() {
                 output::empty(format_args!("No readiness services registered."));
             } else {
+                // One clock reading for every block and for the seeded
+                // verdicts, so the tags shown here and the first flip the
+                // ticker could report agree on one point in time.
+                let now = SystemTime::now();
                 for (idx, report) in reports.iter().enumerate() {
                     if idx > 0 {
                         println!();
                     }
 
-                    print_report(report, scope_width, cmd.stale_after);
+                    print_report(report, scope_width, cmd.stale_multiple, now);
                 }
+
+                // Seed the verdicts the ticker and message paths flip
+                // against; the blocks above just showed the tags, so the
+                // seed call's own flips are dropped.
+                let _ = render::staleness_flips(&aggregate.snapshot, &mut stale_flags, now, cmd.stale_multiple);
             }
 
             render::print_watching_line();
@@ -132,16 +143,169 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
         supervisors.insert(service.clone(), handle.abort_handle());
     }
 
+    // The render loop resolves a staleness flip's service key to its alias
+    // for the service column. It maintains its own alias map kept in
+    // lockstep with membership events rather than a shared reference: the
+    // re-discovery task owns the original and never rewrites an alias a
+    // running supervisor already holds, while every assignment it makes is
+    // announced in the membership event itself, so this copy never serves
+    // a missing or stale alias for a rediscovered service.
+    let mut alias_index = aliases.clone();
+
     tokio::spawn(rediscover(connection.clone(), supervisors, aliases, sender.clone()));
 
     drop(sender);
 
-    while let Some(event) = receiver.recv().await {
-        grow_widths(&event, &mut scope_width, &mut alias_width);
-        render_event(event, &mut aggregate, scope_width, alias_width);
+    let mut ticker = tokio::time::interval(render::STALENESS_TICK);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            event = receiver.recv() => {
+                let Some(event) = event else { break };
+
+                // An initial message is authoritative for its service, so
+                // the render loop must also forget the service's scopes the
+                // snapshot no longer lists — they disappeared while the
+                // stream was down.
+                let mut initial_scopes: Option<(String, Vec<Scope>)> = None;
+                let carried_scopes = match &event {
+                    Event::Service { service, data: EventData::Message { scopes, initial }, .. } => {
+                        if *initial {
+                            initial_scopes = Some((service.clone(), scopes.clone()));
+                        }
+                        true
+                    }
+                    _ => false,
+                };
+                let membership_delta = match &event {
+                    Event::Membership { discovered, departed } => {
+                        Some((discovered.clone(), departed.clone()))
+                    }
+                    _ => None,
+                };
+
+                if let Some((discovered, _)) = &membership_delta {
+                    for (service, alias) in discovered {
+                        alias_index.insert(service.clone(), alias.clone());
+                    }
+                }
+
+                // An authoritative snapshot must shape the aggregate before
+                // the one readiness recompute render_event performs: forgetting
+                // absent scopes after it would leave a stale crossing (an old
+                // all-ready set with a now-empty snapshot) uncorrected.
+                if let Some((service, present)) = &initial_scopes {
+                    forget_absent_scopes(&mut aggregate.snapshot, &mut stale_flags, service, present);
+                }
+
+                grow_widths(&event, &mut scope_width, &mut alias_width);
+                render_event(event, &mut aggregate, scope_width, alias_width);
+
+                if let Some((_, departed)) = &membership_delta {
+                    for (service, _) in departed {
+                        forget_service(&mut stale_flags, &mut alias_index, service);
+                    }
+                }
+
+                // A message refreshes the observations it carries, so its
+                // scopes may have just gone fresh again; scopes it did not
+                // carry keep their verdicts until the next tick.
+                if carried_scopes {
+                    render_staleness_flips(
+                        &aggregate.snapshot,
+                        &mut stale_flags,
+                        cmd.stale_multiple,
+                        &alias_index,
+                        alias_width,
+                        scope_width,
+                    );
+                }
+            }
+            _ = ticker.tick() => {
+                render_staleness_flips(
+                    &aggregate.snapshot,
+                    &mut stale_flags,
+                    cmd.stale_multiple,
+                    &alias_index,
+                    alias_width,
+                    scope_width,
+                );
+            }
+        }
     }
 
     Ok(true)
+}
+
+/// Drops a departed service's staleness verdicts and alias.
+///
+/// The aggregate snapshot already forgot the service's scopes, so their
+/// verdicts must go too: a later re-registration re-evaluates them from
+/// scratch instead of flipping against the departed era's verdict — which
+/// would print a spurious `fresh again` or swallow a warranted `stale` —
+/// and the verdict map does not grow without bound across the watch's
+/// lifetime. The alias goes with it, since the re-discovery task reassigns
+/// it independently of this copy.
+fn forget_service(
+    stale_flags: &mut BTreeMap<(String, String), bool>,
+    alias_index: &mut BTreeMap<String, String>,
+    service: &str,
+) {
+    stale_flags.retain(|(known, _), _| known != service);
+    alias_index.remove(service);
+}
+
+/// Drops a service's snapshot scopes that its authoritative initial message
+/// no longer lists, together with their staleness verdicts.
+///
+/// An initial `Watch` message after a (re)connect is the server's full and
+/// current truth: a scope it omits no longer exists, so keeping it in the
+/// snapshot would leave it influencing the readiness aggregate and letting
+/// the ticker later print a stale line for a scope that is simply gone.
+/// The present set is taken from the message itself, never derived from the
+/// snapshot, which by definition still holds the scopes in question.
+fn forget_absent_scopes(
+    snapshot: &mut BTreeMap<(String, String), Scope>,
+    stale_flags: &mut BTreeMap<(String, String), bool>,
+    service: &str,
+    present: &[Scope],
+) {
+    let present: HashSet<&str> = present.iter().map(|scope| scope.name.as_str()).collect();
+
+    snapshot.retain(|(known, scope), _| known != service || present.contains(scope.as_str()));
+    stale_flags.retain(|(known, scope), _| known != service || present.contains(scope.as_str()));
+}
+
+/// Renders every staleness flip against the aggregate snapshot, in human
+/// output only — see the single-service watch's own copy for why a
+/// serializing backend sees none.
+fn render_staleness_flips(
+    snapshot: &BTreeMap<(String, String), Scope>,
+    stale_flags: &mut BTreeMap<(String, String), bool>,
+    stale_multiple: u32,
+    aliases: &BTreeMap<String, String>,
+    alias_width: usize,
+    scope_width: usize,
+) {
+    if output::serializes() {
+        return;
+    }
+
+    let flips = render::staleness_flips(snapshot, stale_flags, SystemTime::now(), stale_multiple);
+    for ((service, scope_name), staleness) in flips {
+        let alias = aliases
+            .get(service.as_str())
+            .map(String::as_str)
+            .unwrap_or(service.as_str());
+
+        render::print_staleness_line(
+            render::ServiceColumn::Named { alias, width: alias_width },
+            scope_name.as_str(),
+            scope_width,
+            &staleness,
+        );
+    }
 }
 
 /// Grows `scope_width` and `alias_width` to fit every name `event` carries,
@@ -161,7 +325,7 @@ fn grow_widths(event: &Event, scope_width: &mut usize, alias_width: &mut usize) 
         Event::Service { alias, data, .. } => {
             *alias_width = render::name_width([alias.as_str()]).max(*alias_width);
 
-            if let EventData::Message(scopes) = data {
+            if let EventData::Message { scopes, .. } = data {
                 let names = scopes.iter().map(|scope| scope.name.as_str());
                 *scope_width = render::name_width(names).max(*scope_width);
             }
@@ -228,9 +392,12 @@ enum Event {
 /// string: the human renderer composes them into one line at render time,
 /// and the serialized payload's `error` is `cause` alone.
 enum EventData {
-    /// A `Watch` message arrived, carrying the scopes it changed (or, for
-    /// the first message after a stream opens, the full snapshot).
-    Message(Vec<Scope>),
+    /// A `Watch` message arrived. The server's contract makes the first
+    /// message after a stream opens a full snapshot of every scope, so
+    /// `initial` marks it: the render loop treats it as authoritative
+    /// and replaces the service's scopes wholesale rather than diffing
+    /// against pre-disconnect state.
+    Message { scopes: Vec<Scope>, initial: bool },
     /// The stream (re)established after a previous disconnect.
     Reattached,
     /// The stream ended or errored; the supervisor is retrying after
@@ -285,6 +452,12 @@ struct EventPayload<'a> {
     service: &'a str,
     event: EventKind,
     scopes: &'a [Scope],
+    /// Present (as `true`) only when this message is the full snapshot that
+    /// opens a stream attempt, so a JSON consumer can treat the scopes as
+    /// authoritative without inferring it from the preceding `reattached`
+    /// line.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    snapshot: bool,
     error: Option<&'a str>,
 }
 
@@ -305,11 +478,11 @@ struct MembershipPayload<'a> {
 }
 
 impl Event {
-    fn message(service: &str, alias: &str, scopes: Vec<Scope>) -> Self {
+    fn message(service: &str, alias: &str, scopes: Vec<Scope>, initial: bool) -> Self {
         Self::Service {
             service: service.to_owned(),
             alias: alias.to_owned(),
-            data: EventData::Message(scopes),
+            data: EventData::Message { scopes, initial },
         }
     }
 
@@ -410,13 +583,19 @@ async fn supervise(connection: Arc<Connection>, service: String, alias: String, 
 
     loop {
         let mut opened_this_attempt = false;
+        let mut snapshot_seen = false;
 
         let result = connection
             .invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
                 "ready",
                 &service,
                 "Watch",
-                ReadyRequest { scopes: Vec::new() },
+                // Opt into observation updates so heartbeats reach the
+                // staleness tracker instead of only state changes.
+                ReadyRequest {
+                    scopes: Vec::new(),
+                    include_observation_updates: true,
+                },
                 |resp: ReadyResponse| {
                     if !opened_this_attempt {
                         opened_this_attempt = true;
@@ -427,7 +606,11 @@ async fn supervise(connection: Arc<Connection>, service: String, alias: String, 
                         }
                     }
 
-                    let _ = sender.send(Event::message(&service, &alias, resp.scopes));
+                    // The first message of every attempt is the server's
+                    // full snapshot; later ones carry only what changed.
+                    let initial = !snapshot_seen;
+                    snapshot_seen = true;
+                    let _ = sender.send(Event::message(&service, &alias, resp.scopes, initial));
                 },
             )
             .await;
@@ -816,11 +999,12 @@ impl Aggregate {
 fn render_event(event: Event, aggregate: &mut Aggregate, scope_width: usize, alias_width: usize) {
     match event {
         Event::Service { service, alias, data } => match data {
-            EventData::Message(scopes) => {
+            EventData::Message { scopes, initial } => {
                 let payload = EventPayload {
                     service: &service,
                     event: EventKind::Message,
                     scopes: &scopes,
+                    snapshot: initial,
                     error: None,
                 };
 
@@ -856,6 +1040,7 @@ fn render_event(event: Event, aggregate: &mut Aggregate, scope_width: usize, ali
                     service: &service,
                     event: EventKind::Reattached,
                     scopes: &[],
+                    snapshot: false,
                     error: None,
                 };
 
@@ -871,6 +1056,7 @@ fn render_event(event: Event, aggregate: &mut Aggregate, scope_width: usize, ali
                     service: &service,
                     event: EventKind::Lost,
                     scopes: &[],
+                    snapshot: false,
                     error: Some(&cause),
                 };
 
@@ -923,6 +1109,7 @@ mod test {
             reasons: Vec::new(),
             observed_at: None,
             last_transition_time: None,
+            expected_observation_interval: None,
         }
     }
 
@@ -950,7 +1137,7 @@ mod test {
         let event = Event::Service {
             service: "svc".to_owned(),
             alias: "x".repeat(16),
-            data: EventData::Message(Vec::new()),
+            data: EventData::Message { scopes: Vec::new(), initial: false },
         };
         grow_widths(&event, &mut scope_width, &mut alias_width);
 
@@ -960,7 +1147,7 @@ mod test {
         let shorter = Event::Service {
             service: "svc2".to_owned(),
             alias: "a".to_owned(),
-            data: EventData::Message(Vec::new()),
+            data: EventData::Message { scopes: Vec::new(), initial: false },
         };
         grow_widths(&shorter, &mut scope_width, &mut alias_width);
 
@@ -975,7 +1162,7 @@ mod test {
         let event = Event::Service {
             service: "svc".to_owned(),
             alias: "x".repeat(100),
-            data: EventData::Message(Vec::new()),
+            data: EventData::Message { scopes: Vec::new(), initial: false },
         };
         grow_widths(&event, &mut scope_width, &mut alias_width);
 
@@ -990,7 +1177,10 @@ mod test {
         let event = Event::Service {
             service: "svc".to_owned(),
             alias: "svc".to_owned(),
-            data: EventData::Message(vec![scope(&"x".repeat(20), State::Ready)]),
+            data: EventData::Message {
+                scopes: vec![scope(&"x".repeat(20), State::Ready)],
+                initial: false,
+            },
         };
         grow_widths(&event, &mut scope_width, &mut alias_width);
 
@@ -1380,5 +1570,75 @@ mod test {
 
         let departed = vec![("b".to_owned(), "b".to_owned())];
         assert!(aggregate.apply_membership(&[], &departed));
+    }
+
+    /// verifies that forgetting a departed service drops its staleness
+    /// verdicts and alias while a sibling service's survive untouched.
+    #[test]
+    fn test_forget_service_drops_verdicts_and_alias_for_that_service_only() {
+        let mut stale_flags = BTreeMap::from([
+            (("a".to_owned(), "rib".to_owned()), true),
+            (("b".to_owned(), "rib".to_owned()), false),
+        ]);
+        let mut alias_index = BTreeMap::from([
+            ("a".to_owned(), "route".to_owned()),
+            ("b".to_owned(), "forward".to_owned()),
+        ]);
+
+        forget_service(&mut stale_flags, &mut alias_index, "b");
+
+        assert!(!stale_flags.contains_key(&("b".to_owned(), "rib".to_owned())));
+        assert!(!alias_index.contains_key("b"));
+        assert_eq!(Some(&true), stale_flags.get(&("a".to_owned(), "rib".to_owned())));
+        assert_eq!(Some(&"route".to_owned()), alias_index.get("a"));
+    }
+
+    /// verifies that an authoritative initial message drops the service's
+    /// scopes it no longer lists — together with their staleness verdicts —
+    /// while keeping the ones it does list and every sibling's scopes.
+    #[test]
+    fn test_forget_absent_scopes_drops_only_unlisted_scopes_of_that_service() {
+        let mut snapshot = BTreeMap::from([
+            (("a".to_owned(), "rib".to_owned()), scope("rib", State::Ready)),
+            (("a".to_owned(), "fib".to_owned()), scope("fib", State::Ready)),
+            (("b".to_owned(), "rib".to_owned()), scope("rib", State::Ready)),
+        ]);
+        let mut stale_flags = BTreeMap::from([
+            (("a".to_owned(), "rib".to_owned()), false),
+            (("a".to_owned(), "fib".to_owned()), true),
+            (("b".to_owned(), "rib".to_owned()), false),
+        ]);
+
+        // The reconnect snapshot lists only "rib" for service "a": "fib"
+        // disappeared while the stream was down.
+        let present = vec![scope("rib", State::Ready)];
+        forget_absent_scopes(&mut snapshot, &mut stale_flags, "a", &present);
+
+        assert!(snapshot.contains_key(&("a".to_owned(), "rib".to_owned())));
+        assert!(!snapshot.contains_key(&("a".to_owned(), "fib".to_owned())));
+        assert!(snapshot.contains_key(&("b".to_owned(), "rib".to_owned())));
+        assert!(!stale_flags.contains_key(&("a".to_owned(), "fib".to_owned())));
+        assert_eq!(Some(&false), stale_flags.get(&("a".to_owned(), "rib".to_owned())));
+    }
+
+    /// verifies that an empty authoritative snapshot wipes the service's
+    /// every scope, and that the readiness recompute performed on the
+    /// resulting aggregate reports no crossing — an empty snapshot must not
+    /// read as "all subsystems are ready".
+    #[test]
+    fn test_forget_absent_scopes_empty_snapshot_leaves_no_crossing() {
+        let reports = vec![report("a", vec![scope("rib", State::Ready)])];
+        let mut aggregate = Aggregate::seed(&reports);
+        assert!(aggregate.all_ready);
+
+        let mut stale_flags = BTreeMap::from([(("a".to_owned(), "rib".to_owned()), false)]);
+        let present: Vec<Scope> = Vec::new();
+
+        forget_absent_scopes(&mut aggregate.snapshot, &mut stale_flags, "a", &present);
+
+        assert!(aggregate.snapshot.is_empty());
+        assert!(stale_flags.is_empty());
+        assert!(!aggregate.refresh(), "an emptied snapshot must not cross into ready");
+        assert!(!aggregate.all_ready);
     }
 }

--- a/common/go/readiness/readiness.go
+++ b/common/go/readiness/readiness.go
@@ -3,7 +3,6 @@ package readiness
 import (
 	"context"
 	"errors"
-	"sort"
 	"sync"
 	"time"
 
@@ -14,14 +13,11 @@ import (
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 )
 
-// readinessTransitionBuffer caps a subscriber's queue of undelivered state
-// and reason transitions. Overflowing it drops the subscriber: silently
-// discarding a promised transition would be worse than disconnecting.
-const readinessTransitionBuffer = 1024
+// readinessWatchBuffer is the per-subscriber channel capacity.
+const readinessWatchBuffer = 16
 
-// ErrSlowConsumer is returned by Watch when the subscriber's transition
-// queue overflows.
-var ErrSlowConsumer = errors.New("readiness watch subscriber too slow")
+// errSlowConsumer is returned by Watch when a subscriber's buffer overflows.
+var errSlowConsumer = errors.New("readiness watch subscriber too slow")
 
 // scopeState holds the mutable readiness state for one scope.
 type scopeState struct {
@@ -94,37 +90,11 @@ func (m *scopeState) Apply(
 }
 
 // subscriber holds state for one active Watch call.
-//
-// Delivery has two paths with different durability rules. State and reason
-// transitions go into a bounded FIFO queue: their order and completeness are
-// the stream's contract, so a reader that falls more than
-// readinessTransitionBuffer transitions behind is dropped with
-// ErrSlowConsumer rather than silently losing a transition it was promised.
-// Pure observation refreshes coalesce per scope name: only the newest
-// snapshot per scope matters to a freshness consumer, so a burst costs
-// memory proportional to the scope count, never to the event rate. signal
-// (capacity one) wakes Watch; a token already queued guarantees the reader
-// will drain both paths, including later updates.
 type subscriber struct {
 	// filter is the set of scope names this subscriber wants. Empty means all.
-	filter map[string]struct{}
-	// includeObservations reports whether the subscriber opted into pure
-	// observation refreshes; without it only state or reason changes are
-	// offered at all.
-	includeObservations bool
-
-	pendingMu      sync.Mutex
-	transitions    []*readinesspb.Scope
-	observations   map[string]*readinesspb.Scope
-	signal         chan struct{}
-	dropped        chan struct{}
-	overflowedOnce bool
-}
-
-// WantsObservations reports whether the subscriber opted into pure
-// observation refreshes.
-func (m *subscriber) WantsObservations() bool {
-	return m.includeObservations
+	filter  map[string]struct{}
+	ch      chan *readinesspb.ReadyResponse
+	dropped chan struct{}
 }
 
 // Matches reports whether the subscriber wants updates for the named scope.
@@ -138,73 +108,35 @@ func (m *subscriber) Matches(name string) bool {
 	return ok
 }
 
-// Offer files one updated scope and wakes Watch.
+// Send delivers resp to the subscriber without blocking.
 //
-// A state or reason change is appended to the transition queue and retires
-// any coalesced observation of the same scope: the observation is
-// guaranteed older, because the tracker serializes updates under its mutex,
-// and delivering it after the transition would leave the reader on a stale
-// snapshot. A pure observation refresh replaces the newest coalesced
-// snapshot of its scope. Waking is non-blocking: a token already queued
-// guarantees the reader will drain the mailbox, including this update. It
-// reports false when the transition queue is full — the caller must drop
-// the subscriber then.
-func (m *subscriber) Offer(scope *readinesspb.Scope, changed bool) bool {
-	m.pendingMu.Lock()
-	if changed {
-		if len(m.transitions) >= readinessTransitionBuffer {
-			if !m.overflowedOnce {
-				m.overflowedOnce = true
-				close(m.dropped)
-			}
-			m.pendingMu.Unlock()
-			return false
-		}
-		m.transitions = append(m.transitions, scope)
-		delete(m.observations, scope.Name)
-	} else {
-		m.observations[scope.Name] = scope
-	}
-	m.pendingMu.Unlock()
-
+// It reports false when the subscriber's buffer is full. The caller is
+// responsible for dropping the subscriber in that case.
+func (m *subscriber) Send(resp *readinesspb.ReadyResponse) bool {
 	select {
-	case m.signal <- struct{}{}:
+	case m.ch <- resp:
+		return true
 	default:
+		return false
 	}
-	return true
 }
 
-// Drain returns the queued transitions in order, followed by the coalesced
-// observation snapshots in name order, and empties both paths.
-func (m *subscriber) Drain() []*readinesspb.Scope {
-	m.pendingMu.Lock()
-	scopes := make([]*readinesspb.Scope, 0, len(m.transitions)+len(m.observations))
-	scopes = append(scopes, m.transitions...)
-	transitionCount := len(m.transitions)
-	m.transitions = m.transitions[:0]
-	for _, scope := range m.observations {
-		scopes = append(scopes, scope)
-	}
-	clear(m.observations)
-	m.pendingMu.Unlock()
-
-	observed := scopes[transitionCount:]
-	sort.Slice(observed, func(idx, jdx int) bool {
-		return observed[idx].Name < observed[jdx].Name
-	})
-	return scopes
+// Drop closes the subscriber's dropped channel, signalling Watch to return
+// errSlowConsumer.
+func (m *subscriber) Drop() {
+	close(m.dropped)
 }
 
-// Dropped returns the channel that is closed when the transition queue
-// overflowed and the subscriber must be dropped.
+// Dropped returns the channel that is closed when the subscriber is dropped
+// for being too slow.
 func (m *subscriber) Dropped() <-chan struct{} {
 	return m.dropped
 }
 
-// Signal returns the channel that receives a token whenever the mailbox
-// gains content.
-func (m *subscriber) Signal() <-chan struct{} {
-	return m.signal
+// Events returns the channel of readiness updates delivered to the
+// subscriber.
+func (m *subscriber) Events() <-chan *readinesspb.ReadyResponse {
+	return m.ch
 }
 
 // Tracker tracks readiness state across named scopes.
@@ -344,30 +276,31 @@ func (m *Tracker) snapshotLocked(filter map[string]struct{}) *readinesspb.ReadyR
 	return &readinesspb.ReadyResponse{Scopes: out}
 }
 
-// notifySubscribersLocked fans out updated scopes to all registered
-// subscribers.
+// notifySubscribersLocked fans out changed scopes to all registered subscribers.
 //
-// Each subscriber's mailbox receives only the subset of updated scopes that
-// matches its filter; a subscriber that did not opt into observation
-// refreshes receives only the updates that changed state or reason. A
-// transition-queue overflow drops the subscriber — its Watch returns
-// ErrSlowConsumer. Caller must hold m.mu.
-func (m *Tracker) notifySubscribersLocked(updated []*readinesspb.Scope, changed bool) {
-	if len(m.subscribers) == 0 || len(updated) == 0 {
+// Each subscriber receives only the subset of changed scopes that match its
+// filter. The send is non-blocking: a subscriber whose channel is full is
+// dropped (its dropped channel is closed and it is removed from the registry).
+// Caller must hold m.mu.
+func (m *Tracker) notifySubscribersLocked(changed []*readinesspb.Scope) {
+	if len(m.subscribers) == 0 || len(changed) == 0 {
 		return
 	}
 
 	for sub := range m.subscribers {
-		if !changed && !sub.WantsObservations() {
+		var matching []*readinesspb.Scope
+		for _, sc := range changed {
+			if sub.Matches(sc.Name) {
+				matching = append(matching, sc)
+			}
+		}
+		if len(matching) == 0 {
 			continue
 		}
-		for _, sc := range updated {
-			if sub.Matches(sc.Name) {
-				if !sub.Offer(sc, changed) {
-					delete(m.subscribers, sub)
-					break
-				}
-			}
+		resp := &readinesspb.ReadyResponse{Scopes: matching}
+		if !sub.Send(resp) {
+			sub.Drop()
+			delete(m.subscribers, sub)
 		}
 	}
 }
@@ -375,20 +308,14 @@ func (m *Tracker) notifySubscribersLocked(updated []*readinesspb.Scope, changed 
 // subscribe registers a new subscriber and atomically captures the initial
 // snapshot. It returns the subscriber and the snapshot to send as the first
 // streamed message.
-func (m *Tracker) subscribe(
-	filter map[string]struct{},
-	includeObservations bool,
-) (*subscriber, *readinesspb.ReadyResponse) {
+func (m *Tracker) subscribe(filter map[string]struct{}) (*subscriber, *readinesspb.ReadyResponse) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	sub := &subscriber{
-		filter:              filter,
-		includeObservations: includeObservations,
-		observations:        map[string]*readinesspb.Scope{},
-		transitions:         make([]*readinesspb.Scope, 0, 16),
-		signal:              make(chan struct{}, 1),
-		dropped:             make(chan struct{}),
+		filter:  filter,
+		ch:      make(chan *readinesspb.ReadyResponse, readinessWatchBuffer),
+		dropped: make(chan struct{}),
 	}
 	m.subscribers[sub] = struct{}{}
 	snapshot := m.snapshotLocked(filter)
@@ -403,18 +330,17 @@ func (m *Tracker) unsubscribe(sub *subscriber) {
 	delete(m.subscribers, sub)
 }
 
-// applyLocked applies next and reason to s, logs any state transition, and
+// applyLocked applies next and reason to s, logs the transition, and
 // notifies Watch subscribers.
 //
-// A subscriber that opted into observation updates receives the scope's
-// current snapshot on every apply — a repeated identical outcome still
-// streams the advanced observation timestamp that freshness consumers
-// depend on. A legacy subscriber receives it only when state or reason
-// actually changed. Must be called with m.mu held.
+// Subscribers are notified only when the apply actually changed state or
+// reason. Must be called with m.mu held.
 func (m *Tracker) applyLocked(s *scopeState, next readinesspb.State, reason *readinesspb.Reason) {
 	prevState, changed := s.Apply(next, reason, time.Now())
 	m.logTransition(s.Name(), prevState, next, reason)
-	m.notifySubscribersLocked([]*readinesspb.Scope{s.ToProto()}, changed)
+	if changed {
+		m.notifySubscribersLocked([]*readinesspb.Scope{s.ToProto()})
+	}
 }
 
 // observeOutcome derives the next state and reason for an apply attempt
@@ -496,10 +422,8 @@ func (m *Tracker) set(scope string, state readinesspb.State, reason *readinesspb
 //
 // It records that the underlying source was successfully re-evaluated, so
 // freshness consumers can distinguish a live scope from one whose last event
-// was long ago. Only Watch subscribers that opted into observation updates
-// receive the refreshed snapshot, since the advanced timestamp is what they
-// consume for staleness. Touch is a no-op for unknown scopes — it never
-// creates a scope. state, reason, and lastTransitionTime are left unchanged.
+// was long ago. Touch is a no-op for unknown scopes — it never creates a
+// scope. state, reason, and lastTransitionTime are left unchanged.
 func (m *Tracker) Touch(scope string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -510,17 +434,13 @@ func (m *Tracker) Touch(scope string) {
 	}
 
 	s.Touch(time.Now())
-	m.notifySubscribersLocked([]*readinesspb.Scope{s.ToProto()}, false)
 }
 
 // Drain marks every scope as STATE_NOT_READY with a SHUTTING_DOWN reason.
 //
-// last_transition_time is updated only for scopes that change state, but
-// every scope is re-observed. A subscriber that opted into observation
-// updates receives every scope; a legacy subscriber receives only the ones
-// whose state or reason actually changed. When the Tracker was constructed
-// with WithDrainLatch, subsequent Set and Observe calls become no-ops after
-// Drain returns.
+// last_transition_time is updated only for scopes that change state. When
+// the Tracker was constructed with WithDrainLatch, subsequent Set and Observe
+// calls become no-ops after Drain returns.
 func (m *Tracker) Drain() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -528,25 +448,16 @@ func (m *Tracker) Drain() {
 	now := time.Now()
 	reason := &readinesspb.Reason{Code: "SHUTTING_DOWN"}
 
-	// One fan-out pass over all scopes per change class: a legacy
-	// subscriber must not see an unchanged scope, an opted-in one must see
-	// even the unchanged ones re-observed. A changed scope travels through
-	// the transition queue only, so its delivery is never duplicated.
-	changedScopes := make([]*readinesspb.Scope, 0, len(m.scopes))
-	unchangedScopes := make([]*readinesspb.Scope, 0, len(m.scopes))
+	var changedScopes []*readinesspb.Scope
 	for _, s := range m.scopes {
 		prevState, changed := s.Apply(readinesspb.State_STATE_NOT_READY, reason, now)
 		m.logTransition(s.Name(), prevState, readinesspb.State_STATE_NOT_READY, reason)
-		proto := s.ToProto()
 		if changed {
-			changedScopes = append(changedScopes, proto)
-		} else {
-			unchangedScopes = append(unchangedScopes, proto)
+			changedScopes = append(changedScopes, s.ToProto())
 		}
 	}
 
-	m.notifySubscribersLocked(changedScopes, true)
-	m.notifySubscribersLocked(unchangedScopes, false)
+	m.notifySubscribersLocked(changedScopes)
 
 	if m.latchOnDrain {
 		m.drained = true
@@ -567,20 +478,16 @@ func (m *Tracker) Ready(req *readinesspb.ReadyRequest) *readinesspb.ReadyRespons
 	return m.snapshotLocked(filter)
 }
 
-// Watch streams readiness updates to the caller via send.
+// Watch streams readiness state changes to the caller via send.
 //
 // The first message carries the current state of every scope matching the
-// request filter (same semantics as Ready). Without
-// include_observation_updates in the request, each subsequent message
-// carries only the scopes whose state or reason changed since the previous
-// message, in order. With it, pure observed_at refreshes are delivered too,
-// coalesced per scope: a burst of refreshes between two reads yields the
-// newest snapshot of each affected scope. Transitions are never coalesced
-// away — a subscriber that falls more than a bounded number of transitions
-// behind is dropped with an error instead of losing one.
+// request filter (same semantics as Ready). Each subsequent message carries
+// only the scopes whose state or reason changed since the previous message.
+// A pure observed_at refresh (Touch) never emits. A no-op mutation (same
+// state and same reason) never emits.
 //
-// Watch returns nil on ctx cancellation, the send error on stream write
-// failure, and ErrSlowConsumer if the subscriber's transition queue
+// Watch returns nil on ctx cancellation, returns the send error on stream
+// write failure, and returns errSlowConsumer if the subscriber's buffer
 // overflows.
 func (m *Tracker) Watch(
 	ctx context.Context,
@@ -592,7 +499,7 @@ func (m *Tracker) Watch(
 		filter[name] = struct{}{}
 	}
 
-	sub, snapshot := m.subscribe(filter, req.GetIncludeObservationUpdates())
+	sub, snapshot := m.subscribe(filter)
 	defer m.unsubscribe(sub)
 
 	if err := send(snapshot); err != nil {
@@ -604,13 +511,12 @@ func (m *Tracker) Watch(
 		case <-ctx.Done():
 			return nil
 		case <-sub.Dropped():
-			return ErrSlowConsumer
-		case <-sub.Signal():
-			scopes := sub.Drain()
-			if len(scopes) == 0 {
-				continue
+			return errSlowConsumer
+		case resp, ok := <-sub.Events():
+			if !ok {
+				return errSlowConsumer
 			}
-			if err := send(&readinesspb.ReadyResponse{Scopes: scopes}); err != nil {
+			if err := send(resp); err != nil {
 				return err
 			}
 		}

--- a/common/go/readiness/readiness.go
+++ b/common/go/readiness/readiness.go
@@ -3,28 +3,34 @@ package readiness
 import (
 	"context"
 	"errors"
+	"sort"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 )
 
-// readinessWatchBuffer is the per-subscriber channel capacity.
-const readinessWatchBuffer = 16
+// readinessTransitionBuffer caps a subscriber's queue of undelivered state
+// and reason transitions. Overflowing it drops the subscriber: silently
+// discarding a promised transition would be worse than disconnecting.
+const readinessTransitionBuffer = 1024
 
-// errSlowConsumer is returned by Watch when a subscriber's buffer overflows.
-var errSlowConsumer = errors.New("readiness watch subscriber too slow")
+// ErrSlowConsumer is returned by Watch when the subscriber's transition
+// queue overflows.
+var ErrSlowConsumer = errors.New("readiness watch subscriber too slow")
 
 // scopeState holds the mutable readiness state for one scope.
 type scopeState struct {
-	name               string
-	state              readinesspb.State
-	reason             *readinesspb.Reason
-	observedAt         time.Time
-	lastTransitionTime time.Time
+	name                        string
+	state                       readinesspb.State
+	reason                      *readinesspb.Reason
+	observedAt                  time.Time
+	lastTransitionTime          time.Time
+	expectedObservationInterval time.Duration
 }
 
 // Name returns the scope's name.
@@ -51,6 +57,9 @@ func (m *scopeState) ToProto() *readinesspb.Scope {
 	if !m.observedAt.IsZero() {
 		scope.ObservedAt = timestamppb.New(m.observedAt)
 		scope.LastTransitionTime = timestamppb.New(m.lastTransitionTime)
+	}
+	if m.expectedObservationInterval > 0 {
+		scope.ExpectedObservationInterval = durationpb.New(m.expectedObservationInterval)
 	}
 	return scope
 }
@@ -85,11 +94,37 @@ func (m *scopeState) Apply(
 }
 
 // subscriber holds state for one active Watch call.
+//
+// Delivery has two paths with different durability rules. State and reason
+// transitions go into a bounded FIFO queue: their order and completeness are
+// the stream's contract, so a reader that falls more than
+// readinessTransitionBuffer transitions behind is dropped with
+// ErrSlowConsumer rather than silently losing a transition it was promised.
+// Pure observation refreshes coalesce per scope name: only the newest
+// snapshot per scope matters to a freshness consumer, so a burst costs
+// memory proportional to the scope count, never to the event rate. signal
+// (capacity one) wakes Watch; a token already queued guarantees the reader
+// will drain both paths, including later updates.
 type subscriber struct {
 	// filter is the set of scope names this subscriber wants. Empty means all.
-	filter  map[string]struct{}
-	ch      chan *readinesspb.ReadyResponse
-	dropped chan struct{}
+	filter map[string]struct{}
+	// includeObservations reports whether the subscriber opted into pure
+	// observation refreshes; without it only state or reason changes are
+	// offered at all.
+	includeObservations bool
+
+	pendingMu      sync.Mutex
+	transitions    []*readinesspb.Scope
+	observations   map[string]*readinesspb.Scope
+	signal         chan struct{}
+	dropped        chan struct{}
+	overflowedOnce bool
+}
+
+// WantsObservations reports whether the subscriber opted into pure
+// observation refreshes.
+func (m *subscriber) WantsObservations() bool {
+	return m.includeObservations
 }
 
 // Matches reports whether the subscriber wants updates for the named scope.
@@ -103,35 +138,73 @@ func (m *subscriber) Matches(name string) bool {
 	return ok
 }
 
-// Send delivers resp to the subscriber without blocking.
+// Offer files one updated scope and wakes Watch.
 //
-// It reports false when the subscriber's buffer is full. The caller is
-// responsible for dropping the subscriber in that case.
-func (m *subscriber) Send(resp *readinesspb.ReadyResponse) bool {
-	select {
-	case m.ch <- resp:
-		return true
-	default:
-		return false
+// A state or reason change is appended to the transition queue and retires
+// any coalesced observation of the same scope: the observation is
+// guaranteed older, because the tracker serializes updates under its mutex,
+// and delivering it after the transition would leave the reader on a stale
+// snapshot. A pure observation refresh replaces the newest coalesced
+// snapshot of its scope. Waking is non-blocking: a token already queued
+// guarantees the reader will drain the mailbox, including this update. It
+// reports false when the transition queue is full — the caller must drop
+// the subscriber then.
+func (m *subscriber) Offer(scope *readinesspb.Scope, changed bool) bool {
+	m.pendingMu.Lock()
+	if changed {
+		if len(m.transitions) >= readinessTransitionBuffer {
+			if !m.overflowedOnce {
+				m.overflowedOnce = true
+				close(m.dropped)
+			}
+			m.pendingMu.Unlock()
+			return false
+		}
+		m.transitions = append(m.transitions, scope)
+		delete(m.observations, scope.Name)
+	} else {
+		m.observations[scope.Name] = scope
 	}
+	m.pendingMu.Unlock()
+
+	select {
+	case m.signal <- struct{}{}:
+	default:
+	}
+	return true
 }
 
-// Drop closes the subscriber's dropped channel, signalling Watch to return
-// errSlowConsumer.
-func (m *subscriber) Drop() {
-	close(m.dropped)
+// Drain returns the queued transitions in order, followed by the coalesced
+// observation snapshots in name order, and empties both paths.
+func (m *subscriber) Drain() []*readinesspb.Scope {
+	m.pendingMu.Lock()
+	scopes := make([]*readinesspb.Scope, 0, len(m.transitions)+len(m.observations))
+	scopes = append(scopes, m.transitions...)
+	transitionCount := len(m.transitions)
+	m.transitions = m.transitions[:0]
+	for _, scope := range m.observations {
+		scopes = append(scopes, scope)
+	}
+	clear(m.observations)
+	m.pendingMu.Unlock()
+
+	observed := scopes[transitionCount:]
+	sort.Slice(observed, func(idx, jdx int) bool {
+		return observed[idx].Name < observed[jdx].Name
+	})
+	return scopes
 }
 
-// Dropped returns the channel that is closed when the subscriber is dropped
-// for being too slow.
+// Dropped returns the channel that is closed when the transition queue
+// overflowed and the subscriber must be dropped.
 func (m *subscriber) Dropped() <-chan struct{} {
 	return m.dropped
 }
 
-// Events returns the channel of readiness updates delivered to the
-// subscriber.
-func (m *subscriber) Events() <-chan *readinesspb.ReadyResponse {
-	return m.ch
+// Signal returns the channel that receives a token whenever the mailbox
+// gains content.
+func (m *subscriber) Signal() <-chan struct{} {
+	return m.signal
 }
 
 // Tracker tracks readiness state across named scopes.
@@ -184,19 +257,35 @@ func WithDrainLatch() Option {
 	}
 }
 
-// NewTracker creates a Tracker pre-seeded with the supplied scope names, each
+// ScopeSpec declares one scope at tracker construction.
+type ScopeSpec struct {
+	Name string
+	// ExpectedObservationInterval is the scope's freshness contract: the
+	// nominal cadence at which the scope's source re-observes it, i.e. the
+	// source's own ticker or heartbeat interval. Consumers judge staleness
+	// per scope against this cadence instead of a single global threshold;
+	// retries and slow applies can legitimately exceed it. Leave it zero
+	// for scopes with no natural heartbeat — such scopes are never judged
+	// stale. A zero or negative value is treated as none, and the contract
+	// is fixed for the tracker's lifetime.
+	ExpectedObservationInterval time.Duration
+}
+
+// NewTracker creates a Tracker pre-seeded with the supplied scopes, each
 // starting at STATE_UNKNOWN.
-func NewTracker(scopeNames []string, options ...Option) *Tracker {
+func NewTracker(specs []ScopeSpec, options ...Option) *Tracker {
 	opts := newOptions()
 	for _, o := range options {
 		o(opts)
 	}
 
 	scopes := map[string]*scopeState{}
-	for _, id := range scopeNames {
-		scopes[id] = &scopeState{
-			name:  id,
-			state: readinesspb.State_STATE_UNKNOWN,
+	for _, spec := range specs {
+		interval := max(spec.ExpectedObservationInterval, 0)
+		scopes[spec.Name] = &scopeState{
+			name:                        spec.Name,
+			state:                       readinesspb.State_STATE_UNKNOWN,
+			expectedObservationInterval: interval,
 		}
 	}
 
@@ -255,31 +344,30 @@ func (m *Tracker) snapshotLocked(filter map[string]struct{}) *readinesspb.ReadyR
 	return &readinesspb.ReadyResponse{Scopes: out}
 }
 
-// notifySubscribersLocked fans out changed scopes to all registered subscribers.
+// notifySubscribersLocked fans out updated scopes to all registered
+// subscribers.
 //
-// Each subscriber receives only the subset of changed scopes that match its
-// filter. The send is non-blocking: a subscriber whose channel is full is
-// dropped (its dropped channel is closed and it is removed from the registry).
-// Caller must hold m.mu.
-func (m *Tracker) notifySubscribersLocked(changed []*readinesspb.Scope) {
-	if len(m.subscribers) == 0 || len(changed) == 0 {
+// Each subscriber's mailbox receives only the subset of updated scopes that
+// matches its filter; a subscriber that did not opt into observation
+// refreshes receives only the updates that changed state or reason. A
+// transition-queue overflow drops the subscriber — its Watch returns
+// ErrSlowConsumer. Caller must hold m.mu.
+func (m *Tracker) notifySubscribersLocked(updated []*readinesspb.Scope, changed bool) {
+	if len(m.subscribers) == 0 || len(updated) == 0 {
 		return
 	}
 
 	for sub := range m.subscribers {
-		var matching []*readinesspb.Scope
-		for _, sc := range changed {
-			if sub.Matches(sc.Name) {
-				matching = append(matching, sc)
-			}
-		}
-		if len(matching) == 0 {
+		if !changed && !sub.WantsObservations() {
 			continue
 		}
-		resp := &readinesspb.ReadyResponse{Scopes: matching}
-		if !sub.Send(resp) {
-			sub.Drop()
-			delete(m.subscribers, sub)
+		for _, sc := range updated {
+			if sub.Matches(sc.Name) {
+				if !sub.Offer(sc, changed) {
+					delete(m.subscribers, sub)
+					break
+				}
+			}
 		}
 	}
 }
@@ -287,14 +375,20 @@ func (m *Tracker) notifySubscribersLocked(changed []*readinesspb.Scope) {
 // subscribe registers a new subscriber and atomically captures the initial
 // snapshot. It returns the subscriber and the snapshot to send as the first
 // streamed message.
-func (m *Tracker) subscribe(filter map[string]struct{}) (*subscriber, *readinesspb.ReadyResponse) {
+func (m *Tracker) subscribe(
+	filter map[string]struct{},
+	includeObservations bool,
+) (*subscriber, *readinesspb.ReadyResponse) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	sub := &subscriber{
-		filter:  filter,
-		ch:      make(chan *readinesspb.ReadyResponse, readinessWatchBuffer),
-		dropped: make(chan struct{}),
+		filter:              filter,
+		includeObservations: includeObservations,
+		observations:        map[string]*readinesspb.Scope{},
+		transitions:         make([]*readinesspb.Scope, 0, 16),
+		signal:              make(chan struct{}, 1),
+		dropped:             make(chan struct{}),
 	}
 	m.subscribers[sub] = struct{}{}
 	snapshot := m.snapshotLocked(filter)
@@ -309,17 +403,18 @@ func (m *Tracker) unsubscribe(sub *subscriber) {
 	delete(m.subscribers, sub)
 }
 
-// applyLocked applies next and reason to s, logs the transition, and
+// applyLocked applies next and reason to s, logs any state transition, and
 // notifies Watch subscribers.
 //
-// Subscribers are notified only when the apply actually changed state or
-// reason. Must be called with m.mu held.
+// A subscriber that opted into observation updates receives the scope's
+// current snapshot on every apply — a repeated identical outcome still
+// streams the advanced observation timestamp that freshness consumers
+// depend on. A legacy subscriber receives it only when state or reason
+// actually changed. Must be called with m.mu held.
 func (m *Tracker) applyLocked(s *scopeState, next readinesspb.State, reason *readinesspb.Reason) {
 	prevState, changed := s.Apply(next, reason, time.Now())
 	m.logTransition(s.Name(), prevState, next, reason)
-	if changed {
-		m.notifySubscribersLocked([]*readinesspb.Scope{s.ToProto()})
-	}
+	m.notifySubscribersLocked([]*readinesspb.Scope{s.ToProto()}, changed)
 }
 
 // observeOutcome derives the next state and reason for an apply attempt
@@ -401,8 +496,10 @@ func (m *Tracker) set(scope string, state readinesspb.State, reason *readinesspb
 //
 // It records that the underlying source was successfully re-evaluated, so
 // freshness consumers can distinguish a live scope from one whose last event
-// was long ago. Touch is a no-op for unknown scopes — it never creates a
-// scope. state, reason, and lastTransitionTime are left unchanged.
+// was long ago. Only Watch subscribers that opted into observation updates
+// receive the refreshed snapshot, since the advanced timestamp is what they
+// consume for staleness. Touch is a no-op for unknown scopes — it never
+// creates a scope. state, reason, and lastTransitionTime are left unchanged.
 func (m *Tracker) Touch(scope string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -413,13 +510,17 @@ func (m *Tracker) Touch(scope string) {
 	}
 
 	s.Touch(time.Now())
+	m.notifySubscribersLocked([]*readinesspb.Scope{s.ToProto()}, false)
 }
 
 // Drain marks every scope as STATE_NOT_READY with a SHUTTING_DOWN reason.
 //
-// last_transition_time is updated only for scopes that change state. When
-// the Tracker was constructed with WithDrainLatch, subsequent Set and Observe
-// calls become no-ops after Drain returns.
+// last_transition_time is updated only for scopes that change state, but
+// every scope is re-observed. A subscriber that opted into observation
+// updates receives every scope; a legacy subscriber receives only the ones
+// whose state or reason actually changed. When the Tracker was constructed
+// with WithDrainLatch, subsequent Set and Observe calls become no-ops after
+// Drain returns.
 func (m *Tracker) Drain() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -427,16 +528,25 @@ func (m *Tracker) Drain() {
 	now := time.Now()
 	reason := &readinesspb.Reason{Code: "SHUTTING_DOWN"}
 
-	var changedScopes []*readinesspb.Scope
+	// One fan-out pass over all scopes per change class: a legacy
+	// subscriber must not see an unchanged scope, an opted-in one must see
+	// even the unchanged ones re-observed. A changed scope travels through
+	// the transition queue only, so its delivery is never duplicated.
+	changedScopes := make([]*readinesspb.Scope, 0, len(m.scopes))
+	unchangedScopes := make([]*readinesspb.Scope, 0, len(m.scopes))
 	for _, s := range m.scopes {
 		prevState, changed := s.Apply(readinesspb.State_STATE_NOT_READY, reason, now)
 		m.logTransition(s.Name(), prevState, readinesspb.State_STATE_NOT_READY, reason)
+		proto := s.ToProto()
 		if changed {
-			changedScopes = append(changedScopes, s.ToProto())
+			changedScopes = append(changedScopes, proto)
+		} else {
+			unchangedScopes = append(unchangedScopes, proto)
 		}
 	}
 
-	m.notifySubscribersLocked(changedScopes)
+	m.notifySubscribersLocked(changedScopes, true)
+	m.notifySubscribersLocked(unchangedScopes, false)
 
 	if m.latchOnDrain {
 		m.drained = true
@@ -457,16 +567,20 @@ func (m *Tracker) Ready(req *readinesspb.ReadyRequest) *readinesspb.ReadyRespons
 	return m.snapshotLocked(filter)
 }
 
-// Watch streams readiness state changes to the caller via send.
+// Watch streams readiness updates to the caller via send.
 //
 // The first message carries the current state of every scope matching the
-// request filter (same semantics as Ready). Each subsequent message carries
-// only the scopes whose state or reason changed since the previous message.
-// A pure observed_at refresh (Touch) never emits. A no-op mutation (same
-// state and same reason) never emits.
+// request filter (same semantics as Ready). Without
+// include_observation_updates in the request, each subsequent message
+// carries only the scopes whose state or reason changed since the previous
+// message, in order. With it, pure observed_at refreshes are delivered too,
+// coalesced per scope: a burst of refreshes between two reads yields the
+// newest snapshot of each affected scope. Transitions are never coalesced
+// away — a subscriber that falls more than a bounded number of transitions
+// behind is dropped with an error instead of losing one.
 //
-// Watch returns nil on ctx cancellation, returns the send error on stream
-// write failure, and returns errSlowConsumer if the subscriber's buffer
+// Watch returns nil on ctx cancellation, the send error on stream write
+// failure, and ErrSlowConsumer if the subscriber's transition queue
 // overflows.
 func (m *Tracker) Watch(
 	ctx context.Context,
@@ -478,7 +592,7 @@ func (m *Tracker) Watch(
 		filter[name] = struct{}{}
 	}
 
-	sub, snapshot := m.subscribe(filter)
+	sub, snapshot := m.subscribe(filter, req.GetIncludeObservationUpdates())
 	defer m.unsubscribe(sub)
 
 	if err := send(snapshot); err != nil {
@@ -490,12 +604,13 @@ func (m *Tracker) Watch(
 		case <-ctx.Done():
 			return nil
 		case <-sub.Dropped():
-			return errSlowConsumer
-		case resp, ok := <-sub.Events():
-			if !ok {
-				return errSlowConsumer
+			return ErrSlowConsumer
+		case <-sub.Signal():
+			scopes := sub.Drain()
+			if len(scopes) == 0 {
+				continue
 			}
-			if err := send(resp); err != nil {
+			if err := send(&readinesspb.ReadyResponse{Scopes: scopes}); err != nil {
 				return err
 			}
 		}

--- a/common/go/readiness/readiness.go
+++ b/common/go/readiness/readiness.go
@@ -192,14 +192,8 @@ func WithDrainLatch() Option {
 // ScopeSpec declares one scope at tracker construction.
 type ScopeSpec struct {
 	Name string
-	// ExpectedObservationInterval is the scope's freshness contract: the
-	// nominal cadence at which the scope's source re-observes it, i.e. the
-	// source's own ticker or heartbeat interval. Consumers judge staleness
-	// per scope against this cadence instead of a single global threshold;
-	// retries and slow applies can legitimately exceed it. Leave it zero
-	// for scopes with no natural heartbeat — such scopes are never judged
-	// stale. A zero or negative value is treated as none, and the contract
-	// is fixed for the tracker's lifetime.
+	// ExpectedObservationInterval is the nominal freshness cadence.
+	// A non-positive value disables staleness detection for the scope.
 	ExpectedObservationInterval time.Duration
 }
 

--- a/common/go/readiness/readiness_test.go
+++ b/common/go/readiness/readiness_test.go
@@ -3,6 +3,7 @@ package readiness_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func TestTracker_InitialState(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+	r := readiness.NewTracker(specs("gw-a", "gw-b"))
 	resp := r.Ready(&readinesspb.ReadyRequest{})
 
 	require.Len(t, resp.Scopes, 2)
@@ -56,7 +57,7 @@ func TestTracker_Transitions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := readiness.NewTracker([]string{"gw-a"})
+			r := readiness.NewTracker(specs("gw-a"))
 			r.Observe("gw-a", tt.observeErr)
 
 			resp := r.Ready(&readinesspb.ReadyRequest{})
@@ -142,7 +143,7 @@ func TestTracker_ObserveHoldOnRegression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := readiness.NewTracker([]string{"gw"})
+			r := readiness.NewTracker(specs("gw"))
 			tt.seed(r)
 
 			var finalErr error
@@ -166,7 +167,7 @@ func TestTracker_ObserveHoldOnRegression(t *testing.T) {
 }
 
 func TestTracker_LastTransitionTime_OnlyChangesOnStateChange(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a"})
+	r := readiness.NewTracker(specs("gw-a"))
 
 	// First observation: UNKNOWN -> READY.
 	r.Observe("gw-a", nil)
@@ -198,7 +199,7 @@ func TestTracker_LastTransitionTime_OnlyChangesOnStateChange(t *testing.T) {
 }
 
 func TestTracker_ScopeFilter(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a", "gw-b", "gw-c"})
+	r := readiness.NewTracker(specs("gw-a", "gw-b", "gw-c"))
 	r.Observe("gw-a", nil)
 	r.Observe("gw-b", errors.New("down"))
 
@@ -209,13 +210,13 @@ func TestTracker_ScopeFilter(t *testing.T) {
 }
 
 func TestTracker_ScopeFilter_Empty_ReturnsAll(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+	r := readiness.NewTracker(specs("gw-a", "gw-b"))
 	resp := r.Ready(&readinesspb.ReadyRequest{})
 	assert.Len(t, resp.Scopes, 2)
 }
 
 func TestTracker_UnknownGatewayIgnored(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a"})
+	r := readiness.NewTracker(specs("gw-a"))
 	// Observe on an unknown id must not panic.
 	r.Observe("gw-x", nil)
 
@@ -226,7 +227,7 @@ func TestTracker_UnknownGatewayIgnored(t *testing.T) {
 }
 
 func TestTracker_Drain(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+	r := readiness.NewTracker(specs("gw-a", "gw-b"))
 
 	// Bring gw-a to READY.
 	r.Observe("gw-a", nil)
@@ -244,7 +245,7 @@ func TestTracker_Drain(t *testing.T) {
 }
 
 func TestTracker_Drain_TransitionTimeOnlyOnChange(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a"})
+	r := readiness.NewTracker(specs("gw-a"))
 
 	// Put gw-a in NOT_READY already via a failed observe.
 	r.Observe("gw-a", errors.New("boom"))
@@ -261,7 +262,7 @@ func TestTracker_Drain_TransitionTimeOnlyOnChange(t *testing.T) {
 }
 
 func TestTracker_Set_UpsertNewScope(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a"})
+	r := readiness.NewTracker(specs("gw-a"))
 
 	// Set a scope that was not in the initial list.
 	r.Set("rib", readinesspb.State_STATE_READY)
@@ -282,7 +283,7 @@ func TestTracker_Set_UpsertNewScope(t *testing.T) {
 }
 
 func TestTracker_Set_TransitionTimeOnlyOnStateChange(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a"})
+	r := readiness.NewTracker(specs("gw-a"))
 
 	r.Set("gw-a", readinesspb.State_STATE_READY)
 	resp1 := r.Ready(&readinesspb.ReadyRequest{})
@@ -306,7 +307,7 @@ func TestTracker_Set_TransitionTimeOnlyOnStateChange(t *testing.T) {
 }
 
 func TestTracker_Set_ReasonsUpdated(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a"})
+	r := readiness.NewTracker(specs("gw-a"))
 
 	r.SetWithReason("gw-a", readinesspb.State_STATE_NOT_READY,
 		&readinesspb.Reason{Code: "SYNCING"})
@@ -323,7 +324,7 @@ func TestTracker_Set_ReasonsUpdated(t *testing.T) {
 }
 
 func TestTracker_Touch_AdvancesObservedAt(t *testing.T) {
-	r := readiness.NewTracker([]string{"neighbours"})
+	r := readiness.NewTracker(specs("neighbours"))
 
 	// Drive the scope to a known state.
 	r.SetWithReason("neighbours",
@@ -360,7 +361,7 @@ func TestTracker_Touch_AdvancesObservedAt(t *testing.T) {
 }
 
 func TestTracker_Touch_UnknownScope_NoOp(t *testing.T) {
-	r := readiness.NewTracker([]string{"neighbours"})
+	r := readiness.NewTracker(specs("neighbours"))
 
 	// Touch an unknown scope must not panic and must not create the scope.
 	r.Touch("bird-session")
@@ -370,6 +371,64 @@ func TestTracker_Touch_UnknownScope_NoOp(t *testing.T) {
 	assert.Equal(t, "neighbours", resp.Scopes[0].Name)
 }
 
+// specs builds scope declarations without a freshness contract, for tests
+// that exercise state and timestamps rather than freshness.
+func specs(names ...string) []readiness.ScopeSpec {
+	out := make([]readiness.ScopeSpec, 0, len(names))
+	for _, name := range names {
+		out = append(out, readiness.ScopeSpec{Name: name})
+	}
+	return out
+}
+
+func TestTracker_ExpectedObservationInterval_ExposedInSnapshot(t *testing.T) {
+	r := readiness.NewTracker([]readiness.ScopeSpec{
+		{Name: "neighbours", ExpectedObservationInterval: 5 * time.Minute},
+		{Name: "gateway"},
+		{Name: "rib", ExpectedObservationInterval: -time.Second},
+	})
+
+	resp := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.Scopes, 3)
+	for _, scope := range resp.Scopes {
+		switch scope.Name {
+		case "neighbours":
+			require.NotNil(t, scope.ExpectedObservationInterval,
+				"a declared observation interval must be exposed")
+			assert.Equal(t, 5*time.Minute, scope.ExpectedObservationInterval.AsDuration())
+		case "gateway", "rib":
+			assert.Nil(t, scope.ExpectedObservationInterval,
+				"a zero or negative interval must stay absent")
+		}
+	}
+}
+
+func TestTracker_ExpectedObservationInterval_CarriedByWatchSnapshot(t *testing.T) {
+	r := readiness.NewTracker([]readiness.ScopeSpec{
+		{Name: "neighbours", ExpectedObservationInterval: 5 * time.Minute},
+	})
+
+	messages := make(chan *readinesspb.ReadyResponse, 16)
+	go func() {
+		_ = r.Watch(t.Context(), &readinesspb.ReadyRequest{}, func(resp *readinesspb.ReadyResponse) error {
+			messages <- resp
+			return nil
+		})
+	}()
+
+	var snapshot *readinesspb.ReadyResponse
+	select {
+	case snapshot = <-messages:
+	case <-time.After(time.Second):
+		t.Fatal("no initial Watch snapshot arrived")
+	}
+
+	require.Len(t, snapshot.Scopes, 1)
+	require.NotNil(t, snapshot.Scopes[0].ExpectedObservationInterval,
+		"the initial Watch snapshot must carry the observation contract")
+	assert.Equal(t, 5*time.Minute, snapshot.Scopes[0].ExpectedObservationInterval.AsDuration())
+}
+
 // newObservedTracker constructs a Tracker backed by a zap observer so tests
 // can inspect emitted log entries. The operatorName is pre-tagged on the
 // logger before passing it to the tracker, matching the expected caller pattern.
@@ -377,7 +436,7 @@ func newObservedTracker(t *testing.T, scopes []string, operatorName string) (*re
 	t.Helper()
 	core, logs := observer.New(zapcore.InfoLevel)
 	r := readiness.NewTracker(
-		scopes,
+		specs(scopes...),
 		readiness.WithLog(zap.New(core).With(zap.String("operator", operatorName))),
 	)
 	return r, logs
@@ -522,7 +581,7 @@ func TestTracker_DrainLatch_SetAfterDrainIsNoop(t *testing.T) {
 			if tt.latch {
 				opts = append(opts, readiness.WithDrainLatch())
 			}
-			r := readiness.NewTracker([]string{"gw"}, opts...)
+			r := readiness.NewTracker(specs("gw"), opts...)
 
 			r.Drain()
 			r.Set("gw", readinesspb.State_STATE_READY)
@@ -604,7 +663,7 @@ const watchTimeout = 200 * time.Millisecond
 const watchQuietWindow = 30 * time.Millisecond
 
 func TestWatch_InitialSnapshot_AllScopes(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+	r := readiness.NewTracker(specs("gw-a", "gw-b"))
 	r.Set("gw-a", readinesspb.State_STATE_READY)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -628,7 +687,7 @@ func TestWatch_InitialSnapshot_AllScopes(t *testing.T) {
 }
 
 func TestWatch_InitialSnapshot_HonorsFilter(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a", "gw-b", "gw-c"})
+	r := readiness.NewTracker(specs("gw-a", "gw-b", "gw-c"))
 	r.Set("gw-a", readinesspb.State_STATE_READY)
 	r.Set("gw-b", readinesspb.State_STATE_NOT_READY)
 
@@ -647,7 +706,7 @@ func TestWatch_InitialSnapshot_HonorsFilter(t *testing.T) {
 }
 
 func TestWatch_StateChange_EmitsDelta(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+	r := readiness.NewTracker(specs("gw-a", "gw-b"))
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -669,7 +728,7 @@ func TestWatch_StateChange_EmitsDelta(t *testing.T) {
 }
 
 func TestWatch_ReasonOnlyChange_EmitsDelta(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a"})
+	r := readiness.NewTracker(specs("gw-a"))
 	r.SetWithReason("gw-a", readinesspb.State_STATE_DEGRADED, &readinesspb.Reason{Code: "OLD"})
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -694,8 +753,44 @@ func TestWatch_ReasonOnlyChange_EmitsDelta(t *testing.T) {
 	require.NoError(t, eg.Wait())
 }
 
-func TestWatch_Touch_EmitsNothing(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a"})
+// TestWatch_Touch_EmitsObservedAtRefresh verifies that a pure observation
+// refresh is streamed to a subscriber that opted into observation updates:
+// the delta carries the same state and transition time but an advanced
+// observation timestamp.
+func TestWatch_Touch_EmitsObservedAtRefresh(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a"))
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, observationReq(), 8)
+
+	snap := recvTimeout(t, ch, watchTimeout)
+	observedBefore := snap.Scopes[0].ObservedAt.AsTime()
+	transitionBefore := snap.Scopes[0].LastTransitionTime.AsTime()
+
+	time.Sleep(2 * time.Millisecond)
+	r.Touch("gw-a")
+
+	delta := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, delta.Scopes, 1)
+	assert.Equal(t, "gw-a", delta.Scopes[0].Name)
+	assert.True(t, delta.Scopes[0].ObservedAt.AsTime().After(observedBefore),
+		"Touch must stream the advanced observation timestamp")
+	assert.Equal(t, transitionBefore, delta.Scopes[0].LastTransitionTime.AsTime(),
+		"Touch must not change last_transition_time")
+	assert.Equal(t, readinesspb.State_STATE_READY, delta.Scopes[0].State)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+// TestWatch_Touch_LegacyEmitsNothing verifies that a subscriber that did not
+// opt into observation updates never receives pure heartbeat refreshes, so
+// every message it sees is a state or reason change.
+func TestWatch_Touch_LegacyEmitsNothing(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a"))
 	r.Set("gw-a", readinesspb.State_STATE_READY)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -713,8 +808,41 @@ func TestWatch_Touch_EmitsNothing(t *testing.T) {
 	require.NoError(t, eg.Wait())
 }
 
-func TestWatch_NoopSet_EmitsNothing(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a"})
+// TestWatch_NoopSet_EmitsObservedAtRefresh verifies that a repeated identical
+// mutation still streams the scope to an opted-in subscriber: the
+// re-observation advances the freshness clock even though state and reason
+// are unchanged.
+func TestWatch_NoopSet_EmitsObservedAtRefresh(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a"))
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, observationReq(), 8)
+
+	snap := recvTimeout(t, ch, watchTimeout)
+	observedBefore := snap.Scopes[0].ObservedAt.AsTime()
+
+	time.Sleep(2 * time.Millisecond)
+	// Same state, same reason (nil).
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	delta := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, delta.Scopes, 1)
+	assert.True(t, delta.Scopes[0].ObservedAt.AsTime().After(observedBefore),
+		"a repeated identical outcome must still stream the refresh")
+	assert.Equal(t, readinesspb.State_STATE_READY, delta.Scopes[0].State)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+// TestWatch_NoopSet_LegacyEmitsNothing verifies that a repeated identical
+// mutation is silent for a legacy subscriber: without the observation opt-in
+// only state or reason changes are delivered.
+func TestWatch_NoopSet_LegacyEmitsNothing(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a"))
 	r.Set("gw-a", readinesspb.State_STATE_READY)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -724,7 +852,7 @@ func TestWatch_NoopSet_EmitsNothing(t *testing.T) {
 
 	recvTimeout(t, ch, watchTimeout)
 
-	// Same state, same reason (nil) — must not emit.
+	// Same state, same reason (nil).
 	r.Set("gw-a", readinesspb.State_STATE_READY)
 
 	assertNoMsg(t, ch, watchQuietWindow)
@@ -733,8 +861,38 @@ func TestWatch_NoopSet_EmitsNothing(t *testing.T) {
 	require.NoError(t, eg.Wait())
 }
 
+// TestWatch_Observe_SameOutcome_EmitsObservedAtRefresh verifies that the
+// reconcile-style observation path streams repeated identical outcomes to an
+// opted-in subscriber, so a long-lived consumer never mistakes a live scope
+// for a stale one.
+func TestWatch_Observe_SameOutcome_EmitsObservedAtRefresh(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a"))
+	r.Observe("gw-a", nil)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, observationReq(), 8)
+
+	snap := recvTimeout(t, ch, watchTimeout)
+	observedBefore := snap.Scopes[0].ObservedAt.AsTime()
+
+	time.Sleep(2 * time.Millisecond)
+	// A second successful apply does not change state or reason.
+	r.Observe("gw-a", nil)
+
+	delta := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, delta.Scopes, 1)
+	assert.True(t, delta.Scopes[0].ObservedAt.AsTime().After(observedBefore),
+		"a repeated identical observe must still stream the refresh")
+	assert.Equal(t, readinesspb.State_STATE_READY, delta.Scopes[0].State)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
 func TestWatch_DeltaFilteredForDifferentScope(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+	r := readiness.NewTracker(specs("gw-a", "gw-b"))
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -760,34 +918,8 @@ func TestWatch_DeltaFilteredForDifferentScope(t *testing.T) {
 	require.NoError(t, eg.Wait())
 }
 
-func TestWatch_Drain_EmitsChangedScopes(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
-	r.Set("gw-a", readinesspb.State_STATE_READY)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
-
-	recvTimeout(t, ch, watchTimeout)
-
-	r.Drain()
-
-	delta := recvTimeout(t, ch, watchTimeout)
-	// Both scopes transitioned: gw-a READY->NOT_READY, gw-b UNKNOWN->NOT_READY.
-	require.Len(t, delta.Scopes, 2)
-	for _, s := range delta.Scopes {
-		assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
-		require.Len(t, s.Reasons, 1)
-		assert.Equal(t, "SHUTTING_DOWN", s.Reasons[0].Code)
-	}
-
-	cancel()
-	require.NoError(t, eg.Wait())
-}
-
 func TestWatch_CtxCancel_ReturnsNil(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a"})
+	r := readiness.NewTracker(specs("gw-a"))
 
 	ctx, cancel := context.WithCancel(t.Context())
 
@@ -806,7 +938,7 @@ func TestWatch_CtxCancel_ReturnsNil(t *testing.T) {
 }
 
 func TestWatch_GatewayStyle_DrainLatch(t *testing.T) {
-	r := readiness.NewTracker([]string{"gateway"}, readiness.WithDrainLatch())
+	r := readiness.NewTracker(specs("gateway"), readiness.WithDrainLatch())
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -840,12 +972,274 @@ func TestWatch_GatewayStyle_DrainLatch(t *testing.T) {
 	require.NoError(t, eg.Wait())
 }
 
+// TestWatch_Drain_LegacyEmitsOnlyChangedScopes verifies that Drain streams a
+// message only for scopes whose state or reason actually changed when the
+// subscriber did not opt into observation updates.
+func TestWatch_Drain_LegacyEmitsOnlyChangedScopes(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a", "gw-b", "gw-c"))
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+	// gw-c already holds the drained state and reason.
+	r.SetWithReason("gw-c", readinesspb.State_STATE_NOT_READY,
+		&readinesspb.Reason{Code: "SHUTTING_DOWN"},
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
+
+	recvTimeout(t, ch, watchTimeout)
+
+	r.Drain()
+
+	delta := recvTimeout(t, ch, watchTimeout)
+	// gw-a (READY -> NOT_READY) and gw-b (UNKNOWN -> NOT_READY) changed;
+	// gw-c was already NOT_READY with the same reason.
+	require.Len(t, delta.Scopes, 2)
+	for _, s := range delta.Scopes {
+		assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+		require.Len(t, s.Reasons, 1)
+		assert.Equal(t, "SHUTTING_DOWN", s.Reasons[0].Code)
+	}
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+// TestWatch_Drain_OptedInEmitsEveryScope verifies that Drain streams a
+// message for every scope, including one already holding the drained state
+// and reason, when the subscriber opted into observation updates.
+func TestWatch_Drain_OptedInEmitsEveryScope(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a", "gw-b", "gw-c"))
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+	// gw-c already holds the drained state and reason, so only its
+	// observation timestamp changes.
+	r.SetWithReason("gw-c", readinesspb.State_STATE_NOT_READY,
+		&readinesspb.Reason{Code: "SHUTTING_DOWN"},
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, observationReq(), 8)
+
+	recvTimeout(t, ch, watchTimeout)
+
+	r.Drain()
+
+	delta := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, delta.Scopes, 3)
+	for _, s := range delta.Scopes {
+		assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+		require.Len(t, s.Reasons, 1)
+		assert.Equal(t, "SHUTTING_DOWN", s.Reasons[0].Code)
+	}
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+// observationReq builds a Watch request that opts into observation updates.
+func observationReq() *readinesspb.ReadyRequest {
+	return &readinesspb.ReadyRequest{IncludeObservationUpdates: true}
+}
+
+// TestWatch_TransitionsPreservedUnderBlockedSend verifies that a blocked
+// stream still receives every state transition in order: transitions queue
+// rather than coalesce, so a READY -> NOT_READY -> READY burst during a send
+// stall cannot collapse into the final READY.
+func TestWatch_TransitionsPreservedUnderBlockedSend(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a"))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	block := make(chan struct{})
+	delivered := make(chan *readinesspb.ReadyResponse, 4)
+	sending := make(chan struct{}, 1)
+
+	eg, _ := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return r.Watch(ctx, observationReq(), func(resp *readinesspb.ReadyResponse) error {
+			// Block the snapshot send: the transitions that follow queue
+			// behind it instead of being coalesced away.
+			select {
+			case sending <- struct{}{}:
+				<-block
+			default:
+			}
+			delivered <- resp
+			return nil
+		})
+	})
+
+	// Fire the burst while the snapshot send is stalled: both transitions
+	// land in the queue before the reader drains anything.
+	<-sending
+	r.Set("gw-a", readinesspb.State_STATE_NOT_READY)
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+	close(block)
+
+	// The snapshot first, then every transition in order.
+	snapshot := recvTimeout(t, delivered, watchTimeout)
+	require.Len(t, snapshot.Scopes, 1)
+	assert.Equal(t, readinesspb.State_STATE_UNKNOWN, snapshot.Scopes[0].State)
+
+	delta := recvTimeout(t, delivered, watchTimeout)
+	states := []readinesspb.State{}
+	for _, scope := range delta.Scopes {
+		states = append(states, scope.State)
+	}
+	assert.Equal(t, []readinesspb.State{
+		readinesspb.State_STATE_NOT_READY,
+		readinesspb.State_STATE_READY,
+	}, states, "both transitions must be delivered in order despite the stall")
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+// TestWatch_ObservationSupersededByTransition verifies ordering between the
+// two delivery paths for one scope: a heartbeat snapshotted before a state
+// change is retired by that change, so a stalled reader cannot be handed the
+// stale snapshot after the transition — the neighbour-recovery shape where
+// a liveness touch precedes the resynced state.
+func TestWatch_ObservationSupersededByTransition(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a"))
+	r.SetWithReason("gw-a", readinesspb.State_STATE_DEGRADED, &readinesspb.Reason{Code: "RESYNC"})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	block := make(chan struct{})
+	delivered := make(chan *readinesspb.ReadyResponse, 4)
+	sending := make(chan struct{}, 1)
+
+	eg, _ := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return r.Watch(ctx, observationReq(), func(resp *readinesspb.ReadyResponse) error {
+			select {
+			case sending <- struct{}{}:
+				<-block
+			default:
+			}
+			delivered <- resp
+			return nil
+		})
+	})
+
+	// Heartbeat first, then the recovery transition, both queued behind the
+	// stalled snapshot send.
+	<-sending
+	r.Touch("gw-a")
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+	close(block)
+
+	recvTimeout(t, delivered, watchTimeout) // snapshot
+
+	delta := recvTimeout(t, delivered, watchTimeout)
+	require.Len(t, delta.Scopes, 1,
+		"the superseded observation must be retired, not delivered after the transition")
+	assert.Equal(t, readinesspb.State_STATE_READY, delta.Scopes[0].State)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+// TestWatch_PureObservationsCoalesceToNewest verifies that consecutive
+// heartbeats of one scope with no state change between them collapse into
+// the single newest snapshot.
+func TestWatch_PureObservationsCoalesceToNewest(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a"))
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	block := make(chan struct{})
+	delivered := make(chan *readinesspb.ReadyResponse, 4)
+	sending := make(chan struct{}, 1)
+
+	eg, _ := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return r.Watch(ctx, observationReq(), func(resp *readinesspb.ReadyResponse) error {
+			select {
+			case sending <- struct{}{}:
+				<-block
+			default:
+			}
+			delivered <- resp
+			return nil
+		})
+	})
+
+	<-sending
+	for range 5 {
+		time.Sleep(2 * time.Millisecond)
+		r.Touch("gw-a")
+	}
+	close(block)
+
+	recvTimeout(t, delivered, watchTimeout) // snapshot
+
+	delta := recvTimeout(t, delivered, watchTimeout)
+	require.Len(t, delta.Scopes, 1, "five pure touches must coalesce into one snapshot")
+	assert.Equal(t, readinesspb.State_STATE_READY, delta.Scopes[0].State)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+// TestWatch_SlowConsumerDroppedOnTransitionOverflow verifies that a
+// subscriber whose transition queue overflows is dropped with an explicit
+// error rather than silently losing a promised transition. The mutation
+// count far exceeds the queue, so the exact limit does not matter.
+func TestWatch_SlowConsumerDroppedOnTransitionOverflow(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a"))
+
+	release := make(chan struct{})
+	sending := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- r.Watch(ctx, &readinesspb.ReadyRequest{}, func(_ *readinesspb.ReadyResponse) error {
+			// Stall every delta after the snapshot until released.
+			select {
+			case sending <- struct{}{}:
+				<-release
+			default:
+			}
+			return nil
+		})
+	}()
+
+	<-sending
+	for range 5000 {
+		r.Set("gw-a", readinesspb.State_STATE_READY)
+		r.Set("gw-a", readinesspb.State_STATE_NOT_READY)
+	}
+
+	close(release)
+	require.ErrorIs(t, <-done, readiness.ErrSlowConsumer,
+		"an overflowed transition queue must drop the subscriber explicitly")
+}
+
+// TestWatch_ConcurrentSubscribersAndMutators verifies that a burst of
+// mutations across many scopes never disconnects a reading subscriber: the
+// coalescing mailbox bounds per-subscriber cost by the scope count, not the
+// event rate, so Watch must return nil on cancellation for every consumer.
 func TestWatch_ConcurrentSubscribersAndMutators(t *testing.T) {
-	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+	names := make([]string, 0, 32)
+	for idx := range 32 {
+		names = append(names, fmt.Sprintf("gw-%02d", idx))
+	}
+	r := readiness.NewTracker(specs(names...))
 
 	const (
-		numSubscribers = 8
-		numMutations   = 50
+		numSubscribers = 4
+		numMutations   = 500
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -854,22 +1248,26 @@ func TestWatch_ConcurrentSubscribersAndMutators(t *testing.T) {
 	subEg, _ := errgroup.WithContext(t.Context())
 	for range numSubscribers {
 		subEg.Go(func() error {
-			_ = r.Watch(ctx, &readinesspb.ReadyRequest{}, func(_ *readinesspb.ReadyResponse) error {
+			return r.Watch(ctx, observationReq(), func(_ *readinesspb.ReadyResponse) error {
 				return nil
 			})
-			return nil
 		})
 	}
+
+	// Let every subscriber register before the burst starts.
+	time.Sleep(10 * time.Millisecond)
 
 	eg, _ := errgroup.WithContext(t.Context())
 	eg.Go(func() error {
 		for idx := range numMutations {
-			if idx%3 == 0 {
-				r.Set("gw-a", readinesspb.State_STATE_READY)
-			} else if idx%3 == 1 {
-				r.Set("gw-b", readinesspb.State_STATE_NOT_READY)
-			} else {
-				r.Touch("gw-a")
+			name := names[idx%len(names)]
+			switch idx % 3 {
+			case 0:
+				r.Set(name, readinesspb.State_STATE_READY)
+			case 1:
+				r.Set(name, readinesspb.State_STATE_NOT_READY)
+			default:
+				r.Touch(name)
 			}
 		}
 		return nil
@@ -877,5 +1275,5 @@ func TestWatch_ConcurrentSubscribersAndMutators(t *testing.T) {
 	require.NoError(t, eg.Wait())
 
 	cancel()
-	require.NoError(t, subEg.Wait())
+	require.NoError(t, subEg.Wait(), "no subscriber may be dropped under a burst")
 }

--- a/common/go/readiness/readiness_test.go
+++ b/common/go/readiness/readiness_test.go
@@ -370,8 +370,7 @@ func TestTracker_Touch_UnknownScope_NoOp(t *testing.T) {
 	assert.Equal(t, "neighbours", resp.Scopes[0].Name)
 }
 
-// specs builds scope declarations without a freshness contract, for tests
-// that exercise state and timestamps rather than freshness.
+// specs returns scopes without freshness contracts for non-freshness tests.
 func specs(names ...string) []readiness.ScopeSpec {
 	out := make([]readiness.ScopeSpec, 0, len(names))
 	for _, name := range names {

--- a/common/go/readiness/readiness_test.go
+++ b/common/go/readiness/readiness_test.go
@@ -3,7 +3,6 @@ package readiness_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -381,52 +380,34 @@ func specs(names ...string) []readiness.ScopeSpec {
 	return out
 }
 
-func TestTracker_ExpectedObservationInterval_ExposedInSnapshot(t *testing.T) {
+// verifies that each scope exposes its own positive freshness cadence and
+// omits no-heartbeat scopes from freshness evaluation.
+func TestTracker_Ready_ExpectedObservationIntervalsByScope(t *testing.T) {
 	r := readiness.NewTracker([]readiness.ScopeSpec{
 		{Name: "neighbours", ExpectedObservationInterval: 5 * time.Minute},
+		{Name: "route", ExpectedObservationInterval: 30 * time.Second},
 		{Name: "gateway"},
-		{Name: "rib", ExpectedObservationInterval: -time.Second},
 	})
+	r.Set("neighbours", readinesspb.State_STATE_READY)
+	r.Set("route", readinesspb.State_STATE_READY)
+	r.Set("gateway", readinesspb.State_STATE_READY)
 
 	resp := r.Ready(&readinesspb.ReadyRequest{})
 	require.Len(t, resp.Scopes, 3)
-	for _, scope := range resp.Scopes {
-		switch scope.Name {
-		case "neighbours":
-			require.NotNil(t, scope.ExpectedObservationInterval,
-				"a declared observation interval must be exposed")
-			assert.Equal(t, 5*time.Minute, scope.ExpectedObservationInterval.AsDuration())
-		case "gateway", "rib":
-			assert.Nil(t, scope.ExpectedObservationInterval,
-				"a zero or negative interval must stay absent")
-		}
-	}
-}
 
-func TestTracker_ExpectedObservationInterval_CarriedByWatchSnapshot(t *testing.T) {
-	r := readiness.NewTracker([]readiness.ScopeSpec{
-		{Name: "neighbours", ExpectedObservationInterval: 5 * time.Minute},
-	})
-
-	messages := make(chan *readinesspb.ReadyResponse, 16)
-	go func() {
-		_ = r.Watch(t.Context(), &readinesspb.ReadyRequest{}, func(resp *readinesspb.ReadyResponse) error {
-			messages <- resp
-			return nil
-		})
-	}()
-
-	var snapshot *readinesspb.ReadyResponse
-	select {
-	case snapshot = <-messages:
-	case <-time.After(time.Second):
-		t.Fatal("no initial Watch snapshot arrived")
+	scopes := map[string]*readinesspb.Scope{}
+	for _, scope := range resp.GetScopes() {
+		scopes[scope.GetName()] = scope
 	}
 
-	require.Len(t, snapshot.Scopes, 1)
-	require.NotNil(t, snapshot.Scopes[0].ExpectedObservationInterval,
-		"the initial Watch snapshot must carry the observation contract")
-	assert.Equal(t, 5*time.Minute, snapshot.Scopes[0].ExpectedObservationInterval.AsDuration())
+	require.NotNil(t, scopes["neighbours"])
+	require.NotNil(t, scopes["neighbours"].ExpectedObservationInterval)
+	assert.Equal(t, 5*time.Minute, scopes["neighbours"].ExpectedObservationInterval.AsDuration())
+	require.NotNil(t, scopes["route"])
+	require.NotNil(t, scopes["route"].ExpectedObservationInterval)
+	assert.Equal(t, 30*time.Second, scopes["route"].ExpectedObservationInterval.AsDuration())
+	require.NotNil(t, scopes["gateway"])
+	assert.Nil(t, scopes["gateway"].ExpectedObservationInterval)
 }
 
 // newObservedTracker constructs a Tracker backed by a zap observer so tests
@@ -753,43 +734,9 @@ func TestWatch_ReasonOnlyChange_EmitsDelta(t *testing.T) {
 	require.NoError(t, eg.Wait())
 }
 
-// TestWatch_Touch_EmitsObservedAtRefresh verifies that a pure observation
-// refresh is streamed to a subscriber that opted into observation updates:
-// the delta carries the same state and transition time but an advanced
-// observation timestamp.
-func TestWatch_Touch_EmitsObservedAtRefresh(t *testing.T) {
-	r := readiness.NewTracker(specs("gw-a"))
-	r.Set("gw-a", readinesspb.State_STATE_READY)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	ch, eg := collectWatch(t, ctx, r, observationReq(), 8)
-
-	snap := recvTimeout(t, ch, watchTimeout)
-	observedBefore := snap.Scopes[0].ObservedAt.AsTime()
-	transitionBefore := snap.Scopes[0].LastTransitionTime.AsTime()
-
-	time.Sleep(2 * time.Millisecond)
-	r.Touch("gw-a")
-
-	delta := recvTimeout(t, ch, watchTimeout)
-	require.Len(t, delta.Scopes, 1)
-	assert.Equal(t, "gw-a", delta.Scopes[0].Name)
-	assert.True(t, delta.Scopes[0].ObservedAt.AsTime().After(observedBefore),
-		"Touch must stream the advanced observation timestamp")
-	assert.Equal(t, transitionBefore, delta.Scopes[0].LastTransitionTime.AsTime(),
-		"Touch must not change last_transition_time")
-	assert.Equal(t, readinesspb.State_STATE_READY, delta.Scopes[0].State)
-
-	cancel()
-	require.NoError(t, eg.Wait())
-}
-
-// TestWatch_Touch_LegacyEmitsNothing verifies that a subscriber that did not
-// opt into observation updates never receives pure heartbeat refreshes, so
-// every message it sees is a state or reason change.
-func TestWatch_Touch_LegacyEmitsNothing(t *testing.T) {
+// verifies that a timestamp-only refresh remains visible through readiness
+// queries without producing a stream event.
+func TestWatch_Touch_EmitsNothing(t *testing.T) {
 	r := readiness.NewTracker(specs("gw-a"))
 	r.Set("gw-a", readinesspb.State_STATE_READY)
 
@@ -798,50 +745,24 @@ func TestWatch_Touch_LegacyEmitsNothing(t *testing.T) {
 
 	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
 
-	recvTimeout(t, ch, watchTimeout)
-
-	r.Touch("gw-a")
-
-	assertNoMsg(t, ch, watchQuietWindow)
-
-	cancel()
-	require.NoError(t, eg.Wait())
-}
-
-// TestWatch_NoopSet_EmitsObservedAtRefresh verifies that a repeated identical
-// mutation still streams the scope to an opted-in subscriber: the
-// re-observation advances the freshness clock even though state and reason
-// are unchanged.
-func TestWatch_NoopSet_EmitsObservedAtRefresh(t *testing.T) {
-	r := readiness.NewTracker(specs("gw-a"))
-	r.Set("gw-a", readinesspb.State_STATE_READY)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	ch, eg := collectWatch(t, ctx, r, observationReq(), 8)
-
 	snap := recvTimeout(t, ch, watchTimeout)
 	observedBefore := snap.Scopes[0].ObservedAt.AsTime()
 
 	time.Sleep(2 * time.Millisecond)
-	// Same state, same reason (nil).
-	r.Set("gw-a", readinesspb.State_STATE_READY)
+	r.Touch("gw-a")
 
-	delta := recvTimeout(t, ch, watchTimeout)
-	require.Len(t, delta.Scopes, 1)
-	assert.True(t, delta.Scopes[0].ObservedAt.AsTime().After(observedBefore),
-		"a repeated identical outcome must still stream the refresh")
-	assert.Equal(t, readinesspb.State_STATE_READY, delta.Scopes[0].State)
+	assertNoMsg(t, ch, watchQuietWindow)
+	resp := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.Scopes, 1)
+	assert.True(t, resp.Scopes[0].ObservedAt.AsTime().After(observedBefore))
 
 	cancel()
 	require.NoError(t, eg.Wait())
 }
 
-// TestWatch_NoopSet_LegacyEmitsNothing verifies that a repeated identical
-// mutation is silent for a legacy subscriber: without the observation opt-in
-// only state or reason changes are delivered.
-func TestWatch_NoopSet_LegacyEmitsNothing(t *testing.T) {
+// verifies that an unchanged mutation refreshes the observation timestamp
+// without producing a stream event.
+func TestWatch_NoopSet_EmitsNothing(t *testing.T) {
 	r := readiness.NewTracker(specs("gw-a"))
 	r.Set("gw-a", readinesspb.State_STATE_READY)
 
@@ -850,42 +771,42 @@ func TestWatch_NoopSet_LegacyEmitsNothing(t *testing.T) {
 
 	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
 
-	recvTimeout(t, ch, watchTimeout)
+	snap := recvTimeout(t, ch, watchTimeout)
+	observedBefore := snap.Scopes[0].ObservedAt.AsTime()
 
-	// Same state, same reason (nil).
+	time.Sleep(2 * time.Millisecond)
 	r.Set("gw-a", readinesspb.State_STATE_READY)
 
 	assertNoMsg(t, ch, watchQuietWindow)
+	resp := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.Scopes, 1)
+	assert.True(t, resp.Scopes[0].ObservedAt.AsTime().After(observedBefore))
 
 	cancel()
 	require.NoError(t, eg.Wait())
 }
 
-// TestWatch_Observe_SameOutcome_EmitsObservedAtRefresh verifies that the
-// reconcile-style observation path streams repeated identical outcomes to an
-// opted-in subscriber, so a long-lived consumer never mistakes a live scope
-// for a stale one.
-func TestWatch_Observe_SameOutcome_EmitsObservedAtRefresh(t *testing.T) {
+// verifies that a repeated outcome refreshes the observation timestamp without
+// producing a stream event.
+func TestWatch_NoopObserve_EmitsNothing(t *testing.T) {
 	r := readiness.NewTracker(specs("gw-a"))
 	r.Observe("gw-a", nil)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	ch, eg := collectWatch(t, ctx, r, observationReq(), 8)
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
 
 	snap := recvTimeout(t, ch, watchTimeout)
 	observedBefore := snap.Scopes[0].ObservedAt.AsTime()
 
 	time.Sleep(2 * time.Millisecond)
-	// A second successful apply does not change state or reason.
 	r.Observe("gw-a", nil)
 
-	delta := recvTimeout(t, ch, watchTimeout)
-	require.Len(t, delta.Scopes, 1)
-	assert.True(t, delta.Scopes[0].ObservedAt.AsTime().After(observedBefore),
-		"a repeated identical observe must still stream the refresh")
-	assert.Equal(t, readinesspb.State_STATE_READY, delta.Scopes[0].State)
+	assertNoMsg(t, ch, watchQuietWindow)
+	resp := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.Scopes, 1)
+	assert.True(t, resp.Scopes[0].ObservedAt.AsTime().After(observedBefore))
 
 	cancel()
 	require.NoError(t, eg.Wait())
@@ -913,6 +834,32 @@ func TestWatch_DeltaFilteredForDifferentScope(t *testing.T) {
 	delta := recvTimeout(t, ch, watchTimeout)
 	require.Len(t, delta.Scopes, 1)
 	assert.Equal(t, "gw-b", delta.Scopes[0].Name)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func TestWatch_Drain_EmitsChangedScopes(t *testing.T) {
+	r := readiness.NewTracker(specs("gw-a", "gw-b"))
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
+
+	recvTimeout(t, ch, watchTimeout)
+
+	r.Drain()
+
+	delta := recvTimeout(t, ch, watchTimeout)
+	// Both scopes transitioned: gw-a READY->NOT_READY, gw-b UNKNOWN->NOT_READY.
+	require.Len(t, delta.Scopes, 2)
+	for _, s := range delta.Scopes {
+		assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+		require.Len(t, s.Reasons, 1)
+		assert.Equal(t, "SHUTTING_DOWN", s.Reasons[0].Code)
+	}
 
 	cancel()
 	require.NoError(t, eg.Wait())
@@ -972,274 +919,12 @@ func TestWatch_GatewayStyle_DrainLatch(t *testing.T) {
 	require.NoError(t, eg.Wait())
 }
 
-// TestWatch_Drain_LegacyEmitsOnlyChangedScopes verifies that Drain streams a
-// message only for scopes whose state or reason actually changed when the
-// subscriber did not opt into observation updates.
-func TestWatch_Drain_LegacyEmitsOnlyChangedScopes(t *testing.T) {
-	r := readiness.NewTracker(specs("gw-a", "gw-b", "gw-c"))
-	r.Set("gw-a", readinesspb.State_STATE_READY)
-	// gw-c already holds the drained state and reason.
-	r.SetWithReason("gw-c", readinesspb.State_STATE_NOT_READY,
-		&readinesspb.Reason{Code: "SHUTTING_DOWN"},
-	)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
-
-	recvTimeout(t, ch, watchTimeout)
-
-	r.Drain()
-
-	delta := recvTimeout(t, ch, watchTimeout)
-	// gw-a (READY -> NOT_READY) and gw-b (UNKNOWN -> NOT_READY) changed;
-	// gw-c was already NOT_READY with the same reason.
-	require.Len(t, delta.Scopes, 2)
-	for _, s := range delta.Scopes {
-		assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
-		require.Len(t, s.Reasons, 1)
-		assert.Equal(t, "SHUTTING_DOWN", s.Reasons[0].Code)
-	}
-
-	cancel()
-	require.NoError(t, eg.Wait())
-}
-
-// TestWatch_Drain_OptedInEmitsEveryScope verifies that Drain streams a
-// message for every scope, including one already holding the drained state
-// and reason, when the subscriber opted into observation updates.
-func TestWatch_Drain_OptedInEmitsEveryScope(t *testing.T) {
-	r := readiness.NewTracker(specs("gw-a", "gw-b", "gw-c"))
-	r.Set("gw-a", readinesspb.State_STATE_READY)
-	// gw-c already holds the drained state and reason, so only its
-	// observation timestamp changes.
-	r.SetWithReason("gw-c", readinesspb.State_STATE_NOT_READY,
-		&readinesspb.Reason{Code: "SHUTTING_DOWN"},
-	)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	ch, eg := collectWatch(t, ctx, r, observationReq(), 8)
-
-	recvTimeout(t, ch, watchTimeout)
-
-	r.Drain()
-
-	delta := recvTimeout(t, ch, watchTimeout)
-	require.Len(t, delta.Scopes, 3)
-	for _, s := range delta.Scopes {
-		assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
-		require.Len(t, s.Reasons, 1)
-		assert.Equal(t, "SHUTTING_DOWN", s.Reasons[0].Code)
-	}
-
-	cancel()
-	require.NoError(t, eg.Wait())
-}
-
-// observationReq builds a Watch request that opts into observation updates.
-func observationReq() *readinesspb.ReadyRequest {
-	return &readinesspb.ReadyRequest{IncludeObservationUpdates: true}
-}
-
-// TestWatch_TransitionsPreservedUnderBlockedSend verifies that a blocked
-// stream still receives every state transition in order: transitions queue
-// rather than coalesce, so a READY -> NOT_READY -> READY burst during a send
-// stall cannot collapse into the final READY.
-func TestWatch_TransitionsPreservedUnderBlockedSend(t *testing.T) {
-	r := readiness.NewTracker(specs("gw-a"))
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	block := make(chan struct{})
-	delivered := make(chan *readinesspb.ReadyResponse, 4)
-	sending := make(chan struct{}, 1)
-
-	eg, _ := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		return r.Watch(ctx, observationReq(), func(resp *readinesspb.ReadyResponse) error {
-			// Block the snapshot send: the transitions that follow queue
-			// behind it instead of being coalesced away.
-			select {
-			case sending <- struct{}{}:
-				<-block
-			default:
-			}
-			delivered <- resp
-			return nil
-		})
-	})
-
-	// Fire the burst while the snapshot send is stalled: both transitions
-	// land in the queue before the reader drains anything.
-	<-sending
-	r.Set("gw-a", readinesspb.State_STATE_NOT_READY)
-	r.Set("gw-a", readinesspb.State_STATE_READY)
-	close(block)
-
-	// The snapshot first, then every transition in order.
-	snapshot := recvTimeout(t, delivered, watchTimeout)
-	require.Len(t, snapshot.Scopes, 1)
-	assert.Equal(t, readinesspb.State_STATE_UNKNOWN, snapshot.Scopes[0].State)
-
-	delta := recvTimeout(t, delivered, watchTimeout)
-	states := []readinesspb.State{}
-	for _, scope := range delta.Scopes {
-		states = append(states, scope.State)
-	}
-	assert.Equal(t, []readinesspb.State{
-		readinesspb.State_STATE_NOT_READY,
-		readinesspb.State_STATE_READY,
-	}, states, "both transitions must be delivered in order despite the stall")
-
-	cancel()
-	require.NoError(t, eg.Wait())
-}
-
-// TestWatch_ObservationSupersededByTransition verifies ordering between the
-// two delivery paths for one scope: a heartbeat snapshotted before a state
-// change is retired by that change, so a stalled reader cannot be handed the
-// stale snapshot after the transition — the neighbour-recovery shape where
-// a liveness touch precedes the resynced state.
-func TestWatch_ObservationSupersededByTransition(t *testing.T) {
-	r := readiness.NewTracker(specs("gw-a"))
-	r.SetWithReason("gw-a", readinesspb.State_STATE_DEGRADED, &readinesspb.Reason{Code: "RESYNC"})
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	block := make(chan struct{})
-	delivered := make(chan *readinesspb.ReadyResponse, 4)
-	sending := make(chan struct{}, 1)
-
-	eg, _ := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		return r.Watch(ctx, observationReq(), func(resp *readinesspb.ReadyResponse) error {
-			select {
-			case sending <- struct{}{}:
-				<-block
-			default:
-			}
-			delivered <- resp
-			return nil
-		})
-	})
-
-	// Heartbeat first, then the recovery transition, both queued behind the
-	// stalled snapshot send.
-	<-sending
-	r.Touch("gw-a")
-	r.Set("gw-a", readinesspb.State_STATE_READY)
-	close(block)
-
-	recvTimeout(t, delivered, watchTimeout) // snapshot
-
-	delta := recvTimeout(t, delivered, watchTimeout)
-	require.Len(t, delta.Scopes, 1,
-		"the superseded observation must be retired, not delivered after the transition")
-	assert.Equal(t, readinesspb.State_STATE_READY, delta.Scopes[0].State)
-
-	cancel()
-	require.NoError(t, eg.Wait())
-}
-
-// TestWatch_PureObservationsCoalesceToNewest verifies that consecutive
-// heartbeats of one scope with no state change between them collapse into
-// the single newest snapshot.
-func TestWatch_PureObservationsCoalesceToNewest(t *testing.T) {
-	r := readiness.NewTracker(specs("gw-a"))
-	r.Set("gw-a", readinesspb.State_STATE_READY)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	block := make(chan struct{})
-	delivered := make(chan *readinesspb.ReadyResponse, 4)
-	sending := make(chan struct{}, 1)
-
-	eg, _ := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		return r.Watch(ctx, observationReq(), func(resp *readinesspb.ReadyResponse) error {
-			select {
-			case sending <- struct{}{}:
-				<-block
-			default:
-			}
-			delivered <- resp
-			return nil
-		})
-	})
-
-	<-sending
-	for range 5 {
-		time.Sleep(2 * time.Millisecond)
-		r.Touch("gw-a")
-	}
-	close(block)
-
-	recvTimeout(t, delivered, watchTimeout) // snapshot
-
-	delta := recvTimeout(t, delivered, watchTimeout)
-	require.Len(t, delta.Scopes, 1, "five pure touches must coalesce into one snapshot")
-	assert.Equal(t, readinesspb.State_STATE_READY, delta.Scopes[0].State)
-
-	cancel()
-	require.NoError(t, eg.Wait())
-}
-
-// TestWatch_SlowConsumerDroppedOnTransitionOverflow verifies that a
-// subscriber whose transition queue overflows is dropped with an explicit
-// error rather than silently losing a promised transition. The mutation
-// count far exceeds the queue, so the exact limit does not matter.
-func TestWatch_SlowConsumerDroppedOnTransitionOverflow(t *testing.T) {
-	r := readiness.NewTracker(specs("gw-a"))
-
-	release := make(chan struct{})
-	sending := make(chan struct{}, 1)
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- r.Watch(ctx, &readinesspb.ReadyRequest{}, func(_ *readinesspb.ReadyResponse) error {
-			// Stall every delta after the snapshot until released.
-			select {
-			case sending <- struct{}{}:
-				<-release
-			default:
-			}
-			return nil
-		})
-	}()
-
-	<-sending
-	for range 5000 {
-		r.Set("gw-a", readinesspb.State_STATE_READY)
-		r.Set("gw-a", readinesspb.State_STATE_NOT_READY)
-	}
-
-	close(release)
-	require.ErrorIs(t, <-done, readiness.ErrSlowConsumer,
-		"an overflowed transition queue must drop the subscriber explicitly")
-}
-
-// TestWatch_ConcurrentSubscribersAndMutators verifies that a burst of
-// mutations across many scopes never disconnects a reading subscriber: the
-// coalescing mailbox bounds per-subscriber cost by the scope count, not the
-// event rate, so Watch must return nil on cancellation for every consumer.
 func TestWatch_ConcurrentSubscribersAndMutators(t *testing.T) {
-	names := make([]string, 0, 32)
-	for idx := range 32 {
-		names = append(names, fmt.Sprintf("gw-%02d", idx))
-	}
-	r := readiness.NewTracker(specs(names...))
+	r := readiness.NewTracker(specs("gw-a", "gw-b"))
 
 	const (
-		numSubscribers = 4
-		numMutations   = 500
+		numSubscribers = 8
+		numMutations   = 50
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -1248,26 +933,22 @@ func TestWatch_ConcurrentSubscribersAndMutators(t *testing.T) {
 	subEg, _ := errgroup.WithContext(t.Context())
 	for range numSubscribers {
 		subEg.Go(func() error {
-			return r.Watch(ctx, observationReq(), func(_ *readinesspb.ReadyResponse) error {
+			_ = r.Watch(ctx, &readinesspb.ReadyRequest{}, func(_ *readinesspb.ReadyResponse) error {
 				return nil
 			})
+			return nil
 		})
 	}
-
-	// Let every subscriber register before the burst starts.
-	time.Sleep(10 * time.Millisecond)
 
 	eg, _ := errgroup.WithContext(t.Context())
 	eg.Go(func() error {
 		for idx := range numMutations {
-			name := names[idx%len(names)]
-			switch idx % 3 {
-			case 0:
-				r.Set(name, readinesspb.State_STATE_READY)
-			case 1:
-				r.Set(name, readinesspb.State_STATE_NOT_READY)
-			default:
-				r.Touch(name)
+			if idx%3 == 0 {
+				r.Set("gw-a", readinesspb.State_STATE_READY)
+			} else if idx%3 == 1 {
+				r.Set("gw-b", readinesspb.State_STATE_NOT_READY)
+			} else {
+				r.Touch("gw-a")
 			}
 		}
 		return nil
@@ -1275,5 +956,5 @@ func TestWatch_ConcurrentSubscribersAndMutators(t *testing.T) {
 	require.NoError(t, eg.Wait())
 
 	cancel()
-	require.NoError(t, subEg.Wait(), "no subscriber may be dropped under a burst")
+	require.NoError(t, subEg.Wait())
 }

--- a/common/readinesspb/v1/readiness.proto
+++ b/common/readinesspb/v1/readiness.proto
@@ -30,14 +30,8 @@ message Scope {
   google.protobuf.Timestamp observed_at = 4;
   // Timestamp of the last state transition for this scope.
   google.protobuf.Timestamp last_transition_time = 5;
-  // Nominal cadence at which the scope's source re-observes it: the
-  // source's own ticker or heartbeat interval. A staleness consumer judges
-  // the scope stale once observed_at lags by more than a small multiple of
-  // this interval; retries and slow applies can legitimately exceed it,
-  // which is exactly what the consumer should surface. Absent for scopes
-  // with no natural heartbeat — such scopes are never judged stale. A
-  // scope with a contract but no observation yet stays UNKNOWN and is
-  // never judged stale: the UNKNOWN state is itself the signal.
+  // Nominal freshness cadence; absent when the scope has no heartbeat.
+  // Consumers apply their own tolerance before marking observations stale.
   google.protobuf.Duration expected_observation_interval = 6;
 }
 

--- a/common/readinesspb/v1/readiness.proto
+++ b/common/readinesspb/v1/readiness.proto
@@ -15,13 +15,6 @@ message ReadyRequest {
   // If empty, return state for all known scopes.
   // Otherwise, return only the requested scopes.
   repeated string scopes = 1;
-  // Opt the Watch stream into observation refreshes: without it, Watch
-  // delivers only state or reason changes; with it, pure observed_at
-  // refreshes are delivered too, coalesced per scope — a burst between two
-  // reads yields the newest snapshot of each affected scope. State and
-  // reason transitions are always delivered in order and never coalesced
-  // away. Ready ignores this field.
-  bool include_observation_updates = 2;
 }
 
 message ReadyResponse { repeated Scope scopes = 1; }

--- a/common/readinesspb/v1/readiness.proto
+++ b/common/readinesspb/v1/readiness.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package common.readinesspb.v1;
 
+import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/common/readinesspb/v1;readinesspb";
@@ -14,6 +15,13 @@ message ReadyRequest {
   // If empty, return state for all known scopes.
   // Otherwise, return only the requested scopes.
   repeated string scopes = 1;
+  // Opt the Watch stream into observation refreshes: without it, Watch
+  // delivers only state or reason changes; with it, pure observed_at
+  // refreshes are delivered too, coalesced per scope — a burst between two
+  // reads yields the newest snapshot of each affected scope. State and
+  // reason transitions are always delivered in order and never coalesced
+  // away. Ready ignores this field.
+  bool include_observation_updates = 2;
 }
 
 message ReadyResponse { repeated Scope scopes = 1; }
@@ -29,6 +37,15 @@ message Scope {
   google.protobuf.Timestamp observed_at = 4;
   // Timestamp of the last state transition for this scope.
   google.protobuf.Timestamp last_transition_time = 5;
+  // Nominal cadence at which the scope's source re-observes it: the
+  // source's own ticker or heartbeat interval. A staleness consumer judges
+  // the scope stale once observed_at lags by more than a small multiple of
+  // this interval; retries and slow applies can legitimately exceed it,
+  // which is exactly what the consumer should surface. Absent for scopes
+  // with no natural heartbeat — such scopes are never judged stale. A
+  // scope with a contract but no observation yet stays UNKNOWN and is
+  // never judged stale: the UNKNOWN state is itself the signal.
+  google.protobuf.Duration expected_observation_interval = 6;
 }
 
 enum State {

--- a/common/rust/readinesspb/Cargo.toml
+++ b/common/rust/readinesspb/Cargo.toml
@@ -14,5 +14,8 @@ prost-types = "0.13"
 serde = { version = "1", features = ["derive"] }
 tonic = { version = "0.13", features = ["gzip"] }
 
+[dev-dependencies]
+serde_json = "1"
+
 [build-dependencies]
 tonic-build = "0.13"

--- a/common/rust/readinesspb/build.rs
+++ b/common/rust/readinesspb/build.rs
@@ -22,6 +22,10 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             "common.readinesspb.v1.Scope.last_transition_time",
             "#[serde(serialize_with = \"crate::serialize_timestamp\")]",
         )
+        .field_attribute(
+            "common.readinesspb.v1.Scope.expected_observation_interval",
+            "#[serde(serialize_with = \"crate::serialize_duration\")]",
+        )
         .enum_attribute(".", "#[derive(serde::Serialize)]")
         .compile_protos(&["common/readinesspb/v1/readiness.proto"], &["../../.."])
         .map_err(Into::into)

--- a/common/rust/readinesspb/src/lib.rs
+++ b/common/rust/readinesspb/src/lib.rs
@@ -45,3 +45,29 @@ where
         None => serializer.serialize_none(),
     }
 }
+
+/// Serializes an `Option<prost_types::Duration>` as
+/// `{"seconds": i64, "nanos": i32}` or `null` when absent, keeping the
+/// nanosecond part that a floating-point seconds value would lose.
+pub fn serialize_duration<S>(value: &Option<prost_types::Duration>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use serde::Serialize;
+
+    match value {
+        Some(duration) => {
+            #[derive(serde::Serialize)]
+            struct Dur {
+                seconds: i64,
+                nanos: i32,
+            }
+            Dur {
+                seconds: duration.seconds,
+                nanos: duration.nanos,
+            }
+            .serialize(serializer)
+        }
+        None => serializer.serialize_none(),
+    }
+}

--- a/common/rust/readinesspb/src/lib.rs
+++ b/common/rust/readinesspb/src/lib.rs
@@ -46,9 +46,10 @@ where
     }
 }
 
-/// Serializes an `Option<prost_types::Duration>` as
-/// `{"seconds": i64, "nanos": i32}` or `null` when absent, keeping the
-/// nanosecond part that a floating-point seconds value would lose.
+/// Preserves nanoseconds when serializing an optional duration.
+///
+/// The output is an object with integer seconds and nanoseconds, or null when
+/// no duration is present.
 pub fn serialize_duration<S>(value: &Option<prost_types::Duration>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,

--- a/common/rust/readinesspb/src/lib.rs
+++ b/common/rust/readinesspb/src/lib.rs
@@ -71,3 +71,31 @@ where
         None => serializer.serialize_none(),
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_scope_json_serializes_expected_observation_interval() {
+        let scope = pb::Scope {
+            expected_observation_interval: Some(prost_types::Duration { seconds: 30, nanos: 123 }),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_value(scope).expect("readiness scope must serialize");
+
+        assert_eq!(
+            &serde_json::json!({"seconds": 30, "nanos": 123}),
+            json.get("expected_observation_interval")
+                .expect("duration field must be present")
+        );
+    }
+
+    #[test]
+    fn test_scope_json_serializes_absent_observation_interval_as_null() {
+        let json = serde_json::to_value(pb::Scope::default()).expect("readiness scope must serialize");
+
+        assert!(json["expected_observation_interval"].is_null());
+    }
+}

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -325,8 +325,10 @@ func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 
 	ynpb.RegisterAuthServiceServer(server, authService)
 
+	// The gateway scope is set once at startup and has no heartbeat source,
+	// so it declares no expected freshness.
 	rdTracker := readiness.NewTracker(
-		[]string{gatewayReadinessScope},
+		[]readiness.ScopeSpec{{Name: gatewayReadinessScope}},
 		readiness.WithDrainLatch(),
 		readiness.WithLog(log),
 	)

--- a/controlplane/gateway/readiness_test.go
+++ b/controlplane/gateway/readiness_test.go
@@ -25,7 +25,7 @@ const testGatewayReadinessScope = "gateway"
 
 func newTestTracker() *readiness.Tracker {
 	return readiness.NewTracker(
-		[]string{testGatewayReadinessScope},
+		[]readiness.ScopeSpec{{Name: testGatewayReadinessScope}},
 		readiness.WithDrainLatch(),
 		readiness.WithLog(zap.NewNop()),
 	)

--- a/controlplane/gateway/readiness_test.go
+++ b/controlplane/gateway/readiness_test.go
@@ -159,10 +159,9 @@ func (m *readinessLatchService) ServicesNames() []string {
 
 func (m *readinessLatchService) RegisterService(_ *grpc.Server) {}
 
-// TestGateway_Run_ReadinessDrainLatchesLateReady verifies through the public
-// run and readiness surfaces that a late READY attempt after shutdown drain
-// cannot restore the gateway's readiness state.
-func TestGateway_Run_ReadinessDrainLatchesLateReady(t *testing.T) {
+// verifies that shutdown drain blocks late readiness while the gateway's
+// set-once scope declares no freshness contract.
+func Test_GatewayRun_ReadinessDrainLatchesLateReady(t *testing.T) {
 	t.Parallel()
 
 	core, observed := observer.New(zap.InfoLevel)
@@ -235,8 +234,10 @@ func TestGateway_Run_ReadinessDrainLatchesLateReady(t *testing.T) {
 	response, err := stream.Recv()
 	require.NoError(t, err)
 	require.Len(t, response.GetScopes(), 1)
-	require.Equal(t, readinesspb.State_STATE_NOT_READY, response.GetScopes()[0].GetState())
-	require.Equal(t, "SHUTTING_DOWN", response.GetScopes()[0].GetReasons()[0].GetCode())
+	scope := response.GetScopes()[0]
+	require.Nil(t, scope.GetExpectedObservationInterval())
+	require.Equal(t, readinesspb.State_STATE_NOT_READY, scope.GetState())
+	require.Equal(t, "SHUTTING_DOWN", scope.GetReasons()[0].GetCode())
 
 	releaseReadyLogFunc()
 	watchCancel()

--- a/controlplane/ynpb/v1/readiness.proto
+++ b/controlplane/ynpb/v1/readiness.proto
@@ -11,10 +11,12 @@ service ReadinessService {
   // Ready returns the current readiness state of the gateway.
   rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
 
-  // Watch streams readiness state changes.
+  // Watch streams readiness updates.
   //
   // The first message carries the current state of every selected scope;
-  // each subsequent message carries only the scopes whose state or reason
-  // changed.
+  // each subsequent message carries the scopes whose state or reason
+  // changed, in order. With include_observation_updates in the request,
+  // pure observation refreshes are delivered too, coalesced per scope;
+  // see the shared request message for the full semantics.
   rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/controlplane/ynpb/v1/readiness.proto
+++ b/controlplane/ynpb/v1/readiness.proto
@@ -15,8 +15,6 @@ service ReadinessService {
   //
   // The first message carries the current state of every selected scope;
   // each subsequent message carries the scopes whose state or reason
-  // changed, in order. With include_observation_updates in the request,
-  // pure observation refreshes are delivered too, coalesced per scope;
-  // see the shared request message for the full semantics.
+  // changed since the previous message.
   rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/decap/internal/operator/cfg_test.go
+++ b/operators/decap/internal/operator/cfg_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -208,23 +207,20 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
-// TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval verifies that
-// each gateway scope's observation contract is the reconcile interval — the
-// nominal cadence — not a backoff-inflated bound: a slow or hung apply must
-// surface as staleness after a multiple of the nominal interval, not be
-// hidden behind the retry ceiling.
-func TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
-	cfg.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
-	cfg.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
+// verifies that gateway scopes map by name to the nominal reconcile interval,
+// independent of retry backoff and declaration order.
+func Test_ReadinessScopeSpecs_GatewaysUseNominalReconcileInterval(t *testing.T) {
+	config := DefaultConfig()
+	config.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
+	config.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
+	config.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
 
-	specs := readinessScopeSpecs(cfg)
-
-	require.Len(t, specs, 2)
-	assert.Equal(t, "config:gw0", specs[0].Name)
-	assert.Equal(t, "config:gw1", specs[1].Name)
-	for _, spec := range specs {
-		assert.Equal(t, 10*time.Second, spec.ExpectedObservationInterval)
+	intervalsByName := map[string]time.Duration{}
+	for _, scopeSpec := range readinessScopeSpecs(config) {
+		intervalsByName[scopeSpec.Name] = scopeSpec.ExpectedObservationInterval
 	}
+	require.Equal(t, map[string]time.Duration{
+		"config:gw0": 10 * time.Second,
+		"config:gw1": 10 * time.Second,
+	}, intervalsByName)
 }

--- a/operators/decap/internal/operator/cfg_test.go
+++ b/operators/decap/internal/operator/cfg_test.go
@@ -3,7 +3,9 @@ package operator
 import (
 	"os"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -203,5 +205,26 @@ func TestConfigValidate(t *testing.T) {
 				require.NoError(t, err)
 			}
 		})
+	}
+}
+
+// TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval verifies that
+// each gateway scope's observation contract is the reconcile interval — the
+// nominal cadence — not a backoff-inflated bound: a slow or hung apply must
+// surface as staleness after a multiple of the nominal interval, not be
+// hidden behind the retry ceiling.
+func TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
+	cfg.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
+	cfg.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
+
+	specs := readinessScopeSpecs(cfg)
+
+	require.Len(t, specs, 2)
+	assert.Equal(t, "config:gw0", specs[0].Name)
+	assert.Equal(t, "config:gw1", specs[1].Name)
+	for _, spec := range specs {
+		assert.Equal(t, 10*time.Second, spec.ExpectedObservationInterval)
 	}
 }

--- a/operators/decap/internal/operator/operator.go
+++ b/operators/decap/internal/operator/operator.go
@@ -99,13 +99,7 @@ func (m *Operator) Close() error {
 	return m.app.Close()
 }
 
-// readinessScopeSpecs declares one scope per gateway, covering all configs
-// pushed there.
-//
-// Each scope is re-observed on every apply attempt, so the nominal contract
-// is the reconcile interval. A slow or hung apply, or a retry backoff,
-// legitimately exceeds it — exactly the lag a staleness consumer should
-// surface.
+// readinessScopeSpecs maps each gateway to the reconcile freshness cadence.
 func readinessScopeSpecs(cfg *Config) []readiness.ScopeSpec {
 	freshness := cfg.Reconcile.Interval.Unwrap()
 	specs := make([]readiness.ScopeSpec, len(cfg.Gateways))

--- a/operators/decap/internal/operator/operator.go
+++ b/operators/decap/internal/operator/operator.go
@@ -42,12 +42,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		})
 	}
 
-	// One config:<gateway> scope per gateway, covering all module configs pushed there.
-	scopeNames := make([]string, len(cfg.Gateways))
-	for idx, gw := range cfg.Gateways {
-		scopeNames[idx] = fmt.Sprintf("config:%s", gw.Name)
-	}
-	tracker := readiness.NewTracker(scopeNames,
+	tracker := readiness.NewTracker(readinessScopeSpecs(cfg),
 		readiness.WithLog(log.With(zap.String("operator", "decap"))),
 	)
 
@@ -102,4 +97,23 @@ func (m *Operator) Run(ctx context.Context) error {
 // Close releases resources owned by the operator.
 func (m *Operator) Close() error {
 	return m.app.Close()
+}
+
+// readinessScopeSpecs declares one scope per gateway, covering all configs
+// pushed there.
+//
+// Each scope is re-observed on every apply attempt, so the nominal contract
+// is the reconcile interval. A slow or hung apply, or a retry backoff,
+// legitimately exceeds it — exactly the lag a staleness consumer should
+// surface.
+func readinessScopeSpecs(cfg *Config) []readiness.ScopeSpec {
+	freshness := cfg.Reconcile.Interval.Unwrap()
+	specs := make([]readiness.ScopeSpec, len(cfg.Gateways))
+	for idx, gw := range cfg.Gateways {
+		specs[idx] = readiness.ScopeSpec{
+			Name:                        fmt.Sprintf("config:%s", gw.Name),
+			ExpectedObservationInterval: freshness,
+		}
+	}
+	return specs
 }

--- a/operators/decap/internal/operator/readiness.md
+++ b/operators/decap/internal/operator/readiness.md
@@ -51,9 +51,9 @@ never streams — a `Watch`-based checker would hold a stale `observed_at` while
 the service stays fresh.
 
 A stale `observed_at` means the reconcile loop has stopped refreshing — the
-operator is shutting down, dead, or frozen. Recommended staleness threshold:
-base it on `max(reconcile.interval, reconcile.max_backoff)` — the largest gap
-between apply attempts in success or retry. At the defaults (both 30s) a
-threshold around twice that (~60s) covers jitter and slow applies. If
-`max_backoff` is raised above `interval`, size the threshold off `max_backoff`
-or a live, retrying operator will false-alarm as stale.
+operator is shutting down, dead, or frozen. Each scope publishes
+`expected_observation_interval = reconcile.interval`; consumers choose a small
+multiplier and judge the scope stale when its age exceeds that product. Retry
+backoff deliberately does not inflate the contract: a prolonged retry or slow
+apply remains visible as freshness lag instead of being hidden by
+`reconcile.max_backoff`.

--- a/operators/decap/operatorpb/v1/readiness.proto
+++ b/operators/decap/operatorpb/v1/readiness.proto
@@ -11,10 +11,12 @@ service ReadinessService {
   // Ready returns the current per-gateway readiness state.
   rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
 
-  // Watch streams readiness state changes.
+  // Watch streams readiness updates.
   //
   // The first message carries the current state of every selected scope;
-  // each subsequent message carries only the scopes whose state or reason
-  // changed.
+  // each subsequent message carries the scopes whose state or reason
+  // changed, in order. With include_observation_updates in the request,
+  // pure observation refreshes are delivered too, coalesced per scope;
+  // see the shared request message for the full semantics.
   rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/decap/operatorpb/v1/readiness.proto
+++ b/operators/decap/operatorpb/v1/readiness.proto
@@ -15,8 +15,6 @@ service ReadinessService {
   //
   // The first message carries the current state of every selected scope;
   // each subsequent message carries the scopes whose state or reason
-  // changed, in order. With include_observation_updates in the request,
-  // pure observation refreshes are delivered too, coalesced per scope;
-  // see the shared request message for the full semantics.
+  // changed since the previous message.
   rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/forward/internal/operator/cfg_test.go
+++ b/operators/forward/internal/operator/cfg_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
@@ -182,23 +181,20 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
-// TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval verifies that
-// each gateway scope's observation contract is the reconcile interval — the
-// nominal cadence — not a backoff-inflated bound: a slow or hung apply must
-// surface as staleness after a multiple of the nominal interval, not be
-// hidden behind the retry ceiling.
-func TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
-	cfg.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
-	cfg.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
+// verifies that gateway scopes map by name to the nominal reconcile interval,
+// independent of retry backoff and declaration order.
+func Test_ReadinessScopeSpecs_GatewaysUseNominalReconcileInterval(t *testing.T) {
+	config := DefaultConfig()
+	config.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
+	config.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
+	config.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
 
-	specs := readinessScopeSpecs(cfg)
-
-	require.Len(t, specs, 2)
-	assert.Equal(t, "config:gw0", specs[0].Name)
-	assert.Equal(t, "config:gw1", specs[1].Name)
-	for _, spec := range specs {
-		assert.Equal(t, 10*time.Second, spec.ExpectedObservationInterval)
+	intervalsByName := map[string]time.Duration{}
+	for _, scopeSpec := range readinessScopeSpecs(config) {
+		intervalsByName[scopeSpec.Name] = scopeSpec.ExpectedObservationInterval
 	}
+	require.Equal(t, map[string]time.Duration{
+		"config:gw0": 10 * time.Second,
+		"config:gw1": 10 * time.Second,
+	}, intervalsByName)
 }

--- a/operators/forward/internal/operator/cfg_test.go
+++ b/operators/forward/internal/operator/cfg_test.go
@@ -3,7 +3,9 @@ package operator
 import (
 	"os"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
@@ -177,5 +179,26 @@ func TestConfigValidate(t *testing.T) {
 				require.NoError(t, err)
 			}
 		})
+	}
+}
+
+// TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval verifies that
+// each gateway scope's observation contract is the reconcile interval — the
+// nominal cadence — not a backoff-inflated bound: a slow or hung apply must
+// surface as staleness after a multiple of the nominal interval, not be
+// hidden behind the retry ceiling.
+func TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
+	cfg.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
+	cfg.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
+
+	specs := readinessScopeSpecs(cfg)
+
+	require.Len(t, specs, 2)
+	assert.Equal(t, "config:gw0", specs[0].Name)
+	assert.Equal(t, "config:gw1", specs[1].Name)
+	for _, spec := range specs {
+		assert.Equal(t, 10*time.Second, spec.ExpectedObservationInterval)
 	}
 }

--- a/operators/forward/internal/operator/operator.go
+++ b/operators/forward/internal/operator/operator.go
@@ -98,13 +98,7 @@ func (m *Operator) Close() error {
 	return m.app.Close()
 }
 
-// readinessScopeSpecs declares one scope per gateway, covering all configs
-// pushed there.
-//
-// Each scope is re-observed on every apply attempt, so the nominal contract
-// is the reconcile interval. A slow or hung apply, or a retry backoff,
-// legitimately exceeds it — exactly the lag a staleness consumer should
-// surface.
+// readinessScopeSpecs maps each gateway to the reconcile freshness cadence.
 func readinessScopeSpecs(cfg *Config) []readiness.ScopeSpec {
 	freshness := cfg.Reconcile.Interval.Unwrap()
 	specs := make([]readiness.ScopeSpec, len(cfg.Gateways))

--- a/operators/forward/internal/operator/operator.go
+++ b/operators/forward/internal/operator/operator.go
@@ -41,12 +41,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		})
 	}
 
-	// One config:<gateway> scope per gateway, covering all module configs pushed there.
-	scopeNames := make([]string, len(cfg.Gateways))
-	for idx, gw := range cfg.Gateways {
-		scopeNames[idx] = fmt.Sprintf("config:%s", gw.Name)
-	}
-	tracker := readiness.NewTracker(scopeNames,
+	tracker := readiness.NewTracker(readinessScopeSpecs(cfg),
 		readiness.WithLog(log.With(zap.String("operator", "forward"))),
 	)
 
@@ -101,4 +96,23 @@ func (m *Operator) Run(ctx context.Context) error {
 // Close releases resources owned by the operator.
 func (m *Operator) Close() error {
 	return m.app.Close()
+}
+
+// readinessScopeSpecs declares one scope per gateway, covering all configs
+// pushed there.
+//
+// Each scope is re-observed on every apply attempt, so the nominal contract
+// is the reconcile interval. A slow or hung apply, or a retry backoff,
+// legitimately exceeds it — exactly the lag a staleness consumer should
+// surface.
+func readinessScopeSpecs(cfg *Config) []readiness.ScopeSpec {
+	freshness := cfg.Reconcile.Interval.Unwrap()
+	specs := make([]readiness.ScopeSpec, len(cfg.Gateways))
+	for idx, gw := range cfg.Gateways {
+		specs[idx] = readiness.ScopeSpec{
+			Name:                        fmt.Sprintf("config:%s", gw.Name),
+			ExpectedObservationInterval: freshness,
+		}
+	}
+	return specs
 }

--- a/operators/forward/internal/operator/readiness.md
+++ b/operators/forward/internal/operator/readiness.md
@@ -51,9 +51,9 @@ never streams — a `Watch`-based checker would hold a stale `observed_at` while
 the service stays fresh.
 
 A stale `observed_at` means the reconcile loop has stopped refreshing — the
-operator is shutting down, dead, or frozen. Recommended staleness threshold:
-base it on `max(reconcile.interval, reconcile.max_backoff)` — the largest gap
-between apply attempts in success or retry. At the defaults (both 30s) a
-threshold around twice that (~60s) covers jitter and slow applies. If
-`max_backoff` is raised above `interval`, size the threshold off `max_backoff`
-or a live, retrying operator will false-alarm as stale.
+operator is shutting down, dead, or frozen. Each scope publishes
+`expected_observation_interval = reconcile.interval`; consumers choose a small
+multiplier and judge the scope stale when its age exceeds that product. Retry
+backoff deliberately does not inflate the contract: a prolonged retry or slow
+apply remains visible as freshness lag instead of being hidden by
+`reconcile.max_backoff`.

--- a/operators/forward/operatorpb/v1/readiness.proto
+++ b/operators/forward/operatorpb/v1/readiness.proto
@@ -11,10 +11,12 @@ service ReadinessService {
   // Ready returns the current per-gateway readiness state.
   rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
 
-  // Watch streams readiness state changes.
+  // Watch streams readiness updates.
   //
   // The first message carries the current state of every selected scope;
-  // each subsequent message carries only the scopes whose state or reason
-  // changed.
+  // each subsequent message carries the scopes whose state or reason
+  // changed, in order. With include_observation_updates in the request,
+  // pure observation refreshes are delivered too, coalesced per scope;
+  // see the shared request message for the full semantics.
   rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/forward/operatorpb/v1/readiness.proto
+++ b/operators/forward/operatorpb/v1/readiness.proto
@@ -15,8 +15,6 @@ service ReadinessService {
   //
   // The first message carries the current state of every selected scope;
   // each subsequent message carries the scopes whose state or reason
-  // changed, in order. With include_observation_updates in the request,
-  // pure observation refreshes are delivered too, coalesced per scope;
-  // see the shared request message for the full semantics.
+  // changed since the previous message.
   rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/pipeline/internal/operator/operator.go
+++ b/operators/pipeline/internal/operator/operator.go
@@ -133,15 +133,8 @@ func (m *Operator) Run(ctx context.Context) error {
 	return m.app.Run(ctx)
 }
 
-// readinessScopeSpecs declares one scope per gateway, covering all stages
-// pushed there.
-//
-// Each scope is re-observed on every apply attempt — the queue's tail stage
-// stays the steady-state target — so the nominal contract is the reconcile
-// interval. A slow or hung apply, or a retry backoff, legitimately exceeds
-// it: exactly the lag a staleness consumer should surface. With no stages
-// configured the reconcile loop stays idle and the scopes are never
-// re-observed, so they declare no contract.
+// readinessScopeSpecs uses the reconcile cadence for gateways with stages.
+// Gateways without stages have no freshness contract because they stay idle.
 func readinessScopeSpecs(cfg *Config) []readiness.ScopeSpec {
 	freshness := cfg.Reconcile.Interval.Unwrap()
 	if len(cfg.Stages) == 0 {

--- a/operators/pipeline/internal/operator/operator.go
+++ b/operators/pipeline/internal/operator/operator.go
@@ -41,12 +41,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		WithServiceLog(log),
 	)
 
-	// One pipeline:<gateway> scope per gateway, covering all stages pushed there.
-	scopeNames := make([]string, len(cfg.Gateways))
-	for idx, gw := range cfg.Gateways {
-		scopeNames[idx] = fmt.Sprintf("pipeline:%s", gw.Name)
-	}
-	tracker := readiness.NewTracker(scopeNames,
+	tracker := readiness.NewTracker(readinessScopeSpecs(cfg),
 		readiness.WithLog(log.With(zap.String("operator", "pipeline"))),
 	)
 
@@ -136,4 +131,28 @@ func (m *Operator) Close() error {
 // Run drives the operator until the supplied context is cancelled.
 func (m *Operator) Run(ctx context.Context) error {
 	return m.app.Run(ctx)
+}
+
+// readinessScopeSpecs declares one scope per gateway, covering all stages
+// pushed there.
+//
+// Each scope is re-observed on every apply attempt — the queue's tail stage
+// stays the steady-state target — so the nominal contract is the reconcile
+// interval. A slow or hung apply, or a retry backoff, legitimately exceeds
+// it: exactly the lag a staleness consumer should surface. With no stages
+// configured the reconcile loop stays idle and the scopes are never
+// re-observed, so they declare no contract.
+func readinessScopeSpecs(cfg *Config) []readiness.ScopeSpec {
+	freshness := cfg.Reconcile.Interval.Unwrap()
+	if len(cfg.Stages) == 0 {
+		freshness = 0
+	}
+	specs := make([]readiness.ScopeSpec, len(cfg.Gateways))
+	for idx, gw := range cfg.Gateways {
+		specs[idx] = readiness.ScopeSpec{
+			Name:                        fmt.Sprintf("pipeline:%s", gw.Name),
+			ExpectedObservationInterval: freshness,
+		}
+	}
+	return specs
 }

--- a/operators/pipeline/internal/operator/readiness.md
+++ b/operators/pipeline/internal/operator/readiness.md
@@ -65,9 +65,9 @@ for a pipeline deployed without stages. Once at least one stage is queued, the
 tail stage is retained as a steady-state target and `observed_at` advances on
 every apply as described above.
 
-Recommended staleness threshold (when stages are present): base it on
-`max(reconcile.interval, reconcile.max_backoff)` — the largest gap between
-apply attempts in success or retry. At the defaults (both 30s) a threshold
-around twice that (~60s) covers jitter and slow applies. If `max_backoff` is
-raised above `interval`, size the threshold off `max_backoff` or a live,
-retrying operator will false-alarm as stale.
+When stages are present, each scope publishes
+`expected_observation_interval = reconcile.interval`. Consumers choose a small
+multiplier and judge the scope stale when its age exceeds that product. Retry
+backoff deliberately does not inflate the contract: a prolonged retry or slow
+apply remains visible as freshness lag. With no stages the field is absent, so
+staleness is not applicable.

--- a/operators/pipeline/internal/operator/stage_source_test.go
+++ b/operators/pipeline/internal/operator/stage_source_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
@@ -153,36 +152,42 @@ func Test_StageQueueSource_SetStagesEmptyIdles(t *testing.T) {
 	require.Nil(t, target)
 }
 
-// TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval verifies that
-// each gateway scope's observation contract is the reconcile interval — the
-// nominal cadence — not a backoff-inflated bound.
-func TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
-	cfg.Stages = []StageConfig{{Name: "stage0"}}
-	cfg.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
-	cfg.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
-
-	specs := readinessScopeSpecs(cfg)
-
-	require.Len(t, specs, 2)
-	assert.Equal(t, "pipeline:gw0", specs[0].Name)
-	assert.Equal(t, "pipeline:gw1", specs[1].Name)
-	for _, spec := range specs {
-		assert.Equal(t, 10*time.Second, spec.ExpectedObservationInterval)
+// verifies that stage activity selects the production freshness contract for
+// every gateway scope without depending on scope order.
+func Test_ReadinessScopeSpecs_StageActivityContracts(t *testing.T) {
+	tests := []struct {
+		name             string
+		stages           []StageConfig
+		expectedInterval time.Duration
+	}{
+		{
+			name:             "active stages use nominal reconcile interval",
+			stages:           []StageConfig{{Name: "stage0"}},
+			expectedInterval: 10 * time.Second,
+		},
+		{
+			name:             "no stages declare no freshness contract",
+			stages:           nil,
+			expectedInterval: 0,
+		},
 	}
-}
 
-// TestReadiness_ScopeSpecs_NoStages_NoContract verifies that with no stages
-// configured the reconcile loop stays idle, so the scopes declare no
-// freshness contract rather than a periodic one.
-func TestReadiness_ScopeSpecs_NoStages_NoContract(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}}
-	cfg.Stages = nil
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := DefaultConfig()
+			config.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
+			config.Stages = test.stages
+			config.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
+			config.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
 
-	specs := readinessScopeSpecs(cfg)
-
-	require.Len(t, specs, 1)
-	assert.Zero(t, specs[0].ExpectedObservationInterval)
+			intervalsByName := map[string]time.Duration{}
+			for _, scopeSpec := range readinessScopeSpecs(config) {
+				intervalsByName[scopeSpec.Name] = scopeSpec.ExpectedObservationInterval
+			}
+			require.Equal(t, map[string]time.Duration{
+				"pipeline:gw0": test.expectedInterval,
+				"pipeline:gw1": test.expectedInterval,
+			}, intervalsByName)
+		})
+	}
 }

--- a/operators/pipeline/internal/operator/stage_source_test.go
+++ b/operators/pipeline/internal/operator/stage_source_test.go
@@ -2,8 +2,13 @@ package operator
 
 import (
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 // drainWake consumes a single buffered wake signal if present.
@@ -146,4 +151,38 @@ func Test_StageQueueSource_SetStagesEmptyIdles(t *testing.T) {
 	target, ok := src.Snapshot()
 	require.False(t, ok)
 	require.Nil(t, target)
+}
+
+// TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval verifies that
+// each gateway scope's observation contract is the reconcile interval — the
+// nominal cadence — not a backoff-inflated bound.
+func TestReadiness_ScopeSpecs_MirrorNominalReconcileInterval(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
+	cfg.Stages = []StageConfig{{Name: "stage0"}}
+	cfg.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
+	cfg.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
+
+	specs := readinessScopeSpecs(cfg)
+
+	require.Len(t, specs, 2)
+	assert.Equal(t, "pipeline:gw0", specs[0].Name)
+	assert.Equal(t, "pipeline:gw1", specs[1].Name)
+	for _, spec := range specs {
+		assert.Equal(t, 10*time.Second, spec.ExpectedObservationInterval)
+	}
+}
+
+// TestReadiness_ScopeSpecs_NoStages_NoContract verifies that with no stages
+// configured the reconcile loop stays idle, so the scopes declare no
+// freshness contract rather than a periodic one.
+func TestReadiness_ScopeSpecs_NoStages_NoContract(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}}
+	cfg.Stages = nil
+
+	specs := readinessScopeSpecs(cfg)
+
+	require.Len(t, specs, 1)
+	assert.Zero(t, specs[0].ExpectedObservationInterval)
 }

--- a/operators/pipeline/operatorpb/v1/readiness.proto
+++ b/operators/pipeline/operatorpb/v1/readiness.proto
@@ -11,10 +11,12 @@ service ReadinessService {
   // Ready returns the current per-gateway readiness state.
   rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
 
-  // Watch streams readiness state changes.
+  // Watch streams readiness updates.
   //
   // The first message carries the current state of every selected scope;
-  // each subsequent message carries only the scopes whose state or reason
-  // changed.
+  // each subsequent message carries the scopes whose state or reason
+  // changed, in order. With include_observation_updates in the request,
+  // pure observation refreshes are delivered too, coalesced per scope;
+  // see the shared request message for the full semantics.
   rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/pipeline/operatorpb/v1/readiness.proto
+++ b/operators/pipeline/operatorpb/v1/readiness.proto
@@ -15,8 +15,6 @@ service ReadinessService {
   //
   // The first message carries the current state of every selected scope;
   // each subsequent message carries the scopes whose state or reason
-  // changed, in order. With include_observation_updates in the request,
-  // pure observation refreshes are delivered too, coalesced per scope;
-  // see the shared request message for the full semantics.
+  // changed since the previous message.
   rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/route/internal/discovery/neigh/neigh.go
+++ b/operators/route/internal/discovery/neigh/neigh.go
@@ -135,11 +135,10 @@ func WithKernelTable(kernelTable KernelTable) Option {
 	}
 }
 
-// DefaultUpdateInterval is the default period of the monitor's periodic
-// force-update pass. Netlink events refresh the table more often; this
-// interval is the worst-case gap between two successful refreshes, and
-// therefore the natural expected-freshness contract for the neighbours
-// readiness scope.
+// DefaultUpdateInterval bounds the expected gap between periodic refreshes.
+//
+// Event-driven refreshes may update the table sooner, while this period
+// defines the freshness contract for the neighbours readiness scope.
 const DefaultUpdateInterval = 5 * time.Minute
 
 type options struct {

--- a/operators/route/internal/discovery/neigh/neigh.go
+++ b/operators/route/internal/discovery/neigh/neigh.go
@@ -135,6 +135,13 @@ func WithKernelTable(kernelTable KernelTable) Option {
 	}
 }
 
+// DefaultUpdateInterval is the default period of the monitor's periodic
+// force-update pass. Netlink events refresh the table more often; this
+// interval is the worst-case gap between two successful refreshes, and
+// therefore the natural expected-freshness contract for the neighbours
+// readiness scope.
+const DefaultUpdateInterval = 5 * time.Minute
+
 type options struct {
 	UpdateInterval time.Duration
 	LinkMap        map[string]string
@@ -148,7 +155,7 @@ type options struct {
 
 func newOptions() *options {
 	return &options{
-		UpdateInterval: 5 * time.Minute,
+		UpdateInterval: DefaultUpdateInterval,
 		LinkMap:        make(map[string]string),
 		OnSynced:       func() {},
 		OnError:        func(error) {},

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -383,18 +383,8 @@ func parseMAC(s string) ([6]byte, error) {
 	return [6]byte(hw), nil
 }
 
-// readinessScopeSpecs declares the operator's readiness scopes: one
-// fib:<gateway>:<module> scope per gateway, plus a neighbours scope, a rib
-// scope, and optionally a bird-session scope.
-//
-// Each scope's observation contract mirrors the ticker that nominally drives
-// it: the fib scopes are re-observed on every reconcile apply attempt, the
-// rib and bird-session scopes by the readiness sampler, and the neighbours
-// scope by the monitor's periodic force-update pass (netlink events only
-// make it fresher). A slow or hung apply, or a retry backoff, legitimately
-// exceeds the nominal interval — exactly the lag a staleness consumer
-// should surface. With the netlink monitor disabled the neighbours scope is
-// set once, so it declares no contract.
+// readinessScopeSpecs maps each readiness source to its nominal cadence.
+// Disabled neighbour monitoring leaves its set-once scope without a contract.
 func readinessScopeSpecs(cfg *Config, moduleName string) []readiness.ScopeSpec {
 	fibInterval := cfg.Reconcile.Interval.Unwrap()
 	specs := make([]readiness.ScopeSpec, 0, len(cfg.Gateways)+3)

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -61,17 +61,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 
 	routeRIBStore := newRIBStore(withRIBStoreLog(log))
 
-	// Build the readiness tracker scope list: one fib:<gateway>:<module> scope per
-	// gateway, plus a neighbours scope, a rib scope, and optionally a bird-session scope.
-	scopeNames := make([]string, 0, len(cfg.Gateways)+3)
-	for _, gw := range cfg.Gateways {
-		scopeNames = append(scopeNames, fmt.Sprintf("fib:%s:%s", gw.Name, moduleName))
-	}
-	scopeNames = append(scopeNames, "neighbours", "rib")
-	if cfg.Readiness.ExpectBird {
-		scopeNames = append(scopeNames, "bird-session")
-	}
-	tracker := readiness.NewTracker(scopeNames,
+	tracker := readiness.NewTracker(readinessScopeSpecs(cfg, moduleName),
 		readiness.WithLog(log.With(zap.String("operator", "route"))),
 	)
 
@@ -391,4 +381,45 @@ func parseMAC(s string) ([6]byte, error) {
 		return [6]byte{}, fmt.Errorf("expected 6-byte MAC, got %d bytes", len(hw))
 	}
 	return [6]byte(hw), nil
+}
+
+// readinessScopeSpecs declares the operator's readiness scopes: one
+// fib:<gateway>:<module> scope per gateway, plus a neighbours scope, a rib
+// scope, and optionally a bird-session scope.
+//
+// Each scope's observation contract mirrors the ticker that nominally drives
+// it: the fib scopes are re-observed on every reconcile apply attempt, the
+// rib and bird-session scopes by the readiness sampler, and the neighbours
+// scope by the monitor's periodic force-update pass (netlink events only
+// make it fresher). A slow or hung apply, or a retry backoff, legitimately
+// exceeds the nominal interval — exactly the lag a staleness consumer
+// should surface. With the netlink monitor disabled the neighbours scope is
+// set once, so it declares no contract.
+func readinessScopeSpecs(cfg *Config, moduleName string) []readiness.ScopeSpec {
+	fibInterval := cfg.Reconcile.Interval.Unwrap()
+	specs := make([]readiness.ScopeSpec, 0, len(cfg.Gateways)+3)
+	for _, gw := range cfg.Gateways {
+		specs = append(specs, readiness.ScopeSpec{
+			Name:                        fmt.Sprintf("fib:%s:%s", gw.Name, moduleName),
+			ExpectedObservationInterval: fibInterval,
+		})
+	}
+	neighbours := readiness.ScopeSpec{Name: "neighbours"}
+	if !cfg.NetlinkMonitor.Disabled {
+		neighbours.ExpectedObservationInterval = neigh.DefaultUpdateInterval
+	}
+	specs = append(specs,
+		neighbours,
+		readiness.ScopeSpec{
+			Name:                        "rib",
+			ExpectedObservationInterval: cfg.Readiness.SampleInterval,
+		},
+	)
+	if cfg.Readiness.ExpectBird {
+		specs = append(specs, readiness.ScopeSpec{
+			Name:                        "bird-session",
+			ExpectedObservationInterval: cfg.Readiness.SampleInterval,
+		})
+	}
+	return specs
 }

--- a/operators/route/internal/operator/readiness.md
+++ b/operators/route/internal/operator/readiness.md
@@ -118,12 +118,12 @@ Config parameters (under `reconcile:`):
 - `reconcile.max_backoff` (default 30s): cap on the exponential backoff during
   persistent failure. `observed_at` still advances on each failed retry.
 
-Recommended staleness threshold: base it on `max(reconcile.interval,
-reconcile.max_backoff)` — the largest gap between apply attempts in success or
-retry. At the defaults (both 30s) a threshold around twice that (~60s) covers
-jitter and slow applies. If `max_backoff` is raised above `interval`, size the
-threshold off `max_backoff` or a live, retrying operator will false-alarm as
-stale.
+Each FIB scope publishes
+`expected_observation_interval = reconcile.interval`. Consumers choose a small
+multiplier and judge the scope stale when its age exceeds that product. Retry
+backoff deliberately does not inflate the contract: a prolonged retry or slow
+apply remains visible as freshness lag instead of being hidden by
+`reconcile.max_backoff`.
 
 ### `neighbours`
 
@@ -143,9 +143,9 @@ Config parameters (under `netlink_monitor:`):
   becomes a latch (see below) and `observed_at` stops advancing entirely. The
   event-driven and periodic refresh paths have no separate config knobs.
 
-A quiet network therefore shows up to ~5min of staleness. Recommended
-threshold: roughly 10-15min (2-3 periodic intervals). An active network stays
-near-real-time.
+A quiet network therefore shows up to ~5min of age. The scope publishes that
+5min periodic interval; a multiplier of 2-3 gives a 10-15min threshold. An
+active network stays near-real-time.
 
 When the monitor is disabled, the scope is set READY once and never refreshed,
 so a staleness check is **not applicable** (treat READY as fresh regardless of
@@ -165,9 +165,8 @@ Config parameters (under `readiness:`):
   for `rib` and whether `bird-session` exists at all, but does **not** change
   the tick cadence — both modes tick at `sample_interval`.
 
-Recommended staleness threshold for both: a few `readiness.sample_interval`s
-(~5-10s only at the default 1s). If `sample_interval` is raised, scale the
-threshold with it — a healthy operator on a 30s interval goes that long between
-ticks by design. Beyond the scaled threshold the sampling ticker has stopped,
-which means the operator is shutting down or the RIB readiness worker is no
-longer running.
+Both scopes publish
+`expected_observation_interval = readiness.sample_interval`, so a consumer's
+multiplier scales automatically when the configured interval changes. Beyond
+that scaled threshold the sampling ticker has stopped, which means the
+operator is shutting down or the RIB readiness worker is no longer running.

--- a/operators/route/internal/operator/readiness_test.go
+++ b/operators/route/internal/operator/readiness_test.go
@@ -42,48 +42,78 @@ func specs(names ...string) []readiness.ScopeSpec {
 	return out
 }
 
-// TestReadiness_ScopeSpecs_MirrorSourceIntervals verifies that each scope's
-// observation contract is the nominal interval of the ticker that
-// re-observes it, and that scopes without a heartbeat source declare none.
-func TestReadiness_ScopeSpecs_MirrorSourceIntervals(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
-	cfg.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
-	// The backoff ceiling must not inflate the fib contract: a slow or hung
-	// apply has to surface as staleness after a multiple of the nominal
-	// interval, not after a multiple of the retry ceiling.
-	cfg.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
-	cfg.Readiness.SampleInterval = 2 * time.Second
-
-	specsByName := map[string]readiness.ScopeSpec{}
-	for _, spec := range readinessScopeSpecs(cfg, "route0") {
-		specsByName[spec.Name] = spec
+// verifies that route configuration selects each production scope and its
+// source interval, including scopes that are disabled or omitted.
+func Test_ReadinessScopeSpecs_ConfigurationMappings(t *testing.T) {
+	tests := []struct {
+		name              string
+		configure         func(*Config)
+		expectedIntervals map[string]time.Duration
+		absentScopes      []string
+	}{
+		{
+			name:      "normal sources use their nominal intervals",
+			configure: func(config *Config) {},
+			expectedIntervals: map[string]time.Duration{
+				"fib:gw0:route0": 10 * time.Second,
+				"fib:gw1:route0": 10 * time.Second,
+				"neighbours":     neigh.DefaultUpdateInterval,
+				"rib":            2 * time.Second,
+				"bird-session":   2 * time.Second,
+			},
+		},
+		{
+			name: "disabled neighbours remain present without a contract",
+			configure: func(config *Config) {
+				config.NetlinkMonitor.Disabled = true
+			},
+			expectedIntervals: map[string]time.Duration{
+				"fib:gw0:route0": 10 * time.Second,
+				"fib:gw1:route0": 10 * time.Second,
+				"neighbours":     0,
+				"rib":            2 * time.Second,
+				"bird-session":   2 * time.Second,
+			},
+		},
+		{
+			name: "bird not expected omits bird session scope",
+			configure: func(config *Config) {
+				config.Readiness.ExpectBird = false
+			},
+			expectedIntervals: map[string]time.Duration{
+				"fib:gw0:route0": 10 * time.Second,
+				"fib:gw1:route0": 10 * time.Second,
+				"neighbours":     neigh.DefaultUpdateInterval,
+				"rib":            2 * time.Second,
+			},
+			absentScopes: []string{"bird-session"},
+		},
 	}
 
-	require.Len(t, specsByName, 5)
-	for _, name := range []string{"fib:gw0:route0", "fib:gw1:route0"} {
-		assert.Equal(t, 10*time.Second, specsByName[name].ExpectedObservationInterval,
-			"%s must mirror the nominal reconcile interval", name)
-	}
-	assert.Equal(t, 2*time.Second, specsByName["rib"].ExpectedObservationInterval,
-		"rib must mirror the sampler interval")
-	assert.Equal(t, 2*time.Second, specsByName["bird-session"].ExpectedObservationInterval,
-		"bird-session must mirror the sampler interval")
-	assert.Equal(t, neigh.DefaultUpdateInterval, specsByName["neighbours"].ExpectedObservationInterval,
-		"neighbours must mirror the monitor force-update interval")
-}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := DefaultConfig()
+			config.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
+			config.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
+			config.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
+			config.Readiness.SampleInterval = 2 * time.Second
+			test.configure(config)
 
-// TestReadiness_ScopeSpecs_NeighboursDisabled_NoContract verifies that a
-// set-once neighbours scope declares no freshness contract.
-func TestReadiness_ScopeSpecs_NeighboursDisabled_NoContract(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}}
-	cfg.NetlinkMonitor.Disabled = true
+			scopeSpecsByName := map[string]readiness.ScopeSpec{}
+			for _, scopeSpec := range readinessScopeSpecs(config, "route0") {
+				scopeSpecsByName[scopeSpec.Name] = scopeSpec
+			}
 
-	for _, spec := range readinessScopeSpecs(cfg, "route0") {
-		if spec.Name == "neighbours" {
-			assert.Zero(t, spec.ExpectedObservationInterval)
-		}
+			require.Len(t, scopeSpecsByName, len(test.expectedIntervals))
+			for name, expectedInterval := range test.expectedIntervals {
+				scopeSpec, ok := scopeSpecsByName[name]
+				require.True(t, ok, "required scope %q is absent", name)
+				assert.Equal(t, expectedInterval, scopeSpec.ExpectedObservationInterval)
+			}
+			for _, name := range test.absentScopes {
+				assert.NotContains(t, scopeSpecsByName, name)
+			}
+		})
 	}
 }
 

--- a/operators/route/internal/operator/readiness_test.go
+++ b/operators/route/internal/operator/readiness_test.go
@@ -32,8 +32,7 @@ func requireScope(t *testing.T, tracker *readiness.Tracker, name string) *readin
 	return nil
 }
 
-// specs builds scope declarations without a freshness contract, for tests
-// that exercise state and timestamps rather than freshness.
+// specs returns scopes without freshness contracts for non-freshness tests.
 func specs(names ...string) []readiness.ScopeSpec {
 	out := make([]readiness.ScopeSpec, 0, len(names))
 	for _, name := range names {

--- a/operators/route/internal/operator/readiness_test.go
+++ b/operators/route/internal/operator/readiness_test.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
 	"github.com/yanet-platform/yanet2/common/go/readiness"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
+	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
 	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
 )
 
@@ -30,13 +32,68 @@ func requireScope(t *testing.T, tracker *readiness.Tracker, name string) *readin
 	return nil
 }
 
+// specs builds scope declarations without a freshness contract, for tests
+// that exercise state and timestamps rather than freshness.
+func specs(names ...string) []readiness.ScopeSpec {
+	out := make([]readiness.ScopeSpec, 0, len(names))
+	for _, name := range names {
+		out = append(out, readiness.ScopeSpec{Name: name})
+	}
+	return out
+}
+
+// TestReadiness_ScopeSpecs_MirrorSourceIntervals verifies that each scope's
+// observation contract is the nominal interval of the ticker that
+// re-observes it, and that scopes without a heartbeat source declare none.
+func TestReadiness_ScopeSpecs_MirrorSourceIntervals(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}, {Name: "gw1"}}
+	cfg.Reconcile.Interval = xcfg.MustNonZero(10 * time.Second)
+	// The backoff ceiling must not inflate the fib contract: a slow or hung
+	// apply has to surface as staleness after a multiple of the nominal
+	// interval, not after a multiple of the retry ceiling.
+	cfg.Reconcile.MaxBackoff = xcfg.MustNonZero(2 * time.Minute)
+	cfg.Readiness.SampleInterval = 2 * time.Second
+
+	specsByName := map[string]readiness.ScopeSpec{}
+	for _, spec := range readinessScopeSpecs(cfg, "route0") {
+		specsByName[spec.Name] = spec
+	}
+
+	require.Len(t, specsByName, 5)
+	for _, name := range []string{"fib:gw0:route0", "fib:gw1:route0"} {
+		assert.Equal(t, 10*time.Second, specsByName[name].ExpectedObservationInterval,
+			"%s must mirror the nominal reconcile interval", name)
+	}
+	assert.Equal(t, 2*time.Second, specsByName["rib"].ExpectedObservationInterval,
+		"rib must mirror the sampler interval")
+	assert.Equal(t, 2*time.Second, specsByName["bird-session"].ExpectedObservationInterval,
+		"bird-session must mirror the sampler interval")
+	assert.Equal(t, neigh.DefaultUpdateInterval, specsByName["neighbours"].ExpectedObservationInterval,
+		"neighbours must mirror the monitor force-update interval")
+}
+
+// TestReadiness_ScopeSpecs_NeighboursDisabled_NoContract verifies that a
+// set-once neighbours scope declares no freshness contract.
+func TestReadiness_ScopeSpecs_NeighboursDisabled_NoContract(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}}
+	cfg.NetlinkMonitor.Disabled = true
+
+	for _, spec := range readinessScopeSpecs(cfg, "route0") {
+		if spec.Name == "neighbours" {
+			assert.Zero(t, spec.ExpectedObservationInterval)
+		}
+	}
+}
+
 func TestReadiness_NeighboursDisabled_ImmediatelyReady(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.NetlinkMonitor.Disabled = true
 	cfg.Readiness.ExpectBird = false
 	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}}
 
-	tracker := readiness.NewTracker([]string{"fib:gw0:route0", "neighbours", "rib"})
+	tracker := readiness.NewTracker(specs("fib:gw0:route0", "neighbours", "rib"))
 
 	// When netlink monitor is disabled, mark neighbours READY immediately.
 	if cfg.NetlinkMonitor.Disabled {
@@ -48,7 +105,7 @@ func TestReadiness_NeighboursDisabled_ImmediatelyReady(t *testing.T) {
 }
 
 func TestReadiness_ExpectBirdFalse_RibImmediatelyReady(t *testing.T) {
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 
 	// When BIRD is not expected, mark rib READY immediately.
 	tracker.Set("rib", readinesspb.State_STATE_READY)
@@ -58,7 +115,7 @@ func TestReadiness_ExpectBirdFalse_RibImmediatelyReady(t *testing.T) {
 }
 
 func TestReadiness_FIBObserve(t *testing.T) {
-	tracker := readiness.NewTracker([]string{"fib:gw0:route0"})
+	tracker := readiness.NewTracker(specs("fib:gw0:route0"))
 
 	// Initial state is UNKNOWN.
 	s := requireScope(t, tracker, "fib:gw0:route0")
@@ -99,7 +156,7 @@ func TestRIBReadiness_SessionStart_SYNCING(t *testing.T) {
 	}
 
 	store := newRIBStore()
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -119,7 +176,7 @@ func TestRIBReadiness_HighRate_SYNCING(t *testing.T) {
 	}
 
 	store := newRIBStore()
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -167,7 +224,7 @@ func TestRIBReadiness_LowRate_READY(t *testing.T) {
 	store := newRIBStore()
 	// Seed a route so that settled && routes>0 produces READY.
 	seedRoute(t, store, "route0")
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -198,7 +255,7 @@ func TestRIBReadiness_MidWindowSpike_ResetsBelowSince(t *testing.T) {
 	}
 
 	store := newRIBStore()
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -241,7 +298,7 @@ func TestRIBReadiness_SessionEnd_Degraded(t *testing.T) {
 	// Seed a route so that the settled state produces READY and the session
 	// end with live routes produces DEGRADED(SESSION_ENDED).
 	seedRoute(t, store, "route0")
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -315,7 +372,7 @@ func TestRIBReadiness_Syncing(t *testing.T) {
 			}
 
 			store := newRIBStore()
-			tracker := readiness.NewTracker([]string{"rib"})
+			tracker := readiness.NewTracker(specs("rib"))
 			helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 			if tc.seedRoutes {
@@ -381,7 +438,7 @@ func TestRIBReadiness_SupersededSession(t *testing.T) {
 	store := newRIBStore()
 	// Seed a route so that the settled state produces READY.
 	seedRoute(t, store, "route0")
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	// Session A starts (id=1) — routes are present so tracker enters
@@ -439,7 +496,7 @@ func TestBirdSession_InitialDegraded(t *testing.T) {
 	}
 
 	store := newRIBStore()
-	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker(specs("bird-session", "rib"))
 	newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	s := requireScope(t, tracker, "bird-session")
@@ -459,7 +516,7 @@ func TestBirdSession_SessionStartReady(t *testing.T) {
 	}
 
 	store := newRIBStore()
-	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker(specs("bird-session", "rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -480,7 +537,7 @@ func TestBirdSession_SessionEndReconnecting(t *testing.T) {
 	}
 
 	store := newRIBStore()
-	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker(specs("bird-session", "rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -503,7 +560,7 @@ func TestBirdSession_GraceExpiry(t *testing.T) {
 	}
 
 	store := newRIBStore()
-	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker(specs("bird-session", "rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -538,7 +595,7 @@ func TestBirdSession_NeverNotReady(t *testing.T) {
 	}
 
 	store := newRIBStore()
-	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker(specs("bird-session", "rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -572,7 +629,7 @@ func TestBirdSession_ReconnectFromDown(t *testing.T) {
 	}
 
 	store := newRIBStore()
-	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker(specs("bird-session", "rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -612,7 +669,7 @@ func TestRIBReadiness_SettledNoRoutes(t *testing.T) {
 
 	store := newRIBStore()
 	// No routes seeded — empty RIB.
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -647,7 +704,7 @@ func TestRIBReadiness_SessionEndedWithRoutes(t *testing.T) {
 
 	store := newRIBStore()
 	seedRoute(t, store, "route0")
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -688,7 +745,7 @@ func TestRIBReadiness_TTLPurgeAfterSessionEnd(t *testing.T) {
 
 	store := newRIBStore()
 	seedRoute(t, store, "route0")
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -736,7 +793,7 @@ func TestRIBReadiness_TTLPurgeAfterSessionEnd(t *testing.T) {
 // NOT_READY(SYNCING) -> READY on first sync, then DEGRADED(RESYNC) on error,
 // then READY on recovery.
 func TestNeighbours_SyncThenError(t *testing.T) {
-	tracker := readiness.NewTracker([]string{"neighbours"})
+	tracker := readiness.NewTracker(specs("neighbours"))
 
 	// Seed initial NOT_READY(SYNCING) as operator.go does.
 	tracker.SetWithReason("neighbours",
@@ -788,7 +845,7 @@ func TestBirdRestartHoldInvariant(t *testing.T) {
 
 	store := newRIBStore()
 	seedRoute(t, store, "route0")
-	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker(specs("bird-session", "rib"))
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker)
 
 	helper.OnSessionStart("route0", 1)
@@ -842,7 +899,7 @@ func TestStaticRIBReadiness_ReadyWhenRoutesPresent(t *testing.T) {
 	seedRoute(t, store, "route0")
 
 	// Register both rib and bird-session so we can assert bird-session is never set.
-	tracker := readiness.NewTracker([]string{"rib", "bird-session"})
+	tracker := readiness.NewTracker(specs("rib", "bird-session"))
 
 	helper := newStaticRIBReadiness(store, "route0", tracker, 20*time.Millisecond)
 
@@ -886,7 +943,7 @@ func TestStaticRIBReadiness_ReadyWhenRoutesPresent(t *testing.T) {
 // rib=NOT_READY(NO_ROUTES) on construction when the store is empty.
 func TestStaticRIBReadiness_ColdStart(t *testing.T) {
 	store := newRIBStore()
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 
 	newStaticRIBReadiness(store, "route0", tracker, 20*time.Millisecond)
 
@@ -905,7 +962,7 @@ func TestStaticRIBReadiness_PostPreRunReady(t *testing.T) {
 
 	// Empty store at construction — seeds NOT_READY(NO_ROUTES), mirroring the
 	// real operator where PreRun has not yet populated static.routes.
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 	helper := newStaticRIBReadiness(store, "route0", tracker, 500*time.Millisecond)
 
 	s := requireScope(t, tracker, "rib")
@@ -941,7 +998,7 @@ func TestStaticRIBReadiness_PostPreRunReady(t *testing.T) {
 func TestStaticRIBReadiness_NoopsIgnored(t *testing.T) {
 	store := newRIBStore()
 	seedRoute(t, store, "route0")
-	tracker := readiness.NewTracker([]string{"rib"})
+	tracker := readiness.NewTracker(specs("rib"))
 
 	helper := newStaticRIBReadiness(store, "route0", tracker, 20*time.Millisecond)
 

--- a/operators/route/operatorpb/v1/readiness.proto
+++ b/operators/route/operatorpb/v1/readiness.proto
@@ -11,10 +11,12 @@ service ReadinessService {
   // Ready returns the current readiness state for all scopes.
   rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
 
-  // Watch streams readiness state changes.
+  // Watch streams readiness updates.
   //
   // The first message carries the current state of every selected scope;
-  // each subsequent message carries only the scopes whose state or reason
-  // changed.
+  // each subsequent message carries the scopes whose state or reason
+  // changed, in order. With include_observation_updates in the request,
+  // pure observation refreshes are delivered too, coalesced per scope;
+  // see the shared request message for the full semantics.
   rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/route/operatorpb/v1/readiness.proto
+++ b/operators/route/operatorpb/v1/readiness.proto
@@ -15,8 +15,6 @@ service ReadinessService {
   //
   // The first message carries the current state of every selected scope;
   // each subsequent message carries the scopes whose state or reason
-  // changed, in order. With include_observation_updates in the request,
-  // pure observation refreshes are delivered too, coalesced per scope;
-  // see the shared request message for the full semantics.
+  // changed since the previous message.
   rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }


### PR DESCRIPTION
- Adds `expected_observation_interval` to readiness scopes so consumers can derive a threshold from each source's nominal cadence.
- Publishes reconcile, RIB, BIRD, and neighbour observation intervals from the gateway and operator scope registrations while leaving set-once scopes without a freshness contract.
- Replaces the CLI's absolute `--stale-after` threshold with `--stale-multiple`, using `age > multiplier * expected_observation_interval`; `0` disables stale tags.
- Keeps `Watch` transition-only: its initial message is a full snapshot and subsequent messages contain only state or reason changes; freshness checks use current `Ready` snapshots.
- Serializes the observation interval in CLI JSON output and documents the per-scope freshness contract for each operator.
- Covers distinct source cadences, scopes without heartbeats, CLI boundaries and arguments, and JSON serialization.

Closes #1747.