### PR TITLE
chore(ci): publish architecture-specific debian packages

### DIFF
--- a/.github/scripts/release-deb-artifacts.sh
+++ b/.github/scripts/release-deb-artifacts.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -euo pipefail
+
+export LC_ALL=C
+
+fail() {
+    echo "release Debian artifact validation failed: $*" >&2
+    exit 1
+}
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+    fail "usage: $0 <artifact-directory> <output-directory> [--include-2204]"
+fi
+
+artifact_dir=$1
+output_dir=$2
+include_2204=false
+if [[ $# -eq 3 ]]; then
+    [[ $3 == --include-2204 ]] || fail "unknown option: $3"
+    include_2204=true
+fi
+[[ -d $artifact_dir ]] || fail "artifact directory does not exist: $artifact_dir"
+artifact_dir=$(cd -- "$artifact_dir" && pwd -P)
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+verifier=${DEB_ARTIFACT_VERIFIER:-$script_dir/../../scripts/verify-deb-artifacts.sh}
+[[ -x $verifier ]] || fail "verifier is not executable: $verifier"
+
+expected_sets=(debs-24.04-amd64 debs-24.04-arm64)
+if [[ $include_2204 == true ]]; then
+    expected_sets+=(debs-22.04-amd64)
+fi
+mapfile -t expected_sets < <(printf '%s\n' "${expected_sets[@]}" | sort)
+mapfile -t artifact_sets < <(
+    find "$artifact_dir" -mindepth 1 -maxdepth 1 -type d -name 'debs-*' -printf '%f\n' | sort
+)
+if [[ "${artifact_sets[*]-}" != "${expected_sets[*]}" ]]; then
+    fail "unexpected Debian artifact sets: ${artifact_sets[*]-}; expected: ${expected_sets[*]}"
+fi
+
+artifact_version=
+for artifact_set in "${artifact_sets[@]}"; do
+    case $artifact_set in
+        debs-24.04-amd64|debs-22.04-amd64)
+            expected_arch=amd64
+            ;;
+        debs-24.04-arm64)
+            expected_arch=arm64
+            ;;
+        *)
+            fail "unsupported Debian artifact set: $artifact_set"
+            ;;
+    esac
+
+    mapfile -t changes_files < <(
+        find "$artifact_dir/$artifact_set" -maxdepth 1 -type f -name '*.changes' -print | sort
+    )
+    (( ${#changes_files[@]} == 1 )) ||
+        fail "expected exactly one .changes file in $artifact_set"
+    changes_version=$(awk -F': ' '$1 == "Version" { print $2; exit }' "${changes_files[0]}")
+    [[ -n $changes_version ]] || fail "missing Version in ${changes_files[0]}"
+    if [[ -z $artifact_version ]]; then
+        artifact_version=$changes_version
+    elif [[ $changes_version != "$artifact_version" ]]; then
+        fail "mixed release versions: $artifact_version and $changes_version"
+    fi
+
+    echo "Verifying $artifact_set"
+    "$verifier" "$artifact_dir/$artifact_set" "$expected_arch"
+done
+
+release_sets=(debs-24.04-amd64 debs-24.04-arm64)
+mkdir -p -- "$output_dir"
+for release_set in "${release_sets[@]}"; do
+    while IFS= read -r -d '' artifact; do
+        destination=$output_dir/$(basename "$artifact")
+        [[ ! -e $destination ]] || fail "artifact filename collision: $(basename "$artifact")"
+        cp -- "$artifact" "$destination"
+    done < <(
+        find "$artifact_dir/$release_set" -type f \( -name '*.changes' -o -name '*.deb' -o -name '*.ddeb' \) -print0 |
+            sort -z
+    )
+done
+
+echo "Validated ${#artifact_sets[@]} Debian artifact sets at version $artifact_version"
+echo "Flattened ${#release_sets[@]} release artifact sets into $output_dir"

--- a/.github/scripts/release-deb-artifacts_test.sh
+++ b/.github/scripts/release-deb-artifacts_test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -euo pipefail
+
+export LC_ALL=C
+
+repo_root=$(cd -- "$(dirname -- "$0")/../.." && pwd -P)
+helper=$repo_root/.github/scripts/release-deb-artifacts.sh
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+fail() {
+    echo "release Debian artifact test failed: $*" >&2
+    exit 1
+}
+
+fake_verifier=$test_root/fake-verifier
+verification_log=$test_root/verifications
+printf '%s\n' \
+    '#!/bin/bash' \
+    'set -euo pipefail' \
+    '[[ $# -eq 2 ]] || exit 2' \
+    'printf '\''%s %s\n'\'' "$(basename "$1")" "$2" >>"$VERIFY_LOG"' \
+    >"$fake_verifier"
+chmod +x "$fake_verifier"
+export DEB_ARTIFACT_VERIFIER=$fake_verifier
+export VERIFY_LOG=$verification_log
+
+make_set() {
+    local set_dir=$1
+    local architecture=$2
+    local version=$3
+    local prefix=${4:-yanet}
+    local changes_name=${5:-$prefix-$architecture.changes}
+    mkdir -p "$set_dir"
+    printf 'Version: %s\n' "$version" >"$set_dir/$changes_name"
+    : >"$set_dir/${prefix}_${architecture}.deb"
+    : >"$set_dir/${prefix}-dbgsym_${architecture}.ddeb"
+}
+
+expect_failure() {
+    local expected=$1
+    shift
+    local log=$test_root/failure.log
+    if "$@" >"$log" 2>&1; then
+        fail "command unexpectedly succeeded: $*"
+    fi
+    grep -Fq -- "$expected" "$log" || {
+        cat "$log" >&2
+        fail "failure did not contain: $expected"
+    }
+}
+
+valid=$test_root/valid
+make_set "$valid/artifacts/debs-24.04-amd64" amd64 1.2.3 yanet
+make_set "$valid/artifacts/debs-24.04-arm64" arm64 1.2.3 yanet
+make_set "$valid/artifacts/debs-22.04-amd64" amd64 1.2.3 legacy legacy-22.04.changes
+"$helper" "$valid/artifacts" "$valid/out" --include-2204 >/dev/null
+[[ $(find "$valid/out" -type f | wc -l) -eq 6 ]] || fail 'unexpected release file count'
+[[ ! -e "$valid/out/legacy_amd64.deb" ]] || fail '22.04 package was flattened'
+[[ $(wc -l <"$verification_log") -eq 3 ]] || fail 'not all sets were verified'
+
+unexpected=$test_root/unexpected
+make_set "$unexpected/artifacts/debs-24.04-amd64" amd64 1.2.3
+make_set "$unexpected/artifacts/debs-24.04-arm64" arm64 1.2.3
+make_set "$unexpected/artifacts/debs-22.04-amd64" amd64 1.2.3
+expect_failure 'unexpected Debian artifact sets' "$helper" "$unexpected/artifacts" "$unexpected/out"
+
+mixed=$test_root/mixed
+make_set "$mixed/artifacts/debs-24.04-amd64" amd64 1.2.3
+make_set "$mixed/artifacts/debs-24.04-arm64" arm64 2.0.0
+expect_failure 'mixed release versions' "$helper" "$mixed/artifacts" "$mixed/out"
+
+collision=$test_root/collision
+make_set "$collision/artifacts/debs-24.04-amd64" amd64 1.2.3 yanet shared.changes
+make_set "$collision/artifacts/debs-24.04-arm64" arm64 1.2.3 yanet shared.changes
+expect_failure 'artifact filename collision: shared.changes' "$helper" "$collision/artifacts" "$collision/out"
+
+echo 'release Debian artifact helper tests passed'

--- a/.github/scripts/verify-deb-artifacts_test.sh
+++ b/.github/scripts/verify-deb-artifacts_test.sh
@@ -20,11 +20,6 @@ printf '%s\n' '#!/bin/bash' 'exit 0' >"$fake_bin/dscverify"
 printf '%s\n' \
     '#!/bin/bash' \
     'set -euo pipefail' \
-    'awk '\''$0 == "Files:" { in_files=1; next } in_files && /^[^[:space:]][^:]*:/ { in_files=0 } in_files && $NF ~ /\.(deb|ddeb)$/ { print $NF }'\'' "$1"' \
-    >"$fake_bin/dcmd"
-printf '%s\n' \
-    '#!/bin/bash' \
-    'set -euo pipefail' \
     '[[ ${1:-} == --field ]] || exit 2' \
     'case "$(basename "$2"):$3" in' \
     '  yanet-test_1.2.3_amd64.deb:Package) printf "%s\\n" yanet-test ;;' \
@@ -37,7 +32,7 @@ printf '%s\n' \
     '  *) exit 1 ;;' \
     'esac' \
     >"$fake_bin/dpkg-deb"
-chmod +x "$fake_bin/dscverify" "$fake_bin/dcmd" "$fake_bin/dpkg-deb"
+chmod +x "$fake_bin/dscverify" "$fake_bin/dpkg-deb"
 export PATH="$fake_bin:$PATH"
 
 runtime=yanet-test_1.2.3_amd64.deb

--- a/.github/scripts/verify-deb-artifacts_test.sh
+++ b/.github/scripts/verify-deb-artifacts_test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -euo pipefail
+
+export LC_ALL=C
+
+repo_root=$(cd -- "$(dirname -- "$0")/../.." && pwd -P)
+verifier=$repo_root/scripts/verify-deb-artifacts.sh
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+fail() {
+    echo "deb verifier test failed: $*" >&2
+    exit 1
+}
+
+fake_bin=$test_root/bin
+artifact_dir=$test_root/artifacts
+mkdir -p "$fake_bin" "$artifact_dir"
+printf '%s\n' '#!/bin/bash' 'exit 0' >"$fake_bin/dscverify"
+printf '%s\n' \
+    '#!/bin/bash' \
+    'set -euo pipefail' \
+    'awk '\''$0 == "Files:" { in_files=1; next } in_files && /^[^[:space:]][^:]*:/ { in_files=0 } in_files && $NF ~ /\.(deb|ddeb)$/ { print $NF }'\'' "$1"' \
+    >"$fake_bin/dcmd"
+printf '%s\n' \
+    '#!/bin/bash' \
+    'set -euo pipefail' \
+    '[[ ${1:-} == --field ]] || exit 2' \
+    'case "$(basename "$2"):$3" in' \
+    '  yanet-test_1.2.3_amd64.deb:Package) printf "%s\\n" yanet-test ;;' \
+    '  yanet-test_1.2.3_amd64.deb:Version) printf "%s\\n" 1.2.3 ;;' \
+    '  yanet-test_1.2.3_amd64.deb:Architecture) printf "%s\\n" amd64 ;;' \
+    '  yanet-test-dbgsym_1.2.3_amd64.ddeb:Package) printf "%s\\n" yanet-test-dbgsym ;;' \
+    '  yanet-test-dbgsym_1.2.3_amd64.ddeb:Version) printf "%s\\n" 1.2.3 ;;' \
+    '  yanet-test-dbgsym_1.2.3_amd64.ddeb:Architecture) printf "%s\\n" amd64 ;;' \
+    '  yanet-test-dbgsym_1.2.3_amd64.ddeb:Depends) printf "%s\\n" "yanet-test (= 1.2.3)" ;;' \
+    '  *) exit 1 ;;' \
+    'esac' \
+    >"$fake_bin/dpkg-deb"
+chmod +x "$fake_bin/dscverify" "$fake_bin/dcmd" "$fake_bin/dpkg-deb"
+export PATH="$fake_bin:$PATH"
+
+runtime=yanet-test_1.2.3_amd64.deb
+dbgsym=yanet-test-dbgsym_1.2.3_amd64.ddeb
+: >"$artifact_dir/$runtime"
+: >"$artifact_dir/$dbgsym"
+
+write_changes() {
+    local mode=$1
+    {
+        printf 'Version: 1.2.3\n\nFiles:\n'
+        printf ' 00000000000000000000000000000000 1 misc optional %s\n' "$runtime"
+        if [[ $mode == files-duplicate ]]; then
+            printf ' 00000000000000000000000000000000 1 misc optional %s\n' "$runtime"
+        fi
+        printf ' 00000000000000000000000000000000 1 misc optional %s\n\n' "$dbgsym"
+        [[ $mode != missing-checksums ]] || return 0
+        printf 'Checksums-Sha256:\n'
+        [[ $mode != empty-checksums ]] || return 0
+        printf ' 0000000000000000000000000000000000000000000000000000000000000000 1 %s\n' "$runtime"
+        [[ $mode != mismatch ]] || return 0
+        if [[ $mode == checksums-duplicate ]]; then
+            printf ' 0000000000000000000000000000000000000000000000000000000000000000 1 %s\n' "$runtime"
+        else
+            printf ' 0000000000000000000000000000000000000000000000000000000000000000 1 %s\n' "$dbgsym"
+        fi
+    } >"$artifact_dir/test.changes"
+}
+
+expect_failure() {
+    local mode=$1
+    local expected=$2
+    write_changes "$mode"
+    if "$verifier" "$artifact_dir" amd64 >"$test_root/failure.log" 2>&1; then
+        fail "$mode unexpectedly passed"
+    fi
+    grep -Fq -- "$expected" "$test_root/failure.log" || {
+        cat "$test_root/failure.log" >&2
+        fail "$mode did not report: $expected"
+    }
+}
+
+write_changes valid
+"$verifier" "$artifact_dir" amd64 >/dev/null
+expect_failure missing-checksums 'missing Checksums-Sha256 package manifest'
+expect_failure empty-checksums 'empty Checksums-Sha256 package manifest'
+expect_failure files-duplicate 'duplicate package files in Files'
+expect_failure checksums-duplicate 'duplicate package files in Checksums-Sha256'
+expect_failure mismatch 'Files and Checksums-Sha256 package lists differ'
+
+echo 'deb artifact verifier tests passed'

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -99,9 +99,25 @@ jobs:
             echo 'matrix={"include":[{"unbtver":"24.04","arch":"amd64","runner":"ubuntu-24.04","artifact":"debs-24.04-amd64"},{"unbtver":"24.04","arch":"arm64","runner":"ubuntu-24.04-arm","artifact":"debs-24.04-arm64"}]}' >> "$GITHUB_OUTPUT"
           fi
 
+  test-deb-artifacts:
+    name: Test Debian artifact scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run Debian artifact tests
+        run: |
+          set -euo pipefail
+          bash -n scripts/verify-deb-artifacts.sh \
+            .github/scripts/release-deb-artifacts.sh \
+            .github/scripts/verify-deb-artifacts_test.sh \
+            .github/scripts/release-deb-artifacts_test.sh
+          .github/scripts/verify-deb-artifacts_test.sh
+          .github/scripts/release-deb-artifacts_test.sh
+
   build-deb:
     name: Build DEB (${{ matrix.unbtver }}, ${{ matrix.arch }})
-    needs: set-matrix
+    needs: [set-matrix, test-deb-artifacts]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -92,18 +92,19 @@ jobs:
       - id: set
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.include_2204 }}" == "true" ]]; then
-            echo 'matrix={"unbtver":["24.04","22.04"]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"unbtver":"24.04","arch":"amd64","runner":"ubuntu-24.04","artifact":"debs-24.04"},{"unbtver":"24.04","arch":"arm64","runner":"ubuntu-24.04-arm","artifact":"debs-24.04-arm64"},{"unbtver":"22.04","arch":"amd64","runner":"ubuntu-22.04","artifact":"debs-22.04"}]}' >> "$GITHUB_OUTPUT"
           else
-            echo 'matrix={"unbtver":["24.04"]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"unbtver":"24.04","arch":"amd64","runner":"ubuntu-24.04","artifact":"debs-24.04"},{"unbtver":"24.04","arch":"arm64","runner":"ubuntu-24.04-arm","artifact":"debs-24.04-arm64"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   build-deb:
+    name: Build DEB (${{ matrix.unbtver }}, ${{ matrix.arch }})
     needs: set-matrix
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
 
-    runs-on: ubuntu-${{ matrix.unbtver }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -120,7 +121,7 @@ jobs:
       - uses: hendrikmuhs/ccache-action@v1.2.23
         name: ccache
         with:
-          key: ${{ runner.os }}-deb-ccache-${{ matrix.unbtver }}
+          key: ${{ runner.os }}-deb-ccache-${{ matrix.unbtver }}-${{ matrix.arch }}
           max-size: 2G
           verbose: 2
           save: ${{ github.ref == 'refs/heads/main' }}
@@ -139,7 +140,7 @@ jobs:
       - name: Cache rust
         uses: Swatinem/rust-cache@v2.9.2
         with:
-          shared-key: deb-${{ matrix.unbtver }}
+          shared-key: deb-${{ matrix.unbtver }}-${{ matrix.arch }}
           cache-targets: false
 
       - name: Install packaging tools
@@ -162,10 +163,27 @@ jobs:
           sudo -E env "PATH=$PATH" ./scripts/build-deb.sh
           sudo chown -R $(id -u) ~/.cargo  # fix caching for Rust
 
+      - name: Verify package architecture
+        run: |
+          set -euo pipefail
+          actual_host_arch=$(dpkg --print-architecture)
+          if [[ "$actual_host_arch" != '${{ matrix.arch }}' ]]; then
+            echo "Runner architecture mismatch: $actual_host_arch (expected ${{ matrix.arch }})" >&2
+            exit 1
+          fi
+          expected_arch='${{ matrix.arch }}'
+          for package in outdeb/*.deb outdeb/*.ddeb; do
+            actual_arch=$(dpkg-deb --field "$package" Architecture)
+            if [[ "$actual_arch" != "$expected_arch" ]]; then
+              echo "Unexpected architecture for $(basename "$package"): $actual_arch (expected $expected_arch)" >&2
+              exit 1
+            fi
+          done
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v5
         with:
-          name: debs-${{ matrix.unbtver }}
+          name: ${{ matrix.artifact }}
           path: |
             outdeb/*.changes
             outdeb/*.deb
@@ -185,13 +203,65 @@ jobs:
           path: artifacts
 
       - name: Verify downloaded packages
-        run: ./scripts/verify-deb-artifacts.sh artifacts
+        run: |
+          set -euo pipefail
+
+          mapfile -t artifact_sets < <(find artifacts -mindepth 1 -maxdepth 1 -type d -name 'debs-*' -printf '%f\n' | sort)
+          ((${#artifact_sets[@]} > 0)) || { echo 'No Debian artifact sets found' >&2; exit 1; }
+
+          # Normal tag pushes build the two 24.04 release architectures. A
+          # manually dispatched tag build may additionally verify the
+          # optional Ubuntu 22.04 amd64 artifact, but it is not published.
+          expected_sets=(debs-24.04 debs-24.04-arm64)
+          if [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.include_2204 }}" == 'true' ]]; then
+            expected_sets+=(debs-22.04)
+          fi
+          mapfile -t expected_sets < <(printf '%s\n' "${expected_sets[@]}" | sort)
+          if [[ "${artifact_sets[*]}" != "${expected_sets[*]}" ]]; then
+            echo "Unexpected Debian artifact sets: ${artifact_sets[*]}" >&2
+            echo "Expected Debian artifact sets: ${expected_sets[*]}" >&2
+            exit 1
+          fi
+
+          release_sets=(debs-24.04 debs-24.04-arm64)
+
+          release_version=''
+          for artifact_set in "${artifact_sets[@]}"; do
+            mapfile -t changes_files < <(find "artifacts/$artifact_set" -maxdepth 1 -type f -name '*.changes' -print)
+            ((${#changes_files[@]} == 1)) || {
+              echo "Expected exactly one .changes file in $artifact_set" >&2
+              exit 1
+            }
+            changes_version=$(awk -F': ' '$1 == "Version" { print $2; exit }' "${changes_files[0]}")
+            [[ -n "$changes_version" ]] || {
+              echo "Missing Version in ${changes_files[0]}" >&2
+              exit 1
+            }
+            if [[ -z "$release_version" ]]; then
+              release_version="$changes_version"
+            elif [[ "$changes_version" != "$release_version" ]]; then
+              echo "Mixed release versions: $release_version and $changes_version" >&2
+              exit 1
+            fi
+            echo "Verifying $artifact_set"
+            ./scripts/verify-deb-artifacts.sh "artifacts/$artifact_set"
+          done
 
       - name: Flatten artifacts
         run: |
+          set -euo pipefail
           mkdir -p outdeb
-          find artifacts -type f \( -name "*.changes" -o -name "*.deb" -o -name "*.ddeb" \) -exec cp {} outdeb/ \;
-          ./scripts/verify-deb-artifacts.sh outdeb
+          release_sets=(debs-24.04 debs-24.04-arm64)
+          for release_set in "${release_sets[@]}"; do
+            while IFS= read -r -d '' artifact; do
+              destination="outdeb/$(basename "$artifact")"
+              if [[ -e "$destination" ]]; then
+                echo "Artifact filename collision: $(basename "$artifact")" >&2
+                exit 1
+              fi
+              cp -- "$artifact" "$destination"
+            done < <(find "artifacts/$release_set" -type f \( -name "*.changes" -o -name "*.deb" -o -name "*.ddeb" \) -print0 | sort -z)
+          done
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -184,6 +184,7 @@ jobs:
           name: ${{ matrix.artifact }}
           path: |
             outdeb/*.changes
+            outdeb/*.buildinfo
             outdeb/*.deb
             outdeb/*.ddeb
 

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -30,6 +30,7 @@ on:
       - "go.mod"
       - "go.sum"
       - ".github/actions/**"
+      - ".github/scripts/**"
       - ".github/workflows/build-deb.yml"
       # A later match wins, so these negations drop the documentation and
       # web sources that would otherwise ride in on the source trees above.
@@ -64,6 +65,7 @@ on:
       - "go.mod"
       - "go.sum"
       - ".github/actions/**"
+      - ".github/scripts/**"
       - ".github/workflows/build-deb.yml"
       - "!**.md"
       - "!modules/**/web/**"

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -92,9 +92,9 @@ jobs:
       - id: set
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.include_2204 }}" == "true" ]]; then
-            echo 'matrix={"include":[{"unbtver":"24.04","arch":"amd64","runner":"ubuntu-24.04","artifact":"debs-24.04"},{"unbtver":"24.04","arch":"arm64","runner":"ubuntu-24.04-arm","artifact":"debs-24.04-arm64"},{"unbtver":"22.04","arch":"amd64","runner":"ubuntu-22.04","artifact":"debs-22.04"}]}' >> "$GITHUB_OUTPUT"
+            echo 'matrix={"include":[{"unbtver":"24.04","arch":"amd64","runner":"ubuntu-24.04","artifact":"debs-24.04-amd64"},{"unbtver":"24.04","arch":"arm64","runner":"ubuntu-24.04-arm","artifact":"debs-24.04-arm64"},{"unbtver":"22.04","arch":"amd64","runner":"ubuntu-22.04","artifact":"debs-22.04-amd64"}]}' >> "$GITHUB_OUTPUT"
           else
-            echo 'matrix={"include":[{"unbtver":"24.04","arch":"amd64","runner":"ubuntu-24.04","artifact":"debs-24.04"},{"unbtver":"24.04","arch":"arm64","runner":"ubuntu-24.04-arm","artifact":"debs-24.04-arm64"}]}' >> "$GITHUB_OUTPUT"
+            echo 'matrix={"include":[{"unbtver":"24.04","arch":"amd64","runner":"ubuntu-24.04","artifact":"debs-24.04-amd64"},{"unbtver":"24.04","arch":"arm64","runner":"ubuntu-24.04-arm","artifact":"debs-24.04-arm64"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   build-deb:
@@ -212,9 +212,9 @@ jobs:
           # Normal tag pushes build the two 24.04 release architectures. A
           # manually dispatched tag build may additionally verify the
           # optional Ubuntu 22.04 amd64 artifact, but it is not published.
-          expected_sets=(debs-24.04 debs-24.04-arm64)
+          expected_sets=(debs-24.04-amd64 debs-24.04-arm64)
           if [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.include_2204 }}" == 'true' ]]; then
-            expected_sets+=(debs-22.04)
+            expected_sets+=(debs-22.04-amd64)
           fi
           mapfile -t expected_sets < <(printf '%s\n' "${expected_sets[@]}" | sort)
           if [[ "${artifact_sets[*]}" != "${expected_sets[*]}" ]]; then
@@ -223,7 +223,7 @@ jobs:
             exit 1
           fi
 
-          release_sets=(debs-24.04 debs-24.04-arm64)
+          release_sets=(debs-24.04-amd64 debs-24.04-arm64)
 
           release_version=''
           for artifact_set in "${artifact_sets[@]}"; do
@@ -251,7 +251,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p outdeb
-          release_sets=(debs-24.04 debs-24.04-arm64)
+          release_sets=(debs-24.04-amd64 debs-24.04-arm64)
           for release_set in "${release_sets[@]}"; do
             while IFS= read -r -d '' artifact; do
               destination="outdeb/$(basename "$artifact")"

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -163,22 +163,18 @@ jobs:
           sudo -E env "PATH=$PATH" ./scripts/build-deb.sh
           sudo chown -R $(id -u) ~/.cargo  # fix caching for Rust
 
-      - name: Verify package architecture
+      - name: Verify package artifacts
+        run: sudo ./scripts/verify-deb-artifacts.sh outdeb '${{ matrix.arch }}'
+
+      - name: Verify runner architecture
         run: |
           set -euo pipefail
           actual_host_arch=$(dpkg --print-architecture)
-          if [[ "$actual_host_arch" != '${{ matrix.arch }}' ]]; then
-            echo "Runner architecture mismatch: $actual_host_arch (expected ${{ matrix.arch }})" >&2
+          expected_host_arch='${{ matrix.arch }}'
+          if [[ "$actual_host_arch" != "$expected_host_arch" ]]; then
+            echo "Runner architecture mismatch: $actual_host_arch (expected $expected_host_arch)" >&2
             exit 1
           fi
-          expected_arch='${{ matrix.arch }}'
-          for package in outdeb/*.deb outdeb/*.ddeb; do
-            actual_arch=$(dpkg-deb --field "$package" Architecture)
-            if [[ "$actual_arch" != "$expected_arch" ]]; then
-              echo "Unexpected architecture for $(basename "$package"): $actual_arch (expected $expected_arch)" >&2
-              exit 1
-            fi
-          done
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v5
@@ -202,66 +198,23 @@ jobs:
         with:
           path: artifacts
 
-      - name: Verify downloaded packages
+      - name: Install Debian verification tools
+        timeout-minutes: 10
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends devscripts
+
+      # Normal tag pushes validate and publish the two 24.04 architectures. A
+      # manual dispatch on a tag with include_2204=true additionally validates
+      # the optional Ubuntu 22.04 amd64 set, but does not publish it.
+      - name: Verify and flatten Debian artifacts
         run: |
           set -euo pipefail
-
-          mapfile -t artifact_sets < <(find artifacts -mindepth 1 -maxdepth 1 -type d -name 'debs-*' -printf '%f\n' | sort)
-          ((${#artifact_sets[@]} > 0)) || { echo 'No Debian artifact sets found' >&2; exit 1; }
-
-          # Normal tag pushes build the two 24.04 release architectures. A
-          # manually dispatched tag build may additionally verify the
-          # optional Ubuntu 22.04 amd64 artifact, but it is not published.
-          expected_sets=(debs-24.04-amd64 debs-24.04-arm64)
+          helper_args=(artifacts outdeb)
           if [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.include_2204 }}" == 'true' ]]; then
-            expected_sets+=(debs-22.04-amd64)
+            helper_args+=(--include-2204)
           fi
-          mapfile -t expected_sets < <(printf '%s\n' "${expected_sets[@]}" | sort)
-          if [[ "${artifact_sets[*]}" != "${expected_sets[*]}" ]]; then
-            echo "Unexpected Debian artifact sets: ${artifact_sets[*]}" >&2
-            echo "Expected Debian artifact sets: ${expected_sets[*]}" >&2
-            exit 1
-          fi
-
-          release_sets=(debs-24.04-amd64 debs-24.04-arm64)
-
-          release_version=''
-          for artifact_set in "${artifact_sets[@]}"; do
-            mapfile -t changes_files < <(find "artifacts/$artifact_set" -maxdepth 1 -type f -name '*.changes' -print)
-            ((${#changes_files[@]} == 1)) || {
-              echo "Expected exactly one .changes file in $artifact_set" >&2
-              exit 1
-            }
-            changes_version=$(awk -F': ' '$1 == "Version" { print $2; exit }' "${changes_files[0]}")
-            [[ -n "$changes_version" ]] || {
-              echo "Missing Version in ${changes_files[0]}" >&2
-              exit 1
-            }
-            if [[ -z "$release_version" ]]; then
-              release_version="$changes_version"
-            elif [[ "$changes_version" != "$release_version" ]]; then
-              echo "Mixed release versions: $release_version and $changes_version" >&2
-              exit 1
-            fi
-            echo "Verifying $artifact_set"
-            ./scripts/verify-deb-artifacts.sh "artifacts/$artifact_set"
-          done
-
-      - name: Flatten artifacts
-        run: |
-          set -euo pipefail
-          mkdir -p outdeb
-          release_sets=(debs-24.04-amd64 debs-24.04-arm64)
-          for release_set in "${release_sets[@]}"; do
-            while IFS= read -r -d '' artifact; do
-              destination="outdeb/$(basename "$artifact")"
-              if [[ -e "$destination" ]]; then
-                echo "Artifact filename collision: $(basename "$artifact")" >&2
-                exit 1
-              fi
-              cp -- "$artifact" "$destination"
-            done < <(find "artifacts/$release_set" -type f \( -name "*.changes" -o -name "*.deb" -o -name "*.ddeb" \) -print0 | sort -z)
-          done
+          .github/scripts/release-deb-artifacts.sh "${helper_args[@]}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Cache rust
         uses: Swatinem/rust-cache@v2.9.2
         with:
-          shared-key: deb-24.04
+          shared-key: deb-24.04-amd64
           cache-targets: false
 
       - name: Install packaging tools
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/upload-artifact@v5
         with:
-          name: debs-24.04
+          name: debs-24.04-amd64
           path: |
             outdeb/*.deb
             outdeb/*.ddeb
@@ -99,7 +99,7 @@ jobs:
       - name: Download deb packages
         uses: actions/download-artifact@v5
         with:
-          name: debs-24.04
+          name: debs-24.04-amd64
           path: deploy/packages/
 
       - name: Set up Docker Buildx

--- a/scripts/verify-deb-artifacts.sh
+++ b/scripts/verify-deb-artifacts.sh
@@ -1,124 +1,64 @@
 #!/bin/bash
 set -euo pipefail
 
+export LC_ALL=C
+
 fail() {
     echo "deb artifact verification failed: $*" >&2
     exit 1
 }
 
-if [[ $# -ne 1 ]]; then
-    fail "usage: $0 <artifact-directory>"
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    fail "usage: $0 <artifact-directory> [expected-architecture]"
 fi
 
 artifact_dir=$1
+expected_arch=${2:-}
 [[ -d $artifact_dir ]] || fail "artifact directory does not exist: $artifact_dir"
-
-if ! tmpdir=$(mktemp -d); then
-    fail "could not create temporary directory"
+if [[ -n $expected_arch && ! $expected_arch =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    fail "invalid expected architecture: $expected_arch"
 fi
-trap 'rm -rf "$tmpdir"' EXIT
 
-if ! find "$artifact_dir" -type f -name '*.changes' -print0 >"$tmpdir/changes-files"; then
-    fail "could not enumerate .changes files"
-fi
-mapfile -d '' changes_files <"$tmpdir/changes-files"
+command -v dscverify >/dev/null 2>&1 || fail "dscverify is required"
+command -v dcmd >/dev/null 2>&1 || fail "dcmd is required"
+command -v dpkg-deb >/dev/null 2>&1 || fail "dpkg-deb is required"
+
+mapfile -d '' changes_files < <(find "$artifact_dir" -type f -name '*.changes' -print0)
 (( ${#changes_files[@]} == 1 )) || fail "expected exactly one .changes file"
 changes_file=${changes_files[0]}
+changes_dir=${changes_file%/*}
+changes_name=${changes_file##*/}
 
-read_changes_field() {
-    set -e
+if ! (cd "$changes_dir" && dscverify --nosigcheck "$changes_name"); then
+    fail "dscverify rejected $changes_file"
+fi
 
-    local field=$1
-    local file=$2
-    awk -v field="$field" '
-        index($0, field ":") == 1 {
-            sub(/^[^:]+:[[:space:]]*/, "")
-            print
-            exit
-        }
-    ' "$file"
-}
-
-extract_changes_packages() {
-    set -e
-
-    local section=$1
-    local file=$2
-    awk -v section="$section" '
-        $0 == section ":" {
-            in_section = 1
-            found_section = 1
-            next
-        }
-        in_section && /^[^[:space:]][^:]*:/ {
-            in_section = 0
-        }
-        in_section && /^[[:space:]]+/ && $NF ~ /\.(deb|ddeb)$/ {
-            print $NF
-        }
-        END {
-            if (!found_section) {
-                exit 1
-            }
-        }
-    ' "$file"
-}
-
-if ! changes_version=$(read_changes_field Version "$changes_file"); then
+if ! changes_version=$(awk -F': ' '$1 == "Version" { print $2; exit }' "$changes_file"); then
     fail "could not read Version from $changes_file"
 fi
 [[ -n $changes_version ]] || fail "empty Version in $changes_file"
 
-if ! files_packages=$(extract_changes_packages Files "$changes_file"); then
-    fail "could not read package files from Files in $changes_file"
+if ! declared_output=$(cd "$changes_dir" && dcmd "$changes_name"); then
+    fail "dcmd could not read $changes_file"
 fi
-if ! checksums_packages=$(extract_changes_packages Checksums-Sha256 "$changes_file"); then
-    fail "could not read package files from Checksums-Sha256 in $changes_file"
-fi
+mapfile -t declared_packages < <(
+    printf '%s\n' "$declared_output" |
+        awk '$NF ~ /\.(deb|ddeb)$/ { sub(/^.*\//, "", $NF); print $NF }' |
+        sort
+)
+(( ${#declared_packages[@]} > 0 )) || fail "no package files declared by $changes_file"
+mapfile -t duplicate_declared < <(printf '%s\n' "${declared_packages[@]}" | uniq -d)
+(( ${#duplicate_declared[@]} == 0 )) ||
+    fail "duplicate package files declared by $changes_file: ${duplicate_declared[*]}"
 
-validate_manifest_packages() {
-    set -e
-
-    local section=$1
-    local section_name=$2
-    if ! printf '%s\n' "$section" | awk '
-        BEGIN {
-            valid = 1
-        }
-        NF {
-            if ($0 !~ /^[^[:space:]]+\.(deb|ddeb)$/ || ++seen[$0] > 1) {
-                valid = 0
-                next
-            }
-            count++
-        }
-        END {
-            exit valid == 0 || count == 0 ? 1 : 0
-        }
-    '; then
-        fail "invalid or duplicate package files in $section_name of $changes_file"
-    fi
-}
-
-validate_manifest_packages "$files_packages" Files
-validate_manifest_packages "$checksums_packages" Checksums-Sha256
-
-printf '%s\n' "$files_packages" | sort >"$tmpdir/files-packages"
-printf '%s\n' "$checksums_packages" | sort >"$tmpdir/checksums-packages"
-if ! cmp -s "$tmpdir/files-packages" "$tmpdir/checksums-packages"; then
-    fail "Files and Checksums-Sha256 package lists differ in $changes_file"
-fi
-
-mapfile -t declared_packages <"$tmpdir/files-packages"
 declare -A declared_package
 for package_file_name in "${declared_packages[@]}"; do
     declared_package[$package_file_name]=1
 done
 
-if ! find "$artifact_dir" -type f \( -name '*.deb' -o -name '*.ddeb' \) -print0 >"$tmpdir/package-files"; then
-    fail "could not enumerate package files"
-fi
-mapfile -d '' package_files <"$tmpdir/package-files"
+mapfile -d '' package_files < <(
+    find "$artifact_dir" -type f \( -name '*.deb' -o -name '*.ddeb' \) -print0 | sort -z
+)
 (( ${#package_files[@]} > 0 )) || fail "no .deb or .ddeb files found"
 
 declare -A actual_package
@@ -126,9 +66,8 @@ for package_file_path in "${package_files[@]}"; do
     package_file_name=${package_file_path##*/}
     [[ ${declared_package[$package_file_name]+present} == present ]] ||
         fail "unmanifested package file: $package_file_name"
-    if [[ ${actual_package[$package_file_name]+present} ]]; then
+    [[ ${actual_package[$package_file_name]+present} != present ]] ||
         fail "duplicate package file: $package_file_name"
-    fi
     actual_package[$package_file_name]=$package_file_path
 done
 
@@ -137,20 +76,18 @@ for package_file_name in "${declared_packages[@]}"; do
         fail "missing package file declared by $changes_file: $package_file_name"
 done
 
+read_field() {
+    local field=$1
+    local package_file_path=$2
+    dpkg-deb --field "$package_file_path" "$field"
+}
+
 declare -A package_file
 declare -A package_version
 runtime_count=0
 dbgsym_count=0
 dbgsym_ddeb_count=0
 artifact_version=
-
-read_field() {
-    set -e
-
-    local field=$1
-    local package_file_path=$2
-    dpkg-deb --field "$package_file_path" "$field"
-}
 
 for package_file_name in "${declared_packages[@]}"; do
     package_file_path=${actual_package[$package_file_name]}
@@ -160,12 +97,17 @@ for package_file_name in "${declared_packages[@]}"; do
     if ! version=$(read_field Version "$package_file_path"); then
         fail "could not read Version from $package_file_path"
     fi
+    if ! package_arch=$(read_field Architecture "$package_file_path"); then
+        fail "could not read Architecture from $package_file_path"
+    fi
     [[ -n $package_name ]] || fail "empty Package in $package_file_path"
     [[ -n $version ]] || fail "empty Version in $package_file_path"
-
-    if [[ ${package_file[$package_name]+present} ]]; then
-        fail "duplicate package name: $package_name"
+    if [[ -n $expected_arch && $package_arch != "$expected_arch" ]]; then
+        fail "unexpected architecture for $(basename "$package_file_path"): $package_arch (expected $expected_arch)"
     fi
+
+    [[ ${package_file[$package_name]+present} != present ]] ||
+        fail "duplicate package name: $package_name"
     package_file[$package_name]=$package_file_path
     package_version[$package_name]=$version
 
@@ -176,12 +118,12 @@ for package_file_name in "${declared_packages[@]}"; do
     fi
 
     if [[ $package_name == *-dbgsym ]]; then
-        ((dbgsym_count += 1))
+        dbgsym_count=$((dbgsym_count + 1))
         if [[ $package_file_path == *.ddeb ]]; then
-            ((dbgsym_ddeb_count += 1))
+            dbgsym_ddeb_count=$((dbgsym_ddeb_count + 1))
         fi
     else
-        ((runtime_count += 1))
+        runtime_count=$((runtime_count + 1))
     fi
 done
 
@@ -191,13 +133,13 @@ done
 (( dbgsym_count > 0 )) || fail "no dbgsym packages found"
 (( dbgsym_ddeb_count > 0 )) || fail "no dbgsym .ddeb files found"
 
-for package_name in "${!package_file[@]}"; do
+mapfile -t package_names < <(printf '%s\n' "${!package_file[@]}" | sort)
+for package_name in "${package_names[@]}"; do
     [[ $package_name == *-dbgsym ]] || continue
 
     runtime_name=${package_name%-dbgsym}
-    if [[ ${package_file[$runtime_name]+present} != present ]]; then
+    [[ ${package_file[$runtime_name]+present} == present ]] ||
         fail "missing runtime package $runtime_name for $package_name"
-    fi
 
     if ! depends=$(read_field Depends "${package_file[$package_name]}"); then
         fail "could not read Depends from ${package_file[$package_name]}"

--- a/scripts/verify-deb-artifacts.sh
+++ b/scripts/verify-deb-artifacts.sh
@@ -38,6 +38,41 @@ if ! changes_version=$(awk -F': ' '$1 == "Version" { print $2; exit }' "$changes
 fi
 [[ -n $changes_version ]] || fail "empty Version in $changes_file"
 
+extract_manifest_packages() {
+    local section=$1
+    awk -v section="$section" '
+        $0 == section ":" { in_section = 1; found_section = 1; next }
+        in_section && /^[^[:space:]][^:]*:/ { in_section = 0 }
+        in_section && /^[[:space:]]+/ && $NF ~ /\.(deb|ddeb)$/ {
+            package = $NF
+            sub(/^.*\//, "", package)
+            print package
+        }
+        END {
+            exit found_section ? 0 : 1
+        }
+    ' "$changes_file"
+}
+
+if ! files_manifest=$(extract_manifest_packages Files); then
+    fail "missing Files package manifest in $changes_file"
+fi
+if ! checksums_manifest=$(extract_manifest_packages Checksums-Sha256); then
+    fail "missing Checksums-Sha256 package manifest in $changes_file"
+fi
+mapfile -t files_packages < <(printf '%s\n' "$files_manifest" | awk 'NF' | sort)
+mapfile -t checksums_packages < <(printf '%s\n' "$checksums_manifest" | awk 'NF' | sort)
+(( ${#files_packages[@]} > 0 )) || fail "empty Files package manifest in $changes_file"
+(( ${#checksums_packages[@]} > 0 )) || fail "empty Checksums-Sha256 package manifest in $changes_file"
+mapfile -t duplicate_files < <(printf '%s\n' "${files_packages[@]}" | uniq -d)
+mapfile -t duplicate_checksums < <(printf '%s\n' "${checksums_packages[@]}" | uniq -d)
+(( ${#duplicate_files[@]} == 0 )) ||
+    fail "duplicate package files in Files of $changes_file: ${duplicate_files[*]}"
+(( ${#duplicate_checksums[@]} == 0 )) ||
+    fail "duplicate package files in Checksums-Sha256 of $changes_file: ${duplicate_checksums[*]}"
+[[ "${files_packages[*]}" == "${checksums_packages[*]}" ]] ||
+    fail "Files and Checksums-Sha256 package lists differ in $changes_file"
+
 if ! declared_output=$(cd "$changes_dir" && dcmd "$changes_name"); then
     fail "dcmd could not read $changes_file"
 fi

--- a/scripts/verify-deb-artifacts.sh
+++ b/scripts/verify-deb-artifacts.sh
@@ -20,7 +20,6 @@ if [[ -n $expected_arch && ! $expected_arch =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
 fi
 
 command -v dscverify >/dev/null 2>&1 || fail "dscverify is required"
-command -v dcmd >/dev/null 2>&1 || fail "dcmd is required"
 command -v dpkg-deb >/dev/null 2>&1 || fail "dpkg-deb is required"
 
 mapfile -d '' changes_files < <(find "$artifact_dir" -type f -name '*.changes' -print0)
@@ -73,18 +72,7 @@ mapfile -t duplicate_checksums < <(printf '%s\n' "${checksums_packages[@]}" | un
 [[ "${files_packages[*]}" == "${checksums_packages[*]}" ]] ||
     fail "Files and Checksums-Sha256 package lists differ in $changes_file"
 
-if ! declared_output=$(cd "$changes_dir" && dcmd "$changes_name"); then
-    fail "dcmd could not read $changes_file"
-fi
-mapfile -t declared_packages < <(
-    printf '%s\n' "$declared_output" |
-        awk '$NF ~ /\.(deb|ddeb)$/ { sub(/^.*\//, "", $NF); print $NF }' |
-        sort
-)
-(( ${#declared_packages[@]} > 0 )) || fail "no package files declared by $changes_file"
-mapfile -t duplicate_declared < <(printf '%s\n' "${declared_packages[@]}" | uniq -d)
-(( ${#duplicate_declared[@]} == 0 )) ||
-    fail "duplicate package files declared by $changes_file: ${duplicate_declared[*]}"
+declared_packages=("${files_packages[@]}")
 
 declare -A declared_package
 for package_file_name in "${declared_packages[@]}"; do


### PR DESCRIPTION
- Builds complete Ubuntu 24.04 amd64 and arm64 Debian package sets on native GitHub-hosted runners.
- Publishes symmetric architecture-explicit artifacts as `debs-24.04-amd64` and `debs-24.04-arm64`.
- Verifies runner and package architecture, per-architecture manifests, and a common release version.
- Keeps the optional Ubuntu 22.04 amd64 artifact verifiable without mixing it into the 24.04 release.
- Uses no cross-compilation or emulation.

Closes #1752.