### PR TITLE
refactor(filter,acl): use scalar lpm lookup for net6 classification

### DIFF
--- a/lib/filter/query/net6.h
+++ b/lib/filter/query/net6.h
@@ -9,22 +9,12 @@
 #include <rte_mbuf.h>
 
 #include <stdint.h>
-#include <string.h>
 
 static inline void
 FILTER_ATTR_QUERY_FUNC(net6_dst)(
 	void *data, struct packet **packets, uint32_t *result, uint32_t count
 ) {
-	if (!count) {
-		return;
-	}
-
 	struct net6_classifier *c = (struct net6_classifier *)data;
-
-	uint8_t hi_keys[count][8];
-	uint8_t lo_keys[count][8];
-	uint32_t hi_values[count];
-	uint32_t lo_values[count];
 
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		struct rte_mbuf *mbuf = packet_to_mbuf(packets[idx]);
@@ -34,17 +24,12 @@ FILTER_ATTR_QUERY_FUNC(net6_dst)(
 			packets[idx]->network_header.offset
 		);
 
-		memcpy(hi_keys[idx], ipv6_hdr->dst_addr, 8);
-		memcpy(lo_keys[idx], ipv6_hdr->dst_addr + 8, 8);
-	}
+		const uint8_t *daddr = (const uint8_t *)ipv6_hdr->dst_addr;
 
-	lpm8_lookup_batch(&c->hi, hi_keys[0], hi_values, count);
-	lpm8_lookup_batch(&c->lo, lo_keys[0], lo_values, count);
+		uint32_t hi = lpm8_lookup(&c->hi, daddr);
+		uint32_t lo = lpm8_lookup(&c->lo, daddr + 8);
 
-	for (uint32_t idx = 0; idx < count; ++idx) {
-		result[idx] = value_table_get(
-			&c->comb, hi_values[idx], lo_values[idx]
-		);
+		result[idx] = value_table_get(&c->comb, hi, lo);
 	}
 }
 
@@ -52,16 +37,7 @@ static inline void
 FILTER_ATTR_QUERY_FUNC(net6_src)(
 	void *data, struct packet **packets, uint32_t *result, uint32_t count
 ) {
-	if (!count) {
-		return;
-	}
-
 	struct net6_classifier *c = (struct net6_classifier *)data;
-
-	uint8_t hi_keys[count][8];
-	uint8_t lo_keys[count][8];
-	uint32_t hi_values[count];
-	uint32_t lo_values[count];
 
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		struct rte_mbuf *mbuf = packet_to_mbuf(packets[idx]);
@@ -71,16 +47,11 @@ FILTER_ATTR_QUERY_FUNC(net6_src)(
 			packets[idx]->network_header.offset
 		);
 
-		memcpy(hi_keys[idx], ipv6_hdr->src_addr, 8);
-		memcpy(lo_keys[idx], ipv6_hdr->src_addr + 8, 8);
-	}
+		const uint8_t *saddr = (const uint8_t *)ipv6_hdr->src_addr;
 
-	lpm8_lookup_batch(&c->hi, hi_keys[0], hi_values, count);
-	lpm8_lookup_batch(&c->lo, lo_keys[0], lo_values, count);
+		uint32_t hi = lpm8_lookup(&c->hi, saddr);
+		uint32_t lo = lpm8_lookup(&c->lo, saddr + 8);
 
-	for (uint32_t idx = 0; idx < count; ++idx) {
-		result[idx] = value_table_get(
-			&c->comb, hi_values[idx], lo_values[idx]
-		);
+		result[idx] = value_table_get(&c->comb, hi, lo);
 	}
 }

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -338,14 +338,11 @@ acl_handle_packets(
 		struct net6_share_dir *share_src = &acl_config->net6_share_src;
 		struct net6_share_dir *share_dst = &acl_config->net6_share_dst;
 
-		// Classify each v6 address half once on the union tries. The
-		// keys are packed per half so the batched walk can interleave
-		// each trie's dependent page chains across the batch instead of
-		// stalling on every hop of every packet.
-		uint8_t src_hi_keys[count][8];
-		uint8_t src_lo_keys[count][8];
-		uint8_t dst_hi_keys[count][8];
-		uint8_t dst_lo_keys[count][8];
+		// Classify each v6 address half once on the union tries.
+		uint32_t src_hi[count];
+		uint32_t src_lo[count];
+		uint32_t dst_hi[count];
+		uint32_t dst_lo[count];
 
 		for (uint64_t idx = 0; idx < ip6_idx; ++idx) {
 			struct rte_mbuf *mbuf =
@@ -360,29 +357,11 @@ acl_handle_packets(
 			const uint8_t *daddr =
 				(const uint8_t *)ipv6_hdr->dst_addr;
 
-			memcpy(src_hi_keys[idx], saddr, 8);
-			memcpy(src_lo_keys[idx], saddr + 8, 8);
-			memcpy(dst_hi_keys[idx], daddr, 8);
-			memcpy(dst_lo_keys[idx], daddr + 8, 8);
+			src_hi[idx] = lpm8_lookup(&share_src->hi, saddr);
+			src_lo[idx] = lpm8_lookup(&share_src->lo, saddr + 8);
+			dst_hi[idx] = lpm8_lookup(&share_dst->hi, daddr);
+			dst_lo[idx] = lpm8_lookup(&share_dst->lo, daddr + 8);
 		}
-
-		uint32_t src_hi[count];
-		uint32_t src_lo[count];
-		uint32_t dst_hi[count];
-		uint32_t dst_lo[count];
-
-		lpm8_lookup_batch(
-			&share_src->hi, src_hi_keys[0], src_hi, ip6_idx
-		);
-		lpm8_lookup_batch(
-			&share_src->lo, src_lo_keys[0], src_lo, ip6_idx
-		);
-		lpm8_lookup_batch(
-			&share_dst->hi, dst_hi_keys[0], dst_hi, ip6_idx
-		);
-		lpm8_lookup_batch(
-			&share_dst->lo, dst_lo_keys[0], dst_lo, ip6_idx
-		);
 
 		const uint32_t *src_hi_a = ADDR_OF(&share_src->remap_hi_a);
 		const uint32_t *src_lo_a = ADDR_OF(&share_src->remap_lo_a);


### PR DESCRIPTION
- Walk the hi/lo tries with per-packet scalar lookups in the net6 source and destination filter queries and in the acl shared v6 classification path, dropping the per-half key staging arrays.
- Results are bit-identical to the batched walk, verified by the net6-share differential parity tests.
- The batched lookup API stays in place for its own tests.