### PR TITLE
refactor(counters): store counter tags in fixed-size fields

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -3,15 +3,30 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "common/strutils.h"
 #include "lib/counters/counters.h"
 #include "lib/errors/errors.h"
 
 struct dp_config;
 
+#define COUNTER_TAG_KEY_LEN 80
+#define COUNTER_TAG_VALUE_LEN 80
+
+// A fixed-size (key, value) pair: tags travel by value inside predicates
+// and handle snapshots, so no string outlives the struct that carries it.
 struct counter_tag {
-	const char *key;
-	const char *value;
+	char key[COUNTER_TAG_KEY_LEN];
+	char value[COUNTER_TAG_VALUE_LEN];
 };
+
+// Return a tag with key and value truncated to the fixed field sizes.
+static inline struct counter_tag
+counter_tag_init(const char *key, const char *value) {
+	struct counter_tag tag;
+	(void)strtcpy(tag.key, key, sizeof(tag.key));
+	(void)strtcpy(tag.value, value, sizeof(tag.value));
+	return tag;
+}
 
 struct counter_handle {
 	char name[COUNTER_NAME_LEN];
@@ -55,6 +70,12 @@ yanet_counter_query_compile(
 void
 yanet_counter_query_free(struct counter_query *query);
 
+// The name-parameter reads below select storages by their entity-name
+// tags; entity names are truncated to the tag field sizes before the
+// comparison, matching any entity whose name shares the first
+// COUNTER_TAG_VALUE_LEN - 1 characters. Every name a configuration
+// accepts fits untruncated, so this only relaxes the match for
+// over-long caller-supplied names.
 struct counter_handle_list *
 yanet_get_device_counters(struct dp_config *dp_config, const char *device_name);
 
@@ -198,9 +219,11 @@ yanet_get_counter_values(
 // additionally carries a "config" tag naming its counter registry.
 //
 // A tag is rejected with err filled and NULL returned if any of the
-// following holds: key is NULL; value is NULL; key is unrecognized;
-// or tags contains another predicate with the same key. Tag strings
-// are borrowed only for the duration of the call.
+// following holds: key is unrecognized; or tags contains another
+// predicate with the same key. Keys and values are copied into the
+// tags' fixed-size fields, truncating anything longer than
+// COUNTER_TAG_KEY_LEN - 1 / COUNTER_TAG_VALUE_LEN - 1 characters; the
+// Go bindings reject such tags before the call instead.
 //
 // The returned list must be released with yanet_counter_handle_list_free.
 // On failure NULL is returned and err is filled; an empty match is a

--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -175,7 +175,8 @@ func (m *Counters) ByTags(
 	dpConfig := m.shm.DPConfig(m.instanceID)
 	groups, err := dpConfig.CountersByTags(tags, request.GetQuery())
 	if err != nil {
-		if errors.Is(err, ffi.ErrInvalidQuery) {
+		if errors.Is(err, ffi.ErrInvalidQuery) ||
+			errors.Is(err, ffi.ErrInvalidTag) {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		return nil, err

--- a/controlplane/ffi/counter.go
+++ b/controlplane/ffi/counter.go
@@ -347,6 +347,39 @@ func ValidateQuery(query []string) error {
 	return nil
 }
 
+const (
+	counterTagKeyLen   = C.COUNTER_TAG_KEY_LEN
+	counterTagValueLen = C.COUNTER_TAG_VALUE_LEN
+)
+
+// ErrInvalidTag reports a counter tag the fixed-size C counter_tag fields
+// cannot carry.
+var ErrInvalidTag = errors.New("invalid counter tag")
+
+// ValidateTag rejects a tag the fixed-size C counter_tag fields cannot
+// carry: one with a NUL byte, or a key or value that does not fit.
+func ValidateTag(tag CounterTag) error {
+	if strings.ContainsRune(tag.Key, 0) || strings.ContainsRune(tag.Value, 0) {
+		return fmt.Errorf("%w: key or value contains a NUL byte", ErrInvalidTag)
+	}
+	if len(tag.Key) >= counterTagKeyLen {
+		return fmt.Errorf(
+			"%w: key exceeds %d bytes",
+			ErrInvalidTag,
+			counterTagKeyLen-1,
+		)
+	}
+	if len(tag.Value) >= counterTagValueLen {
+		return fmt.Errorf(
+			"%w: value exceeds %d bytes",
+			ErrInvalidTag,
+			counterTagValueLen-1,
+		)
+	}
+
+	return nil
+}
+
 // CounterGroup is a set of counters that share the same tag set.
 type CounterGroup struct {
 	Tags     []CounterTag
@@ -370,13 +403,21 @@ func (m *DPConfig) CountersByTags(
 		return nil, err
 	}
 
+	// The tag fields are fixed-size arrays, zero-terminated by the
+	// zeroed slice; the C side reads no pointer out of them.
 	cTags := make([]C.struct_counter_tag, len(tags))
 	for idx, tag := range tags {
-		cKey := C.CString(tag.Key)
-		cValue := C.CString(tag.Value)
-		defer C.free(unsafe.Pointer(cKey))
-		defer C.free(unsafe.Pointer(cValue))
-		cTags[idx] = C.struct_counter_tag{key: cKey, value: cValue}
+		if err := ValidateTag(tag); err != nil {
+			return nil, err
+		}
+		key := []byte(tag.Key)
+		for pos := range key {
+			cTags[idx].key[pos] = C.char(key[pos])
+		}
+		value := []byte(tag.Value)
+		for pos := range value {
+			cTags[idx].value[pos] = C.char(value[pos])
+		}
 	}
 
 	cQuery := make([]*C.char, len(query))
@@ -581,8 +622,8 @@ func decodeCounterTags(
 	out := make([]CounterTag, count)
 	for idx := range cTags {
 		out[idx] = CounterTag{
-			Key:   C.GoString(cTags[idx].key),
-			Value: C.GoString(cTags[idx].value),
+			Key:   C.GoString(&cTags[idx].key[0]),
+			Value: C.GoString(&cTags[idx].value[0]),
 		}
 	}
 	return out

--- a/lib/controlplane/agent/counters.c
+++ b/lib/controlplane/agent/counters.c
@@ -82,13 +82,13 @@ yanet_get_module_counters(
 	// yanet_get_counters_by_tags, as are relation counters on
 	// module_object_link-kind storages sharing these six tags.
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = function_name},
-		{.key = "chain", .value = chain_name},
-		{.key = "module_type", .value = module_type},
-		{.key = "module_name", .value = module_name},
-		{.key = "kind", .value = "module"},
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("chain", chain_name),
+		counter_tag_init("module_type", module_type),
+		counter_tag_init("module_name", module_name),
+		counter_tag_init("kind", "module"),
 	};
 	return yanet_get_counters_by_tags(dp_config, tags, 7, query, NULL);
 }
@@ -108,40 +108,16 @@ counter_registry_match_count(
 	return matches;
 }
 
-// Deep-copy a tag array into freshly allocated memory.
+// Copy a tag array into freshly allocated memory, so a handle outlives
+// the generation arena the tags may live in.
 static struct counter_tag *
 counter_tags_dup(const struct counter_tag *tags, size_t tag_count) {
 	struct counter_tag *dup = malloc(tag_count * sizeof(*dup));
 	if (dup == NULL) {
 		return NULL;
 	}
-	for (size_t i = 0; i < tag_count; ++i) {
-		dup[i].key = NULL;
-		dup[i].value = NULL;
-	}
-	for (size_t i = 0; i < tag_count; ++i) {
-		dup[i].key = strdup(tags[i].key);
-		dup[i].value = strdup(tags[i].value);
-		if (dup[i].key == NULL || dup[i].value == NULL) {
-			for (size_t j = 0; j < tag_count; ++j) {
-				free((void *)dup[j].key);
-				free((void *)dup[j].value);
-			}
-			free(dup);
-			return NULL;
-		}
-	}
+	memcpy(dup, tags, tag_count * sizeof(*dup));
 	return dup;
-}
-
-static struct counter_tag *
-cp_counter_storage_copy_tags(const struct cp_counter_storage *storage) {
-	struct counter_tag view[MAX_TAG_COUNT];
-	for (size_t i = 0; i < storage->tag_count; ++i) {
-		view[i].key = storage->tags[i].key;
-		view[i].value = storage->tags[i].value;
-	}
-	return counter_tags_dup(view, storage->tag_count);
 }
 
 // Copy one already-described counter's per-worker value snapshot into
@@ -348,9 +324,9 @@ worker_counter_list_build(
 				continue;
 			}
 			if (storage_tags == NULL) {
-				storage_tags =
-					cp_counter_storage_copy_tags(cp_storage
-					);
+				storage_tags = counter_tags_dup(
+					cp_storage->tags, cp_storage->tag_count
+				);
 				if (storage_tags == NULL) {
 					yanet_error_add(err, "malloc failed");
 					yanet_counter_handle_list_free(list);
@@ -865,11 +841,11 @@ yanet_get_chain_counters(
 	const char *chain_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = function_name},
-		{.key = "chain", .value = chain_name},
-		{.key = "kind", .value = "chain"}
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("chain", chain_name),
+		counter_tag_init("kind", "chain")
 	};
 	return yanet_get_counters_by_tags(dp_config, tags, 5, NULL, NULL);
 }
@@ -882,10 +858,10 @@ yanet_get_function_counters(
 	const char *function_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = function_name},
-		{.key = "kind", .value = "function"}
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("kind", "function")
 	};
 	return yanet_get_counters_by_tags(dp_config, tags, 4, NULL, NULL);
 }
@@ -897,9 +873,9 @@ yanet_get_pipeline_counters(
 	const char *pipeline_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "kind", .value = "pipeline"}
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("kind", "pipeline")
 	};
 	return yanet_get_counters_by_tags(dp_config, tags, 3, NULL, NULL);
 }
@@ -909,8 +885,8 @@ yanet_get_device_counters(
 	struct dp_config *dp_config, const char *device_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "kind", .value = "device"}
+		counter_tag_init("device", device_name),
+		counter_tag_init("kind", "device")
 	};
 	return yanet_get_counters_by_tags(dp_config, tags, 2, NULL, NULL);
 }
@@ -922,9 +898,9 @@ yanet_get_object_counters(
 	const char *object_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "object_type", .value = object_type},
-		{.key = "object_name", .value = object_name},
-		{.key = "kind", .value = "object"}
+		counter_tag_init("object_type", object_type),
+		counter_tag_init("object_name", object_name),
+		counter_tag_init("kind", "object")
 	};
 	return yanet_get_counters_by_tags(dp_config, tags, 3, NULL, NULL);
 }
@@ -1131,11 +1107,9 @@ yanet_counter_handle_list_free(struct counter_handle_list *counters) {
 	}
 	struct counter_handle *handles = counters->counters;
 	for (size_t i = 0; i < counters->count; ++i) {
+		// Handles from one storage share that storage's tag array;
+		// free it once, on its first handle.
 		if (i == 0 || handles[i].tags != handles[i - 1].tags) {
-			for (size_t j = 0; j < handles[i].tag_count; ++j) {
-				free((void *)handles[i].tags[j].key);
-				free((void *)handles[i].tags[j].value);
-			}
 			free(handles[i].tags);
 		}
 		// This pointer is the base of the single allocation that also

--- a/lib/controlplane/config/cp_counter.c
+++ b/lib/controlplane/config/cp_counter.c
@@ -43,23 +43,22 @@ cp_config_counter_storage_registry_init(
 
 static int
 validate_tag(struct counter_tag *tag, bool predicate, yanet_error **err) {
-	if (tag->key == NULL) {
-		yanet_error_add(err, "key is required");
-		return -1;
-	}
-	if (tag->value == NULL) {
-		yanet_error_add(err, "value is required");
-		return -1;
-	}
-	if (strnlen(tag->key, KEY_MAX_SIZE) == KEY_MAX_SIZE) {
+	// The fixed-size fields cannot be NULL; the length checks only guard
+	// against a struct built without NUL termination.
+	if (strnlen(tag->key, COUNTER_TAG_KEY_LEN) == COUNTER_TAG_KEY_LEN) {
 		yanet_error_add(
-			err, "key length exceeds max %d", KEY_MAX_SIZE - 1
+			err,
+			"key length exceeds max %d",
+			COUNTER_TAG_KEY_LEN - 1
 		);
 		return -1;
 	}
-	if (strnlen(tag->value, VALUE_MAX_SIZE) == VALUE_MAX_SIZE) {
+	if (strnlen(tag->value, COUNTER_TAG_VALUE_LEN) ==
+	    COUNTER_TAG_VALUE_LEN) {
 		yanet_error_add(
-			err, "value length exceeds max %d", VALUE_MAX_SIZE - 1
+			err,
+			"value length exceeds max %d",
+			COUNTER_TAG_VALUE_LEN - 1
 		);
 		return -1;
 	}
@@ -154,8 +153,7 @@ cp_config_counter_storage_registry_insert(
 	}
 	struct counter_tag tags[MAX_TAG_COUNT];
 	for (size_t i = 0; i < tag_count; ++i) {
-		tags[i].key = const_tags[i].key;
-		tags[i].value = const_tags[i].value;
+		tags[i] = const_tags[i];
 	}
 
 	if (normalize_tags(tags, tag_count, false, err) != 0) {
@@ -197,10 +195,7 @@ cp_config_counter_storage_registry_insert(
 	SET_OFFSET_OF(&dst->storage, storage);
 	dst->tag_count = tag_count;
 	for (size_t i = 0; i < tag_count; ++i) {
-		struct cp_counter_tag *dst_tag = &dst->tags[i];
-		struct counter_tag *src = &tags[i];
-		strcpy(dst_tag->key, src->key);
-		strcpy(dst_tag->value, src->value);
+		dst->tags[i] = tags[i];
 	}
 
 	registry->count += 1;
@@ -212,7 +207,7 @@ static int
 check_match(
 	const struct counter_tag *filter,
 	size_t filter_count,
-	const struct cp_counter_tag *present,
+	const struct counter_tag *present,
 	size_t present_count
 ) {
 	size_t j = 0;
@@ -252,8 +247,7 @@ cp_config_counter_storage_registry_find(
 	}
 	struct counter_tag tags[MAX_TAG_COUNT];
 	for (size_t i = 0; i < tag_count; ++i) {
-		tags[i].key = const_tags[i].key;
-		tags[i].value = const_tags[i].value;
+		tags[i] = const_tags[i];
 	}
 
 	if (normalize_tags(tags, tag_count, true, err) != 0) {
@@ -326,8 +320,8 @@ cp_config_counter_storage_registry_lookup_device(
 	const char *device_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "kind", .value = "device"}
+		counter_tag_init("device", device_name),
+		counter_tag_init("kind", "device")
 	};
 	return get_one(registry, tags, 2);
 }
@@ -340,8 +334,8 @@ cp_config_counter_storage_registry_insert_device(
 	yanet_error **err
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "kind", .value = "device"},
+		counter_tag_init("device", device_name),
+		counter_tag_init("kind", "device"),
 	};
 	return cp_config_counter_storage_registry_insert(
 		registry, tags, 2, counter_storage, err
@@ -355,9 +349,9 @@ cp_config_counter_storage_registry_lookup_pipeline(
 	const char *pipeline_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "kind", .value = "pipeline"}
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("kind", "pipeline")
 	};
 	return get_one(registry, tags, 3);
 }
@@ -371,9 +365,9 @@ cp_config_counter_storage_registry_insert_pipeline(
 	yanet_error **err
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "kind", .value = "pipeline"},
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("kind", "pipeline"),
 	};
 	return cp_config_counter_storage_registry_insert(
 		registry, tags, 3, counter_storage, err
@@ -388,13 +382,10 @@ cp_config_counter_storage_registry_lookup_function(
 	const char *function_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{
-			.key = "function",
-			.value = function_name,
-		},
-		{.key = "kind", .value = "function"}
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("kind", "function")
 	};
 	return get_one(registry, tags, 4);
 }
@@ -409,10 +400,10 @@ cp_config_counter_storage_registry_insert_function(
 	yanet_error **err
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = function_name},
-		{.key = "kind", .value = "function"},
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("kind", "function"),
 	};
 	return cp_config_counter_storage_registry_insert(
 		registry, tags, 4, counter_storage, err
@@ -428,14 +419,11 @@ cp_config_counter_storage_registry_lookup_chain(
 	const char *chain_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{
-			.key = "function",
-			.value = function_name,
-		},
-		{.key = "chain", .value = chain_name},
-		{.key = "kind", .value = "chain"}
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("chain", chain_name),
+		counter_tag_init("kind", "chain")
 	};
 	return get_one(registry, tags, 5);
 }
@@ -451,11 +439,11 @@ cp_config_counter_storage_registry_insert_chain(
 	yanet_error **err
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = function_name},
-		{.key = "chain", .value = chain_name},
-		{.key = "kind", .value = "chain"},
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("chain", chain_name),
+		counter_tag_init("kind", "chain"),
 	};
 	return cp_config_counter_storage_registry_insert(
 		registry, tags, 5, counter_storage, err
@@ -473,13 +461,13 @@ cp_config_counter_storage_registry_lookup_module(
 	const char *module_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = function_name},
-		{.key = "chain", .value = chain_name},
-		{.key = "module_type", .value = module_type},
-		{.key = "module_name", .value = module_name},
-		{.key = "kind", .value = "module"},
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("chain", chain_name),
+		counter_tag_init("module_type", module_type),
+		counter_tag_init("module_name", module_name),
+		counter_tag_init("kind", "module"),
 	};
 	return get_one(registry, tags, 7);
 }
@@ -497,13 +485,13 @@ cp_config_counter_storage_registry_insert_module(
 	yanet_error **err
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = function_name},
-		{.key = "chain", .value = chain_name},
-		{.key = "module_type", .value = module_type},
-		{.key = "module_name", .value = module_name},
-		{.key = "kind", .value = "module"},
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("chain", chain_name),
+		counter_tag_init("module_type", module_type),
+		counter_tag_init("module_name", module_name),
+		counter_tag_init("kind", "module"),
 	};
 	return cp_config_counter_storage_registry_insert(
 		registry, tags, 7, counter_storage, err
@@ -522,14 +510,14 @@ cp_config_counter_storage_registry_lookup_module_tagged(
 	const char *registry_tag
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = function_name},
-		{.key = "chain", .value = chain_name},
-		{.key = "module_type", .value = module_type},
-		{.key = "module_name", .value = module_name},
-		{.key = "kind", .value = "runtime"},
-		{.key = "config", .value = registry_tag},
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("chain", chain_name),
+		counter_tag_init("module_type", module_type),
+		counter_tag_init("module_name", module_name),
+		counter_tag_init("kind", "runtime"),
+		counter_tag_init("config", registry_tag),
 	};
 	return get_one(registry, tags, 8);
 }
@@ -548,14 +536,14 @@ cp_config_counter_storage_registry_insert_module_tagged(
 	yanet_error **err
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = function_name},
-		{.key = "chain", .value = chain_name},
-		{.key = "module_type", .value = module_type},
-		{.key = "module_name", .value = module_name},
-		{.key = "kind", .value = "runtime"},
-		{.key = "config", .value = registry_tag},
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("chain", chain_name),
+		counter_tag_init("module_type", module_type),
+		counter_tag_init("module_name", module_name),
+		counter_tag_init("kind", "runtime"),
+		counter_tag_init("config", registry_tag),
 	};
 	return cp_config_counter_storage_registry_insert(
 		registry, tags, 8, counter_storage, err
@@ -569,9 +557,9 @@ cp_config_counter_storage_registry_lookup_object(
 	const char *object_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "object_type", .value = object_type},
-		{.key = "object_name", .value = object_name},
-		{.key = "kind", .value = "object"}
+		counter_tag_init("object_type", object_type),
+		counter_tag_init("object_name", object_name),
+		counter_tag_init("kind", "object")
 	};
 	return get_one(registry, tags, 3);
 }
@@ -585,9 +573,9 @@ cp_config_counter_storage_registry_insert_object(
 	yanet_error **err
 ) {
 	struct counter_tag tags[] = {
-		{.key = "object_type", .value = object_type},
-		{.key = "object_name", .value = object_name},
-		{.key = "kind", .value = "object"},
+		counter_tag_init("object_type", object_type),
+		counter_tag_init("object_name", object_name),
+		counter_tag_init("kind", "object"),
 	};
 	return cp_config_counter_storage_registry_insert(
 		registry, tags, 3, counter_storage, err
@@ -607,14 +595,14 @@ cp_config_counter_storage_registry_lookup_module_object_link(
 	const char *object_name
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = function_name},
-		{.key = "chain", .value = chain_name},
-		{.key = "module_type", .value = module_type},
-		{.key = "module_name", .value = module_name},
-		{.key = "object_type", .value = object_type},
-		{.key = "object_name", .value = object_name}
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("chain", chain_name),
+		counter_tag_init("module_type", module_type),
+		counter_tag_init("module_name", module_name),
+		counter_tag_init("object_type", object_type),
+		counter_tag_init("object_name", object_name)
 	};
 	return get_one(registry, tags, 8);
 }
@@ -634,15 +622,15 @@ cp_config_counter_storage_registry_insert_module_object_link(
 	yanet_error **err
 ) {
 	struct counter_tag tags[] = {
-		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = function_name},
-		{.key = "chain", .value = chain_name},
-		{.key = "module_type", .value = module_type},
-		{.key = "module_name", .value = module_name},
-		{.key = "object_type", .value = object_type},
-		{.key = "object_name", .value = object_name},
-		{.key = "kind", .value = "module_object_link"}
+		counter_tag_init("device", device_name),
+		counter_tag_init("pipeline", pipeline_name),
+		counter_tag_init("function", function_name),
+		counter_tag_init("chain", chain_name),
+		counter_tag_init("module_type", module_type),
+		counter_tag_init("module_name", module_name),
+		counter_tag_init("object_type", object_type),
+		counter_tag_init("object_name", object_name),
+		counter_tag_init("kind", "module_object_link")
 	};
 	return cp_config_counter_storage_registry_insert(
 		registry, tags, 9, counter_storage, err

--- a/lib/controlplane/config/cp_counter.h
+++ b/lib/controlplane/config/cp_counter.h
@@ -7,17 +7,13 @@
 
 struct memory_context;
 
-#define KEY_MAX_SIZE 80
-#define VALUE_MAX_SIZE 80
 #define MAX_TAG_COUNT 16
 
-struct cp_counter_tag {
-	char key[KEY_MAX_SIZE];
-	char value[VALUE_MAX_SIZE];
-};
-
+// Tag sets are stored by value: the fixed-size counter_tag keeps them
+// copyable between the arena and plain heap memory without per-string
+// allocation.
 struct cp_counter_storage {
-	struct cp_counter_tag tags[MAX_TAG_COUNT];
+	struct counter_tag tags[MAX_TAG_COUNT];
 	size_t tag_count;
 	struct counter_storage *storage;
 };

--- a/lib/controlplane/tests/counters_test.c
+++ b/lib/controlplane/tests/counters_test.c
@@ -6,7 +6,8 @@
  * These port two confirmed use-after-free repros against the copy-on-read
  * fix: a value-page surface (the agent counters API snapshots
  * handle->values under cp_config_lock) and a tag-string surface (tags are
- * strdup'd instead of borrowed from the freed generation arena).
+ * copied into fixed-size fields instead of borrowed from the freed
+ * generation arena).
  */
 
 #include "api/agent.h"

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -2,6 +2,7 @@ package acl
 
 import (
 	"context"
+	"errors"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -120,6 +121,9 @@ func (m *ACLService) RuleMetrics(req *aclpb.GetMetricsRulesRequest) ([]*commonpb
 
 	groups, err := dpConfig.CountersByTags(ruleQueryTags(req), nil)
 	if err != nil {
+		if errors.Is(err, ffi.ErrInvalidTag) {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 		return nil, status.Errorf(
 			codes.Internal, "failed to read rule counters: %v", err,
 		)

--- a/tests/counters/query_test.go
+++ b/tests/counters/query_test.go
@@ -192,3 +192,41 @@ func TestCountersByTagsRejectsBadQuery(t *testing.T) {
 		})
 	}
 }
+
+// tagFieldLen mirrors the fixed size of the C counter_tag key and value
+// fields.
+const tagFieldLen = 80
+
+// A tag the fixed-size C fields cannot carry fails the call instead of
+// being silently truncated into a predicate for a different tag set.
+func TestCountersByTagsRejectsBadTag(t *testing.T) {
+	dp := installQuerySurface(t)
+
+	for _, tc := range []struct {
+		name string
+		tag  ffi.CounterTag
+	}{
+		{
+			name: "over-long key",
+			tag:  ffi.CounterTag{Key: strings.Repeat("k", tagFieldLen)},
+		},
+		{
+			name: "over-long value",
+			tag: ffi.CounterTag{
+				Key:   "device",
+				Value: strings.Repeat("v", tagFieldLen),
+			},
+		},
+		{
+			name: "embedded NUL",
+			tag:  ffi.CounterTag{Key: "device", Value: "port0\x00x"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			groups, err := dp.CountersByTags([]ffi.CounterTag{tc.tag}, nil)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ffi.ErrInvalidTag)
+			require.Nil(t, groups)
+		})
+	}
+}


### PR DESCRIPTION
- Convert `struct counter_tag` from `const char *` pointers to fixed-size `char` arrays, so counter tag retrieval copies tags by value instead of `strdup`/`free`-ing every key and string value.
- Fold the duplicate `cp_counter_tag` into `counter_tag`, making tag sets single `memcpy`-able values across the arena registry, handle snapshots, and the per-worker merge paths.
- Replace the per-string `strdup` duplication with one allocation per tag array, freed once per storage in the list free path.
- Reject tags the fixed fields cannot carry (NUL bytes, ≥80-byte keys/values) in the Go bindings with `ErrInvalidTag`, mapped to `InvalidArgument` by the builtin counters service and the ACL rule-metrics service.
- Document the name-parameter entrypoints' truncation behavior and add `TestCountersByTagsRejectsBadTag` covering over-long keys, over-long values, and embedded NULs.