### PR TITLE
refactor(commonpb): drop the unused range constructor

### DIFF
--- a/common/commonpb/v1/iprange.go
+++ b/common/commonpb/v1/iprange.go
@@ -33,18 +33,6 @@ func NewIPRange(start, end netip.Addr) (*IPRange, error) {
 	}, nil
 }
 
-// MustIPRange is like NewIPRange but panics if validation fails.
-//
-// Intended for tests and package-level variable initialisation where the
-// inputs are static and any failure indicates a programming bug.
-func MustIPRange(start, end netip.Addr) *IPRange {
-	r, err := NewIPRange(start, end)
-	if err != nil {
-		panic(err)
-	}
-	return r
-}
-
 // ToRange converts the IPRange back to a pair of netip.Addr values.
 //
 // Returns an error if either endpoint fails to parse or if the endpoints

--- a/common/commonpb/v1/iprange_test.go
+++ b/common/commonpb/v1/iprange_test.go
@@ -114,7 +114,7 @@ func TestIPRange_ToRange_RoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := MustIPRange(tt.start, tt.end)
+			r := mustIPRange(t, tt.start, tt.end)
 			gotStart, gotEnd, err := r.ToRange()
 			require.NoError(t, err)
 			require.Equal(t, tt.start, gotStart)
@@ -159,12 +159,12 @@ func TestIPRange_MarshalJSON(t *testing.T) {
 	}{
 		{
 			name: "IPv4",
-			r:    MustIPRange(netip.MustParseAddr("10.0.0.0"), netip.MustParseAddr("10.0.0.255")),
+			r:    mustIPRange(t, netip.MustParseAddr("10.0.0.0"), netip.MustParseAddr("10.0.0.255")),
 			want: `{"start":"10.0.0.0","end":"10.0.0.255"}`,
 		},
 		{
 			name: "IPv6",
-			r:    MustIPRange(netip.MustParseAddr("2001:db8::"), netip.MustParseAddr("2001:db8::ffff")),
+			r:    mustIPRange(t, netip.MustParseAddr("2001:db8::"), netip.MustParseAddr("2001:db8::ffff")),
 			want: `{"start":"2001:db8::","end":"2001:db8::ffff"}`,
 		},
 		{
@@ -289,7 +289,7 @@ func TestIPRange_JSONRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			original := MustIPRange(tt.start, tt.end)
+			original := mustIPRange(t, tt.start, tt.end)
 
 			data, err := json.Marshal(original)
 			require.NoError(t, err)
@@ -313,12 +313,12 @@ func TestIPRange_AsLogValue(t *testing.T) {
 	}{
 		{
 			name: "IPv4",
-			r:    MustIPRange(netip.MustParseAddr("10.0.0.0"), netip.MustParseAddr("10.0.0.255")),
+			r:    mustIPRange(t, netip.MustParseAddr("10.0.0.0"), netip.MustParseAddr("10.0.0.255")),
 			want: "[10.0.0.0, 10.0.0.255]",
 		},
 		{
 			name: "IPv6",
-			r:    MustIPRange(netip.MustParseAddr("2001:db8::"), netip.MustParseAddr("2001:db8::ffff")),
+			r:    mustIPRange(t, netip.MustParseAddr("2001:db8::"), netip.MustParseAddr("2001:db8::ffff")),
 			want: "[2001:db8::, 2001:db8::ffff]",
 		},
 		{
@@ -344,4 +344,13 @@ func TestIPRange_AsLogValue(t *testing.T) {
 			assert.Equal(t, tt.want, tt.r.AsLogValue())
 		})
 	}
+}
+
+// mustIPRange builds a valid range from two addresses of one family,
+// failing the test on any constructor error.
+func mustIPRange(t *testing.T, start, end netip.Addr) *IPRange {
+	t.Helper()
+	r, err := NewIPRange(start, end)
+	require.NoError(t, err)
+	return r
 }


### PR DESCRIPTION
- Remove the panicking range constructor, which had no callers in the public or private tree.
- Build test fixtures through the fallible constructor, so a broken fixture fails the test instead of panicking.
