### PR TITLE
fix(unrdup): build against current main

### DIFF
--- a/modules/unrdup/api/controlplane.c
+++ b/modules/unrdup/api/controlplane.c
@@ -251,14 +251,7 @@ unrdup_module_config_new(
 		return NULL;
 	}
 
-	if (cp_module_init(
-		    &config->cp_module,
-		    agent,
-		    "unrdup",
-		    name,
-		    unrdup_module_config_free,
-		    err
-	    )) {
+	if (cp_module_init(&config->cp_module, agent, "unrdup", name, err)) {
 		yanet_error_add(err, "failed to init module");
 		memory_bfree(
 			&agent->memory_context,
@@ -271,7 +264,7 @@ unrdup_module_config_new(
 	unrdup_module_config_data_init(config);
 
 	if (unrdup_module_config_register_counters(&config->cp_module, err)) {
-		unrdup_module_config_free(&config->cp_module);
+		unrdup_module_config_destroy(&config->cp_module);
 		return NULL;
 	}
 
@@ -328,7 +321,7 @@ unrdup_module_config_register_counters(
 }
 
 void
-unrdup_module_config_free(struct cp_module *cp_module) {
+unrdup_module_config_destroy(struct cp_module *cp_module) {
 	struct unrdup_module_config *config =
 		container_of(cp_module, struct unrdup_module_config, cp_module);
 
@@ -343,6 +336,16 @@ unrdup_module_config_free(struct cp_module *cp_module) {
 		config,
 		sizeof(struct unrdup_module_config)
 	);
+}
+
+int
+unrdup_module_config_free(struct cp_module *cp_module, yanet_error **err) {
+	if (cp_module_try_destroy(cp_module, err)) {
+		return -1;
+	}
+
+	unrdup_module_config_destroy(cp_module);
+	return 0;
 }
 
 int

--- a/modules/unrdup/api/controlplane.h
+++ b/modules/unrdup/api/controlplane.h
@@ -16,7 +16,10 @@ unrdup_module_config_new(
 );
 
 void
-unrdup_module_config_free(struct cp_module *cp_module);
+unrdup_module_config_destroy(struct cp_module *cp_module);
+
+int
+unrdup_module_config_free(struct cp_module *cp_module, yanet_error **err);
 
 void
 unrdup_module_config_data_fini(struct unrdup_module_config *config);

--- a/modules/unrdup/bindings/go/cunrdup/cgo.go
+++ b/modules/unrdup/bindings/go/cunrdup/cgo.go
@@ -9,7 +9,9 @@ package cunrdup
 import "C"
 
 import (
+	"errors"
 	"fmt"
+	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -43,11 +45,32 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-func (m *ModuleConfig) Free() {
-	if ptr := m.asRawPtr(); ptr != nil {
-		C.unrdup_module_config_free(ptr)
-		m.ptr = ffi.ModuleConfig{}
+// Free releases the module config unless the dataplane still references it.
+//
+// A refused attempt reports ErrStillReferenced and leaves the object intact,
+// so it can be retried once the generations holding it drain. Safe to call
+// multiple times: subsequent calls are no-ops reporting nil.
+func (m *ModuleConfig) Free() error {
+	ptr := m.asRawPtr()
+	if ptr == nil {
+		return nil
 	}
+
+	var cErr *C.yanet_error
+	rc, errno := C.unrdup_module_config_free(ptr, &cErr)
+	if rc == 0 {
+		m.ptr = ffi.ModuleConfig{}
+		return nil
+	}
+	if errors.Is(errno, syscall.EAGAIN) {
+		C.yanet_error_free(cErr)
+		return ffi.ErrStillReferenced
+	}
+
+	return fmt.Errorf(
+		"failed to free module config: %w",
+		cerrors.FromC(unsafe.Pointer(cErr)),
+	)
 }
 
 func (m *ModuleConfig) setSource(family C.enum_ip_family, addr *C.uint8_t, mask *C.uint8_t) error {

--- a/modules/unrdup/controlplane/backend.go
+++ b/modules/unrdup/controlplane/backend.go
@@ -30,18 +30,18 @@ func (m *backend) UpdateModule(
 
 	for _, source := range sources {
 		if err := module.SetSource(source); err != nil {
-			module.Free()
+			_ = module.Free()
 			return nil, fmt.Errorf("failed to set source: %w", err)
 		}
 	}
 
 	if err := module.UpdateServices(services); err != nil {
-		module.Free()
+		_ = module.Free()
 		return nil, fmt.Errorf("failed to update services: %w", err)
 	}
 
 	if err := m.agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
-		module.Free()
+		_ = module.Free()
 		return nil, fmt.Errorf("failed to update module: %w", err)
 	}
 

--- a/modules/unrdup/controlplane/service.go
+++ b/modules/unrdup/controlplane/service.go
@@ -2,6 +2,7 @@ package unrdup
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 	"sync"
@@ -10,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/xnetip"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/unrdup/bindings/go/cunrdup"
 	"github.com/yanet-platform/yanet2/modules/unrdup/controlplane/unrduppb/v1"
 )
@@ -42,7 +44,7 @@ func validateConfigName(name string) error {
 
 // ModuleHandle is a handle to a module configuration.
 type ModuleHandle interface {
-	Free()
+	Free() error
 }
 
 // Backend abstracts shared memory operations.
@@ -58,9 +60,39 @@ type Backend interface {
 type UnrdupService struct {
 	unrduppb.UnimplementedUnrdupServiceServer
 
-	mu      sync.RWMutex
-	backend Backend
-	configs map[string]*config
+	mu       sync.RWMutex
+	backend  Backend
+	configs  map[string]*config
+	deferred []ModuleHandle
+}
+
+// parkOrFree frees a superseded handle, keeping it for a later retry while a
+// live generation still references it. The caller must hold m.mu.
+func (m *UnrdupService) parkOrFree(handle ModuleHandle) {
+	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
+		m.deferred = append(m.deferred, handle)
+	}
+}
+
+// ReclaimDeferred retries every parked handle, dropping the ones whose
+// generations have drained and keeping the rest parked.
+func (m *UnrdupService) ReclaimDeferred() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reclaimDeferred()
+}
+
+// reclaimDeferred is ReclaimDeferred without the lock. The caller must hold
+// m.mu.
+func (m *UnrdupService) reclaimDeferred() {
+	kept := m.deferred[:0]
+	for _, handle := range m.deferred {
+		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
+			kept = append(kept, handle)
+		}
+	}
+	clear(m.deferred[len(kept):])
+	m.deferred = kept
 }
 
 type config struct {
@@ -155,8 +187,10 @@ func (m *UnrdupService) UpdateConfig(
 		)
 	}
 
+	m.reclaimDeferred()
+
 	if previous, ok := m.configs[name]; ok && previous.Module != nil {
-		previous.Module.Free()
+		m.parkOrFree(previous.Module)
 	}
 
 	updated.Module = module

--- a/modules/unrdup/controlplane/service_test.go
+++ b/modules/unrdup/controlplane/service_test.go
@@ -25,8 +25,9 @@ type fakeHandle struct {
 	freed bool
 }
 
-func (m *fakeHandle) Free() {
+func (m *fakeHandle) Free() error {
 	m.freed = true
+	return nil
 }
 
 type fakeBackend struct {

--- a/modules/unrdup/tests/functional/unrdup_test.go
+++ b/modules/unrdup/tests/functional/unrdup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/xerror"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	plain "github.com/yanet-platform/yanet2/devices/plain/controlplane"
 	cforward "github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
 	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
 	"github.com/yanet-platform/yanet2/modules/unrdup/bindings/go/cunrdup"
@@ -71,7 +72,7 @@ func setupHarness(
 
 	module, err := cunrdup.NewModuleConfig(agent, configName)
 	require.NoError(t, err)
-	t.Cleanup(module.Free)
+	t.Cleanup(func() { _ = module.Free() })
 
 	for _, source := range sources {
 		require.NoError(t, module.SetSource(source))
@@ -110,7 +111,7 @@ func wirePipeline(t *testing.T, agent *ffi.Agent) {
 	sinkName := configName + "-sink"
 	sink, err := forward.NewBackend(agent).UpdateModule(sinkName, catchAllRules())
 	require.NoError(t, err)
-	t.Cleanup(sink.Free)
+	t.Cleanup(func() { _ = sink.Free() })
 
 	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: configName,
@@ -130,11 +131,12 @@ func wirePipeline(t *testing.T, agent *ffi.Agent) {
 		Functions: []string{configName},
 	}))
 	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
-	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
 		Name:   deviceName,
 		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
-	}}))
+	}})
+	require.NoError(t, err)
 }
 
 func catchAllRules() []cforward.ForwardRule {
@@ -143,15 +145,15 @@ func catchAllRules() []cforward.ForwardRule {
 			Target:  deviceName,
 			Mode:    cforward.ModeOut,
 			Counter: "sink4",
-			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
-			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+			Dst4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
 		},
 		{
 			Target:  deviceName,
 			Mode:    cforward.ModeOut,
 			Counter: "sink6",
-			Src6s:   filter.IPNets{filter.UnspecifiedIPv6},
-			Dst6s:   filter.IPNets{filter.UnspecifiedIPv6},
+			Src6s:   []xnetip.BiContiguous{filter.UnspecifiedIPv6},
+			Dst6s:   []xnetip.BiContiguous{filter.UnspecifiedIPv6},
 		},
 		{
 			Target:  deviceName,


### PR DESCRIPTION
The module merged without a final rebase, so it was written against a tree that has since moved twice: the untyped network lists the filter bindings carried were removed by #2240, and module teardown split into an unconditional destroy and a free that can refuse while the dataplane still references the config. Neither the C library nor the Go packages compiled, so the meson build and every Go job on main went red.

Follow the shapes the other modules already use. Teardown destroys directly on the construction failure path and, when superseding a live config, parks the handle for a later retry rather than dropping it on the floor. The functional test builds its match sets per family and attaches devices through the plain device package.