### PR TITLE
fix(acl,filterpb)!: revert the untyped ipnet message removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3619,6 +3619,7 @@ dependencies = [
 name = "yanet-filterpb"
 version = "0.1.0"
 dependencies = [
+ "netip",
  "prost",
  "serde",
  "serde_json",

--- a/bindings/go/filter/builders.go
+++ b/bindings/go/filter/builders.go
@@ -12,12 +12,12 @@ func CBuildDevices[T any](dst *T, m Devices, pinner *runtime.Pinner) {
 	*dst = *(*T)(unsafe.Pointer(m.cBuild(pinner)))
 }
 
-// CBuildNet4s writes the C representation of IPv4 networks into dst.
+// CBuildNet4s writes the C representation of IPv4 IPNets into dst.
 func CBuildNet4s[T any](dst *T, m []xnetip.Contiguous[xnetip.Network4], pinner *runtime.Pinner) {
 	*dst = *(*T)(unsafe.Pointer(cBuildNet4s(m, pinner)))
 }
 
-// CBuildNet6s writes the C representation of IPv6 networks into dst.
+// CBuildNet6s writes the C representation of IPv6 IPNets into dst.
 func CBuildNet6s[T any](dst *T, m []xnetip.BiContiguous, pinner *runtime.Pinner) {
 	*dst = *(*T)(unsafe.Pointer(cBuildNet6s(m, pinner)))
 }

--- a/bindings/go/filterpbconv/v1/convert.go
+++ b/bindings/go/filterpbconv/v1/convert.go
@@ -6,6 +6,8 @@
 package filterpbconv
 
 import (
+	"net/netip"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -25,6 +27,92 @@ func ToDevices(pb []*filterpb.Device) (filter.Devices, error) {
 	}
 
 	return out, nil
+}
+
+// ToNet4s converts legacy protobuf IPNet messages to contiguous IPv4
+// filter networks, keeping only IPv4 entries.
+func ToNet4s(pb []*filterpb.IPNet) ([]xnetip.Contiguous[xnetip.Network4], error) {
+	out := make([]xnetip.Contiguous[xnetip.Network4], 0, len(pb))
+
+	for idx := range pb {
+		addr, mask, err := legacyNetParts(pb[idx])
+		if err != nil {
+			return nil, err
+		}
+		if !addr.Is4() {
+			continue
+		}
+
+		net, err := xnetip.Network4From(addr, mask)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, "invalid network address")
+		}
+		typed, ok := xnetip.ContiguousFrom(net)
+		if !ok {
+			return nil, status.Error(codes.InvalidArgument, "network mask must be contiguous")
+		}
+
+		out = append(out, typed)
+	}
+
+	return out, nil
+}
+
+// ToNet6s converts legacy protobuf IPNet messages to bi-contiguous IPv6
+// filter networks, keeping only IPv6 entries.
+func ToNet6s(pb []*filterpb.IPNet) ([]xnetip.BiContiguous, error) {
+	out := make([]xnetip.BiContiguous, 0, len(pb))
+
+	for idx := range pb {
+		addr, mask, err := legacyNetParts(pb[idx])
+		if err != nil {
+			return nil, err
+		}
+		if !addr.Is6() {
+			continue
+		}
+
+		net, err := xnetip.Network6From(addr, mask)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, "invalid network address")
+		}
+		typed, ok := xnetip.BiContiguousFrom6(net)
+		if !ok {
+			return nil, status.Error(codes.InvalidArgument, "network mask must be bi-contiguous")
+		}
+
+		out = append(out, typed)
+	}
+
+	return out, nil
+}
+
+// legacyNetParts decodes and validates the address and mask bytes a legacy
+// IPNet message carries.
+func legacyNetParts(pb *filterpb.IPNet) (netip.Addr, netip.Addr, error) {
+	addr, ok := netip.AddrFromSlice(pb.Addr)
+	if !ok {
+		return netip.Addr{}, netip.Addr{}, status.Error(
+			codes.InvalidArgument,
+			"invalid network address",
+		)
+	}
+	mask, ok := netip.AddrFromSlice(pb.Mask)
+	if !ok {
+		return netip.Addr{}, netip.Addr{}, status.Error(
+			codes.InvalidArgument,
+			"invalid network mask",
+		)
+	}
+
+	if addr.Is4() != mask.Is4() {
+		return netip.Addr{}, netip.Addr{}, status.Error(
+			codes.InvalidArgument,
+			"network address and mask must be the same IP family",
+		)
+	}
+
+	return addr, mask, nil
 }
 
 // ToNet4sFromNetworks converts family-typed IPv4 network messages to

--- a/common/filterpb/v1/filter.go
+++ b/common/filterpb/v1/filter.go
@@ -1,0 +1,51 @@
+package filterpb
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/bits"
+	"net/netip"
+)
+
+// AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
+func (m *IPNet) AsLogValue() any {
+	if m == nil {
+		return "::/0"
+	}
+
+	addr, _ := netip.AddrFromSlice(m.Addr)
+	mask, _ := netip.AddrFromSlice(m.Mask)
+
+	switch {
+	case addr.Is4() && mask.Is4():
+		maskU32 := binary.BigEndian.Uint32(mask.AsSlice())
+		cidr := 32 - bits.TrailingZeros32(maskU32)
+
+		switch {
+		case cidr == 32:
+			return addr.String()
+		case cidr != bits.OnesCount32(maskU32):
+			return fmt.Sprintf("%s/%s", addr, mask)
+		default:
+			return fmt.Sprintf("%s/%d", addr, cidr)
+		}
+	case addr.Is6() && mask.Is6():
+		maskU64Hi := binary.BigEndian.Uint64(mask.AsSlice()[:8])
+		maskU64Lo := binary.BigEndian.Uint64(mask.AsSlice()[8:])
+
+		cidrHi := 64 - bits.TrailingZeros64(maskU64Hi)
+		cidrLo := 64 - bits.TrailingZeros64(maskU64Lo)
+
+		cidr := cidrHi + cidrLo
+		switch {
+		case cidr == 128:
+			return addr.String()
+		case cidrHi != bits.OnesCount64(maskU64Hi) || cidrLo != bits.OnesCount64(maskU64Lo):
+			return fmt.Sprintf("%s/%s", addr, mask)
+		default:
+			return fmt.Sprintf("%s/%d", addr, cidr)
+		}
+	default:
+		return fmt.Sprintf("%s/%s", addr, mask)
+	}
+}

--- a/common/filterpb/v1/filter.proto
+++ b/common/filterpb/v1/filter.proto
@@ -11,6 +11,11 @@ message VlanRange {
   uint32 to = 2;
 }
 
+message IPNet {
+  bytes addr = 1;
+  bytes mask = 2;
+}
+
 // Represents a protocol number range [from; to]
 // For transport protocols, upper byte may contain flag bits
 message ProtoRange {

--- a/common/rust/filterpb/Cargo.toml
+++ b/common/rust/filterpb/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.88"
 workspace = true
 
 [dependencies]
+netip = "0.3"
 prost = "0.13"
 serde = { version = "1", features = ["derive"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/common/rust/filterpb/src/network.rs
+++ b/common/rust/filterpb/src/network.rs
@@ -1,4 +1,63 @@
-use crate::pb::Device;
+use core::fmt::{self, Display, Formatter};
+
+use netip::{Contiguous, IpNetwork, Ipv4Network, Ipv6Network};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+use crate::pb::{Device, IpNet};
+
+impl Display for IpNet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match (self.addr.len(), self.mask.len()) {
+            (4, 4) => {
+                let addr = u32::from_be_bytes(<[u8; 4]>::try_from(self.addr.as_slice()).expect("checked above"));
+                let mask = u32::from_be_bytes(<[u8; 4]>::try_from(self.mask.as_slice()).expect("checked above"));
+                Ipv4Network::from_bits(addr, mask).fmt(f)
+            }
+            (16, 16) => {
+                let addr = u128::from_be_bytes(<[u8; 16]>::try_from(self.addr.as_slice()).expect("checked above"));
+                let mask = u128::from_be_bytes(<[u8; 16]>::try_from(self.mask.as_slice()).expect("checked above"));
+                Ipv6Network::from_bits(addr, mask).fmt(f)
+            }
+            (a, n) => write!(f, "<invalid IpNet: addr={a}B mask={n}B>"),
+        }
+    }
+}
+
+impl Serialize for IpNet {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for IpNet {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        IpNetwork::parse(&s)
+            .map(IpNet::from)
+            .map_err(|e| de::Error::custom(format!("invalid network address `{s}`: {e}")))
+    }
+}
+
+impl From<IpNetwork> for IpNet {
+    fn from(net: IpNetwork) -> Self {
+        match net {
+            IpNetwork::V4(net) => Self {
+                addr: net.addr().octets().to_vec(),
+                mask: net.mask().octets().to_vec(),
+            },
+            IpNetwork::V6(net) => Self {
+                addr: net.addr().octets().to_vec(),
+                mask: net.mask().octets().to_vec(),
+            },
+        }
+    }
+}
+
+impl From<Contiguous<IpNetwork>> for IpNet {
+    fn from(net: Contiguous<IpNetwork>) -> Self {
+        Self::from(*net)
+    }
+}
 
 impl From<String> for Device {
     fn from(name: String) -> Self {
@@ -9,6 +68,27 @@ impl From<String> for Device {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn ipnet_v4_cidr_roundtrip() {
+        let net: IpNet = serde_json::from_str("\"192.0.2.0/24\"").expect("IpNet parse must not fail");
+        let serialized = serde_json::to_string(&net).expect("IpNet serialization must not fail");
+        assert_eq!("\"192.0.2.0/24\"", serialized);
+    }
+
+    #[test]
+    fn ipnet_v4_mask_parse() {
+        let net: IpNet = serde_json::from_str("\"192.0.2.0/255.255.255.0\"").expect("IpNet mask parse must not fail");
+        let serialized = serde_json::to_string(&net).expect("IpNet serialization must not fail");
+        assert_eq!("\"192.0.2.0/24\"", serialized);
+    }
+
+    #[test]
+    fn ipnet_v6_cidr_roundtrip() {
+        let net: IpNet = serde_json::from_str("\"2001:db8::/32\"").expect("IpNet parse must not fail");
+        let serialized = serde_json::to_string(&net).expect("IpNet serialization must not fail");
+        assert_eq!("\"2001:db8::/32\"", serialized);
+    }
 
     #[test]
     fn device_object_roundtrip() {

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -81,14 +81,20 @@ message Rule {
 
   repeated common.filterpb.v1.Device devices = 3;
   repeated common.filterpb.v1.VlanRange vlan_ranges = 4;
-  repeated common.commonpb.v1.IPv4Network sources4 = 5;
-  repeated common.commonpb.v1.IPv6Network sources6 = 6;
-  repeated common.commonpb.v1.IPv4Network destinations4 = 7;
-  repeated common.commonpb.v1.IPv6Network destinations6 = 8;
-  repeated common.filterpb.v1.ProtoRange proto_ranges = 9;
-  repeated common.filterpb.v1.PortRange src_port_ranges = 10;
-  repeated common.filterpb.v1.PortRange dst_port_ranges = 11;
-  common.filterpb.v1.Fragment fragment = 12;
+  // srcs and dsts carry mixed-family networks with free-form byte
+  // masks; they remain accepted for backward compatibility and merge
+  // with the typed lists below. New clients use the typed lists, which
+  // make invalid mask shapes unrepresentable.
+  repeated common.filterpb.v1.IPNet srcs = 5 [deprecated = true];
+  repeated common.filterpb.v1.IPNet dsts = 6 [deprecated = true];
+  repeated common.filterpb.v1.ProtoRange proto_ranges = 7;
+  repeated common.filterpb.v1.PortRange src_port_ranges = 8;
+  repeated common.filterpb.v1.PortRange dst_port_ranges = 9;
+  common.filterpb.v1.Fragment fragment = 10;
+  repeated common.commonpb.v1.IPv4Network sources4 = 11;
+  repeated common.commonpb.v1.IPv6Network sources6 = 12;
+  repeated common.commonpb.v1.IPv4Network destinations4 = 13;
+  repeated common.commonpb.v1.IPv6Network destinations6 = 14;
 }
 
 message Action { ActionKind kind = 1; }

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/yanet-platform/xnetip"
 	"strings"
 	"sync"
 
@@ -15,6 +16,8 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	filterpbconv "github.com/yanet-platform/yanet2/bindings/go/filterpbconv/v1"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -368,6 +371,36 @@ func labeler(fullMethod string, req any) metrics.Labels {
 	}
 }
 
+// mergedNet4s decodes the IPv4 networks a rule carries in the legacy
+// mixed-family list and the typed list, legacy entries first.
+func mergedNet4s(legacy []*filterpb.IPNet, typed []*commonpb.IPv4Network) ([]xnetip.Contiguous[xnetip.Network4], error) {
+	nets, err := filterpbconv.ToNet4s(legacy)
+	if err != nil {
+		return nil, err
+	}
+	typedNets, err := filterpbconv.ToNet4sFromNetworks(typed)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(nets, typedNets...), nil
+}
+
+// mergedNet6s decodes the IPv6 networks a rule carries in the legacy
+// mixed-family list and the typed list, legacy entries first.
+func mergedNet6s(legacy []*filterpb.IPNet, typed []*commonpb.IPv6Network) ([]xnetip.BiContiguous, error) {
+	nets, err := filterpbconv.ToNet6s(legacy)
+	if err != nil {
+		return nil, err
+	}
+	typedNets, err := filterpbconv.ToNet6sFromNetworks(typed)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(nets, typedNets...), nil
+}
+
 func convertRules(reqRules []*aclpb.Rule) ([]cacl.AclRule, error) {
 	rules := make([]cacl.AclRule, 0, len(reqRules))
 	for _, reqRule := range reqRules {
@@ -379,19 +412,19 @@ func convertRules(reqRules []*aclpb.Rule) ([]cacl.AclRule, error) {
 		if err != nil {
 			return nil, err
 		}
-		src4s, err := filterpbconv.ToNet4sFromNetworks(reqRule.Sources4)
+		src4s, err := mergedNet4s(reqRule.Srcs, reqRule.Sources4)
 		if err != nil {
 			return nil, err
 		}
-		dst4s, err := filterpbconv.ToNet4sFromNetworks(reqRule.Destinations4)
+		dst4s, err := mergedNet4s(reqRule.Dsts, reqRule.Destinations4)
 		if err != nil {
 			return nil, err
 		}
-		src6s, err := filterpbconv.ToNet6sFromNetworks(reqRule.Sources6)
+		src6s, err := mergedNet6s(reqRule.Srcs, reqRule.Sources6)
 		if err != nil {
 			return nil, err
 		}
-		dst6s, err := filterpbconv.ToNet6sFromNetworks(reqRule.Destinations6)
+		dst6s, err := mergedNet6s(reqRule.Dsts, reqRule.Destinations6)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -20,6 +20,7 @@ import (
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -942,6 +943,30 @@ func TestConvertRules_RejectsUnknownActionKind(t *testing.T) {
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+// TestUpdateConfig_RejectsNonContiguousMask verifies that a rule with a
+// non-contiguous network mask is rejected before reaching the backend.
+func TestUpdateConfig_RejectsNonContiguousMask(t *testing.T) {
+	svc := newTestService(newFakeBackend())
+
+	req := &aclpb.UpdateConfigRequest{
+		Name: "acl0",
+		Rules: []*aclpb.Rule{
+			{
+				Srcs: []*filterpb.IPNet{
+					{
+						Addr: []byte{192, 0, 2, 0},
+						Mask: []byte{0xff, 0x00, 0xff, 0x00},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := svc.UpdateConfig(t.Context(), req)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
 // mustV4Network builds an IPv4Network from a test literal in the CIDR or
 // address/mask form.
 func mustV4Network(s string) *commonpb.IPv4Network {
@@ -989,6 +1014,37 @@ func TestUpdateConfig_TypedNetworkLists(t *testing.T) {
 	assert.Equal(t, []xnetip.BiContiguous{xnetip.MustParseBiContiguous("2001:db8::/32")}, rules[0].Src6s)
 	assert.Equal(t, []xnetip.Contiguous[xnetip.Network4]{xnetip.MustParseContiguous4("198.51.100.0/24")}, rules[0].Dst4s)
 	assert.Equal(t, []xnetip.BiContiguous{xnetip.MustParseBiContiguous("2001:db8:1::/ffff:ffff:ffff:0:ffff::")}, rules[0].Dst6s)
+}
+
+// TestUpdateConfig_MergesLegacyAndTypedNetworks verifies that legacy and
+// typed lists merge into one match set, legacy entries first.
+func TestUpdateConfig_MergesLegacyAndTypedNetworks(t *testing.T) {
+	backend := newFakeBackend()
+	svc := newTestService(backend)
+
+	typed := mustV4Network("198.51.100.0/24")
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name: "acl0",
+		Rules: []*aclpb.Rule{{
+			Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}},
+			Srcs: []*filterpb.IPNet{{
+				Addr: []byte{192, 0, 2, 0},
+				Mask: []byte{255, 255, 255, 0},
+			}},
+			Sources4: []*commonpb.IPv4Network{typed},
+		}},
+	})
+	require.NoError(t, err)
+
+	handles := backend.CreatedHandles()
+	require.Len(t, handles, 1)
+	rules := handles[0].Rules()
+	require.Len(t, rules, 1)
+	assert.Equal(t, []xnetip.Contiguous[xnetip.Network4]{
+		xnetip.MustParseContiguous4("192.0.2.0/24"),
+		xnetip.MustParseContiguous4("198.51.100.0/24"),
+	}, rules[0].Src4s)
 }
 
 // TestUpdateConfig_RejectsTypedOutOfClassMasks verifies that masks outside

--- a/modules/acl/web/AclPage.tsx
+++ b/modules/acl/web/AclPage.tsx
@@ -3,6 +3,7 @@ import { Button, Icon, Label, TextInput } from '@gravity-ui/uikit';
 import { Funnel, Pause, Play, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '@yanet/core/components';
 import { useConfigListCache, useListNavigation, usePageContribution } from '@yanet/core/hooks';
+import { extractBytes } from '@yanet/core/utils';
 import { useAclDraft } from './useAclDraft';
 import type { Rule } from '@yanet/core/api/acl';
 import { ActionKind } from '@yanet/core/api/acl';
@@ -41,8 +42,13 @@ const statefulRuleRequiredFamilies = (rules: Rule[]): Set<'v4' | 'v6'> => {
         if (!stateful) {
             continue;
         }
-        const hasV4 = (rule.sources4?.length ?? 0) > 0 || (rule.destinations4?.length ?? 0) > 0;
-        const hasV6 = (rule.sources6?.length ?? 0) > 0 || (rule.destinations6?.length ?? 0) > 0;
+        let hasV4 = false;
+        let hasV6 = false;
+        for (const net of [...(rule.srcs ?? []), ...(rule.dsts ?? [])]) {
+            const len = extractBytes(net.addr)?.length ?? 0;
+            if (len === 4) hasV4 = true;
+            else if (len === 16) hasV6 = true;
+        }
         if (hasV4 || hasV6) {
             if (hasV4) required.add('v4');
             if (hasV6) required.add('v6');

--- a/modules/acl/web/SaveDiffModal.tsx
+++ b/modules/acl/web/SaveDiffModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Dialog, Text } from '@gravity-ui/uikit';
 import type { Rule } from '@yanet/core/api/acl';
 import { ActionKind } from '@yanet/core/api/acl';
-import { dumpYamlDoc } from '@yanet/core/utils';
+import { formatIPNetItem, dumpYamlDoc } from '@yanet/core/utils';
 
 // TODO(acl): structured diff disabled until the per-card layout is reworked.
 
@@ -17,7 +17,14 @@ const ACTION_KIND_YAML_NAMES: Record<ActionKind, string> = {
 
 /** Build the serialisable object array for a set of ACL rules. Used by both YAML and JSON export. */
 export const rulesToYamlObjects = (rules: Rule[]): Array<Record<string, unknown>> => {
+    const isV6 = (cidr: string): boolean => cidr.split('/')[0].includes(':');
     return rules.map(r => {
+        const srcs = [...(r.srcs ?? []).map(formatIPNetItem).filter(Boolean), ...(r.sources4 ?? []), ...(r.sources6 ?? [])];
+        const dsts = [
+            ...(r.dsts ?? []).map(formatIPNetItem).filter(Boolean),
+            ...(r.destinations4 ?? []),
+            ...(r.destinations6 ?? []),
+        ];
         const fmtRange = (rng: { from?: number; to?: number }): { from: number; to: number } => ({
             from: rng.from ?? 0,
             to: rng.to ?? 0,
@@ -32,10 +39,10 @@ export const rulesToYamlObjects = (rules: Rule[]): Array<Record<string, unknown>
         }));
 
         const entry: Record<string, unknown> = {};
-        const sources4 = r.sources4 ?? [];
-        const sources6 = r.sources6 ?? [];
-        const destinations4 = r.destinations4 ?? [];
-        const destinations6 = r.destinations6 ?? [];
+        const sources4 = srcs.filter(s => !isV6(s));
+        const sources6 = srcs.filter(isV6);
+        const destinations4 = dsts.filter(d => !isV6(d));
+        const destinations6 = dsts.filter(isV6);
         if (sources4.length > 0) entry['sources4'] = sources4;
         if (sources6.length > 0) entry['sources6'] = sources6;
         if (destinations4.length > 0) entry['destinations4'] = destinations4;

--- a/modules/acl/web/hooks.ts
+++ b/modules/acl/web/hooks.ts
@@ -1,9 +1,9 @@
 import type { Rule, PortRange, VlanRange, ProtoRange, Action } from '@yanet/core/api/acl';
 import { ActionKind } from '@yanet/core/api/acl';
-import { formatRange } from '@yanet/core/utils';
+import { extractBytes, formatIPNetItem, formatRange } from '@yanet/core/utils';
 import type { RuleDraft, RuleItem } from './types';
 import { parseRangesRaw, parseProtoRangesRaw, partitionCidrsToTyped } from './parseHelpers';
-export { parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
+export { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
 
 /**
  * Normalize a wire-shape Action.kind into a concrete ActionKind.
@@ -67,13 +67,15 @@ export const expandRule = (rule: Rule): {
     isDeadProto: boolean;
     isDead: boolean;
 } => {
+    const srcs = rule.srcs ?? [];
+    const dsts = rule.dsts ?? [];
     const sources4 = rule.sources4 ?? [];
     const sources6 = rule.sources6 ?? [];
     const destinations4 = rule.destinations4 ?? [];
     const destinations6 = rule.destinations6 ?? [];
 
-    const sourceCidrs = [...sources4, ...sources6];
-    const dstCidrs = [...destinations4, ...destinations6];
+    const sourceCidrs = [...srcs.map(formatIPNetItem).filter(Boolean), ...sources4, ...sources6];
+    const dstCidrs = [...dsts.map(formatIPNetItem).filter(Boolean), ...destinations4, ...destinations6];
 
     const srcPortRanges = (rule.src_port_ranges ?? []).map(formatRange);
     const dstPortRanges = (rule.dst_port_ranges ?? []).map(formatRange);
@@ -81,11 +83,22 @@ export const expandRule = (rule: Rule): {
     const vlanRanges = (rule.vlan_ranges ?? []).map(formatRange);
     const deviceNames = (rule.devices ?? []).map(d => d.name ?? '').filter(Boolean);
 
-    // Per-family counts for classification.
-    const v4SrcCount = sources4.length;
-    const v6SrcCount = sources6.length;
-    const v4DstCount = destinations4.length;
-    const v6DstCount = destinations6.length;
+    // Per-family counts for classification (addr byte length: 4 = IPv4, 16 = IPv6).
+    let v4SrcCount = sources4.length;
+    let v6SrcCount = sources6.length;
+    for (const net of srcs) {
+        const len = extractBytes(net.addr)?.length ?? 0;
+        if (len === 4) v4SrcCount++;
+        else if (len === 16) v6SrcCount++;
+    }
+
+    let v4DstCount = destinations4.length;
+    let v6DstCount = destinations6.length;
+    for (const net of dsts) {
+        const len = extractBytes(net.addr)?.length ?? 0;
+        if (len === 4) v4DstCount++;
+        else if (len === 16) v6DstCount++;
+    }
 
     const hasIP4 = v4SrcCount > 0 && v4DstCount > 0;
     const hasIP6 = v6SrcCount > 0 && v6DstCount > 0;

--- a/modules/acl/web/parseHelpers.ts
+++ b/modules/acl/web/parseHelpers.ts
@@ -8,7 +8,7 @@
 import type { ProtoRange } from '@yanet/core/api/acl';
 import { parseRangesRaw } from '@yanet/core/utils';
 
-export { parseRangesRaw, partitionCidrsToTyped } from '@yanet/core/utils';
+export { parseCidrsToIPNets, parseRangesRaw, partitionCidrsToTyped } from '@yanet/core/utils';
 
 /** Parse encoded proto ranges (e.g. "1536-1791") to ProtoRange wire objects. */
 export const parseProtoRangesRaw = (raw: string): ProtoRange[] => parseRangesRaw(raw) as ProtoRange[];

--- a/modules/acl/web/structuredDiff.ts
+++ b/modules/acl/web/structuredDiff.ts
@@ -1,4 +1,5 @@
 import type { Rule, Action } from '@yanet/core/api/acl';
+import { formatIPNetItem } from '@yanet/core/utils';
 
 /** Serialize a range {from, to} to a canonical string for equality comparison. */
 const fmtRange = (r: { from?: number; to?: number }): string =>
@@ -52,9 +53,17 @@ const fieldValues = (rule: Rule, field: RuleField): string[] => {
         case 'counter':
             return [rule.counter ?? ''];
         case 'srcs':
-            return [...(rule.sources4 ?? []), ...(rule.sources6 ?? [])];
+            return [
+                ...(rule.srcs ?? []).map(formatIPNetItem).filter(Boolean),
+                ...(rule.sources4 ?? []),
+                ...(rule.sources6 ?? []),
+            ];
         case 'dsts':
-            return [...(rule.destinations4 ?? []), ...(rule.destinations6 ?? [])];
+            return [
+                ...(rule.dsts ?? []).map(formatIPNetItem).filter(Boolean),
+                ...(rule.destinations4 ?? []),
+                ...(rule.destinations6 ?? []),
+            ];
         case 'src_port_ranges':
             return (rule.src_port_ranges ?? []).map(fmtRange);
         case 'dst_port_ranges':

--- a/web/src/core/api/acl.ts
+++ b/web/src/core/api/acl.ts
@@ -6,8 +6,8 @@ import { createService, type CallOptions } from './client';
 import type { MACAddress } from './neighbours';
 import type { IPAddressWire } from '../utils/netip';
 
-import type { VlanRange, Device, ListConfigsResponse } from './shared';
-export type { VlanRange, Device, ListConfigsResponse };
+import type { IPNet, VlanRange, Device, ListConfigsResponse } from './shared';
+export type { IPNet, VlanRange, Device, ListConfigsResponse };
 
 export interface PortRange {
     from?: number;
@@ -47,12 +47,14 @@ export interface Rule {
     counter?: string;
     devices?: Device[];
     vlan_ranges?: VlanRange[];
+    srcs?: IPNet[];
+    dsts?: IPNet[];
     proto_ranges?: ProtoRange[];
     src_port_ranges?: PortRange[];
     dst_port_ranges?: PortRange[];
     // Family-typed network lists (commonpb.IPv4Network and
     // commonpb.IPv6Network), serialized by the gateway as bare network
-    // strings.
+    // strings. They merge with the legacy srcs/dsts lists.
     sources4?: string[];
     sources6?: string[];
     destinations4?: string[];

--- a/web/src/core/api/shared.ts
+++ b/web/src/core/api/shared.ts
@@ -9,6 +9,11 @@ export interface VlanRange {
     to?: number;
 }
 
+export interface IPNet {
+    addr?: string | Uint8Array | number[]; // Base64 encoded bytes or raw bytes
+    mask?: string | Uint8Array | number[]; // Base64 encoded bytes or raw bytes
+}
+
 export interface ListConfigsResponse {
     configs?: string[];
 }

--- a/web/src/core/utils/netip.test.ts
+++ b/web/src/core/utils/netip.test.ts
@@ -7,6 +7,7 @@ import {
     normalizeIPRange,
     ipRangeSpan,
     parseCIDRPrefix,
+    parseCidrsToIPNets,
     partitionCidrsToTyped,
     parseIPToBytes,
     parseIPv6ToBytes,
@@ -272,31 +273,31 @@ describe('parseIPv6ToBytes malformed :: and empty-group rejection', () => {
     });
 });
 
-describe('partitionCidrsToTyped rejects malformed :: forms in both spellings', () => {
+describe('parseCidrsToIPNets rejects malformed :: forms in both spellings', () => {
     it('drops ::: bare and with /128', () => {
-        expect(partitionCidrsToTyped([':::'])).toEqual({ v4: [], v6: [] });
-        expect(partitionCidrsToTyped([':::/128'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets([':::'])).toEqual([]);
+        expect(parseCidrsToIPNets([':::/128'])).toEqual([]);
     });
 
     it('drops 1::2::3 bare and with /128', () => {
-        expect(partitionCidrsToTyped(['1::2::3'])).toEqual({ v4: [], v6: [] });
-        expect(partitionCidrsToTyped(['1::2::3/128'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets(['1::2::3'])).toEqual([]);
+        expect(parseCidrsToIPNets(['1::2::3/128'])).toEqual([]);
     });
 });
 
-describe('partitionCidrsToTyped hex-group strictness', () => {
+describe('parseCidrsToIPNets hex-group strictness', () => {
     it('drops an entry with trailing junk in the first group', () => {
-        expect(partitionCidrsToTyped(['1abcg::/64'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets(['1abcg::/64'])).toEqual([]);
     });
 
     it('drops an entry with trailing junk in a non-first group', () => {
-        expect(partitionCidrsToTyped(['1:2:3:4:5:6:7:8abcg/128'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets(['1:2:3:4:5:6:7:8abcg/128'])).toEqual([]);
     });
 
     it('keeps well-formed entries alongside a dropped junk-group one', () => {
-        expect(partitionCidrsToTyped(['1abcg::/64', '2001:db8::/32']))
-            .toEqual(partitionCidrsToTyped(['2001:db8::/32']));
-        expect(partitionCidrsToTyped(['2001:db8::/32']).v6).toHaveLength(1);
+        expect(parseCidrsToIPNets(['1abcg::/64', '2001:db8::/32']))
+            .toEqual(parseCidrsToIPNets(['2001:db8::/32']));
+        expect(parseCidrsToIPNets(['2001:db8::/32'])).toHaveLength(1);
     });
 });
 
@@ -350,83 +351,89 @@ describe('IPv4Prefix.parse mask strictness', () => {
     });
 });
 
-describe('partitionCidrsToTyped mask strictness', () => {
+describe('parseCidrsToIPNets mask strictness', () => {
     it('converts a well-formed CIDR list (positive control)', () => {
-        expect(partitionCidrsToTyped(['10.0.0.0/24'])).toEqual({ v4: ['10.0.0.0/24'], v6: [] });
+        expect(parseCidrsToIPNets(['10.0.0.0/24'])).toEqual([
+            { addr: 'CgAAAA==', mask: '////AA==' },
+        ]);
     });
 
     it('drops an entry with trailing alphabetic junk in the mask', () => {
-        expect(partitionCidrsToTyped(['10.0.0.0/24abc'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets(['10.0.0.0/24abc'])).toEqual([]);
     });
 
     it('drops an entry with a trailing decimal fraction in the mask', () => {
-        expect(partitionCidrsToTyped(['10.0.0.0/24.5'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets(['10.0.0.0/24.5'])).toEqual([]);
     });
 
     it('drops an entry with an explicit leading plus sign in the mask', () => {
-        expect(partitionCidrsToTyped(['10.0.0.0/+24'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets(['10.0.0.0/+24'])).toEqual([]);
     });
 
     it('drops an entry with an empty mask', () => {
-        expect(partitionCidrsToTyped(['10.0.0.0/'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets(['10.0.0.0/'])).toEqual([]);
     });
 
     it('keeps well-formed entries alongside dropped malformed ones', () => {
-        expect(partitionCidrsToTyped(['10.0.0.0/24abc', '10.0.0.0/24'])).toEqual({ v4: ['10.0.0.0/24'], v6: [] });
+        expect(parseCidrsToIPNets(['10.0.0.0/24abc', '10.0.0.0/24'])).toEqual([
+            { addr: 'CgAAAA==', mask: '////AA==' },
+        ]);
     });
 
     it('drops an entry with trailing junk in an embedded-IPv4 tail octet', () => {
-        expect(partitionCidrsToTyped(['1:2:3:4:5:6:10.0.0.1abc/128'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets(['1:2:3:4:5:6:10.0.0.1abc/128'])).toEqual([]);
     });
 
     it('keeps a valid embedded-IPv4 CIDR alongside a dropped junk-tail one', () => {
-        expect(partitionCidrsToTyped(['1:2:3:4:5:6:10.0.0.1abc/128', '64:ff9b::10.0.0.0/120']))
-            .toEqual(partitionCidrsToTyped(['64:ff9b::10.0.0.0/120']));
-        expect(partitionCidrsToTyped(['64:ff9b::10.0.0.0/120']).v6).toHaveLength(1);
+        expect(parseCidrsToIPNets(['1:2:3:4:5:6:10.0.0.1abc/128', '64:ff9b::10.0.0.0/120']))
+            .toEqual(parseCidrsToIPNets(['64:ff9b::10.0.0.0/120']));
+        expect(parseCidrsToIPNets(['64:ff9b::10.0.0.0/120'])).toHaveLength(1);
     });
 
     it('drops an entry with a zero-padded IPv4 mask', () => {
-        expect(partitionCidrsToTyped(['10.0.0.0/024'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets(['10.0.0.0/024'])).toEqual([]);
     });
 
     it('drops an entry with a zero-padded IPv6 mask', () => {
-        expect(partitionCidrsToTyped(['2001:db8::/0128'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets(['2001:db8::/0128'])).toEqual([]);
     });
 
     it('keeps a mask of exactly "/0" (positive control, guard is not over-broad)', () => {
-        expect(partitionCidrsToTyped(['0.0.0.0/0']).v4).toHaveLength(1);
-        expect(partitionCidrsToTyped(['::/0']).v6).toHaveLength(1);
+        expect(parseCidrsToIPNets(['0.0.0.0/0'])).toHaveLength(1);
+        expect(parseCidrsToIPNets(['::/0'])).toHaveLength(1);
     });
 });
 
-describe('partitionCidrsToTyped mask-less host addresses', () => {
+describe('parseCidrsToIPNets mask-less host addresses', () => {
     it('converts a mask-less IPv4 address identically to the same address written /32', () => {
-        expect(partitionCidrsToTyped(['192.168.1.1'])).toEqual(
-            partitionCidrsToTyped(['192.168.1.1/32']),
+        expect(parseCidrsToIPNets(['192.168.1.1'])).toEqual(
+            parseCidrsToIPNets(['192.168.1.1/32']),
         );
-        expect(partitionCidrsToTyped(['192.168.1.1']).v4).toHaveLength(1);
+        expect(parseCidrsToIPNets(['192.168.1.1'])).toHaveLength(1);
     });
 
     it('encodes a mask-less IPv6 address as a full-width /128 host prefix', () => {
-        expect(partitionCidrsToTyped(['2001:db8::1'])).toEqual({ v4: [], v6: ['2001:db8::1/128'] });
+        expect(parseCidrsToIPNets(['2001:db8::1'])).toEqual([
+            { addr: 'IAENuAAAAAAAAAAAAAAAAQ==', mask: '/////////////////////w==' },
+        ]);
     });
 
     it('converts a mask-less embedded-IPv4 address identically to the same address written /128', () => {
-        expect(partitionCidrsToTyped(['::ffff:192.168.1.1'])).toEqual(
-            partitionCidrsToTyped(['::ffff:192.168.1.1/128']),
+        expect(parseCidrsToIPNets(['::ffff:192.168.1.1'])).toEqual(
+            parseCidrsToIPNets(['::ffff:192.168.1.1/128']),
         );
-        expect(partitionCidrsToTyped(['::ffff:192.168.1.1']).v6).toHaveLength(1);
+        expect(parseCidrsToIPNets(['::ffff:192.168.1.1'])).toHaveLength(1);
     });
 
     it('still drops an entry with an empty mask rather than treating it as mask-less', () => {
-        expect(partitionCidrsToTyped(['10.0.0.0/'])).toEqual({ v4: [], v6: [] });
+        expect(parseCidrsToIPNets(['10.0.0.0/'])).toEqual([]);
     });
 
     it('keeps a mask-less entry alongside a well-formed masked one, in order', () => {
-        expect(partitionCidrsToTyped(['192.168.1.1', '10.0.0.0/24'])).toEqual({
-            v4: ['192.168.1.1/32', '10.0.0.0/24'],
-            v6: [],
-        });
+        expect(parseCidrsToIPNets(['192.168.1.1', '10.0.0.0/24'])).toEqual([
+            ...parseCidrsToIPNets(['192.168.1.1/32']),
+            ...parseCidrsToIPNets(['10.0.0.0/24']),
+        ]);
     });
 });
 

--- a/web/src/core/utils/netip.ts
+++ b/web/src/core/utils/netip.ts
@@ -1,3 +1,5 @@
+import { bytesToBase64, extractBytes } from './bytes';
+
 // Result types for error handling
 export type Ok<T> = { ok: true; value: T };
 export type Err<E> = { ok: false; error: E };
@@ -680,6 +682,67 @@ export const countPrefixLength = (maskBytes: number[]): number => {
     return prefixLen;
 };
 
+/**
+ * Create mask bytes from prefix length
+ * @param prefixLen - Number of leading 1 bits
+ * @param totalBytes - Total number of bytes (4 for IPv4, 16 for IPv6)
+ * @returns Array of mask bytes
+ */
+export const prefixLengthToMaskBytes = (prefixLen: number, totalBytes: number): number[] => {
+    const mask: number[] = [];
+    let remaining = prefixLen;
+    for (let i = 0; i < totalBytes; i++) {
+        if (remaining >= 8) {
+            mask.push(255);
+            remaining -= 8;
+        } else if (remaining > 0) {
+            mask.push((0xff << (8 - remaining)) & 0xff);
+            remaining = 0;
+        } else {
+            mask.push(0);
+        }
+    }
+    return mask;
+};
+
+/**
+ * Format IP network (address + mask) to human-readable string
+ * Supports both contiguous (CIDR) and non-contiguous masks
+ * @param addrBytes - Array of bytes for address
+ * @param maskBytes - Array of bytes for mask (optional)
+ * @returns Formatted network string (e.g., "192.168.1.0/24" or "192.168.1.0/255.255.255.0")
+ */
+export const formatIPNet = (
+    addrBytes: number[],
+    maskBytes?: number[]
+): string => {
+    if (addrBytes.length === 0) return '';
+
+    const ipStr = formatIPFromBytes(addrBytes);
+    if (!maskBytes || maskBytes.length === 0) return ipStr;
+
+    if (isContiguousMask(maskBytes)) {
+        const prefixLen = countPrefixLength(maskBytes);
+        return `${ipStr}/${prefixLen}`;
+    } else {
+        // Non-contiguous mask - show as IP/mask
+        const maskStr = formatIPFromBytes(maskBytes);
+        return `${ipStr}/${maskStr}`;
+    }
+};
+
+/** Format a wire IPNet ({addr, mask} as base64/bytes) to a CIDR string. */
+export const formatIPNetItem = (
+    net: { addr?: string | Uint8Array | number[]; mask?: string | Uint8Array | number[] },
+): string => {
+    const addrBytes = extractBytes(net.addr);
+    const maskBytes = extractBytes(net.mask);
+    if (!addrBytes || addrBytes.length === 0) {
+        return '';
+    }
+    return formatIPNet(addrBytes, maskBytes);
+};
+
 // Wire-format shape of commonpb.IPAddress as it arrives from the
 // gRPC-JSON gateway. The addr field may be base64 (string), a numeric
 // byte array, or a Uint8Array.
@@ -860,6 +923,13 @@ export const ipRangeSpan = (range: IPRangeWire | undefined): bigint | undefined 
 };
 
 /**
+ * Parse CIDR strings to IPNet array with base64-encoded bytes.
+ *
+ * A token with no `/mask` is a bare host address and is encoded at full
+ * width for its family (/32 for IPv4, /128 for IPv6). A token with an
+ * empty or malformed mask is dropped.
+ */
+/**
  * Check if an IPv6 mask is bi-contiguous: each 64-bit half is
  * independently all 1s followed by all 0s. A hole exactly at the /64
  * boundary is allowed while a hole within a half is not.
@@ -877,7 +947,8 @@ export const isBiContiguousMask = (maskBytes: number[]): boolean =>
  * address gains the full-width prefix for its family. An IP-shaped mask is
  * accepted when it fits the typed message's mask class — contiguous for
  * IPv4 (canonicalized to `addr/len`), per-half contiguous for IPv6 (kept
- * in the address/mask form the wire accepts). Anything else is dropped.
+ * in the address/mask form the wire accepts). Anything else is dropped,
+ * like in parseCidrsToIPNets.
  */
 export const partitionCidrsToTyped = (cidrs: string[]): { v4: string[]; v6: string[] } => {
     const v4: string[] = [];
@@ -912,3 +983,23 @@ export const partitionCidrsToTyped = (cidrs: string[]): { v4: string[]; v6: stri
     return { v4, v6 };
 };
 
+export const parseCidrsToIPNets = (cidrs: string[]): Array<{ addr: string; mask: string }> => {
+    const results: Array<{ addr: string; mask: string }> = [];
+    for (const cidr of cidrs) {
+        const parts = cidr.trim().split('/');
+        if (parts.length > 2) continue;
+        const [ipPart, maskStr] = parts;
+        const addrBytes = parseIPToBytes(ipPart);
+        if (!addrBytes) continue;
+        const isIPv4 = addrBytes.length === 4;
+        const maxPrefix = isIPv4 ? 32 : 128;
+        const prefixLength = parts.length === 1 ? maxPrefix : parseStrictPrefixLength(maskStr, maxPrefix);
+        if (prefixLength === undefined) continue;
+        const maskBytes = prefixLengthToMaskBytes(prefixLength, isIPv4 ? 4 : 16);
+        results.push({
+            addr: bytesToBase64(addrBytes),
+            mask: bytesToBase64(maskBytes),
+        });
+    }
+    return results;
+};


### PR DESCRIPTION
- Reverts #2248: the deployed ACL operator still sends the legacy `srcs`/`dsts` lists and the pre-split `Rule` field numbers, so removing them and reusing tags 5-8 for the typed lists broke its wire compatibility.
- Restores `filterpb.IPNet`, the deprecated legacy lists at tags 5/6 and the original `Rule` numbering, with the typed lists back at 11-14.
- `acl.proto` and `fwstate.proto` are wire-identical to their pre-series state (05d0acfa) for every pre-existing field, with only additive typed fields on top.
- Two doc comments in the restored files are reshaped to satisfy the comment lint that landed after #2248.
- The removal will be redone once the ACL operator migrates to the typed lists (#2232, #2212).