### PR TITLE
feat(lab): up start-or-reuse with bounded timeout and shutdown-marker gate

### DIFF
--- a/cmd/yanet-lab/main.go
+++ b/cmd/yanet-lab/main.go
@@ -67,7 +67,14 @@ const maxSessionNameSlack = 40
 // that bypass ensureSessionDirectory — gets the rejection up front.
 const maxSessionNameLen = sunPathLimit - sunPathSlack - maxSessionNameSlack
 
+// supervisorProtocolVersion is stamped on every Supervisor reply so a stale
+// Supervisor process forked by an older CLI is detected and replaced.
 const supervisorProtocolVersion = 2
+
+// cliProtocolVersion is the version of the CLI JSON envelope itself. It is
+// independent from the Supervisor protocol and travels in its own field so
+// the two contracts can evolve separately (AD-8, FR-18).
+const cliProtocolVersion = 1
 
 type request struct {
 	Action   string   `json:"action"`
@@ -77,13 +84,30 @@ type request struct {
 	Columns  int      `json:"columns,omitempty"`
 }
 
+// response is the wire shape shared by the CLI envelope and every Supervisor
+// reply.
+//
+// Two protocol version fields travel together so the CLI envelope contract
+// (Protocol) and the Supervisor protocol contract (SupervisorProtocolVersion)
+// can evolve independently per AD-8 / FR-21.
+//
+// The CLI side sets Protocol=cliProtocolVersion in JSON output (printResponse);
+// the non-JSON CLI branch leaves it zero. In either case the Supervisor's
+// SupervisorProtocolVersion is forwarded untouched. The Supervisor side never
+// sets Protocol; it stamps SupervisorProtocolVersion=supervisorProtocolVersion
+// on every reply, including the pre-ready and decode-error paths.
 type response struct {
-	OK       bool           `json:"ok"`
-	Output   string         `json:"output,omitempty"`
-	Error    string         `json:"error,omitempty"`
-	Report   *lab.RunReport `json:"report,omitempty"`
-	SSHPort  int            `json:"ssh_port,omitempty"`
-	Protocol int            `json:"protocol,omitempty"`
+	OK      bool           `json:"ok"`
+	Output  string         `json:"output,omitempty"`
+	Error   string         `json:"error,omitempty"`
+	Report  *lab.RunReport `json:"report,omitempty"`
+	SSHPort int            `json:"ssh_port,omitempty"`
+	// Protocol is the CLI JSON envelope version. Set to cliProtocolVersion
+	// by the CLI before printing a response in --json mode.
+	Protocol int `json:"protocol,omitempty"`
+	// SupervisorProtocolVersion is the Supervisor protocol version the
+	// Supervisor stamps on every reply.
+	SupervisorProtocolVersion int `json:"supervisorProtocolVersion,omitempty"`
 }
 
 type application struct {
@@ -177,7 +201,7 @@ func (m *application) Run() int {
 	root := m.command()
 	if err := root.Execute(); err != nil {
 		if m.json {
-			_ = json.NewEncoder(os.Stderr).Encode(response{Error: err.Error()})
+			_ = json.NewEncoder(os.Stderr).Encode(response{Error: err.Error(), Protocol: cliProtocolVersion})
 		} else {
 			fmt.Fprintln(os.Stderr, "yanet-lab:", err)
 		}
@@ -202,7 +226,7 @@ func (m *application) command() *cobra.Command {
 	root.PersistentFlags().BoolVar(&m.json, "json", false, "emit machine-readable JSON")
 	root.AddCommand(
 		&cobra.Command{Use: "doctor", Short: "Check host prerequisites", RunE: func(*cobra.Command, []string) error { return m.doctor() }},
-		&cobra.Command{Use: "up", Short: "Start or reuse the lab VM", RunE: func(*cobra.Command, []string) error { return m.up() }},
+		m.upCommand(),
 		&cobra.Command{Use: "status", Short: "Show lab and YANET readiness", RunE: func(*cobra.Command, []string) error { return m.simple("status", nil) }},
 		&cobra.Command{Use: "reset", Short: "Restore the baseline snapshot", RunE: func(*cobra.Command, []string) error { return m.simple("reset", nil) }},
 		&cobra.Command{Use: "report", Short: "Collect an inspect and readiness report", RunE: func(*cobra.Command, []string) error { return m.simple("report", nil) }},
@@ -216,6 +240,24 @@ func (m *application) execCommand() *cobra.Command {
 	return &cobra.Command{Use: "exec -- COMMAND [ARG...]", Short: "Execute a command in the guest", Args: cobra.MinimumNArgs(1), RunE: func(_ *cobra.Command, args []string) error {
 		return m.simple("exec", args)
 	}}
+}
+
+// upCommand wires the optional positional session name used in the recipe
+// invocations (`just lab up my-session`) on top of the --session flag.
+func (m *application) upCommand() *cobra.Command {
+	return &cobra.Command{Use: "up [SESSION]", Short: "Start or reuse the lab VM", Args: cobra.MaximumNArgs(1), RunE: func(_ *cobra.Command, args []string) error {
+		m.selectSession(args)
+		return m.up()
+	}}
+}
+
+// selectSession applies an optional positional session name to the running
+// application, leaving the --session flag value intact when no positional is
+// given. Extracted so the assignment is testable without spawning serve.
+func (m *application) selectSession(args []string) {
+	if len(args) == 1 {
+		m.session = args[0]
+	}
 }
 
 func (m *application) shellCommand() *cobra.Command {
@@ -647,13 +689,6 @@ func doctorAccelerationCheck(platform string, kvmAvailable func() bool) doctorCh
 }
 
 func (m *application) up() error {
-	status, err := m.shutdownStaleSupervisor()
-	if err != nil {
-		return err
-	}
-	if status != nil {
-		return m.printResponse(status)
-	}
 	dir, _, err := sessionPaths(m.session)
 	if err != nil {
 		return err
@@ -661,20 +696,105 @@ func (m *application) up() error {
 	if err := ensureSessionDirectory(dir); err != nil {
 		return err
 	}
-	executable, err := os.Executable()
+	logPath := filepath.Join(dir, "supervisor.log")
+	if err := shutdownMarkerCheck(dir); err != nil {
+		return err
+	}
+	reuse, replacedFrom, err := m.shutdownStaleSupervisor()
 	if err != nil {
 		return err
 	}
-	logFile, err := openPrivateFile(filepath.Join(dir, "supervisor.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND)
+	if reuse != nil {
+		if !reuse.OK {
+			return sessionUnhealthy(reuse.Error, logPath)
+		}
+		return m.printResponse(reuse)
+	}
+	if err := probeSessionLock(dir); err != nil {
+		return sessionUnhealthy(err.Error(), logPath)
+	}
+	// Re-check the shutdown marker immediately before spawning serve so a
+	// concurrent `down` that wrote the marker between the initial check and
+	// the spawn still blocks `up` instead of clobbering the failed session.
+	if err := shutdownMarkerCheck(dir); err != nil {
+		return err
+	}
+	response, err := serveRunner(m, logPath)
 	if err != nil {
 		return err
+	}
+	annotateReplacement(response, replacedFrom)
+	return m.printResponse(response)
+}
+
+// sessionUnhealthy wraps the exact AC2 error form: a non-zero prefix naming
+// the reason and the supervisor log path the developer should inspect.
+func sessionUnhealthy(reason, logPath string) error {
+	return fmt.Errorf("session unhealthy: %s; see %s", reason, logPath)
+}
+
+// probeSessionLock reports whether another supervisor process still holds the
+// session lock. up uses it to refuse clobbering a locked-but-silent session
+// (AC2 "locked by a stale Supervisor") without spawning a serve process that
+// would just die on flock.
+func probeSessionLock(directory string) error {
+	path := filepath.Join(directory, "supervisor.lock")
+	lock, err := openPrivateFile(path, os.O_RDONLY)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	defer lock.Close()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return fmt.Errorf("supervisor lock is held by another process: %w", err)
+	}
+	return nil
+}
+
+// noteProtocolReplacement records in the up response that a Supervisor with a
+// stale protocol version was torn down and replaced. A negative staleVersion
+// (the noStaleTeardown sentinel) is a no-op so a direct caller cannot emit a
+// bogus "replaced stale supervisor (protocol -1)" prefix.
+func noteProtocolReplacement(output string, staleVersion int) string {
+	if staleVersion < 0 {
+		return output
+	}
+	prefix := fmt.Sprintf("replaced stale supervisor (protocol %d)", staleVersion)
+	if output == "" {
+		return prefix
+	}
+	return prefix + "; " + output
+}
+
+// annotateReplacement prepends the stale-protocol replacement note to the
+// fresh Supervisor's status reply when up tore down a stale Supervisor first.
+// Extracted so the no-op sentinel path is testable without a live Supervisor.
+func annotateReplacement(response *response, replacedFrom int) {
+	if replacedFrom >= 0 {
+		response.Output = noteProtocolReplacement(response.Output, replacedFrom)
+	}
+}
+
+// serveRunner forks the serve subprocess for up and returns its first OK
+// status response. The package var lets tests substitute a fake runner so the
+// stale-protocol replacement wire-up can be exercised without spawning QEMU.
+var serveRunner = func(m *application, logPath string) (*response, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+	logFile, err := openPrivateFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND)
+	if err != nil {
+		return nil, err
 	}
 	command := exec.Command(executable, "--session", m.session, "serve")
 	command.Stdout, command.Stderr, command.Stdin = logFile, logFile, nil
 	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := command.Start(); err != nil {
 		_ = logFile.Close()
-		return err
+		return nil, err
 	}
 	_ = logFile.Close()
 	exited := make(chan error, 1)
@@ -684,13 +804,13 @@ func (m *application) up() error {
 	for time.Now().Before(deadline) {
 		if response, callErr := m.call(request{Action: "status"}); callErr == nil {
 			if response.OK {
-				return m.printResponse(response)
+				return response, nil
 			}
 			lastStatusError = response.Error
 		}
 		select {
 		case processErr := <-exited:
-			return fmt.Errorf("lab supervisor exited during startup: %w; see %s", processErr, filepath.Join(dir, "supervisor.log"))
+			return nil, fmt.Errorf("lab supervisor exited during startup: %w; see %s", processErr, logPath)
 		case <-time.After(250 * time.Millisecond):
 		}
 	}
@@ -701,7 +821,7 @@ func (m *application) up() error {
 		_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
 		<-exited
 	}
-	return startupFailure(lastStatusError, filepath.Join(dir, "supervisor.log"))
+	return nil, startupFailure(lastStatusError, logPath)
 }
 
 func startupTimeout() time.Duration {
@@ -731,30 +851,38 @@ func classifyStaleSupervisor(resp *response, callErr error) staleSupervisorDecis
 	if callErr != nil {
 		return staleSupervisorAbsent
 	}
-	if resp.Protocol == supervisorProtocolVersion {
+	if resp.SupervisorProtocolVersion == supervisorProtocolVersion {
 		return staleSupervisorCurrent
 	}
 	return staleSupervisorStale
 }
 
+// noStaleTeardown is the replacedFrom sentinel returned by shutdownStaleSupervisor
+// when no stale Supervisor was torn down. 0 is a legitimate observed stale
+// version (an old Supervisor that did not stamp supervisorProtocolVersion), so
+// the sentinel is distinct.
+const noStaleTeardown = -1
+
 // shutdownStaleSupervisor checks for a running lab supervisor. If one exists
 // with the current protocol version it returns the status response. If a stale
 // (wrong-version) supervisor is running, it sends "down" and polls until the
-// socket goes away. Returns nil when no stale supervisor remains.
-func (m *application) shutdownStaleSupervisor() (*response, error) {
+// socket goes away, then reports the observed stale version so up can annotate
+// the replacement in its JSON output (AC4).
+func (m *application) shutdownStaleSupervisor() (*response, int, error) {
 	resp, err := m.call(request{Action: "status"})
 	switch classifyStaleSupervisor(resp, err) {
 	case staleSupervisorAbsent:
-		return nil, nil
+		return nil, noStaleTeardown, nil
 	case staleSupervisorCurrent:
-		return resp, nil
+		return resp, noStaleTeardown, nil
 	}
+	staleVersion := resp.SupervisorProtocolVersion
 	staleResponse, staleErr := m.call(request{Action: "down"})
 	if staleErr != nil {
-		return nil, fmt.Errorf("stale lab supervisor is running; stop it before starting a new one: %w", staleErr)
+		return nil, noStaleTeardown, fmt.Errorf("stale lab supervisor is running; stop it before starting a new one: %w", staleErr)
 	}
 	if !staleResponse.OK {
-		return nil, fmt.Errorf("stale lab supervisor refused shutdown: %s", staleResponse.Error)
+		return nil, noStaleTeardown, fmt.Errorf("stale lab supervisor refused shutdown: %s", staleResponse.Error)
 	}
 	deadline := time.Now().Add(supervisorRequestTimeout)
 	for time.Now().Before(deadline) {
@@ -764,9 +892,9 @@ func (m *application) shutdownStaleSupervisor() (*response, error) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	if _, callErr := m.call(request{Action: "status"}); callErr == nil {
-		return nil, fmt.Errorf("stale lab supervisor did not shut down within %s; stop it manually", supervisorRequestTimeout)
+		return nil, noStaleTeardown, fmt.Errorf("stale lab supervisor did not shut down within %s; stop it manually", supervisorRequestTimeout)
 	}
-	return nil, nil
+	return nil, staleVersion, nil
 }
 
 func (m *application) simple(action string, argv []string) error {
@@ -786,6 +914,15 @@ func (m *application) simpleManifest(path string) error {
 }
 
 func (m *application) call(value request) (*response, error) {
+	return callSupervisor(m, value)
+}
+
+// callSupervisor issues a request to the named session's Supervisor over its
+// Unix-domain socket. The function lives at package scope so tests can
+// substitute a fake without standing up a real socket. Tests must not call
+// t.Parallel() while this var is stubbed because the package-level binding
+// is shared.
+var callSupervisor = func(m *application, value request) (*response, error) {
 	connection, err := m.sessionConnection()
 	if err != nil {
 		return nil, err
@@ -846,7 +983,9 @@ func (m *application) sessionConnection() (net.Conn, error) {
 
 func (m *application) printResponse(value *response) error {
 	if m.json {
-		_ = json.NewEncoder(os.Stdout).Encode(value)
+		encoded := *value
+		encoded.Protocol = cliProtocolVersion
+		_ = json.NewEncoder(os.Stdout).Encode(&encoded)
 	} else if value.Report != nil {
 		for _, result := range value.Report.Results {
 			marker := "PASS"
@@ -1017,18 +1156,18 @@ func handleRuntimeConnection(connection net.Conn, dir string, runtime *sessionRu
 	default:
 		var value request
 		if err := decodeRequest(connection, &value); err != nil {
-			_ = json.NewEncoder(connection).Encode(response{Error: err.Error(), Protocol: supervisorProtocolVersion})
+			_ = json.NewEncoder(connection).Encode(response{Error: err.Error(), SupervisorProtocolVersion: supervisorProtocolVersion})
 			return
 		}
 		if value.Action == "down" {
 			if runtime.Interrupted != nil {
 				runtime.Interrupted.Store(true)
 			}
-			_ = json.NewEncoder(connection).Encode(response{OK: true, Output: "lab stopped", Protocol: supervisorProtocolVersion})
+			_ = json.NewEncoder(connection).Encode(response{OK: true, Output: "lab stopped", SupervisorProtocolVersion: supervisorProtocolVersion})
 			stop()
 			return
 		}
-		_ = json.NewEncoder(connection).Encode(response{Error: "lab is starting", Protocol: supervisorProtocolVersion})
+		_ = json.NewEncoder(connection).Encode(response{Error: "lab is starting", SupervisorProtocolVersion: supervisorProtocolVersion})
 	}
 }
 
@@ -1036,10 +1175,10 @@ func handleConnection(connection net.Conn, fw *framework.TestFramework, dir stri
 	defer connection.Close()
 	var value request
 	if err := decodeRequest(connection, &value); err != nil {
-		_ = json.NewEncoder(connection).Encode(response{Error: err.Error()})
+		_ = json.NewEncoder(connection).Encode(response{Error: err.Error(), SupervisorProtocolVersion: supervisorProtocolVersion})
 		return
 	}
-	reply := response{OK: true, Protocol: supervisorProtocolVersion}
+	reply := response{OK: true, SupervisorProtocolVersion: supervisorProtocolVersion}
 	if value.Action == "serial" {
 		if !state.TrySerial(connection) {
 			reply.OK = false
@@ -1468,6 +1607,81 @@ func openPrivateFile(path string, flags int) (*os.File, error) {
 		return nil, err
 	}
 	return file, nil
+}
+
+// shutdownMarkerName is the file a failed down writes atomically into the
+// session runtime directory. Its presence blocks the next up until an
+// explicit successful down retry removes it (AC5/AC6).
+const shutdownMarkerName = "shutdown-failed.json"
+
+// maxShutdownMarkerBytes bounds how much of the marker file checkShutdownMarker
+// reads; any well-formed marker is tiny.
+const maxShutdownMarkerBytes = 4096
+
+// shutdownMarkerCheck rejects up when a previous down left its marker in the
+// session runtime directory. It is a package var so tests can stub the second
+// invocation inside up() and exercise the TOCTOU re-check race without
+// standing up a real marker-writing sibling process.
+var shutdownMarkerCheck = checkShutdownMarker
+
+// checkShutdownMarker rejects up when a previous down left its marker in the
+// session runtime directory. A valid marker names the failing step and reason
+// and is reported back to the caller; any deviation from the exact
+// mode-0600 regular file containing exactly the string fields
+// status="FAILED", non-empty step and reason is treated as an unknown shutdown
+// state so cleanup stays with an explicit down retry.
+func checkShutdownMarker(directory string) error {
+	path := filepath.Join(directory, shutdownMarkerName)
+	if _, err := os.Lstat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return unknownShutdownState(fmt.Errorf("inspect marker: %w", err))
+	}
+	file, err := openPrivateFile(path, os.O_RDONLY)
+	if err != nil {
+		return unknownShutdownState(err)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxShutdownMarkerBytes+1))
+	if err != nil {
+		return unknownShutdownState(fmt.Errorf("read marker: %w", err))
+	}
+	if len(data) > maxShutdownMarkerBytes {
+		return unknownShutdownState(fmt.Errorf("marker exceeds %d bytes", maxShutdownMarkerBytes))
+	}
+	fields := map[string]any{}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return unknownShutdownState(fmt.Errorf("marker is not a JSON object: %w", err))
+	}
+	if len(fields) != 3 {
+		return unknownShutdownState(fmt.Errorf("marker has %d fields, want exactly status, step, reason", len(fields)))
+	}
+	for _, key := range []string{"status", "step", "reason"} {
+		value, present := fields[key]
+		if !present {
+			return unknownShutdownState(fmt.Errorf("marker missing field %q", key))
+		}
+		stringValue, ok := value.(string)
+		if !ok {
+			return unknownShutdownState(fmt.Errorf("marker field %q is not a string", key))
+		}
+		if stringValue == "" {
+			return unknownShutdownState(fmt.Errorf("marker field %q is empty", key))
+		}
+	}
+	if status := fields["status"].(string); status != "FAILED" {
+		return unknownShutdownState(fmt.Errorf("marker status is %q, want FAILED", status))
+	}
+	step := fields["step"].(string)
+	reason := fields["reason"].(string)
+	return fmt.Errorf("previous down failed at step %q: %s; run 'yanet-lab down' to retry cleanup", step, reason)
+}
+
+// unknownShutdownState formats the uniform error checkShutdownMarker returns
+// for every deviation from the contract (AC6).
+func unknownShutdownState(err error) error {
+	return fmt.Errorf("shutdown state unknown: %w; run 'yanet-lab down' to retry cleanup", err)
 }
 
 var sessionNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)

--- a/cmd/yanet-lab/main_test.go
+++ b/cmd/yanet-lab/main_test.go
@@ -8,10 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -428,7 +430,7 @@ func TestRootCommandHasUpSubcommand(t *testing.T) {
 	require.NoError(t, command.Execute())
 	found := false
 	for _, sub := range command.Commands() {
-		if sub.Use == "up" {
+		if sub.Name() == "up" {
 			found = true
 			break
 		}
@@ -498,7 +500,8 @@ func TestHandleRuntimeConnectionIncludesProtocolVersion(t *testing.T) {
 	require.NoError(t, json.NewEncoder(client).Encode(request{Action: "status"}))
 	var reply response
 	require.NoError(t, json.NewDecoder(client).Decode(&reply))
-	require.Equal(t, supervisorProtocolVersion, reply.Protocol)
+	require.Equal(t, supervisorProtocolVersion, reply.SupervisorProtocolVersion)
+	require.Equal(t, 0, reply.Protocol)
 }
 
 func TestRequestTimeoutMatchesActionBudget(t *testing.T) {
@@ -571,6 +574,7 @@ func TestHandleConnectionReturnsBusy(t *testing.T) {
 			require.NoError(t, json.NewDecoder(client).Decode(&reply))
 			require.False(t, reply.OK)
 			require.Equal(t, "lab is busy", reply.Error)
+			require.Equal(t, supervisorProtocolVersion, reply.SupervisorProtocolVersion)
 			require.NoError(t, handlers.Wait())
 		})
 	}
@@ -598,6 +602,7 @@ func TestHandleConnectionDownAcksBeforeShutdown(t *testing.T) {
 	require.NoError(t, json.NewDecoder(client).Decode(&reply))
 	require.True(t, reply.OK)
 	require.Equal(t, "lab stopped", reply.Output)
+	require.Equal(t, supervisorProtocolVersion, reply.SupervisorProtocolVersion)
 	// The response was decoded while shutdown was still blocked — proving
 	// the early ack-before-shutdown ordering.
 	close(shutdownReturned)
@@ -691,13 +696,486 @@ func TestClassifyStaleSupervisor(t *testing.T) {
 		expected staleSupervisorDecision
 	}{
 		{name: "no supervisor", resp: nil, callErr: errors.New("connect: connection refused"), expected: staleSupervisorAbsent},
-		{name: "current version", resp: &response{Protocol: supervisorProtocolVersion}, callErr: nil, expected: staleSupervisorCurrent},
-		{name: "stale version", resp: &response{Protocol: supervisorProtocolVersion + 1}, callErr: nil, expected: staleSupervisorStale},
-		{name: "old supervisor (protocol 0)", resp: &response{Protocol: 0}, callErr: nil, expected: staleSupervisorStale},
+		{name: "current version", resp: &response{SupervisorProtocolVersion: supervisorProtocolVersion}, callErr: nil, expected: staleSupervisorCurrent},
+		{name: "stale version", resp: &response{SupervisorProtocolVersion: supervisorProtocolVersion + 1}, callErr: nil, expected: staleSupervisorStale},
+		{name: "old supervisor (protocol 0)", resp: &response{SupervisorProtocolVersion: 0}, callErr: nil, expected: staleSupervisorStale},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expected, classifyStaleSupervisor(tc.resp, tc.callErr))
+		})
+	}
+}
+
+func TestResponseEnvelopeCarriesBothProtocolVersions(t *testing.T) {
+	data, err := json.Marshal(response{
+		OK:                        true,
+		Output:                    "VM: running; YANET: ready; operators: ready",
+		Protocol:                  cliProtocolVersion,
+		SupervisorProtocolVersion: supervisorProtocolVersion,
+	})
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.EqualValues(t, cliProtocolVersion, decoded["protocol"])
+	require.EqualValues(t, supervisorProtocolVersion, decoded["supervisorProtocolVersion"])
+	require.Equal(t, true, decoded["ok"])
+}
+
+func TestUpCommandPassesPositionalToRunE(t *testing.T) {
+	command := newApplication().upCommand()
+	require.Equal(t, "up [SESSION]", command.Use)
+	var seen []string
+	command.RunE = func(_ *cobra.Command, args []string) error {
+		seen = args
+		return nil
+	}
+	command.SetArgs([]string{"my-session"})
+	require.NoError(t, command.Execute())
+	require.Equal(t, []string{"my-session"}, seen)
+	command.SetArgs([]string{"my-session", "extra"})
+	err := command.Execute()
+	require.Error(t, err)
+}
+
+func TestSelectSessionAssignsPositional(t *testing.T) {
+	application := newApplication()
+	require.Equal(t, defaultSession, application.session)
+	application.selectSession([]string{"my-session"})
+	require.Equal(t, "my-session", application.session)
+	application.selectSession(nil)
+	require.Equal(t, "my-session", application.session)
+}
+
+func TestUpRejectsShutdownMarkerBeforeSpawn(t *testing.T) {
+	// Reset the cached project root so this test can pin it to the temp dir.
+	projectRootCache = projectRootState{}
+	t.Cleanup(func() { projectRootCache = projectRootState{} })
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/lab\n"), 0o644))
+	t.Chdir(root)
+
+	session := "marker-reject"
+	dir, _, err := sessionPaths(session)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, shutdownMarkerName),
+		[]byte(`{"status":"FAILED","step":"stop-vm","reason":"qemu timed out"}`), 0o600))
+
+	stubCallAndServe(t, nil, func(*application, string) (*response, error) {
+		t.Fatal("serveRunner must not run when shutdown-failed.json rejects up")
+		return nil, nil
+	})
+
+	application := newApplication()
+	application.session = session
+	err = application.up()
+	require.EqualError(t, err, `previous down failed at step "stop-vm": qemu timed out; run 'yanet-lab down' to retry cleanup`)
+}
+
+func TestPrintResponseStampsCLIProtocol(t *testing.T) {
+	t.Run("ok path", func(t *testing.T) {
+		application := newApplication()
+		application.json = true
+		value := &response{OK: true, Output: "VM: running", SupervisorProtocolVersion: supervisorProtocolVersion}
+		stdout, err := captureStdout(t, func() error {
+			return application.printResponse(value)
+		})
+		require.NoError(t, err)
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(stdout, &decoded))
+		require.EqualValues(t, cliProtocolVersion, decoded["protocol"])
+		require.EqualValues(t, supervisorProtocolVersion, decoded["supervisorProtocolVersion"])
+		require.Equal(t, true, decoded["ok"])
+		require.Equal(t, "VM: running", decoded["output"])
+		// The caller's struct must not have been mutated.
+		require.Equal(t, 0, value.Protocol)
+	})
+	t.Run("error path", func(t *testing.T) {
+		application := newApplication()
+		application.json = true
+		value := &response{OK: false, Error: "lab stopped", SupervisorProtocolVersion: supervisorProtocolVersion}
+		stdout, callErr := captureStdout(t, func() error {
+			return application.printResponse(value)
+		})
+		require.EqualError(t, callErr, "lab stopped")
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(stdout, &decoded))
+		require.EqualValues(t, cliProtocolVersion, decoded["protocol"])
+		require.EqualValues(t, supervisorProtocolVersion, decoded["supervisorProtocolVersion"])
+		require.Equal(t, false, decoded["ok"])
+		require.Equal(t, "lab stopped", decoded["error"])
+		require.Equal(t, 0, value.Protocol)
+	})
+}
+
+func TestAnnotateReplacementOnlyFiresOnStaleTeardown(t *testing.T) {
+	resp := &response{Output: "VM: running"}
+	annotateReplacement(resp, noStaleTeardown)
+	require.Equal(t, "VM: running", resp.Output)
+	annotateReplacement(resp, 1)
+	require.Equal(t, "replaced stale supervisor (protocol 1); VM: running", resp.Output)
+	resp = &response{Output: "VM: running"}
+	annotateReplacement(resp, 0)
+	require.Equal(t, "replaced stale supervisor (protocol 0); VM: running", resp.Output)
+	resp = &response{}
+	annotateReplacement(resp, 2)
+	require.Equal(t, "replaced stale supervisor (protocol 2)", resp.Output)
+}
+
+// captureStdout redirects os.Stdout during fn and returns whatever was written.
+func captureStdout(t *testing.T, fn func() error) ([]byte, error) {
+	t.Helper()
+	original := os.Stdout
+	readEnd, writeEnd, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = writeEnd
+	defer func() {
+		os.Stdout = original
+		_ = readEnd.Close()
+		_ = writeEnd.Close()
+	}()
+	runErr := fn()
+	require.NoError(t, writeEnd.Close())
+	data, readErr := io.ReadAll(readEnd)
+	return data, errors.Join(runErr, readErr)
+}
+
+// stubCallAndServe swaps the package-level callSupervisor and serveRunner
+// functions for the duration of a test, restoring the originals on cleanup.
+// Tests that exercise up()'s wire-ups use this to drive the production flow
+// without standing up a real Unix-domain socket or forking a QEMU subprocess.
+func stubCallAndServe(t *testing.T, call func(*application, request) (*response, error), run func(*application, string) (*response, error)) {
+	t.Helper()
+	savedCall, savedRun := callSupervisor, serveRunner
+	t.Cleanup(func() {
+		callSupervisor = savedCall
+		serveRunner = savedRun
+	})
+	if call != nil {
+		callSupervisor = call
+	}
+	if run != nil {
+		serveRunner = run
+	}
+}
+
+// tempUp sets projectRootCache to a temp repo and chdir's into it, returning
+// the resolved session runtime directory and a cleanup func.
+func tempUp(t *testing.T, session string) (string, func()) {
+	t.Helper()
+	projectRootCache = projectRootState{}
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/lab\n"), 0o644))
+	t.Chdir(root)
+	dir, _, err := sessionPaths(session)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	return dir, func() {
+		_ = os.RemoveAll(dir)
+		projectRootCache = projectRootState{}
+	}
+}
+
+func TestUpRejectsUnhealthyRunningSupervisor(t *testing.T) {
+	dir, cleanup := tempUp(t, "unhealthy-running")
+	defer cleanup()
+	stubCallAndServe(t,
+		func(*application, request) (*response, error) {
+			return &response{
+				OK:                        false,
+				Error:                     "lab is busy",
+				SupervisorProtocolVersion: supervisorProtocolVersion,
+			}, nil
+		},
+		nil,
+	)
+	application := newApplication()
+	application.session = "unhealthy-running"
+	err := application.up()
+	require.EqualError(t, err, fmt.Sprintf("session unhealthy: lab is busy; see %s", filepath.Join(dir, "supervisor.log")))
+}
+
+func TestUpRejectsLockedButSilentSession(t *testing.T) {
+	dir, cleanup := tempUp(t, "locked-silent")
+	defer cleanup()
+	holder, err := os.OpenFile(filepath.Join(dir, "supervisor.lock"), os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0o600)
+	require.NoError(t, err)
+	defer holder.Close()
+	require.NoError(t, syscall.Flock(int(holder.Fd()), syscall.LOCK_EX|syscall.LOCK_NB))
+	stubCallAndServe(t,
+		func(*application, request) (*response, error) {
+			return nil, errors.New("connect: no such file or directory")
+		},
+		nil,
+	)
+	application := newApplication()
+	application.session = "locked-silent"
+	err = application.up()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "session unhealthy: supervisor lock is held")
+	require.Contains(t, err.Error(), "supervisor.log")
+}
+
+func TestUpReusesHealthyRunningSupervisor(t *testing.T) {
+	_, cleanup := tempUp(t, "healthy-reuse")
+	defer cleanup()
+	var serveRunnerCalled bool
+	stubCallAndServe(t,
+		func(*application, request) (*response, error) {
+			return &response{
+				OK:                        true,
+				Output:                    "VM: running; YANET: ready",
+				SupervisorProtocolVersion: supervisorProtocolVersion,
+			}, nil
+		},
+		func(*application, string) (*response, error) {
+			serveRunnerCalled = true
+			return nil, errors.New("serveRunner must not run on reuse")
+		},
+	)
+	application := newApplication()
+	application.json = true
+	application.session = "healthy-reuse"
+	stdout, err := captureStdout(t, func() error {
+		return application.up()
+	})
+	require.NoError(t, err)
+	require.False(t, serveRunnerCalled, "serveRunner must not run when a current-protocol Supervisor already answers OK")
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(stdout, &decoded))
+	require.Equal(t, "VM: running; YANET: ready", decoded["output"])
+	require.EqualValues(t, cliProtocolVersion, decoded["protocol"])
+	require.EqualValues(t, supervisorProtocolVersion, decoded["supervisorProtocolVersion"])
+	require.Equal(t, true, decoded["ok"])
+}
+
+func TestUpRechecksShutdownMarkerBeforeSpawn(t *testing.T) {
+	// Marker is absent at the first check (so up proceeds past the gate) but
+	// the test stub plants it before the second check (the TOCTOU re-check
+	// immediately before serveRunner). The serveRunner stub would t.Fatal
+	// if invoked, proving the re-check blocked the spawn.
+	_, cleanup := tempUp(t, "marker-recheck")
+	defer cleanup()
+
+	stubCallAndServe(t,
+		func(*application, request) (*response, error) {
+			return nil, errors.New("connect: no such file or directory")
+		},
+		func(*application, string) (*response, error) {
+			t.Fatal("serveRunner must not run when the second marker check rejects up")
+			return nil, nil
+		},
+	)
+
+	session := "marker-recheck"
+	dir, _, err := sessionPaths(session)
+	require.NoError(t, err)
+	_ = dir
+
+	var callCount int
+	savedCheck := shutdownMarkerCheck
+	t.Cleanup(func() { shutdownMarkerCheck = savedCheck })
+	shutdownMarkerCheck = func(directory string) error {
+		callCount++
+		if callCount == 1 {
+			return nil
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(directory, shutdownMarkerName),
+			[]byte(`{"status":"FAILED","step":"stop-vm","reason":"qemu timed out"}`), 0o600))
+		return checkShutdownMarker(directory)
+	}
+
+	application := newApplication()
+	application.session = session
+	err = application.up()
+	require.EqualError(t, err, `previous down failed at step "stop-vm": qemu timed out; run 'yanet-lab down' to retry cleanup`)
+	require.GreaterOrEqual(t, callCount, 2, "up must invoke the marker check at least twice (initial + re-check before spawn)")
+}
+
+func TestUpAnnotatesReplacementAfterStaleTeardown(t *testing.T) {
+	_, cleanup := tempUp(t, "replacement-test")
+	defer cleanup()
+	var callIndex int
+	stubCallAndServe(t,
+		func(m *application, value request) (*response, error) {
+			callIndex++
+			switch callIndex {
+			case 1:
+				// shutdownStaleSupervisor's initial status: stale protocol.
+				return &response{OK: true, SupervisorProtocolVersion: 1}, nil
+			case 2:
+				// shutdownStaleSupervisor's down: success.
+				return &response{OK: true, Output: "lab stopped"}, nil
+			case 3:
+				// shutdownStaleSupervisor's post-teardown poll: socket gone.
+				return nil, errors.New("connect: no such file or directory")
+			}
+			return nil, errors.New("unexpected call")
+		},
+		func(*application, string) (*response, error) {
+			return &response{
+				OK:                        true,
+				Output:                    "VM: running",
+				SupervisorProtocolVersion: supervisorProtocolVersion,
+			}, nil
+		},
+	)
+	application := newApplication()
+	application.json = true
+	application.session = "replacement-test"
+	stdout, err := captureStdout(t, func() error {
+		return application.up()
+	})
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(stdout, &decoded))
+	require.Equal(t, "replaced stale supervisor (protocol 1); VM: running", decoded["output"])
+	require.EqualValues(t, cliProtocolVersion, decoded["protocol"])
+	require.EqualValues(t, supervisorProtocolVersion, decoded["supervisorProtocolVersion"])
+	require.Equal(t, true, decoded["ok"])
+}
+
+func TestSessionUnhealthyIncludesReasonAndLogPath(t *testing.T) {
+	err := sessionUnhealthy("lab is busy", "/tmp/yanet2-lab-0/abc/default/supervisor.log")
+	require.EqualError(t, err, "session unhealthy: lab is busy; see /tmp/yanet2-lab-0/abc/default/supervisor.log")
+}
+
+func TestNoteProtocolReplacement(t *testing.T) {
+	require.Equal(t, "replaced stale supervisor (protocol 1)", noteProtocolReplacement("", 1))
+	require.Equal(t, "replaced stale supervisor (protocol 1); VM: running", noteProtocolReplacement("VM: running", 1))
+	require.Equal(t, "replaced stale supervisor (protocol 0)", noteProtocolReplacement("", 0))
+}
+
+func TestProbeSessionLock(t *testing.T) {
+	t.Run("absent lock file", func(t *testing.T) {
+		require.NoError(t, probeSessionLock(t.TempDir()))
+	})
+	t.Run("free lock file", func(t *testing.T) {
+		dir := t.TempDir()
+		lock, err := os.OpenFile(filepath.Join(dir, "supervisor.lock"), os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0o600)
+		require.NoError(t, err)
+		require.NoError(t, lock.Close())
+		require.NoError(t, probeSessionLock(dir))
+	})
+	t.Run("held lock file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "supervisor.lock")
+		holder, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0o600)
+		require.NoError(t, err)
+		defer holder.Close()
+		require.NoError(t, syscall.Flock(int(holder.Fd()), syscall.LOCK_EX|syscall.LOCK_NB))
+		err = probeSessionLock(dir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "supervisor lock is held")
+	})
+}
+
+func TestCheckShutdownMarkerAbsentIsNotBlocking(t *testing.T) {
+	require.NoError(t, checkShutdownMarker(t.TempDir()))
+}
+
+func TestCheckShutdownMarkerAcceptsValidMarker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, shutdownMarkerName)
+	require.NoError(t, os.WriteFile(path, []byte(`{"status":"FAILED","step":"stop-vm","reason":"qemu timed out"}`), 0o600))
+	err := checkShutdownMarker(dir)
+	require.EqualError(t, err, `previous down failed at step "stop-vm": qemu timed out; run 'yanet-lab down' to retry cleanup`)
+}
+
+func TestCheckShutdownMarkerRejectsInvalidStates(t *testing.T) {
+	cases := []struct {
+		name    string
+		prepare func(string) string
+	}{
+		{
+			name: "wrong mode",
+			prepare: func(dir string) string {
+				path := filepath.Join(dir, shutdownMarkerName)
+				require.NoError(t, os.WriteFile(path, []byte(`{"status":"FAILED","step":"stop-vm","reason":"qemu timed out"}`), 0o600))
+				// Open with explicit chmod after write so a restrictive umask
+				// cannot silently turn this into a 0600 success case.
+				require.NoError(t, os.Chmod(path, 0o644))
+				return path
+			},
+		},
+		{
+			name: "symlink",
+			prepare: func(dir string) string {
+				path := filepath.Join(dir, shutdownMarkerName)
+				require.NoError(t, os.Symlink("/etc/passwd", path))
+				return path
+			},
+		},
+		{
+			name: "malformed JSON",
+			prepare: func(dir string) string {
+				path := filepath.Join(dir, shutdownMarkerName)
+				require.NoError(t, os.WriteFile(path, []byte("not json"), 0o600))
+				return path
+			},
+		},
+		{
+			name: "extra field",
+			prepare: func(dir string) string {
+				path := filepath.Join(dir, shutdownMarkerName)
+				require.NoError(t, os.WriteFile(path, []byte(`{"status":"FAILED","step":"stop-vm","reason":"qemu timed out","extra":"x"}`), 0o600))
+				return path
+			},
+		},
+		{
+			name: "missing field",
+			prepare: func(dir string) string {
+				path := filepath.Join(dir, shutdownMarkerName)
+				require.NoError(t, os.WriteFile(path, []byte(`{"status":"FAILED","step":"stop-vm"}`), 0o600))
+				return path
+			},
+		},
+		{
+			name: "wrong status",
+			prepare: func(dir string) string {
+				path := filepath.Join(dir, shutdownMarkerName)
+				require.NoError(t, os.WriteFile(path, []byte(`{"status":"OK","step":"stop-vm","reason":"qemu timed out"}`), 0o600))
+				return path
+			},
+		},
+		{
+			name: "empty step",
+			prepare: func(dir string) string {
+				path := filepath.Join(dir, shutdownMarkerName)
+				require.NoError(t, os.WriteFile(path, []byte(`{"status":"FAILED","step":"","reason":"qemu timed out"}`), 0o600))
+				return path
+			},
+		},
+		{
+			name: "non-string reason",
+			prepare: func(dir string) string {
+				path := filepath.Join(dir, shutdownMarkerName)
+				require.NoError(t, os.WriteFile(path, []byte(`{"status":"FAILED","step":"stop-vm","reason":5}`), 0o600))
+				return path
+			},
+		},
+		{
+			name: "oversize marker",
+			prepare: func(dir string) string {
+				path := filepath.Join(dir, shutdownMarkerName)
+				padding := strings.Repeat("x", maxShutdownMarkerBytes+1)
+				require.NoError(t, os.WriteFile(path, []byte(`{"status":"FAILED","step":"`+padding+`","reason":"r"}`), 0o600))
+				return path
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.prepare(dir)
+			err := checkShutdownMarker(dir)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "shutdown state unknown")
+			require.Contains(t, err.Error(), "yanet-lab down")
 		})
 	}
 }


### PR DESCRIPTION
- Add Lab `up` start-or-reuse with bounded timeout (Story 2.2 of `_bmad-output/planning-artifacts/lab/epics.md`).
- Split the CLI JSON envelope `protocol` field from the Supervisor-side `supervisorProtocolVersion`, so the two contracts evolve independently.
- Refuse to reuse a Supervisor that reports not OK, and refuse to clobber a session whose `supervisor.lock` is held by another process.
- Block startup while `shutdown-failed.json` is present, with a marker re-check immediately before forking `serve` to cover a concurrent-down race.
- Tear down a stale-protocol Supervisor and announce the replacement in the JSON envelope.
- Extract `callSupervisor`, `serveRunner`, and `shutdownMarkerCheck` package vars so the wire-ups can be tested without a real socket or QEMU.
- Stack on #1661.
