### PR TITLE
feat(controlplane): plumb cancellation through the CGO config-update path

### DIFF
--- a/bindings/go/dataplane_ut/bench_test.go
+++ b/bindings/go/dataplane_ut/bench_test.go
@@ -39,7 +39,7 @@ func BenchmarkPipelineRound(b *testing.B) {
 	require.NoError(b, err)
 	defer func() { _ = agent.CleanUp() }()
 
-	require.NoError(b, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(b, agent.UpdateFunction(b.Context(), ffi.FunctionConfig{
 		Name: "bench",
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -49,14 +49,14 @@ func BenchmarkPipelineRound(b *testing.B) {
 			},
 		}},
 	}))
-	require.NoError(b, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(b, agent.UpdatePipeline(b.Context(), ffi.PipelineConfig{
 		Name:      "bench",
 		Functions: []string{"bench"},
 	}))
-	require.NoError(b, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(b, agent.UpdatePipeline(b.Context(), ffi.PipelineConfig{
 		Name: "dummy",
 	}))
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	_, err = plain.UpdateDevices(b.Context(), agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: "bench", Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},

--- a/bindings/go/dataplane_ut/dataplane_ut_test.go
+++ b/bindings/go/dataplane_ut/dataplane_ut_test.go
@@ -227,11 +227,11 @@ func TestHandleSegmentedPacketsOnDevice_ForwardDeviceScopedRule(t *testing.T) {
 		Counter: "port1_rule",
 		Devices: filter.Devices{{Name: "port1"}},
 	}
-	moduleHandle, err := backend.UpdateModule("demux", []cforward.ForwardRule{rule})
+	moduleHandle, err := backend.UpdateModule(t.Context(), "demux", []cforward.ForwardRule{rule})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = moduleHandle.Free() })
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: "demux",
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -241,15 +241,15 @@ func TestHandleSegmentedPacketsOnDevice_ForwardDeviceScopedRule(t *testing.T) {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      "demux",
 		Functions: []string{"demux"},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy_out"}))
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: "dummy_out"}))
 
 	// Port 0 has no output pipeline: the rule never targets it, so an
 	// unmatched packet has nowhere to go but drop.
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{
+	_, err = plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{
 		{
 			Name:  "port0",
 			Input: []ffi.DevicePipelineConfig{{Name: "demux", Weight: 1}},

--- a/controlplane/builtin/function.go
+++ b/controlplane/builtin/function.go
@@ -204,7 +204,7 @@ func (m *Function) Update(
 	}
 	defer agent.Close()
 
-	if err := agent.UpdateFunction(function); err != nil {
+	if err := agent.UpdateFunction(ctx, function); err != nil {
 		return nil, fmt.Errorf("failed to update function: %w", err)
 	}
 
@@ -228,7 +228,7 @@ func (m *Function) Delete(
 	}
 	defer agent.Close()
 
-	if err := agent.DeleteFunction(functionName); err != nil {
+	if err := agent.DeleteFunction(ctx, functionName); err != nil {
 		return nil, fmt.Errorf("failed to delete function: %w", err)
 	}
 

--- a/controlplane/builtin/pipeline.go
+++ b/controlplane/builtin/pipeline.go
@@ -171,7 +171,7 @@ func (m *Pipeline) Update(
 	}
 	defer agent.Close()
 
-	if err := agent.UpdatePipeline(pipeline); err != nil {
+	if err := agent.UpdatePipeline(ctx, pipeline); err != nil {
 		return nil, fmt.Errorf("failed to update function: %w", err)
 	}
 
@@ -195,7 +195,7 @@ func (m *Pipeline) Delete(
 	}
 	defer agent.Close()
 
-	if err := agent.DeletePipeline(pipelineName); err != nil {
+	if err := agent.DeletePipeline(ctx, pipelineName); err != nil {
 		return nil, fmt.Errorf("failed to delete pipeline: %w", err)
 	}
 

--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -19,6 +19,7 @@ package ffi
 //#include "lib/controlplane/agent/agent.h"
 import "C"
 import (
+	"context"
 	"fmt"
 	"unsafe"
 
@@ -104,7 +105,7 @@ func (m *Agent) AsRawPtr() unsafe.Pointer {
 	return unsafe.Pointer(m.ptr)
 }
 
-func (m *Agent) UpdateModules(modules []ModuleConfig) error {
+func (m *Agent) UpdateModules(ctx context.Context, modules []ModuleConfig) error {
 	if len(modules) == 0 {
 		return fmt.Errorf("no modules provided")
 	}
@@ -121,18 +122,20 @@ func (m *Agent) UpdateModules(modules []ModuleConfig) error {
 		return fmt.Errorf("no module configs to update")
 	}
 
-	var cErr *C.yanet_error
-	rc := C.agent_update_modules(
-		(*C.struct_agent)(m.AsRawPtr()),
-		C.size_t(len(modules)),
-		&configs[0],
-		&cErr,
-	)
-	if rc != 0 {
-		return fmt.Errorf("failed to update modules: %w", cerrors.FromC(unsafe.Pointer(cErr)))
-	}
+	return WithCancellation(ctx, func() error {
+		var cErr *C.yanet_error
+		rc := C.agent_update_modules(
+			(*C.struct_agent)(m.AsRawPtr()),
+			C.size_t(len(modules)),
+			&configs[0],
+			&cErr,
+		)
+		if rc != 0 {
+			return fmt.Errorf("failed to update modules: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+		}
 
-	return nil
+		return nil
+	})
 }
 
 func (m *Agent) DPConfig() *DPConfig {
@@ -141,7 +144,11 @@ func (m *Agent) DPConfig() *DPConfig {
 	}
 }
 
-func (m *Agent) UpdateFunction(functionConfig FunctionConfig) error {
+func (m *Agent) UpdateFunction(ctx context.Context, functionConfig FunctionConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	function, err := newFunctionConfig(functionConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create pipeline config: %w", err)
@@ -151,21 +158,27 @@ func (m *Agent) UpdateFunction(functionConfig FunctionConfig) error {
 	functions := make([]*C.struct_cp_function_config, 1)
 	functions[0] = function.AsRawPtr()
 
-	var cErr *C.yanet_error
-	rc := C.agent_update_functions(
-		m.ptr,
-		1,
-		&functions[0],
-		&cErr,
-	)
-	if rc != 0 {
-		return fmt.Errorf("failed to update functions: %w", cerrors.FromC(unsafe.Pointer(cErr)))
-	}
+	return WithCancellation(ctx, func() error {
+		var cErr *C.yanet_error
+		rc := C.agent_update_functions(
+			m.ptr,
+			1,
+			&functions[0],
+			&cErr,
+		)
+		if rc != 0 {
+			return fmt.Errorf("failed to update functions: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+		}
 
-	return nil
+		return nil
+	})
 }
 
-func (m *Agent) UpdatePipeline(pipelineConfig PipelineConfig) error {
+func (m *Agent) UpdatePipeline(ctx context.Context, pipelineConfig PipelineConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	pipelines := make([]*C.struct_cp_pipeline_config, 0, 1)
 
 	pipeline, err := newPipelineConfig(pipelineConfig)
@@ -176,24 +189,26 @@ func (m *Agent) UpdatePipeline(pipelineConfig PipelineConfig) error {
 
 	pipelines = append(pipelines, pipeline.AsRawPtr())
 
-	var cErr *C.yanet_error
-	rc := C.agent_update_pipelines(
-		m.ptr,
-		1,
-		&pipelines[0],
-		&cErr,
-	)
-	if rc != 0 {
-		return fmt.Errorf("failed to update pipelines: %w", cerrors.FromC(unsafe.Pointer(cErr)))
-	}
+	return WithCancellation(ctx, func() error {
+		var cErr *C.yanet_error
+		rc := C.agent_update_pipelines(
+			m.ptr,
+			1,
+			&pipelines[0],
+			&cErr,
+		)
+		if rc != 0 {
+			return fmt.Errorf("failed to update pipelines: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+		}
 
-	return nil
+		return nil
+	})
 }
 
 // TODO: (*Agent).UpdateVlanDevices
 
 // UpdateDevices attaches the given pipelines to the given device IDs.
-func (m *Agent) UpdateDevices(devices []ShmDeviceConfig) error {
+func (m *Agent) UpdateDevices(ctx context.Context, devices []ShmDeviceConfig) error {
 	if len(devices) == 0 {
 		return nil
 	}
@@ -206,18 +221,20 @@ func (m *Agent) UpdateDevices(devices []ShmDeviceConfig) error {
 		configs[i] = (*C.struct_cp_device)(device.AsRawPtr())
 	}
 
-	var cErr *C.yanet_error
-	rc := C.agent_update_devices(
-		(*C.struct_agent)(m.AsRawPtr()),
-		C.size_t(len(devices)),
-		&configs[0],
-		&cErr,
-	)
-	if rc != 0 {
-		return cerrors.FromC(unsafe.Pointer(cErr))
-	}
+	return WithCancellation(ctx, func() error {
+		var cErr *C.yanet_error
+		rc := C.agent_update_devices(
+			(*C.struct_agent)(m.AsRawPtr()),
+			C.size_t(len(devices)),
+			&configs[0],
+			&cErr,
+		)
+		if rc != 0 {
+			return cerrors.FromC(unsafe.Pointer(cErr))
+		}
 
-	return nil
+		return nil
+	})
 }
 
 type DevicePipeline struct {
@@ -225,54 +242,60 @@ type DevicePipeline struct {
 	Weight uint64
 }
 
-func (m *Agent) DeleteFunction(name string) error {
+func (m *Agent) DeleteFunction(ctx context.Context, name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
-	var cErr *C.yanet_error
-	rc := C.agent_delete_function(m.ptr, cName, &cErr)
-	if rc != 0 {
-		return fmt.Errorf("failed to delete function %q: %w", name, cerrors.FromC(unsafe.Pointer(cErr)))
-	}
+	return WithCancellation(ctx, func() error {
+		var cErr *C.yanet_error
+		rc := C.agent_delete_function(m.ptr, cName, &cErr)
+		if rc != 0 {
+			return fmt.Errorf("failed to delete function %q: %w", name, cerrors.FromC(unsafe.Pointer(cErr)))
+		}
 
-	return nil
+		return nil
+	})
 }
 
-func (m *Agent) DeletePipeline(name string) error {
+func (m *Agent) DeletePipeline(ctx context.Context, name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
-	var cErr *C.yanet_error
-	rc := C.agent_delete_pipeline(m.ptr, cName, &cErr)
-	if rc != 0 {
-		return fmt.Errorf("failed to delete pipeline %q: %w", name, cerrors.FromC(unsafe.Pointer(cErr)))
-	}
+	return WithCancellation(ctx, func() error {
+		var cErr *C.yanet_error
+		rc := C.agent_delete_pipeline(m.ptr, cName, &cErr)
+		if rc != 0 {
+			return fmt.Errorf("failed to delete pipeline %q: %w", name, cerrors.FromC(unsafe.Pointer(cErr)))
+		}
 
-	return nil
+		return nil
+	})
 }
 
-func (m *Agent) DeleteModuleConfig(moduleType, configName string) error {
+func (m *Agent) DeleteModuleConfig(ctx context.Context, moduleType, configName string) error {
 	cTypeName := C.CString(moduleType)
 	defer C.free(unsafe.Pointer(cTypeName))
 
 	cConfigName := C.CString(configName)
 	defer C.free(unsafe.Pointer(cConfigName))
 
-	var cErr *C.yanet_error
-	result := C.agent_delete_module(
-		(*C.struct_agent)(m.AsRawPtr()),
-		cTypeName,
-		cConfigName,
-		&cErr,
-	)
-	if result != 0 {
-		return fmt.Errorf(
-			"failed to delete module config type %q name %q: %w",
-			moduleType,
-			configName,
-			cerrors.FromC(unsafe.Pointer(cErr)),
+	return WithCancellation(ctx, func() error {
+		var cErr *C.yanet_error
+		result := C.agent_delete_module(
+			(*C.struct_agent)(m.AsRawPtr()),
+			cTypeName,
+			cConfigName,
+			&cErr,
 		)
-	}
+		if result != 0 {
+			return fmt.Errorf(
+				"failed to delete module config type %q name %q: %w",
+				moduleType,
+				configName,
+				cerrors.FromC(unsafe.Pointer(cErr)),
+			)
+		}
 
-	return nil
+		return nil
+	})
 }

--- a/controlplane/ffi/cancellation.go
+++ b/controlplane/ffi/cancellation.go
@@ -1,0 +1,57 @@
+package ffi
+
+//#cgo CFLAGS: -I../../
+//#cgo LDFLAGS: -L../../build/lib/controlplane/cancellation -lcancellation
+//
+//#include "lib/controlplane/cancellation/cancellation.h"
+import "C"
+
+import (
+	"context"
+	"runtime"
+)
+
+// WithCancellation runs a blocking C call under the context's control.
+//
+// A one-shot token is bound to the calling OS thread for the duration of
+// the call and raised when the context ends, so C code can poll for the
+// request without a token threaded through every signature. A context
+// that cannot be cancelled binds nothing instead. The call is never
+// abandoned: this returns only after the call itself has returned, and a
+// context that is already done fails fast without entering C.
+func WithCancellation(ctx context.Context, call func() error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// The token is observed through thread-local state, so the goroutine
+	// must not migrate between binding and the call.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// A call that cannot be cancelled still replaces the binding, so it
+	// does not inherit the request that some enclosing call is running
+	// under and give up on work that one was allowed to abandon.
+	if ctx.Done() == nil {
+		previous := C.cancellation_token_bind(nil)
+		defer C.cancellation_token_bind(previous)
+
+		return call()
+	}
+
+	token := new(C.struct_cancellation_token)
+
+	var pinner runtime.Pinner
+	pinner.Pin(token)
+	defer pinner.Unpin()
+
+	previous := C.cancellation_token_bind(token)
+	defer C.cancellation_token_bind(previous)
+
+	stop := context.AfterFunc(ctx, func() {
+		C.cancellation_token_fire(token)
+	})
+	defer stop()
+
+	return call()
+}

--- a/controlplane/ffi/cancellation_test.go
+++ b/controlplane/ffi/cancellation_test.go
@@ -1,0 +1,36 @@
+package ffi_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+// Test_WithCancellation_DoneContextFailsFast verifies that a context that
+// is already done reports its own error without entering the call.
+func Test_WithCancellation_DoneContextFailsFast(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	called := false
+	err := ffi.WithCancellation(ctx, func() error {
+		called = true
+		return nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, called)
+}
+
+// Test_WithCancellation_ReturnsCallError verifies that the call's own
+// error passes through unchanged while the context stays live.
+func Test_WithCancellation_ReturnsCallError(t *testing.T) {
+	callErr := errors.New("call failed")
+	err := ffi.WithCancellation(t.Context(), func() error {
+		return callErr
+	})
+	require.ErrorIs(t, err, callErr)
+}

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -299,6 +299,10 @@ func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 			serverMetrics.UnaryServerInterceptor(),
 			auth.UnaryServerInterceptor(authManager, log),
 			xgrpc.AccessLogInterceptor(log),
+			// Innermost, so the outer logging and metrics observe the
+			// outcome it rewrites rather than the internal failure the
+			// handler reported.
+			xgrpc.ContextStatusInterceptor(),
 		),
 		grpc.ChainStreamInterceptor(
 			serverMetrics.StreamServerInterceptor(),

--- a/controlplane/gateway/runner.go
+++ b/controlplane/gateway/runner.go
@@ -73,6 +73,9 @@ func NewServiceRunner(
 	if provider, ok := module.(UnaryInterceptedService); ok {
 		interceptors = append(interceptors, provider.UnaryServerInterceptors()...)
 	}
+	// Innermost, so the outer logging and metrics observe the outcome it
+	// rewrites rather than the internal failure the handler reported.
+	interceptors = append(interceptors, xgrpc.ContextStatusInterceptor())
 
 	return &ServiceRunner{
 		module:          module,

--- a/controlplane/internal/xgrpc/contextstatus.go
+++ b/controlplane/internal/xgrpc/contextstatus.go
@@ -1,0 +1,68 @@
+package xgrpc
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// callerGone reports whether code says the call ended because whoever
+// asked for it stopped waiting, rather than because the service failed.
+func callerGone(code codes.Code) bool {
+	return code == codes.Canceled || code == codes.DeadlineExceeded
+}
+
+// ContextStatusInterceptor reports a call whose caller walked away with
+// the code describing that, rather than a server fault.
+//
+// A handler that gives up on a dead context wraps the reason into its own
+// internal failure, which metrics and access logs would otherwise count
+// as the service breaking. A failure that merely raced the hangup is
+// relabelled too, because handlers flatten the reason into a message
+// rather than a wrapped error and the caller is gone either way; the
+// original text survives so the log still says what happened. Work that
+// could not be abandoned still finishes after its caller has gone, and
+// counts the same way, so one hangup reads alike however late it lands.
+func ContextStatusInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		response, err := handler(ctx, req)
+
+		var code codes.Code
+		switch {
+		case errors.Is(ctx.Err(), context.Canceled):
+			code = codes.Canceled
+		case errors.Is(ctx.Err(), context.DeadlineExceeded):
+			code = codes.DeadlineExceeded
+		case err != nil:
+			return nil, err
+		default:
+			return response, nil
+		}
+
+		if err == nil {
+			return nil, status.Error(code, "completed after its caller left")
+		}
+
+		// A refusal the handler decided on its own says something the
+		// caller leaving does not explain, so only the two codes it
+		// reaches for when it flattens a reason into a message are
+		// eligible.
+		switch status.Code(err) {
+		case codes.Unknown, codes.Internal:
+		default:
+			return nil, err
+		}
+
+		// Re-wrapping the error itself would nest a rendered status
+		// inside the message of another one.
+		return nil, status.Error(code, status.Convert(err).Message())
+	}
+}

--- a/controlplane/internal/xgrpc/contextstatus_test.go
+++ b/controlplane/internal/xgrpc/contextstatus_test.go
@@ -1,0 +1,180 @@
+package xgrpc_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/xgrpc"
+)
+
+// Test_ContextStatusInterceptor_Outcome verifies which failures are
+// reported as the caller having walked away, and that the reason the
+// handler gave survives the relabelling exactly once.
+func Test_ContextStatusInterceptor_Outcome(t *testing.T) {
+	handlerErr := status.Error(codes.Internal, "failed to update module config")
+
+	tests := []struct {
+		name        string
+		context     func(t *testing.T) context.Context
+		handlerErr  error
+		wantCode    codes.Code
+		wantMessage string
+	}{
+		{
+			name:       "successful handler is untouched",
+			context:    func(t *testing.T) context.Context { return t.Context() },
+			handlerErr: nil,
+			wantCode:   codes.OK,
+		},
+		{
+			name: "cancelled context reports work its caller left behind",
+			context: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			handlerErr:  nil,
+			wantCode:    codes.Canceled,
+			wantMessage: "completed after its caller left",
+		},
+		{
+			name:        "live context keeps the handler's own code",
+			context:     func(t *testing.T) context.Context { return t.Context() },
+			handlerErr:  handlerErr,
+			wantCode:    codes.Internal,
+			wantMessage: "failed to update module config",
+		},
+		{
+			name: "cancelled context reports the caller leaving",
+			context: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			handlerErr:  handlerErr,
+			wantCode:    codes.Canceled,
+			wantMessage: "failed to update module config",
+		},
+		{
+			name: "cancelled context relabels a plain handler error",
+			context: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			handlerErr:  errors.New("failed to update device"),
+			wantCode:    codes.Canceled,
+			wantMessage: "failed to update device",
+		},
+		{
+			name: "cancelled context keeps a refusal the handler chose",
+			context: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			handlerErr:  status.Error(codes.InvalidArgument, "prefix is malformed"),
+			wantCode:    codes.InvalidArgument,
+			wantMessage: "prefix is malformed",
+		},
+		{
+			name: "expired deadline reports the deadline",
+			context: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithDeadline(t.Context(), time.Now())
+				t.Cleanup(cancel)
+				return ctx
+			},
+			handlerErr:  handlerErr,
+			wantCode:    codes.DeadlineExceeded,
+			wantMessage: "failed to update module config",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := func(ctx context.Context, req any) (any, error) {
+				return "response", test.handlerErr
+			}
+
+			response, err := xgrpc.ContextStatusInterceptor()(
+				test.context(t),
+				nil,
+				&grpc.UnaryServerInfo{},
+				handler,
+			)
+
+			require.Equal(t, test.wantCode, status.Code(err))
+			if test.wantCode == codes.OK {
+				require.NoError(t, err)
+				require.Equal(t, "response", response)
+				return
+			}
+			require.Equal(t, test.wantMessage, status.Convert(err).Message())
+			require.Nil(t, response)
+		})
+	}
+}
+
+// Test_AccessLogInterceptor_AbandonedCallLevel verifies that a call its
+// caller walked away from is not logged at the level reserved for the
+// service failing.
+func Test_AccessLogInterceptor_AbandonedCallLevel(t *testing.T) {
+	tests := []struct {
+		name       string
+		handlerErr error
+		wantLevel  string
+	}{
+		{
+			name:       "cancelled call is not a fault",
+			handlerErr: status.Error(codes.Canceled, "gone"),
+			wantLevel:  `"level":"info"`,
+		},
+		{
+			name:       "expired deadline is not a fault",
+			handlerErr: status.Error(codes.DeadlineExceeded, "too late"),
+			wantLevel:  `"level":"info"`,
+		},
+		{
+			name:       "genuine failure stays a fault",
+			handlerErr: status.Error(codes.Internal, "shared memory exhausted"),
+			wantLevel:  `"level":"error"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			logger := zap.New(zapcore.NewCore(
+				zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+					MessageKey:  "msg",
+					LevelKey:    "level",
+					EncodeLevel: zapcore.LowercaseLevelEncoder,
+				}),
+				zapcore.AddSync(buf),
+				zap.DebugLevel,
+			))
+
+			_, err := xgrpc.AccessLogInterceptor(logger)(
+				t.Context(),
+				nil,
+				&grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+				func(ctx context.Context, req any) (any, error) {
+					return nil, test.handlerErr
+				},
+			)
+			require.Error(t, err)
+			require.NoError(t, logger.Sync())
+			require.Contains(t, buf.String(), test.wantLevel)
+		})
+	}
+}

--- a/controlplane/internal/xgrpc/interceptor.go
+++ b/controlplane/internal/xgrpc/interceptor.go
@@ -74,11 +74,15 @@ func AccessLogInterceptor(log *zap.Logger) grpc.UnaryServerInterceptor {
 			)
 		}
 
-		if err != nil {
+		switch {
+		case err == nil:
+			log.Info("completed gRPC execution", fields...)
+		case callerGone(status.Code()):
+			fields = append(fields, zap.Error(err))
+			log.Info("abandoned gRPC execution", fields...)
+		default:
 			fields = append(fields, zap.Error(err))
 			log.Error("failed to execute gRPC", fields...)
-		} else {
-			log.Info("completed gRPC execution", fields...)
 		}
 
 		return resp, err

--- a/controlplane/meson.build
+++ b/controlplane/meson.build
@@ -70,6 +70,7 @@ custom_target(
         lib_dev_trafgen_dp,
         lib_filter_compiler,
         lib_agent_counters,
+        lib_cancellation_cp,
         lib_counter_pattern,
     ] + librure_targets,
     install: true,

--- a/devices/plain/controlplane/ffi.go
+++ b/devices/plain/controlplane/ffi.go
@@ -10,6 +10,7 @@ package plain
 import "C"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"syscall"
@@ -127,7 +128,7 @@ func (m *DeviceConfig) Free() error {
 // with ffi.ErrStillReferenced and the owner must retry once the
 // generations drain. On failure every handle is destroyed here — the
 // devices were never registered — and nil is returned.
-func UpdateDevices(agent *ffi.Agent, devices []ffi.DeviceConfig) ([]*DeviceConfig, error) {
+func UpdateDevices(ctx context.Context, agent *ffi.Agent, devices []ffi.DeviceConfig) ([]*DeviceConfig, error) {
 	handles := make([]*DeviceConfig, 0, len(devices))
 	defer func() {
 		if len(handles) == 0 {
@@ -165,7 +166,7 @@ func UpdateDevices(agent *ffi.Agent, devices []ffi.DeviceConfig) ([]*DeviceConfi
 		configs = append(configs, device.AsFFIDevice())
 	}
 
-	if err := agent.UpdateDevices(configs); err != nil {
+	if err := agent.UpdateDevices(ctx, configs); err != nil {
 		return nil, fmt.Errorf("failed to update devices: %w", err)
 	}
 

--- a/devices/plain/controlplane/service.go
+++ b/devices/plain/controlplane/service.go
@@ -51,9 +51,9 @@ func (m *DevicePlainService) UpdateDevice(
 		return nil, fmt.Errorf("failed to create device config: %w", err)
 	}
 
-	if err := m.agent.UpdateDevices([]ffi.ShmDeviceConfig{deviceConfig.AsFFIDevice()}); err != nil {
-		if err := deviceConfig.Free(); err != nil {
-			return nil, fmt.Errorf("failed to update device and free the unpublished replacement: %w (update error: %v)", err, err)
+	if err := m.agent.UpdateDevices(ctx, []ffi.ShmDeviceConfig{deviceConfig.AsFFIDevice()}); err != nil {
+		if freeErr := deviceConfig.Free(); freeErr != nil {
+			return nil, fmt.Errorf("failed to update device and free the unpublished replacement: %w (free error: %v)", err, freeErr)
 		}
 		return nil, fmt.Errorf("failed to update device: %w", err)
 	}

--- a/devices/trafgen/controlplane/backend.go
+++ b/devices/trafgen/controlplane/backend.go
@@ -1,6 +1,7 @@
 package trafgen
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -20,6 +21,7 @@ func NewBackend(agent *ffi.Agent) Backend {
 }
 
 func (m *backend) UpdateDevice(
+	ctx context.Context,
 	name string,
 	input []Pipeline,
 	output []Pipeline,
@@ -27,6 +29,10 @@ func (m *backend) UpdateDevice(
 	lengths []uint32,
 	ratePps uint64,
 ) (*ctrafgen.DeviceConfig, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	device, err := ctrafgen.NewDeviceConfig(
 		m.agent,
 		name,
@@ -41,6 +47,7 @@ func (m *backend) UpdateDevice(
 	}
 
 	if err := m.agent.UpdateDevices(
+		ctx,
 		[]ffi.ShmDeviceConfig{device.AsFFIDevice()},
 	); err != nil {
 		if err := device.Free(); err != nil {

--- a/devices/trafgen/controlplane/service.go
+++ b/devices/trafgen/controlplane/service.go
@@ -40,7 +40,14 @@ type Backend interface {
 	//
 	// It returns the freshly published handle. The caller owns the handle
 	// and must Free it once a newer generation has superseded it.
-	UpdateDevice(name string, input, output []Pipeline, frames []byte, lengths []uint32, ratePps uint64) (*ctrafgen.DeviceConfig, error)
+	UpdateDevice(
+		ctx context.Context,
+		name string,
+		input, output []Pipeline,
+		frames []byte,
+		lengths []uint32,
+		ratePps uint64,
+	) (*ctrafgen.DeviceConfig, error)
 }
 
 type config struct {
@@ -101,7 +108,7 @@ func (m *TrafgenService) UpdateDevice(
 		ratePps = old.RatePps
 	}
 
-	if err := m.apply(name, packets, ratePps, input, output); err != nil {
+	if err := m.apply(ctx, name, packets, ratePps, input, output); err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to update device config %q: %v", name, err,
@@ -206,7 +213,7 @@ func (m *TrafgenService) UploadPcap(
 		output = old.Output
 	}
 
-	if err := m.apply(name, packets, ratePps, input, output); err != nil {
+	if err := m.apply(ctx, name, packets, ratePps, input, output); err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to update device config %q: %v", name, err,
@@ -238,7 +245,7 @@ func (m *TrafgenService) SetRate(
 		output = old.Output
 	}
 
-	if err := m.apply(name, packets, req.GetRatePps(), input, output); err != nil {
+	if err := m.apply(ctx, name, packets, req.GetRatePps(), input, output); err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to update device config %q: %v", name, err,
@@ -256,6 +263,7 @@ func (m *TrafgenService) SetRate(
 // after: freed outright when dangling, parked while a pinned generation
 // still references it.
 func (m *TrafgenService) apply(
+	ctx context.Context,
 	name string,
 	packets [][]byte,
 	ratePps uint64,
@@ -263,7 +271,7 @@ func (m *TrafgenService) apply(
 ) error {
 	frames, lengths := flattenFrames(packets)
 
-	handle, err := m.backend.UpdateDevice(name, input, output, frames, lengths, ratePps)
+	handle, err := m.backend.UpdateDevice(ctx, name, input, output, frames, lengths, ratePps)
 	if err != nil {
 		return fmt.Errorf("failed to update device config %q: %w", name, err)
 	}

--- a/devices/trafgen/controlplane/service_test.go
+++ b/devices/trafgen/controlplane/service_test.go
@@ -2,6 +2,7 @@ package trafgen
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ type recordingBackend struct {
 }
 
 func (m *recordingBackend) UpdateDevice(
+	ctx context.Context,
 	name string,
 	input, output []Pipeline,
 	frames []byte,

--- a/devices/vlan/controlplane/service.go
+++ b/devices/vlan/controlplane/service.go
@@ -51,9 +51,9 @@ func (m *DeviceVlanService) UpdateDevice(
 		return nil, fmt.Errorf("failed to create device config: %w", err)
 	}
 
-	if err := m.agent.UpdateDevices([]ffi.ShmDeviceConfig{deviceConfig.AsFFIDevice()}); err != nil {
-		if err := deviceConfig.Free(); err != nil {
-			return nil, fmt.Errorf("failed to update device and free the unpublished replacement: %w (update error: %v)", err, err)
+	if err := m.agent.UpdateDevices(ctx, []ffi.ShmDeviceConfig{deviceConfig.AsFFIDevice()}); err != nil {
+		if freeErr := deviceConfig.Free(); freeErr != nil {
+			return nil, fmt.Errorf("failed to update device and free the unpublished replacement: %w (free error: %v)", err, freeErr)
 		}
 		return nil, fmt.Errorf("failed to update device: %w", err)
 	}

--- a/lib/controlplane/cancellation/cancellation.c
+++ b/lib/controlplane/cancellation/cancellation.c
@@ -1,0 +1,25 @@
+#include "cancellation.h"
+
+#include <stddef.h>
+
+static __thread struct cancellation_token *bound_token = NULL;
+
+// Relaxed ordering suffices here and on the matching load: the flag is a
+// monotonic one-shot signal that publishes no data of its own.
+void
+cancellation_token_fire(struct cancellation_token *token) {
+	__atomic_store_n(&token->cancelled, 1, __ATOMIC_RELAXED);
+}
+
+struct cancellation_token *
+cancellation_token_bind(struct cancellation_token *token) {
+	struct cancellation_token *previous = bound_token;
+	bound_token = token;
+	return previous;
+}
+
+bool
+cancellation_requested(void) {
+	return bound_token != NULL &&
+	       __atomic_load_n(&bound_token->cancelled, __ATOMIC_RELAXED);
+}

--- a/lib/controlplane/cancellation/cancellation.h
+++ b/lib/controlplane/cancellation/cancellation.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// One-shot cooperative cancellation request shared between a caller and
+// the thread executing a long operation on its behalf.
+//
+// The flag is raised at most once and is never reset, so a token serves
+// exactly one operation.
+struct cancellation_token {
+	uint32_t cancelled;
+};
+
+// Safe from any thread, including while the bound thread polls the same
+// token. The token must exist.
+void
+cancellation_token_fire(struct cancellation_token *token);
+
+// Binds a token to the calling thread and returns the binding it
+// replaced; NULL unbinds.
+//
+// Long operations poll the binding of their own thread instead of
+// receiving a token through every signature. Restoring the returned
+// binding on the way out keeps an operation nested inside another from
+// disarming the outer one.
+struct cancellation_token *
+cancellation_token_bind(struct cancellation_token *token);
+
+// Reports whether the token bound to the calling thread was raised.
+//
+// A thread with no binding is never cancelled. Giving up on a raise is
+// only safe where nothing has been published and no lock is held: the
+// shared-memory locks have no owner-death recovery, and a generation the
+// workers can already reach cannot be withdrawn.
+bool
+cancellation_requested(void);

--- a/lib/controlplane/cancellation/meson.build
+++ b/lib/controlplane/cancellation/meson.build
@@ -1,0 +1,16 @@
+sources = files(
+  'cancellation.c',
+)
+
+lib_cancellation_cp = static_library(
+  'cancellation',
+  sources,
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  install: false,
+)
+
+lib_cancellation_cp_dep = declare_dependency(
+  link_with: lib_cancellation_cp,
+  include_directories: yanet_rootdir,
+)

--- a/lib/controlplane/meson.build
+++ b/lib/controlplane/meson.build
@@ -1,2 +1,3 @@
+subdir('cancellation')
 subdir('config')
 subdir('agent')

--- a/lib/controlplane/tests/cancellation_test.c
+++ b/lib/controlplane/tests/cancellation_test.c
@@ -1,0 +1,119 @@
+/*
+ * Pins the cancellation token contract.
+ *
+ * A token is raised from any thread but observed through a thread-local
+ * binding: a thread with no binding is never cancelled, a bound thread
+ * sees a raise made elsewhere, the raising thread does not, and a nested
+ * binding restores the one it replaced.
+ */
+
+#include "common/test_assert.h"
+
+#include "lib/controlplane/cancellation/cancellation.h"
+
+#include "lib/logging/log.h"
+
+#include <pthread.h>
+#include <stdbool.h>
+
+struct fire_args {
+	struct cancellation_token *token;
+	bool raiser_saw_cancel;
+};
+
+// Raises the token of another thread, recording whether the raise makes
+// the raising thread itself appear cancelled.
+static void *
+fire_thread(void *arg) {
+	struct fire_args *args = arg;
+	cancellation_token_fire(args->token);
+	args->raiser_saw_cancel = cancellation_requested();
+	return NULL;
+}
+
+// Verifies that a thread without a binding, or holding an unraised
+// token, is not cancelled.
+static int
+run_unbound_test(void) {
+	TEST_ASSERT(!cancellation_requested(), "cancelled with no binding");
+
+	struct cancellation_token token = {0};
+	TEST_ASSERT(
+		cancellation_token_bind(&token) == NULL,
+		"reported a binding that was never made"
+	);
+	TEST_ASSERT(!cancellation_requested(), "cancelled before any raise");
+
+	// The scenarios below start from a thread that holds no binding.
+	cancellation_token_bind(NULL);
+	return TEST_SUCCESS;
+}
+
+// Verifies that a raise reaches the bound thread, leaves the raising
+// thread alone, and stops being visible once the binding is dropped.
+static int
+run_cross_thread_fire_test(void) {
+	struct cancellation_token token = {0};
+	cancellation_token_bind(&token);
+
+	struct fire_args args = {
+		.token = &token,
+		.raiser_saw_cancel = true,
+	};
+	pthread_t raiser;
+	TEST_ASSERT_SUCCESS(
+		pthread_create(&raiser, NULL, fire_thread, &args),
+		"failed to start the raising thread"
+	);
+	TEST_ASSERT_SUCCESS(
+		pthread_join(raiser, NULL), "failed to join the raising thread"
+	);
+
+	TEST_ASSERT(
+		!args.raiser_saw_cancel,
+		"the raise reached a thread that never bound the token"
+	);
+	TEST_ASSERT(cancellation_requested(), "the raise was not observed");
+
+	cancellation_token_bind(NULL);
+	TEST_ASSERT(!cancellation_requested(), "cancelled after unbinding");
+	return TEST_SUCCESS;
+}
+
+// Verifies that a nested binding restores the one it replaced, leaving
+// the outer operation armed.
+static int
+run_nested_bind_test(void) {
+	struct cancellation_token outer = {0};
+	struct cancellation_token inner = {0};
+
+	cancellation_token_bind(&outer);
+	struct cancellation_token *replaced = cancellation_token_bind(&inner);
+	TEST_ASSERT(
+		replaced == &outer, "the replaced binding was not reported"
+	);
+
+	cancellation_token_fire(&outer);
+	TEST_ASSERT(
+		!cancellation_requested(),
+		"the outer raise reached the nested binding"
+	);
+
+	cancellation_token_bind(replaced);
+	TEST_ASSERT(cancellation_requested(), "the outer binding was lost");
+
+	cancellation_token_bind(NULL);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("error");
+
+	if (run_unbound_test() != TEST_SUCCESS ||
+	    run_cross_thread_fire_test() != TEST_SUCCESS ||
+	    run_nested_bind_test() != TEST_SUCCESS) {
+		return 1;
+	}
+	return 0;
+}

--- a/lib/controlplane/tests/meson.build
+++ b/lib/controlplane/tests/meson.build
@@ -215,3 +215,18 @@ dangling_objects_test = executable(
 )
 
 test('dangling_objects', dangling_objects_test, suite: ['lib'])
+
+cancellation_test = executable(
+  'cancellation_test',
+  ['cancellation_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_cancellation_cp_dep,
+    lib_logging_dep,
+    dependency('threads'),
+  ],
+  include_directories: yanet_rootdir,
+)
+
+test('cancellation', cancellation_test, suite: ['lib'])

--- a/modules/acl/bindings/go/cacl/cgo.go
+++ b/modules/acl/bindings/go/cacl/cgo.go
@@ -11,6 +11,7 @@ package cacl
 import "C"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -37,14 +38,20 @@ type ModuleConfig struct {
 // are declared as object links here and resolve against published
 // objects when the config is published. An empty name declares no link,
 // and CHECK_STATE then finds no state for that family. Pass nil
-// emitConfig for a ruleset that emits no sync packets.
+// emitConfig for a ruleset that emits no sync packets. A context that is
+// already done returns without compiling anything.
 func NewModuleConfig(
+	ctx context.Context,
 	agent *ffi.Agent,
 	name string,
 	rules []AclRule,
 	fw4MapName, fw6MapName string,
 	emitConfig *cfwstate.SyncEmitConfig,
 ) (*ModuleConfig, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	pinner := &runtime.Pinner{}
 	defer pinner.Unpin()
 
@@ -83,18 +90,29 @@ func NewModuleConfig(
 	defer C.free(unsafe.Pointer(cName))
 
 	var cErr *C.yanet_error
-	ptr := C.acl_module_config_init(
-		(*C.struct_agent)(agent.AsRawPtr()),
-		cName,
-		cRulesPtr,
-		C.uint32_t(len(cRules)),
-		cFw4Name,
-		cFw6Name,
-		(*C.struct_fwstate_sync_emit_config)(cEmitPtr),
-		&cErr,
-	)
-	if ptr == nil {
-		return nil, fmt.Errorf("failed to initialize module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	var ptr *C.struct_cp_module
+
+	// Compiling the ruleset is the long step of an update, so it runs
+	// under the caller's cancellation rather than ahead of it.
+	err := ffi.WithCancellation(ctx, func() error {
+		ptr = C.acl_module_config_init(
+			(*C.struct_agent)(agent.AsRawPtr()),
+			cName,
+			cRulesPtr,
+			C.uint32_t(len(cRules)),
+			cFw4Name,
+			cFw6Name,
+			(*C.struct_fwstate_sync_emit_config)(cEmitPtr),
+			&cErr,
+		)
+		if ptr == nil {
+			return fmt.Errorf("failed to initialize module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &ModuleConfig{

--- a/modules/acl/controlplane/backend.go
+++ b/modules/acl/controlplane/backend.go
@@ -1,6 +1,7 @@
 package acl
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -19,13 +20,14 @@ func NewBackend(agent *ffi.Agent) Backend {
 }
 
 func (m *backend) NewModule(
+	ctx context.Context,
 	name string,
 	rules []cacl.AclRule,
 	fw4MapName, fw6MapName string,
 	emitConfig *cfwstate.SyncEmitConfig,
 ) (ModuleHandle, error) {
 	handle, err := cacl.NewModuleConfig(
-		m.agent, name, rules, fw4MapName, fw6MapName, emitConfig,
+		ctx, m.agent, name, rules, fw4MapName, fw6MapName, emitConfig,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module config: %w", err)
@@ -34,12 +36,12 @@ func (m *backend) NewModule(
 	return handle, nil
 }
 
-func (m *backend) UpdateModule(handle ModuleHandle) error {
-	return m.agent.UpdateModules([]ffi.ModuleConfig{handle.AsFFIModule()})
+func (m *backend) UpdateModule(ctx context.Context, handle ModuleHandle) error {
+	return m.agent.UpdateModules(ctx, []ffi.ModuleConfig{handle.AsFFIModule()})
 }
 
-func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(moduleType, name)
+func (m *backend) DeleteModule(ctx context.Context, name string) error {
+	return m.agent.DeleteModuleConfig(ctx, moduleType, name)
 }
 
 func (m *backend) DPConfig() *ffi.DPConfig {

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -43,6 +43,7 @@ type Backend interface {
 	// the ruleset compiled into it and the named fwstate-map objects
 	// linked. The returned handle is not yet published to the dataplane.
 	NewModule(
+		ctx context.Context,
 		name string,
 		rules []cacl.AclRule,
 		fw4MapName, fw6MapName string,
@@ -50,9 +51,9 @@ type Backend interface {
 	) (ModuleHandle, error)
 	// UpdateModule publishes handle to dp_config_gen so the dataplane
 	// picks it up on the next round.
-	UpdateModule(handle ModuleHandle) error
+	UpdateModule(ctx context.Context, handle ModuleHandle) error
 	// DeleteModule removes a module config from the dataplane.
-	DeleteModule(name string) error
+	DeleteModule(ctx context.Context, name string) error
 	// DPConfig returns the dataplane configuration handle for counter
 	// and position queries.
 	DPConfig() *ffi.DPConfig
@@ -631,13 +632,13 @@ func (m *ACLService) UpdateConfig(
 		}
 
 		handle, err := m.backend.NewModule(
-			name, rules, fw4MapName, fw6MapName, emitCfg,
+			ctx, name, rules, fw4MapName, fw6MapName, emitCfg,
 		)
 		if err != nil {
 			return status.Errorf(codes.Internal, "failed to create module config: %v", err)
 		}
 
-		if err := m.backend.UpdateModule(handle); err != nil {
+		if err := m.backend.UpdateModule(ctx, handle); err != nil {
 			if err := handle.Free(); err != nil {
 				m.log.Error("failed to free unpublished acl module",
 					zap.Error(err))
@@ -777,7 +778,7 @@ func (m *ACLService) DeleteConfig(
 		}
 
 		if config.Handle() != nil {
-			if err := m.backend.DeleteModule(name); err != nil {
+			if err := m.backend.DeleteModule(ctx, name); err != nil {
 				return status.Errorf(codes.Internal, "could not delete acl module config '%s': %v", name, err)
 			}
 			m.log.Info("successfully deleted ACL module config", zap.String("name", name))

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -169,7 +169,7 @@ func (m *blockingUpdateBackend) blockNextUpdate() (<-chan struct{}, func()) {
 	})
 }
 
-func (m *blockingUpdateBackend) UpdateModule(handle acl.ModuleHandle) error {
+func (m *blockingUpdateBackend) UpdateModule(ctx context.Context, handle acl.ModuleHandle) error {
 	m.blockMu.Lock()
 	block := m.nextBlock
 	m.nextBlock = nil
@@ -180,7 +180,7 @@ func (m *blockingUpdateBackend) UpdateModule(handle acl.ModuleHandle) error {
 		<-block.release
 	}
 
-	return m.fakeBackend.UpdateModule(handle)
+	return m.fakeBackend.UpdateModule(ctx, handle)
 }
 
 func newBlockingDPConfigBackend(dpConfig *ffi.DPConfig) *blockingDPConfigBackend {
@@ -249,14 +249,14 @@ func newMetricsSnapshotHarness(testingTB testing.TB) (*dataplaneut.Harness, *ffi
 	moduleNames := []string{"acl0", "a", "b", "c", "d"}
 	moduleConfigs := make([]ffi.ModuleConfig, 0, len(moduleNames))
 	for _, name := range moduleNames {
-		moduleConfig, moduleErr := cacl.NewModuleConfig(agent, name, nil, "", "", nil)
+		moduleConfig, moduleErr := cacl.NewModuleConfig(testingTB.Context(), agent, name, nil, "", "", nil)
 		require.NoError(testingTB, moduleErr)
 		testingTB.Cleanup(func() { _ = moduleConfig.Free() })
 		moduleConfigs = append(moduleConfigs, moduleConfig.AsFFIModule())
 	}
-	require.NoError(testingTB, agent.UpdateModules(moduleConfigs))
+	require.NoError(testingTB, agent.UpdateModules(testingTB.Context(), moduleConfigs))
 
-	require.NoError(testingTB, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(testingTB, agent.UpdateFunction(testingTB.Context(), ffi.FunctionConfig{
 		Name: "function0",
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -275,11 +275,11 @@ func newMetricsSnapshotHarness(testingTB testing.TB) (*dataplaneut.Harness, *ffi
 			},
 		}},
 	}))
-	require.NoError(testingTB, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(testingTB, agent.UpdatePipeline(testingTB.Context(), ffi.PipelineConfig{
 		Name:      "pipeline0",
 		Functions: []string{"function0"},
 	}))
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	_, err = plain.UpdateDevices(testingTB.Context(), agent, []ffi.DeviceConfig{{
 		Name:  "port0",
 		Input: []ffi.DevicePipelineConfig{{Name: "pipeline0", Weight: 1}},
 	}})
@@ -289,6 +289,7 @@ func newMetricsSnapshotHarness(testingTB testing.TB) (*dataplaneut.Harness, *ffi
 }
 
 func (m *fakeBackend) NewModule(
+	ctx context.Context,
 	name string,
 	rules []cacl.AclRule,
 	fw4MapName, fw6MapName string,
@@ -321,7 +322,7 @@ func (m *fakeBackend) CreatedHandles() []*fakeHandle {
 	return append([]*fakeHandle(nil), m.created...)
 }
 
-func (m *fakeBackend) UpdateModule(handle acl.ModuleHandle) error {
+func (m *fakeBackend) UpdateModule(ctx context.Context, handle acl.ModuleHandle) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -336,7 +337,7 @@ func (m *fakeBackend) UpdateModule(handle acl.ModuleHandle) error {
 	return nil
 }
 
-func (m *fakeBackend) DeleteModule(name string) error {
+func (m *fakeBackend) DeleteModule(ctx context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -482,6 +483,7 @@ func (m *compileBlockingBackend) entryOrder() []string {
 }
 
 func (m *compileBlockingBackend) NewModule(
+	ctx context.Context,
 	name string,
 	rules []cacl.AclRule,
 	fw4MapName, fw6MapName string,
@@ -492,7 +494,7 @@ func (m *compileBlockingBackend) NewModule(
 		close(block.entered)
 		<-block.release
 	}
-	return m.fakeBackend.NewModule(name, rules, fw4MapName, fw6MapName, emitConfig)
+	return m.fakeBackend.NewModule(ctx, name, rules, fw4MapName, fw6MapName, emitConfig)
 }
 
 func newTestService(b acl.Backend) *acl.ACLService {

--- a/modules/acl/tests/functional/acl_bench_dataset_test.go
+++ b/modules/acl/tests/functional/acl_bench_dataset_test.go
@@ -677,12 +677,12 @@ func datasetBenchSetup(b *testing.B) *datasetBenchState {
 		}
 		backend := acl.NewBackend(agent)
 
-		handle, err := backend.NewModule("dataset", rules, "", "", nil)
+		handle, err := backend.NewModule(b.Context(), "dataset", rules, "", "", nil)
 		if err != nil {
 			datasetBenchErr = err
 			return
 		}
-		if datasetBenchErr = backend.UpdateModule(handle); datasetBenchErr != nil {
+		if datasetBenchErr = backend.UpdateModule(b.Context(), handle); datasetBenchErr != nil {
 			return
 		}
 		datasetBench = &datasetBenchState{
@@ -828,12 +828,12 @@ func datasetTopoBenchSetup(b *testing.B) *datasetBenchState {
 		}
 		backend := acl.NewBackend(agent)
 
-		handle, err := backend.NewModule("dataset", rules, "", "", nil)
+		handle, err := backend.NewModule(b.Context(), "dataset", rules, "", "", nil)
 		if err != nil {
 			topoBenchErr = err
 			return
 		}
-		if topoBenchErr = backend.UpdateModule(handle); topoBenchErr != nil {
+		if topoBenchErr = backend.UpdateModule(b.Context(), handle); topoBenchErr != nil {
 			return
 		}
 		topoBench = &datasetBenchState{
@@ -869,11 +869,11 @@ func wireACLTopoPipeline(tb testing.TB, agent *ffi.Agent, configName string) {
 			Devices: filter.Devices{{Name: dev}},
 		})
 	}
-	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, sinkRules)
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(tb.Context(), sinkName, sinkRules)
 	require.NoError(tb, err)
 	tb.Cleanup(func() { _ = sinkHandle.Free() })
 
-	require.NoError(tb, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(tb, agent.UpdateFunction(tb.Context(), ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -886,14 +886,14 @@ func wireACLTopoPipeline(tb testing.TB, agent *ffi.Agent, configName string) {
 			},
 		}},
 	}))
-	require.NoError(tb, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(tb, agent.UpdatePipeline(tb.Context(), ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
-	require.NoError(tb, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(tb, agent.UpdatePipeline(tb.Context(), ffi.PipelineConfig{
 		Name: "dummy-in",
 	}))
-	require.NoError(tb, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(tb, agent.UpdatePipeline(tb.Context(), ffi.PipelineConfig{
 		Name: "dummy-out",
 	}))
 
@@ -913,7 +913,7 @@ func wireACLTopoPipeline(tb testing.TB, agent *ffi.Agent, configName string) {
 			Output: []ffi.DevicePipelineConfig{{Name: "dummy-out", Weight: 1}},
 		})
 	}
-	_, err = plain.UpdateDevices(agent, devices)
+	_, err = plain.UpdateDevices(tb.Context(), agent, devices)
 	require.NoError(tb, err)
 }
 

--- a/modules/acl/tests/functional/acl_fwstate_agent_test.go
+++ b/modules/acl/tests/functional/acl_fwstate_agent_test.go
@@ -57,7 +57,7 @@ func TestACL_FWStateAgentSharing_TypedDestroyIsolatedPerModule(t *testing.T) {
 
 	fwCfg, err := cfwstate.NewModuleConfig(agent, "fw0", nil, "", "")
 	require.NoError(t, err)
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{fwCfg.AsFFIModule()}))
+	require.NoError(t, agent.UpdateModules(t.Context(), []ffi.ModuleConfig{fwCfg.AsFFIModule()}))
 
 	// The owner's free attempt is refused while the published generation
 	// still references fw0, and is queued for a retry.
@@ -66,7 +66,7 @@ func TestACL_FWStateAgentSharing_TypedDestroyIsolatedPerModule(t *testing.T) {
 	// Retiring the generation that still references fw0 is what lets the
 	// queued free succeed: the delete retries it on its way out and
 	// fwstate's own destructor destroys the module.
-	require.NoError(t, agent.DeleteModuleConfig("fwstate", "fw0"))
+	require.NoError(t, agent.DeleteModuleConfig(t.Context(), "fwstate", "fw0"))
 
 	// An ACL update on the shared agent must not touch anything but its
 	// own acl modules: destruction runs only through each owner's own

--- a/modules/acl/tests/functional/acl_fwtable_object_test.go
+++ b/modules/acl/tests/functional/acl_fwtable_object_test.go
@@ -92,21 +92,22 @@ func TestACL_FWTableObjectStateLookup(t *testing.T) {
 	map4, err := objfwstate.NewMapObjectConfig(agent, "obj4", objfwstate.KindV4)
 	require.NoError(t, err)
 	require.NoError(t, map4.CreateMap(1024, 0, 1))
-	require.NoError(t, map4.Publish(agent))
+	require.NoError(t, map4.Publish(t.Context(), agent))
 	t.Cleanup(func() { _ = map4.Free() })
 
 	map6, err := objfwstate.NewMapObjectConfig(agent, "obj6", objfwstate.KindV6)
 	require.NoError(t, err)
 	require.NoError(t, map6.CreateMap(1024, 0, 1))
-	require.NoError(t, map6.Publish(agent))
+	require.NoError(t, map6.Publish(t.Context(), agent))
 	t.Cleanup(func() { _ = map6.Free() })
 
 	handle, err := backend.NewModule(
+		t.Context(),
 		"acl0", []cacl.AclRule{checkStateDeny4Rule()}, "obj4", "obj6", nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
-	require.NoError(t, backend.UpdateModule(handle))
+	require.NoError(t, backend.UpdateModule(t.Context(), handle))
 
 	wireACLPipeline(t, agent, "port0", "acl0")
 
@@ -163,11 +164,12 @@ func TestACL_FWTableObjectFallbackWithoutNames(t *testing.T) {
 	h, agent, backend := setupACLFWTableHarness(t)
 
 	handle, err := backend.NewModule(
+		t.Context(),
 		"acl0", []cacl.AclRule{checkStateDeny4Rule()}, "", "", nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
-	require.NoError(t, backend.UpdateModule(handle))
+	require.NoError(t, backend.UpdateModule(t.Context(), handle))
 
 	wireACLPipeline(t, agent, "port0", "acl0")
 
@@ -202,12 +204,13 @@ func TestACL_FWTableObjectUnknownNameRejected(t *testing.T) {
 	_, _, backend := setupACLFWTableHarness(t)
 
 	handle, err := backend.NewModule(
+		t.Context(),
 		"acl0", []cacl.AclRule{checkStateDeny4Rule()}, "no-such-map", "", nil,
 	)
 	require.NoError(t, err, "construction only declares the link and must succeed")
 	t.Cleanup(func() { _ = handle.Free() })
 
-	err = backend.UpdateModule(handle)
+	err = backend.UpdateModule(t.Context(), handle)
 	require.Error(t, err, "publishing a config that links an unknown object must fail")
 	require.Contains(t, err.Error(), "linked object")
 	require.Contains(t, err.Error(), "no-such-map")
@@ -226,35 +229,37 @@ func TestACL_FWTableObjectDeleteRefusedWhileLinked(t *testing.T) {
 	map4, err := objfwstate.NewMapObjectConfig(agent, "obj4", objfwstate.KindV4)
 	require.NoError(t, err)
 	require.NoError(t, map4.CreateMap(1024, 0, 1))
-	require.NoError(t, map4.Publish(agent))
+	require.NoError(t, map4.Publish(t.Context(), agent))
 	t.Cleanup(func() { _ = map4.Free() })
 
 	map6, err := objfwstate.NewMapObjectConfig(agent, "obj6", objfwstate.KindV6)
 	require.NoError(t, err)
 	require.NoError(t, map6.CreateMap(1024, 0, 1))
-	require.NoError(t, map6.Publish(agent))
+	require.NoError(t, map6.Publish(t.Context(), agent))
 	t.Cleanup(func() { _ = map6.Free() })
 
 	handle, err := backend.NewModule(
+		t.Context(),
 		"acl0", []cacl.AclRule{checkStateDeny4Rule()}, "obj4", "obj6", nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
-	require.NoError(t, backend.UpdateModule(handle))
+	require.NoError(t, backend.UpdateModule(t.Context(), handle))
 
 	wireACLPipeline(t, agent, "port0", "acl0")
 
-	err = objfwstate.DeleteMapObject(agent, objfwstate.KindV4.ObjectType(), "obj4")
+	err = objfwstate.DeleteMapObject(t.Context(), agent, objfwstate.KindV4.ObjectType(), "obj4")
 	require.Error(t, err, "deleting a map a published module links must be refused")
 	require.Contains(t, err.Error(), "is linked by module")
 
 	unlinked, err := backend.NewModule(
+		t.Context(),
 		"acl0", []cacl.AclRule{checkStateDeny4Rule()}, "", "", nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = unlinked.Free() })
-	require.NoError(t, backend.UpdateModule(unlinked))
+	require.NoError(t, backend.UpdateModule(t.Context(), unlinked))
 	handle.Free()
 
-	require.NoError(t, objfwstate.DeleteMapObject(agent, objfwstate.KindV4.ObjectType(), "obj4"))
+	require.NoError(t, objfwstate.DeleteMapObject(t.Context(), agent, objfwstate.KindV4.ObjectType(), "obj4"))
 }

--- a/modules/acl/tests/functional/acl_sync_config_test.go
+++ b/modules/acl/tests/functional/acl_sync_config_test.go
@@ -70,11 +70,11 @@ func TestACL_UpdateRules_EmitConfigDrivesSyncFrames(t *testing.T) {
 
 	h, agent, backend := setupACLHarness(t, []string{"port0"})
 
-	handle, err := backend.NewModule("sync-emit", []cacl.AclRule{rule}, "", "", syncEmitConfig())
+	handle, err := backend.NewModule(t.Context(), "sync-emit", []cacl.AclRule{rule}, "", "", syncEmitConfig())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
 
-	require.NoError(t, backend.UpdateModule(handle))
+	require.NoError(t, backend.UpdateModule(t.Context(), handle))
 	wireACLPipeline(t, agent, "port0", "sync-emit")
 
 	result, err := h.HandlePackets(syncStatePacket(t))
@@ -99,17 +99,17 @@ func TestACL_UpdateRules_NilEmitConfigClearsPreviousSyncConfig(t *testing.T) {
 	// arena (the sizes the net6-share tests proved under ASan).
 	h, agent, backend := setupACLHarnessSized(t, []string{"port0"}, 192*datasize.MB, 48*datasize.MB)
 
-	handle, err := backend.NewModule("sync-emit", []cacl.AclRule{rule}, "", "", syncEmitConfig())
+	handle, err := backend.NewModule(t.Context(), "sync-emit", []cacl.AclRule{rule}, "", "", syncEmitConfig())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
-	require.NoError(t, backend.UpdateModule(handle))
+	require.NoError(t, backend.UpdateModule(t.Context(), handle))
 	wireACLPipeline(t, agent, "port0", "sync-emit")
 
 	result, err := h.HandlePackets(syncStatePacket(t))
 	require.NoError(t, err)
 	require.Len(t, result.Output, 2, "the emit config must drive a state-sync frame first")
 
-	handle, err = backend.NewModule("sync-emit", []cacl.AclRule{rule}, "", "", nil)
+	handle, err = backend.NewModule(t.Context(), "sync-emit", []cacl.AclRule{rule}, "", "", nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
 
@@ -118,7 +118,7 @@ func TestACL_UpdateRules_NilEmitConfigClearsPreviousSyncConfig(t *testing.T) {
 	// Drive bare rounds until the replacement publish completes.
 	publishDone := make(chan error, 1)
 	go func() {
-		publishDone <- backend.UpdateModule(handle)
+		publishDone <- backend.UpdateModule(t.Context(), handle)
 	}()
 	publishing := true
 	for publishing {

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -115,11 +115,11 @@ func applyACLRules(
 ) acl.ModuleHandle {
 	tb.Helper()
 
-	handle, err := backend.NewModule(name, rules, "", "", nil)
+	handle, err := backend.NewModule(tb.Context(), name, rules, "", "", nil)
 	require.NoError(tb, err)
 	tb.Cleanup(func() { _ = handle.Free() })
 
-	require.NoError(tb, backend.UpdateModule(handle))
+	require.NoError(tb, backend.UpdateModule(tb.Context(), handle))
 	return handle
 }
 
@@ -153,11 +153,11 @@ func wireACLPipeline(
 			Counter: "sink6",
 		},
 	}
-	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, sinkRules)
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(tb.Context(), sinkName, sinkRules)
 	require.NoError(tb, err)
 	tb.Cleanup(func() { _ = sinkHandle.Free() })
 
-	require.NoError(tb, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(tb, agent.UpdateFunction(tb.Context(), ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -170,14 +170,14 @@ func wireACLPipeline(
 			},
 		}},
 	}))
-	require.NoError(tb, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(tb, agent.UpdatePipeline(tb.Context(), ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
-	require.NoError(tb, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(tb, agent.UpdatePipeline(tb.Context(), ffi.PipelineConfig{
 		Name: "dummy",
 	}))
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	_, err = plain.UpdateDevices(tb.Context(), agent, []ffi.DeviceConfig{{
 		Name:   device,
 		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},

--- a/modules/blackhole/controlplane/backend.go
+++ b/modules/blackhole/controlplane/backend.go
@@ -1,6 +1,7 @@
 package blackhole
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -19,13 +20,18 @@ func NewBackend(agent *ffi.Agent) Backend {
 	}
 }
 
-func (m *backend) UpdateModule(name string) (ModuleHandle, error) {
+func (m *backend) UpdateModule(ctx context.Context, name string) (ModuleHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	mod, err := cblackhole.NewModuleConfig(m.agent, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module config: %w", err)
 	}
 
 	if err := m.agent.UpdateModules(
+		ctx,
 		[]ffi.ModuleConfig{mod.AsFFIModule()},
 	); err != nil {
 		if err := mod.Free(); err != nil {
@@ -37,6 +43,6 @@ func (m *backend) UpdateModule(name string) (ModuleHandle, error) {
 	return mod, nil
 }
 
-func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(moduleName, name)
+func (m *backend) DeleteModule(ctx context.Context, name string) error {
+	return m.agent.DeleteModuleConfig(ctx, moduleName, name)
 }

--- a/modules/blackhole/controlplane/service.go
+++ b/modules/blackhole/controlplane/service.go
@@ -25,9 +25,9 @@ type ModuleHandle interface {
 type Backend interface {
 	// UpdateModule creates a module config and publishes it to the
 	// dataplane.
-	UpdateModule(name string) (ModuleHandle, error)
+	UpdateModule(ctx context.Context, name string) (ModuleHandle, error)
 	// DeleteModule removes a module config.
-	DeleteModule(name string) error
+	DeleteModule(ctx context.Context, name string) error
 }
 
 type config struct {
@@ -117,7 +117,7 @@ func (m *BlackholeService) UpdateConfig(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if err := m.updateConfig(name); err != nil {
+	if err := m.updateConfig(ctx, name); err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to update module config %q: %v", name, err,
@@ -131,8 +131,8 @@ func (m *BlackholeService) UpdateConfig(
 // handle and stores the new one.
 //
 // The caller must hold m.mu.
-func (m *BlackholeService) updateConfig(name string) error {
-	mod, err := m.backend.UpdateModule(name)
+func (m *BlackholeService) updateConfig(ctx context.Context, name string) error {
+	mod, err := m.backend.UpdateModule(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func (m *BlackholeService) DeleteConfig(
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
 
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err := m.backend.DeleteModule(ctx, name); err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to delete module config %q: %v", name, err,

--- a/modules/blackhole/controlplane/service_test.go
+++ b/modules/blackhole/controlplane/service_test.go
@@ -1,6 +1,7 @@
 package blackhole
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync/atomic"
@@ -25,11 +26,11 @@ func (m *mockModuleHandle) Free() error {
 
 type mockBackend struct{}
 
-func (m *mockBackend) UpdateModule(name string) (ModuleHandle, error) {
+func (m *mockBackend) UpdateModule(ctx context.Context, name string) (ModuleHandle, error) {
 	return &mockModuleHandle{}, nil
 }
 
-func (m *mockBackend) DeleteModule(name string) error {
+func (m *mockBackend) DeleteModule(ctx context.Context, name string) error {
 	return nil
 }
 
@@ -43,14 +44,14 @@ type flakyBackend struct {
 	numCalls atomic.Int64
 }
 
-func (m *flakyBackend) UpdateModule(name string) (ModuleHandle, error) {
+func (m *flakyBackend) UpdateModule(ctx context.Context, name string) (ModuleHandle, error) {
 	if m.numCalls.Add(1) >= 2 {
 		return nil, errInjectedBackend
 	}
 	return &mockModuleHandle{}, nil
 }
 
-func (m *flakyBackend) DeleteModule(name string) error {
+func (m *flakyBackend) DeleteModule(ctx context.Context, name string) error {
 	return nil
 }
 

--- a/modules/blackhole/tests/functional/blackhole_test.go
+++ b/modules/blackhole/tests/functional/blackhole_test.go
@@ -57,7 +57,7 @@ func setupBlackholeHarness(
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = mod.Free() })
 
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{mod.AsFFIModule()}))
+	require.NoError(t, agent.UpdateModules(t.Context(), []ffi.ModuleConfig{mod.AsFFIModule()}))
 
 	return h, agent, mod
 }
@@ -71,7 +71,7 @@ func wirePipeline(
 ) {
 	t.Helper()
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -83,14 +83,14 @@ func wirePipeline(
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name: "dummy",
 	}))
-	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	_, err := plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:   deviceName,
 		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},

--- a/modules/decap/controlplane/backend.go
+++ b/modules/decap/controlplane/backend.go
@@ -1,6 +1,7 @@
 package decap
 
 import (
+	"context"
 	"fmt"
 	"net/netip"
 
@@ -20,7 +21,11 @@ func NewBackend(agent *ffi.Agent) Backend {
 	}
 }
 
-func (m *backend) UpdateModule(name string, prefixes []netip.Prefix) (ModuleHandle, error) {
+func (m *backend) UpdateModule(ctx context.Context, name string, prefixes []netip.Prefix) (ModuleHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	mod, err := cdecap.NewModuleConfig(m.agent, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module config: %w", err)
@@ -36,6 +41,7 @@ func (m *backend) UpdateModule(name string, prefixes []netip.Prefix) (ModuleHand
 	}
 
 	if err := m.agent.UpdateModules(
+		ctx,
 		[]ffi.ModuleConfig{mod.AsFFIModule()},
 	); err != nil {
 		if err := mod.Free(); err != nil {

--- a/modules/decap/controlplane/service.go
+++ b/modules/decap/controlplane/service.go
@@ -31,7 +31,7 @@ type ModuleHandle interface {
 type Backend interface {
 	// UpdateModule creates a module config, adds prefixes, and publishes
 	// it to the dataplane.
-	UpdateModule(name string, prefixes []netip.Prefix) (ModuleHandle, error)
+	UpdateModule(ctx context.Context, name string, prefixes []netip.Prefix) (ModuleHandle, error)
 }
 
 type config struct {
@@ -149,7 +149,7 @@ func (m *DecapService) UpdateConfig(
 		Prefixes4: normalizePrefixes(prefixes4),
 		Prefixes6: normalizePrefixes(prefixes6),
 	}
-	if err := m.updateConfig(name, cfg); err != nil {
+	if err := m.updateConfig(ctx, name, cfg); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
@@ -177,8 +177,8 @@ func normalizePrefixes(prefixes []netip.Prefix) []netip.Prefix {
 // deferred handles (the publish retired the generations that were
 // holding them), frees or defers the old module handle, and stores the
 // new config. The caller must hold m.mu.
-func (m *DecapService) updateConfig(name string, cfg *config) error {
-	mod, err := m.backend.UpdateModule(name, slices.Concat(cfg.Prefixes4, cfg.Prefixes6))
+func (m *DecapService) updateConfig(ctx context.Context, name string, cfg *config) error {
+	mod, err := m.backend.UpdateModule(ctx, name, slices.Concat(cfg.Prefixes4, cfg.Prefixes6))
 	if err != nil {
 		return fmt.Errorf("failed to update module config %q: %w", name, err)
 	}

--- a/modules/decap/controlplane/service_test.go
+++ b/modules/decap/controlplane/service_test.go
@@ -1,6 +1,7 @@
 package decap
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/netip"
@@ -68,6 +69,7 @@ func (m *mockModuleHandle) Free() error {
 type mockBackend struct{}
 
 func (m *mockBackend) UpdateModule(
+	ctx context.Context,
 	name string,
 	prefixes []netip.Prefix,
 ) (ModuleHandle, error) {
@@ -85,6 +87,7 @@ type flakyBackend struct {
 }
 
 func (m *flakyBackend) UpdateModule(
+	ctx context.Context,
 	name string,
 	prefixes []netip.Prefix,
 ) (ModuleHandle, error) {

--- a/modules/decap/tests/functional/decap_test.go
+++ b/modules/decap/tests/functional/decap_test.go
@@ -79,11 +79,11 @@ func wireDecapPipeline(t *testing.T, agent *ffi.Agent, configName string) {
 			Devices: filter.Devices{{Name: "port0"}},
 		},
 	}
-	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, sinkRules)
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(t.Context(), sinkName, sinkRules)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sinkHandle.Free() })
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -96,12 +96,12 @@ func wireDecapPipeline(t *testing.T, agent *ffi.Agent, configName string) {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: "dummy"}))
+	_, err = plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
@@ -118,7 +118,7 @@ func applyDecapConfig(
 ) {
 	t.Helper()
 
-	handle, err := backend.UpdateModule(name, prefixes)
+	handle, err := backend.UpdateModule(t.Context(), name, prefixes)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
 	wireDecapPipeline(t, agent, name)

--- a/modules/decap/tests/functional/failed_publish_test.go
+++ b/modules/decap/tests/functional/failed_publish_test.go
@@ -67,7 +67,7 @@ func TestFailedPublish_LeavesCallersModuleIntact(t *testing.T) {
 	// before the module is ever upserted into it.
 	originalWorkerCount := zeroWorkerCount(agent.AsRawPtr())
 
-	err = agent.UpdateModules([]ffi.ModuleConfig{mod.AsFFIModule()})
+	err = agent.UpdateModules(t.Context(), []ffi.ModuleConfig{mod.AsFFIModule()})
 	restoreWorkerCount(agent.AsRawPtr(), originalWorkerCount)
 	require.Error(
 		t, err,

--- a/modules/decap/tests/functional/module_lifetime_test.go
+++ b/modules/decap/tests/functional/module_lifetime_test.go
@@ -106,6 +106,7 @@ func TestModuleLifetime_LiveGeneration_ReleaseDoesNotDestroy(t *testing.T) {
 	t.Cleanup(func() { _ = agent.CleanUp() })
 
 	handle, err := decap.NewBackend(agent).UpdateModule(
+		t.Context(),
 		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")},
 	)
 	require.NoError(t, err)
@@ -141,6 +142,7 @@ func TestModuleLifetime_Superseded_DestroyedOnceGenerationRetires(t *testing.T) 
 	backend := decap.NewBackend(agent)
 
 	first, err := backend.UpdateModule(
+		t.Context(),
 		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")},
 	)
 	require.NoError(t, err)
@@ -149,6 +151,7 @@ func TestModuleLifetime_Superseded_DestroyedOnceGenerationRetires(t *testing.T) 
 	mid := agentRootMemoryNode(t, shm, "cpml-supersede")
 
 	second, err := backend.UpdateModule(
+		t.Context(),
 		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:db9::/32")},
 	)
 	require.NoError(t, err)
@@ -178,6 +181,7 @@ func TestModuleLifetime_Superseded_DestroyedOnceGenerationRetires(t *testing.T) 
 	)
 
 	_, err = backend.UpdateModule(
+		t.Context(),
 		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:dba::/32")},
 	)
 	require.NoError(t, err)
@@ -210,6 +214,7 @@ func TestModuleLifetime_PinnedGeneration_DefersDestruction(t *testing.T) {
 	backend := decap.NewBackend(agent)
 
 	first, err := backend.UpdateModule(
+		t.Context(),
 		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")},
 	)
 	require.NoError(t, err)
@@ -226,6 +231,7 @@ func TestModuleLifetime_PinnedGeneration_DefersDestruction(t *testing.T) {
 	mid := agentRootMemoryNode(t, shm, "cpml-pinned")
 
 	second, err := backend.UpdateModule(
+		t.Context(),
 		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:db9::/32")},
 	)
 	require.NoError(t, err)
@@ -247,6 +253,7 @@ func TestModuleLifetime_PinnedGeneration_DefersDestruction(t *testing.T) {
 	)
 
 	_, err = backend.UpdateModule(
+		t.Context(),
 		"decap0", []netip.Prefix{netip.MustParsePrefix("2001:dba::/32")},
 	)
 	require.NoError(t, err)

--- a/modules/decap/tests/functional/restart_leak_test.go
+++ b/modules/decap/tests/functional/restart_leak_test.go
@@ -46,6 +46,7 @@ func TestRestart_WithoutRelease_ReclaimsSupersededAgents(t *testing.T) {
 		// modeling a creator that crashed before it could drop its own
 		// reference.
 		_, err = decap.NewBackend(agent).UpdateModule(
+			t.Context(),
 			moduleName,
 			[]netip.Prefix{netip.MustParsePrefix("2001:db8::/32")},
 		)

--- a/modules/dscp/controlplane/backend.go
+++ b/modules/dscp/controlplane/backend.go
@@ -1,6 +1,7 @@
 package dscp
 
 import (
+	"context"
 	"fmt"
 	"net/netip"
 
@@ -21,11 +22,16 @@ func newBackend(agent *ffi.Agent) *backend {
 }
 
 func (m *backend) UpdateModule(
+	ctx context.Context,
 	name string,
 	prefixes []netip.Prefix,
 	flag uint8,
 	mark uint8,
 ) (ModuleHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	module, err := cdscp.NewModuleConfig(m.agent, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module config: %w", err)
@@ -47,7 +53,7 @@ func (m *backend) UpdateModule(
 		return nil, fmt.Errorf("failed to set DSCP marking: %w", err)
 	}
 
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
+	if err := m.agent.UpdateModules(ctx, []ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
 		if err := module.Free(); err != nil {
 			return nil, fmt.Errorf("failed to free abandoned config: %w", err)
 		}

--- a/modules/dscp/controlplane/service.go
+++ b/modules/dscp/controlplane/service.go
@@ -25,7 +25,7 @@ type ModuleHandle interface {
 type Backend interface {
 	// UpdateModule creates a module config, applies mutations, and publishes it
 	// to the dataplane.
-	UpdateModule(name string, prefixes []netip.Prefix, flag uint8, mark uint8) (ModuleHandle, error)
+	UpdateModule(ctx context.Context, name string, prefixes []netip.Prefix, flag uint8, mark uint8) (ModuleHandle, error)
 }
 
 type DscpService struct {
@@ -171,7 +171,7 @@ func (m *DscpService) AddPrefixes(
 	cfg.Prefixes4 = mergePrefixes(cfg.Prefixes4, toAdd4)
 	cfg.Prefixes6 = mergePrefixes(cfg.Prefixes6, toAdd6)
 
-	if err := m.updateModuleConfig(name, cfg); err != nil {
+	if err := m.updateModuleConfig(ctx, name, cfg); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
@@ -227,7 +227,7 @@ func (m *DscpService) RemovePrefixes(
 	cfg.Prefixes4 = removePrefixes(cfg.Prefixes4, toRemove4)
 	cfg.Prefixes6 = removePrefixes(cfg.Prefixes6, toRemove6)
 
-	if err := m.updateModuleConfig(name, cfg); err != nil {
+	if err := m.updateModuleConfig(ctx, name, cfg); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
@@ -268,15 +268,16 @@ func (m *DscpService) SetDscpMarking(
 		Mark: mark,
 	}
 
-	if err := m.updateModuleConfig(name, cfg); err != nil {
+	if err := m.updateModuleConfig(ctx, name, cfg); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
 	return &dscppb.SetDscpMarkingResponse{}, nil
 }
 
-func (m *DscpService) updateModuleConfig(name string, cfg *config) error {
+func (m *DscpService) updateModuleConfig(ctx context.Context, name string, cfg *config) error {
 	module, err := m.backend.UpdateModule(
+		ctx,
 		name,
 		slices.Concat(cfg.Prefixes4, cfg.Prefixes6),
 		cfg.Config.Flag,

--- a/modules/dscp/controlplane/service_test.go
+++ b/modules/dscp/controlplane/service_test.go
@@ -1,6 +1,7 @@
 package dscp
 
 import (
+	"context"
 	"fmt"
 	"net/netip"
 	"sync"
@@ -71,6 +72,7 @@ func (m *mockModuleHandle) Free() error {
 type mockBackend struct{}
 
 func (m *mockBackend) UpdateModule(
+	ctx context.Context,
 	name string,
 	prefixes []netip.Prefix,
 	flag uint8,
@@ -91,6 +93,7 @@ type flakyBackend struct {
 }
 
 func (m *flakyBackend) UpdateModule(
+	ctx context.Context,
 	name string,
 	prefixes []netip.Prefix,
 	flag uint8,
@@ -104,7 +107,7 @@ func (m *flakyBackend) UpdateModule(
 		return nil, errBackendFailure
 	}
 
-	return m.backend.UpdateModule(name, prefixes, flag, mark)
+	return m.backend.UpdateModule(ctx, name, prefixes, flag, mark)
 }
 
 // Test_DscpService_ListShowAddRemoveSetMarking verifies that prefix mutations

--- a/modules/forward/controlplane/backend.go
+++ b/modules/forward/controlplane/backend.go
@@ -1,6 +1,7 @@
 package forward
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -28,7 +29,11 @@ func NewBackend(agent *ffi.Agent) Backend {
 	}
 }
 
-func (m *backend) UpdateModule(name string, rules []cforward.ForwardRule) (ModuleHandle, error) {
+func (m *backend) UpdateModule(ctx context.Context, name string, rules []cforward.ForwardRule) (ModuleHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	module, err := cforward.NewModuleConfig(m.agent, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module config: %w", err)
@@ -41,7 +46,7 @@ func (m *backend) UpdateModule(name string, rules []cforward.ForwardRule) (Modul
 		return nil, fmt.Errorf("failed to update module config: %w", err)
 	}
 
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
+	if err := m.agent.UpdateModules(ctx, []ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
 		if err := module.Free(); err != nil {
 			return nil, fmt.Errorf("failed to free abandoned config: %w", err)
 		}
@@ -51,8 +56,8 @@ func (m *backend) UpdateModule(name string, rules []cforward.ForwardRule) (Modul
 	return module, nil
 }
 
-func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(moduleType, name)
+func (m *backend) DeleteModule(ctx context.Context, name string) error {
+	return m.agent.DeleteModuleConfig(ctx, moduleType, name)
 }
 
 func (m *backend) ModuleCounters(name string, counterNames []string) []CounterView {

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -25,9 +25,9 @@ type ModuleHandle interface {
 type Backend interface {
 	// UpdateModule creates a module config, writes rules, and publishes
 	// it to the dataplane.
-	UpdateModule(name string, rules []cforward.ForwardRule) (ModuleHandle, error)
+	UpdateModule(ctx context.Context, name string, rules []cforward.ForwardRule) (ModuleHandle, error)
 	// DeleteModule removes a module config.
-	DeleteModule(name string) error
+	DeleteModule(ctx context.Context, name string) error
 	// ModuleCounters returns selected dataplane counters collected for a module config.
 	// If counterNames is nil or empty, it returns all counters for the module config.
 	ModuleCounters(name string, counterNames []string) []CounterView
@@ -208,7 +208,7 @@ func (m *ForwardService) UpdateConfig(ctx context.Context, req *forwardpb.Update
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	module, err := m.backend.UpdateModule(name, rules)
+	module, err := m.backend.UpdateModule(ctx, name, rules)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update module config: %w", err)
 	}
@@ -241,7 +241,7 @@ func (m *ForwardService) DeleteConfig(ctx context.Context, req *forwardpb.Delete
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err := m.backend.DeleteModule(ctx, name); err != nil {
 		return nil, fmt.Errorf("failed to delete module config %q: %w", name, err)
 	}
 

--- a/modules/forward/controlplane/service_test.go
+++ b/modules/forward/controlplane/service_test.go
@@ -30,11 +30,11 @@ func (m *mockModuleHandle) Free() error {
 
 type mockBackend struct{}
 
-func (m *mockBackend) UpdateModule(name string, rules []cforward.ForwardRule) (forward.ModuleHandle, error) {
+func (m *mockBackend) UpdateModule(ctx context.Context, name string, rules []cforward.ForwardRule) (forward.ModuleHandle, error) {
 	return &mockModuleHandle{}, nil
 }
 
-func (m *mockBackend) DeleteModule(name string) error {
+func (m *mockBackend) DeleteModule(ctx context.Context, name string) error {
 	return nil
 }
 
@@ -63,7 +63,7 @@ type nilHandleBackend struct {
 	mockBackend
 }
 
-func (m *nilHandleBackend) UpdateModule(name string, rules []cforward.ForwardRule) (forward.ModuleHandle, error) {
+func (m *nilHandleBackend) UpdateModule(ctx context.Context, name string, rules []cforward.ForwardRule) (forward.ModuleHandle, error) {
 	return nil, nil
 }
 
@@ -78,7 +78,7 @@ type recordingBackend struct {
 	rules []cforward.ForwardRule
 }
 
-func (m *recordingBackend) UpdateModule(name string, rules []cforward.ForwardRule) (forward.ModuleHandle, error) {
+func (m *recordingBackend) UpdateModule(ctx context.Context, name string, rules []cforward.ForwardRule) (forward.ModuleHandle, error) {
 	m.rules = rules
 	return &mockModuleHandle{}, nil
 }

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -77,7 +77,7 @@ func applyRules(
 ) forward.ModuleHandle {
 	t.Helper()
 
-	handle, err := backend.UpdateModule(name, rules)
+	handle, err := backend.UpdateModule(t.Context(), name, rules)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
 	return handle
@@ -133,7 +133,7 @@ func wireForwardPipeline(
 	// Primary device sink: appended after the test module in the chain so
 	// packets that pass through (ModeNone/NoMatch) reach the output stage.
 	primarySink := configName + "-sink"
-	primarySinkHandle, err := fwdBackend.UpdateModule(primarySink, catchAllForwardRules(primaryDevice))
+	primarySinkHandle, err := fwdBackend.UpdateModule(t.Context(), primarySink, catchAllForwardRules(primaryDevice))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = primarySinkHandle.Free() })
 
@@ -141,11 +141,11 @@ func wireForwardPipeline(
 	// sink so packets re-routed via ModeIn reach the output stage.
 	for _, dev := range extraDevices {
 		sinkName := configName + "-sink-" + dev
-		sinkHandle, err := fwdBackend.UpdateModule(sinkName, catchAllForwardRules(dev))
+		sinkHandle, err := fwdBackend.UpdateModule(t.Context(), sinkName, catchAllForwardRules(dev))
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = sinkHandle.Free() })
 
-		require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 			Name: sinkName,
 			Chains: []ffi.FunctionChainConfig{{
 				Weight: 1,
@@ -157,13 +157,13 @@ func wireForwardPipeline(
 				},
 			}},
 		}))
-		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 			Name:      "sink_in_" + dev,
 			Functions: []string{sinkName},
 		}))
 	}
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -176,20 +176,20 @@ func wireForwardPipeline(
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
 
 	// A dummy pipeline with no functions passes packets straight through.
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name: "dummy",
 	}))
 
 	// Additional dummy output pipelines for extra devices — each output must
 	// use a distinct pipeline name to avoid counter-key collisions.
 	for _, dev := range extraDevices {
-		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 			Name: "dummy_extra_out_" + dev,
 		}))
 	}
@@ -210,7 +210,7 @@ func wireForwardPipeline(
 		})
 	}
 
-	_, err = plain.UpdateDevices(agent, allDevices)
+	_, err = plain.UpdateDevices(t.Context(), agent, allDevices)
 	require.NoError(t, err)
 }
 
@@ -745,7 +745,7 @@ func TestForwardConfigMemoryLeak(t *testing.T) {
 		require.NoErrorf(t, module.Update(rules), "round %d: update failed", round)
 		require.NoErrorf(
 			t,
-			agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}),
+			agent.UpdateModules(t.Context(), []ffi.ModuleConfig{module.AsFFIModule()}),
 			"round %d: publish failed", round,
 		)
 		// The publish retired the previous round's generation, so the

--- a/modules/fwstate/controlplane/delete_test.go
+++ b/modules/fwstate/controlplane/delete_test.go
@@ -89,7 +89,7 @@ func newFWStateTestMaps(
 		mapObject, err := objfwstate.NewMapObjectConfig(agent, name+"-"+kind.String(), kind)
 		require.NoError(testingTB, err)
 		require.NoError(testingTB, mapObject.CreateMap(indexSize, 64, 1))
-		require.NoError(testingTB, mapObject.Publish(agent))
+		require.NoError(testingTB, mapObject.Publish(testingTB.Context(), agent))
 		testingTB.Cleanup(func() { _ = mapObject.Free() })
 		return mapObject
 	}
@@ -108,7 +108,7 @@ func newACLDeleteTestConfig(
 ) *cacl.ModuleConfig {
 	testingTB.Helper()
 
-	config, err := cacl.NewModuleConfig(agent, name, nil, "", "", nil)
+	config, err := cacl.NewModuleConfig(testingTB.Context(), agent, name, nil, "", "", nil)
 	require.NoError(testingTB, err)
 	testingTB.Cleanup(func() { _ = config.Free() })
 
@@ -120,7 +120,7 @@ func TestFWStateDeleteKeepsSameNamedACLConfig(t *testing.T) {
 
 	_, agent := newDeleteTestHarness(t, []string{"acl", "fwstate"}, "acl")
 	aclConfig := newACLDeleteTestConfig(t, agent, configName)
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{aclConfig.AsFFIModule()}))
+	require.NoError(t, agent.UpdateModules(t.Context(), []ffi.ModuleConfig{aclConfig.AsFFIModule()}))
 	maps := newFWStateTestMaps(t, agent, configName, 1024)
 
 	service := fwstate.NewFWStateService(agent)
@@ -177,9 +177,9 @@ func TestDeleteModuleConfigUsesRegisteredType(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = config.Free() })
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{config.AsFFIModule()}))
+	require.NoError(t, agent.UpdateModules(t.Context(), []ffi.ModuleConfig{config.AsFFIModule()}))
 
-	require.NoError(t, agent.DeleteModuleConfig(fwstateModuleType, configName))
+	require.NoError(t, agent.DeleteModuleConfig(t.Context(), fwstateModuleType, configName))
 	require.False(t, hasCPConfig(agent.DPConfig().CPConfigs(), fwstateModuleType, configName))
 }
 

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -232,7 +232,7 @@ func (m *FWStateService) UpdateConfig(
 
 		m.log.Debug("update fwstate module config", zap.String("config", name))
 
-		if err := m.publishUpdate(name, newConfig); err != nil {
+		if err := m.publishUpdate(ctx, name, newConfig); err != nil {
 			if err := newConfig.Free(); err != nil {
 				m.log.Error("failed to free unpublished fwstate config",
 					zap.String("config", name), zap.Error(err))
@@ -299,13 +299,14 @@ func (m *FWStateService) prepareUpdate(
 }
 
 func (m *FWStateService) publishUpdate(
+	ctx context.Context,
 	name string,
 	newConfig *FwStateConfig,
 ) error {
 	m.stateMu.Lock()
 	defer m.stateMu.Unlock()
 
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{newConfig.AsFFIModule()}); err != nil {
+	if err := m.agent.UpdateModules(ctx, []ffi.ModuleConfig{newConfig.AsFFIModule()}); err != nil {
 		return err
 	}
 	m.configs[name] = newConfig
@@ -416,7 +417,7 @@ func (m *FWStateService) DeleteConfig(
 		// DeleteModuleConfig removes the shared-memory publication but does not
 		// free the module. Keeping stateMu unlocked lets readers finish against
 		// the old handle before unpublishConfig establishes the Free barrier.
-		if err := m.agent.DeleteModuleConfig(moduleType, name); err != nil {
+		if err := m.agent.DeleteModuleConfig(ctx, moduleType, name); err != nil {
 			return status.Errorf(codes.Internal, "could not delete fwstate module config '%s': %v", name, err)
 		}
 

--- a/modules/fwstate/tests/functional/fwstate_test.go
+++ b/modules/fwstate/tests/functional/fwstate_test.go
@@ -97,7 +97,7 @@ func newPublishedFWStateMaps(
 		mapObject, err := objfwstate.NewMapObjectConfig(agent, objectName, kind)
 		require.NoError(t, err)
 		require.NoError(t, mapObject.CreateMap(indexSize, 64, 1))
-		require.NoError(t, mapObject.Publish(agent))
+		require.NoError(t, mapObject.Publish(t.Context(), agent))
 		t.Cleanup(func() { _ = mapObject.Free() })
 		return mapObject
 	}
@@ -123,7 +123,7 @@ func configureFWState(t *testing.T, agent *ffi.Agent, name string) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = modCfg.Free() })
 
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{modCfg.AsFFIModule()}))
+	require.NoError(t, agent.UpdateModules(t.Context(), []ffi.ModuleConfig{modCfg.AsFFIModule()}))
 }
 
 // wireFWSPipeline wires chain[fwstate:name -> forward:sink] into a pipeline
@@ -152,11 +152,11 @@ func wireFWSPipeline(t *testing.T, agent *ffi.Agent, name string) {
 			Dst6s:   []xnetip.BiContiguous{filter.UnspecifiedIPv6},
 		},
 	}
-	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, sinkRules)
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(t.Context(), sinkName, sinkRules)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sinkHandle.Free() })
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: name,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -169,14 +169,14 @@ func wireFWSPipeline(t *testing.T, agent *ffi.Agent, name string) {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      name,
 		Functions: []string{name},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name: "dummy",
 	}))
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	_, err = plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: name, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},

--- a/modules/fwstate/tests/functional/map_chain_lifetime_test.go
+++ b/modules/fwstate/tests/functional/map_chain_lifetime_test.go
@@ -56,7 +56,7 @@ func newMapChainConfig(
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{modCfg.AsFFIModule()}))
+	require.NoError(t, agent.UpdateModules(t.Context(), []ffi.ModuleConfig{modCfg.AsFFIModule()}))
 
 	return modCfg
 }
@@ -109,7 +109,7 @@ func TestFWStateUpdate_SecondUpdateKeepsLiveMaps(t *testing.T) {
 		agent, "fw0", &syncConfig, mapV4.Name(), mapV6.Name(),
 	)
 	require.NoError(t, err)
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{v2.AsFFIModule()}))
+	require.NoError(t, agent.UpdateModules(t.Context(), []ffi.ModuleConfig{v2.AsFFIModule()}))
 
 	afterPublish := mapChainAgentRootMemoryNode(t, shm, agentName)
 

--- a/modules/mirror/controlplane/backend.go
+++ b/modules/mirror/controlplane/backend.go
@@ -1,6 +1,7 @@
 package mirror
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -19,7 +20,11 @@ func NewBackend(agent *ffi.Agent) Backend {
 	}
 }
 
-func (m *backend) UpdateModule(name string, rules []cmirror.MirrorRule) (ModuleHandle, error) {
+func (m *backend) UpdateModule(ctx context.Context, name string, rules []cmirror.MirrorRule) (ModuleHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	module, err := cmirror.NewModuleConfig(m.agent, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module config: %w", err)
@@ -32,7 +37,7 @@ func (m *backend) UpdateModule(name string, rules []cmirror.MirrorRule) (ModuleH
 		return nil, fmt.Errorf("failed to update module config: %w", err)
 	}
 
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
+	if err := m.agent.UpdateModules(ctx, []ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
 		if err := module.Free(); err != nil {
 			return nil, fmt.Errorf("failed to free abandoned config: %w", err)
 		}
@@ -42,6 +47,6 @@ func (m *backend) UpdateModule(name string, rules []cmirror.MirrorRule) (ModuleH
 	return module, nil
 }
 
-func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(moduleType, name)
+func (m *backend) DeleteModule(ctx context.Context, name string) error {
+	return m.agent.DeleteModuleConfig(ctx, moduleType, name)
 }

--- a/modules/mirror/controlplane/service.go
+++ b/modules/mirror/controlplane/service.go
@@ -24,9 +24,9 @@ type ModuleHandle interface {
 type Backend interface {
 	// UpdateModule creates a module config, writes rules, and publishes
 	// it to the dataplane.
-	UpdateModule(name string, rules []cmirror.MirrorRule) (ModuleHandle, error)
+	UpdateModule(ctx context.Context, name string, rules []cmirror.MirrorRule) (ModuleHandle, error)
 	// DeleteModule removes a module config.
-	DeleteModule(name string) error
+	DeleteModule(ctx context.Context, name string) error
 }
 
 type mirrorConfig struct {
@@ -177,7 +177,7 @@ func (m *MirrorService) UpdateConfig(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	module, err := m.backend.UpdateModule(name, rules)
+	module, err := m.backend.UpdateModule(ctx, name, rules)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update module config: %w", err)
 	}
@@ -213,7 +213,7 @@ func (m *MirrorService) DeleteConfig(
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err := m.backend.DeleteModule(ctx, name); err != nil {
 		return nil, fmt.Errorf("failed to delete module config %q: %w", name, err)
 	}
 

--- a/modules/mirror/controlplane/service_test.go
+++ b/modules/mirror/controlplane/service_test.go
@@ -26,13 +26,14 @@ func (m *mockModuleHandle) Free() error {
 type mockBackend struct{}
 
 func (m *mockBackend) UpdateModule(
+	ctx context.Context,
 	name string,
 	rules []cmirror.MirrorRule,
 ) (mirror.ModuleHandle, error) {
 	return &mockModuleHandle{}, nil
 }
 
-func (m *mockBackend) DeleteModule(name string) error {
+func (m *mockBackend) DeleteModule(ctx context.Context, name string) error {
 	return nil
 }
 
@@ -46,6 +47,7 @@ type nilHandleBackend struct {
 }
 
 func (m *nilHandleBackend) UpdateModule(
+	ctx context.Context,
 	name string,
 	rules []cmirror.MirrorRule,
 ) (mirror.ModuleHandle, error) {
@@ -61,6 +63,7 @@ type recordingBackend struct {
 }
 
 func (m *recordingBackend) UpdateModule(
+	ctx context.Context,
 	name string,
 	rules []cmirror.MirrorRule,
 ) (mirror.ModuleHandle, error) {

--- a/modules/mirror/tests/functional/mirror_test.go
+++ b/modules/mirror/tests/functional/mirror_test.go
@@ -76,7 +76,7 @@ func applyRules(
 ) mirror.ModuleHandle {
 	t.Helper()
 
-	handle, err := backend.UpdateModule(name, rules)
+	handle, err := backend.UpdateModule(t.Context(), name, rules)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
 	return handle
@@ -133,7 +133,7 @@ func wireMirrorPipeline(
 	// packets that pass through (originals and ModeNone mirrors) reach the
 	// output stage.
 	primarySink := configName + "-sink"
-	primarySinkHandle, err := fwdBackend.UpdateModule(primarySink, catchAllForwardRules(primaryDevice))
+	primarySinkHandle, err := fwdBackend.UpdateModule(t.Context(), primarySink, catchAllForwardRules(primaryDevice))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = primarySinkHandle.Free() })
 
@@ -141,11 +141,11 @@ func wireMirrorPipeline(
 	// sink so mirrored packets re-routed via ModeIn reach the output stage.
 	for _, dev := range extraDevices {
 		sinkName := configName + "-sink-" + dev
-		sinkHandle, err := fwdBackend.UpdateModule(sinkName, catchAllForwardRules(dev))
+		sinkHandle, err := fwdBackend.UpdateModule(t.Context(), sinkName, catchAllForwardRules(dev))
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = sinkHandle.Free() })
 
-		require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 			Name: sinkName,
 			Chains: []ffi.FunctionChainConfig{{
 				Weight: 1,
@@ -157,13 +157,13 @@ func wireMirrorPipeline(
 				},
 			}},
 		}))
-		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 			Name:      "sink_in_" + dev,
 			Functions: []string{sinkName},
 		}))
 	}
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -176,20 +176,20 @@ func wireMirrorPipeline(
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
 
 	// A dummy pipeline with no functions passes packets straight through.
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name: "dummy",
 	}))
 
 	// Additional dummy output pipelines for extra devices — each output must
 	// use a distinct pipeline name to avoid counter-key collisions.
 	for _, dev := range extraDevices {
-		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 			Name: "dummy_extra_out_" + dev,
 		}))
 	}
@@ -210,7 +210,7 @@ func wireMirrorPipeline(
 		})
 	}
 
-	_, err = plain.UpdateDevices(agent, allDevices)
+	_, err = plain.UpdateDevices(t.Context(), agent, allDevices)
 	require.NoError(t, err)
 }
 
@@ -672,7 +672,7 @@ func TestMirrorConfigMemoryLeak(t *testing.T) {
 		require.NoErrorf(t, module.Update(rules), "round %d: update failed", round)
 		require.NoErrorf(
 			t,
-			agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}),
+			agent.UpdateModules(t.Context(), []ffi.ModuleConfig{module.AsFFIModule()}),
 			"round %d: publish failed", round,
 		)
 		// The publish retired the previous round's generation, so the

--- a/modules/nat64/controlplane/backend.go
+++ b/modules/nat64/controlplane/backend.go
@@ -1,6 +1,7 @@
 package nat64
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -14,7 +15,7 @@ type ModuleHandle interface {
 var _ ModuleHandle = (*cnat64.ModuleConfig)(nil)
 
 type Backend interface {
-	UpdateModule(name string, config *NAT64Config) (ModuleHandle, error)
+	UpdateModule(ctx context.Context, name string, config *NAT64Config) (ModuleHandle, error)
 }
 
 type backend struct {
@@ -27,7 +28,11 @@ func NewBackend(agent *ffi.Agent) Backend {
 	}
 }
 
-func (m *backend) UpdateModule(name string, config *NAT64Config) (ModuleHandle, error) {
+func (m *backend) UpdateModule(ctx context.Context, name string, config *NAT64Config) (ModuleHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	module, err := cnat64.NewModuleConfig(m.agent, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module config: %w", err)
@@ -65,7 +70,7 @@ func (m *backend) UpdateModule(name string, config *NAT64Config) (ModuleHandle, 
 		return nil, fmt.Errorf("failed to set MTU: %w", err)
 	}
 
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
+	if err := m.agent.UpdateModules(ctx, []ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
 		if err := module.Free(); err != nil {
 			return nil, fmt.Errorf("failed to free abandoned config: %w", err)
 		}

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -209,7 +209,7 @@ func (m *NAT64Service) AddPrefix(ctx context.Context, req *nat64pb.AddPrefixRequ
 	inst := m.instanceFor(name).Clone()
 	inst.Config.Prefixes = append(inst.Config.Prefixes, slices.Clone(req.Prefix))
 
-	if err := m.updateModuleConfig(name, inst); err != nil {
+	if err := m.updateModuleConfig(ctx, name, inst); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
 
@@ -249,7 +249,7 @@ func (m *NAT64Service) RemovePrefix(ctx context.Context, req *nat64pb.RemovePref
 	next.Config.Prefixes = slices.Delete(next.Config.Prefixes, removeIdx, removeIdx+1)
 	next.Config.Mappings = adjustMappingsAfterPrefixRemove(next.Config.Mappings, uint32(removeIdx))
 
-	if err := m.updateModuleConfig(name, next); err != nil {
+	if err := m.updateModuleConfig(ctx, name, next); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
 
@@ -292,7 +292,7 @@ func (m *NAT64Service) AddMapping(ctx context.Context, req *nat64pb.AddMappingRe
 		PrefixIndex: req.PrefixIndex,
 	})
 
-	if err := m.updateModuleConfig(name, inst); err != nil {
+	if err := m.updateModuleConfig(ctx, name, inst); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
 
@@ -326,7 +326,7 @@ func (m *NAT64Service) RemoveMapping(ctx context.Context, req *nat64pb.RemoveMap
 		return &nat64pb.RemoveMappingResponse{}, nil
 	}
 
-	if err := m.updateModuleConfig(name, next); err != nil {
+	if err := m.updateModuleConfig(ctx, name, next); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
 
@@ -358,7 +358,7 @@ func (m *NAT64Service) SetMTU(ctx context.Context, req *nat64pb.SetMTURequest) (
 		IPv6MTU: req.Mtu.Ipv6Mtu,
 	}
 
-	if err := m.updateModuleConfig(name, inst); err != nil {
+	if err := m.updateModuleConfig(ctx, name, inst); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
 
@@ -378,7 +378,7 @@ func (m *NAT64Service) SetDropUnknown(ctx context.Context, req *nat64pb.SetDropU
 	inst.Config.DropUnknownPrefix = req.DropUnknownPrefix
 	inst.Config.DropUnknownMapping = req.DropUnknownMapping
 
-	if err := m.updateModuleConfig(name, inst); err != nil {
+	if err := m.updateModuleConfig(ctx, name, inst); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
 
@@ -395,8 +395,8 @@ func (m *NAT64Service) instanceFor(name string) config {
 	return inst
 }
 
-func (m *NAT64Service) updateModuleConfig(name string, inst config) error {
-	module, err := m.backend.UpdateModule(name, &inst.Config)
+func (m *NAT64Service) updateModuleConfig(ctx context.Context, name string, inst config) error {
+	module, err := m.backend.UpdateModule(ctx, name, &inst.Config)
 	if err != nil {
 		return err
 	}

--- a/modules/nat64/controlplane/service_test.go
+++ b/modules/nat64/controlplane/service_test.go
@@ -1,6 +1,7 @@
 package nat64
 
 import (
+	"context"
 	"errors"
 	"net/netip"
 	"testing"
@@ -30,7 +31,7 @@ type mockBackend struct {
 	failAt  int
 }
 
-func (m *mockBackend) UpdateModule(name string, cfg *NAT64Config) (ModuleHandle, error) {
+func (m *mockBackend) UpdateModule(ctx context.Context, name string, cfg *NAT64Config) (ModuleHandle, error) {
 	if m.failAt != 0 && len(m.configs)+1 == m.failAt {
 		return nil, errInjectedBackend
 	}

--- a/modules/nat64/tests/functional/nat64_test.go
+++ b/modules/nat64/tests/functional/nat64_test.go
@@ -77,11 +77,11 @@ func wireNAT64Pipeline(t *testing.T, agent *ffi.Agent, name string) {
 			Dst6s:   []xnetip.BiContiguous{filter.UnspecifiedIPv6},
 		},
 	}
-	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, sinkRules)
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(t.Context(), sinkName, sinkRules)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sinkHandle.Free() })
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: name,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -94,9 +94,9 @@ func wireNAT64Pipeline(t *testing.T, agent *ffi.Agent, name string) {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: name, Functions: []string{name}}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: name, Functions: []string{name}}))
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: "dummy"}))
+	_, err = plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: name, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},

--- a/modules/pdump/controlplane/service.go
+++ b/modules/pdump/controlplane/service.go
@@ -122,7 +122,6 @@ func (m *PdumpService) ListConfigs(
 	ctx context.Context,
 	request *pdumppb.ListConfigsRequest,
 ) (*pdumppb.ListConfigsResponse, error) {
-
 	response := &pdumppb.ListConfigsResponse{
 		Configs: make([]string, 0),
 	}
@@ -187,7 +186,7 @@ func (m *PdumpService) SetConfig(
 		name,
 		request,
 		func(config *pdumpConfig) error {
-			return m.updateModuleConfig(name, config)
+			return m.updateModuleConfig(ctx, name, config)
 		},
 	)
 	if err != nil {
@@ -223,7 +222,7 @@ func (m *PdumpService) DeleteConfig(
 		func() error {
 			// Delete the module config from the data plane if it exists.
 			if config.FFIModule != nil {
-				if err := m.agent.DeleteModuleConfig(moduleType, name); err != nil {
+				if err := m.agent.DeleteModuleConfig(ctx, moduleType, name); err != nil {
 					return status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
 				}
 
@@ -281,6 +280,7 @@ func (m *PdumpService) transferConfigParameters(
 // updateModuleConfig publishes the current configuration after all readers of
 // the previous ring have stopped and the state lock has been reacquired.
 func (m *PdumpService) updateModuleConfig(
+	ctx context.Context,
 	name string,
 	modConfig *pdumpConfig,
 ) error {
@@ -305,7 +305,7 @@ func (m *PdumpService) updateModuleConfig(
 		}
 	}
 
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{ffiConfig.AsFFIModule()}); err != nil {
+	if err := m.agent.UpdateModules(ctx, []ffi.ModuleConfig{ffiConfig.AsFFIModule()}); err != nil {
 		if err := ffiConfig.Free(); err != nil {
 			m.log.Error("failed to free unpublished pdump module",
 				zap.String("name", name), zap.Error(err))

--- a/modules/route-mpls/controlplane/backend.go
+++ b/modules/route-mpls/controlplane/backend.go
@@ -1,6 +1,7 @@
 package route_mpls
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -22,9 +23,9 @@ var _ ModuleHandle = (*croutempls.ModuleConfig)(nil)
 type Backend interface {
 	// UpdateModule builds a fresh ModuleConfig from the supplied rules and
 	// publishes it to the dataplane atomically.
-	UpdateModule(name string, rules []croutempls.Rule) (ModuleHandle, error)
+	UpdateModule(ctx context.Context, name string, rules []croutempls.Rule) (ModuleHandle, error)
 	// DeleteModule removes a module config from the dataplane.
-	DeleteModule(name string) error
+	DeleteModule(ctx context.Context, name string) error
 }
 
 // backend is the real Backend implementation backed by shared memory.
@@ -39,7 +40,11 @@ func NewBackend(agent *ffi.Agent) Backend {
 	}
 }
 
-func (m *backend) UpdateModule(name string, rules []croutempls.Rule) (ModuleHandle, error) {
+func (m *backend) UpdateModule(ctx context.Context, name string, rules []croutempls.Rule) (ModuleHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	module, err := croutempls.NewModuleConfig(m.agent, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module config: %w", err)
@@ -52,7 +57,7 @@ func (m *backend) UpdateModule(name string, rules []croutempls.Rule) (ModuleHand
 		return nil, fmt.Errorf("failed to update module config: %w", err)
 	}
 
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
+	if err := m.agent.UpdateModules(ctx, []ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
 		if err := module.Free(); err != nil {
 			return nil, fmt.Errorf("failed to free abandoned config: %w", err)
 		}
@@ -62,6 +67,6 @@ func (m *backend) UpdateModule(name string, rules []croutempls.Rule) (ModuleHand
 	return module, nil
 }
 
-func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(moduleType, name)
+func (m *backend) DeleteModule(ctx context.Context, name string) error {
+	return m.agent.DeleteModuleConfig(ctx, moduleType, name)
 }

--- a/modules/route-mpls/controlplane/service.go
+++ b/modules/route-mpls/controlplane/service.go
@@ -285,7 +285,7 @@ func (m *RouteMPLSService) DeleteConfig(
 		return nil, status.Error(codes.NotFound, "not found")
 	}
 
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err := m.backend.DeleteModule(ctx, name); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
 	}
 
@@ -341,7 +341,7 @@ func (m *RouteMPLSService) CreateConfig(
 	m.shmLock.Lock()
 	defer m.shmLock.Unlock()
 
-	handle, err := m.backend.UpdateModule(name, config.BuildRules())
+	handle, err := m.backend.UpdateModule(ctx, name, config.BuildRules())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
@@ -430,7 +430,7 @@ func (m *RouteMPLSService) UpdateConfig(
 		}
 	}
 
-	handle, err := m.backend.UpdateModule(name, config.BuildRules())
+	handle, err := m.backend.UpdateModule(ctx, name, config.BuildRules())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}

--- a/modules/route-mpls/controlplane/service_test.go
+++ b/modules/route-mpls/controlplane/service_test.go
@@ -1,6 +1,7 @@
 package route_mpls
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/netip"
@@ -28,11 +29,11 @@ func (m *mockModuleHandle) Free() error {
 
 type mockBackend struct{}
 
-func (m *mockBackend) UpdateModule(name string, rules []croutempls.Rule) (ModuleHandle, error) {
+func (m *mockBackend) UpdateModule(ctx context.Context, name string, rules []croutempls.Rule) (ModuleHandle, error) {
 	return &mockModuleHandle{}, nil
 }
 
-func (m *mockBackend) DeleteModule(name string) error {
+func (m *mockBackend) DeleteModule(ctx context.Context, name string) error {
 	return nil
 }
 
@@ -41,14 +42,14 @@ type flakyBackend struct {
 	numCalls atomic.Int64
 }
 
-func (m *flakyBackend) UpdateModule(name string, rules []croutempls.Rule) (ModuleHandle, error) {
+func (m *flakyBackend) UpdateModule(ctx context.Context, name string, rules []croutempls.Rule) (ModuleHandle, error) {
 	if m.numCalls.Add(1) >= 2 {
 		return nil, errInjectedBackend
 	}
 	return &mockModuleHandle{}, nil
 }
 
-func (m *flakyBackend) DeleteModule(name string) error {
+func (m *flakyBackend) DeleteModule(ctx context.Context, name string) error {
 	return nil
 }
 

--- a/modules/route-mpls/tests/functional/route_mpls_test.go
+++ b/modules/route-mpls/tests/functional/route_mpls_test.go
@@ -454,16 +454,16 @@ func deployRules(t *testing.T, rules []croutempls.Rule) *dataplaneut.Harness {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = agent.CleanUp() })
 
-	handle, err := routempls.NewBackend(agent).UpdateModule(mplsConfigName, rules)
+	handle, err := routempls.NewBackend(agent).UpdateModule(t.Context(), mplsConfigName, rules)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
 
 	sinkName := mplsConfigName + "-sink"
-	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, catchAllForwardRules(mplsDevice))
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(t.Context(), sinkName, catchAllForwardRules(mplsDevice))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sinkHandle.Free() })
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: mplsConfigName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -476,15 +476,15 @@ func deployRules(t *testing.T, rules []croutempls.Rule) *dataplaneut.Harness {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      mplsConfigName,
 		Functions: []string{mplsConfigName},
 	}))
 	// A pipeline with no functions passes egress packets straight through.
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name: "dummy",
 	}))
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	_, err = plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:   mplsDevice,
 		Input:  []ffi.DevicePipelineConfig{{Name: mplsConfigName, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -1,6 +1,7 @@
 package route
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/yanet-platform/yanet2/common/go/bitset"
@@ -53,9 +54,9 @@ type CounterView struct {
 type Backend interface {
 	// UpdateModule builds a fresh ModuleConfig from the supplied FIB
 	// ranges and publishes it to the dataplane atomically.
-	UpdateModule(name string, entries []*routepb.FIBEntry) (ModuleHandle, error)
+	UpdateModule(ctx context.Context, name string, entries []*routepb.FIBEntry) (ModuleHandle, error)
 	// DeleteModule removes a module config from the dataplane.
-	DeleteModule(name string) error
+	DeleteModule(ctx context.Context, name string) error
 	// ModuleCounters reads the named counters back from every position
 	// at which the named config is installed.
 	ModuleCounters(name string, counterNames []string) []CounterView
@@ -77,7 +78,11 @@ func NewBackend(agent *ffi.Agent) Backend {
 	}
 }
 
-func (m *backend) UpdateModule(name string, entries []*routepb.FIBEntry) (ModuleHandle, error) {
+func (m *backend) UpdateModule(ctx context.Context, name string, entries []*routepb.FIBEntry) (ModuleHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	module, err := croute.NewModuleConfig(m.agent, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module config: %w", err)
@@ -159,7 +164,7 @@ func (m *backend) UpdateModule(name string, entries []*routepb.FIBEntry) (Module
 		}
 	}
 
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
+	if err := m.agent.UpdateModules(ctx, []ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
 		if err := module.Free(); err != nil {
 			return nil, fmt.Errorf("failed to free abandoned config: %w", err)
 		}
@@ -169,8 +174,8 @@ func (m *backend) UpdateModule(name string, entries []*routepb.FIBEntry) (Module
 	return module, nil
 }
 
-func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(moduleType, name)
+func (m *backend) DeleteModule(ctx context.Context, name string) error {
+	return m.agent.DeleteModuleConfig(ctx, moduleType, name)
 }
 
 func (m *backend) ModuleCounters(name string, counterNames []string) []CounterView {

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -273,7 +273,7 @@ func (m *RouteService) DeleteConfig(
 		return &routepb.DeleteConfigResponse{}, nil
 	}
 
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err := m.backend.DeleteModule(ctx, name); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
 	}
 	m.reclaimDeferred()
@@ -412,7 +412,7 @@ func (m *RouteService) UpdateFIB(
 	m.shmLock.Lock()
 	defer m.shmLock.Unlock()
 
-	module, err := m.backend.UpdateModule(name, entries)
+	module, err := m.backend.UpdateModule(ctx, name, entries)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to apply FIB for %q: %v", name, err)
 	}

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -1,6 +1,7 @@
 package route_test
 
 import (
+	"context"
 	"errors"
 	"net/netip"
 	"sort"
@@ -85,7 +86,7 @@ func newFakeBackend() *fakeBackend {
 // straight off entries, without resolving overlaps: the fake has no LPM, so
 // a test exercising shadowed-nexthop exclusion must go through the real
 // backend instead.
-func (m *fakeBackend) UpdateModule(name string, entries []*routepb.FIBEntry) (route.ModuleHandle, error) {
+func (m *fakeBackend) UpdateModule(ctx context.Context, name string, entries []*routepb.FIBEntry) (route.ModuleHandle, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -109,7 +110,7 @@ func (m *fakeBackend) UpdateModule(name string, entries []*routepb.FIBEntry) (ro
 	return m.handle, nil
 }
 
-func (m *fakeBackend) DeleteModule(name string) error {
+func (m *fakeBackend) DeleteModule(ctx context.Context, name string) error {
 	return nil
 }
 

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -107,7 +107,7 @@ func wirePipeline(
 ) {
 	tb.Helper()
 
-	require.NoError(tb, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(tb, agent.UpdateFunction(tb.Context(), ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -119,14 +119,14 @@ func wirePipeline(
 			},
 		}},
 	}))
-	require.NoError(tb, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(tb, agent.UpdatePipeline(tb.Context(), ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
-	require.NoError(tb, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(tb, agent.UpdatePipeline(tb.Context(), ffi.PipelineConfig{
 		Name: "dummy",
 	}))
-	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	_, err := plain.UpdateDevices(tb.Context(), agent, []ffi.DeviceConfig{{
 		Name:   deviceName,
 		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
@@ -174,7 +174,7 @@ func applyFIB(
 ) route.ModuleHandle {
 	tb.Helper()
 
-	handle, err := backend.UpdateModule(name, toFIBEntries(tb, entries))
+	handle, err := backend.UpdateModule(tb.Context(), name, toFIBEntries(tb, entries))
 	require.NoError(tb, err)
 	tb.Cleanup(func() { _ = handle.Free() })
 	return handle
@@ -527,7 +527,7 @@ func TestRoute_ECMP_HashSelection(t *testing.T) {
 
 	// Wire both devices through the pipeline. Each device gets its own
 	// function and chain so the module config reference ("test") resolves.
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: "test",
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -539,17 +539,17 @@ func TestRoute_ECMP_HashSelection(t *testing.T) {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      "test",
 		Functions: []string{"test"},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name: "dummy0",
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name: "dummy1",
 	}))
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{
+	_, err = plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{
 		{
 			Name:   "port0",
 			Input:  []ffi.DevicePipelineConfig{{Name: "test", Weight: 1}},

--- a/modules/unrdup/controlplane/backend.go
+++ b/modules/unrdup/controlplane/backend.go
@@ -1,6 +1,7 @@
 package unrdup
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/yanet-platform/xnetip"
@@ -19,10 +20,15 @@ func newBackend(agent *ffi.Agent) *backend {
 }
 
 func (m *backend) UpdateModule(
+	ctx context.Context,
 	name string,
 	sources []xnetip.Network,
 	services []cunrdup.Service,
 ) (ModuleHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	module, err := cunrdup.NewModuleConfig(m.agent, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module config: %w", err)
@@ -40,7 +46,7 @@ func (m *backend) UpdateModule(
 		return nil, fmt.Errorf("failed to update services: %w", err)
 	}
 
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
+	if err := m.agent.UpdateModules(ctx, []ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
 		_ = module.Free()
 		return nil, fmt.Errorf("failed to update module: %w", err)
 	}

--- a/modules/unrdup/controlplane/service.go
+++ b/modules/unrdup/controlplane/service.go
@@ -51,6 +51,7 @@ type ModuleHandle interface {
 type Backend interface {
 	// UpdateModule publishes a module config to the dataplane.
 	UpdateModule(
+		ctx context.Context,
 		name string,
 		sources []xnetip.Network,
 		services []cunrdup.Service,
@@ -180,7 +181,7 @@ func (m *UnrdupService) UpdateConfig(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	module, err := m.backend.UpdateModule(name, updated.Sources(), updated.Services)
+	module, err := m.backend.UpdateModule(ctx, name, updated.Sources(), updated.Services)
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal, "failed to update config %q: %s", name, err,

--- a/modules/unrdup/controlplane/service_test.go
+++ b/modules/unrdup/controlplane/service_test.go
@@ -1,6 +1,7 @@
 package unrdup_test
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/netip"
@@ -39,6 +40,7 @@ type fakeBackend struct {
 }
 
 func (m *fakeBackend) UpdateModule(
+	ctx context.Context,
 	name string,
 	sources []xnetip.Network,
 	services []cunrdup.Service,

--- a/modules/unrdup/tests/functional/unrdup_test.go
+++ b/modules/unrdup/tests/functional/unrdup_test.go
@@ -83,7 +83,7 @@ func setupHarness(
 		Endpoints: []cunrdup.Endpoint{{Port: servicePort, Proto: ipprotoTCP}},
 	}}))
 
-	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}))
+	require.NoError(t, agent.UpdateModules(t.Context(), []ffi.ModuleConfig{module.AsFFIModule()}))
 	wirePipeline(t, agent)
 
 	return harness
@@ -109,11 +109,11 @@ func wirePipeline(t *testing.T, agent *ffi.Agent) {
 	t.Helper()
 
 	sinkName := configName + "-sink"
-	sink, err := forward.NewBackend(agent).UpdateModule(sinkName, catchAllRules())
+	sink, err := forward.NewBackend(agent).UpdateModule(t.Context(), sinkName, catchAllRules())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sink.Free() })
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -126,12 +126,12 @@ func wirePipeline(t *testing.T, agent *ffi.Agent) {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: "dummy"}))
+	_, err = plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:   deviceName,
 		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},

--- a/objects/fwstate/bindings/go/cfwstate/map.go
+++ b/objects/fwstate/bindings/go/cfwstate/map.go
@@ -55,6 +55,7 @@ package cfwstate
 import "C"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"syscall"
@@ -353,55 +354,65 @@ func (m *MapObjectConfig) Free() error {
 // new generation followed by dp_config_wait_for_gen. Re-upserting the same
 // object pointer is safe — the registry uses reference counting, so the
 // ref/unref pair nets to zero and the object survives intact while only the
-// generation advances.
-func (m *MapObjectConfig) Publish(agent *ffi.Agent) error {
+// generation advances. A caller relying on this as a barrier must pass a
+// context that cannot be cancelled, because an ended one returns without
+// publishing anything.
+func (m *MapObjectConfig) Publish(ctx context.Context, agent *ffi.Agent) error {
 	if m.ptr == nil {
 		return fmt.Errorf("fwstate-map object config is nil")
 	}
 
 	objects := []*C.struct_cp_object{m.ptr}
-	var cErr *C.yanet_error
-	rc := C.agent_update_objects(
-		(*C.struct_agent)(agent.AsRawPtr()),
-		C.size_t(1),
-		&objects[0],
-		&cErr,
-	)
-	if rc != 0 {
-		return fmt.Errorf(
-			"failed to update objects: %w",
-			cerrors.FromC(unsafe.Pointer(cErr)),
-		)
-	}
 
-	return nil
+	return ffi.WithCancellation(ctx, func() error {
+		var cErr *C.yanet_error
+		rc := C.agent_update_objects(
+			(*C.struct_agent)(agent.AsRawPtr()),
+			C.size_t(1),
+			&objects[0],
+			&cErr,
+		)
+		if rc != 0 {
+			return fmt.Errorf(
+				"failed to update objects: %w",
+				cerrors.FromC(unsafe.Pointer(cErr)),
+			)
+		}
+
+		return nil
+	})
 }
 
 // DeleteMapObject removes a named object from the dataplane by type and
 // name (e.g. ("fwstate_map_v4", "default")) via agent_delete_object.
-func DeleteMapObject(agent *ffi.Agent, objectType, objectName string) error {
+func DeleteMapObject(
+	ctx context.Context, agent *ffi.Agent, objectType, objectName string,
+) error {
 	cObjectType := C.CString(objectType)
 	defer C.free(unsafe.Pointer(cObjectType))
 	cObjectName := C.CString(objectName)
 	defer C.free(unsafe.Pointer(cObjectName))
 
-	var cErr *C.yanet_error
-	rc := C.agent_delete_object(
-		(*C.struct_agent)(agent.AsRawPtr()),
-		cObjectType,
-		cObjectName,
-		&cErr,
-	)
-
-	if rc != 0 {
-		return fmt.Errorf(
-			"failed to delete object type %q name %q: %w",
-			objectType,
-			objectName,
-			cerrors.FromC(unsafe.Pointer(cErr)),
+	return ffi.WithCancellation(ctx, func() error {
+		var cErr *C.yanet_error
+		rc := C.agent_delete_object(
+			(*C.struct_agent)(agent.AsRawPtr()),
+			cObjectType,
+			cObjectName,
+			&cErr,
 		)
-	}
-	return nil
+
+		if rc != 0 {
+			return fmt.Errorf(
+				"failed to delete object type %q name %q: %w",
+				objectType,
+				objectName,
+				cerrors.FromC(unsafe.Pointer(cErr)),
+			)
+		}
+
+		return nil
+	})
 }
 
 // ReadForward reads up to count entries in the forward direction.

--- a/objects/fwstate/controlplane/map_service.go
+++ b/objects/fwstate/controlplane/map_service.go
@@ -204,7 +204,11 @@ func NewFWStateMapService(
 // publishGeneration upserts the map object into a new config generation
 // and blocks until every dataplane worker has advanced to it.
 func (m *FWStateMapService) publishGeneration(mapCP cfwstate.MapObjectConfig) error {
-	return mapCP.Publish(m.agent)
+	// Reclamation gives up entirely when this fails, leaving the unlinked
+	// layers parked until some later insert on the same map retries them,
+	// which may never come. The wait therefore outlives whichever request
+	// triggered it, and must not be made cancellable.
+	return mapCP.Publish(context.Background(), m.agent)
 }
 
 // UnaryServerInterceptor returns the service's gRPC metrics interceptor,
@@ -357,7 +361,7 @@ func (m *FWStateMapService) CreateMap(
 		return nil, status.Errorf(codes.Internal, "failed to create fwstate-map table: %v", err)
 	}
 
-	if err := mapConfig.Publish(m.agent); err != nil {
+	if err := mapConfig.Publish(ctx, m.agent); err != nil {
 		if err := mapConfig.Free(); err != nil {
 			m.log.Error("failed to free unpublished fwstate-map",
 				zap.String("map", name), zap.Error(err))
@@ -402,7 +406,7 @@ func (m *FWStateMapService) DeleteMap(
 	}
 
 	if err := cfwstate.DeleteMapObject(
-		m.agent, fwMap.Config().Kind().ObjectType(), name,
+		ctx, m.agent, fwMap.Config().Kind().ObjectType(), name,
 	); err != nil {
 		// The C object deletion refuses while a published module links
 		// the object, failing with the exact error "object

--- a/tests/controlplane/functional/device_registry_test.go
+++ b/tests/controlplane/functional/device_registry_test.go
@@ -39,7 +39,7 @@ func TestDeviceRegistryRejectsSameNameAcrossTypes(t *testing.T) {
 	vlanConfig, err := vlan.NewDeviceConfig(agent, "d0", &commonpb.Device{}, 100)
 	require.NoError(t, err)
 
-	updateErr := agent.UpdateDevices([]ffi.ShmDeviceConfig{
+	updateErr := agent.UpdateDevices(t.Context(), []ffi.ShmDeviceConfig{
 		plainConfig.AsFFIDevice(),
 		vlanConfig.AsFFIDevice(),
 	})

--- a/tests/counters/bulk_value_copy_test.go
+++ b/tests/counters/bulk_value_copy_test.go
@@ -56,10 +56,10 @@ func bulkCopyProbe(t *testing.T, workerCount uint64) (allocs uint64, matched int
 	input := make([]ffi.DevicePipelineConfig, bulkCopyPipelineCount)
 	for idx := range bulkCopyPipelineCount {
 		name := fmt.Sprintf("bulk-copy-pipeline-%d", idx)
-		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: name}))
+		require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: name}))
 		input[idx] = ffi.DevicePipelineConfig{Name: name, Weight: 1}
 	}
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	_, err = plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:  "port0",
 		Input: input,
 	}})

--- a/tests/counters/query_test.go
+++ b/tests/counters/query_test.go
@@ -46,10 +46,10 @@ func installQuerySurface(t *testing.T) *ffi.DPConfig {
 	input := make([]ffi.DevicePipelineConfig, queryPipelineCount)
 	for idx := range queryPipelineCount {
 		name := fmt.Sprintf("query-pipeline-%d", idx)
-		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: name}))
+		require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: name}))
 		input[idx] = ffi.DevicePipelineConfig{Name: name, Weight: 1}
 	}
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	_, err = plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:  "port0",
 		Input: input,
 	}})

--- a/tests/pipeline/dispatch_test.go
+++ b/tests/pipeline/dispatch_test.go
@@ -125,10 +125,10 @@ func publishMatchAllACL(t *testing.T, backend acl.Backend, name string, action u
 		},
 		Fragment: filter.FragmentAny,
 	}
-	handle, err := backend.NewModule(name, []cacl.AclRule{rule}, "", "", nil)
+	handle, err := backend.NewModule(t.Context(), name, []cacl.AclRule{rule}, "", "", nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
-	require.NoError(t, backend.UpdateModule(handle))
+	require.NoError(t, backend.UpdateModule(t.Context(), handle))
 }
 
 // TestZeroWeightFunctionDropsAllPackets verifies that a function whose only
@@ -145,7 +145,7 @@ func TestZeroWeightFunctionDropsAllPackets(t *testing.T) {
 
 	// Register an ACL function whose single chain has weight 0, which the
 	// dataplane treats as fully disabled.
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 0,
@@ -155,12 +155,12 @@ func TestZeroWeightFunctionDropsAllPackets(t *testing.T) {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
-	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: "dummy"}))
+	_, err := plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
@@ -205,7 +205,7 @@ func TestSequentialSingleChainFunctions(t *testing.T) {
 	publishMatchAllACL(t, backend, aclB, cacl.ActionDeny)
 
 	// Wire both single-chain functions into one pipeline in order.
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: aclA,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -215,7 +215,7 @@ func TestSequentialSingleChainFunctions(t *testing.T) {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: aclB,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -225,12 +225,12 @@ func TestSequentialSingleChainFunctions(t *testing.T) {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      pipelineAB,
 		Functions: []string{aclA, aclB},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
-	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: "dummy"}))
+	_, err := plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: pipelineAB, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
@@ -272,7 +272,7 @@ func TestZeroWeightDeviceEntryDropsAllPackets(t *testing.T) {
 	h, agent, backend := setupACLBackend(t, "zw-dev-test")
 	publishMatchAllACL(t, backend, configName, cacl.ActionAllow)
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -282,15 +282,15 @@ func TestZeroWeightDeviceEntryDropsAllPackets(t *testing.T) {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: "dummy"}))
 
 	// Bind the input pipeline with weight 0, which leaves the device entry's
 	// pipeline-map size at 0, so every packet is unroutable.
-	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	_, err := plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 0}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
@@ -337,12 +337,13 @@ func TestSinglePipelineDeviceForwardsAllPackets(t *testing.T) {
 		Dst4s:   []xnetip.Contiguous[xnetip.Network4]{xnetip.MustParseContiguous4("10.0.0.0/8")},
 	}
 	handle, err := forwardBackend.UpdateModule(
+		t.Context(),
 		forwardName, []cforward.ForwardRule{rule},
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Free() })
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(t, agent.UpdateFunction(t.Context(), ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -355,12 +356,12 @@ func TestSinglePipelineDeviceForwardsAllPackets(t *testing.T) {
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
-	_, err = plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: "dummy"}))
+	_, err = plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
@@ -395,10 +396,10 @@ func TestSinglePipelineDeviceForwardsAllPackets(t *testing.T) {
 func TestEmptyPipelineDeviceDropsAllPackets(t *testing.T) {
 	h, agent, _ := setupACLBackend(t, "empty-dev-test")
 
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+	require.NoError(t, agent.UpdatePipeline(t.Context(), ffi.PipelineConfig{Name: "dummy"}))
 	// The device input binds no pipeline at all, so the entry has nothing to
 	// dispatch to.
-	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	_, err := plain.UpdateDevices(t.Context(), agent, []ffi.DeviceConfig{{
 		Name:   "port0",
 		Input:  []ffi.DevicePipelineConfig{},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},

--- a/tests/pipeline/scheduler_bench_test.go
+++ b/tests/pipeline/scheduler_bench_test.go
@@ -128,11 +128,11 @@ func wireRedirect(
 		Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
 		Dst4s:   []xnetip.Contiguous[xnetip.Network4]{xnetip.MustParseContiguous4("10.0.0.0/8")},
 	}
-	handle, err := backend.UpdateModule(name, []cforward.ForwardRule{rule})
+	handle, err := backend.UpdateModule(b.Context(), name, []cforward.ForwardRule{rule})
 	require.NoError(b, err)
 	b.Cleanup(func() { _ = handle.Free() })
 
-	require.NoError(b, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(b, agent.UpdateFunction(b.Context(), ffi.FunctionConfig{
 		Name: name,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -142,19 +142,19 @@ func wireRedirect(
 			},
 		}},
 	}))
-	require.NoError(b, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(b, agent.UpdatePipeline(b.Context(), ffi.PipelineConfig{
 		Name:      name,
 		Functions: []string{name},
 	}))
 
 	// A pipeline with no functions passes packets straight through.
-	require.NoError(b, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+	require.NoError(b, agent.UpdatePipeline(b.Context(), ffi.PipelineConfig{Name: "dummy"}))
 
 	for _, dev := range extra {
-		require.NoError(b, agent.UpdatePipeline(ffi.PipelineConfig{
+		require.NoError(b, agent.UpdatePipeline(b.Context(), ffi.PipelineConfig{
 			Name: "dummy_out_" + dev,
 		}))
-		require.NoError(b, agent.UpdatePipeline(ffi.PipelineConfig{
+		require.NoError(b, agent.UpdatePipeline(b.Context(), ffi.PipelineConfig{
 			Name: "dummy_in_" + dev,
 		}))
 	}
@@ -171,7 +171,7 @@ func wireRedirect(
 			Output: []ffi.DevicePipelineConfig{{Name: "dummy_out_" + dev, Weight: 1}},
 		})
 	}
-	_, err = plain.UpdateDevices(agent, devices)
+	_, err = plain.UpdateDevices(b.Context(), agent, devices)
 	require.NoError(b, err)
 }
 


### PR DESCRIPTION
Stacked on #2231; review that first, and this diff against `fix/pdump-publish-rollback`.

- Add a cooperative cancellation token to the control-plane C library: a one-shot flag bound to the thread executing an operation, so a long C loop polls the binding of its own thread instead of taking a token through every signature, and a poll site can be added later without changing a single prototype.
- Bind the token from Go for the duration of a call, raise it when the context ends, and restore whatever binding was replaced so an operation nested inside another neither inherits nor disarms the enclosing one.
- Accept a context on every shared-memory config write and forward it from the handler that already carried one: the seven agent entry points, the standalone fwstate object publish and delete, and the plain-device helper.
- Run the ACL ruleset compile under a bound token, which is where the first poll site belongs: it is the longest step of an update, it publishes nothing, and it holds no lock.
- Keep the reclamation barrier uncancellable on purpose, because giving up between unlinking layers and freeing them defers the reclaim to a later insert that may never come.
- Report a call whose caller walked away with the matching status code, so a client hangup during a config write is no longer counted and logged as the service breaking.

Behaviour today: no C code polls the token, so the only change a caller can observe is that a call whose context is already done returns without starting. The rest is the plumbing that lets a later change add poll sites without touching these signatures again.

Deliberately left out, all follow-ups to the change that adds the polls:

- Attaching an agent takes the same unrecoverable shared-memory lock and is not wrapped, which matters only for the four builtin handlers that attach per request.
- The status rewrite also relabels a genuine failure that merely raced the hangup, so an internal error coinciding with a client timeout is counted as cancelled; the original text survives in the access log, and the codes a handler chooses deliberately are left alone.
- Streaming RPCs get no equivalent rewrite.

Closes #1680.
