### PR TITLE
feat(acl): serve per-rule counter metrics from their own method

### DIFF
--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -16,6 +16,8 @@ pub enum ModeCmd {
     Show(ShowCmd),
     /// Show ACL metrics
     Metrics(MetricsCmd),
+    /// Show per-rule ACL counter metrics
+    MetricsRules(MetricsRulesCmd),
     /// Show per-rule ACL counters
     RuleCounters(RuleCountersCmd),
 }
@@ -115,6 +117,25 @@ pub struct MetricsCmd {
     /// Show only metrics matching this category
     #[arg(long, short, value_enum)]
     pub name: Option<MetricName>,
+}
+
+#[derive(Debug, Clone, Parser, Default)]
+pub struct MetricsRulesCmd {
+    /// ACL config name; omit to match every config
+    #[arg(long = "config", short = 'c', add = ArgValueCandidates::new(crate::config_candidates))]
+    pub config: Option<String>,
+    /// Dataplane device name; omit to match every device
+    #[arg(long = "device", short = 'd')]
+    pub device: Option<String>,
+    /// Pipeline name; omit to match every pipeline
+    #[arg(long = "pipeline", short = 'p')]
+    pub pipeline: Option<String>,
+    /// Pipeline function name; omit to match every function
+    #[arg(long = "function", short = 'f')]
+    pub function: Option<String>,
+    /// Pipeline chain name; omit to match every chain
+    #[arg(long = "chain")]
+    pub chain: Option<String>,
 }
 
 #[derive(Debug, Clone, Parser, Default)]

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -2,10 +2,10 @@ use core::net::Ipv6Addr;
 use std::{collections::HashMap, fs::File, path::Path};
 
 use aclpb::{
-    DeleteConfigRequest, GetRulesCountersRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
-    acl_service_client::AclServiceClient, metrics_service_client::MetricsServiceClient,
+    DeleteConfigRequest, GetMetricsRulesRequest, GetRulesCountersRequest, ListConfigsRequest, ShowConfigRequest,
+    UpdateConfigRequest, acl_service_client::AclServiceClient, metrics_service_client::MetricsServiceClient,
 };
-use args::{DeleteCmd, MetricsCmd, ModeCmd, RuleCountersCmd, ShowCmd, UpdateCmd};
+use args::{DeleteCmd, MetricsCmd, MetricsRulesCmd, ModeCmd, RuleCountersCmd, ShowCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
 use serde::{Deserialize, Serialize};
@@ -89,6 +89,108 @@ fn print_counter_table(rows: Vec<CounterRow>) {
     }
 
     ync::display::print_table(builder.build());
+}
+
+/// A rule counter's location and its packet and byte totals.
+struct RuleCounterRow {
+    location: RuleLocation,
+    counter: String,
+    packets: Option<u64>,
+    bytes: Option<u64>,
+}
+
+/// The position a rule counter belongs to, kept as raw field values.
+type RuleLocation = (String, String, String, String, String);
+
+fn rule_label(metric: &commonpb::Metric, name: &str) -> String {
+    metric
+        .labels
+        .iter()
+        .find(|label| label.name == name)
+        .map_or_else(String::new, |label| label.value.clone())
+}
+
+/// Groups `acl_rule_packets` and `acl_rule_bytes` into one row per rule
+/// counter, keyed by the raw location fields and the `counter` label.
+///
+/// The metrics table renderer drops counter-labelled metrics, so rule
+/// metrics need their own pairing. Totals are read from the protobuf
+/// `uint64` directly, since routing them through `f64` would round a
+/// counter past 2^53.
+fn rule_counter_rows(metrics: &[commonpb::Metric]) -> Vec<RuleCounterRow> {
+    let mut order: Vec<(RuleLocation, String)> = Vec::new();
+    let mut rows: HashMap<(RuleLocation, String), RuleCounterRow> = HashMap::new();
+
+    for metric in metrics {
+        let counter = rule_label(metric, "counter");
+        if counter.is_empty() {
+            continue;
+        }
+
+        let location: RuleLocation = (
+            rule_label(metric, "config"),
+            rule_label(metric, "device"),
+            rule_label(metric, "pipeline"),
+            rule_label(metric, "function"),
+            rule_label(metric, "chain"),
+        );
+        let key = (location.clone(), counter.clone());
+
+        let row = rows.entry(key.clone()).or_insert_with(|| {
+            order.push(key);
+            RuleCounterRow {
+                location,
+                counter,
+                packets: None,
+                bytes: None,
+            }
+        });
+
+        let Some(commonpb::metric::Value::Counter(value)) = metric.value else {
+            continue;
+        };
+
+        if metric.name.ends_with("_packets") {
+            row.packets = Some(value);
+        } else if metric.name.ends_with("_bytes") {
+            row.bytes = Some(value);
+        }
+    }
+
+    order.into_iter().filter_map(|key| rows.remove(&key)).collect()
+}
+
+fn print_rule_metrics_table(metrics: &[commonpb::Metric]) {
+    let rows = rule_counter_rows(metrics);
+
+    let mut current: Option<&RuleLocation> = None;
+    let mut pending: Vec<CounterRow> = Vec::new();
+
+    for row in &rows {
+        if current != Some(&row.location) {
+            if current.is_some() {
+                print_counter_table(core::mem::take(&mut pending));
+                println!();
+            }
+            let (config, device, pipeline, function, chain) = &row.location;
+            println!(
+                "ACL RULE COUNTERS  config={config} device={device} pipeline={pipeline} function={function} chain={chain}"
+            );
+            println!();
+            current = Some(&row.location);
+        }
+
+        pending.push(CounterRow {
+            counter: row.counter.clone(),
+            packets: row.packets.map_or_else(|| "-".to_string(), metrics::format_number),
+            bytes: row.bytes.map_or_else(|| "-".to_string(), metrics::format_number),
+        });
+    }
+
+    if !pending.is_empty() {
+        print_counter_table(pending);
+        println!();
+    }
 }
 
 fn print_metrics_table(metrics: &[Metric]) {
@@ -599,6 +701,43 @@ impl ACLService {
 
         Ok(())
     }
+
+    pub async fn metrics_rules(&mut self, cmd: MetricsRulesCmd) -> Result<(), Error> {
+        let request = GetMetricsRulesRequest {
+            config: cmd.config.clone().unwrap_or_default(),
+            device: cmd.device.clone().unwrap_or_default(),
+            pipeline: cmd.pipeline.clone().unwrap_or_default(),
+            function: cmd.function.clone().unwrap_or_default(),
+            chain: cmd.chain.clone().unwrap_or_default(),
+        };
+
+        let response = self
+            .metrics
+            .client()
+            .get_metrics_rules(request)
+            .await
+            .map_err(self.metrics.status("metrics-rules"))?
+            .into_inner();
+
+        let metrics = response.metrics;
+
+        output::data(
+            || &metrics,
+            || {
+                if metrics.is_empty() {
+                    match cmd.config.as_deref() {
+                        Some(name) => output::empty(format_args!("No ACL rule metrics found for '{name}'.")),
+                        None => output::empty(format_args!("No ACL rule metrics found.")),
+                    }
+                    return;
+                }
+
+                print_rule_metrics_table(&metrics)
+            },
+        );
+
+        Ok(())
+    }
 }
 
 /// Parses a `NAME=VALUE` tag entry into a [`MetricTag`].
@@ -624,6 +763,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::Update(cmd) => service.update_config(cmd).await,
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
         ModeCmd::Metrics(cmd) => service.metrics(cmd).await,
+        ModeCmd::MetricsRules(cmd) => service.metrics_rules(cmd).await,
         ModeCmd::RuleCounters(cmd) => service.rule_counters(cmd).await,
     }
 }
@@ -665,6 +805,70 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn rule_metric(name: &str, config: &str, counter: &str, value: u64) -> commonpb::Metric {
+        commonpb::Metric {
+            name: name.to_string(),
+            value: Some(commonpb::metric::Value::Counter(value)),
+            labels: [
+                ("config", config),
+                ("device", "port0"),
+                ("pipeline", "p"),
+                ("function", "f"),
+                ("chain", "c"),
+                ("counter", counter),
+            ]
+            .into_iter()
+            .map(|(name, value)| commonpb::Label {
+                name: name.to_string(),
+                value: value.to_string(),
+            })
+            .collect(),
+        }
+    }
+
+    #[test]
+    fn pairs_rule_counters_the_metrics_table_would_drop() {
+        let metrics = vec![
+            rule_metric("acl_rule_packets", "test", "svc_counter", 3),
+            rule_metric("acl_rule_bytes", "test", "svc_counter", 300),
+            rule_metric("acl_rule_packets", "test", "other", 1),
+        ];
+
+        let rows = rule_counter_rows(&metrics);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].counter, "svc_counter");
+        assert_eq!(rows[0].packets, Some(3));
+        assert_eq!(rows[0].bytes, Some(300));
+        assert_eq!(rows[1].counter, "other");
+        assert_eq!(rows[1].packets, Some(1));
+        assert_eq!(rows[1].bytes, None);
+    }
+
+    #[test]
+    fn keeps_totals_beyond_f64_precision() {
+        let exact = (1_u64 << 53) + 1;
+        let metrics = vec![rule_metric("acl_rule_bytes", "test", "svc_counter", exact)];
+
+        let rows = rule_counter_rows(&metrics);
+
+        assert_eq!(rows[0].bytes, Some(exact));
+    }
+
+    #[test]
+    fn keeps_positions_whose_names_carry_field_markers() {
+        let metrics = vec![
+            rule_metric("acl_rule_packets", "a device=b", "svc_counter", 1),
+            rule_metric("acl_rule_packets", "a", "svc_counter", 2),
+        ];
+
+        let rows = rule_counter_rows(&metrics);
+
+        assert_eq!(rows.len(), 2, "two positions must not collapse into one row");
+        assert_eq!(rows[0].packets, Some(1));
+        assert_eq!(rows[1].packets, Some(2));
+    }
 
     #[test]
     fn deserialize_fixture_acl_yaml() {

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -28,8 +28,10 @@ service ACLService {
 
 // MetricsService exposes ACL module metrics.
 service MetricsService {
-  // GetMetrics returns a snapshot of ACL module metrics.
+  // GetMetrics returns a snapshot of ACL module metrics, excluding per-rule counters.
   rpc GetMetrics(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
+  // GetMetricsRules returns the per-rule counter metrics GetMetrics leaves out.
+  rpc GetMetricsRules(GetMetricsRulesRequest) returns (common.commonpb.v1.GetMetricsResponse);
 }
 
 message UpdateConfigRequest {
@@ -139,6 +141,15 @@ message SyncConfig {
 message GetRulesCountersRequest {
   // Optional ACL configuration name.
   string name = 1;
+}
+
+// Positions to report per-rule counters of; an empty field matches every value.
+message GetMetricsRulesRequest {
+  string config = 1;
+  string device = 2;
+  string pipeline = 3;
+  string function = 4;
+  string chain = 5;
 }
 
 // One per-rule counter at the module position holding it.

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -3,6 +3,9 @@ package acl
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -12,6 +15,7 @@ import (
 // metricsSource provides the module's metrics, filtered by tags.
 type metricsSource interface {
 	Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error)
+	RuleMetrics(req *aclpb.GetMetricsRulesRequest) ([]*commonpb.Metric, error)
 }
 
 type moduleCounterReader interface {
@@ -41,6 +45,16 @@ func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetric
 	return &commonpb.GetMetricsResponse{Metrics: all}, nil
 }
 
+// GetMetricsRules returns the per-rule counter metrics GetMetrics leaves out.
+func (m *MetricsService) GetMetricsRules(ctx context.Context, req *aclpb.GetMetricsRulesRequest) (*commonpb.GetMetricsResponse, error) {
+	all, err := m.source.RuleMetrics(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &commonpb.GetMetricsResponse{Metrics: all}, nil
+}
+
 // aclStructuralCounters lists the fixed ACL counters whose metrics carry no
 // "counter" label.
 //
@@ -57,9 +71,9 @@ var aclStructuralCounters = []string{
 // Metrics returns ACL module metrics matching tags: per-pipeline packet
 // counters, ACL compilation info, and gRPC call metrics.
 //
-// Per-rule counters are served by GetRulesCounters, not here. Counter
-// metrics are omitted when all worker values are zero to reduce output
-// noise.
+// Per-rule counters are served by RuleMetrics and GetRulesCounters, not
+// here. Counter metrics are omitted when all worker values are zero to
+// reduce output noise.
 //
 // Labels:
 //   - config:        ACL config name (all counter metrics)
@@ -80,6 +94,130 @@ func (m *ACLService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, e
 		all = append(all, m.metrics.Collect()...)
 	}
 	return metrics.Filter(all, tags), nil
+}
+
+// RuleMetrics returns ACL per-rule counter metrics for the selected
+// positions: one packets and one bytes counter for every rule counter.
+//
+// These are the counters Metrics leaves out, read from the runtime-kind
+// storages it never touches. An empty request field matches every value.
+// One read serves every position, and each metric's position comes from
+// the tags its counter group carries. Counter metrics are omitted when
+// all worker values are zero to reduce output noise.
+//
+// Labels:
+//   - config:    ACL config name
+//   - device:    dataplane device name
+//   - pipeline:  pipeline name
+//   - function:  pipeline function name
+//   - chain:     pipeline chain name
+//   - counter:   rule counter name
+func (m *ACLService) RuleMetrics(req *aclpb.GetMetricsRulesRequest) ([]*commonpb.Metric, error) {
+	dpConfig := m.backend.DPConfig()
+	if dpConfig == nil {
+		return []*commonpb.Metric{}, nil
+	}
+
+	groups, err := dpConfig.CountersByTags(ruleQueryTags(req), nil)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal, "failed to read rule counters: %v", err,
+		)
+	}
+
+	result := make([]*commonpb.Metric, 0)
+	for _, group := range groups {
+		location := groupLocation(group.Tags)
+		if !locationSelected(location, req) {
+			continue
+		}
+
+		base := []*commonpb.Label{
+			{Name: "config", Value: location["module_name"]},
+			{Name: "device", Value: location["device"]},
+			{Name: "pipeline", Value: location["pipeline"]},
+			{Name: "function", Value: location["function"]},
+			{Name: "chain", Value: location["chain"]},
+		}
+
+		for _, counter := range group.Counters {
+			var packets, bytes uint64
+			for _, workerVals := range counter.Values {
+				if len(workerVals) > 0 {
+					packets += workerVals[0]
+				}
+				if len(workerVals) > 1 {
+					bytes += workerVals[1]
+				}
+			}
+
+			if packets == 0 && bytes == 0 {
+				continue
+			}
+
+			labels := make([]*commonpb.Label, 0, len(base)+1)
+			labels = append(labels, base...)
+			labels = append(labels, &commonpb.Label{
+				Name:  "counter",
+				Value: counter.Name,
+			})
+
+			result = append(result,
+				commonpb.NewMetricCounter("acl_rule_packets", packets, labels...),
+				commonpb.NewMetricCounter("acl_rule_bytes", bytes, labels...),
+			)
+		}
+	}
+
+	return result, nil
+}
+
+func ruleQueryTags(req *aclpb.GetMetricsRulesRequest) []ffi.CounterTag {
+	tags := []ffi.CounterTag{
+		{Key: "module_type", Value: moduleType},
+		{Key: "kind", Value: "runtime"},
+	}
+
+	for _, selector := range requestSelectors(req) {
+		key, value := selector[0], selector[1]
+		if value == "" || value == "*" {
+			continue
+		}
+
+		tags = append(tags, ffi.CounterTag{Key: key, Value: value})
+	}
+
+	return tags
+}
+
+func locationSelected(location map[string]string, req *aclpb.GetMetricsRulesRequest) bool {
+	for _, selector := range requestSelectors(req) {
+		key, value := selector[0], selector[1]
+		if value != "" && value != location[key] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func requestSelectors(req *aclpb.GetMetricsRulesRequest) [][2]string {
+	return [][2]string{
+		{"module_name", req.GetConfig()},
+		{"device", req.GetDevice()},
+		{"pipeline", req.GetPipeline()},
+		{"function", req.GetFunction()},
+		{"chain", req.GetChain()},
+	}
+}
+
+func groupLocation(tags []ffi.CounterTag) map[string]string {
+	location := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		location[tag.Key] = tag.Value
+	}
+
+	return location
 }
 
 func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*commonpb.Metric, error) {

--- a/modules/acl/controlplane/metrics_test.go
+++ b/modules/acl/controlplane/metrics_test.go
@@ -8,14 +8,17 @@ import (
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
+	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
 )
 
 // spyMetricsSource records the tags it receives and returns a fixed slice
 // of metrics for MetricsService wiring tests.
 type spyMetricsSource struct {
-	metrics []*commonpb.Metric
+	metrics     []*commonpb.Metric
+	ruleMetrics []*commonpb.Metric
 
 	receivedTags []*commonpb.MetricTag
+	receivedRule *aclpb.GetMetricsRulesRequest
 }
 
 type counterRead struct {
@@ -61,6 +64,11 @@ func (m *counterSpyBackend) CounterReads() []counterRead {
 func (m *spyMetricsSource) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
 	m.receivedTags = tags
 	return m.metrics, nil
+}
+
+func (m *spyMetricsSource) RuleMetrics(req *aclpb.GetMetricsRulesRequest) ([]*commonpb.Metric, error) {
+	m.receivedRule = req
+	return m.ruleMetrics, nil
 }
 
 // verifies that an untagged scrape reads only the fixed counter set and
@@ -154,4 +162,34 @@ func TestMetricsServiceGetMetricsForwardsTags(t *testing.T) {
 			require.Equal(t, metrics, response.GetMetrics())
 		})
 	}
+}
+
+// TestMetricsServiceGetMetricsRulesUsesRuleSource verifies that
+// GetMetricsRules forwards its selectors to the rule source and returns what
+// that source produces, keeping the two reads apart.
+func TestMetricsServiceGetMetricsRulesUsesRuleSource(t *testing.T) {
+	structural := []*commonpb.Metric{
+		{
+			Name:  "acl_action_allow_packets",
+			Value: &commonpb.Metric_Counter{Counter: 42},
+		},
+	}
+	rules := []*commonpb.Metric{
+		{
+			Name:  "acl_rule_packets",
+			Value: &commonpb.Metric_Counter{Counter: 7},
+		},
+	}
+
+	request := &aclpb.GetMetricsRulesRequest{Config: "test", Device: "port0"}
+
+	source := &spyMetricsSource{metrics: structural, ruleMetrics: rules}
+	service := acl.NewMetricsService(source)
+
+	response, err := service.GetMetricsRules(t.Context(), request)
+
+	require.NoError(t, err)
+	require.Equal(t, request, source.receivedRule)
+	require.Nil(t, source.receivedTags)
+	require.Equal(t, rules, response.GetMetrics())
 }

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -1213,6 +1213,69 @@ func TestACL_Counters(t *testing.T) {
 		require.NotContains(t, metricNames, "acl_rule_bytes")
 		require.Contains(t, metricNames, "acl_action_allow_packets")
 
+		ruleMetrics, err := svc.RuleMetrics(&aclpb.GetMetricsRulesRequest{})
+		require.NoError(t, err)
+
+		byName := make(map[string]*commonpb.Metric, len(ruleMetrics))
+		for _, metric := range ruleMetrics {
+			byName[metric.GetName()] = metric
+			require.NotContains(t, metric.GetName(), "acl_action_")
+		}
+
+		rulePackets, ok := byName["acl_rule_packets"]
+		require.True(t, ok, "rule metrics must carry acl_rule_packets")
+		require.Equal(t, uint64(3), rulePackets.GetCounter())
+
+		ruleBytes, ok := byName["acl_rule_bytes"]
+		require.True(t, ok, "rule metrics must carry acl_rule_bytes")
+		require.Equal(t, 3*pktSize, ruleBytes.GetCounter())
+
+		labels := make(map[string]string, len(rulePackets.GetLabels()))
+		for _, label := range rulePackets.GetLabels() {
+			labels[label.GetName()] = label.GetValue()
+		}
+		require.Equal(t, "svc_counter", labels["counter"])
+		require.Equal(t, "test", labels["config"])
+		require.Equal(t, "port0", labels["device"])
+
+		ruleMetricNames := func(req *aclpb.GetMetricsRulesRequest) []string {
+			t.Helper()
+
+			got, err := svc.RuleMetrics(req)
+			require.NoError(t, err)
+
+			names := make([]string, 0, len(got))
+			for _, metric := range got {
+				names = append(names, metric.GetName())
+			}
+
+			return names
+		}
+
+		for _, selected := range []*aclpb.GetMetricsRulesRequest{
+			{Config: "test"},
+			{Device: "port0"},
+			{Pipeline: "test"},
+			{Function: "test"},
+			{Chain: "test_chain"},
+			{Config: "test", Device: "port0", Chain: "test_chain"},
+		} {
+			require.Contains(t, ruleMetricNames(selected), "acl_rule_packets",
+				"selector %v must select the installed position", selected,
+			)
+		}
+
+		for _, excluded := range []*aclpb.GetMetricsRulesRequest{
+			{Config: "other"},
+			{Device: "port9"},
+			{Chain: "other_chain"},
+			{Config: "test", Device: "port9"},
+		} {
+			require.Empty(t, ruleMetricNames(excluded),
+				"selector %v must exclude the installed position", excluded,
+			)
+		}
+
 		_, err = svc.GetRulesCounters(t.Context(), &aclpb.GetRulesCountersRequest{Name: "missing"})
 		require.Equal(t, codes.NotFound, status.Code(err))
 	})


### PR DESCRIPTION
GetMetricsRules returns acl_rule_packets and acl_rule_bytes for every rule counter, labelled with the config, the position and the counter name. It reads the runtime-kind storages GetMetrics never touches, so GetMetrics keeps returning the predefined counters alone.

The request names the config, device, pipeline, function and chain to report on, with an empty field matching every value and the module type implied. A position the request excludes is skipped before its counters are read rather than filtered out afterwards.

The acl CLI gains a metrics-rules command with a flag per selector. Rule metrics need a renderer of their own, because the existing metrics table keeps only counters that carry no counter label. GetRulesCounters keeps serving the same counters in its own shape.