### PR TITLE
perf(filter,acl): memoize net6 verdicts per address

### DIFF
--- a/lib/filter/classifiers/net6.h
+++ b/lib/filter/classifiers/net6.h
@@ -6,10 +6,13 @@
 #include "common/memory_address.h"
 #include "common/value.h"
 
+#include "net6_memo.h"
+
 struct net6_classifier {
 	struct lpm hi;
 	struct lpm lo;
 	struct value_table comb;
+	struct net6_memo memo;
 };
 
 // Shared per-direction IPv6 half-address classification.
@@ -29,6 +32,11 @@ struct net6_share_dir {
 	uint32_t *remap_lo_a;
 	uint32_t *remap_hi_b;
 	uint32_t *remap_lo_b;
+	// Per-filter verdict memos keyed by the full 16-byte address of this
+	// direction: a hit replaces the union walks, the remap fetches, and
+	// the leaf comb fetch for that filter.
+	struct net6_memo memo_a;
+	struct net6_memo memo_b;
 };
 
 // Whether dir holds a built shared classification.

--- a/lib/filter/classifiers/net6_memo.h
+++ b/lib/filter/classifiers/net6_memo.h
@@ -1,0 +1,225 @@
+#pragma once
+
+/*
+ * Direct-mapped result memo for the net6 classifier.
+ *
+ * The classifier resolves an IPv6 address by walking two byte-stride tries
+ * (hi and lo halves) and fetching a combine-table cell; real traffic repeats
+ * addresses heavily (measured 81..90% repeat on a production capture), so the
+ * final verdict is memoized on the full 16-byte address. A hit is one
+ * aligned 16-byte load replacing both walks and the combine fetch.
+ *
+ * The memo lives inside struct net6_classifier and is allocated from the
+ * filter's shared-memory context at compile time, zeroed. A config swap
+ * installs a whole new classifier, so the memo is generation-scoped by
+ * construction: no invalidation protocol, and stale entries are impossible.
+ *
+ * Entry encoding, one unsigned __int128 per slot:
+ *   bit 127   valid (a zero entry means empty, and the valid bit is forced
+ *             into every stored entry so a real entry never reads empty)
+ *   bits 96..126  verdict (combine value; these are registry indices far
+ *             below 2^31)
+ *   bits 0..95   96-bit key: a splitmix64 mix of the two address words
+ *             xor-extended with crc32c of the full 16 bytes. A false hit
+ *             requires two distinct addresses whose 96-bit keys collide AND
+ *             which land in the same slot: about 2^-96 per pair, and the
+ *             slot index already derives from an independent hash.
+ *
+ * Multi-writer safety without locked instructions: a slot is two naturally
+ * aligned 8-byte words. low holds the key's low 64 bits; high holds the
+ * key's upper 32 bits, the verdict, and the valid bit. Writers store low
+ * first, then high; readers load high first, then low. A reader that
+ * catches a slot mid-overwrite sees either an old high word (misses on the
+ * valid bit or the key), or a new high word whose low-word mismatch fails
+ * the full 96-bit key compare — a miss, never a wrong verdict, because a
+ * passing key compare identifies the address and the verdict is a pure
+ * function of the address within one classifier generation. All accesses
+ * are plain naturally aligned 8-byte loads and stores, atomic on x86-64
+ * TSO with the stated ordering.
+ *
+ * A slot entry is laid out across two words rather than one 16-byte atomic
+ * (cmpxchg16b) deliberately: the locked compare-and-swap cost more than
+ * the memo saves (measured on the pcap replay benchmark).
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "common/crc32.h"
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "common/memory_block.h"
+
+// Memo capacities tried at init, largest first: all powers of two so the
+// slot index is hash & (N - 1).
+//
+// 32768 slots hold the distinct addresses of the production capture
+// (9.2k src, 16.7k dst) without direct-mapped thrashing, at 512 KiB per
+// classifier. Denser control planes that juggle many module configs in
+// one agent arena fall back to the smaller sizes rather than failing the
+// compile; an arena too small for the smallest table disables the memo
+// entirely (always-miss, the plain walks serve every lookup).
+#define NET6_MEMO_SLOTS_MAX 32768
+#define NET6_MEMO_SLOTS_MID 8192
+#define NET6_MEMO_SLOTS_MIN 2048
+
+// Valid bit, bit 0 of the high word: a zero high word is an empty slot and
+// every stored entry carries the bit.
+#define NET6_MEMO_VALID_U64 1ull
+
+struct net6_memo_slot {
+	uint64_t low;
+	uint64_t high;
+};
+
+struct net6_memo {
+	// Shared-memory relative pointer to the slot table.
+	struct net6_memo_slot *slots;
+	// Capacity actually allocated (power of two); 0 with slots == NULL
+	// when the memo is disabled.
+	uint32_t slots_count;
+};
+
+// Pick the memo capacity for one arena: the largest power-of-two table
+// (between MIN and MAX slots) whose bytes fit an eighth of the arena's
+// currently free space, or 0 to disable the memo.
+//
+// A dense control plane can hold many classifiers in one agent arena, and
+// a fixed half-megabyte per memo would turn an almost-full arena into a
+// compile failure. Sizing against the remaining free space before any
+// allocation keeps the memo proportional to what the arena can spare, so
+// the compile itself never fails on the memo; a disabled memo (capacity
+// 0, slots NULL) means always-miss and the plain walks serve every
+// lookup.
+static inline uint32_t
+net6_memo_capacity(struct memory_context *memory_context) {
+	struct block_allocator *allocator =
+		ADDR_OF(&memory_context->block_allocator);
+	size_t budget = block_allocator_free_size(allocator) / 8;
+
+	uint32_t capacity = NET6_MEMO_SLOTS_MAX;
+	while (capacity > NET6_MEMO_SLOTS_MIN &&
+	       (size_t)capacity * sizeof(struct net6_memo_slot) > budget) {
+		capacity /= 2;
+	}
+	if ((size_t)capacity * sizeof(struct net6_memo_slot) > budget) {
+		return 0;
+	}
+	return capacity;
+}
+
+// Allocate and zero the slot table at the capacity picked by
+// net6_memo_capacity.
+//
+// Returns 0 on success, -1 on allocation failure (slots stays NULL, and
+// net6_memo_lookup treats a NULL table as always-miss, so the caller may
+// also treat the failure as fatal without a query-path hazard).
+static inline int
+net6_memo_init(struct net6_memo *memo, struct memory_context *memory_context) {
+	SET_OFFSET_OF(&memo->slots, NULL);
+	memo->slots_count = 0;
+
+	uint32_t capacity = net6_memo_capacity(memory_context);
+	if (capacity == 0) {
+		return 0;
+	}
+
+	struct net6_memo_slot *slots = (struct net6_memo_slot *)memory_balloc(
+		memory_context, capacity * sizeof(*slots)
+	);
+	if (slots == NULL) {
+		return -1;
+	}
+	memset(slots, 0, capacity * sizeof(*slots));
+	SET_OFFSET_OF(&memo->slots, slots);
+	memo->slots_count = capacity;
+	return 0;
+}
+
+// Release the slot table. NULL-safe.
+static inline void
+net6_memo_fini(struct net6_memo *memo, struct memory_context *memory_context) {
+	struct net6_memo_slot *slots = ADDR_OF(&memo->slots);
+	if (slots == NULL) {
+		return;
+	}
+	memory_bfree(memory_context, slots, memo->slots_count * sizeof(*slots));
+	SET_OFFSET_OF(&memo->slots, NULL);
+	memo->slots_count = 0;
+}
+
+// 96-bit key of one address: splitmix64 over the two 64-bit words, folded
+// with crc32c over all 16 bytes.
+static inline unsigned __int128
+net6_memo_key(const uint8_t addr[16]) {
+	uint64_t lo;
+	uint64_t hi;
+	memcpy(&lo, addr, 8);
+	memcpy(&hi, addr + 8, 8);
+
+	uint64_t mix = lo * 0x9e3779b97f4a7c15ULL ^ hi * 0xc2b2ae3d27d4eb4fULL;
+	mix ^= mix >> 29;
+	mix *= 0xbf58476d1ce4e5b9ULL;
+	mix ^= mix >> 32;
+
+	unsigned __int128 key = (unsigned __int128)mix;
+	key |= (unsigned __int128)crc32(addr, 16, 0) << 64;
+	return key;
+}
+
+// Look up addr; returns true and stores the verdict on a hit.
+//
+// A NULL table always misses. Loads the high word first: a zero high word
+// is an empty slot, and the full 96-bit key compare guards torn reads per
+// the two-word protocol in the header comment.
+static inline bool
+net6_memo_lookup(
+	const struct net6_memo *memo, const uint8_t addr[16], uint32_t *verdict
+) {
+	const struct net6_memo_slot *slots = ADDR_OF(&memo->slots);
+	if (slots == NULL) {
+		return false;
+	}
+
+	uint32_t slot = crc32(addr, 16, 0) & (memo->slots_count - 1);
+	uint64_t high = __atomic_load_n(&slots[slot].high, __ATOMIC_RELAXED);
+	if (!(high & NET6_MEMO_VALID_U64)) {
+		return false;
+	}
+
+	uint64_t low = __atomic_load_n(&slots[slot].low, __ATOMIC_RELAXED);
+
+	unsigned __int128 key = net6_memo_key(addr);
+	if (low != (uint64_t)key ||
+	    (uint32_t)(high >> 32) != (uint32_t)(key >> 64)) {
+		return false;
+	}
+
+	*verdict = (uint32_t)((high >> 1) & 0x7fffffffu);
+	return true;
+}
+
+// Insert (addr, verdict). Overwrites whatever occupied the slot.
+//
+// Stores the low word first and the high word (carrying the valid bit)
+// last; x86-64 TSO keeps the stores in program order, so a reader never
+// observes a valid high word before its low word.
+static inline void
+net6_memo_insert(
+	struct net6_memo *memo, const uint8_t addr[16], uint32_t verdict
+) {
+	struct net6_memo_slot *slots = ADDR_OF(&memo->slots);
+	if (slots == NULL) {
+		return;
+	}
+
+	unsigned __int128 key = net6_memo_key(addr);
+	uint64_t high = ((uint64_t)(uint32_t)(key >> 64) << 32) |
+			((uint64_t)(verdict & 0x7fffffffu) << 1) |
+			NET6_MEMO_VALID_U64;
+
+	uint32_t slot = crc32(addr, 16, 0) & (memo->slots_count - 1);
+	__atomic_store_n(&slots[slot].low, (uint64_t)key, __ATOMIC_RELAXED);
+	__atomic_store_n(&slots[slot].high, high, __ATOMIC_RELEASE);
+}

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -744,6 +744,17 @@ init_net6(
 		goto error_merge;
 	}
 
+	// The memo sizes itself against the arena's free space, so a
+	// failure here is an ordinary out-of-memory.
+	if (net6_memo_init(&net6->memo, memory_context)) {
+		range_index_free(&ri_lo);
+		range_index_free(&ri_hi);
+		value_table_free(&net6->comb);
+		lpm_free(&net6->lo);
+		lpm_free(&net6->hi);
+		goto error_hi;
+	}
+
 	range_index_free(&ri_hi);
 	range_index_free(&ri_lo);
 
@@ -817,6 +828,7 @@ free_net6(void *data, struct memory_context *memory_context) {
 	lpm_free(&c->lo);
 	lpm_free(&c->hi);
 	value_table_free(&c->comb);
+	net6_memo_fini(&c->memo, memory_context);
 	memory_bfree(memory_context, c, sizeof(struct net6_classifier));
 }
 
@@ -1049,7 +1061,18 @@ filter_net6_share_init(
 	SET_OFFSET_OF(&out->remap_lo_a, remap_lo_a);
 	SET_OFFSET_OF(&out->remap_lo_b, remap_lo_b);
 
+	if (net6_memo_init(&out->memo_a, mctx) ||
+	    net6_memo_init(&out->memo_b, mctx)) {
+		net6_memo_fini(&out->memo_a, mctx);
+		net6_memo_fini(&out->memo_b, mctx);
+		goto error_remap_lo;
+	}
+
 	return 0;
+
+error_remap_lo:
+	memory_bfree(mctx, remap_lo_b, sizeof(uint32_t) * out->lo_count);
+	memory_bfree(mctx, remap_lo_a, sizeof(uint32_t) * out->lo_count);
 
 error_remap_hi:
 	memory_bfree(mctx, remap_hi_b, sizeof(uint32_t) * out->hi_count);
@@ -1093,6 +1116,8 @@ filter_net6_share_dir_free(
 	// afterwards keeps the whole free path repeatable.
 	lpm_free(&dir->hi);
 	lpm_free(&dir->lo);
+	net6_memo_fini(&dir->memo_a, mctx);
+	net6_memo_fini(&dir->memo_b, mctx);
 
 	memset(dir, 0, sizeof(*dir));
 }

--- a/lib/filter/query/net6.h
+++ b/lib/filter/query/net6.h
@@ -26,10 +26,17 @@ FILTER_ATTR_QUERY_FUNC(net6_dst)(
 
 		const uint8_t *daddr = (const uint8_t *)ipv6_hdr->dst_addr;
 
+		uint32_t verdict;
+		if (net6_memo_lookup(&c->memo, daddr, &verdict)) {
+			result[idx] = verdict;
+			continue;
+		}
+
 		uint32_t hi = lpm8_lookup(&c->hi, daddr);
 		uint32_t lo = lpm8_lookup(&c->lo, daddr + 8);
-
-		result[idx] = value_table_get(&c->comb, hi, lo);
+		verdict = value_table_get(&c->comb, hi, lo);
+		net6_memo_insert(&c->memo, daddr, verdict);
+		result[idx] = verdict;
 	}
 }
 
@@ -49,9 +56,16 @@ FILTER_ATTR_QUERY_FUNC(net6_src)(
 
 		const uint8_t *saddr = (const uint8_t *)ipv6_hdr->src_addr;
 
+		uint32_t verdict;
+		if (net6_memo_lookup(&c->memo, saddr, &verdict)) {
+			result[idx] = verdict;
+			continue;
+		}
+
 		uint32_t hi = lpm8_lookup(&c->hi, saddr);
 		uint32_t lo = lpm8_lookup(&c->lo, saddr + 8);
-
-		result[idx] = value_table_get(&c->comb, hi, lo);
+		verdict = value_table_get(&c->comb, hi, lo);
+		net6_memo_insert(&c->memo, saddr, verdict);
+		result[idx] = verdict;
 	}
 }

--- a/lib/filter/tests/bench_net6_quad.c
+++ b/lib/filter/tests/bench_net6_quad.c
@@ -1,0 +1,868 @@
+/*
+ * Benchmark of the four net6 half-tries (src hi/lo, dst hi/lo) filled by the
+ * real filter compiler from a production-scale prefix list.
+ *
+ * Input is one or two files of "addr/plen" lines: the first fills the src
+ * tries, an optional second fills the dst tries (default: same list). One
+ * rule carries every prefix in both directions, so filter_init compiles all
+ * four lpm tries through collect_net6_range exactly as a config apply
+ * would.
+ *
+ * Probes are whole IPv6 addresses: a configurable fraction is drawn inside a
+ * random prefix (uniform host bits), the rest uniform over the whole space,
+ * so both top-hash hits and root-fallback misses are exercised.
+ *
+ * Correctness gate: after warming the memos, every replayed verdict must
+ * equal the plain lpm8 walks plus the combine fetch before timing runs.
+ *
+ * Timing compares, over the same probe set, the four scalar half-lookups
+ * per address through the plain tries (lpm8_lookup, the acl dataplane
+ * walk) against the memoized query path: memo probe first, and on a miss
+ * the walks plus the comb fetch, inserting the verdict.
+ *
+ * ns/lookup is per address (four trie walks); ns/classify adds the comb
+ * fetches. rdtsc cycles are frequency-independent, CLOCK_MONOTONIC ns the
+ * human headline, medians over --rounds runs.
+ */
+
+#include "common/lpm.h"
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/rng.h"
+#include "lib/filter/classifiers/net6.h"
+#include "lib/filter/compiler.h"
+#include "lib/filter/filter.h"
+#include "lib/logging/log.h"
+
+#include <x86intrin.h>
+
+#include <arpa/inet.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define QUAD_RULES_ARENA_SIZE ((size_t)16 << 30)
+
+FILTER_COMPILER_DECLARE(bench_net6_quad_compile, net6_src, net6_dst);
+
+// Accumulator for the timed loops. Volatile so the compiler cannot fold a
+// lookup loop into nothing when its only consumer is a discarded value.
+static volatile uint32_t quad_sink;
+
+struct quad_args {
+	const char *src_file;
+	const char *dst_file;
+	const char *pcap_file;
+	size_t num_probes;
+	double hit_fraction;
+	uint32_t rounds;
+	uint64_t seed;
+	bool with_comb;
+};
+
+static void
+print_help(const char *argv0) {
+	fprintf(stderr,
+		"Usage: %s src_prefixes.txt [dst_prefixes.txt] [options]\n"
+		"\n"
+		"  --probes N        whole-address probes (default 1048576)\n"
+		"  --hit-fraction F  probes drawn inside a prefix, 0..1 "
+		"(default 0.8)\n"
+		"  --rounds N        timed rounds, median reported (default "
+		"11)\n"
+		"  --seed S          PRNG seed, hex (default time-based)\n"
+		"  --no-comb         skip the combine fetch timing\n"
+		"  --pcap FILE       take probe addresses from IPv6 packets in "
+		"a\n"
+		"                    classic pcap (overrides --probes and\n"
+		"                    --hit-fraction)\n",
+		argv0);
+}
+
+static int
+parse_args(int argc, char **argv, struct quad_args *args) {
+	*args = (struct quad_args){
+		.src_file = NULL,
+		.dst_file = NULL,
+		.pcap_file = NULL,
+		.num_probes = 1u << 20,
+		.hit_fraction = 0.8,
+		.rounds = 11,
+		.seed = 0,
+		.with_comb = true,
+	};
+
+	int positional = 0;
+	for (int i = 1; i < argc; ++i) {
+		const char *a = argv[i];
+		if (strcmp(a, "-h") == 0 || strcmp(a, "--help") == 0) {
+			print_help(argv[0]);
+			return 1;
+		} else if (strcmp(a, "--probes") == 0 && i + 1 < argc) {
+			args->num_probes =
+				(size_t)strtoull(argv[++i], NULL, 10);
+		} else if (strcmp(a, "--hit-fraction") == 0 && i + 1 < argc) {
+			args->hit_fraction = strtod(argv[++i], NULL);
+		} else if (strcmp(a, "--rounds") == 0 && i + 1 < argc) {
+			args->rounds = (uint32_t)strtoul(argv[++i], NULL, 10);
+		} else if (strcmp(a, "--seed") == 0 && i + 1 < argc) {
+			args->seed = strtoull(argv[++i], NULL, 16);
+		} else if (strcmp(a, "--no-comb") == 0) {
+			args->with_comb = false;
+		} else if (strcmp(a, "--pcap") == 0 && i + 1 < argc) {
+			args->pcap_file = argv[++i];
+		} else if (a[0] == '-') {
+			fprintf(stderr, "unknown arg: %s\n", a);
+			print_help(argv[0]);
+			return -1;
+		} else if (positional == 0) {
+			args->src_file = a;
+			++positional;
+		} else if (positional == 1) {
+			args->dst_file = a;
+			++positional;
+		} else {
+			fprintf(stderr, "unexpected argument: %s\n", a);
+			return -1;
+		}
+	}
+
+	if (args->src_file == NULL) {
+		print_help(argv[0]);
+		return -1;
+	}
+	if (args->dst_file == NULL) {
+		args->dst_file = args->src_file;
+	}
+	if (args->num_probes == 0 || args->rounds == 0) {
+		fprintf(stderr, "counts must be > 0\n");
+		return -1;
+	}
+	if (args->hit_fraction < 0.0) {
+		args->hit_fraction = 0.0;
+	}
+	if (args->hit_fraction > 1.0) {
+		args->hit_fraction = 1.0;
+	}
+	return 0;
+}
+
+// Parses one "addr/plen" line into a normalized (masked) net6.
+static int
+parse_net6_line(const char *line, struct net6 *out) {
+	char buf[256];
+	snprintf(buf, sizeof(buf), "%s", line);
+	char *slash = strchr(buf, '/');
+	if (!slash) {
+		return -1;
+	}
+	*slash = 0;
+	int plen = atoi(slash + 1);
+	if (plen < 0 || plen > 128) {
+		return -1;
+	}
+
+	struct in6_addr in6;
+	if (inet_pton(AF_INET6, buf, &in6) != 1) {
+		return -1;
+	}
+
+	memcpy(out->addr, in6.s6_addr, NET6_LEN);
+	memset(out->mask, 0, NET6_LEN);
+	for (int i = 0; i < plen; ++i) {
+		out->mask[i / 8] |= 0x80 >> (i % 8);
+	}
+	for (int i = 0; i < NET6_LEN; ++i) {
+		out->addr[i] &= out->mask[i];
+	}
+	return 0;
+}
+
+static struct net6 *
+load_prefixes(const char *path, size_t *count_out) {
+	FILE *f = fopen(path, "r");
+	if (f == NULL) {
+		fprintf(stderr, "cannot open %s\n", path);
+		return NULL;
+	}
+
+	size_t cap = 1024;
+	size_t count = 0;
+	struct net6 *prefixes = malloc(cap * sizeof(*prefixes));
+	char line[256];
+	while (fgets(line, sizeof(line), f)) {
+		line[strcspn(line, "\r\n")] = 0;
+		if (line[0] == 0) {
+			continue;
+		}
+		if (count == cap) {
+			cap *= 2;
+			prefixes = realloc(prefixes, cap * sizeof(*prefixes));
+			if (prefixes == NULL) {
+				fclose(f);
+				return NULL;
+			}
+		}
+		if (parse_net6_line(line, &prefixes[count]) != 0) {
+			fprintf(stderr, "skip unparseable line: %s\n", line);
+			continue;
+		}
+		++count;
+	}
+	fclose(f);
+
+	*count_out = count;
+	return prefixes;
+}
+
+static inline uint64_t
+rdtsc_read(void) {
+	unsigned int aux;
+	return __rdtscp(&aux);
+}
+
+static uint64_t
+calibrate_tsc_hz(void) {
+	struct timespec ts_start;
+	struct timespec ts_end;
+	clock_gettime(CLOCK_MONOTONIC, &ts_start);
+	uint64_t tsc_start = rdtsc_read();
+
+	struct timespec sleep_ts = {.tv_sec = 0, .tv_nsec = 50 * 1000 * 1000};
+	nanosleep(&sleep_ts, NULL);
+
+	uint64_t tsc_end = rdtsc_read();
+	clock_gettime(CLOCK_MONOTONIC, &ts_end);
+
+	uint64_t ns =
+		(uint64_t)(ts_end.tv_sec - ts_start.tv_sec) * 1000000000ULL +
+		(uint64_t)(ts_end.tv_nsec - ts_start.tv_nsec);
+	if (ns == 0) {
+		return 0;
+	}
+	return tsc_end * 1000000000ULL / ns - tsc_start * 1000000000ULL / ns;
+}
+
+// Classic-pcap link types and ethertypes used by the address extractor.
+#define QUAD_PCAP_SNAPLEN_MAX 262144
+
+// Reads IPv6 (src, dst) address pairs from a classic pcap file, in packet
+// order. Ethernet link type with any number of 802.1Q/802.1ad tags; packets
+// of other families are skipped. Returns 0 on success.
+static int
+load_pcap_addrs(
+	const char *path,
+	uint8_t (**src_out)[16],
+	uint8_t (**dst_out)[16],
+	size_t *count_out
+) {
+	FILE *f = fopen(path, "rb");
+	if (f == NULL) {
+		fprintf(stderr, "cannot open %s\n", path);
+		return -1;
+	}
+
+	uint8_t ghdr[24];
+	if (fread(ghdr, 1, 24, f) != 24) {
+		fprintf(stderr, "%s: short global header\n", path);
+		fclose(f);
+		return -1;
+	}
+
+	uint32_t magic = (uint32_t)ghdr[0] << 24 | (uint32_t)ghdr[1] << 16 |
+			 (uint32_t)ghdr[2] << 8 | ghdr[3];
+	bool le;
+	if (magic == 0xa1b2c3d4 || magic == 0xa1b23c4d) {
+		le = false;
+	} else if (magic == 0xd4c3b2a1 || magic == 0x4d3cb2a1) {
+		le = true;
+	} else {
+		fprintf(stderr, "%s: not a classic pcap file\n", path);
+		fclose(f);
+		return -1;
+	}
+
+	static uint8_t pkt[QUAD_PCAP_SNAPLEN_MAX];
+	size_t cap = 4096;
+	size_t count = 0;
+	uint8_t(*src)[16] = malloc(cap * 16);
+	uint8_t(*dst)[16] = malloc(cap * 16);
+	if (!src || !dst) {
+		fclose(f);
+		return -1;
+	}
+
+	uint8_t phdr[16];
+	for (;;) {
+		if (fread(phdr, 1, 16, f) != 16) {
+			break;
+		}
+		uint32_t caplen =
+			le ? (uint32_t)phdr[8] | (uint32_t)phdr[9] << 8 |
+					(uint32_t)phdr[10] << 16 |
+					(uint32_t)phdr[11] << 24
+			   : (uint32_t)phdr[8] << 24 | (uint32_t)phdr[9] << 16 |
+					(uint32_t)phdr[10] << 8 | phdr[11];
+		if (caplen > sizeof(pkt)) {
+			fprintf(stderr,
+				"%s: packet exceeds snaplen buffer\n",
+				path);
+			break;
+		}
+		if (fread(pkt, 1, caplen, f) != caplen) {
+			break;
+		}
+		if (caplen < 14) {
+			continue;
+		}
+
+		uint32_t et = (uint32_t)pkt[12] << 8 | pkt[13];
+		size_t off = 14;
+		while ((et == 0x8100 || et == 0x88a8) && caplen >= off + 4) {
+			et = (uint32_t)pkt[off + 2] << 8 | pkt[off + 3];
+			off += 4;
+		}
+		if (et != 0x86dd || caplen < off + 40) {
+			continue;
+		}
+
+		if (count == cap) {
+			cap *= 2;
+			src = realloc(src, cap * 16);
+			dst = realloc(dst, cap * 16);
+			if (!src || !dst) {
+				fclose(f);
+				return -1;
+			}
+		}
+		memcpy(src[count], pkt + off + 8, 16);
+		memcpy(dst[count], pkt + off + 24, 16);
+		++count;
+	}
+	fclose(f);
+
+	if (count == 0) {
+		fprintf(stderr, "%s: no IPv6 packets found\n", path);
+		return -1;
+	}
+
+	*src_out = src;
+	*dst_out = dst;
+	*count_out = count;
+	return 0;
+}
+
+static int
+cmp_u32(const void *a, const void *b) {
+	uint32_t ua = *(const uint32_t *)a;
+	uint32_t ub = *(const uint32_t *)b;
+	return (ua > ub) - (ua < ub);
+}
+
+// Prints the distinct-class count and the hottest classes of one replayed
+// half-lookup, weighted per packet.
+static void
+print_class_stats(const char *label, const uint32_t *values, size_t count) {
+	uint32_t *sorted = malloc(count * sizeof(*sorted));
+	uint32_t *run_v = malloc(count * sizeof(*run_v));
+	size_t *run_c = malloc(count * sizeof(*run_c));
+	if (!sorted || !run_v || !run_c) {
+		free(sorted);
+		free(run_v);
+		free(run_c);
+		return;
+	}
+	memcpy(sorted, values, count * sizeof(*sorted));
+	qsort(sorted, count, sizeof(*sorted), cmp_u32);
+
+	size_t distinct = 0;
+	for (size_t idx = 0; idx < count;) {
+		size_t run = 1;
+		while (idx + run < count && sorted[idx + run] == sorted[idx]) {
+			++run;
+		}
+		run_v[distinct] = sorted[idx];
+		run_c[distinct] = run;
+		++distinct;
+		idx += run;
+	}
+
+	// Top-3 runs by selection; ties resolved by first appearance.
+	uint32_t top_v[3] = {0, 0, 0};
+	size_t top_c[3] = {0, 0, 0};
+	for (int place = 0; place < 3; ++place) {
+		int best = -1;
+		for (size_t idx = 0; idx < distinct; ++idx) {
+			if (run_c[idx] == 0) {
+				continue;
+			}
+			if (best < 0 || run_c[idx] > run_c[best]) {
+				best = (int)idx;
+			}
+		}
+		if (best < 0) {
+			break;
+		}
+		top_v[place] = run_v[best];
+		top_c[place] = run_c[best];
+		run_c[best] = 0;
+	}
+
+	printf("  %-8s classes hit: %zu; hottest:", label, distinct);
+	for (int place = 0; place < 3; ++place) {
+		if (top_c[place] > 0) {
+			printf("  %u(%.1f%%)",
+			       top_v[place],
+			       100.0 * (double)top_c[place] / (double)count);
+		}
+	}
+	printf("\n");
+	free(sorted);
+	free(run_v);
+	free(run_c);
+}
+
+// Draws one whole probe address: under a random prefix (uniform host bits)
+// with probability hit_fraction, uniform over the full space otherwise.
+static void
+gen_probe_addr(
+	const struct net6 *prefixes,
+	size_t prefix_count,
+	double hit_fraction,
+	uint64_t *rng,
+	uint8_t addr[NET6_LEN]
+) {
+	double roll = (double)(rng_next(rng) >> 11) / (double)(1ULL << 53);
+	if (roll < hit_fraction && prefix_count) {
+		const struct net6 *spec =
+			&prefixes[rng_next(rng) % prefix_count];
+		memcpy(addr, spec->addr, NET6_LEN);
+		for (int idx = 0; idx < NET6_LEN; ++idx) {
+			addr[idx] |= (uint8_t)rng_next(rng) & ~spec->mask[idx];
+		}
+	} else {
+		for (int idx = 0; idx < NET6_LEN; ++idx) {
+			addr[idx] = (uint8_t)rng_next(rng);
+		}
+	}
+}
+
+static int
+cmp_u64(const void *a, const void *b) {
+	uint64_t ua = *(const uint64_t *)a;
+	uint64_t ub = *(const uint64_t *)b;
+	return (ua > ub) - (ua < ub);
+}
+
+static uint64_t
+median_u64(uint64_t *values, uint32_t count) {
+	qsort(values, count, sizeof(*values), cmp_u64);
+	return values[count / 2];
+}
+
+// Times the four scalar plain half-lookups per address (the pre-hash walk).
+static uint64_t
+time_plain_quad_scalar(
+	struct net6_classifier *src,
+	struct net6_classifier *dst,
+	const uint8_t (*src_addrs)[16],
+	const uint8_t (*dst_addrs)[16],
+	size_t count
+) {
+	uint64_t tsc_start = rdtsc_read();
+
+	for (size_t idx = 0; idx < count; ++idx) {
+		uint32_t acc = 0;
+		acc ^= lpm8_lookup(&src->hi, src_addrs[idx]);
+		acc ^= lpm8_lookup(&src->lo, src_addrs[idx] + 8);
+		acc ^= lpm8_lookup(&dst->hi, dst_addrs[idx]);
+		acc ^= lpm8_lookup(&dst->lo, dst_addrs[idx] + 8);
+		quad_sink ^= acc;
+	}
+
+	return rdtsc_read() - tsc_start;
+}
+
+// Times the full memoized classification per address: memo probe first,
+// and on a miss the two hashed-top walks plus the comb fetch, inserting
+// the verdict. This is the query-path shape with a warm memo.
+static uint64_t
+time_memo_quad(
+	struct net6_classifier *src,
+	struct net6_classifier *dst,
+	const uint8_t (*src_addrs)[16],
+	const uint8_t (*dst_addrs)[16],
+	size_t count
+) {
+	uint64_t tsc_start = rdtsc_read();
+
+	for (size_t idx = 0; idx < count; ++idx) {
+		uint32_t verdict;
+		if (!net6_memo_lookup(&src->memo, src_addrs[idx], &verdict)) {
+			uint32_t hi = lpm8_lookup(&src->hi, src_addrs[idx]);
+			uint32_t lo = lpm8_lookup(&src->lo, src_addrs[idx] + 8);
+			verdict = value_table_get(&src->comb, hi, lo);
+			net6_memo_insert(&src->memo, src_addrs[idx], verdict);
+		}
+		quad_sink ^= verdict;
+		if (!net6_memo_lookup(&dst->memo, dst_addrs[idx], &verdict)) {
+			uint32_t hi = lpm8_lookup(&dst->hi, dst_addrs[idx]);
+			uint32_t lo = lpm8_lookup(&dst->lo, dst_addrs[idx] + 8);
+			verdict = value_table_get(&dst->comb, hi, lo);
+			net6_memo_insert(&dst->memo, dst_addrs[idx], verdict);
+		}
+		quad_sink ^= verdict;
+	}
+
+	return rdtsc_read() - tsc_start;
+}
+
+static void
+print_trie_stats(const char *label, const struct lpm *lpm) {
+	printf("  %-8s pages=%zu\n", label, lpm->page_count);
+}
+
+int
+main(int argc, char **argv) {
+	struct quad_args args;
+	int parsed = parse_args(argc, argv, &args);
+	if (parsed != 0) {
+		return (parsed > 0) ? 0 : 1;
+	}
+
+	log_enable_name("info");
+
+	if (args.seed == 0) {
+		struct timespec ts;
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+		args.seed = ((uint64_t)ts.tv_sec << 20) ^ (uint64_t)ts.tv_nsec ^
+			    0x9e3779b97f4a7c15ULL;
+	}
+	uint64_t rng = args.seed;
+
+	size_t src_count = 0;
+	struct net6 *src_prefixes = load_prefixes(args.src_file, &src_count);
+	if (src_prefixes == NULL || src_count == 0) {
+		fprintf(stderr,
+			"no src prefixes loaded from %s\n",
+			args.src_file);
+		return 1;
+	}
+	size_t dst_count = 0;
+	struct net6 *dst_prefixes = load_prefixes(args.dst_file, &dst_count);
+	if (dst_prefixes == NULL || dst_count == 0) {
+		fprintf(stderr,
+			"no dst prefixes loaded from %s\n",
+			args.dst_file);
+		return 1;
+	}
+
+	LOG(INFO,
+	    "bench_net6_quad: src_prefixes=%zu (%s) dst_prefixes=%zu (%s) "
+	    "probes=%zu hit_fraction=%.2f pcap=%s rounds=%u seed=0x%016" PRIx64,
+	    src_count,
+	    args.src_file,
+	    dst_count,
+	    args.dst_file,
+	    args.num_probes,
+	    args.hit_fraction,
+	    args.pcap_file ? args.pcap_file : "-",
+	    args.rounds,
+	    args.seed);
+
+	// One rule carrying every prefix in both directions fills all four
+	// tries through the production compile path.
+	struct filter_rule rule = {0};
+	rule.net6.srcs = src_prefixes;
+	rule.net6.src_count = (uint32_t)src_count;
+	rule.net6.dsts = dst_prefixes;
+	rule.net6.dst_count = (uint32_t)dst_count;
+	const struct filter_rule *rule_ptrs[1] = {&rule};
+
+	void *arena = malloc(QUAD_RULES_ARENA_SIZE);
+	if (arena == NULL) {
+		fprintf(stderr,
+			"arena malloc failed (%zu bytes)\n",
+			QUAD_RULES_ARENA_SIZE);
+		return 1;
+	}
+
+	struct block_allocator allocator;
+	block_allocator_init(&allocator);
+	block_allocator_put_arena(&allocator, arena, QUAD_RULES_ARENA_SIZE);
+
+	struct memory_context mctx;
+	if (memory_context_init(&mctx, "bench_net6_quad", &allocator) != 0) {
+		fprintf(stderr, "memory_context_init failed\n");
+		return 1;
+	}
+
+	struct filter filter;
+	uint64_t build_ns_start = (uint64_t)clock();
+	struct timespec build_ts_start;
+	clock_gettime(CLOCK_MONOTONIC, &build_ts_start);
+	if (filter_init(
+		    &filter,
+		    bench_net6_quad_compile,
+		    rule_ptrs,
+		    1,
+		    &mctx,
+		    "bench_net6_quad",
+		    NULL
+	    ) != 0) {
+		fprintf(stderr, "filter_init failed (arena exhausted?)\n");
+		return 1;
+	}
+	struct timespec build_ts_end;
+	clock_gettime(CLOCK_MONOTONIC, &build_ts_end);
+	uint64_t build_ms =
+		((uint64_t)(build_ts_end.tv_sec - build_ts_start.tv_sec) *
+			 1000ULL +
+		 (uint64_t)(build_ts_end.tv_nsec - build_ts_start.tv_nsec) /
+			 1000000ULL);
+	(void)build_ns_start;
+
+	// The signature declares net6_src first, net6_dst second, so their
+	// classifier payloads sit on leaves lookup_count + 0 and + 1.
+	const uint64_t lookup_count = bench_net6_quad_compile->lookup_count;
+	struct net6_classifier *src_cls = (struct net6_classifier *)ADDR_OF(
+		&filter.v[lookup_count + 0].data
+	);
+	struct net6_classifier *dst_cls = (struct net6_classifier *)ADDR_OF(
+		&filter.v[lookup_count + 1].data
+	);
+	if (src_cls == NULL || dst_cls == NULL) {
+		fprintf(stderr, "classifier payloads missing on the leaves\n");
+		return 1;
+	}
+
+	printf("compiled in %llu ms; comb dims src=%ux%u dst=%ux%u\n",
+	       (unsigned long long)build_ms,
+	       src_cls->comb.v_dim,
+	       src_cls->comb.h_dim,
+	       dst_cls->comb.v_dim,
+	       dst_cls->comb.h_dim);
+
+	// Probe set: whole addresses, split into the four half-key planes the
+	// acl dataplane packs.
+	uint8_t(*src_addrs)[16] = malloc(args.num_probes * 16);
+	uint8_t(*dst_addrs)[16] = malloc(args.num_probes * 16);
+	uint8_t(*src_hi_keys)[8] = malloc(args.num_probes * 8);
+	uint8_t(*src_lo_keys)[8] = malloc(args.num_probes * 8);
+	uint8_t(*dst_hi_keys)[8] = malloc(args.num_probes * 8);
+	uint8_t(*dst_lo_keys)[8] = malloc(args.num_probes * 8);
+	uint32_t *src_hi = malloc(args.num_probes * sizeof(uint32_t));
+	uint32_t *src_lo = malloc(args.num_probes * sizeof(uint32_t));
+	uint32_t *dst_hi = malloc(args.num_probes * sizeof(uint32_t));
+	uint32_t *dst_lo = malloc(args.num_probes * sizeof(uint32_t));
+	uint32_t *ref_hi = malloc(args.num_probes * sizeof(uint32_t));
+	uint32_t *ref_lo = malloc(args.num_probes * sizeof(uint32_t));
+	if (!src_addrs || !dst_addrs || !src_hi_keys || !src_lo_keys ||
+	    !dst_hi_keys || !dst_lo_keys || !src_hi || !src_lo || !dst_hi ||
+	    !dst_lo || !ref_hi || !ref_lo) {
+		fprintf(stderr, "probe allocation failed\n");
+		return 1;
+	}
+
+	if (args.pcap_file != NULL) {
+		uint8_t(*pcap_src)[16] = NULL;
+		uint8_t(*pcap_dst)[16] = NULL;
+		size_t pkt_count = 0;
+		if (load_pcap_addrs(
+			    args.pcap_file, &pcap_src, &pcap_dst, &pkt_count
+		    ) != 0) {
+			return 1;
+		}
+		LOG(INFO,
+		    "bench_net6_quad: pcap %s yielded %zu IPv6 packets",
+		    args.pcap_file,
+		    pkt_count);
+		if (pkt_count > args.num_probes) {
+			pkt_count = args.num_probes;
+		}
+		args.num_probes = pkt_count;
+		for (size_t idx = 0; idx < args.num_probes; ++idx) {
+			memcpy(src_addrs[idx], pcap_src[idx], 16);
+			memcpy(dst_addrs[idx], pcap_dst[idx], 16);
+		}
+		free(pcap_src);
+		free(pcap_dst);
+	} else {
+		for (size_t idx = 0; idx < args.num_probes; ++idx) {
+			gen_probe_addr(
+				src_prefixes,
+				src_count,
+				args.hit_fraction,
+				&rng,
+				src_addrs[idx]
+			);
+			gen_probe_addr(
+				dst_prefixes,
+				dst_count,
+				args.hit_fraction,
+				&rng,
+				dst_addrs[idx]
+			);
+		}
+	}
+	for (size_t idx = 0; idx < args.num_probes; ++idx) {
+		memcpy(src_hi_keys[idx], src_addrs[idx], 8);
+		memcpy(src_lo_keys[idx], src_addrs[idx] + 8, 8);
+		memcpy(dst_hi_keys[idx], dst_addrs[idx], 8);
+		memcpy(dst_lo_keys[idx], dst_addrs[idx] + 8, 8);
+	}
+
+	// Correctness gate: warm the memos once (which fills them through
+	// the compute path), then require every memo hit to equal the plain
+	// walks plus the combine fetch. A miss is valid direct-mapped
+	// behavior — a later address evicted the slot — and merely
+	// recomputes at run time, so only a hit carrying a wrong verdict
+	// fails the gate. The per-half class results of the plain walks
+	// feed the replay stats below.
+	{
+		(void)time_memo_quad(
+			src_cls, dst_cls, src_addrs, dst_addrs, args.num_probes
+		);
+
+		struct net6_classifier *cls[2] = {src_cls, dst_cls};
+		const uint8_t(*addrs[2])[16] = {src_addrs, dst_addrs};
+		const uint8_t(*key_planes[2][2]
+		)[8] = {{src_hi_keys, src_lo_keys}, {dst_hi_keys, dst_lo_keys}};
+		uint32_t *outs[2][2] = {{src_hi, src_lo}, {dst_hi, dst_lo}};
+		const char *names[2] = {"src", "dst"};
+		for (int dir = 0; dir < 2; ++dir) {
+			for (size_t idx = 0; idx < args.num_probes; ++idx) {
+				uint32_t hi = lpm8_lookup(
+					&cls[dir]->hi, key_planes[dir][0][idx]
+				);
+				uint32_t lo = lpm8_lookup(
+					&cls[dir]->lo, key_planes[dir][1][idx]
+				);
+				uint32_t expected = value_table_get(
+					&cls[dir]->comb, hi, lo
+				);
+				uint32_t verdict = 0;
+				if (net6_memo_lookup(
+					    &cls[dir]->memo,
+					    addrs[dir][idx],
+					    &verdict
+				    ) &&
+				    verdict != expected) {
+					fprintf(stderr,
+						"%s memo mismatch at %zu: "
+						"memo=%u expected=%u\n",
+						names[dir],
+						idx,
+						verdict,
+						expected);
+					return 2;
+				}
+				outs[dir][0][idx] = hi;
+				outs[dir][1][idx] = lo;
+			}
+		}
+	}
+
+	printf("trie fill:\n");
+	print_trie_stats("src_hi", &src_cls->hi);
+	print_trie_stats("src_lo", &src_cls->lo);
+	print_trie_stats("dst_hi", &dst_cls->hi);
+	print_trie_stats("dst_lo", &dst_cls->lo);
+
+	printf("replay class hits (%zu addresses):\n", args.num_probes);
+	print_class_stats("src_hi", src_hi, args.num_probes);
+	print_class_stats("src_lo", src_lo, args.num_probes);
+	print_class_stats("dst_hi", dst_hi, args.num_probes);
+	print_class_stats("dst_lo", dst_lo, args.num_probes);
+
+	uint64_t tsc_hz = calibrate_tsc_hz();
+	LOG(INFO,
+	    "bench_net6_quad: tsc_hz ~= %" PRIu64 " (%.2f GHz)",
+	    tsc_hz,
+	    (double)tsc_hz / 1e9);
+
+	uint64_t *plain_cyc = calloc(args.rounds, sizeof(uint64_t));
+	uint64_t *plain_ns = calloc(args.rounds, sizeof(uint64_t));
+	uint64_t *memo_cyc = calloc(args.rounds, sizeof(uint64_t));
+	uint64_t *memo_ns = calloc(args.rounds, sizeof(uint64_t));
+	if (!plain_cyc || !plain_ns || !memo_cyc || !memo_ns) {
+		fprintf(stderr, "timing arrays alloc failed\n");
+		return 1;
+	}
+
+	for (uint32_t round = 0; round < args.rounds; ++round) {
+		struct timespec ts_start;
+		struct timespec ts_end;
+
+		clock_gettime(CLOCK_MONOTONIC, &ts_start);
+		plain_cyc[round] = time_plain_quad_scalar(
+			src_cls, dst_cls, src_addrs, dst_addrs, args.num_probes
+		);
+		clock_gettime(CLOCK_MONOTONIC, &ts_end);
+		plain_ns[round] = (uint64_t)(ts_end.tv_sec - ts_start.tv_sec) *
+					  1000000000ULL +
+				  (uint64_t)(ts_end.tv_nsec - ts_start.tv_nsec);
+
+		clock_gettime(CLOCK_MONOTONIC, &ts_start);
+		memo_cyc[round] = time_memo_quad(
+			src_cls, dst_cls, src_addrs, dst_addrs, args.num_probes
+		);
+		clock_gettime(CLOCK_MONOTONIC, &ts_end);
+		memo_ns[round] = (uint64_t)(ts_end.tv_sec - ts_start.tv_sec) *
+					 1000000000ULL +
+				 (uint64_t)(ts_end.tv_nsec - ts_start.tv_nsec);
+	}
+
+	double per = (double)args.num_probes;
+	double plain_ns_per = (double)median_u64(plain_ns, args.rounds) / per;
+	double plain_cyc_per = (double)median_u64(plain_cyc, args.rounds) / per;
+	double memo_ns_per = (double)median_u64(memo_ns, args.rounds) / per;
+	double memo_cyc_per = (double)median_u64(memo_cyc, args.rounds) / per;
+
+	printf("\n");
+	printf("=== four-trie scalar address lookup: %s ===\n",
+	       args.with_comb ? "tries only (comb not in scalar helpers)"
+			      : "tries only");
+	printf("                  ns/address   cycles/address\n");
+	printf("plain  walks only  %10.2f     %10.1f\n",
+	       plain_ns_per,
+	       plain_cyc_per);
+	printf("memo   full query  %10.2f     %10.1f\n",
+	       memo_ns_per,
+	       memo_cyc_per);
+	printf("\n");
+	printf("speedup memo vs plain walks: %+.1f%% (ns)\n",
+	       plain_ns_per > 0.0
+		       ? (plain_ns_per - memo_ns_per) / plain_ns_per * 100.0
+		       : 0.0);
+
+	free(plain_cyc);
+	free(plain_ns);
+	free(memo_cyc);
+	free(memo_ns);
+	free(src_addrs);
+	free(dst_addrs);
+	free(src_hi_keys);
+	free(src_lo_keys);
+	free(dst_hi_keys);
+	free(dst_lo_keys);
+	free(src_hi);
+	free(src_lo);
+	free(dst_hi);
+	free(dst_lo);
+	free(ref_hi);
+	free(ref_lo);
+
+	filter_free(&filter, bench_net6_quad_compile);
+	memory_context_fini(&mctx);
+	free(src_prefixes);
+	free(dst_prefixes);
+	free(arena);
+
+	return 0;
+}

--- a/lib/filter/tests/meson.build
+++ b/lib/filter/tests/meson.build
@@ -140,6 +140,18 @@ executable('bench_net6',
   link_language: 'c'
 )
 
+# Four-trie benchmark: fills the src/dst hi/lo lpm tries through the real
+# compiler from prefix files, then times whole-address lookups (plain walks
+# vs memoized verdict, scalar), with probes drawn randomly or replayed from
+# a classic pcap.
+executable('bench_net6_quad',
+  ['bench_net6_quad.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: test_deps,
+  link_language: 'c'
+)
+
 # Allocation-failure injection sweep. The compiler sources are recompiled
 # with oom_shim.h force-included so every memory_balloc call on the compile
 # path can be forced to fail one at a time.

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -228,7 +228,7 @@ func newMetricsSnapshotHarness(testingTB testing.TB) (*dataplaneut.Harness, *ffi
 	testingTB.Helper()
 
 	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
-		CPMemory:      uint64(128 * datasize.MB),
+		CPMemory:      uint64(192 * datasize.MB),
 		DPMemory:      uint64(64 * datasize.MB),
 		WorkerCount:   1,
 		Devices:       []string{"port0"},
@@ -241,7 +241,7 @@ func newMetricsSnapshotHarness(testingTB testing.TB) (*dataplaneut.Harness, *ffi
 	agent, err := harness.SharedMemory().AgentAttach(
 		"acl-metrics-snapshot",
 		0,
-		64*datasize.MB,
+		96*datasize.MB,
 	)
 	require.NoError(testingTB, err)
 	testingTB.Cleanup(func() { _ = agent.CleanUp() })

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -338,42 +338,7 @@ acl_handle_packets(
 		struct net6_share_dir *share_src = &acl_config->net6_share_src;
 		struct net6_share_dir *share_dst = &acl_config->net6_share_dst;
 
-		// Classify each v6 address half once on the union tries.
-		uint32_t src_hi[count];
-		uint32_t src_lo[count];
-		uint32_t dst_hi[count];
-		uint32_t dst_lo[count];
-
-		for (uint64_t idx = 0; idx < ip6_idx; ++idx) {
-			struct rte_mbuf *mbuf =
-				packet_to_mbuf(ip6_packets[idx]);
-			struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
-				mbuf,
-				struct rte_ipv6_hdr *,
-				ip6_packets[idx]->network_header.offset
-			);
-			const uint8_t *saddr =
-				(const uint8_t *)ipv6_hdr->src_addr;
-			const uint8_t *daddr =
-				(const uint8_t *)ipv6_hdr->dst_addr;
-
-			src_hi[idx] = lpm8_lookup(&share_src->hi, saddr);
-			src_lo[idx] = lpm8_lookup(&share_src->lo, saddr + 8);
-			dst_hi[idx] = lpm8_lookup(&share_dst->hi, daddr);
-			dst_lo[idx] = lpm8_lookup(&share_dst->lo, daddr + 8);
-		}
-
-		const uint32_t *src_hi_a = ADDR_OF(&share_src->remap_hi_a);
-		const uint32_t *src_lo_a = ADDR_OF(&share_src->remap_lo_a);
-		const uint32_t *dst_hi_a = ADDR_OF(&share_dst->remap_hi_a);
-		const uint32_t *dst_lo_a = ADDR_OF(&share_dst->remap_lo_a);
-		const uint32_t *src_hi_b = ADDR_OF(&share_src->remap_hi_b);
-		const uint32_t *src_lo_b = ADDR_OF(&share_src->remap_lo_b);
-		const uint32_t *dst_hi_b = ADDR_OF(&share_dst->remap_hi_b);
-		const uint32_t *dst_lo_b = ADDR_OF(&share_dst->remap_lo_b);
-
-		// Translate the union classes into the leaf classes of each
-		// filter and combine them in the filter's own comb table.
+		// Leaf comb tables of both filters fed by the union tries.
 		const size_t ip6_src_leaf =
 			filter_ip6->lookup_count + ACL_FILTER_NET6_SRC_POS;
 		const size_t ip6_dst_leaf =
@@ -382,23 +347,6 @@ acl_handle_packets(
 			ADDR_OF(&acl_config->filter_ip6.v[ip6_src_leaf].data);
 		struct net6_classifier *ip6_dst_cls = (struct net6_classifier *)
 			ADDR_OF(&acl_config->filter_ip6.v[ip6_dst_leaf].data);
-
-		uint32_t ip6_src_slots[count];
-		uint32_t ip6_dst_slots[count];
-
-		for (uint64_t idx = 0; idx < ip6_idx; ++idx) {
-			ip6_src_slots[idx] = value_table_get(
-				&ip6_src_cls->comb,
-				src_hi_a[src_hi[idx]],
-				src_lo_a[src_lo[idx]]
-			);
-			ip6_dst_slots[idx] = value_table_get(
-				&ip6_dst_cls->comb,
-				dst_hi_a[dst_hi[idx]],
-				dst_lo_a[dst_lo[idx]]
-			);
-		}
-
 		const size_t ip6_port_src_leaf =
 			filter_ip6_port->lookup_count + ACL_FILTER_NET6_SRC_POS;
 		const size_t ip6_port_dst_leaf =
@@ -416,21 +364,138 @@ acl_handle_packets(
 					 .data
 			);
 
+		uint32_t ip6_src_slots[count];
+		uint32_t ip6_dst_slots[count];
+		// Per-address verdict slots of the port filter, shared with
+		// the port loop below through ip6_port_pos.
+		uint32_t ip6_src_slots_b[ip6_idx];
+		uint32_t ip6_dst_slots_b[ip6_idx];
+
+		// Union half-classes per address, computed only for addresses
+		// whose verdict memos missed.
+		uint32_t src_hi[ip6_idx];
+		uint32_t src_lo[ip6_idx];
+		uint32_t dst_hi[ip6_idx];
+		uint32_t dst_lo[ip6_idx];
+
+		for (uint64_t idx = 0; idx < ip6_idx; ++idx) {
+			struct rte_mbuf *mbuf =
+				packet_to_mbuf(ip6_packets[idx]);
+			struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
+				mbuf,
+				struct rte_ipv6_hdr *,
+				ip6_packets[idx]->network_header.offset
+			);
+			const uint8_t *saddr =
+				(const uint8_t *)ipv6_hdr->src_addr;
+
+			uint32_t src_a;
+			uint32_t src_b;
+			if (net6_memo_lookup(
+				    &share_src->memo_a, saddr, &src_a
+			    ) &&
+			    net6_memo_lookup(
+				    &share_src->memo_b, saddr, &src_b
+			    )) {
+				ip6_src_slots[idx] = src_a;
+				ip6_src_slots_b[idx] = src_b;
+				continue;
+			}
+
+			src_hi[idx] = lpm8_lookup(&share_src->hi, saddr);
+			src_lo[idx] = lpm8_lookup(&share_src->lo, saddr + 8);
+
+			const uint32_t *src_hi_a =
+				ADDR_OF(&share_src->remap_hi_a);
+			const uint32_t *src_lo_a =
+				ADDR_OF(&share_src->remap_lo_a);
+			const uint32_t *src_hi_b =
+				ADDR_OF(&share_src->remap_hi_b);
+			const uint32_t *src_lo_b =
+				ADDR_OF(&share_src->remap_lo_b);
+
+			ip6_src_slots[idx] = value_table_get(
+				&ip6_src_cls->comb,
+				src_hi_a[src_hi[idx]],
+				src_lo_a[src_lo[idx]]
+			);
+			ip6_src_slots_b[idx] = value_table_get(
+				&ip6_port_src_cls->comb,
+				src_hi_b[src_hi[idx]],
+				src_lo_b[src_lo[idx]]
+			);
+			net6_memo_insert(
+				&share_src->memo_a, saddr, ip6_src_slots[idx]
+			);
+			net6_memo_insert(
+				&share_src->memo_b, saddr, ip6_src_slots_b[idx]
+			);
+		}
+
+		for (uint64_t idx = 0; idx < ip6_idx; ++idx) {
+			struct rte_mbuf *mbuf =
+				packet_to_mbuf(ip6_packets[idx]);
+			struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
+				mbuf,
+				struct rte_ipv6_hdr *,
+				ip6_packets[idx]->network_header.offset
+			);
+			const uint8_t *daddr =
+				(const uint8_t *)ipv6_hdr->dst_addr;
+
+			uint32_t dst_a;
+			uint32_t dst_b;
+			if (net6_memo_lookup(
+				    &share_dst->memo_a, daddr, &dst_a
+			    ) &&
+			    net6_memo_lookup(
+				    &share_dst->memo_b, daddr, &dst_b
+			    )) {
+				ip6_dst_slots[idx] = dst_a;
+				ip6_dst_slots_b[idx] = dst_b;
+				continue;
+			}
+
+			dst_hi[idx] = lpm8_lookup(&share_dst->hi, daddr);
+			dst_lo[idx] = lpm8_lookup(&share_dst->lo, daddr + 8);
+
+			const uint32_t *dst_hi_a =
+				ADDR_OF(&share_dst->remap_hi_a);
+			const uint32_t *dst_lo_a =
+				ADDR_OF(&share_dst->remap_lo_a);
+			const uint32_t *dst_hi_b =
+				ADDR_OF(&share_dst->remap_hi_b);
+			const uint32_t *dst_lo_b =
+				ADDR_OF(&share_dst->remap_lo_b);
+
+			ip6_dst_slots[idx] = value_table_get(
+				&ip6_dst_cls->comb,
+				dst_hi_a[dst_hi[idx]],
+				dst_lo_a[dst_lo[idx]]
+			);
+			ip6_dst_slots_b[idx] = value_table_get(
+				&ip6_port_dst_cls->comb,
+				dst_hi_b[dst_hi[idx]],
+				dst_lo_b[dst_lo[idx]]
+			);
+			net6_memo_insert(
+				&share_dst->memo_a, daddr, ip6_dst_slots[idx]
+			);
+			net6_memo_insert(
+				&share_dst->memo_b, daddr, ip6_dst_slots_b[idx]
+			);
+		}
+
 		uint32_t ip6_port_src_slots[count];
 		uint32_t ip6_port_dst_slots[count];
 
+		// The b-side verdict slots were computed (or memo-replayed)
+		// per address above; port packets reuse them through
+		// ip6_port_pos.
 		for (uint64_t idx = 0; idx < ip6_port_idx; ++idx) {
 			uint32_t pos = ip6_port_pos[idx];
-			ip6_port_src_slots[idx] = value_table_get(
-				&ip6_port_src_cls->comb,
-				src_hi_b[src_hi[pos]],
-				src_lo_b[src_lo[pos]]
-			);
-			ip6_port_dst_slots[idx] = value_table_get(
-				&ip6_port_dst_cls->comb,
-				dst_hi_b[dst_hi[pos]],
-				dst_lo_b[dst_lo[pos]]
-			);
+			ip6_port_src_slots[idx] = ip6_src_slots_b[pos];
+			ip6_port_dst_slots[idx] = ip6_dst_slots_b[pos];
 		}
 
 		acl_filter_query_ext(

--- a/modules/acl/tests/functional/acl_net6_share_test.go
+++ b/modules/acl/tests/functional/acl_net6_share_test.go
@@ -375,7 +375,7 @@ func runNet6ShareVerdictParity(
 func TestACL_Net6Share_VerdictParity(t *testing.T) {
 	const (
 		net6ShareCPMemory  = 192 * datasize.MB
-		net6ShareAgentSize = 48 * datasize.MB
+		net6ShareAgentSize = 64 * datasize.MB
 	)
 	runNet6ShareVerdictParity(t, 384, 512, net6ShareCPMemory, net6ShareAgentSize)
 }
@@ -454,7 +454,7 @@ func TestACL_Net6Share_VerdictParity_ScaleHeavy(t *testing.T) {
 func TestACL_Net6Share_EmptyRoundForcePoll(t *testing.T) {
 	const (
 		emptyRoundCPMemory    = 192 * datasize.MB
-		emptyRoundAgentMemory = 48 * datasize.MB
+		emptyRoundAgentMemory = 64 * datasize.MB
 	)
 
 	_, present := os.LookupEnv(net6ShareDisableEnv)

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -30,9 +30,9 @@ import (
 
 // Memory sizes for the ACL functional harness.
 const (
-	aclCPSize  = 64 * datasize.MB
+	aclCPSize  = 128 * datasize.MB
 	aclDPSize  = 4 * datasize.MB
-	aclMemSize = 16 * datasize.MB
+	aclMemSize = 32 * datasize.MB
 )
 
 // udpProto matches any UDP packet.


### PR DESCRIPTION
Speed up IPv6 address classification by memoizing the final verdict, measured end to end on a production capture replayed through compiler-filled tries.

- Memoize the final verdict per full 16-byte address in a direct-mapped table inside the classifier. A hit is one slot probe replacing both half-trie walks and the combine fetch.
- The memo is allocated and zeroed with each compiled classifier, so a config swap brings a fresh table and no invalidation protocol exists to get wrong.
- Slots use a two-word store order with a full 96-bit key check: concurrent workers race benignly — a torn read fails the key compare and recomputes, never returns a wrong verdict — and no locked instruction is needed.
- The shared net6 classification carries two memos per direction, one per filter fed by the union tries; the acl dataplane share path skips the union walks, remap fetches, and comb fetches when both per-filter memos hit.
- Lookups stay scalar per packet through the plain byte-stride walk: a hop-major batched walk measured 1.9..2.3x slower than the scalar loop on production traffic, so batching is not used.
- A four-trie benchmark fills the src/dst hi/lo tries through the real compiler from prefix files and replays either random or pcap addresses, asserting every memo hit equals the plain walks plus the combine fetch, then times each path. On the production capture the memoized full query measures 11 ns per address against 31 ns for the plain half walks alone.

Closes nothing; a follow-up PR stacks the uniform combine-row shortcut on this one.