### PR TITLE
fix(commonpb): reject zoned addresses when decoding ip address text

### DIFF
--- a/common/commonpb/v1/ipaddr.go
+++ b/common/commonpb/v1/ipaddr.go
@@ -2,8 +2,14 @@ package commonpb
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/netip"
+)
+
+var (
+	errEmptyAddress = errors.New("empty IP address is not allowed")
+	errZonedAddress = errors.New("zoned IPv6 address is not allowed")
 )
 
 // NewIPAddressFromAddr creates an IPAddress from a netip.Addr value.
@@ -66,20 +72,37 @@ func (m *IPAddress) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON accepts a bare IPv4 or IPv6 address string.
+//
+// A zoned address is rejected.
 func (m *IPAddress) UnmarshalJSON(data []byte) error {
 	var raw string
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	if raw == "" {
-		return fmt.Errorf("empty IP address is not allowed")
-	}
 
-	parsed, err := netip.ParseAddr(raw)
+	parsed, err := parseAddr(raw)
 	if err != nil {
 		return fmt.Errorf("failed to parse IP address: %w", err)
 	}
 
 	*m = *NewIPAddressFromAddr(parsed)
 	return nil
+}
+
+// parseAddr parses a bare address string for the JSON decoders, rejecting
+// an empty string and a zoned address.
+func parseAddr(raw string) (netip.Addr, error) {
+	if raw == "" {
+		return netip.Addr{}, errEmptyAddress
+	}
+
+	addr, err := netip.ParseAddr(raw)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	if addr.Zone() != "" {
+		return netip.Addr{}, fmt.Errorf("%w: %s", errZonedAddress, raw)
+	}
+
+	return addr, nil
 }

--- a/common/commonpb/v1/ipaddr_test.go
+++ b/common/commonpb/v1/ipaddr_test.go
@@ -175,6 +175,11 @@ func TestIPAddress_UnmarshalJSON(t *testing.T) {
 			want:  netip.MustParseAddr("2001:db8::1"),
 		},
 		{
+			name:    "zoned IPv6",
+			input:   `"fe80::1%eth0"`,
+			wantErr: true,
+		},
+		{
 			name:    "empty string",
 			input:   `""`,
 			wantErr: true,

--- a/common/commonpb/v1/ipnetwork.go
+++ b/common/commonpb/v1/ipnetwork.go
@@ -1,9 +1,12 @@
 package commonpb
 
 import (
+	"errors"
 	"fmt"
 	"net/netip"
 )
+
+var errEmptyNetwork = errors.New("empty IP network is not allowed")
 
 // networksFromPrefixes converts netip.Prefix values to network messages
 // through the supplied per-family constructor.

--- a/common/commonpb/v1/ipprefix.go
+++ b/common/commonpb/v1/ipprefix.go
@@ -83,7 +83,7 @@ func (m *IPPrefix) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if raw == "" {
-		return fmt.Errorf("empty IP network is not allowed")
+		return fmt.Errorf("failed to parse IP network: %w", errEmptyNetwork)
 	}
 
 	prefix, err := netip.ParsePrefix(raw)

--- a/common/commonpb/v1/iprange.go
+++ b/common/commonpb/v1/iprange.go
@@ -103,24 +103,20 @@ func (m *IPRange) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON accepts start and end as IPv4 or IPv6 address strings.
+//
+// A zoned address is rejected.
 func (m *IPRange) UnmarshalJSON(data []byte) error {
 	var raw ipRangeJSON
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	if raw.Start == "" {
-		return fmt.Errorf("empty start address is not allowed")
-	}
-	if raw.End == "" {
-		return fmt.Errorf("empty end address is not allowed")
-	}
 
-	start, err := netip.ParseAddr(raw.Start)
+	start, err := parseAddr(raw.Start)
 	if err != nil {
 		return fmt.Errorf("failed to parse start address: %w", err)
 	}
 
-	end, err := netip.ParseAddr(raw.End)
+	end, err := parseAddr(raw.End)
 	if err != nil {
 		return fmt.Errorf("failed to parse end address: %w", err)
 	}

--- a/common/commonpb/v1/iprange_test.go
+++ b/common/commonpb/v1/iprange_test.go
@@ -231,6 +231,16 @@ func TestIPRange_UnmarshalJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "zoned start",
+			input:   `{"start":"fe80::1%eth0","end":"fe80::ff"}`,
+			wantErr: true,
+		},
+		{
+			name:    "zoned end",
+			input:   `{"start":"fe80::1","end":"fe80::ff%eth0"}`,
+			wantErr: true,
+		},
+		{
 			name:    "family mismatch v4 start v6 end",
 			input:   `{"start":"10.0.0.0","end":"2001:db8::ffff"}`,
 			wantErr: true,

--- a/common/commonpb/v1/ipv4addr.go
+++ b/common/commonpb/v1/ipv4addr.go
@@ -53,11 +53,8 @@ func (m *IPv4Address) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	if raw == "" {
-		return fmt.Errorf("empty IP address is not allowed")
-	}
 
-	parsed, err := netip.ParseAddr(raw)
+	parsed, err := parseAddr(raw)
 	if err != nil {
 		return fmt.Errorf("failed to parse IP address: %w", err)
 	}

--- a/common/commonpb/v1/ipv4network.go
+++ b/common/commonpb/v1/ipv4network.go
@@ -61,7 +61,7 @@ func (m *IPv4Network) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if raw == "" {
-		return fmt.Errorf("empty IP network is not allowed")
+		return fmt.Errorf("failed to parse IP network: %w", errEmptyNetwork)
 	}
 
 	net, err := xnetip.ParseNetwork4(raw)

--- a/common/commonpb/v1/ipv4prefix.go
+++ b/common/commonpb/v1/ipv4prefix.go
@@ -97,7 +97,7 @@ func (m *IPv4Prefix) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if raw == "" {
-		return fmt.Errorf("empty IP network is not allowed")
+		return fmt.Errorf("failed to parse IP network: %w", errEmptyNetwork)
 	}
 
 	prefix, err := netip.ParsePrefix(raw)

--- a/common/commonpb/v1/ipv6addr.go
+++ b/common/commonpb/v1/ipv6addr.go
@@ -60,11 +60,8 @@ func (m *IPv6Address) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	if raw == "" {
-		return fmt.Errorf("empty IP address is not allowed")
-	}
 
-	parsed, err := netip.ParseAddr(raw)
+	parsed, err := parseAddr(raw)
 	if err != nil {
 		return fmt.Errorf("failed to parse IP address: %w", err)
 	}

--- a/common/commonpb/v1/ipv6network.go
+++ b/common/commonpb/v1/ipv6network.go
@@ -61,7 +61,7 @@ func (m *IPv6Network) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if raw == "" {
-		return fmt.Errorf("empty IP network is not allowed")
+		return fmt.Errorf("failed to parse IP network: %w", errEmptyNetwork)
 	}
 
 	net, err := xnetip.ParseNetwork6(raw)

--- a/common/commonpb/v1/ipv6prefix.go
+++ b/common/commonpb/v1/ipv6prefix.go
@@ -97,7 +97,7 @@ func (m *IPv6Prefix) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if raw == "" {
-		return fmt.Errorf("empty IP network is not allowed")
+		return fmt.Errorf("failed to parse IP network: %w", errEmptyNetwork)
 	}
 
 	prefix, err := netip.ParsePrefix(raw)


### PR DESCRIPTION
- Reject a zoned IPv6 address when decoding IPAddress and IPRange from JSON instead of silently dropping the zone.
- Route every address decoder through one parser with private sentinel errors for the empty and zoned cases, wrapped with the field being parsed.
- The constructor keeps dropping the zone, since the wire form never carries one.
