### PR TITLE
fix(fwstate): account map object layers on the object memory context

### DIFF
--- a/modules/fwstate/tests/dataplane/harness.c
+++ b/modules/fwstate/tests/dataplane/harness.c
@@ -342,9 +342,15 @@ fwstate_test_trim_stale_layers(struct cp_module *cp_module, uint64_t now) {
 	// same call — no generation barrier is needed here.
 	int rc4 = fwtable_unlink_stale_cp(fw4table, now);
 	int rc6 = fwtable_unlink_stale_cp(fw6table, now);
-	struct agent *agent = ADDR_OF(&cp_module->agent);
-	fwtable_free_stale(fw4table, &agent->memory_context);
-	fwtable_free_stale(fw6table, &agent->memory_context);
+
+	// Layer memory is charged to the owning map object's context, so the
+	// release must free through the same context.
+	struct fwstate_map_v4_object *object4 =
+		container_of(fw4table, struct fwstate_map_v4_object, table);
+	struct fwstate_map_v6_object *object6 =
+		container_of(fw6table, struct fwstate_map_v6_object, table);
+	fwtable_free_stale(fw4table, &object4->cp_object.memory_context);
+	fwtable_free_stale(fw6table, &object6->cp_object.memory_context);
 	return (rc4 || rc6) ? -1 : 0;
 }
 
@@ -365,4 +371,30 @@ fwstate_test_table_layer(
 		map = (fwmap_t *)ADDR_OF(&map->next);
 	}
 	return map;
+}
+
+// Snapshot one context's accounting counters. The harness is
+// single-threaded between setup calls, so plain reads race with nothing.
+static void
+fwstate_test_mem_counters_read(
+	const struct memory_context *ctx, struct fwstate_test_mem_counters *out
+) {
+	out->balloc_count = ctx->balloc_count;
+	out->bfree_count = ctx->bfree_count;
+	out->balloc_size = ctx->balloc_size;
+	out->bfree_size = ctx->bfree_size;
+}
+
+void
+fwstate_test_agent_mem_counters(
+	struct agent *agent, struct fwstate_test_mem_counters *out
+) {
+	fwstate_test_mem_counters_read(&agent->memory_context, out);
+}
+
+void
+fwstate_test_object_mem_counters(
+	struct cp_object *cp_object, struct fwstate_test_mem_counters *out
+) {
+	fwstate_test_mem_counters_read(&cp_object->memory_context, out);
 }

--- a/modules/fwstate/tests/dataplane/harness.h
+++ b/modules/fwstate/tests/dataplane/harness.h
@@ -113,6 +113,27 @@ fwstate_test_table_layer(
 	struct cp_module *cp_module, bool is_ipv6, uint32_t layer_index
 );
 
+// Accounting snapshot of one memory context, for tests that assert where
+// allocations and frees were charged.
+struct fwstate_test_mem_counters {
+	uint64_t balloc_count;
+	uint64_t bfree_count;
+	uint64_t balloc_size;
+	uint64_t bfree_size;
+};
+
+// Snapshot the stand-in agent's context counters into out.
+void
+fwstate_test_agent_mem_counters(
+	struct agent *agent, struct fwstate_test_mem_counters *out
+);
+
+// Snapshot a map object's own context counters into out.
+void
+fwstate_test_object_mem_counters(
+	struct cp_object *cp_object, struct fwstate_test_mem_counters *out
+);
+
 // Mock implementation of clock_get_time_ns for tests. Returns current
 // monotonic time in nanoseconds. Declared here so cgo can call it directly
 // from Go.

--- a/modules/fwstate/tests/dataplane/map_object_memory_helper.go
+++ b/modules/fwstate/tests/dataplane/map_object_memory_helper.go
@@ -1,0 +1,101 @@
+package fwstate
+
+/*
+#include <harness.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/yanet-platform/yanet2/common/go/testutils"
+)
+
+// MemCounters is a snapshot of one memory context's accounting counters,
+// for tests that assert where allocations and frees were charged.
+type MemCounters struct {
+	BallocCount uint64
+	BfreeCount  uint64
+	BallocSize  uint64
+	BfreeSize   uint64
+}
+
+// NewHarnessAgent allocates a stand-alone harness agent in the given
+// memory context, without any module config or linked map objects.
+func NewHarnessAgent(memCtx testutils.MemoryContext) *C.struct_agent {
+	cStubAgent := C.CString("stub agent")
+	defer C.free(unsafe.Pointer(cStubAgent))
+	return C.fwstate_test_agent_new(
+		(*C.struct_memory_context)(memCtx.AsRawPtr()),
+		cStubAgent,
+	)
+}
+
+// NewMapV4Object creates an IPv4 map object with its first table layer
+// already installed, leaving it unregistered (dangling).
+func NewMapV4Object(agent *C.struct_agent, name string) *C.struct_fwstate_map_v4_object {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	obj := C.fwstate_test_map_object_new(agent, false, cName)
+	if obj == nil {
+		return nil
+	}
+	// The common-object header is the first field of the map object.
+	return (*C.struct_fwstate_map_v4_object)(unsafe.Pointer(obj))
+}
+
+// AgentMemCounters snapshots the stand-in agent's context counters.
+func AgentMemCounters(agent *C.struct_agent) MemCounters {
+	var counters C.struct_fwstate_test_mem_counters
+	C.fwstate_test_agent_mem_counters(agent, &counters)
+	return MemCounters{
+		BallocCount: uint64(counters.balloc_count),
+		BfreeCount:  uint64(counters.bfree_count),
+		BallocSize:  uint64(counters.balloc_size),
+		BfreeSize:   uint64(counters.bfree_size),
+	}
+}
+
+// ObjectMemCounters snapshots a map object's own context counters.
+func ObjectMemCounters(object *C.struct_fwstate_map_v4_object) MemCounters {
+	var counters C.struct_fwstate_test_mem_counters
+	C.fwstate_test_object_mem_counters(
+		(*C.struct_cp_object)(unsafe.Pointer(object)), &counters,
+	)
+	return MemCounters{
+		BallocCount: uint64(counters.balloc_count),
+		BfreeCount:  uint64(counters.bfree_count),
+		BallocSize:  uint64(counters.balloc_size),
+		BfreeSize:   uint64(counters.bfree_size),
+	}
+}
+
+// InsertMapV4Layer appends one layer to the object's table chain and
+// reports the C return code.
+func InsertMapV4Layer(
+	object *C.struct_fwstate_map_v4_object,
+	indexSize uint32,
+	extraBucketCount uint32,
+	workerCount uint16,
+) int {
+	return int(C.fwstate_map_v4_object_insert_layer(
+		object,
+		C.uint32_t(indexSize),
+		C.uint32_t(extraBucketCount),
+		C.uint16_t(workerCount),
+	))
+}
+
+// UnlinkStaleMapV4Layers parks expired tail layers in the stale chain and
+// reports the C return code.
+func UnlinkStaleMapV4Layers(object *C.struct_fwstate_map_v4_object, now uint64) int {
+	return int(C.fwstate_map_v4_object_unlink_stale_layers(
+		object, C.uint64_t(now),
+	))
+}
+
+// FreeStaleMapV4Layers releases the layers parked by
+// UnlinkStaleMapV4Layers.
+func FreeStaleMapV4Layers(object *C.struct_fwstate_map_v4_object) {
+	C.fwstate_map_v4_object_free_stale_layers(object)
+}

--- a/modules/fwstate/tests/dataplane/map_object_memory_test.go
+++ b/modules/fwstate/tests/dataplane/map_object_memory_test.go
@@ -1,0 +1,45 @@
+package fwstate_test
+
+import (
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/testutils"
+	fwstate "github.com/yanet-platform/yanet2/modules/fwstate/tests/dataplane"
+)
+
+// verifies that map-object layers are charged to the object's own memory
+// context: growing and reclaiming the layer chain moves only the object's
+// accounting counters, never the agent's.
+func Test_MapObjectMemory_LayerBytesChargedToObjectContext(t *testing.T) {
+	memCtx := testutils.NewMemoryContext("fwstate_map_obj_mem", datasize.MB*64)
+	defer memCtx.Free()
+
+	agent := fwstate.NewHarnessAgent(memCtx)
+	require.NotNil(t, agent)
+
+	object := fwstate.NewMapV4Object(agent, "mem_v4")
+	require.NotNil(t, object)
+
+	agentBefore := fwstate.AgentMemCounters(agent)
+	objectBefore := fwstate.ObjectMemCounters(object)
+
+	require.Zero(t, fwstate.InsertMapV4Layer(object, 1024, 64, 1))
+
+	agentAfter := fwstate.AgentMemCounters(agent)
+	objectAfter := fwstate.ObjectMemCounters(object)
+	require.Greater(t, objectAfter.BallocSize, objectBefore.BallocSize)
+	require.Equal(t, agentBefore, agentAfter)
+
+	// A far-future expiry parks the empty tail layer; releasing it must
+	// charge the same context the layer was allocated from.
+	require.Zero(t, fwstate.UnlinkStaleMapV4Layers(object, 1<<62))
+	fwstate.FreeStaleMapV4Layers(object)
+
+	agentAfter = fwstate.AgentMemCounters(agent)
+	objectAfter = fwstate.ObjectMemCounters(object)
+	require.Greater(t, objectAfter.BfreeSize, objectBefore.BfreeSize)
+	require.Equal(t, agentBefore, agentAfter)
+}

--- a/objects/fwstate/api/fwstate_map_object.c
+++ b/objects/fwstate/api/fwstate_map_object.c
@@ -20,6 +20,10 @@
 // to grow the layer chain (key size and key/copy callbacks). The helpers
 // below carry the family-agnostic machinery; each per-family function is
 // a thin wrapper that selects its key initializer.
+//
+// Layer memory is allocated and freed through the object's own memory
+// context, so the per-object accounting attributes the fwtable stores to
+// the map object rather than to the agent.
 
 typedef void (*map_init_keys_fn)(fwmap_config_t *config);
 
@@ -161,7 +165,9 @@ fwstate_map_v4_object_fini(struct fwstate_map_v4_object *self) {
 
 	struct agent *agent = ADDR_OF(&self->cp_object.agent);
 	if (agent != NULL) {
-		map_free_table(&self->table, &agent->memory_context);
+		// Runs before the common teardown zeroes the object's memory
+		// context, which the table free must still charge.
+		map_free_table(&self->table, &self->cp_object.memory_context);
 	}
 	cp_object_fini(&self->cp_object);
 }
@@ -238,11 +244,9 @@ fwstate_map_v4_object_insert_layer(
 	uint32_t extra_bucket_count,
 	uint16_t worker_count
 ) {
-	struct agent *agent = ADDR_OF(&self->cp_object.agent);
-
 	int rc = map_insert_layer(
 		&self->table,
-		&agent->memory_context,
+		&self->cp_object.memory_context,
 		map_v4_init_keys,
 		index_size,
 		extra_bucket_count,
@@ -267,9 +271,7 @@ fwstate_map_v4_object_unlink_stale_layers(
 
 void
 fwstate_map_v4_object_free_stale_layers(struct fwstate_map_v4_object *self) {
-	struct agent *agent = ADDR_OF(&self->cp_object.agent);
-
-	fwtable_free_stale(&self->table, &agent->memory_context);
+	fwtable_free_stale(&self->table, &self->cp_object.memory_context);
 }
 
 // --- IPv6 object -------------------------------------------------------------
@@ -318,7 +320,9 @@ fwstate_map_v6_object_fini(struct fwstate_map_v6_object *self) {
 
 	struct agent *agent = ADDR_OF(&self->cp_object.agent);
 	if (agent != NULL) {
-		map_free_table(&self->table, &agent->memory_context);
+		// Runs before the common teardown zeroes the object's memory
+		// context, which the table free must still charge.
+		map_free_table(&self->table, &self->cp_object.memory_context);
 	}
 	cp_object_fini(&self->cp_object);
 }
@@ -395,11 +399,9 @@ fwstate_map_v6_object_insert_layer(
 	uint32_t extra_bucket_count,
 	uint16_t worker_count
 ) {
-	struct agent *agent = ADDR_OF(&self->cp_object.agent);
-
 	int rc = map_insert_layer(
 		&self->table,
-		&agent->memory_context,
+		&self->cp_object.memory_context,
 		map_v6_init_keys,
 		index_size,
 		extra_bucket_count,
@@ -424,9 +426,7 @@ fwstate_map_v6_object_unlink_stale_layers(
 
 void
 fwstate_map_v6_object_free_stale_layers(struct fwstate_map_v6_object *self) {
-	struct agent *agent = ADDR_OF(&self->cp_object.agent);
-
-	fwtable_free_stale(&self->table, &agent->memory_context);
+	fwtable_free_stale(&self->table, &self->cp_object.memory_context);
 }
 
 // --- object factories --------------------------------------------------------


### PR DESCRIPTION
- Allocate and free fwstate-map table layers through the map object's own named memory context instead of the agent context, so the per-object accounting surfaces the dominant per-map cost on the right node of the shared-memory context tree.
- Free parked stale layers through the same owning context in the dataplane test harness.
- Add a Go regression test asserting layer insert and stale-layer release move only the object's accounting counters, never the agent's.

Closes #2250.