### PR TITLE
perf(filter,acl): skip the lo walk on uniform combine rows

### DIFF
--- a/lib/filter/classifiers/net6.h
+++ b/lib/filter/classifiers/net6.h
@@ -13,6 +13,13 @@ struct net6_classifier {
 	struct lpm lo;
 	struct value_table comb;
 	struct net6_memo memo;
+	// Per-hi-class uniform-row shortcut: bit set in hi_uniform means
+	// every lo class combines with this hi class to hi_uniform_value, so
+	// the lookup can skip the lo walk and the combine fetch entirely.
+	// hi_uniform holds ceil(v_dim / 8) bytes and hi_uniform_value holds
+	// v_dim entries; both are shared-memory relative pointers.
+	uint8_t *hi_uniform;
+	uint32_t *hi_uniform_value;
 };
 
 // Shared per-direction IPv6 half-address classification.

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -532,9 +532,10 @@ merge_net6_range(
 	action_get_net6_func get_net6,
 	const struct range_index *ri_hi,
 	const struct range_index *ri_lo,
-	struct value_table *table,
+	struct net6_classifier *net6,
 	struct value_registry *registry
 ) {
+	struct value_table *table = &net6->comb;
 	struct net6 *nets;
 	uint64_t net_cnt = 0;
 	struct radix net_radix;
@@ -576,6 +577,59 @@ merge_net6_range(
 		    table
 	    )) {
 		goto error_table;
+	}
+
+	// Row-uniformity shortcut: a hi class whose whole combine row holds
+	// one value resolves without the lo walk. Rows never touched by any
+	// network read back the compacted default and are uniform too. The
+	// scan early-exits on the first differing cell, so non-uniform rows
+	// cost a couple of loads.
+	{
+		uint32_t hi_count = table->v_dim;
+		uint8_t *uniform = (uint8_t *)memory_balloc(
+			memory_context, (hi_count + 7) / 8
+		);
+		uint32_t *uniform_value = (uint32_t *)memory_balloc(
+			memory_context, sizeof(uint32_t) * hi_count
+		);
+		if (uniform == NULL || uniform_value == NULL) {
+			if (uniform != NULL) {
+				memory_bfree(
+					memory_context,
+					uniform,
+					(hi_count + 7) / 8
+				);
+			}
+			if (uniform_value != NULL) {
+				memory_bfree(
+					memory_context,
+					uniform_value,
+					sizeof(uint32_t) * hi_count
+				);
+			}
+			goto error_table;
+		}
+
+		memset(uniform, 0, (hi_count + 7) / 8);
+		for (uint32_t idx_hi = 0; idx_hi < hi_count; ++idx_hi) {
+			uint32_t first = value_table_get(table, idx_hi, 0);
+			bool row_uniform = true;
+			for (uint32_t idx_lo = 1; idx_lo < table->h_dim;
+			     ++idx_lo) {
+				if (value_table_get(table, idx_hi, idx_lo) !=
+				    first) {
+					row_uniform = false;
+					break;
+				}
+			}
+			if (row_uniform) {
+				uniform[idx_hi / 8] |= 1u << (idx_hi % 8);
+				uniform_value[idx_hi] = first;
+			}
+		}
+
+		SET_OFFSET_OF(&net6->hi_uniform, uniform);
+		SET_OFFSET_OF(&net6->hi_uniform_value, uniform_value);
 	}
 
 	struct value_registry net_registry;
@@ -658,8 +712,23 @@ error_registry:
 error_net_registry:
 	value_registry_fini(&net_registry);
 
-error_table:
+error_table: {
+	uint8_t *uniform = ADDR_OF(&net6->hi_uniform);
+	if (uniform != NULL) {
+		memory_bfree(memory_context, uniform, (table->v_dim + 7) / 8);
+		SET_OFFSET_OF(&net6->hi_uniform, NULL);
+	}
+	uint32_t *uniform_value = ADDR_OF(&net6->hi_uniform_value);
+	if (uniform_value != NULL) {
+		memory_bfree(
+			memory_context,
+			uniform_value,
+			sizeof(uint32_t) * table->v_dim
+		);
+		SET_OFFSET_OF(&net6->hi_uniform_value, NULL);
+	}
 	value_table_free(table);
+}
 
 error_info:
 	for (uint32_t idx = 0; idx < net_range_count; ++idx) {
@@ -701,6 +770,9 @@ init_net6(
 	if (net6 == NULL) {
 		return -1;
 	}
+	// Zero so every error unwind sees NULL optional pointers (memo,
+	// uniform-row shortcut) instead of arena poison.
+	memset(net6, 0, sizeof(struct net6_classifier));
 	SET_OFFSET_OF(data, net6);
 
 	struct range_index ri_hi;
@@ -738,7 +810,7 @@ init_net6(
 		    get_net6,
 		    &ri_hi,
 		    &ri_lo,
-		    &net6->comb,
+		    net6,
 		    registry
 	    )) {
 		goto error_merge;
@@ -749,6 +821,23 @@ init_net6(
 	if (net6_memo_init(&net6->memo, memory_context)) {
 		range_index_free(&ri_lo);
 		range_index_free(&ri_hi);
+
+		uint8_t *uniform = ADDR_OF(&net6->hi_uniform);
+		if (uniform != NULL) {
+			memory_bfree(
+				memory_context,
+				uniform,
+				(net6->comb.v_dim + 7) / 8
+			);
+		}
+		uint32_t *uniform_value = ADDR_OF(&net6->hi_uniform_value);
+		if (uniform_value != NULL) {
+			memory_bfree(
+				memory_context,
+				uniform_value,
+				sizeof(uint32_t) * net6->comb.v_dim
+			);
+		}
 		value_table_free(&net6->comb);
 		lpm_free(&net6->lo);
 		lpm_free(&net6->hi);
@@ -829,6 +918,22 @@ free_net6(void *data, struct memory_context *memory_context) {
 	lpm_free(&c->hi);
 	value_table_free(&c->comb);
 	net6_memo_fini(&c->memo, memory_context);
+
+	uint8_t *uniform = ADDR_OF(&c->hi_uniform);
+	if (uniform != NULL) {
+		memory_bfree(memory_context, uniform, (c->comb.v_dim + 7) / 8);
+		SET_OFFSET_OF(&c->hi_uniform, NULL);
+	}
+	uint32_t *uniform_value = ADDR_OF(&c->hi_uniform_value);
+	if (uniform_value != NULL) {
+		memory_bfree(
+			memory_context,
+			uniform_value,
+			sizeof(uint32_t) * c->comb.v_dim
+		);
+		SET_OFFSET_OF(&c->hi_uniform_value, NULL);
+	}
+
 	memory_bfree(memory_context, c, sizeof(struct net6_classifier));
 }
 

--- a/lib/filter/query/net6.h
+++ b/lib/filter/query/net6.h
@@ -33,8 +33,19 @@ FILTER_ATTR_QUERY_FUNC(net6_dst)(
 		}
 
 		uint32_t hi = lpm8_lookup(&c->hi, daddr);
-		uint32_t lo = lpm8_lookup(&c->lo, daddr + 8);
-		verdict = value_table_get(&c->comb, hi, lo);
+
+		// A uniform combine row resolves the address without the lo
+		// walk: every lo class yields the same verdict for this hi
+		// class.
+		const uint8_t *uniform = ADDR_OF(&c->hi_uniform);
+		if (uniform != NULL && (uniform[hi / 8] & (1u << (hi % 8)))) {
+			const uint32_t *uniform_value =
+				ADDR_OF(&c->hi_uniform_value);
+			verdict = uniform_value[hi];
+		} else {
+			uint32_t lo = lpm8_lookup(&c->lo, daddr + 8);
+			verdict = value_table_get(&c->comb, hi, lo);
+		}
 		net6_memo_insert(&c->memo, daddr, verdict);
 		result[idx] = verdict;
 	}
@@ -63,8 +74,19 @@ FILTER_ATTR_QUERY_FUNC(net6_src)(
 		}
 
 		uint32_t hi = lpm8_lookup(&c->hi, saddr);
-		uint32_t lo = lpm8_lookup(&c->lo, saddr + 8);
-		verdict = value_table_get(&c->comb, hi, lo);
+
+		// A uniform combine row resolves the address without the lo
+		// walk: every lo class yields the same verdict for this hi
+		// class.
+		const uint8_t *uniform = ADDR_OF(&c->hi_uniform);
+		if (uniform != NULL && (uniform[hi / 8] & (1u << (hi % 8)))) {
+			const uint32_t *uniform_value =
+				ADDR_OF(&c->hi_uniform_value);
+			verdict = uniform_value[hi];
+		} else {
+			uint32_t lo = lpm8_lookup(&c->lo, saddr + 8);
+			verdict = value_table_get(&c->comb, hi, lo);
+		}
 		net6_memo_insert(&c->memo, saddr, verdict);
 		result[idx] = verdict;
 	}

--- a/lib/filter/tests/bench_net6_quad.c
+++ b/lib/filter/tests/bench_net6_quad.c
@@ -505,15 +505,33 @@ time_memo_quad(
 		uint32_t verdict;
 		if (!net6_memo_lookup(&src->memo, src_addrs[idx], &verdict)) {
 			uint32_t hi = lpm8_lookup(&src->hi, src_addrs[idx]);
-			uint32_t lo = lpm8_lookup(&src->lo, src_addrs[idx] + 8);
-			verdict = value_table_get(&src->comb, hi, lo);
+
+			const uint8_t *uniform = ADDR_OF(&src->hi_uniform);
+			if (uniform != NULL &&
+			    (uniform[hi / 8] & (1u << (hi % 8)))) {
+				verdict = ADDR_OF(&src->hi_uniform_value)[hi];
+			} else {
+				uint32_t lo = lpm8_lookup(
+					&src->lo, src_addrs[idx] + 8
+				);
+				verdict = value_table_get(&src->comb, hi, lo);
+			}
 			net6_memo_insert(&src->memo, src_addrs[idx], verdict);
 		}
 		quad_sink ^= verdict;
 		if (!net6_memo_lookup(&dst->memo, dst_addrs[idx], &verdict)) {
 			uint32_t hi = lpm8_lookup(&dst->hi, dst_addrs[idx]);
-			uint32_t lo = lpm8_lookup(&dst->lo, dst_addrs[idx] + 8);
-			verdict = value_table_get(&dst->comb, hi, lo);
+
+			const uint8_t *uniform = ADDR_OF(&dst->hi_uniform);
+			if (uniform != NULL &&
+			    (uniform[hi / 8] & (1u << (hi % 8)))) {
+				verdict = ADDR_OF(&dst->hi_uniform_value)[hi];
+			} else {
+				uint32_t lo = lpm8_lookup(
+					&dst->lo, dst_addrs[idx] + 8
+				);
+				verdict = value_table_get(&dst->comb, hi, lo);
+			}
 			net6_memo_insert(&dst->memo, dst_addrs[idx], verdict);
 		}
 		quad_sink ^= verdict;

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -457,7 +457,6 @@ acl_handle_packets(
 			}
 
 			dst_hi[idx] = lpm8_lookup(&share_dst->hi, daddr);
-			dst_lo[idx] = lpm8_lookup(&share_dst->lo, daddr + 8);
 
 			const uint32_t *dst_hi_a =
 				ADDR_OF(&share_dst->remap_hi_a);
@@ -468,14 +467,49 @@ acl_handle_packets(
 			const uint32_t *dst_lo_b =
 				ADDR_OF(&share_dst->remap_lo_b);
 
+			// Both leaf filters resolving this hi class through a
+			// uniform combine row makes the lo union walk
+			// unnecessary: every lo class yields the same verdicts.
+			uint32_t local_hi_a = dst_hi_a[dst_hi[idx]];
+			uint32_t local_hi_b = dst_hi_b[dst_hi[idx]];
+			const uint8_t *uniform_a =
+				ADDR_OF(&ip6_dst_cls->hi_uniform);
+			const uint8_t *uniform_b =
+				ADDR_OF(&ip6_port_dst_cls->hi_uniform);
+			if (uniform_a != NULL && uniform_b != NULL &&
+			    (uniform_a[local_hi_a / 8] &
+			     (1u << (local_hi_a % 8))) &&
+			    (uniform_b[local_hi_b / 8] &
+			     (1u << (local_hi_b % 8)))) {
+				ip6_dst_slots[idx] =
+					ADDR_OF(&ip6_dst_cls->hi_uniform_value
+					)[local_hi_a];
+				ip6_dst_slots_b[idx] = ADDR_OF(
+					&ip6_port_dst_cls->hi_uniform_value
+				)[local_hi_b];
+				net6_memo_insert(
+					&share_dst->memo_a,
+					daddr,
+					ip6_dst_slots[idx]
+				);
+				net6_memo_insert(
+					&share_dst->memo_b,
+					daddr,
+					ip6_dst_slots_b[idx]
+				);
+				continue;
+			}
+
+			dst_lo[idx] = lpm8_lookup(&share_dst->lo, daddr + 8);
+
 			ip6_dst_slots[idx] = value_table_get(
 				&ip6_dst_cls->comb,
-				dst_hi_a[dst_hi[idx]],
+				local_hi_a,
 				dst_lo_a[dst_lo[idx]]
 			);
 			ip6_dst_slots_b[idx] = value_table_get(
 				&ip6_port_dst_cls->comb,
-				dst_hi_b[dst_hi[idx]],
+				local_hi_b,
 				dst_lo_b[dst_lo[idx]]
 			);
 			net6_memo_insert(


### PR DESCRIPTION
Cut the lo half-trie walk for addresses whose hi class resolves through a uniform combine row, stacked on the net6 verdict memo PR.

- The compiler marks, per hi class, whether every lo class combines to the same verdict, and stores a bitmap plus the per-class uniform value alongside the combine table. Untouched rows are uniform too — they read the compacted default.
- The query path checks the bit right after the hi walk and skips both the lo walk and the combine fetch when set. This covers the short-prefix majority, where no lo-side prefix differentiates verdicts.
- The shared net6 classification takes the same shortcut when both leaf filters fed by the union tries resolve the hi class through uniform rows, skipping the lo union walk and both leaf combine fetches.
- On the production capture replay this drops the memoized miss path from 11 to 7.5 ns per address, because most misses now walk only the hi trie.

Rebase onto main once the memo PR lands; the branch contains only the uniform-row commit on top of it.