### PR TITLE
fix(controlplane): store runtime counter registries out of line

### DIFF
--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -173,13 +173,20 @@ void
 cp_module_fini(struct cp_module *cp_module) {
 	counter_registry_fini(&cp_module->counter_registry);
 
-	struct cp_module_counter_registry *runtime_registries =
+	struct cp_module_counter_registry **runtime_registries =
 		ADDR_OF(&cp_module->runtime_counter_registries);
 	if (runtime_registries != NULL) {
 		for (uint64_t i = 0;
 		     i < cp_module->runtime_counter_registry_count;
 		     ++i) {
-			counter_registry_fini(&runtime_registries[i].registry);
+			struct cp_module_counter_registry *entry =
+				ADDR_OF(runtime_registries + i);
+			counter_registry_fini(&entry->registry);
+			memory_bfree(
+				&cp_module->memory_context,
+				entry,
+				sizeof(*entry)
+			);
 		}
 		memory_bfree(
 			&cp_module->memory_context,
@@ -227,30 +234,31 @@ cp_module_counter_registry(
 	uint64_t *index_out,
 	yanet_error **err
 ) {
-	struct cp_module_counter_registry *runtime_registries =
+	struct cp_module_counter_registry **runtime_registries =
 		ADDR_OF(&cp_module->runtime_counter_registries);
 	for (uint64_t idx = 0; idx < cp_module->runtime_counter_registry_count;
 	     ++idx) {
-		if (!strncmp(
-			    runtime_registries[idx].tag, tag, COUNTER_NAME_LEN
-		    )) {
+		struct cp_module_counter_registry *entry =
+			ADDR_OF(runtime_registries + idx);
+		if (!strncmp(entry->tag, tag, COUNTER_NAME_LEN)) {
 			if (index_out != NULL) {
 				*index_out = idx;
 			}
-			return &runtime_registries[idx].registry;
+			return &entry->registry;
 		}
 	}
 
 	uint64_t old_count = cp_module->runtime_counter_registry_count;
 	uint64_t new_count = old_count + 1;
-	struct cp_module_counter_registry *new_registries =
-		(struct cp_module_counter_registry *)memory_brealloc(
-			&cp_module->memory_context,
-			runtime_registries,
-			sizeof(*runtime_registries) * old_count,
-			sizeof(*runtime_registries) * new_count
+
+	// Both fallible allocations happen before anything published is
+	// touched, so every failure path below leaves the previous array
+	// intact and usable.
+	struct cp_module_counter_registry *slot =
+		(struct cp_module_counter_registry *)memory_balloc(
+			&cp_module->memory_context, sizeof(*slot)
 		);
-	if (new_registries == NULL) {
+	if (slot == NULL) {
 		yanet_error_add(
 			err,
 			"failed to allocate counter registry '%s' for module "
@@ -261,18 +269,11 @@ cp_module_counter_registry(
 		);
 		return NULL;
 	}
-
-	// realloc freed the old array, so publish the new one before any
-	// fallible step below. A failure past this point leaves the count
-	// unchanged, so the partially initialized slot sits beyond the live
-	// range and is reaped with the array at cp_module_fini.
-	SET_OFFSET_OF(&cp_module->runtime_counter_registries, new_registries);
-
-	struct cp_module_counter_registry *slot = &new_registries[old_count];
 	strtcpy(slot->tag, tag, sizeof(slot->tag));
 	if (counter_registry_init(
 		    &slot->registry, &cp_module->memory_context, 0
 	    )) {
+		memory_bfree(&cp_module->memory_context, slot, sizeof(*slot));
 		yanet_error_add(
 			err,
 			"failed to initialize counter registry '%s' for module "
@@ -284,6 +285,43 @@ cp_module_counter_registry(
 		return NULL;
 	}
 
+	struct cp_module_counter_registry **new_registries =
+		(struct cp_module_counter_registry **)memory_balloc(
+			&cp_module->memory_context,
+			sizeof(*new_registries) * new_count
+		);
+	if (new_registries == NULL) {
+		counter_registry_fini(&slot->registry);
+		memory_bfree(&cp_module->memory_context, slot, sizeof(*slot));
+		yanet_error_add(
+			err,
+			"failed to allocate counter registry '%s' for module "
+			"'%s:%s'",
+			tag,
+			cp_module->type,
+			cp_module->name
+		);
+		return NULL;
+	}
+
+	// A registry embeds self-relative offsets, so it is allocated
+	// out-of-line and never moved; growing therefore only reallocates
+	// the pointer array. Each pointer slot is re-derived against its new
+	// slot address instead of byte-copied — a copied offset would
+	// resolve to a shifted, bogus target.
+	for (uint64_t idx = 0; idx < old_count; ++idx) {
+		SET_OFFSET_OF(
+			new_registries + idx, ADDR_OF(runtime_registries + idx)
+		);
+	}
+	SET_OFFSET_OF(new_registries + old_count, slot);
+
+	memory_bfree(
+		&cp_module->memory_context,
+		runtime_registries,
+		sizeof(*runtime_registries) * old_count
+	);
+	SET_OFFSET_OF(&cp_module->runtime_counter_registries, new_registries);
 	cp_module->runtime_counter_registry_count = new_count;
 
 	if (index_out != NULL) {
@@ -622,38 +660,41 @@ cp_module_registry_upsert(
 	// Link each new runtime registry against the matching-tag registry on
 	// the displaced module so per-rule counters survive a config rebuild
 	// that leaves the layout unchanged.
-	struct cp_module_counter_registry *new_runtime =
+	struct cp_module_counter_registry **new_runtime =
 		ADDR_OF(&new_module->runtime_counter_registries);
 	for (uint64_t idx = 0; idx < new_module->runtime_counter_registry_count;
 	     ++idx) {
+		struct cp_module_counter_registry *new_entry =
+			ADDR_OF(new_runtime + idx);
 		struct counter_registry *old_registry = NULL;
 		if (old_module != NULL) {
-			struct cp_module_counter_registry *old_runtime =
+			struct cp_module_counter_registry **old_runtime =
 				ADDR_OF(&old_module->runtime_counter_registries
 				);
 			for (uint64_t old_idx = 0;
 			     old_idx <
 			     old_module->runtime_counter_registry_count;
 			     ++old_idx) {
+				struct cp_module_counter_registry *old_entry =
+					ADDR_OF(old_runtime + old_idx);
 				if (!strncmp(
-					    old_runtime[old_idx].tag,
-					    new_runtime[idx].tag,
+					    old_entry->tag,
+					    new_entry->tag,
 					    COUNTER_NAME_LEN
 				    )) {
-					old_registry =
-						&old_runtime[old_idx].registry;
+					old_registry = &old_entry->registry;
 					break;
 				}
 			}
 		}
 
 		if (counter_registry_link(
-			    &new_runtime[idx].registry, old_registry, err
+			    &new_entry->registry, old_registry, err
 		    )) {
 			yanet_error_add(
 				err,
 				"failed to link counter registry '%s'",
-				new_runtime[idx].tag
+				new_entry->tag
 			);
 			return -1;
 		}

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -67,8 +67,13 @@ struct cp_module {
 	// per-route, etc.). Each registry carries a module-unique tag. All
 	// registries are expanded into per-worker storages on config-gen
 	// installation.
+	//
+	// The array holds shared-memory offset pointers to out-of-line
+	// registries: a registry embeds self-relative offsets, so it must
+	// never move after creation, while the pointer array itself may be
+	// reallocated on growth.
 	uint64_t runtime_counter_registry_count;
-	struct cp_module_counter_registry *runtime_counter_registries;
+	struct cp_module_counter_registry **runtime_counter_registries;
 
 	// Rx packet/byte counter (size 2: [packets, bytes])
 	uint64_t rx_counter_id;

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -244,11 +244,13 @@ module_ectx_create(
 			&module_ectx->runtime_counter_storages, runtime_storages
 		);
 
-		struct cp_module_counter_registry *runtime_registries =
+		struct cp_module_counter_registry **runtime_registries =
 			ADDR_OF(&cp_module->runtime_counter_registries);
 		for (uint64_t idx = 0;
 		     idx < cp_module->runtime_counter_registry_count;
 		     ++idx) {
+			struct cp_module_counter_registry *entry =
+				ADDR_OF(runtime_registries + idx);
 			struct counter_storage *old_storage = NULL;
 			if (old_ectx != NULL) {
 				old_storage =
@@ -261,21 +263,21 @@ module_ectx_create(
 						cp_chain->name,
 						cp_module->type,
 						cp_module->name,
-						runtime_registries[idx].tag
+						entry->tag
 					);
 			}
 
 			struct counter_storage *storage = counter_storage_spawn(
 				&cp_config->counter_storage_memory_context,
 				old_storage,
-				&runtime_registries[idx].registry
+				&entry->registry
 			);
 			if (storage == NULL) {
 				yanet_error_add(
 					err,
 					"failed to spawn counter storage for "
 					"registry '%s' on module '%s:%s'",
-					runtime_registries[idx].tag,
+					entry->tag,
 					cp_module->type,
 					cp_module->name
 				);
@@ -292,7 +294,7 @@ module_ectx_create(
 				    cp_chain->name,
 				    cp_module->type,
 				    cp_module->name,
-				    runtime_registries[idx].tag,
+				    entry->tag,
 				    storage,
 				    err
 			    )) {
@@ -301,7 +303,7 @@ module_ectx_create(
 					err,
 					"failed to insert counter storage for "
 					"registry '%s' on module '%s:%s'",
-					runtime_registries[idx].tag,
+					entry->tag,
 					cp_module->type,
 					cp_module->name
 				);

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 17
+#define YANET_MODULE_ABI_VERSION 18
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -567,10 +567,11 @@ fib_iter_nexthop_counter_name(const struct fib_iter *it, uint64_t nexthop_idx) {
 	    config->cp_module.runtime_counter_registry_count) {
 		return "";
 	}
-	struct cp_module_counter_registry *registries =
+	struct cp_module_counter_registry **registries =
 		ADDR_OF(&config->cp_module.runtime_counter_registries);
-	struct counter_registry *registry =
-		&registries[config->routes_registry_idx].registry;
+	struct cp_module_counter_registry *entry =
+		ADDR_OF(registries + config->routes_registry_idx);
+	struct counter_registry *registry = &entry->registry;
 	if (r->counter_id < registry->count) {
 		return ADDR_OF(&registry->names)[r->counter_id].name;
 	}

--- a/tests/controlplane/cp_module_counter_registry_test.c
+++ b/tests/controlplane/cp_module_counter_registry_test.c
@@ -1,0 +1,300 @@
+/*
+ * Regression test for GH#2159: growing a module's runtime counter
+ * registry array must never move a populated registry.
+ *
+ * A counter registry embeds shared-memory offsets relative to its own
+ * address, so a registry whose bytes are copied to a new array slot
+ * resolves its names and string index to shifted, bogus targets. The
+ * growth path therefore allocates each registry out-of-line and
+ * reallocates only the array of pointers to them; these scenarios drive
+ * a second tag through that growth and then keep using the first
+ * registry, including under swept arena exhaustion. The exhaustion
+ * sweep needs a private allocator per round, fork isolation and
+ * free-size introspection, which the shared in-process harnesses
+ * cannot provide, hence a plain C test.
+ */
+
+#include "common/asan.h"
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+
+#include "lib/controlplane/config/cp_module.h"
+#include "lib/counters/counters.h"
+#include "lib/errors/errors.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define ARENA_BUFFER_SIZE MEMORY_BLOCK_ALLOCATOR_MAX_ALIGN
+#define FULL_ARENA_SIZE (64u * 1024u)
+#define SWEEP_MIN_ARENA_SIZE 256u
+#define SWEEP_MAX_ARENA_SIZE (16u * 1024u)
+#define SWEEP_STEP 8u
+
+// Builds a module whose runtime registry allocations come from a fresh
+// poisoned arena of the given size carved out of arena_buffer.
+static void
+module_init(
+	struct cp_module *module,
+	struct block_allocator *allocator,
+	void *arena_buffer,
+	size_t arena_size
+) {
+	memset(module, 0, sizeof(*module));
+	// Round N+1 reuses a buffer the previous round's frees left
+	// poisoned; lift the poison before overwriting it.
+	asan_unpoison_memory_region(arena_buffer, arena_size);
+	memset(arena_buffer, 0xa5, arena_size);
+	block_allocator_init(allocator);
+	block_allocator_put_arena(allocator, arena_buffer, arena_size);
+	memory_context_init(
+		&module->memory_context, "cp-module-test", allocator
+	);
+	strtcpy(module->type, "test", sizeof(module->type));
+	strtcpy(module->name, "test0", sizeof(module->name));
+}
+
+// Tears the module down and requires the arena to come back whole.
+//
+// Every block the module and its registries borrowed must return, so
+// the restored free size catches a growth or failure path that strands
+// an allocation; the context's own counters are unreadable here because
+// the teardown zeroes them.
+static int
+module_fini(
+	struct cp_module *module,
+	struct block_allocator *allocator,
+	size_t initial_free_size
+) {
+	cp_module_fini(module);
+
+	TEST_ASSERT_EQUAL(
+		block_allocator_free_size(allocator),
+		initial_free_size,
+		"arena not fully restored after teardown"
+	);
+	block_allocator_fini(allocator);
+	return TEST_SUCCESS;
+}
+
+// verifies that a registry registered before an array growth keeps
+// resolving counters and backing per-worker storage afterwards
+static int
+run_first_registry_survives_growth_test(void) {
+	void *arena_buffer =
+		aligned_alloc(ARENA_BUFFER_SIZE, ARENA_BUFFER_SIZE);
+	TEST_ASSERT_NOT_NULL(arena_buffer, "failed to allocate arena buffer");
+
+	struct block_allocator allocator;
+	struct cp_module module;
+	module_init(&module, &allocator, arena_buffer, FULL_ARENA_SIZE);
+	size_t initial_free_size = block_allocator_free_size(&allocator);
+
+	yanet_error *err = NULL;
+
+	uint64_t first_idx = UINT64_MAX;
+	struct counter_registry *first =
+		cp_module_counter_registry(&module, "first", &first_idx, &err);
+	TEST_ASSERT_NOT_NULL(first, "first tag registration failed");
+	TEST_ASSERT_EQUAL(first_idx, 0, "unexpected first registry index");
+
+	uint64_t c0 = counter_registry_register(first, "c0", 2, &err);
+	TEST_ASSERT(c0 != COUNTER_INVALID, "c0 registration failed");
+
+	uint64_t second_idx = UINT64_MAX;
+	struct counter_registry *second = cp_module_counter_registry(
+		&module, "second", &second_idx, &err
+	);
+	TEST_ASSERT_NOT_NULL(second, "second tag registration failed");
+	TEST_ASSERT_EQUAL(second_idx, 1, "unexpected second registry index");
+
+	// The first registry must resolve through its own offsets after the
+	// array growth: re-registering the pre-growth counter resolves to
+	// its existing id, and a fresh counter goes through the same names
+	// and string index.
+	TEST_ASSERT(
+		counter_registry_register(first, "c0", 2, &err) == c0,
+		"pre-growth counter no longer resolves"
+	);
+	uint64_t c1 = counter_registry_register(first, "c1", 2, &err);
+	TEST_ASSERT(c1 != COUNTER_INVALID, "c1 registration failed");
+
+	TEST_ASSERT_SUCCESS(
+		counter_registry_link(first, NULL, &err),
+		"failed to link the first registry"
+	);
+
+	struct counter_storage *storage =
+		counter_storage_spawn(&module.memory_context, NULL, first);
+	TEST_ASSERT_NOT_NULL(
+		storage, "failed to spawn storage for the first registry"
+	);
+
+	uint64_t *c0_value =
+		counter_handle_get_value(counter_get_value_handle(c0, storage));
+	uint64_t *c1_value =
+		counter_handle_get_value(counter_get_value_handle(c1, storage));
+	*c0_value += 1;
+	*c1_value += 2;
+	TEST_ASSERT_EQUAL(*c0_value, 1, "c0 storage round-trip failed");
+	TEST_ASSERT_EQUAL(*c1_value, 2, "c1 storage round-trip failed");
+
+	counter_storage_free(storage);
+
+	uint64_t idx = UINT64_MAX;
+	TEST_ASSERT(
+		cp_module_counter_registry(&module, "first", &idx, &err) ==
+				first &&
+			idx == 0,
+		"first tag no longer resolves to its registry"
+	);
+	TEST_ASSERT(
+		cp_module_counter_registry(&module, "second", &idx, &err) ==
+				second &&
+			idx == 1,
+		"second tag no longer resolves to its registry"
+	);
+
+	int fini_result = module_fini(&module, &allocator, initial_free_size);
+	free(arena_buffer);
+	return fini_result;
+}
+
+enum sweep_outcome {
+	OUTCOME_FIRST_FAILED,
+	OUTCOME_GROWTH_FAILED,
+	OUTCOME_GROWN,
+};
+
+// One exhaustion round: registers the first tag and one counter, then
+// drives the array growth, and checks whichever state the arena leaves.
+static int
+run_sweep_round(
+	void *arena_buffer, size_t arena_size, enum sweep_outcome *outcome
+) {
+	struct block_allocator allocator;
+	struct cp_module module;
+	module_init(&module, &allocator, arena_buffer, arena_size);
+	size_t initial_free_size = block_allocator_free_size(&allocator);
+
+	yanet_error *err = NULL;
+
+	struct counter_registry *first =
+		cp_module_counter_registry(&module, "first", NULL, &err);
+	// The first counter registered on a fresh registry always gets id
+	// zero; anything else means the registry resolves to the wrong
+	// arena address.
+	if (first == NULL ||
+	    counter_registry_register(first, "c0", 2, &err) != 0) {
+		*outcome = OUTCOME_FIRST_FAILED;
+		return module_fini(&module, &allocator, initial_free_size);
+	}
+
+	struct counter_registry *second =
+		cp_module_counter_registry(&module, "second", NULL, &err);
+	if (second == NULL) {
+		*outcome = OUTCOME_GROWTH_FAILED;
+
+		// The failed growth must leave the previous array in place:
+		// the first registry still answers by tag and keeps resolving
+		// and re-registering its counter through its own offsets.
+		uint64_t idx = UINT64_MAX;
+		TEST_ASSERT(
+			cp_module_counter_registry(
+				&module, "first", &idx, &err
+			) == first &&
+				idx == 0,
+			"first registry lost after a failed growth at arena "
+			"size %zu",
+			arena_size
+		);
+		TEST_ASSERT(
+			counter_registry_register(first, "c0", 2, &err) == 0,
+			"counter lookup broke after a failed growth at arena "
+			"size %zu",
+			arena_size
+		);
+		TEST_ASSERT(
+			counter_registry_register(first, "c0", 2, &err) == 0,
+			"counter re-registration broke after a failed growth "
+			"at arena size %zu",
+			arena_size
+		);
+	} else {
+		*outcome = OUTCOME_GROWN;
+	}
+
+	return module_fini(&module, &allocator, initial_free_size);
+}
+
+// verifies that an allocation failure while growing the registry array
+// leaves the previous array intact, usable and fully reclaimable
+static int
+run_growth_failure_sweep_test(void) {
+	void *arena_buffer =
+		aligned_alloc(ARENA_BUFFER_SIZE, ARENA_BUFFER_SIZE);
+	TEST_ASSERT_NOT_NULL(arena_buffer, "failed to allocate arena buffer");
+
+	bool saw_growth_failed = false;
+	bool saw_grown = false;
+
+	for (size_t arena_size = SWEEP_MIN_ARENA_SIZE;
+	     arena_size <= SWEEP_MAX_ARENA_SIZE;
+	     arena_size += SWEEP_STEP) {
+		enum sweep_outcome outcome;
+		TEST_ASSERT_SUCCESS(
+			run_sweep_round(arena_buffer, arena_size, &outcome),
+			"sweep round failed at arena size %zu",
+			arena_size
+		);
+		saw_growth_failed |= outcome == OUTCOME_GROWTH_FAILED;
+		saw_grown |= outcome == OUTCOME_GROWN;
+	}
+
+	free(arena_buffer);
+
+	TEST_ASSERT(
+		saw_growth_failed,
+		"sweep never hit an allocation failure during growth"
+	);
+	TEST_ASSERT(saw_grown, "sweep never grew the registry array");
+	return TEST_SUCCESS;
+}
+
+// Isolates one scenario so a crash is reported as a test failure.
+static int
+run_isolated(int (*scenario)(void)) {
+	pid_t pid = fork();
+	TEST_ASSERT(pid >= 0, "fork failed");
+	if (pid == 0) {
+		_exit(scenario() == TEST_SUCCESS ? EXIT_SUCCESS : EXIT_FAILURE);
+	}
+
+	int child_status = 0;
+	TEST_ASSERT(waitpid(pid, &child_status, 0) == pid, "waitpid failed");
+	TEST_ASSERT(
+		WIFEXITED(child_status) && WEXITSTATUS(child_status) == 0,
+		"scenario failed with status %d",
+		child_status
+	);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	if (run_isolated(run_first_registry_survives_growth_test) !=
+	    TEST_SUCCESS) {
+		return EXIT_FAILURE;
+	}
+	if (run_isolated(run_growth_failure_sweep_test) != TEST_SUCCESS) {
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+}

--- a/tests/controlplane/meson.build
+++ b/tests/controlplane/meson.build
@@ -28,3 +28,18 @@ agent_memory_tree_test = executable(
   include_directories: yanet_rootdir,
 )
 test('agent_memory_tree', agent_memory_tree_test, suite: ['controlplane'])
+
+cp_module_counter_registry_test = executable(
+  'cp_module_counter_registry_test',
+  ['cp_module_counter_registry_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_common_dep,
+    lib_logging_dep,
+    lib_config_cp_dep,
+    lib_config_dp_dep,
+  ],
+  include_directories: yanet_rootdir,
+)
+test('cp_module_counter_registry', cp_module_counter_registry_test, suite: ['controlplane'])


### PR DESCRIPTION
- Grow the module's tagged counter registry set as an array of shared-memory pointers to out-of-line registries instead of a reallocated inline array, so a populated registry never moves and its self-relative offsets stay valid.
- Re-derive each pointer slot against its new slot address on growth; a failed growth unwinds only its own allocations and leaves the previous array intact and usable.
- Bump YANET_MODULE_ABI_VERSION 17 to 18 for the changed cp_module layout. Deploy note: run go clean -cache, remove standalone CGO binaries and /dev/hugepages/yanet\* before restarting on this version.
- Add a C regression test covering two-tag growth and a swept allocation-failure sweep with arena restoration checks.

Closes #2159.