### PR TITLE
refactor(commonpb)!: serialize the ip address container as a bare string

### DIFF
--- a/common/commonpb/v1/ipaddr.go
+++ b/common/commonpb/v1/ipaddr.go
@@ -56,32 +56,26 @@ func (m *IPAddress) AsLogValue() any {
 	return addr.String()
 }
 
-// ipAddressJSON is the JSON wire shape shared by MarshalJSON and
-// UnmarshalJSON.
-type ipAddressJSON struct {
-	Addr string `json:"addr"`
-}
-
-// MarshalJSON serializes addr as a human-readable IP address string.
+// MarshalJSON serializes the message as a bare IP address string.
 func (m *IPAddress) MarshalJSON() ([]byte, error) {
 	addr, err := m.ToAddr()
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(ipAddressJSON{Addr: addr.String()})
+	return json.Marshal(addr.String())
 }
 
-// UnmarshalJSON accepts addr as an IPv4 or IPv6 address string.
+// UnmarshalJSON accepts a bare IPv4 or IPv6 address string.
 func (m *IPAddress) UnmarshalJSON(data []byte) error {
-	var raw ipAddressJSON
+	var raw string
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	if raw.Addr == "" {
+	if raw == "" {
 		return fmt.Errorf("empty IP address is not allowed")
 	}
 
-	parsed, err := netip.ParseAddr(raw.Addr)
+	parsed, err := netip.ParseAddr(raw)
 	if err != nil {
 		return fmt.Errorf("failed to parse IP address: %w", err)
 	}

--- a/common/commonpb/v1/ipaddr.proto
+++ b/common/commonpb/v1/ipaddr.proto
@@ -4,18 +4,19 @@ package common.commonpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/common/commonpb/v1;commonpb";
 
-// IPAddress represents an IPv4 or IPv6 host address.
+// IPAddress is the container for fields whose family varies per record.
 //
-// Family is determined by the length of addr:
-//   - 4 bytes  - IPv4 in network byte order;
-//   - 16 bytes - IPv6 in network byte order.
+// The byte length of addr is the family discriminant by design:
+//   - 4 bytes is IPv4 in network byte order.
+//   - 16 bytes is IPv6 in network byte order.
 // Any other length is invalid.
+//
+// A scope or zone is host-local. It belongs as a sibling field on the
+// owning message, not here.
 message IPAddress {
   // Network-byte-order address bytes.
   //
   // MUST be exactly 4 (IPv4) or 16 (IPv6) bytes. Any other length is a
   // malformed message.
   bytes addr = 1;
-  // Reserved for zone.
-  reserved 2;
 }

--- a/common/commonpb/v1/ipaddr_test.go
+++ b/common/commonpb/v1/ipaddr_test.go
@@ -130,12 +130,12 @@ func TestIPAddress_MarshalJSON(t *testing.T) {
 		{
 			name: "IPv4",
 			ip:   NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.1")),
-			want: `{"addr":"10.0.0.1"}`,
+			want: `"10.0.0.1"`,
 		},
 		{
 			name: "IPv6",
 			ip:   NewIPAddressFromAddr(netip.MustParseAddr("2001:db8::1")),
-			want: `{"addr":"2001:db8::1"}`,
+			want: `"2001:db8::1"`,
 		},
 		{
 			name:    "invalid length",
@@ -166,27 +166,32 @@ func TestIPAddress_UnmarshalJSON(t *testing.T) {
 	}{
 		{
 			name:  "IPv4",
-			input: `{"addr":"10.0.0.1"}`,
+			input: `"10.0.0.1"`,
 			want:  netip.MustParseAddr("10.0.0.1"),
 		},
 		{
 			name:  "IPv6",
-			input: `{"addr":"2001:db8::1"}`,
+			input: `"2001:db8::1"`,
 			want:  netip.MustParseAddr("2001:db8::1"),
 		},
 		{
 			name:    "empty string",
-			input:   `{"addr":""}`,
+			input:   `""`,
 			wantErr: true,
 		},
 		{
 			name:    "malformed address",
-			input:   `{"addr":"not-an-ip"}`,
+			input:   `"not-an-ip"`,
+			wantErr: true,
+		},
+		{
+			name:    "object form",
+			input:   `{"addr":"10.0.0.1"}`,
 			wantErr: true,
 		},
 		{
 			name:    "invalid JSON",
-			input:   `{"addr":`,
+			input:   `"10.0`,
 			wantErr: true,
 		},
 	}
@@ -233,6 +238,27 @@ func TestIPAddress_JSONRoundTrip(t *testing.T) {
 			require.Equal(t, tt.addr, gotAddr)
 		})
 	}
+}
+
+func TestIPAddress_JSONRoundTrip_IPv4Mapped(t *testing.T) {
+	mapped := netip.MustParseAddr("::ffff:10.0.0.1")
+	original := NewIPAddressFromAddr(mapped)
+	require.Len(t, original.Addr, 16, "mapped input must stay in the 16-byte wire form")
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+	require.Equal(t, `"::ffff:10.0.0.1"`, string(data))
+
+	var got IPAddress
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, original.Addr, got.Addr)
+
+	gotAddr, err := got.ToAddr()
+	require.NoError(t, err)
+	require.Equal(t, mapped, gotAddr)
+
+	native := NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.1"))
+	require.NotEqual(t, native.Addr, got.Addr, "mapped and native forms must stay distinct on the wire")
 }
 
 func TestIPAddress_AsLogValue(t *testing.T) {

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -144,17 +144,20 @@ impl FromStr for pb::IpAddress {
 }
 
 impl Serialize for pb::IpAddress {
-    /// Serializes as the plain address string `Display` renders.
+    /// Serializes the decoded address in its faithful form, not the
+    /// unmapped form `Display` renders for humans.
     ///
-    /// A malformed byte length renders as the literal `"invalid"`, since
-    /// that is what `Display` already falls back to. An IPv4-mapped IPv6
-    /// address renders as its unmapped 4-byte form too, so the round trip
-    /// through this string is lossy for that one input shape as well.
+    /// An IPv4-mapped IPv6 address keeps its mapped rendering here, so the
+    /// round trip through this string is lossless. A malformed byte length
+    /// still renders as the literal `"invalid"`.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer.collect_str(self)
+        match IpAddr::try_from(self) {
+            Ok(addr) => serializer.collect_str(&addr),
+            Err(..) => serializer.serialize_str("invalid"),
+        }
     }
 }
 
@@ -997,23 +1000,21 @@ mod test {
         assert_eq!(ip, got);
     }
 
-    /// An IPv4-mapped IPv6 address's `Display` unmaps it, so its string
-    /// form serializes and deserializes as a plain 4-byte IPv4 address --
-    /// not the original 16-byte mapped wire form. The round trip is
-    /// therefore family-normalizing, not byte-preserving, for this one
-    /// input shape.
+    /// An IPv4-mapped IPv6 address renders as `::ffff:a.b.c.d`, distinct
+    /// from the bare 4-byte form, so the 16-byte wire shape round trips
+    /// losslessly through the string encoding.
     #[test]
-    fn serde_ip_address_v4_mapped_does_not_round_trip_bytes() {
+    fn serde_ip_address_v4_mapped_round_trips_bytes() {
         let mapped = pb::IpAddress::from(IpAddr::V6(Ipv4Addr::new(141, 8, 128, 254).to_ipv6_mapped()));
         assert_eq!(16, mapped.addr.len());
 
         let json = serde_json::to_string(&mapped).unwrap();
-        assert_eq!(r#""141.8.128.254""#, json);
+        assert_eq!(r#""::ffff:141.8.128.254""#, json);
 
         let got: pb::IpAddress = serde_json::from_str(&json).unwrap();
-        assert_eq!(4, got.addr.len());
-        assert_ne!(mapped, got);
-        assert_eq!(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(141, 8, 128, 254))), got);
+        assert_eq!(16, got.addr.len());
+        assert_eq!(mapped, got);
+        assert_ne!(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(141, 8, 128, 254))), got);
     }
 
     /// A malformed byte length serializes to the same `"invalid"` literal

--- a/modules/fwstate/web/FWStatePage.tsx
+++ b/modules/fwstate/web/FWStatePage.tsx
@@ -17,7 +17,7 @@ import { useConfigListCache, useSearchParamHelpers, usePageContribution, useCont
 import { API, inventoryConfigNames, loadKnownConfigs, unionConfigNames } from '@yanet/core/api';
 import { Direction, MapKind, type FwStateEntry, type ListEntriesRequest, type MapStats } from '@yanet/core/api/fwstatemap';
 import { ConfigTabStrip, PageLayout, PageLoader, EmptyPagePlaceholder } from '@yanet/core/components';
-import { ipAddressToString, isValidIPAddress, parseIPToBytes, stringToIPAddress, type IPAddressWire } from '@yanet/core/utils/netip';
+import { isValidIPAddress, parseIPToBytes, stringToIPAddress } from '@yanet/core/utils/netip';
 import { formatBytes, toaster, compareNatural, warnConfigsUnknown } from '@yanet/core/utils';
 import { AddConfigModal, CommandPaletteHeader, ConfirmModal, DeleteConfigModal } from '@yanet/core/components';
 import { SaveIcon, TrashIcon } from '@yanet/core/components/draft';
@@ -102,8 +102,8 @@ const toDraftConfig = (config: Awaited<ReturnType<typeof API.fwstate.showConfig>
     return {
         mapNameV4: config?.map_name_v4 ?? '',
         mapNameV6: config?.map_name_v6 ?? '',
-        srcAddr: ipAddressToString(sync?.src_addr as IPAddressWire | undefined),
-        dstAddrMulticast: ipAddressToString(sync?.dst_addr_multicast as IPAddressWire | undefined),
+        srcAddr: sync?.src_addr ?? '',
+        dstAddrMulticast: sync?.dst_addr_multicast ?? '',
         portMulticast: sync?.port_multicast ?? 0,
         tcpSynAck: formatDurationNsAsSeconds(sync?.tcp_syn_ack ?? DEFAULT_NS.tcpSynAck),
         tcpSyn: formatDurationNsAsSeconds(sync?.tcp_syn ?? DEFAULT_NS.tcpSyn),
@@ -488,8 +488,8 @@ const FlatStateRow: React.FC<FlatStateRowProps> = ({ row, start, isExpired }) =>
         >
             <div style={colCellStyle(0)}><StatusDot health={row._health} /></div>
             <div style={{ ...colCellStyle(1), color: 'var(--fws-text-3)', fontFamily: 'var(--fws-mono)', fontSize: 11.5 }}>{formatStateIdx(row.idx)}</div>
-            <div style={colCellStyle(2)}><span className="fws-pill fws-pill--src">{ipAddressToString(row.key?.src_addr as IPAddressWire | undefined) || '—'}</span></div>
-            <div style={colCellStyle(3)}><span className="fws-pill fws-pill--dst">{ipAddressToString(row.key?.dst_addr as IPAddressWire | undefined) || '—'}</span></div>
+            <div style={colCellStyle(2)}><span className="fws-pill fws-pill--src">{row.key?.src_addr || '—'}</span></div>
+            <div style={colCellStyle(3)}><span className="fws-pill fws-pill--dst">{row.key?.dst_addr || '—'}</span></div>
             <div style={colCellStyle(4)}><span className={protoClass(row._proto)}>{protoLabel(row._proto)}</span></div>
             <div style={colCellStyle(5)}>{renderFlagChips(row._srcFlags)}</div>
             <div style={colCellStyle(6)}>{renderFlagChips(row._dstFlags)}</div>

--- a/operators/neighbours/web/NeighbourPanel.tsx
+++ b/operators/neighbours/web/NeighbourPanel.tsx
@@ -3,7 +3,7 @@ import { Bulb, CircleInfo, Layers } from '@gravity-ui/icons';
 import { Select } from '@gravity-ui/uikit';
 import { useDrawerKeyboard } from '@yanet/core/hooks';
 import { DotBadge } from '@yanet/core/components/VirtualTable';
-import { ipAddressToString, stringToIPAddress } from '@yanet/core/utils/netip';
+import { stringToIPAddress } from '@yanet/core/utils/netip';
 import { formatUnixSeconds } from '@yanet/core/utils';
 import type { Neighbour, NeighbourTableInfo } from '@yanet/core/api/neighbours';
 import { validateMAC, validateNextHop, resolveSubmitTable } from './utils';
@@ -137,7 +137,7 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
         setSelectedTable([defaultTable]);
 
         if (neighbour) {
-            setNextHop(ipAddressToString(neighbour.next_hop));
+            setNextHop(neighbour.next_hop ?? '');
             setLinkAddr(neighbour.link_addr?.addr || '');
             setHardwareAddr(neighbour.hardware_addr?.addr || '');
             setDevice(neighbour.device || '');
@@ -209,7 +209,7 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
         canApply: canSubmit,
     });
 
-    const ip = neighbour ? (ipAddressToString(neighbour.next_hop) || '—') : '—';
+    const ip = neighbour ? (neighbour.next_hop || '—') : '—';
     const family = ip !== '—' ? getFamily(ip) : '';
     const deviceDisplay = neighbour?.device || '—';
 

--- a/operators/neighbours/web/NeighbourTable.tsx
+++ b/operators/neighbours/web/NeighbourTable.tsx
@@ -4,7 +4,6 @@ import { Tooltip } from '@gravity-ui/uikit';
 import { DotBadge } from '@yanet/core/components/VirtualTable';
 import type { Neighbour, NeighbourTableInfo } from '@yanet/core/api/neighbours';
 import { formatUnixSeconds } from '@yanet/core/utils';
-import { ipAddressToString } from '@yanet/core/utils/netip';
 import { getNeighbourId } from './utils';
 import { nudStateToName, getStateMeta } from './stateMeta';
 import { getMergeDebug } from './mergeDebug';
@@ -156,7 +155,7 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
             gridTrack: '230px',
             sortKey: 'next_hop',
             renderCell: (neighbour) => {
-                const addr = ipAddressToString(neighbour.next_hop) || '-';
+                const addr = neighbour.next_hop || '-';
                 return (
                     <div style={{ display: 'flex', alignItems: 'center', gap: 5, overflow: 'hidden', width: '100%' }}>
                         {addr !== '-' && <FamilyBadge address={addr} />}

--- a/operators/neighbours/web/NeighboursPage.tsx
+++ b/operators/neighbours/web/NeighboursPage.tsx
@@ -6,7 +6,7 @@ import { Plus, Layers } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder } from '@yanet/core/components';
 import { BulkDeleteModal, DeleteConfigModal, CommandPaletteHeader } from '@yanet/core/components';
 import type { Command, RowAdapter, ShortcutSection, PagePaletteContribution } from '@yanet/core/components/command-palette';
-import { stringToIPAddress, ipAddressToString } from '@yanet/core/utils/netip';
+import { stringToIPAddress } from '@yanet/core/utils/netip';
 import { parseIPAddress } from '@yanet/core/utils';
 import type { Neighbour, NeighbourTableInfo } from '@yanet/core/api/neighbours';
 import { NeighbourTable } from './NeighbourTable';
@@ -151,7 +151,7 @@ const NeighboursPage: React.FC = () => {
         let res = allRows;
         if (family !== 'all') {
             res = res.filter((n) => {
-                const addr = ipAddressToString(n.next_hop);
+                const addr = n.next_hop ?? '';
                 return family === 'v6' ? addr.includes(':') : !addr.includes(':');
             });
         }
@@ -474,7 +474,7 @@ const NeighboursPage: React.FC = () => {
     const neighbourDynamicCommands = useCallback((q: string): Command[] => {
         if (!parseIPAddress(q.trim()).ok) return [];
         const ip = q.trim();
-        const existing = allRows.find((n) => ipAddressToString(n.next_hop) === ip);
+        const existing = allRows.find((n) => n.next_hop === ip);
         if (existing) {
             const id = getNeighbourId(existing);
             return [
@@ -507,9 +507,9 @@ const NeighboursPage: React.FC = () => {
     const neighbourRowAdapter = useMemo((): RowAdapter<Neighbour> => ({
         rows: allRows,
         getId: getNeighbourId,
-        getLabel: (n) => ipAddressToString(n.next_hop) || '—',
+        getLabel: (n) => n.next_hop || '—',
         getSub: (n) => [n.device, n.source, nudStateToName(n.state)].filter(Boolean).join(' · '),
-        searchText: (n) => ipAddressToString(n.next_hop) + ' ' + (n.device || '') + ' ' + (n.source || ''),
+        searchText: (n) => (n.next_hop ?? '') + ' ' + (n.device || '') + ' ' + (n.source || ''),
         onSelect: (id) => handleJumpToRow(id),
         icon: '→',
         max: 7,

--- a/operators/neighbours/web/mergeDebug.ts
+++ b/operators/neighbours/web/mergeDebug.ts
@@ -1,5 +1,4 @@
 import type { Neighbour, NeighbourTableInfo } from '@yanet/core/api/neighbours';
-import { ipAddressToString } from '@yanet/core/utils/netip';
 
 const ZERO_MAC = '00:00:00:00:00:00';
 
@@ -36,7 +35,7 @@ export const getMergeDebug = (
     cache: Map<string, Neighbour[]>,
     tables: NeighbourTableInfo[],
 ): MergeDebugResult => {
-    const winnerIp = ipAddressToString(winner.next_hop);
+    const winnerIp = winner.next_hop ?? '';
     const winnerMac = winner.link_addr?.addr || '';
 
     const candidates: ShadowedCandidate[] = [];
@@ -48,7 +47,7 @@ export const getMergeDebug = (
 
         const entries = cache.get(tableName) || [];
         for (const entry of entries) {
-            const entryIp = ipAddressToString(entry.next_hop);
+            const entryIp = entry.next_hop ?? '';
             if (entryIp !== winnerIp) continue;
 
             const entryMac = entry.link_addr?.addr || '';

--- a/operators/neighbours/web/useNeighbours.ts
+++ b/operators/neighbours/web/useNeighbours.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { API } from '@yanet/core/api';
 import { toaster } from '@yanet/core/utils';
-import type { IPAddressWire } from '@yanet/core/utils/netip';
 import type { Neighbour, NeighbourTableInfo } from '@yanet/core/api/neighbours';
 import { MERGED_TAB } from './types';
 
@@ -14,7 +13,7 @@ export interface UseNeighboursResult {
     activeTabRef: React.MutableRefObject<string>;
     addNeighbour: (table: string, entry: Neighbour) => Promise<void>;
     updateNeighbour: (table: string, entry: Neighbour) => Promise<void>;
-    removeNeighbours: (table: string, nextHopWires: (IPAddressWire | undefined)[]) => Promise<void>;
+    removeNeighbours: (table: string, nextHopWires: (string | undefined)[]) => Promise<void>;
     createTable: (name: string, priority: number) => Promise<void>;
     updateTable: (name: string, priority: number) => Promise<void>;
     removeTable: (name: string) => Promise<void>;
@@ -140,8 +139,8 @@ export const useNeighbours = (activeTab: string, paused = false): UseNeighboursR
     }, [reloadAll]);
 
     const removeNeighbours = useCallback(
-        async (table: string, nextHopWires: (IPAddressWire | undefined)[]): Promise<void> => {
-            const wires = nextHopWires.filter((w): w is IPAddressWire => w !== undefined);
+        async (table: string, nextHopWires: (string | undefined)[]): Promise<void> => {
+            const wires = nextHopWires.filter((w): w is string => w !== undefined);
             try {
                 await API.neighbours.removeNeighbours(table, wires);
                 toaster.success('nb-removed', `${wires.length} neighbour(s) removed.`);

--- a/operators/neighbours/web/utils.test.ts
+++ b/operators/neighbours/web/utils.test.ts
@@ -102,8 +102,8 @@ describe('sortComparators', () => {
     const makeNeighbour = (overrides: Partial<Neighbour>): Neighbour => ({ ...overrides });
 
     it('next_hop: sorts by IP string representation', () => {
-        const a = makeNeighbour({ next_hop: { addr: '10.0.0.1' } });
-        const b = makeNeighbour({ next_hop: { addr: '192.168.1.1' } });
+        const a = makeNeighbour({ next_hop: '10.0.0.1' });
+        const b = makeNeighbour({ next_hop: '192.168.1.1' });
         expect(sortComparators.next_hop(a, b)).toBeLessThan(0);
         expect(sortComparators.next_hop(b, a)).toBeGreaterThan(0);
     });

--- a/operators/neighbours/web/utils.ts
+++ b/operators/neighbours/web/utils.ts
@@ -7,7 +7,7 @@ import {
     getUnixSecondsValue,
     isValidMAC,
 } from '@yanet/core/utils';
-import { ipAddressToString, stringToIPAddress } from '@yanet/core/utils/netip';
+import { stringToIPAddress } from '@yanet/core/utils/netip';
 import type { SortableColumn } from './types';
 import { MERGED_TAB } from './types';
 
@@ -31,7 +31,7 @@ export const resolveSubmitTable = (
 export { isValidMAC };
 
 /** Returns a stable string key for a neighbour row. */
-export const getNeighbourId = (n: Neighbour): string => ipAddressToString(n.next_hop);
+export const getNeighbourId = (n: Neighbour): string => n.next_hop ?? '';
 
 /** Type guard for sortable column names. */
 export const isSortableColumn = (value: string): value is SortableColumn =>
@@ -61,10 +61,7 @@ export const validateNextHop = (value: string): string | undefined => {
 /** Sort comparators for each sortable neighbour column. */
 export const sortComparators: Record<SortableColumn, (a: Neighbour, b: Neighbour) => number> = {
     next_hop: (a, b) =>
-        compareNullableStrings(
-            ipAddressToString(a.next_hop) || undefined,
-            ipAddressToString(b.next_hop) || undefined,
-        ),
+        compareNullableStrings(a.next_hop || undefined, b.next_hop || undefined),
     link_addr: (a, b) =>
         compareMACAddressValues(
             getMACAddressValue(a.link_addr?.addr),
@@ -80,10 +77,7 @@ export const sortComparators: Record<SortableColumn, (a: Neighbour, b: Neighbour
         const stateA = a.state ?? 0;
         const stateB = b.state ?? 0;
         if (stateA !== stateB) return stateA - stateB;
-        return compareNullableStrings(
-            ipAddressToString(a.next_hop) || undefined,
-            ipAddressToString(b.next_hop) || undefined,
-        );
+        return compareNullableStrings(a.next_hop || undefined, b.next_hop || undefined);
     },
     source: (a, b) => compareNullableStrings(a.source, b.source),
     priority: (a, b) => (a.priority ?? 0) - (b.priority ?? 0),

--- a/operators/route/web/LookupDrawer.tsx
+++ b/operators/route/web/LookupDrawer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { API } from '@yanet/core/api';
 import { toaster } from '@yanet/core/utils';
-import { stringToIPAddress, ipAddressToString } from '@yanet/core/utils/netip';
+import { stringToIPAddress } from '@yanet/core/utils/netip';
 import { parseIPAddress } from '@yanet/core/utils';
 import type { Route } from '@yanet/core/api/routes';
 import { bestPathReason, routePrefix } from './utils';
@@ -215,10 +215,10 @@ const LookupDrawer: React.FC<LookupDrawerProps> = ({
                                                         {routePrefix(r) || '—'}
                                                     </td>
                                                     <td className="yn-cell-mono yn-cell-muted">
-                                                        {ipAddressToString(r.next_hop) || '—'}
+                                                        {r.next_hop || '—'}
                                                     </td>
                                                     <td className="yn-cell-mono yn-cell-muted">
-                                                        {ipAddressToString(r.peer) || '—'}
+                                                        {r.peer || '—'}
                                                     </td>
                                                     <td>
                                                         <SourceChip source={r.source} />

--- a/operators/route/web/RIBTable.tsx
+++ b/operators/route/web/RIBTable.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { Route } from '@yanet/core/api/routes';
-import { ipAddressToString } from '@yanet/core/utils/netip';
 import { getRouteId, routePrefix } from './utils';
 import { BestPill, SourceChip, FamilyBadge, ConflictBadge } from './cells';
 import type { RouteSortableColumn, RouteSortState } from './types';
@@ -73,7 +72,7 @@ export const RIBTable: React.FC<RIBTableProps> = ({
             sortKey: 'next_hop',
             renderCell: (route) => (
                 <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                    <span className="yn-cell-mono" style={{ fontSize: 12.5, color: 'var(--yn-text-2)' }}>{ipAddressToString(route.next_hop) || '-'}</span>
+                    <span className="yn-cell-mono" style={{ fontSize: 12.5, color: 'var(--yn-text-2)' }}>{route.next_hop || '-'}</span>
                 </div>
             ),
         },
@@ -84,7 +83,7 @@ export const RIBTable: React.FC<RIBTableProps> = ({
             sortKey: 'peer',
             renderCell: (route) => (
                 <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                    <span className="yn-cell-mono" style={{ fontSize: 12.5, color: 'var(--yn-text-3)' }}>{ipAddressToString(route.peer) || '-'}</span>
+                    <span className="yn-cell-mono" style={{ fontSize: 12.5, color: 'var(--yn-text-3)' }}>{route.peer || '-'}</span>
                 </div>
             ),
         },

--- a/operators/route/web/RouteDrawer.tsx
+++ b/operators/route/web/RouteDrawer.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Icon, Switch } from '@gravity-ui/uikit';
 import { Plus, TrashBin } from '@gravity-ui/icons';
 import { DraftItemDrawer } from '@yanet/core/components/draft';
-import { ipAddressToString } from '@yanet/core/utils/netip';
 import { validatePrefix, validateNexthop, routePrefix } from './utils';
 import type { Route } from '@yanet/core/api/routes';
 import { CidrPrefixField } from '@yanet/core/components';
@@ -52,7 +51,7 @@ const RouteDrawer: React.FC<RouteDrawerProps> = ({
             setPrefix(mode === 'edit' && route ? routePrefix(route) : '');
             setNexthopRows(
                 mode === 'edit' && route
-                    ? [makeRow(ipAddressToString(route.next_hop))]
+                    ? [makeRow(route.next_hop ?? '')]
                     : [makeRow('')],
             );
             setDoFlush(false);
@@ -204,7 +203,7 @@ const RouteDrawer: React.FC<RouteDrawerProps> = ({
                     <div className="yn-section__body">
                         <dl className="ro-attr-grid">
                             <dt>Peer</dt>
-                            <dd className="yn-cell-mono">{ipAddressToString(route.peer) || '—'}</dd>
+                            <dd className="yn-cell-mono">{route.peer || '—'}</dd>
                             <dt>Best</dt>
                             <dd><BestPill isBest={route.is_best ?? false} /></dd>
                             <dt>Pref</dt>

--- a/operators/route/web/RoutePage.tsx
+++ b/operators/route/web/RoutePage.tsx
@@ -8,7 +8,7 @@ import type { Command, RowAdapter, ShortcutSection, PagePaletteContribution } fr
 import { useListNavigation, usePageContribution, useTabCycle } from '@yanet/core/hooks';
 import { API } from '@yanet/core/api';
 import { toaster, parseIPAddress } from '@yanet/core/utils';
-import { stringToIPAddress, ipAddressToString, type IPAddressWire } from '@yanet/core/utils/netip';
+import { stringToIPAddress } from '@yanet/core/utils/netip';
 import { RouteSourceID, type Route } from '@yanet/core/api/routes';
 import { useRIB } from './useRIB';
 import { RIBTable } from './RIBTable';
@@ -80,8 +80,8 @@ const RoutePage: React.FC = () => {
         if (q) {
             res = res.filter((r) =>
                 routePrefix(r).toLowerCase().includes(q) ||
-                ipAddressToString(r.next_hop).toLowerCase().includes(q) ||
-                ipAddressToString(r.peer).toLowerCase().includes(q)
+                (r.next_hop ?? '').toLowerCase().includes(q) ||
+                (r.peer ?? '').toLowerCase().includes(q)
             );
         }
         if (sortState.column) {
@@ -146,12 +146,12 @@ const RoutePage: React.FC = () => {
             toaster.error('route-nexthop-error', 'One or more next-hop addresses are invalid');
             return;
         }
-        const nexthopIps = parsed as IPAddressWire[];
+        const nexthopIps = parsed as string[];
 
         const isEdit = drawer.mode === 'edit';
         const original = drawer.route;
-        const newNexthopStr = ipAddressToString(nexthopIps[0]);
-        const originalNexthopStr = ipAddressToString(original?.next_hop);
+        const newNexthopStr = nexthopIps[0] ?? '';
+        const originalNexthopStr = original?.next_hop ?? '';
         const ops = planRouteSubmit(
             drawer.mode,
             { prefix: params.prefix, nexthopIps, doFlush: params.doFlush },
@@ -376,8 +376,8 @@ const RoutePage: React.FC = () => {
         rows: allRows,
         getId: getRouteId,
         getLabel: (r) => routePrefix(r) || '(no prefix)',
-        getSub: (r) => ipAddressToString(r.next_hop) || '—',
-        searchText: (r) => routePrefix(r) + ' ' + ipAddressToString(r.next_hop),
+        getSub: (r) => r.next_hop || '—',
+        searchText: (r) => routePrefix(r) + ' ' + (r.next_hop ?? ''),
         onSelect: (id) => handleJumpToRow(id),
         icon: '→',
         max: 7,

--- a/operators/route/web/utils.test.ts
+++ b/operators/route/web/utils.test.ts
@@ -296,8 +296,8 @@ describe('bestPathReason', () => {
 describe('getRouteId', () => {
     const base: Route = {
         prefix: net('::/0'),
-        next_hop: { addr: 'fe80::a1a' },
-        peer: { addr: '::' },
+        next_hop: 'fe80::a1a',
+        peer: '::',
         route_distinguisher: '',
         pref: 100,
         peer_as: 65000,
@@ -335,7 +335,7 @@ describe('getRouteId', () => {
         const minimal: Route = { prefix: net('10.0.0.0/8') };
         const id = getRouteId(minimal);
         expect(id).not.toContain('undefined');
-        // next_hop.addr='' peer.addr='' rd='' source=0 pref=0 peerAs=0 originAs=0 med=0 asPathLen=0
+        // next_hop='' peer='' rd='' source=0 pref=0 peerAs=0 originAs=0 med=0 asPathLen=0
         expect(id).toBe('10.0.0.0/8____0_0_0_0_0_0');
     });
 });

--- a/operators/route/web/utils.ts
+++ b/operators/route/web/utils.ts
@@ -1,6 +1,5 @@
 import type { Route } from '@yanet/core/api/routes';
 import { parseCIDRPrefix, parseIPAddress, CIDRParseError, IPParseError } from '@yanet/core/utils';
-import { ipAddressToString, type IPAddressWire } from '@yanet/core/utils/netip';
 import type { RouteSortableColumn, IPFamily } from './types';
 
 /** Reads a route's destination prefix as a CIDR string.
@@ -11,13 +10,13 @@ export const routePrefix = (route: Route): string => route.prefix ?? '';
 
 export interface RouteSubmitParams {
     prefix: string;
-    nexthopIps: IPAddressWire[];
+    nexthopIps: string[];
     doFlush: boolean;
 }
 
 export type RouteSubmitOp =
-    | { type: 'delete'; prefix: string; nexthop: IPAddressWire }
-    | { type: 'insert'; prefix: string; nexthops: IPAddressWire[]; doFlush: boolean };
+    | { type: 'delete'; prefix: string; nexthop: string }
+    | { type: 'insert'; prefix: string; nexthops: string[]; doFlush: boolean };
 
 /** Plan API operations for submitting a route. In add mode, just insert.
  *
@@ -46,7 +45,7 @@ export const ROUTE_SOURCES = ['Unknown', 'Static', 'BIRD'] as const;
 
 /** Returns a stable string key for a route row. */
 export const getRouteId = (route: Route): string =>
-    `${routePrefix(route)}_${String(route.next_hop?.addr ?? '')}_${String(route.peer?.addr ?? '')}_${route.route_distinguisher ?? ''}_${route.source ?? 0}_${route.pref ?? 0}_${route.peer_as ?? 0}_${route.origin_as ?? 0}_${route.med ?? 0}_${route.as_path_len ?? 0}`;
+    `${routePrefix(route)}_${route.next_hop ?? ''}_${route.peer ?? ''}_${route.route_distinguisher ?? ''}_${route.source ?? 0}_${route.pref ?? 0}_${route.peer_as ?? 0}_${route.origin_as ?? 0}_${route.med ?? 0}_${route.as_path_len ?? 0}`;
 
 /** Validates a CIDR prefix string. Returns an error message or undefined when valid. */
 export const validatePrefix = (prefix: string): string | undefined => {
@@ -159,8 +158,8 @@ export const bestPathReason = (cands: Route[]): string => {
 /** Sort comparators for each sortable column. */
 export const sortComparators: Record<RouteSortableColumn, (a: Route, b: Route) => number> = {
     prefix: (a, b) => routePrefix(a).localeCompare(routePrefix(b)),
-    next_hop: (a, b) => ipAddressToString(a.next_hop).localeCompare(ipAddressToString(b.next_hop)),
-    peer: (a, b) => ipAddressToString(a.peer).localeCompare(ipAddressToString(b.peer)),
+    next_hop: (a, b) => (a.next_hop ?? '').localeCompare(b.next_hop ?? ''),
+    peer: (a, b) => (a.peer ?? '').localeCompare(b.peer ?? ''),
     is_best: (a, b) => (a.is_best ? 1 : 0) - (b.is_best ? 1 : 0),
     pref: (a, b) => (a.pref ?? 0) - (b.pref ?? 0),
     as_path_len: (a, b) => (a.as_path_len ?? 0) - (b.as_path_len ?? 0),

--- a/web/src/core/api/acl.ts
+++ b/web/src/core/api/acl.ts
@@ -4,7 +4,6 @@ import { createService, type CallOptions } from './client';
 // No Action.counter, no keep_state, no MapConfig, no DUMP kind.
 
 import type { MACAddress } from './neighbours';
-import type { IPAddressWire } from '../utils/netip';
 
 import type { IPNet, VlanRange, Device, ListConfigsResponse } from './shared';
 export type { IPNet, VlanRange, Device, ListConfigsResponse };
@@ -67,9 +66,10 @@ export interface ShowConfigRequest {
 
 export interface SyncConfig {
     dst_ether?: MACAddress;
-    dst_addr_multicast?: IPAddressWire;
+    // commonpb.IPAddress, serialized by the gateway as a bare IP string.
+    dst_addr_multicast?: string;
     port_multicast?: number;
-    dst_addr_unicast?: IPAddressWire;
+    dst_addr_unicast?: string;
     port_unicast?: number;
 }
 

--- a/web/src/core/api/fwstate.ts
+++ b/web/src/core/api/fwstate.ts
@@ -1,9 +1,9 @@
 import { createService, type CallOptions } from './client';
-import type { IPAddressWire } from '../utils/netip';
 
 export interface SyncConfig {
-    src_addr?: IPAddressWire;
-    dst_addr_multicast?: IPAddressWire;
+    // commonpb.IPAddress, serialized by the gateway as a bare IP string.
+    src_addr?: string;
+    dst_addr_multicast?: string;
     port_multicast?: number;
     tcp_syn_ack?: number;
     tcp_syn?: number;

--- a/web/src/core/api/fwstatemap.ts
+++ b/web/src/core/api/fwstatemap.ts
@@ -1,5 +1,4 @@
 import { createService, type CallOptions } from './client';
-import type { IPAddressWire } from '../utils/netip';
 
 export interface MapStats {
     index_size?: number;
@@ -47,8 +46,9 @@ export interface FwStateKey {
     proto?: number;
     src_port?: number;
     dst_port?: number;
-    src_addr?: IPAddressWire;
-    dst_addr?: IPAddressWire;
+    // commonpb.IPAddress, serialized by the gateway as a bare IP string.
+    src_addr?: string;
+    dst_addr?: string;
 }
 
 export interface FwStateValue {

--- a/web/src/core/api/neighbours.ts
+++ b/web/src/core/api/neighbours.ts
@@ -1,5 +1,4 @@
 import { createService, type CallOptions } from './client';
-import type { IPAddressWire } from '../utils/netip';
 
 // Neighbour types
 export interface MACAddress {
@@ -7,7 +6,8 @@ export interface MACAddress {
 }
 
 export interface Neighbour {
-    next_hop?: IPAddressWire;
+    // commonpb.IPAddress, serialized by the gateway as a bare IP string.
+    next_hop?: string;
     link_addr?: MACAddress;
     hardware_addr?: MACAddress;
     state?: number; // NeighbourState enum
@@ -50,7 +50,7 @@ export const neighbours = {
         return neighbourService.callWithBody<void>('UpdateNeighbours', { table, entries }, options);
     },
 
-    removeNeighbours: (table: string, nextHops: IPAddressWire[], options?: CallOptions): Promise<void> => {
+    removeNeighbours: (table: string, nextHops: string[], options?: CallOptions): Promise<void> => {
         return neighbourService.callWithBody<void>('RemoveNeighbours', { table, next_hops: nextHops }, options);
     },
 

--- a/web/src/core/api/routes.ts
+++ b/web/src/core/api/routes.ts
@@ -1,6 +1,6 @@
 import { createService, type CallOptions } from './client';
 import type { MACAddress } from './neighbours';
-import type { IPAddressWire, IPRangeWire } from '../utils/netip';
+import type { IPRangeWire } from '../utils/netip';
 
 // Route types
 
@@ -19,8 +19,9 @@ export interface LargeCommunity {
 export interface Route {
     // commonpb.IPPrefix, serialized by the gateway as a bare CIDR string.
     prefix?: string;
-    next_hop?: IPAddressWire;
-    peer?: IPAddressWire;
+    // commonpb.IPAddress, serialized by the gateway as a bare IP string.
+    next_hop?: string;
+    peer?: string;
     route_distinguisher?: string | number; // uint64
     peer_as?: number;
     origin_as?: number;
@@ -49,7 +50,7 @@ export interface InsertRouteRequest {
     name?: string;
     // commonpb.IPPrefix, serialized by the gateway as a bare CIDR string.
     prefix?: string;
-    nexthop_addrs?: IPAddressWire[];
+    nexthop_addrs?: string[];
     do_flush?: boolean;
     source_id?: RouteSourceID;
 }
@@ -61,7 +62,7 @@ export interface DeleteRouteRequest {
     name?: string;
     // commonpb.IPPrefix, serialized by the gateway as a bare CIDR string.
     prefix?: string;
-    nexthop_addrs?: IPAddressWire[];
+    nexthop_addrs?: string[];
     do_flush?: boolean;
     source_id?: RouteSourceID;
 }
@@ -106,7 +107,7 @@ const operatorRouteService = createService('operators.route.operatorpb.v1.RouteS
 
 export interface LookupRouteRequest {
     name?: string;
-    ip_addr?: IPAddressWire;
+    ip_addr?: string;
 }
 
 export interface LookupRouteResponse {

--- a/web/src/core/utils/netip.test.ts
+++ b/web/src/core/utils/netip.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import {
-    ipAddressToString,
     stringToIPAddress,
     ipRangeToCIDRs,
     cidrToIPRange,
@@ -16,43 +15,13 @@ import {
     CIDRParseError,
 } from './netip';
 
-describe('ipAddressToString', () => {
-    it('returns the string directly for IPv4 wire form', () => {
-        expect(ipAddressToString({ addr: '10.0.0.1' })).toBe('10.0.0.1');
-    });
-
-    it('returns the string directly for IPv6 wire form', () => {
-        expect(ipAddressToString({ addr: '2001:db8::1' })).toBe('2001:db8::1');
-    });
-
-    it('returns the string directly for link-local IPv6', () => {
-        expect(ipAddressToString({ addr: 'fe80::1' })).toBe('fe80::1');
-    });
-
-    it('handles number[] bytes as defensive fallback (IPv4)', () => {
-        expect(ipAddressToString({ addr: [10, 0, 0, 1] })).toBe('10.0.0.1');
-    });
-
-    it('handles Uint8Array bytes as defensive fallback (IPv4)', () => {
-        expect(ipAddressToString({ addr: new Uint8Array([10, 0, 0, 1]) })).toBe('10.0.0.1');
-    });
-
-    it('returns empty string for undefined', () => {
-        expect(ipAddressToString(undefined)).toBe('');
-    });
-
-    it('returns empty string for missing addr', () => {
-        expect(ipAddressToString({})).toBe('');
-    });
-});
-
 describe('stringToIPAddress', () => {
-    it('encodes a valid IPv4 address', () => {
-        expect(stringToIPAddress('10.0.0.1')).toEqual({ addr: '10.0.0.1' });
+    it('validates and returns a valid IPv4 address', () => {
+        expect(stringToIPAddress('10.0.0.1')).toBe('10.0.0.1');
     });
 
-    it('encodes a valid IPv6 address', () => {
-        expect(stringToIPAddress('2001:db8::1')).toEqual({ addr: '2001:db8::1' });
+    it('validates and returns a valid IPv6 address', () => {
+        expect(stringToIPAddress('2001:db8::1')).toBe('2001:db8::1');
     });
 
     it('returns undefined for an invalid address', () => {

--- a/web/src/core/utils/netip.ts
+++ b/web/src/core/utils/netip.ts
@@ -743,13 +743,6 @@ export const formatIPNetItem = (
     return formatIPNet(addrBytes, maskBytes);
 };
 
-// Wire-format shape of commonpb.IPAddress as it arrives from the
-// gRPC-JSON gateway. The addr field may be base64 (string), a numeric
-// byte array, or a Uint8Array.
-export type IPAddressWire = {
-    addr?: string | number[] | Uint8Array;
-};
-
 // Wire-format shape of an IP range as returned by the gRPC-JSON gateway.
 // Both endpoints are plain IP strings — Go's IPRange.MarshalJSON flattens
 // the nested IPAddress shape into top-level strings rather than nesting
@@ -759,26 +752,14 @@ export interface IPRangeWire {
     end?: string;
 }
 
-// Decode a wire IPAddress into a human-readable IP string. Returns an
-// empty string when the message is missing or has an empty addr.
-// The canonical wire form from Go's MarshalJSON is a plain IP string.
-export const ipAddressToString = (ip: IPAddressWire | undefined): string => {
-    if (!ip || ip.addr === undefined || ip.addr === null) return '';
-    if (typeof ip.addr === 'string') {
-        return ip.addr;
-    }
-    const bytes = ip.addr instanceof Uint8Array ? Array.from(ip.addr) : ip.addr;
-    if (bytes.length === 0) return '';
-    return formatIPFromBytes(bytes);
-};
-
-// Encode an IPv4 or IPv6 string into a wire IPAddress message. Returns
-// undefined for empty input or unparseable addresses.
-export const stringToIPAddress = (s: string): IPAddressWire | undefined => {
+// Validate an IP string before sending it as commonpb.IPAddress, which the
+// gateway marshals as a bare IP string. Returns undefined for empty input
+// or unparseable addresses.
+export const stringToIPAddress = (s: string): string | undefined => {
     if (!s) return undefined;
     const parsed = parseIPAddress(s);
     if (!parsed.ok) return undefined;
-    return { addr: s };
+    return s;
 };
 
 // Convert an IP bytes array to a BigInt.


### PR DESCRIPTION
- `commonpb.IPAddress` stays the `bytes` mixed-family container, but its hand-written JSON unifies on one bare address string: Go rendered the `{"addr": ...}` object while Rust already rendered a string, and the two shapes drifted.
- Go `MarshalJSON`/`UnmarshalJSON` use the bare string and the web TS types move to plain `string`, mirroring the earlier `IPPrefix` bare-CIDR migration.
- Rust `Serialize` now renders the faithful decoded address, so `::ffff:a.b.c.d` round-trips losslessly and identically to Go, while `Display` keeps the unmapped human rendering for CLI tables: the RIB table shows `10.0.0.1` where JSON carries `::ffff:10.0.0.1`, an intended human/machine split.
- The `reserved 2` zone slot is dropped with a comment recording that a scope/zone belongs on the owning message and that the byte length is the family discriminant by design.
- The binary wire encoding of `addr` is unchanged; no consumer migration.
- The Buf breaking job is expected red on the reserved-range removal and is merged over per the epic's standing practice.

Closes #2211.