### PR TITLE
chore(ci): bump GitHub Actions to Node.js 24 runtime

### DIFF
--- a/.github/actions/go-modcache/action.yml
+++ b/.github/actions/go-modcache/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Restore the module cache
       id: restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ steps.resolve.outputs.path }}
         key: ${{ steps.resolve.outputs.key }}

--- a/.github/workflows/agents-lint.yml
+++ b/.github/workflows/agents-lint.yml
@@ -14,9 +14,9 @@ jobs:
     name: Generate and verify agent charters
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -105,7 +105,7 @@ jobs:
 
     runs-on: ubuntu-${{ matrix.unbtver }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -117,7 +117,7 @@ jobs:
             || git fetch --tags --filter=blob:none origin \
             || true
 
-      - uses: hendrikmuhs/ccache-action@v1.2.18
+      - uses: hendrikmuhs/ccache-action@v1.2.23
         name: ccache
         with:
           key: ${{ runner.os }}-deb-ccache-${{ matrix.unbtver }}
@@ -147,7 +147,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends devscripts
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24.x"
           cache: false
@@ -163,7 +163,7 @@ jobs:
           sudo chown -R $(id -u) ~/.cargo  # fix caching for Rust
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: debs-${{ matrix.unbtver }}
           path: |
@@ -177,10 +177,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
 
@@ -194,7 +194,7 @@ jobs:
           ./scripts/verify-deb-artifacts.sh outdeb
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             outdeb/*.deb

--- a/.github/workflows/build-push-base-image.yml
+++ b/.github/workflows/build-push-base-image.yml
@@ -7,16 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: .github/workflows/Dockerfile.base
           push: true

--- a/.github/workflows/build-push-clang-format-image.yml
+++ b/.github/workflows/build-push-clang-format-image.yml
@@ -18,21 +18,21 @@ jobs:
   build-push:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .github/actions/clang-format
           push: true

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -16,7 +16,7 @@ jobs:
   build-deb:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends devscripts
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24.x"
           cache: false
@@ -62,7 +62,7 @@ jobs:
           sudo -E env "PATH=$PATH" ./scripts/build-deb.sh
           sudo chown -R $(id -u) ~/.cargo
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: debs-24.04
           path: |
@@ -94,19 +94,19 @@ jobs:
             image: ghcr.io/yanet-platform/yanet2/route-operator
             dockerfile: deploy/yanet-route-operator.Dockerfile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download deb packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: debs-24.04
           path: deploy/packages/
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ matrix.image }}
           tags: |
@@ -125,7 +125,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.tag == '' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -70,7 +70,7 @@ jobs:
         with:
           packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler
 
-      - uses: hendrikmuhs/ccache-action@v1.2.18
+      - uses: hendrikmuhs/ccache-action@v1.2.23
         name: ccache
         with:
           key: ${{ runner.os }}-build-asan-test-cache
@@ -78,7 +78,7 @@ jobs:
           verbose: 2
           save: ${{ github.ref == 'refs/heads/main' }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24.x"
           cache: false
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -116,7 +116,7 @@ jobs:
         with:
           packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler
 
-      - uses: hendrikmuhs/ccache-action@v1.2.18
+      - uses: hendrikmuhs/ccache-action@v1.2.23
         name: ccache
         with:
           key: ${{ runner.os }}-build-tsan-test-cache
@@ -124,7 +124,7 @@ jobs:
           verbose: 2
           save: ${{ github.ref == 'refs/heads/main' }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24.x"
           cache: false
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -167,7 +167,7 @@ jobs:
           shared-key: build-release
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - uses: hendrikmuhs/ccache-action@v1.2.18
+      - uses: hendrikmuhs/ccache-action@v1.2.23
         name: ccache
         with:
           key: ${{ runner.os }}-build-release-artifacts-cache
@@ -175,7 +175,7 @@ jobs:
           verbose: 2
           save: ${{ github.ref == 'refs/heads/main' }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24.x"
           cache: false
@@ -212,7 +212,7 @@ jobs:
       # earlier step fails the job.
       - name: Save Go module cache
         if: steps.go-modcache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ steps.go-modcache.outputs.path }}
           key: ${{ steps.go-modcache.outputs.key }}
@@ -256,7 +256,7 @@ jobs:
           fi
 
       - name: Upload YANET binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: yanet2-binaries
           path: |
@@ -271,7 +271,7 @@ jobs:
     needs: build-release-artifacts
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -282,7 +282,7 @@ jobs:
           echo "Cleaned build/ and target/ directories"
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24.x"
           cache: true
@@ -312,7 +312,7 @@ jobs:
 
       - name: Cache Ubuntu cloud image
         id: cache-ubuntu-image
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: tests/functional/ubuntu-24.04-minimal-cloudimg-amd64.img
           key: ${{ runner.os }}-ubuntu-image-${{ hashFiles('tests/functional/Makefile') }}
@@ -321,7 +321,7 @@ jobs:
 
       - name: Cache QEMU image
         id: cache-qemu-image
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             tests/functional/yanet-test.qcow2
@@ -351,7 +351,7 @@ jobs:
           fi
 
       - name: Download YANET binaries from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: yanet2-binaries
           path: ./
@@ -442,7 +442,7 @@ jobs:
         timeout-minutes: 45
 
       - name: Upload functional test logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: functional-test-logs

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -26,7 +26,7 @@ jobs:
     name: C formatting
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run clang-format
         uses: ./.github/actions/clang-format
         with:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -13,7 +13,7 @@ jobs:
     name: Custom commitlint linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get clean
           docker rmi $(docker images -q) 2>/dev/null || true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -33,7 +33,7 @@ jobs:
         with:
           packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24.x"
           cache: false
@@ -44,7 +44,7 @@ jobs:
       - name: Install Go Protobuf Plugins
         uses: ./.github/actions/protoc-plugins
 
-      - uses: hendrikmuhs/ccache-action@v1.2.18
+      - uses: hendrikmuhs/ccache-action@v1.2.23
         name: ccache
         with:
           key: ${{ runner.os }}-fuzz-build-cache
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload fuzz binaries
         id: upload-fuzz-binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: fuzz-binaries
           path: fuzz-out/
@@ -109,7 +109,7 @@ jobs:
           fi
 
       - name: Upload Go fuzz failure testdata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always() && steps.go-fuzz.outcome == 'failure'
         with:
           name: go-fuzz-testdata
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Download fuzz binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: fuzz-binaries
           path: fuzz-binaries/

--- a/.github/workflows/glm-review.yml
+++ b/.github/workflows/glm-review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/go-formatting.yml
+++ b/.github/workflows/go-formatting.yml
@@ -24,12 +24,12 @@ jobs:
     name: Check Go Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # gofmt only reformats source text. It resolves no imports and never
       # touches GOMODCACHE, so this job needs no module cache.
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -30,9 +30,9 @@ jobs:
     name: Custom stylelint linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -46,11 +46,11 @@ jobs:
     name: golangci-lint modernize
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/go-race.yml
+++ b/.github/workflows/go-race.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -33,7 +33,7 @@ jobs:
         with:
           packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler
 
-      - uses: hendrikmuhs/ccache-action@v1.2.18
+      - uses: hendrikmuhs/ccache-action@v1.2.23
         name: ccache
         with:
           key: ${{ runner.os }}-go-race-cache
@@ -41,7 +41,7 @@ jobs:
           verbose: 2
           save: ${{ github.ref == 'refs/heads/main' }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false

--- a/.github/workflows/meson-lint.yml
+++ b/.github/workflows/meson-lint.yml
@@ -26,7 +26,7 @@ jobs:
     name: mesonlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download mesonlint
         run: |

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -24,7 +24,7 @@ jobs:
     name: Buf lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: bufbuild/buf-action@v1
         with:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: bufbuild/buf-action@v1
         with:
@@ -64,9 +64,9 @@ jobs:
     name: Custom protolint linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -37,7 +37,7 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
@@ -48,7 +48,7 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.88.0
       - name: Cache cargo registry and target directory
         uses: Swatinem/rust-cache@v2.9.2
@@ -68,7 +68,7 @@ jobs:
     name: cargo clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: clippy

--- a/.github/workflows/web-check.yml
+++ b/.github/workflows/web-check.yml
@@ -32,8 +32,8 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'


### PR DESCRIPTION
GitHub deprecated Node.js 20 on 2025-09-19 and is force-running Node 20 actions on Node 24 with a warning. Bump all actions/* and third-party actions to Node 24-compatible major versions:

- actions/checkout v4 → v5
- actions/setup-go v5 → v6
- actions/cache v4 → v5 (incl. save/restore)
- actions/upload-artifact v4 → v5
- actions/download-artifact v4 → v5
- actions/setup-node v4 → v5
- hendrikmuhs/ccache-action v1.2.18 → v1.2.23
- softprops/action-gh-release v1 → v3
- docker/login-action v3 → v4
- docker/build-push-action v6 → v7
- docker/metadata-action v5 → v6
- docker/setup-buildx-action v3 → v4
- docker/setup-qemu-action v3 → v4

Closes #2261.