### PR TITLE
feat(counters): match every worker registry independently in by-tags reads

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -180,6 +180,11 @@ yanet_get_counter_values(
 // name query. Pass tag_count == 0 to impose no per-tag constraint and a
 // NULL query to impose no name constraint.
 //
+// Each worker's counter storage registry is matched independently and
+// the result is the union across workers: every returned counter spans
+// instance_count == worker_count instances, and a worker whose registry
+// does not carry the counter contributes zero values for its instance.
+//
 // Each counter_tag is a predicate against the counter's tags, with
 // the check encoded in value: an empty string requires the tag to be
 // absent, "*" requires the tag to be present with any value, and any
@@ -208,6 +213,56 @@ yanet_get_counters_by_tags(
 	const struct counter_query *query,
 	yanet_error **err
 );
+
+// One worker's independently matched counter set.
+//
+// counters holds only that worker's snapshot: its instance_count is 1
+// and every handle's values are copied from that worker's own storages.
+struct counter_worker_set {
+	uint64_t worker_idx;
+	struct counter_handle_list *counters;
+};
+
+// Per-worker counter sets, one entry per dataplane worker in index
+// order.
+//
+// A worker whose registry holds no match carries an empty set, so entry
+// i always belongs to worker i.
+struct counter_worker_set_list {
+	uint64_t worker_count;
+	struct counter_worker_set sets[];
+};
+
+// Return each worker's counters that satisfy every predicate in tags
+// and the compiled name query, matched against that worker's own
+// counter storage registry.
+//
+// The tag predicates and their value semantics are those of
+// yanet_get_counters_by_tags; unlike it, no cross-worker union is
+// taken, so the sets may differ from worker to worker.
+//
+// The returned list must be released with
+// yanet_counter_worker_set_list_free. On failure NULL is returned and
+// err is filled; a worker without a match yields an empty set, not
+// failure.
+struct counter_worker_set_list *
+yanet_get_counters_by_tags_per_worker(
+	struct dp_config *dp_config,
+	const struct counter_tag *tags,
+	size_t tag_count,
+	const struct counter_query *query,
+	yanet_error **err
+);
+
+// Return the set belonging to worker_idx, or NULL when out of range.
+struct counter_worker_set *
+yanet_get_counter_worker_set(
+	struct counter_worker_set_list *sets, uint64_t worker_idx
+);
+
+// Release a per-worker set list. No-op on NULL.
+void
+yanet_counter_worker_set_list_free(struct counter_worker_set_list *sets);
 
 void
 yanet_counter_handle_list_free(struct counter_handle_list *counters);

--- a/controlplane/ffi/counter.go
+++ b/controlplane/ffi/counter.go
@@ -13,6 +13,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"unsafe"
 
@@ -355,6 +356,12 @@ type CounterGroup struct {
 // CountersByTags returns counters matching every predicate in tags and at
 // least one pattern in query. A nil or empty tags slice imposes no per-tag
 // constraint. A nil or empty query matches any counter name.
+//
+// Every worker's counter storage registry is matched independently and the
+// sets are merged: a counter is identified by its group's tag set and its
+// name, and a worker that does not carry it contributes zero values for
+// its instance. Every returned counter therefore spans exactly one value
+// set per dataplane worker.
 func (m *DPConfig) CountersByTags(
 	tags []CounterTag,
 	query []string,
@@ -405,22 +412,43 @@ func (m *DPConfig) CountersByTags(
 	}
 
 	var cErr *C.yanet_error
-	counters := C.yanet_get_counters_by_tags(
+	sets := C.yanet_get_counters_by_tags_per_worker(
 		m.ptr,
 		cTagsPtr,
 		C.size_t(len(cTags)),
 		compiled,
 		&cErr,
 	)
-	if counters == nil {
+	if sets == nil {
 		if err := cerrors.FromC(unsafe.Pointer(cErr)); err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf("unknown error")
 	}
-	defer C.yanet_counter_handle_list_free(counters)
+	defer C.yanet_counter_worker_set_list_free(sets)
 
+	workerCount := int(sets.worker_count)
+	perWorker := make([][]CounterGroup, workerCount)
+	for idx := range workerCount {
+		set := C.yanet_get_counter_worker_set(sets, C.uint64_t(idx))
+		if set == nil {
+			return nil, fmt.Errorf("counter set for worker %d is missing", idx)
+		}
+		perWorker[idx] = decodeCounterGroups(set.counters)
+	}
+
+	return MergeWorkerCounterGroups(workerCount, perWorker), nil
+}
+
+// decodeCounterGroups splits one handle list into groups of counters
+// sharing the same tag set. Consecutive handles of one storage share the
+// tags pointer, which marks the group boundary. A nil list decodes to no
+// groups.
+func decodeCounterGroups(counters *C.struct_counter_handle_list) []CounterGroup {
 	groups := make([]CounterGroup, 0)
+	if counters == nil {
+		return groups
+	}
 
 	for idx := C.uint64_t(0); idx < counters.count; idx++ {
 		handle := C.yanet_get_counter(counters, idx)
@@ -436,7 +464,109 @@ func (m *DPConfig) CountersByTags(
 			decodeCounterHandle(handle, counters.instance_count))
 	}
 
-	return groups, nil
+	return groups
+}
+
+// counterGroupKey builds a canonical identity of a tag set, independent
+// of the tags' order.
+func counterGroupKey(tags []CounterTag) string {
+	ordered := slices.Clone(tags)
+	slices.SortFunc(ordered, func(a, b CounterTag) int {
+		return strings.Compare(a.Key, b.Key)
+	})
+
+	var key strings.Builder
+	for _, tag := range ordered {
+		key.WriteString(tag.Key)
+		key.WriteByte(0)
+		key.WriteString(tag.Value)
+		key.WriteByte(1)
+	}
+	return key.String()
+}
+
+// MergeWorkerCounterGroups combines per-worker counter groups into one
+// slice spanning every worker.
+//
+// A counter is identified by its group's tag set and its name. The first
+// worker carrying it defines its position and its size, every other
+// carrier's snapshot lands in that worker's instance slot, and workers
+// without the counter contribute zero values in theirs. Sizes come from
+// the module's registry and are expected to agree across workers; on
+// disagreement the first worker's size stays and the disagreeing worker's
+// instance remains zero.
+func MergeWorkerCounterGroups(
+	workerCount int,
+	perWorker [][]CounterGroup,
+) []CounterGroup {
+	type mergedGroup struct {
+		tags     []CounterTag
+		counters []CounterInfo
+		sizes    []int
+		byName   map[string]int
+	}
+
+	groups := make([]*mergedGroup, 0)
+	groupIndex := map[string]int{}
+
+	for workerIdx, workerGroups := range perWorker {
+		for _, group := range workerGroups {
+			key := counterGroupKey(group.Tags)
+			idx, found := groupIndex[key]
+			if !found {
+				idx = len(groups)
+				groupIndex[key] = idx
+				groups = append(groups, &mergedGroup{
+					tags:   group.Tags,
+					byName: map[string]int{},
+				})
+			}
+			merged := groups[idx]
+			for _, counter := range group.Counters {
+				size := 0
+				if len(counter.Values) > 0 {
+					size = len(counter.Values[0])
+				}
+
+				counterIdx, found := merged.byName[counter.Name]
+				if !found {
+					counterIdx = len(merged.counters)
+					merged.byName[counter.Name] = counterIdx
+					merged.counters = append(
+						merged.counters,
+						CounterInfo{
+							Name:   counter.Name,
+							Values: make([][]uint64, workerCount),
+						},
+					)
+					merged.sizes = append(merged.sizes, size)
+				}
+
+				if size != merged.sizes[counterIdx] {
+					continue
+				}
+				if len(counter.Values) > 0 {
+					merged.counters[counterIdx].Values[workerIdx] = counter.Values[0]
+				}
+			}
+		}
+	}
+
+	merged := make([]CounterGroup, 0, len(groups))
+	for _, group := range groups {
+		for idx, counter := range group.counters {
+			for workerIdx := range counter.Values {
+				if counter.Values[workerIdx] == nil {
+					counter.Values[workerIdx] = make([]uint64, group.sizes[idx])
+				}
+			}
+		}
+		merged = append(merged, CounterGroup{
+			Tags:     group.tags,
+			Counters: group.counters,
+		})
+	}
+	return merged
 }
 
 func decodeCounterTags(

--- a/controlplane/ffi/counter_merge_test.go
+++ b/controlplane/ffi/counter_merge_test.go
@@ -1,0 +1,109 @@
+package ffi_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+type (
+	CounterTag   = ffi.CounterTag
+	CounterInfo  = ffi.CounterInfo
+	CounterGroup = ffi.CounterGroup
+)
+
+func workerGroup(tags []CounterTag, counters ...CounterInfo) CounterGroup {
+	return CounterGroup{Tags: tags, Counters: counters}
+}
+
+// perWorkerCounter wraps one worker's snapshot: a single instance.
+func perWorkerCounter(name string, values ...uint64) CounterInfo {
+	return CounterInfo{Name: name, Values: [][]uint64{values}}
+}
+
+func TestMergeWorkerCounterGroups(t *testing.T) {
+	deviceTags := []CounterTag{{Key: "device", Value: "dev0"}, {Key: "kind", Value: "device"}}
+	runtimeTags := []CounterTag{{Key: "kind", Value: "runtime"}, {Key: "config", Value: "rules"}}
+
+	t.Run("SingleWorkerKeepsValues", func(t *testing.T) {
+		merged := ffi.MergeWorkerCounterGroups(1, [][]CounterGroup{{
+			workerGroup(deviceTags,
+				perWorkerCounter("input", 7, 9),
+			),
+		}})
+
+		assert.Len(t, merged, 1)
+		assert.Equal(t, deviceTags, merged[0].Tags)
+		assert.Equal(t, []CounterInfo{
+			{Name: "input", Values: [][]uint64{{7, 9}}},
+		}, merged[0].Counters)
+	})
+
+	t.Run("AbsentWorkerIsZeroFilled", func(t *testing.T) {
+		merged := ffi.MergeWorkerCounterGroups(2, [][]CounterGroup{
+			{workerGroup(deviceTags, perWorkerCounter("input", 11))},
+			nil,
+		})
+
+		assert.Equal(t, []CounterInfo{
+			{Name: "input", Values: [][]uint64{{11}, {0}}},
+		}, merged[0].Counters)
+	})
+
+	t.Run("UnionKeepsEveryWorkersValues", func(t *testing.T) {
+		merged := ffi.MergeWorkerCounterGroups(3, [][]CounterGroup{
+			{workerGroup(runtimeTags, perWorkerCounter("rule0", 1))},
+			{workerGroup(runtimeTags, perWorkerCounter("rule0", 2), perWorkerCounter("rule1", 3))},
+			{workerGroup(runtimeTags, perWorkerCounter("rule1", 4))},
+		})
+
+		assert.Len(t, merged, 1)
+		assert.Equal(t, []CounterInfo{
+			{Name: "rule0", Values: [][]uint64{{1}, {2}, {0}}},
+			{Name: "rule1", Values: [][]uint64{{0}, {3}, {4}}},
+		}, merged[0].Counters)
+	})
+
+	t.Run("TagOrderDoesNotSplitGroups", func(t *testing.T) {
+		reordered := []CounterTag{{Key: "kind", Value: "device"}, {Key: "device", Value: "dev0"}}
+
+		merged := ffi.MergeWorkerCounterGroups(2, [][]CounterGroup{
+			{workerGroup(deviceTags, perWorkerCounter("input", 5))},
+			{workerGroup(reordered, perWorkerCounter("input", 6))},
+		})
+
+		assert.Len(t, merged, 1, "the same tag set in another order is the same group")
+		assert.Equal(t, []CounterInfo{
+			{Name: "input", Values: [][]uint64{{5}, {6}}},
+		}, merged[0].Counters)
+	})
+
+	t.Run("DistinctTagSetsStayDistinct", func(t *testing.T) {
+		other := []CounterTag{{Key: "device", Value: "dev1"}, {Key: "kind", Value: "device"}}
+
+		merged := ffi.MergeWorkerCounterGroups(2, [][]CounterGroup{
+			{workerGroup(deviceTags, perWorkerCounter("input", 1))},
+			{workerGroup(other, perWorkerCounter("input", 2))},
+		})
+
+		assert.Len(t, merged, 2)
+		assert.Equal(t, [][]uint64{{1}, {0}}, merged[0].Counters[0].Values)
+		assert.Equal(t, [][]uint64{{0}, {2}}, merged[1].Counters[0].Values)
+	})
+
+	t.Run("SizeDisagreementKeepsFirstSize", func(t *testing.T) {
+		merged := ffi.MergeWorkerCounterGroups(2, [][]CounterGroup{
+			{workerGroup(deviceTags, perWorkerCounter("hist", 1, 2))},
+			{workerGroup(deviceTags, perWorkerCounter("hist", 3, 4, 5))},
+		})
+
+		assert.Equal(t, []CounterInfo{
+			{Name: "hist", Values: [][]uint64{{1, 2}, {0, 0}}},
+		}, merged[0].Counters)
+	})
+
+	t.Run("ZeroWorkersYieldNoGroups", func(t *testing.T) {
+		assert.Empty(t, ffi.MergeWorkerCounterGroups(0, nil))
+	})
+}

--- a/lib/controlplane/agent/counters.c
+++ b/lib/controlplane/agent/counters.c
@@ -1,9 +1,11 @@
 #include "agent.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "common/hash.h"
 #include "common/memory_address.h"
 
 #include "lib/controlplane/config/cp_module.h"
@@ -106,29 +108,40 @@ counter_registry_match_count(
 	return matches;
 }
 
+// Deep-copy a tag array into freshly allocated memory.
 static struct counter_tag *
-cp_counter_storage_copy_tags(const struct cp_counter_storage *storage) {
-	struct counter_tag *tags = malloc(storage->tag_count * sizeof(*tags));
-	if (tags == NULL) {
+counter_tags_dup(const struct counter_tag *tags, size_t tag_count) {
+	struct counter_tag *dup = malloc(tag_count * sizeof(*dup));
+	if (dup == NULL) {
 		return NULL;
 	}
-	for (size_t i = 0; i < storage->tag_count; ++i) {
-		tags[i].key = NULL;
-		tags[i].value = NULL;
+	for (size_t i = 0; i < tag_count; ++i) {
+		dup[i].key = NULL;
+		dup[i].value = NULL;
 	}
-	for (size_t i = 0; i < storage->tag_count; ++i) {
-		tags[i].key = strdup(storage->tags[i].key);
-		tags[i].value = strdup(storage->tags[i].value);
-		if (tags[i].key == NULL || tags[i].value == NULL) {
-			for (size_t j = 0; j < storage->tag_count; ++j) {
-				free((void *)tags[j].key);
-				free((void *)tags[j].value);
+	for (size_t i = 0; i < tag_count; ++i) {
+		dup[i].key = strdup(tags[i].key);
+		dup[i].value = strdup(tags[i].value);
+		if (dup[i].key == NULL || dup[i].value == NULL) {
+			for (size_t j = 0; j < tag_count; ++j) {
+				free((void *)dup[j].key);
+				free((void *)dup[j].value);
 			}
-			free(tags);
+			free(dup);
 			return NULL;
 		}
 	}
-	return tags;
+	return dup;
+}
+
+static struct counter_tag *
+cp_counter_storage_copy_tags(const struct cp_counter_storage *storage) {
+	struct counter_tag view[MAX_TAG_COUNT];
+	for (size_t i = 0; i < storage->tag_count; ++i) {
+		view[i].key = storage->tags[i].key;
+		view[i].value = storage->tags[i].value;
+	}
+	return counter_tags_dup(view, storage->tag_count);
 }
 
 // Copy one already-described counter's per-worker value snapshot into
@@ -209,10 +222,9 @@ fill_counter_handle(
 // Per-worker counter storages matching one tag predicate.
 //
 // Each worker's entry is a NULL-terminated array of matches, or NULL for
-// a worker without an execution context. Every worker registry is built
-// by the same execution-context traversal, so the match order is
-// identical across workers: for match index i, every worker's array
-// names the same tag set at that index.
+// a worker without an execution context. The registries of two workers
+// are built independently, so their match arrays may differ in length
+// and content.
 struct worker_counter_matches {
 	struct cp_counter_storage ***by_worker;
 	uint64_t worker_count;
@@ -270,16 +282,7 @@ worker_counter_matches_collect(
 	return 0;
 }
 
-// Bookkeeping needed to find a matched counter's per-worker storages again
-// during the value-copy pass, since a handle list keeps only a counter's
-// name, size, generation and tags.
-struct matched_counter {
-	size_t m_idx;
-	uint64_t r_idx;
-};
-
 // Allocate a handle list sized for match_count handles and zero it.
-//
 // Sets instance_count and count on success. The caller still owns filling
 // in each handle.
 static struct counter_handle_list *
@@ -300,56 +303,40 @@ counter_handle_list_alloc(
 	return list;
 }
 
-// Count the matches, allocate the handle list, and fill every handle's
-// name, size, generation and tags.
+// Build one worker's handle list from its matching storages.
 //
-// Leaves every handle's value snapshot unset, which a later pass fills
-// in. On success, fills out_sources with one entry per handle, in the same
-// order as the list, for the value-copy pass to consume.
+// matches is that worker's NULL-terminated storage match array, or NULL
+// for a worker without an execution context. The resulting list carries
+// instance_count == 1 and values snapshotted from that worker's own
+// storages only. Handles of one storage share a tags copy and sit next
+// to each other, matching the list free path's sharing convention.
 static struct counter_handle_list *
-counter_handle_list_build_metadata(
-	const struct worker_counter_matches *matches,
+worker_counter_list_build(
+	struct cp_counter_storage **matches,
 	const struct counter_pattern_set *names,
-	struct matched_counter **out_sources,
 	yanet_error **err
 ) {
-	// A worker set with no execution context yet (the initial generation
-	// before any install) yields an empty list.
-	if (matches->worker_count == 0 || matches->by_worker[0] == NULL) {
-		*out_sources = NULL;
-		return counter_handle_list_alloc(matches->worker_count, 0, err);
+	if (matches == NULL) {
+		return counter_handle_list_alloc(1, 0, err);
 	}
-	struct cp_counter_storage **matches0 = matches->by_worker[0];
 
 	size_t match_count = 0;
-	for (size_t i = 0; matches0[i] != NULL; ++i) {
-		struct counter_storage *storage =
-			ADDR_OF(&matches0[i]->storage);
+	for (size_t i = 0; matches[i] != NULL; ++i) {
+		struct counter_storage *storage = ADDR_OF(&matches[i]->storage);
 		match_count += counter_registry_match_count(
 			ADDR_OF(&storage->registry), names
 		);
 	}
 
-	struct counter_handle_list *list = counter_handle_list_alloc(
-		matches->worker_count, match_count, err
-	);
+	struct counter_handle_list *list =
+		counter_handle_list_alloc(1, match_count, err);
 	if (list == NULL) {
 		return NULL;
 	}
 
-	struct matched_counter *sources = NULL;
-	if (match_count > 0) {
-		sources = malloc(match_count * sizeof(*sources));
-		if (sources == NULL) {
-			yanet_error_add(err, "malloc failed");
-			free(list);
-			return NULL;
-		}
-	}
-
 	size_t next = 0;
-	for (size_t i = 0; matches0[i] != NULL; ++i) {
-		struct cp_counter_storage *cp_storage = matches0[i];
+	for (size_t i = 0; matches[i] != NULL; ++i) {
+		struct cp_counter_storage *cp_storage = matches[i];
 		struct counter_storage *storage = ADDR_OF(&cp_storage->storage);
 		struct counter_registry *registry = ADDR_OF(&storage->registry);
 		struct counter *counters = ADDR_OF(&registry->names);
@@ -366,7 +353,6 @@ counter_handle_list_build_metadata(
 					);
 				if (storage_tags == NULL) {
 					yanet_error_add(err, "malloc failed");
-					free(sources);
 					yanet_counter_handle_list_free(list);
 					return NULL;
 				}
@@ -376,72 +362,413 @@ counter_handle_list_build_metadata(
 			strtcpy(dst->name, src->name, sizeof(dst->name));
 			dst->size = src->size;
 			dst->gen = src->gen;
+			// Attach the tags before the fallible value copy so
+			// the list free path reclaims them even when this
+			// handle's value array is left NULL.
 			dst->tags = storage_tags;
 			dst->tag_count = cp_storage->tag_count;
-			sources[next] = (struct matched_counter){
-				.m_idx = i,
-				.r_idx = idx,
+			struct counter_storage *worker_storages[1] = {
+				storage,
 			};
+			if (counter_handle_copy_values(
+				    dst, worker_storages, 1, idx
+			    )) {
+				yanet_error_add(err, "malloc failed");
+				yanet_counter_handle_list_free(list);
+				return NULL;
+			}
 			++next;
 		}
 	}
-
-	*out_sources = sources;
 	return list;
 }
 
-// Copy every matched counter's per-worker value snapshot into the list
-// built by the metadata pass.
+// FNV-1a over a tag's key and value, separated so that no key/value
+// split of the same bytes hashes the same.
+static uint64_t
+counter_tag_hash(const struct counter_tag *tag) {
+	uint64_t hash = 14695981039346656037ull;
+	for (const char *str = tag->key; *str != '\0'; ++str) {
+		hash = (hash ^ (uint64_t)(unsigned char)*str) *
+		       1099511628211ull;
+	}
+	hash = (hash ^ 0x1f) * 1099511628211ull;
+	for (const char *str = tag->value; *str != '\0'; ++str) {
+		hash = (hash ^ (uint64_t)(unsigned char)*str) *
+		       1099511628211ull;
+	}
+	return hash;
+}
+
+// Tag-set hash, commutative over the tags so that two storages carrying
+// the same tags in different orders hash the same.
+static uint64_t
+counter_tag_set_hash(const struct counter_tag *tags, size_t tag_count) {
+	uint64_t hash = 0;
+	for (size_t idx = 0; idx < tag_count; ++idx) {
+		hash ^= counter_tag_hash(tags + idx);
+	}
+	return hash;
+}
+
+static bool
+counter_tag_set_equal(
+	const struct counter_tag *left,
+	size_t left_count,
+	const struct counter_tag *right,
+	size_t right_count
+) {
+	if (left_count != right_count) {
+		return false;
+	}
+	for (size_t l = 0; l < left_count; ++l) {
+		bool found = false;
+		for (size_t r = 0; r < right_count; ++r) {
+			if (strcmp(left[l].key, right[r].key) == 0 &&
+			    strcmp(left[l].value, right[r].value) == 0) {
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// A distinct tag set seen during a merge, in first-seen order.
+//
+// tags are borrowed from the worker list that first carried the group
+// and are only read for the duration of the merge.
+struct counter_merge_group {
+	const struct counter_tag *tags;
+	size_t tag_count;
+};
+
+struct counter_merge_group_slot {
+	uint64_t hash;
+	// Group index plus one; zero marks an empty slot.
+	uint64_t group;
+};
+
+struct counter_merge_counter_slot {
+	uint64_t hash;
+	// Merged handle index plus one; zero marks an empty slot.
+	uint64_t handle;
+};
+
+// State of one merge of per-worker sets into a union list.
+struct counter_merge {
+	struct counter_handle_list *list;
+	// Group of every merged handle, parallel to list->counters.
+	uint64_t *handle_group;
+	size_t used;
+
+	struct counter_merge_group *groups;
+	size_t group_count;
+
+	struct counter_merge_group_slot *group_slots;
+	size_t group_mask;
+
+	struct counter_merge_counter_slot *counter_slots;
+	size_t counter_mask;
+};
+
+// Smallest power of two not smaller than count.
+static size_t
+pow2_at_least(size_t count) {
+	size_t size = 1;
+	while (size < count) {
+		size <<= 1;
+	}
+	return size;
+}
+
+// Release the merge indexes. The merged list stays owned by the caller.
+static void
+counter_merge_fini(struct counter_merge *merge) {
+	free(merge->handle_group);
+	free(merge->groups);
+	free(merge->group_slots);
+	free(merge->counter_slots);
+}
+
+// Allocate a merged list sized for total handles plus its indexes.
+//
+// On failure every allocation of this merge is already released.
 static int
-counter_handle_list_fill_values(
-	struct counter_handle_list *list,
-	const struct worker_counter_matches *matches,
-	const struct matched_counter *sources,
+counter_merge_init(
+	struct counter_merge *merge,
+	uint64_t worker_count,
+	size_t total,
 	yanet_error **err
 ) {
-	uint64_t worker_count = matches->worker_count;
-	struct counter_storage **worker_storages =
-		worker_count > 0
-			? malloc(worker_count * sizeof(*worker_storages))
-			: NULL;
-	if (worker_count > 0 && worker_storages == NULL) {
-		yanet_error_add(err, "malloc failed");
+	memset(merge, 0, sizeof(*merge));
+
+	merge->list = counter_handle_list_alloc(worker_count, total, err);
+	if (merge->list == NULL) {
 		return -1;
 	}
+	merge->list->count = 0;
 
-	for (uint64_t k = 0; k < list->count; ++k) {
-		size_t m_idx = sources[k].m_idx;
-		uint64_t r_idx = sources[k].r_idx;
-		for (uint64_t w_idx = 0; w_idx < worker_count; ++w_idx) {
-			struct cp_counter_storage *cps =
-				matches->by_worker[w_idx][m_idx];
-			worker_storages[w_idx] = ADDR_OF(&cps->storage);
-		}
-		if (counter_handle_copy_values(
-			    &list->counters[k],
-			    worker_storages,
-			    worker_count,
-			    r_idx
-		    )) {
-			yanet_error_add(err, "malloc failed");
-			free(worker_storages);
-			return -1;
-		}
+	if (total == 0) {
+		return 0;
 	}
-	free(worker_storages);
+
+	merge->handle_group = malloc(total * sizeof(*merge->handle_group));
+	merge->groups = malloc(total * sizeof(*merge->groups));
+	size_t slot_count = pow2_at_least(2 * total);
+	merge->group_slots = calloc(slot_count, sizeof(*merge->group_slots));
+	merge->counter_slots =
+		calloc(slot_count, sizeof(*merge->counter_slots));
+	if (merge->handle_group == NULL || merge->groups == NULL ||
+	    merge->group_slots == NULL || merge->counter_slots == NULL) {
+		yanet_error_add(err, "malloc failed");
+		yanet_counter_handle_list_free(merge->list);
+		merge->list = NULL;
+		counter_merge_fini(merge);
+		return -1;
+	}
+	merge->group_mask = slot_count - 1;
+	merge->counter_mask = slot_count - 1;
 	return 0;
 }
 
-// Match the tag and name predicates against the active configuration generation
-// and return every matching counter's metadata and per-worker values.
+// Return the group index of a handle's tag set, registering a new group
+// when the set is seen for the first time.
+static uint64_t
+counter_merge_group(
+	struct counter_merge *merge, const struct counter_handle *handle
+) {
+	uint64_t hash = counter_tag_set_hash(handle->tags, handle->tag_count);
+	size_t slot = (size_t)hash & merge->group_mask;
+	for (;;) {
+		struct counter_merge_group_slot *cur =
+			&merge->group_slots[slot];
+		if (cur->group == 0) {
+			cur->hash = hash;
+			cur->group = merge->group_count + 1;
+			merge->groups[merge->group_count] =
+				(struct counter_merge_group){
+					.tags = handle->tags,
+					.tag_count = handle->tag_count,
+				};
+			return merge->group_count++;
+		}
+		if (cur->hash == hash) {
+			uint64_t group = cur->group - 1;
+			const struct counter_merge_group *known =
+				&merge->groups[group];
+			if (counter_tag_set_equal(
+				    handle->tags,
+				    handle->tag_count,
+				    known->tags,
+				    known->tag_count
+			    )) {
+				return group;
+			}
+		}
+		slot = (slot + 1) & merge->group_mask;
+	}
+}
+
+// Hash a merged counter's identity: its group and its name.
+static uint64_t
+counter_merge_counter_hash(uint64_t group, const char *name) {
+	uint64_t hash = 14695981039346656037ull;
+	for (; *name != '\0'; ++name) {
+		hash = (hash ^ (uint64_t)(unsigned char)*name) *
+		       1099511628211ull;
+	}
+	return wyhash64(hash ^ (group + 1));
+}
+
+// Return the merged handle index for (group, name), reserving the next
+// free handle and setting *created when the counter is new to the merge.
+static uint64_t
+counter_merge_handle(
+	struct counter_merge *merge,
+	uint64_t group,
+	const char *name,
+	bool *created
+) {
+	uint64_t hash = counter_merge_counter_hash(group, name);
+	size_t slot = (size_t)hash & merge->counter_mask;
+	for (;;) {
+		struct counter_merge_counter_slot *cur =
+			&merge->counter_slots[slot];
+		if (cur->handle == 0) {
+			cur->hash = hash;
+			cur->handle = merge->used + 1;
+			merge->handle_group[merge->used] = group;
+			*created = true;
+			return merge->used++;
+		}
+		if (cur->hash == hash) {
+			uint64_t handle = cur->handle - 1;
+			if (merge->handle_group[handle] == group &&
+			    strcmp(merge->list->counters[handle].name, name) ==
+				    0) {
+				*created = false;
+				return handle;
+			}
+		}
+		slot = (slot + 1) & merge->counter_mask;
+	}
+}
+
+// Fill a freshly reserved merged handle from the first worker carrying
+// the counter: metadata, its own tags copy, and a zeroed value block
+// spanning every worker.
+static int
+counter_merge_handle_init(
+	struct counter_merge *merge,
+	uint64_t handle_idx,
+	const struct counter_handle *src,
+	yanet_error **err
+) {
+	struct counter_handle *dst = &merge->list->counters[handle_idx];
+	strtcpy(dst->name, src->name, sizeof(dst->name));
+	dst->size = src->size;
+	dst->gen = src->gen;
+	dst->tags = counter_tags_dup(src->tags, src->tag_count);
+	if (dst->tags == NULL && src->tag_count > 0) {
+		yanet_error_add(err, "malloc failed");
+		return -1;
+	}
+	dst->tag_count = src->tag_count;
+
+	uint64_t worker_count = merge->list->instance_count;
+	size_t ptr_array_size = worker_count * sizeof(uint64_t *);
+	uint8_t *base = calloc(
+		1, ptr_array_size + worker_count * dst->size * sizeof(uint64_t)
+	);
+	if (base == NULL) {
+		yanet_error_add(err, "malloc failed");
+		return -1;
+	}
+	dst->values = (uint64_t **)base;
+	uint64_t *blocks = (uint64_t *)(base + ptr_array_size);
+	for (uint64_t w_idx = 0; w_idx < worker_count; ++w_idx) {
+		if (dst->size == 0) {
+			dst->values[w_idx] = NULL;
+			continue;
+		}
+		dst->values[w_idx] = blocks + w_idx * dst->size;
+	}
+	return 0;
+}
+
+// Union of the per-worker matched counter sets.
+//
+// A counter's identity is its tag set plus its name. The first worker
+// carrying it defines its position and metadata; every other worker
+// that carries it has its snapshot copied into its instance slot, and
+// the instance slots of workers without the counter stay zero.
+static struct counter_handle_list *
+counter_worker_sets_merge(
+	const struct counter_worker_set_list *sets, yanet_error **err
+) {
+	uint64_t worker_count = sets->worker_count;
+
+	size_t total = 0;
+	for (uint64_t w_idx = 0; w_idx < worker_count; ++w_idx) {
+		total += sets->sets[w_idx].counters->count;
+	}
+
+	struct counter_merge merge;
+	if (counter_merge_init(&merge, worker_count, total, err)) {
+		return NULL;
+	}
+
+	for (uint64_t w_idx = 0; w_idx < worker_count; ++w_idx) {
+		struct counter_handle_list *src = sets->sets[w_idx].counters;
+		for (size_t i = 0; i < src->count; ++i) {
+			struct counter_handle *handle = &src->counters[i];
+			uint64_t group = counter_merge_group(&merge, handle);
+			bool created = false;
+			uint64_t handle_idx = counter_merge_handle(
+				&merge, group, handle->name, &created
+			);
+			if (created && counter_merge_handle_init(
+					       &merge, handle_idx, handle, err
+				       )) {
+				goto error;
+			}
+			struct counter_handle *dst =
+				&merge.list->counters[handle_idx];
+			// Sizes come from the module's registry and are
+			// expected to agree across workers; on disagreement
+			// the first worker's size stays and this worker's
+			// instance remains zero.
+			if (handle->size != dst->size || dst->size == 0) {
+				continue;
+			}
+			memcpy(dst->values[w_idx],
+			       handle->values[0],
+			       dst->size * sizeof(uint64_t));
+		}
+	}
+
+	merge.list->count = merge.used;
+	counter_merge_fini(&merge);
+	return merge.list;
+
+error:
+	// Every handle below merge.used is initialized, including the one
+	// whose init failed halfway, so publishing the count lets the free
+	// path reclaim their tags and value blocks.
+	merge.list->count = merge.used;
+	yanet_counter_handle_list_free(merge.list);
+	counter_merge_fini(&merge);
+	return NULL;
+}
+
+// Build the per-worker set list from the collected matches.
+static struct counter_worker_set_list *
+counter_worker_set_list_build(
+	const struct worker_counter_matches *matches,
+	const struct counter_pattern_set *names,
+	yanet_error **err
+) {
+	// Zero-initialized so the free path below only visits slots this
+	// function actually filled in before a failure.
+	struct counter_worker_set_list *sets =
+		(struct counter_worker_set_list *)calloc(
+			1,
+			sizeof(*sets) +
+				sizeof(sets->sets[0]) * matches->worker_count
+		);
+	if (sets == NULL) {
+		yanet_error_add(err, "malloc failed");
+		return NULL;
+	}
+	sets->worker_count = matches->worker_count;
+
+	for (uint64_t w_idx = 0; w_idx < matches->worker_count; ++w_idx) {
+		sets->sets[w_idx].worker_idx = w_idx;
+		sets->sets[w_idx].counters = worker_counter_list_build(
+			matches->by_worker[w_idx], names, err
+		);
+		if (sets->sets[w_idx].counters == NULL) {
+			yanet_counter_worker_set_list_free(sets);
+			return NULL;
+		}
+	}
+	return sets;
+}
+
+// Match the tag and name predicates against every worker's own counter
+// storage registry and return each worker's matched counters separately.
 //
 // The config lock is held only long enough to acquire the generation pin
 // at the start and to drop it again at the end. The pin itself stays held
 // for the whole call: matching, allocation and the value copy all run
 // unlocked against the pinned generation, so a concurrent config update
 // can retire and replace it mid-call without disturbing this read.
-struct counter_handle_list *
-yanet_get_counters_by_tags(
+struct counter_worker_set_list *
+yanet_get_counters_by_tags_per_worker(
 	struct dp_config *dp_config,
 	const struct counter_tag *tags,
 	size_t tag_count,
@@ -464,8 +791,7 @@ yanet_get_counters_by_tags(
 		.by_worker = NULL,
 		.worker_count = 0,
 	};
-	struct counter_handle_list *list = NULL;
-	struct matched_counter *sources = NULL;
+	struct counter_worker_set_list *sets = NULL;
 
 	if (worker_counter_matches_collect(
 		    config_gen, worker_count, tags, tag_count, &matches, err
@@ -473,27 +799,60 @@ yanet_get_counters_by_tags(
 		goto out;
 	}
 
-	list = counter_handle_list_build_metadata(
-		&matches, names, &sources, err
-	);
-	if (list == NULL) {
-		goto out;
-	}
-
-	if (counter_handle_list_fill_values(list, &matches, sources, err)) {
-		yanet_counter_handle_list_free(list);
-		list = NULL;
-		goto out;
-	}
+	sets = counter_worker_set_list_build(&matches, names, err);
 
 out:
-	free(sources);
 	worker_counter_matches_free(&matches);
 
 	cp_config_lock(cp_config);
 	cp_config_gen_release(cp_config, config_gen);
 	cp_config_unlock(cp_config);
 
+	return sets;
+}
+
+struct counter_worker_set *
+yanet_get_counter_worker_set(
+	struct counter_worker_set_list *sets, uint64_t worker_idx
+) {
+	if (sets == NULL || worker_idx >= sets->worker_count) {
+		return NULL;
+	}
+	return sets->sets + worker_idx;
+}
+
+void
+yanet_counter_worker_set_list_free(struct counter_worker_set_list *sets) {
+	if (sets == NULL) {
+		return;
+	}
+	for (uint64_t w_idx = 0; w_idx < sets->worker_count; ++w_idx) {
+		yanet_counter_handle_list_free(sets->sets[w_idx].counters);
+	}
+	free(sets);
+}
+
+// Match the tag and name predicates against every worker's own registry
+// and merge the sets into one list spanning all workers, with zero
+// values wherever a worker does not carry the counter.
+struct counter_handle_list *
+yanet_get_counters_by_tags(
+	struct dp_config *dp_config,
+	const struct counter_tag *tags,
+	size_t tag_count,
+	const struct counter_query *query,
+	yanet_error **err
+) {
+	struct counter_worker_set_list *sets =
+		yanet_get_counters_by_tags_per_worker(
+			dp_config, tags, tag_count, query, err
+		);
+	if (sets == NULL) {
+		return NULL;
+	}
+
+	struct counter_handle_list *list = counter_worker_sets_merge(sets, err);
+	yanet_counter_worker_set_list_free(sets);
 	return list;
 }
 

--- a/lib/controlplane/tests/counter_workers_test.c
+++ b/lib/controlplane/tests/counter_workers_test.c
@@ -1,0 +1,476 @@
+/*
+ * Tests for per-worker counter reads under divergent registries.
+ *
+ * Every worker's config_gen_ectx owns its own counter storage registry,
+ * and those registries may hold different storages. The per-worker read
+ * returns each worker's matched set independently, while the merged read
+ * unions the sets and zero-fills the instances of workers that do not
+ * carry a counter.
+ *
+ * Divergence is produced by writing distinct values into the two workers'
+ * pipeline storages and by registering an extra tagged storage in only
+ * one worker's registry.
+ */
+
+#include "api/agent.h"
+#include "api/counter.h"
+
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "common/test_assert.h"
+#include "devices/plain/api/controlplane.h"
+#include "lib/controlplane/agent/agent.h"
+#include "lib/controlplane/config/cp_pipeline.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/counters/counters.h"
+#include "lib/dataplane/pipeline/econtext.h"
+#include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CW_TEST_MEMORY_LIMIT (4u * 1024u * 1024u)
+
+#define CW_WORKER_COUNT 2
+#define CW_W0_INPUT 0x10
+#define CW_W1_INPUT 0x20
+#define CW_W1_EXTRA_0 0xAA
+#define CW_W1_EXTRA_1 0xBB
+
+static int
+install_empty_pipeline(
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	const char *name
+) {
+	yanet_error *err = NULL;
+	struct cp_pipeline_config *cfg =
+		calloc(1, sizeof(struct cp_pipeline_config));
+	TEST_ASSERT_NOT_NULL(cfg, "failed to allocate pipeline config");
+	strncpy(cfg->name, name, CP_PIPELINE_NAME_LEN - 1);
+	cfg->length = 0;
+	struct cp_pipeline_config *cfgs[] = {cfg};
+	int rc =
+		cp_config_update_pipelines(dp_config, cp_config, 1, cfgs, &err);
+	free(cfg);
+	TEST_ASSERT_SUCCESS(
+		rc,
+		"update_pipelines failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	return TEST_SUCCESS;
+}
+
+static int
+install_device(
+	struct agent *agent,
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	const char *name,
+	const char *input_pipeline
+) {
+	yanet_error *err = NULL;
+	struct cp_device_plain_config *cfg =
+		cp_device_plain_config_new(name, 1, 0, &err);
+	TEST_ASSERT_NOT_NULL(
+		cfg,
+		"device config new failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_device_plain_config_set_input_pipeline(cfg, 0, input_pipeline, 1);
+	struct cp_device *dev = cp_device_plain_new(agent, cfg, &err);
+	cp_device_plain_config_free(cfg);
+	TEST_ASSERT_NOT_NULL(
+		dev,
+		"device new failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	struct cp_device *devs[] = {dev};
+	int rc = cp_config_update_devices(dp_config, cp_config, 1, devs, &err);
+	TEST_ASSERT_SUCCESS(
+		rc,
+		"update_devices failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	return TEST_SUCCESS;
+}
+
+// Index of a counter in a storage's registry, or COUNTER_INVALID when the
+// registry does not carry the name.
+static uint64_t
+counter_index_by_name(struct counter_storage *storage, const char *name) {
+	struct counter_registry *registry = ADDR_OF(&storage->registry);
+	struct counter *counters = ADDR_OF(&registry->names);
+	for (uint64_t idx = 0; idx < registry->count; ++idx) {
+		if (strcmp(counters[idx].name, name) == 0) {
+			return idx;
+		}
+	}
+	return COUNTER_INVALID;
+}
+
+// Write value into the first slot of a counter named name in a worker's
+// pipeline storage, so the two workers report different snapshots.
+static int
+write_pipeline_counter(
+	struct config_gen_ectx *ectx, const char *counter_name, uint64_t value
+) {
+	struct cp_config_counter_storage_registry *registry =
+		ADDR_OF(&ectx->counter_storage_registry);
+	struct counter_storage *storage =
+		cp_config_counter_storage_registry_lookup_pipeline(
+			registry, "dev0", "pipe0"
+		);
+	TEST_ASSERT_NOT_NULL(
+		storage, "no pipeline counter storage in the worker registry"
+	);
+
+	uint64_t idx = counter_index_by_name(storage, counter_name);
+	TEST_ASSERT(
+		idx != COUNTER_INVALID,
+		"counter '%s' not found in the pipeline registry",
+		counter_name
+	);
+
+	uint64_t *values =
+		counter_handle_get_value(counter_get_value_handle(idx, storage)
+		);
+	values[0] = value;
+	return TEST_SUCCESS;
+}
+
+// Register a tagged storage carrying one counter in a single worker's
+// registry, with marker values in both of the counter's slots.
+static int
+insert_worker1_extra_storage(struct cp_config *cp_config) {
+	yanet_error *err = NULL;
+	struct memory_context *memory_context =
+		&cp_config->counter_storage_memory_context;
+
+	struct counter_registry *registry = (struct counter_registry *)
+		memory_balloc(memory_context, sizeof(*registry));
+	TEST_ASSERT_NOT_NULL(
+		registry, "failed to allocate the extra counter registry"
+	);
+	memset(registry, 0, sizeof(*registry));
+	TEST_ASSERT_SUCCESS(
+		counter_registry_init(registry, memory_context, 0),
+		"failed to init the extra counter registry"
+	);
+
+	uint64_t counter_id =
+		counter_registry_register(registry, "w1_only", 2, &err);
+	TEST_ASSERT(
+		counter_id != COUNTER_INVALID,
+		"failed to register the extra counter: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	// Assign the counter's pool offset, the same way every config upsert
+	// links a registry before a storage is spawned from it.
+	TEST_ASSERT_SUCCESS(
+		counter_registry_link(registry, NULL, &err),
+		"failed to link the extra counter registry: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct counter_storage *storage =
+		counter_storage_spawn(memory_context, NULL, registry);
+	TEST_ASSERT_NOT_NULL(storage, "failed to spawn the extra storage");
+
+	uint64_t *values = counter_handle_get_value(
+		counter_get_value_handle(counter_id, storage)
+	);
+	values[0] = CW_W1_EXTRA_0;
+	values[1] = CW_W1_EXTRA_1;
+
+	struct counter_tag tags[] = {
+		{.key = "object_type", .value = "extra"},
+		{.key = "object_name", .value = "w1"},
+		{.key = "kind", .value = "object"},
+	};
+
+	cp_config_lock(cp_config);
+	struct cp_config_gen *config_gen = cp_config_gen_acquire(cp_config);
+	cp_config_unlock(cp_config);
+
+	struct config_gen_ectx *ectx = cp_config_gen_worker_ectx(config_gen, 1);
+	TEST_ASSERT_NOT_NULL(ectx, "worker 1 has no execution context");
+
+	TEST_ASSERT_SUCCESS(
+		cp_config_counter_storage_registry_insert(
+			ADDR_OF(&ectx->counter_storage_registry),
+			tags,
+			3,
+			storage,
+			&err
+		),
+		"failed to insert the extra storage: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	cp_config_lock(cp_config);
+	cp_config_gen_release(cp_config, config_gen);
+	cp_config_unlock(cp_config);
+	return TEST_SUCCESS;
+}
+
+// Diverge the workers' registries: distinct pipeline values everywhere
+// plus an extra storage only worker 1 knows about.
+static int
+make_workers_diverge(
+	struct agent *agent,
+	struct dp_config *dp_config,
+	struct cp_config *cp_config
+) {
+	TEST_ASSERT_SUCCESS(
+		install_empty_pipeline(dp_config, cp_config, "pipe0"),
+		"failed to install pipe0"
+	);
+	TEST_ASSERT_SUCCESS(
+		install_device(agent, dp_config, cp_config, "dev0", "pipe0"),
+		"failed to install dev0 with input pipeline pipe0"
+	);
+
+	cp_config_lock(cp_config);
+	struct cp_config_gen *config_gen = cp_config_gen_acquire(cp_config);
+	cp_config_unlock(cp_config);
+
+	for (uint64_t w_idx = 0; w_idx < CW_WORKER_COUNT; ++w_idx) {
+		struct config_gen_ectx *ectx =
+			cp_config_gen_worker_ectx(config_gen, w_idx);
+		TEST_ASSERT_NOT_NULL(
+			ectx,
+			"worker %lu has no execution context",
+			(unsigned long)w_idx
+		);
+		uint64_t value = w_idx == 0 ? CW_W0_INPUT : CW_W1_INPUT;
+		TEST_ASSERT_SUCCESS(
+			write_pipeline_counter(ectx, "input", value),
+			"failed to write worker %lu pipeline counter",
+			(unsigned long)w_idx
+		);
+	}
+
+	cp_config_lock(cp_config);
+	cp_config_gen_release(cp_config, config_gen);
+	cp_config_unlock(cp_config);
+
+	TEST_ASSERT_SUCCESS(
+		insert_worker1_extra_storage(cp_config),
+		"failed to register the worker-1-only storage"
+	);
+	return TEST_SUCCESS;
+}
+
+static struct counter_handle *
+find_handle(struct counter_handle_list *list, const char *name) {
+	for (size_t idx = 0; idx < list->count; ++idx) {
+		struct counter_handle *handle = yanet_get_counter(list, idx);
+		if (handle != NULL && strcmp(handle->name, name) == 0) {
+			return handle;
+		}
+	}
+	return NULL;
+}
+
+// Verifies that the per-worker read returns each worker's matched set
+// independently: the worker-1-only storage shows up with its own values
+// in worker 1's set and not at all in worker 0's.
+static int
+test_per_worker_sets(struct dp_config *dp_config) {
+	struct counter_tag tags[] = {
+		{.key = "object_type", .value = "extra"},
+		{.key = "object_name", .value = "w1"},
+		{.key = "kind", .value = "object"},
+	};
+
+	struct counter_worker_set_list *sets =
+		yanet_get_counters_by_tags_per_worker(
+			dp_config, tags, 3, NULL, NULL
+		);
+	TEST_ASSERT_NOT_NULL(
+		sets, "yanet_get_counters_by_tags_per_worker returned NULL"
+	);
+	TEST_ASSERT_EQUAL(
+		sets->worker_count, CW_WORKER_COUNT, "unexpected worker count"
+	);
+
+	struct counter_worker_set *set0 = yanet_get_counter_worker_set(sets, 0);
+	struct counter_worker_set *set1 = yanet_get_counter_worker_set(sets, 1);
+	TEST_ASSERT_NOT_NULL(set0, "worker 0 set is missing");
+	TEST_ASSERT_NOT_NULL(set1, "worker 1 set is missing");
+	TEST_ASSERT_EQUAL(0, set0->counters->count, "worker 0 matched");
+	TEST_ASSERT_EQUAL(1, set1->counters->count, "worker 1 match count");
+	TEST_ASSERT_EQUAL(1, set1->counters->instance_count, "instance count");
+
+	struct counter_handle *handle = yanet_get_counter(set1->counters, 0);
+	TEST_ASSERT_NOT_NULL(handle, "worker 1 set has no handle");
+	TEST_ASSERT(
+		strcmp(handle->name, "w1_only") == 0,
+		"counter name is '%s', expected 'w1_only'",
+		handle->name
+	);
+	TEST_ASSERT_EQUAL(2, handle->size, "counter size");
+	TEST_ASSERT_EQUAL(
+		CW_W1_EXTRA_0,
+		yanet_get_counter_value(handle->values, 0, 0),
+		"worker 1 extra counter slot 0"
+	);
+	TEST_ASSERT_EQUAL(
+		CW_W1_EXTRA_1,
+		yanet_get_counter_value(handle->values, 1, 0),
+		"worker 1 extra counter slot 1"
+	);
+
+	TEST_ASSERT_NULL(
+		yanet_get_counter_worker_set(sets, CW_WORKER_COUNT),
+		"out-of-range worker set must return NULL"
+	);
+
+	yanet_counter_worker_set_list_free(sets);
+	return TEST_SUCCESS;
+}
+
+// Verifies that the merged read unions the workers' sets and zero-fills
+// the instances of workers without the counter.
+static int
+test_merged_zero_fill(struct dp_config *dp_config) {
+	struct counter_tag tags[] = {
+		{.key = "object_type", .value = "extra"},
+		{.key = "object_name", .value = "w1"},
+		{.key = "kind", .value = "object"},
+	};
+
+	struct counter_handle_list *list =
+		yanet_get_counters_by_tags(dp_config, tags, 3, NULL, NULL);
+	TEST_ASSERT_NOT_NULL(list, "yanet_get_counters_by_tags returned NULL");
+	TEST_ASSERT_EQUAL(1, list->count, "merged match count");
+	TEST_ASSERT_EQUAL(
+		CW_WORKER_COUNT, list->instance_count, "merged instance count"
+	);
+
+	struct counter_handle *handle = find_handle(list, "w1_only");
+	TEST_ASSERT_NOT_NULL(handle, "merged list lacks the worker-1 counter");
+	TEST_ASSERT_EQUAL(2, handle->size, "merged counter size");
+	TEST_ASSERT_EQUAL(
+		0,
+		yanet_get_counter_value(handle->values, 0, 0),
+		"absent worker 0 slot 0 must be zero"
+	);
+	TEST_ASSERT_EQUAL(
+		0,
+		yanet_get_counter_value(handle->values, 1, 0),
+		"absent worker 0 slot 1 must be zero"
+	);
+	TEST_ASSERT_EQUAL(
+		CW_W1_EXTRA_0,
+		yanet_get_counter_value(handle->values, 0, 1),
+		"worker 1 slot 0"
+	);
+	TEST_ASSERT_EQUAL(
+		CW_W1_EXTRA_1,
+		yanet_get_counter_value(handle->values, 1, 1),
+		"worker 1 slot 1"
+	);
+
+	yanet_counter_handle_list_free(list);
+	return TEST_SUCCESS;
+}
+
+// Verifies that a counter present in every worker's registry keeps every
+// worker's own value in the merged view.
+static int
+test_merged_shared_counter(struct dp_config *dp_config) {
+	struct counter_tag tags[] = {
+		{.key = "device", .value = "dev0"},
+		{.key = "kind", .value = "pipeline"},
+	};
+
+	struct counter_handle_list *list =
+		yanet_get_counters_by_tags(dp_config, tags, 2, NULL, NULL);
+	TEST_ASSERT_NOT_NULL(list, "yanet_get_counters_by_tags returned NULL");
+	TEST_ASSERT_EQUAL(
+		CW_WORKER_COUNT, list->instance_count, "merged instance count"
+	);
+
+	struct counter_handle *handle = find_handle(list, "input");
+	TEST_ASSERT_NOT_NULL(handle, "merged list lacks the input counter");
+	TEST_ASSERT_EQUAL(
+		CW_W0_INPUT,
+		yanet_get_counter_value(handle->values, 0, 0),
+		"worker 0 input value"
+	);
+	TEST_ASSERT_EQUAL(
+		CW_W1_INPUT,
+		yanet_get_counter_value(handle->values, 0, 1),
+		"worker 1 input value"
+	);
+
+	yanet_counter_handle_list_free(list);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	const char *port_names[] = {"01:00.0"};
+	const char *devs_to_load[] = {"plain"};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 25,
+		.dp_memory = 1u << 20,
+		.worker_count = CW_WORKER_COUNT,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = NULL,
+		.module_count = 0,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+	};
+
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	if (ut == NULL) {
+		fprintf(stderr, "dataplane_ut_new failed\n");
+		return 1;
+	}
+
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	if (shm == NULL) {
+		fprintf(stderr, "dataplane_ut_shm returned NULL\n");
+		dataplane_ut_free(ut);
+		return 1;
+	}
+
+	yanet_error *err = NULL;
+	struct agent *agent =
+		agent_attach(shm, 0, "cnt-workers", CW_TEST_MEMORY_LIMIT, &err);
+	if (agent == NULL) {
+		fprintf(stderr, "agent_attach failed\n");
+		dataplane_ut_free(ut);
+		return 1;
+	}
+
+	struct dp_config *dp_config = agent_dp_config(agent);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	int res = make_workers_diverge(agent, dp_config, cp_config);
+	if (res == TEST_SUCCESS) {
+		res = test_per_worker_sets(dp_config);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_merged_zero_fill(dp_config);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_merged_shared_counter(dp_config);
+	}
+
+	agent_detach(agent);
+	dataplane_ut_free(ut);
+
+	return (res == TEST_SUCCESS) ? 0 : 1;
+}

--- a/lib/controlplane/tests/meson.build
+++ b/lib/controlplane/tests/meson.build
@@ -52,6 +52,29 @@ test(
   timeout: 90,
 )
 
+counter_workers_test = executable(
+  'counter_workers_test',
+  ['counter_workers_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_device_plain',
+    '-Wl,--export-dynamic-symbol=new_device_plain',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_agent_counters_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_dev_plain_api,
+    libdpdk_dep,
+  ],
+  link_with: [lib_dev_plain_dp],
+  include_directories: yanet_rootdir,
+)
+
+test('counter_workers', counter_workers_test, suite: ['lib'])
+
 loaded_counts_test = executable(
   'loaded_counts_test',
   ['loaded_counts_test.c'],

--- a/tests/counters/alloc_probe.go
+++ b/tests/counters/alloc_probe.go
@@ -1,39 +1,107 @@
 package counters_test
 
-//#cgo LDFLAGS: -Wl,--wrap=malloc -Wl,--wrap=calloc
+// The probes interpose this binary's own dynamic allocations so a test
+// can observe both how many allocations a read performs and how many
+// stay outstanding after it returns.
+
 /*
+#cgo LDFLAGS: -Wl,--wrap=malloc -Wl,--wrap=calloc -Wl,--wrap=strdup -Wl,--wrap=free
+
+#include <malloc.h>
 #include <stddef.h>
+#include <stdint.h>
 
 extern void *__real_malloc(size_t size);
 extern void *__real_calloc(size_t nmemb, size_t size);
+extern char *__real_strdup(const char *str);
+extern void __real_free(void *ptr);
 
 static size_t alloc_count = 0;
+static size_t live_count = 0;
+static size_t live_bytes = 0;
+
+static void
+track_alloc(void *ptr) {
+	__atomic_fetch_add(&alloc_count, 1, __ATOMIC_RELAXED);
+	if (ptr == NULL) {
+		return;
+	}
+	__atomic_fetch_add(&live_count, 1, __ATOMIC_RELAXED);
+	// Book the usable size, the same figure free books, so the
+	// outstanding bytes balance exactly instead of drifting by the
+	// allocator's rounding on every short string.
+	__atomic_fetch_add(&live_bytes, malloc_usable_size(ptr), __ATOMIC_RELAXED);
+}
 
 void *
 __wrap_malloc(size_t size) {
-	__atomic_fetch_add(&alloc_count, 1, __ATOMIC_RELAXED);
-	return __real_malloc(size);
+	void *ptr = __real_malloc(size);
+	track_alloc(ptr);
+	return ptr;
 }
 
 void *
 __wrap_calloc(size_t nmemb, size_t size) {
-	__atomic_fetch_add(&alloc_count, 1, __ATOMIC_RELAXED);
-	return __real_calloc(nmemb, size);
+	void *ptr = __real_calloc(nmemb, size);
+	track_alloc(ptr);
+	return ptr;
+}
+
+char *
+__wrap_strdup(const char *str) {
+	char *ptr = __real_strdup(str);
+	track_alloc(ptr);
+	return ptr;
+}
+
+void
+__wrap_free(void *ptr) {
+	if (ptr != NULL) {
+		size_t size = malloc_usable_size(ptr);
+		__atomic_fetch_sub(&live_count, 1, __ATOMIC_RELAXED);
+		__atomic_fetch_sub(&live_bytes, size, __ATOMIC_RELAXED);
+	}
+	__real_free(ptr);
 }
 
 size_t
 alloc_count_load(void) {
 	return __atomic_load_n(&alloc_count, __ATOMIC_RELAXED);
 }
+
+size_t
+live_count_load(void) {
+	return __atomic_load_n(&live_count, __ATOMIC_RELAXED);
+}
+
+size_t
+live_bytes_load(void) {
+	return __atomic_load_n(&live_bytes, __ATOMIC_RELAXED);
+}
 */
 import "C"
 
-// allocCount returns the number of malloc/calloc calls observed so far by
-// the __wrap_malloc/__wrap_calloc probes linked into this test binary.
+// allocCount returns the number of malloc/calloc/strdup calls observed so
+// far by the probes linked into this test binary.
 //
 // This is a lower bound covering only this binary's own object files: a
 // call made inside a precompiled shared library, such as glibc's internal
 // strdup, is not linked against the wrap symbols and stays uncounted.
 func allocCount() uint64 {
 	return uint64(C.alloc_count_load())
+}
+
+// outstandingAllocs is the number of tracked allocations not yet freed
+// and the usable bytes they retain, for catching a read that leaves
+// blocks behind.
+type outstandingAllocs struct {
+	count uint64
+	bytes uint64
+}
+
+func liveOutstanding() outstandingAllocs {
+	return outstandingAllocs{
+		count: uint64(C.live_count_load()),
+		bytes: uint64(C.live_bytes_load()),
+	}
 }

--- a/tests/counters/bulk_value_copy_test.go
+++ b/tests/counters/bulk_value_copy_test.go
@@ -1,5 +1,5 @@
 // Package counters_test holds regression tests for the counter value-copy
-// path implemented in lib/controlplane/agent/agent.c.
+// path implemented in lib/controlplane/agent/counters.c.
 package counters_test
 
 import (
@@ -21,19 +21,24 @@ const (
 	bulkCopyAgentSize = 2 * datasize.MB
 
 	// bulkCopyPipelineCount is chosen so the per-counter allocation term
-	// dominates the fixed per-call overhead: 20 empty pipelines register
-	// 6 counters each and the single device storage registers another
-	// 12, so the nil tag filter matches 132 counters across 21 storages
-	// against a fixed term of 4+workerCount+21 allocations (27 at 2
-	// workers, 33 at 8).
+	// dominates the fixed per-worker overhead: 20 empty pipelines
+	// register 6 counters each and the single device storage registers
+	// another 12, so the nil tag filter matches 132 counters across 21
+	// storages. One worker's set costs on the order of one allocation
+	// per matched counter (its value blocks) plus a few per matched
+	// storage (its tag copies), so a per-worker budget of twice the
+	// matched counter count leaves room for that fixed term.
 	bulkCopyPipelineCount = 20
+
+	// bulkCopyCycles is the number of repeated read cycles the leak
+	// guard measures; a cycle that leaks counted allocations raises the
+	// delta of every later cycle above the first one's.
+	bulkCopyCycles = 10
 )
 
-// bulkCopyProbe installs a device and bulkCopyPipelineCount empty pipelines
-// at the given worker count, snapshots the wrapped allocator count
-// immediately around one CountersByTags call, and returns the number of
-// allocations it performed together with the number of counters it matched.
-func bulkCopyProbe(t *testing.T, workerCount uint64) (allocs uint64, matched int) {
+// bulkCopyHarness installs a device and bulkCopyPipelineCount empty
+// pipelines at the given worker count and returns the harness's DPConfig.
+func bulkCopyHarness(t *testing.T, workerCount uint64) *ffi.DPConfig {
 	t.Helper()
 
 	cfg := dataplaneut.Config{
@@ -45,13 +50,13 @@ func bulkCopyProbe(t *testing.T, workerCount uint64) (allocs uint64, matched int
 	}
 	h, err := dataplaneut.NewHarness(cfg)
 	require.NoError(t, err)
-	defer h.Free()
+	t.Cleanup(h.Free)
 
 	agent, err := h.SharedMemory().AgentAttach(
 		"bulk-copy-probe", 0, bulkCopyAgentSize,
 	)
 	require.NoError(t, err)
-	defer func() { _ = agent.CleanUp() }()
+	t.Cleanup(func() { _ = agent.CleanUp() })
 
 	input := make([]ffi.DevicePipelineConfig, bulkCopyPipelineCount)
 	for idx := range bulkCopyPipelineCount {
@@ -65,7 +70,17 @@ func bulkCopyProbe(t *testing.T, workerCount uint64) (allocs uint64, matched int
 	}})
 	require.NoError(t, err)
 
-	dp := h.SharedMemory().DPConfig(0)
+	return h.SharedMemory().DPConfig(0)
+}
+
+// bulkCopyProbe runs one CountersByTags call at the given worker count,
+// snapshots the wrapped allocator count immediately around it, and
+// returns the number of allocations it performed together with the
+// number of counters it matched.
+func bulkCopyProbe(t *testing.T, workerCount uint64) (allocs uint64, matched int) {
+	t.Helper()
+
+	dp := bulkCopyHarness(t, workerCount)
 
 	before := allocCount()
 	groups, err := dp.CountersByTags(nil, nil)
@@ -79,13 +94,13 @@ func bulkCopyProbe(t *testing.T, workerCount uint64) (allocs uint64, matched int
 	return after - before, matched
 }
 
-// TestCountersByTagsAllocationsDoNotScaleWithWorkerCount pins the bulk
-// value-copy shape of counter_handle_copy_values: reading the same matched
-// counter set at a higher worker count must not multiply the allocation
-// count by that worker count, and the read overall must cost on the order
-// of one allocation per matched counter rather than one per counter per
-// worker.
-func TestCountersByTagsAllocationsDoNotScaleWithWorkerCount(t *testing.T) {
+// TestCountersByTagsPerWorkerAllocationsAreBounded pins the allocation
+// shape of the per-worker counter read: every worker's matched set is
+// materialized separately, so the total scales once per worker — one
+// worker's share stays on the order of one allocation per matched
+// counter — and a higher worker count must not grow any single worker's
+// share.
+func TestCountersByTagsPerWorkerAllocationsAreBounded(t *testing.T) {
 	const (
 		lowWorkers  = 2
 		highWorkers = 8
@@ -100,14 +115,50 @@ func TestCountersByTagsAllocationsDoNotScaleWithWorkerCount(t *testing.T) {
 	)
 
 	matched := uint64(highMatched)
-	require.Less(t, highAllocs, lowAllocs+matched,
-		"allocation count must not scale with worker count",
+	perWorkerLow := lowAllocs / lowWorkers
+	perWorkerHigh := highAllocs / highWorkers
+
+	require.Less(t, perWorkerHigh, 2*matched,
+		"one worker's share must cost on the order of one allocation "+
+			"per matched counter",
 	)
-	require.Less(t, highAllocs, 2*matched,
-		"read must cost on the order of one allocation per counter",
+	require.Less(t, perWorkerHigh, perWorkerLow+matched,
+		"a higher worker count must not grow a single worker's share",
 	)
-	require.GreaterOrEqual(t, highAllocs, matched,
-		"read must average at least one allocation per matched counter, "+
-			"or the probe stopped observing the copy",
+	require.GreaterOrEqual(t, perWorkerHigh, matched,
+		"a worker's share must average at least one allocation per "+
+			"matched counter, or the probe stopped observing the copy",
 	)
+}
+
+// TestCountersByTagsRepeatedReadsDoNotAccumulate verifies that a full
+// read cycle leaves nothing behind: every counted allocation of a call
+// is released by the time the call returns, so repeated cycles allocate
+// the same count. A cycle that leaks one of the per-worker lists, tag
+// copies, or value blocks raises the delta of every later cycle.
+//
+// The probe only counts this binary's own malloc/calloc calls, so a leak
+// of memory allocated inside libc (such as strdup) stays invisible here.
+func TestCountersByTagsRepeatedReadsDoNotAccumulate(t *testing.T) {
+	const workerCount = 4
+
+	dp := bulkCopyHarness(t, workerCount)
+
+	deltas := make([]uint64, 0, bulkCopyCycles)
+	for range bulkCopyCycles {
+		before := allocCount()
+		groups, err := dp.CountersByTags(nil, nil)
+		after := allocCount()
+		require.NoError(t, err)
+		require.NotEmpty(t, groups, "read must keep matching counters")
+		deltas = append(deltas, after-before)
+	}
+
+	for idx, delta := range deltas {
+		require.Equal(t, deltas[0], delta,
+			"cycle %d allocated %d, the first cycle allocated %d; "+
+				"a repeated read must not accumulate allocations",
+			idx, delta, deltas[0],
+		)
+	}
 }

--- a/tests/counters/bulk_value_copy_test.go
+++ b/tests/counters/bulk_value_copy_test.go
@@ -24,15 +24,16 @@ const (
 	// dominates the fixed per-worker overhead: 20 empty pipelines
 	// register 6 counters each and the single device storage registers
 	// another 12, so the nil tag filter matches 132 counters across 21
-	// storages. One worker's set costs on the order of one allocation
-	// per matched counter (its value blocks) plus a few per matched
-	// storage (its tag copies), so a per-worker budget of twice the
-	// matched counter count leaves room for that fixed term.
+	// storages. One worker's set costs one value block per matched
+	// counter plus a small tag term per matched storage (one tags array
+	// and two strdup'd strings per tag), so a per-worker budget of the
+	// matched counters plus eight allocations per storage leaves room
+	// for both terms.
 	bulkCopyPipelineCount = 20
 
 	// bulkCopyCycles is the number of repeated read cycles the leak
-	// guard measures; a cycle that leaks counted allocations raises the
-	// delta of every later cycle above the first one's.
+	// guard measures; a cycle that leaks tracked allocations or bytes
+	// raises every later cycle's floor above the first cycle's.
 	bulkCopyCycles = 10
 )
 
@@ -115,12 +116,14 @@ func TestCountersByTagsPerWorkerAllocationsAreBounded(t *testing.T) {
 	)
 
 	matched := uint64(highMatched)
+	storageCount := uint64(bulkCopyPipelineCount + 1)
+	perWorkerBudget := matched + 8*storageCount
 	perWorkerLow := lowAllocs / lowWorkers
 	perWorkerHigh := highAllocs / highWorkers
 
-	require.Less(t, perWorkerHigh, 2*matched,
-		"one worker's share must cost on the order of one allocation "+
-			"per matched counter",
+	require.Less(t, perWorkerHigh, perWorkerBudget,
+		"one worker's share must cost one allocation per matched "+
+			"counter plus a small tag term per storage",
 	)
 	require.Less(t, perWorkerHigh, perWorkerLow+matched,
 		"a higher worker count must not grow a single worker's share",
@@ -132,33 +135,54 @@ func TestCountersByTagsPerWorkerAllocationsAreBounded(t *testing.T) {
 }
 
 // TestCountersByTagsRepeatedReadsDoNotAccumulate verifies that a full
-// read cycle leaves nothing behind: every counted allocation of a call
-// is released by the time the call returns, so repeated cycles allocate
-// the same count. A cycle that leaks one of the per-worker lists, tag
-// copies, or value blocks raises the delta of every later cycle.
+// read cycle leaves nothing behind: after each call the number of
+// outstanding tracked allocations and the bytes they retain return to
+// the level the first cycle settled at. A cycle that leaks one of the
+// per-worker lists, tag copies, or value blocks leaves its blocks
+// outstanding and raises every later cycle's floor.
 //
-// The probe only counts this binary's own malloc/calloc calls, so a leak
-// of memory allocated inside libc (such as strdup) stays invisible here.
+// The probe only observes this binary's own allocations: memory
+// allocated inside a precompiled shared library stays invisible here.
 func TestCountersByTagsRepeatedReadsDoNotAccumulate(t *testing.T) {
 	const workerCount = 4
 
 	dp := bulkCopyHarness(t, workerCount)
 
-	deltas := make([]uint64, 0, bulkCopyCycles)
-	for range bulkCopyCycles {
-		before := allocCount()
+	// Prime every lazy one-time allocation the first call makes, so the
+	// baseline the later cycles are compared against is steady state.
+	_, err := dp.CountersByTags(nil, nil)
+	require.NoError(t, err)
+
+	var baseline outstandingAllocs
+	var firstDelta uint64
+	deltas := make([]uint64, 0, bulkCopyCycles-1)
+	for idx := range bulkCopyCycles {
+		allocsBefore := allocCount()
 		groups, err := dp.CountersByTags(nil, nil)
-		after := allocCount()
+		after := liveOutstanding()
 		require.NoError(t, err)
 		require.NotEmpty(t, groups, "read must keep matching counters")
-		deltas = append(deltas, after-before)
+
+		delta := allocCount() - allocsBefore
+		if idx == 0 {
+			baseline = after
+			firstDelta = delta
+			continue
+		}
+		deltas = append(deltas, delta)
+		require.Equal(t, baseline, after,
+			"cycle %d left %d allocations outstanding, the first "+
+				"cycle settled at %d; a completed read must "+
+				"not retain allocations",
+			idx, after.count, baseline.count,
+		)
 	}
 
 	for idx, delta := range deltas {
-		require.Equal(t, deltas[0], delta,
+		require.Equal(t, firstDelta, delta,
 			"cycle %d allocated %d, the first cycle allocated %d; "+
-				"a repeated read must not accumulate allocations",
-			idx, delta, deltas[0],
+				"a repeated read must not change its allocation count",
+			idx+1, delta, firstDelta,
 		)
 	}
 }


### PR DESCRIPTION
Each worker's counter storage registry is matched independently, so per-worker registries that diverge no longer drop or misattribute counters.
yanet_get_counters_by_tags now returns the union of the per-worker sets, with zero values for the instances of workers that do not carry a counter, preserving the gRPC response shape.
A new yanet_get_counters_by_tags_per_worker API exposes the raw per-worker sets, and the Go control plane merges them with zero-fill on absent values.