### PR TITLE
refactor(commonpb,web)!: serialize mac addresses as bare eui-48 strings

### DIFF
--- a/common/commonpb/v1/ipv4addr.go
+++ b/common/commonpb/v1/ipv4addr.go
@@ -43,10 +43,6 @@ func (m *IPv4Address) AsLogValue() any {
 
 // MarshalJSON serializes the message as a bare dotted-quad address
 // string.
-//
-// Unlike the mixed message's object form, there is no wrapping: the
-// value is the same bare string the Rust side renders, so both
-// languages share one JSON encoding.
 func (m *IPv4Address) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.ToAddr().String())
 }

--- a/common/commonpb/v1/ipv4prefix.go
+++ b/common/commonpb/v1/ipv4prefix.go
@@ -81,8 +81,7 @@ func (m *IPv4Prefix) AsLogValue() any {
 	return prefix.String()
 }
 
-// MarshalJSON serializes the network as a bare CIDR string, the same
-// form the Rust side renders.
+// MarshalJSON serializes the network as a bare CIDR string.
 func (m *IPv4Prefix) MarshalJSON() ([]byte, error) {
 	prefix, err := m.ToPrefix()
 	if err != nil {

--- a/common/commonpb/v1/ipv6addr.go
+++ b/common/commonpb/v1/ipv6addr.go
@@ -49,8 +49,7 @@ func (m *IPv6Address) AsLogValue() any {
 	return m.ToAddr().String()
 }
 
-// MarshalJSON serializes the message as a bare IPv6 address string, the
-// same form the Rust side renders.
+// MarshalJSON serializes the message as a bare IPv6 address string.
 func (m *IPv6Address) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.ToAddr().String())
 }

--- a/common/commonpb/v1/ipv6prefix.go
+++ b/common/commonpb/v1/ipv6prefix.go
@@ -81,8 +81,7 @@ func (m *IPv6Prefix) AsLogValue() any {
 	return prefix.String()
 }
 
-// MarshalJSON serializes the network as a bare CIDR string, the same
-// form the Rust side renders.
+// MarshalJSON serializes the network as a bare CIDR string.
 func (m *IPv6Prefix) MarshalJSON() ([]byte, error) {
 	prefix, err := m.ToPrefix()
 	if err != nil {

--- a/common/commonpb/v1/macaddr.go
+++ b/common/commonpb/v1/macaddr.go
@@ -7,6 +7,10 @@ import (
 	"net"
 )
 
+// eui48TextLen is the length of the separated EUI-48 text form,
+// "xx:xx:xx:xx:xx:xx".
+const eui48TextLen = 17
+
 // NewMACAddressEUI48 creates a MACAddress from a 6-byte EUI-48
 // address.
 func NewMACAddressEUI48(addr [6]byte) *MACAddress {
@@ -26,41 +30,54 @@ func (m *MACAddress) EUI48() [6]byte {
 	return [6]byte(buf[2:])
 }
 
+// eui48Text renders the address as six colon-separated lowercase hex
+// octets, rejecting set upper 16 bits instead of truncating them.
+func (m *MACAddress) eui48Text() (string, error) {
+	if m.GetAddr()>>48 != 0 {
+		return "", fmt.Errorf("upper 16 bits are set for MAC address")
+	}
+
+	eui48 := m.EUI48()
+	return net.HardwareAddr(eui48[:]).String(), nil
+}
+
 // AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
 func (m *MACAddress) AsLogValue() any {
-	eui48 := m.EUI48()
-	return net.HardwareAddr(eui48[:]).String()
+	text, err := m.eui48Text()
+	if err != nil {
+		return "invalid"
+	}
+
+	return text
 }
 
-// macAddressJSON is the JSON wire shape shared by MarshalJSON and
-// UnmarshalJSON.
-type macAddressJSON struct {
-	Addr string `json:"addr"`
-}
-
-// MarshalJSON serializes addr as a human-readable MAC address string.
+// MarshalJSON serializes the address as a bare EUI-48 string such as
+// "3a:ac:26:9b:5b:f9".
 func (m *MACAddress) MarshalJSON() ([]byte, error) {
-	eui48 := m.EUI48()
-	return json.Marshal(macAddressJSON{Addr: net.HardwareAddr(eui48[:]).String()})
+	text, err := m.eui48Text()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(text)
 }
 
-// UnmarshalJSON accepts addr as a MAC address string in various EUI-48
-// formats.
+// UnmarshalJSON accepts a bare EUI-48 string: colon- or hyphen-separated
+// hex octets in either letter case. Other layouts are rejected.
 func (m *MACAddress) UnmarshalJSON(data []byte) error {
-	var raw macAddressJSON
+	var raw string
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	if raw.Addr == "" {
+	if raw == "" {
 		return fmt.Errorf("empty MAC address is not allowed")
 	}
+	if len(raw) != eui48TextLen {
+		return fmt.Errorf("invalid MAC address format: expected EUI-48 xx:xx:xx:xx:xx:xx, got %q", raw)
+	}
 
-	parsed, err := net.ParseMAC(raw.Addr)
+	parsed, err := net.ParseMAC(raw)
 	if err != nil {
 		return err
-	}
-	if len(parsed) != 6 {
-		return fmt.Errorf("invalid MAC address format: expected 6 octets, got %d", len(parsed))
 	}
 
 	*m = *NewMACAddressEUI48([6]byte(parsed))

--- a/common/commonpb/v1/macaddr.proto
+++ b/common/commonpb/v1/macaddr.proto
@@ -5,6 +5,8 @@ package common.commonpb.v1;
 option go_package = "github.com/yanet-platform/yanet2/common/commonpb/v1;commonpb";
 
 // MACAddress represents a hardware address in EUI-48 format.
+//
+// Its JSON and string form is the EUI-48 text, such as "3a:ac:26:9b:5b:f9".
 message MACAddress {
   reserved 1;
   // Addr keeps MAC address bytes as a 64-bit unsigned integer in network

--- a/common/commonpb/v1/macaddr_test.go
+++ b/common/commonpb/v1/macaddr_test.go
@@ -1,56 +1,63 @@
-package commonpb
+package commonpb_test
 
 import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 )
 
-func TestMACAddress_MarshalJSON(t *testing.T) {
+// Test_MACAddress_MarshalJSON verifies that a well-formed address
+// marshals as a bare lowercase colon-separated EUI-48 string.
+func Test_MACAddress_MarshalJSON(t *testing.T) {
 	tests := []struct {
-		name    string
-		mac     *MACAddress
-		want    string
-		wantErr bool
+		name string
+		mac  *commonpb.MACAddress
+		want string
 	}{
 		{
-			name: "typical MAC",
-			mac:  NewMACAddressEUI48([6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9}),
-			want: `{"addr":"3a:ac:26:9b:5b:f9"}`,
+			name: "typical address",
+			mac:  commonpb.NewMACAddressEUI48([6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9}),
+			want: `"3a:ac:26:9b:5b:f9"`,
 		},
 		{
 			name: "all zeros",
-			mac:  NewMACAddressEUI48([6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
-			want: `{"addr":"00:00:00:00:00:00"}`,
+			mac:  commonpb.NewMACAddressEUI48([6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
+			want: `"00:00:00:00:00:00"`,
 		},
 		{
 			name: "all ones",
-			mac:  NewMACAddressEUI48([6]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}),
-			want: `{"addr":"ff:ff:ff:ff:ff:ff"}`,
+			mac:  commonpb.NewMACAddressEUI48([6]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}),
+			want: `"ff:ff:ff:ff:ff:ff"`,
 		},
 		{
-			name: "zero value MAC",
-			mac:  &MACAddress{Addr: 0},
-			want: `{"addr":"00:00:00:00:00:00"}`,
+			name: "zero message",
+			mac:  &commonpb.MACAddress{},
+			want: `"00:00:00:00:00:00"`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := json.Marshal(tt.mac)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if string(got) != tt.want {
-				t.Errorf("MarshalJSON() = %v, want %v", string(got), tt.want)
-			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(got))
 		})
 	}
 }
 
-func TestMACAddress_UnmarshalJSON(t *testing.T) {
+// Test_MACAddress_MarshalJSON_RejectsUpperBits verifies that set upper
+// 16 bits are reported as an error instead of being truncated.
+func Test_MACAddress_MarshalJSON_RejectsUpperBits(t *testing.T) {
+	_, err := json.Marshal(&commonpb.MACAddress{Addr: 0x1_0000_0000_0000})
+	require.Error(t, err)
+}
+
+// Test_MACAddress_UnmarshalJSON verifies that only the colon- and
+// hyphen-separated EUI-48 layouts are accepted.
+func Test_MACAddress_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string
 		json    string
@@ -59,131 +66,145 @@ func TestMACAddress_UnmarshalJSON(t *testing.T) {
 	}{
 		{
 			name: "colon-separated",
-			json: `{"addr":"3a:ac:26:9b:5b:f9"}`,
+			json: `"3a:ac:26:9b:5b:f9"`,
 			want: [6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9},
 		},
 		{
 			name: "hyphen-separated",
-			json: `{"addr":"3a-ac-26-9b-5b-f9"}`,
+			json: `"3a-ac-26-9b-5b-f9"`,
 			want: [6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9},
 		},
 		{
-			name: "dot-separated (Cisco)",
-			json: `{"addr":"3aac.269b.5bf9"}`,
+			name: "uppercase hex",
+			json: `"3A:AC:26:9B:5B:F9"`,
 			want: [6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9},
 		},
 		{
-			name: "uppercase",
-			json: `{"addr":"3A:AC:26:9B:5B:F9"}`,
-			want: [6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9},
+			name:    "dot-separated is rejected",
+			json:    `"3aac.269b.5bf9"`,
+			wantErr: true,
+		},
+		{
+			name:    "unseparated is rejected",
+			json:    `"3aac269b5bf9"`,
+			wantErr: true,
+		},
+		{
+			name:    "mixed separators are rejected",
+			json:    `"3a:ac-26:9b-5b:f9"`,
+			wantErr: true,
+		},
+		{
+			name:    "legacy object form is rejected",
+			json:    `{"addr":"3a:ac:26:9b:5b:f9"}`,
+			wantErr: true,
 		},
 		{
 			name:    "empty string",
-			json:    `{"addr":""}`,
+			json:    `""`,
 			wantErr: true,
 		},
 		{
-			name:    "invalid format",
-			json:    `{"addr":"invalid"}`,
+			name:    "not an address",
+			json:    `"invalid"`,
 			wantErr: true,
 		},
 		{
-			name:    "invalid JSON",
-			json:    `{"addr":`,
+			name:    "truncated JSON",
+			json:    `"3a:ac`,
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var mac MACAddress
+			var mac commonpb.MACAddress
 			err := json.Unmarshal([]byte(tt.json), &mac)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if !tt.wantErr {
-				got := mac.EUI48()
-				if got != tt.want {
-					t.Errorf("UnmarshalJSON() = %v, want %v", got, tt.want)
-				}
-			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, mac.EUI48())
 		})
 	}
 }
 
-func TestMACAddress_RoundTrip(t *testing.T) {
+// Test_MACAddress_JSONRoundTrip verifies that a marshalled address
+// unmarshals to the same wire value.
+func Test_MACAddress_JSONRoundTrip(t *testing.T) {
 	tests := []struct {
 		name string
-		mac  *MACAddress
+		mac  *commonpb.MACAddress
 	}{
 		{
-			name: "typical MAC",
-			mac:  NewMACAddressEUI48([6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9}),
+			name: "typical address",
+			mac:  commonpb.NewMACAddressEUI48([6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9}),
 		},
 		{
 			name: "all zeros",
-			mac:  NewMACAddressEUI48([6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
+			mac:  commonpb.NewMACAddressEUI48([6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
 		},
 		{
 			name: "all ones",
-			mac:  NewMACAddressEUI48([6]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}),
+			mac:  commonpb.NewMACAddressEUI48([6]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			data, err := json.Marshal(tt.mac)
-			if err != nil {
-				t.Fatalf("Marshal() error = %v", err)
-			}
+			require.NoError(t, err)
 
-			var got MACAddress
-			if err := json.Unmarshal(data, &got); err != nil {
-				t.Fatalf("Unmarshal() error = %v", err)
-			}
-
-			if got.Addr != tt.mac.Addr {
-				t.Errorf("Round trip failed: got %v, want %v", got.Addr, tt.mac.Addr)
-			}
+			var got commonpb.MACAddress
+			require.NoError(t, json.Unmarshal(data, &got))
+			require.Equal(t, tt.mac.Addr, got.Addr)
 		})
 	}
 }
 
-func TestMACAddress_AsLogValue(t *testing.T) {
+// Test_MACAddress_AsLogValue verifies that logging renders the EUI-48
+// text and falls back to a literal marker for a malformed message.
+func Test_MACAddress_AsLogValue(t *testing.T) {
 	tests := []struct {
 		name string
-		mac  *MACAddress
+		mac  *commonpb.MACAddress
 		want string
 	}{
 		{
-			name: "typical MAC",
-			mac:  NewMACAddressEUI48([6]byte{0x7c, 0xc3, 0x85, 0x70, 0x5a, 0xd6}),
+			name: "typical address",
+			mac:  commonpb.NewMACAddressEUI48([6]byte{0x7c, 0xc3, 0x85, 0x70, 0x5a, 0xd6}),
 			want: "7c:c3:85:70:5a:d6",
 		},
 		{
-			name: "all zeros",
-			mac:  &MACAddress{},
+			name: "zero message",
+			mac:  &commonpb.MACAddress{},
 			want: "00:00:00:00:00:00",
+		},
+		{
+			name: "upper bits set",
+			mac:  &commonpb.MACAddress{Addr: 0x1_0000_0000_0000},
+			want: "invalid",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.mac.AsLogValue())
+			require.Equal(t, tt.want, tt.mac.AsLogValue())
 		})
 	}
 }
 
-func TestMACAddress_FromProto(t *testing.T) {
-	mac := &MACAddress{
-		Addr: 0x00003aac269b5bf9,
-	}
-
-	assert.Equal(t, [6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9}, mac.EUI48())
+// Test_MACAddress_EUI48 verifies that the wire value decodes to the
+// octets in network order.
+func Test_MACAddress_EUI48(t *testing.T) {
+	mac := &commonpb.MACAddress{Addr: 0x00003aac269b5bf9}
+	require.Equal(t, [6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9}, mac.EUI48())
 }
 
-func TestMACAddress_ToProto(t *testing.T) {
-	mac := NewMACAddressEUI48([6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9})
-	assert.Equal(t, uint64(0x00003aac269b5bf9), mac.Addr)
+// Test_NewMACAddressEUI48_WireValue verifies that the octets encode into
+// the lower 48 bits of the wire value.
+func Test_NewMACAddressEUI48_WireValue(t *testing.T) {
+	mac := commonpb.NewMACAddressEUI48([6]byte{0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9})
+	require.Equal(t, uint64(0x00003aac269b5bf9), mac.Addr)
 }

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -74,7 +74,8 @@ impl Display for pb::MacAddress {
 }
 
 impl Serialize for pb::MacAddress {
-    /// Serializes as the string `Display` renders.
+    /// Serializes as the bare EUI-48 string `Display` renders, such as
+    /// `"3a:ac:26:9b:5b:f9"`.
     ///
     /// A message with the upper 16 bits set renders as the literal
     /// `"invalid"`, since that is what `Display` already falls back to.
@@ -87,7 +88,7 @@ impl Serialize for pb::MacAddress {
 }
 
 impl<'de> Deserialize<'de> for pb::MacAddress {
-    /// Parses the string `Serialize` produces, via `FromStr`.
+    /// Parses the bare EUI-48 string `Serialize` produces, via `FromStr`.
     ///
     /// The literal `"invalid"` a set upper 16 bits serializes to is not
     /// itself a parseable MAC address, so it fails here with a

--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -192,7 +192,6 @@ testpkg:bindings/go/dataplane_ut/bench_test.go:dataplaneut:1  # legacy: migrate 
 testpkg:bindings/go/dataplane_ut/dataplane_ut_test.go:dataplaneut:1  # legacy: migrate to the external test package
 testpkg:common/commonpb/v1/ipaddr_test.go:commonpb:1  # legacy: migrate to the external test package
 testpkg:common/commonpb/v1/iprange_test.go:commonpb:1  # legacy: migrate to the external test package
-testpkg:common/commonpb/v1/macaddr_test.go:commonpb:1  # legacy: migrate to the external test package
 testpkg:common/commonpb/v1/metrics_test.go:commonpb:1  # legacy: migrate to the external test package
 testpkg:common/go/bitset/bitset_test.go:bitset:1  # legacy: migrate to the external test package
 testpkg:common/go/dataplane/packet_test.go:dataplane:1  # legacy: migrate to the external test package

--- a/modules/route/web/useFIBDraft.hook.test.ts
+++ b/modules/route/web/useFIBDraft.hook.test.ts
@@ -24,7 +24,7 @@ import { useFIBDraft } from './useFIBDraft';
 const fibResp = (device: string) => ({
     entries: [{
         range: { start: '10.0.0.0', end: '10.0.0.255' },
-        nexthops: [{ dst_mac: { addr: 'aa:bb:cc:dd:ee:ff' }, src_mac: { addr: '11:22:33:44:55:66' }, device, counter: '' }],
+        nexthops: [{ dst_mac: 'aa:bb:cc:dd:ee:ff', src_mac: '11:22:33:44:55:66', device, counter: '' }],
     }],
 });
 

--- a/modules/route/web/useFIBDraft.test.ts
+++ b/modules/route/web/useFIBDraft.test.ts
@@ -4,8 +4,8 @@ import { flattenFIBEntries, rowsToFIBEntries } from './useFIBDraft';
 import type { FIBRowItem } from './types';
 
 const nexthop = (device: string, counter = ''): FIBNexthop[] => [{
-    dst_mac: { addr: 'aa:bb:cc:dd:ee:ff' },
-    src_mac: { addr: '11:22:33:44:55:66' },
+    dst_mac: 'aa:bb:cc:dd:ee:ff',
+    src_mac: '11:22:33:44:55:66',
     device,
     counter,
 }];
@@ -117,5 +117,19 @@ describe('rowsToFIBEntries commit ordering', () => {
         const merged = entries.find((e) => e.range?.start === '10.0.0.0' && e.range?.end === '10.0.0.255');
         expect(entries).toHaveLength(2);
         expect(merged?.nexthops?.map((nh) => nh.device)).toEqual(['eth0', 'eth2']);
+    });
+});
+
+describe('rowsToFIBEntries nexthop MACs', () => {
+    it('canonicalizes a dotted MAC from an unvalidated import into colon-separated octets', () => {
+        const entries = rowsToFIBEntries([rowFor('10.0.0.0', '10.0.0.255', { dst_mac: '3AAC.269B.5BF9' })]);
+
+        expect(entries[0].nexthops?.[0].dst_mac).toBe('3a:ac:26:9b:5b:f9');
+    });
+
+    it('passes a malformed MAC through unchanged so the gateway reports it', () => {
+        const entries = rowsToFIBEntries([rowFor('10.0.0.0', '10.0.0.255', { dst_mac: 'not-a-mac' })]);
+
+        expect(entries[0].nexthops?.[0].dst_mac).toBe('not-a-mac');
     });
 });

--- a/modules/route/web/useFIBDraft.test.ts
+++ b/modules/route/web/useFIBDraft.test.ts
@@ -132,4 +132,10 @@ describe('rowsToFIBEntries nexthop MACs', () => {
 
         expect(entries[0].nexthops?.[0].dst_mac).toBe('not-a-mac');
     });
+
+    it('passes a MAC with a non-hex octet through unchanged instead of rewriting the typo', () => {
+        const entries = rowsToFIBEntries([rowFor('10.0.0.0', '10.0.0.255', { dst_mac: '1g:02:03:04:05:06' })]);
+
+        expect(entries[0].nexthops?.[0].dst_mac).toBe('1g:02:03:04:05:06');
+    });
 });

--- a/modules/route/web/useFIBDraft.ts
+++ b/modules/route/web/useFIBDraft.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { API, inventoryConfigNames, loadKnownConfigs, unionConfigNames } from '@yanet/core/api';
-import { warnConfigsUnknown } from '@yanet/core/utils';
+import { normalizeMAC, warnConfigsUnknown } from '@yanet/core/utils';
 import type { FIBEntry, FIBNexthop } from '@yanet/core/api/routes';
 import { ipRangeSpan, normalizeIPRange } from '@yanet/core/utils/netip';
 import type { IPRangeWire } from '@yanet/core/utils/netip';
@@ -27,8 +27,8 @@ export const flattenFIBEntries = (entries: FIBEntry[]): FIBRowItem[] => {
                     id: newRowId(),
                     from,
                     to,
-                    dst_mac: nh.dst_mac?.addr || '',
-                    src_mac: nh.src_mac?.addr || '',
+                    dst_mac: nh.dst_mac || '',
+                    src_mac: nh.src_mac || '',
                     device: nh.device || '',
                     counter: nh.counter || '',
                 });
@@ -83,8 +83,8 @@ export const rowsToFIBEntries = (rows: FIBRowItem[]): FIBEntry[] => {
         }
 
         const nh: FIBNexthop = {
-            dst_mac: { addr: row.dst_mac },
-            src_mac: { addr: row.src_mac },
+            dst_mac: normalizeMAC(row.dst_mac) ?? row.dst_mac,
+            src_mac: normalizeMAC(row.src_mac) ?? row.src_mac,
             device: row.device,
             counter: row.counter,
         };

--- a/operators/neighbours/web/NeighbourPanel.tsx
+++ b/operators/neighbours/web/NeighbourPanel.tsx
@@ -4,7 +4,7 @@ import { Select } from '@gravity-ui/uikit';
 import { useDrawerKeyboard } from '@yanet/core/hooks';
 import { DotBadge } from '@yanet/core/components/VirtualTable';
 import { stringToIPAddress } from '@yanet/core/utils/netip';
-import { formatUnixSeconds } from '@yanet/core/utils';
+import { formatUnixSeconds, normalizeMAC } from '@yanet/core/utils';
 import type { Neighbour, NeighbourTableInfo } from '@yanet/core/api/neighbours';
 import { validateMAC, validateNextHop, resolveSubmitTable } from './utils';
 import { nudStateToName, getStateMeta } from './stateMeta';
@@ -138,8 +138,8 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
 
         if (neighbour) {
             setNextHop(neighbour.next_hop ?? '');
-            setLinkAddr(neighbour.link_addr?.addr || '');
-            setHardwareAddr(neighbour.hardware_addr?.addr || '');
+            setLinkAddr(neighbour.link_addr || '');
+            setHardwareAddr(neighbour.hardware_addr || '');
             setDevice(neighbour.device || '');
             setPriority(neighbour.priority?.toString() || '');
         } else {
@@ -187,8 +187,10 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                 device: device.trim() || undefined,
                 priority: priority.trim() ? Number(priority.trim()) : undefined,
             };
-            if (linkAddr.trim()) entry.link_addr = { addr: linkAddr.trim() };
-            if (hardwareAddr.trim()) entry.hardware_addr = { addr: hardwareAddr.trim() };
+            const linkAddrWire = normalizeMAC(linkAddr);
+            if (linkAddrWire) entry.link_addr = linkAddrWire;
+            const hardwareAddrWire = normalizeMAC(hardwareAddr);
+            if (hardwareAddrWire) entry.hardware_addr = hardwareAddrWire;
 
             await onSubmit(resolvedTable, entry);
             onClose();
@@ -215,8 +217,8 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
 
     const stateName = nudStateToName(neighbour?.state);
     const meta = getStateMeta(neighbour?.state);
-    const neighbourMac = neighbour?.link_addr?.addr || '—';
-    const interfaceMac = neighbour?.hardware_addr?.addr || '—';
+    const neighbourMac = neighbour?.link_addr || '—';
+    const interfaceMac = neighbour?.hardware_addr || '—';
     const source = neighbour?.source || '—';
     const isStatic = source === 'static';
     const priorityDisplay = neighbour?.priority != null ? String(neighbour.priority) : '—';
@@ -381,8 +383,8 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                                                 </div>
 
                                                 {shadowed.map((cand) => {
-                                                    const candMac = cand.entry.link_addr?.addr || '—';
-                                                    const candImac = cand.entry.hardware_addr?.addr || '—';
+                                                    const candMac = cand.entry.link_addr || '—';
+                                                    const candImac = cand.entry.hardware_addr || '—';
                                                     const candUpdated = formatUnixSeconds(cand.entry.updated_at);
                                                     return (
                                                         <div key={cand.table} className="nb-cand">

--- a/operators/neighbours/web/NeighbourTable.tsx
+++ b/operators/neighbours/web/NeighbourTable.tsx
@@ -171,7 +171,7 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
             sortKey: 'link_addr',
             renderCell: (neighbour) => (
                 <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', width: '100%' }}>
-                    <span className="yn-cell-mono yn-cell-muted">{neighbour.link_addr?.addr || '-'}</span>
+                    <span className="yn-cell-mono yn-cell-muted">{neighbour.link_addr || '-'}</span>
                 </div>
             ),
         },
@@ -182,7 +182,7 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
             sortKey: 'hardware_addr',
             renderCell: (neighbour) => (
                 <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', width: '100%' }}>
-                    <span className="yn-cell-mono yn-cell-muted">{neighbour.hardware_addr?.addr || '-'}</span>
+                    <span className="yn-cell-mono yn-cell-muted">{neighbour.hardware_addr || '-'}</span>
                 </div>
             ),
         },

--- a/operators/neighbours/web/mergeDebug.ts
+++ b/operators/neighbours/web/mergeDebug.ts
@@ -36,7 +36,7 @@ export const getMergeDebug = (
     tables: NeighbourTableInfo[],
 ): MergeDebugResult => {
     const winnerIp = winner.next_hop ?? '';
-    const winnerMac = winner.link_addr?.addr || '';
+    const winnerMac = winner.link_addr || '';
 
     const candidates: ShadowedCandidate[] = [];
 
@@ -50,7 +50,7 @@ export const getMergeDebug = (
             const entryIp = entry.next_hop ?? '';
             if (entryIp !== winnerIp) continue;
 
-            const entryMac = entry.link_addr?.addr || '';
+            const entryMac = entry.link_addr || '';
             const macDiffers =
                 entryMac !== winnerMac &&
                 entryMac !== ZERO_MAC &&

--- a/operators/neighbours/web/utils.ts
+++ b/operators/neighbours/web/utils.ts
@@ -64,13 +64,13 @@ export const sortComparators: Record<SortableColumn, (a: Neighbour, b: Neighbour
         compareNullableStrings(a.next_hop || undefined, b.next_hop || undefined),
     link_addr: (a, b) =>
         compareMACAddressValues(
-            getMACAddressValue(a.link_addr?.addr),
-            getMACAddressValue(b.link_addr?.addr),
+            getMACAddressValue(a.link_addr),
+            getMACAddressValue(b.link_addr),
         ),
     hardware_addr: (a, b) =>
         compareMACAddressValues(
-            getMACAddressValue(a.hardware_addr?.addr),
-            getMACAddressValue(b.hardware_addr?.addr),
+            getMACAddressValue(a.hardware_addr),
+            getMACAddressValue(b.hardware_addr),
         ),
     device: (a, b) => compareNullableStrings(a.device, b.device),
     state: (a, b) => {

--- a/web/src/core/api/neighbours.ts
+++ b/web/src/core/api/neighbours.ts
@@ -1,9 +1,8 @@
 import { createService, type CallOptions } from './client';
 
-// Neighbour types
-export interface MACAddress {
-    addr: string; // MAC address string in format "xx:xx:xx:xx:xx:xx"
-}
+// commonpb.MACAddress, serialized by the gateway as a bare EUI-48 string
+// such as "3a:ac:26:9b:5b:f9".
+export type MACAddress = string;
 
 export interface Neighbour {
     // commonpb.IPAddress, serialized by the gateway as a bare IP string.

--- a/web/src/core/utils/mac.test.ts
+++ b/web/src/core/utils/mac.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeMAC } from './mac';
+
+describe('MAC address normalization', () => {
+    it('keeps a canonical colon-separated address unchanged', () => {
+        expect(normalizeMAC('3a:ac:26:9b:5b:f9')).toBe('3a:ac:26:9b:5b:f9');
+    });
+
+    it('lowercases hex digits and replaces hyphens with colons', () => {
+        expect(normalizeMAC('3A-AC-26-9B-5B-F9')).toBe('3a:ac:26:9b:5b:f9');
+    });
+
+    it('expands the dotted layout into colon-separated octets', () => {
+        expect(normalizeMAC('3aac.269b.5bf9')).toBe('3a:ac:26:9b:5b:f9');
+    });
+
+    it('expands the unseparated layout into colon-separated octets', () => {
+        expect(normalizeMAC('3aac269b5bf9')).toBe('3a:ac:26:9b:5b:f9');
+    });
+
+    it('zero-pads single-digit octets', () => {
+        expect(normalizeMAC('1:2:3:4:5:6')).toBe('01:02:03:04:05:06');
+    });
+
+    it('returns undefined for an empty input', () => {
+        expect(normalizeMAC('')).toBeUndefined();
+    });
+
+    it('returns undefined for a malformed input', () => {
+        expect(normalizeMAC('not-a-mac')).toBeUndefined();
+    });
+});

--- a/web/src/core/utils/mac.test.ts
+++ b/web/src/core/utils/mac.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeMAC } from './mac';
+import { isValidMAC, normalizeMAC } from './mac';
 
 describe('MAC address normalization', () => {
     it('keeps a canonical colon-separated address unchanged', () => {
@@ -28,5 +28,20 @@ describe('MAC address normalization', () => {
 
     it('returns undefined for a malformed input', () => {
         expect(normalizeMAC('not-a-mac')).toBeUndefined();
+    });
+});
+
+describe('MAC address validation', () => {
+    it('rejects a separated octet whose hex prefix parses but whose tail is not hex', () => {
+        expect(normalizeMAC('1g:02:03:04:05:06')).toBeUndefined();
+        expect(isValidMAC('1g:02:03:04:05:06')).toBe(false);
+    });
+
+    it('rejects a dotted group with a non-hex digit', () => {
+        expect(normalizeMAC('3aag.269b.5bf9')).toBeUndefined();
+    });
+
+    it('rejects an unseparated address with a non-hex digit', () => {
+        expect(normalizeMAC('3aac269b5bfg')).toBeUndefined();
     });
 });

--- a/web/src/core/utils/mac.ts
+++ b/web/src/core/utils/mac.ts
@@ -103,3 +103,12 @@ export const parseMACToBytes = (mac: string): number[] | undefined => {
 export const isValidMAC = (mac: string): boolean => {
     return parseMACToBytes(mac) !== undefined;
 };
+
+/**
+ * Canonicalizes user MAC input into the colon-separated EUI-48 text the
+ * gateway accepts, or undefined when the input is malformed.
+ */
+export const normalizeMAC = (mac: string): string | undefined => {
+    const bytes = parseMACToBytes(mac);
+    return bytes ? formatMACFromBytes(bytes) : undefined;
+};

--- a/web/src/core/utils/mac.ts
+++ b/web/src/core/utils/mac.ts
@@ -52,15 +52,16 @@ export const parseMACToBytes = (mac: string): number[] | undefined => {
     const trimmed = mac.trim();
     if (!trimmed) return undefined;
 
+    // Tokens are matched as whole hex before parsing: the numeric parser
+    // accepts a hex prefix and would silently rewrite a typo.
     if (trimmed.includes(':') || trimmed.includes('-')) {
         const parts = trimmed.split(/[:-]/);
         if (parts.length !== 6) return undefined;
 
         const bytes: number[] = [];
         for (const part of parts) {
-            const num = parseInt(part, 16);
-            if (isNaN(num) || num < 0 || num > 255) return undefined;
-            bytes.push(num);
+            if (!/^[0-9a-fA-F]{1,2}$/.test(part)) return undefined;
+            bytes.push(parseInt(part, 16));
         }
         return bytes;
     }
@@ -71,21 +72,18 @@ export const parseMACToBytes = (mac: string): number[] | undefined => {
 
         const bytes: number[] = [];
         for (const part of parts) {
-            if (part.length !== 4) return undefined;
+            if (!/^[0-9a-fA-F]{4}$/.test(part)) return undefined;
             const val = parseInt(part, 16);
-            if (isNaN(val)) return undefined;
             bytes.push((val >> 8) & 0xff);
             bytes.push(val & 0xff);
         }
         return bytes;
     }
 
-    if (trimmed.length === 12) {
+    if (/^[0-9a-fA-F]{12}$/.test(trimmed)) {
         const bytes: number[] = [];
         for (let i = 0; i < 6; i++) {
-            const num = parseInt(trimmed.substring(i * 2, i * 2 + 2), 16);
-            if (isNaN(num)) return undefined;
-            bytes.push(num);
+            bytes.push(parseInt(trimmed.substring(i * 2, i * 2 + 2), 16));
         }
         return bytes;
     }


### PR DESCRIPTION
- Encode MACAddress in JSON as the bare EUI-48 text instead of an object wrapping it.
- Accept only the colon- or hyphen-separated EUI-48 layout on decode and reject set upper 16 bits instead of truncating them.
- Switch the web MACAddress type to a string and canonicalize form and import input before submit.
- Drop the stale cross-language mentions from the sibling address comments.
- The web bundle and the gateway roll out together: an old bundle fails to submit against a new gateway and a new bundle cannot render the old object form.
