### PR TITLE
feat(agents): add comment hygiene skill

### DIFF
--- a/.agents/skills/better-comment/SKILL.md
+++ b/.agents/skills/better-comment/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: better-comment
+description: >-
+  Improve or audit source comments in a bounded code change without touching
+  executable code or unrelated files. Use when adding or editing comments,
+  reviewing noisy, stale, overlong, or AI-generated comments, or before a
+  complete-change review.
+---
+
+# Better Comment
+
+Read `.agents/conventions/comments.md` before acting. It is the only source of
+truth for comment policy; do not copy its rules into this skill.
+
+## Select a mode
+
+- Author mode is for an explicit fix, rewrite, cleanup, or authoring request.
+  It may edit comment text only within the supplied candidate manifest.
+- Review mode is for an explicit review, audit, or reviewer-gate request. It
+  never edits files and reports findings only.
+- If the request does not identify a mode, use Review mode. Never infer write
+  access from a general request to inspect a change.
+
+## Establish the candidate
+
+Use the caller's explicit file manifest when one is supplied. Otherwise use the
+requested diff boundary (`base...candidate` or the staged/unstaged working
+tree), and include untracked or ignored paths named by the caller. If neither a
+manifest nor a diff boundary is available, stop and request one.
+
+Inspect comments that were added or edited, plus nearby existing comments whose
+claims may have been invalidated by changed executable behavior. Do not expand
+the candidate to unrelated comments or files.
+
+## Pass
+
+Classify every candidate comment as `preserve`, `rewrite`, `delete`, or
+`blocker`.
+
+Apply the loaded convention when choosing among these classifications. If a
+claim cannot be verified, report a blocker instead of deleting it.
+
+Preserve compiler, build, generator, formatter, linter, and generated-file
+directives exactly, including unknown directive-like comments. If it is unclear
+whether a comment is a directive, classify it as a blocker. Do not rename
+symbols or change executable code when a comment exposes a design problem.
+
+Re-read the candidate after the pass. Confirm that only comment text changed,
+the complete manifest was considered, and every candidate comment has a
+classification.
+
+## Output
+
+Author mode:
+
+```text
+Mode: Author
+Classifications: <file:line=preserve|rewrite|delete|blocker; ... or none>
+Changed: <file:line or none>
+Deleted: <file:line or none>
+Blockers: <finding or none>
+Result: COMPLETE
+```
+
+Review mode:
+
+```text
+Mode: Review
+Classifications: <file:line=preserve|rewrite|delete|blocker; ... or none>
+Findings:
+- <severity> <file:line> <finding and concrete consequence>
+Result: APPROVED
+```
+
+Use `Result: APPROVED` only when there are no findings. In Review mode, use
+`Result: CHANGES REQUESTED` when any finding remains. In Author mode, use
+`Result: BLOCKED` when any blocker remains; otherwise use `COMPLETE`.

--- a/.agents/skills/review-change/SKILL.md
+++ b/.agents/skills/review-change/SKILL.md
@@ -14,6 +14,15 @@ Treat the change as an untrusted state transition: prove the complete candidate 
 
 Brief and acceptance criteria · exact base and candidate (worktree or PR head SHA) · full manifest including untracked and gitignored paths · what the author claims was verified. Narration that disagrees with the diff is a finding.
 
+## Comment obligations
+
+After reconstructing the manifest and before the final verdict, invoke
+`$better-comment` in Review mode for the complete candidate. Require
+`Result: APPROVED`; propagate `CHANGES REQUESTED` findings and do not approve
+the outer review. It must inspect changed comments and nearby comments whose
+claims may have been invalidated by changed behavior. A comment-only finding is
+still a review finding; do not switch to Author mode in this gate.
+
 ## Look for
 
 - **Lost obligations**: a guarantee, error path, counter, log line, registration or packaging entry the old code had and the new one drops; a caller left on the old contract (grep the class).

--- a/.claude/skills/better-comment
+++ b/.claude/skills/better-comment
@@ -1,0 +1,1 @@
+../../.agents/skills/better-comment

--- a/.gitignore
+++ b/.gitignore
@@ -159,11 +159,13 @@ deploy/packages/
 # no change here.
 .agents/skills/*
 !.agents/skills/autopilot
+!.agents/skills/better-comment
 !.agents/skills/issue-create
 !.agents/skills/review-change
 !.agents/skills/ship-pr
 .claude/skills/*
 !.claude/skills/autopilot
+!.claude/skills/better-comment
 !.claude/skills/issue-create
 !.claude/skills/review-change
 !.claude/skills/ship-pr

--- a/.rulesync/subagents/coder-c.md
+++ b/.rulesync/subagents/coder-c.md
@@ -31,6 +31,8 @@ You write C for the YANET2 dataplane (`AGENTS.md` for layout and build; `.agents
 - Minimal means minimal: no new function or field without a production reader, no renames or reformatting outside the change.
 - Stop and report instead of guessing when the change needs a public API, another repository, a shared struct layout (`YANET_MODULE_ABI_VERSION`), or ~40 tool calls have not converged.
 
+Before running the gate, invoke `$better-comment` in Author mode for the complete candidate. Require `Result: COMPLETE`; stop and report any `BLOCKED` result. Include comment-only edits in the formatter and all subsequent gate commands.
+
 ## Gate (run it, do not assume)
 
 `clang-format -i` on changed files · `meson compile -C build` clean · `meson test -C build <name>` for touched tests · `go test -count=1` for Go packages that link the changed C · fuzz target updated when input parsing changed · meson files updated for new sources.

--- a/.rulesync/subagents/coder-go.md
+++ b/.rulesync/subagents/coder-go.md
@@ -32,6 +32,8 @@ You write Go for YANET2 (`AGENTS.md` for layout and build; `.agents/conventions/
 - Tests: table-driven, plus a `-race` test where concurrency matters; a test must fail on the defect it pins. C-only changes still need `go test -count=1`.
 - Minimal means minimal: no renames, no reformatting, no unused symbols. Stop and report when the change needs a C-side contract, another repository, or ~40 tool calls have not converged.
 
+Before running the gate, invoke `$better-comment` in Author mode for the complete candidate. Require `Result: COMPLETE`; stop and report any `BLOCKED` result. Include comment-only edits in the formatter and all subsequent gate commands.
+
 ## Gate (run it, do not assume)
 
 `gofmt -w` changed files · `go vet ./...` · `go build ./...` · `go test -count=1 <affected packages>` · `go test -race -count=10 -run <pattern>` where relevant · proto `meson.build` updated for new protos · `make proto-go` when protos changed.

--- a/.rulesync/subagents/coder-rust.md
+++ b/.rulesync/subagents/coder-rust.md
@@ -29,6 +29,8 @@ You write Rust for the YANET2 CLIs (`AGENTS.md` → Rust CLI for the workspace s
 - A new CLI is registered in root `Cargo.toml` members, root `Makefile` (`CLI_CORE_MODULES`/`CLI_MODULES`) and `debian/yanet2-cli.install`; a private CLI is a standalone workspace.
 - Minimal means minimal: no renames, no reformatting outside the change. Stop and report when the change needs a proto or Go change, or ~40 tool calls have not converged.
 
+Before running the gate, invoke `$better-comment` in Author mode for the complete candidate. Require `Result: COMPLETE`; stop and report any `BLOCKED` result. Include comment-only edits in the formatter and all subsequent gate commands.
+
 ## Gate (run it, do not assume)
 
 `cargo +nightly fmt` · `cargo clippy` · `cargo build --workspace` · `cargo test --workspace`.

--- a/.rulesync/subagents/coder-ui.md
+++ b/.rulesync/subagents/coder-ui.md
@@ -30,6 +30,8 @@ You write TypeScript/React for the YANET2 web UI (`.agents/conventions/ts.md` be
 - A new page is registered in three places: `types.ts` `PAGE_IDS`, `App.tsx` route, `MainMenu.tsx` entry. Shared components re-export from `components/index.ts`. Prefer Gravity UI primitives; SCSS imports tokens from `src/styles/`.
 - Minimal means minimal. Stop and report when the change needs a backend RPC that does not exist, or ~40 tool calls have not converged.
 
+Before running the gate, invoke `$better-comment` in Author mode for the complete candidate. Require `Result: COMPLETE`; stop and report any `BLOCKED` result. Include comment-only edits in the formatter and all subsequent gate commands.
+
 ## Gate (run it, do not assume)
 
 `npm run build -w web` · `npx tsc --noEmit` (from `web/`) · vitest for touched specs · for visible UI, a Playwright pass through the real user path with a saved screenshot when the environment allows.

--- a/.rulesync/subagents/reviewer.md
+++ b/.rulesync/subagents/reviewer.md
@@ -27,9 +27,10 @@ The brief names the candidate root (worktree or PR), the base, and the intended 
 
 1. Reconstruct the contract: what the change claims, which callers, tests, docs, packaging and registration surfaces it touches (`grep` the class, not the sample).
 2. Read the whole diff. For each hunk ask: what input or state makes this wrong, what did the old code guarantee that this drops, what else must change for this to be complete.
-3. Run the gate once, from the candidate root, only for the layers touched: `gofmt -l` + `go vet` + `go test -count=1 <pkgs>`; `clang-format --dry-run` + `meson compile -C build` + `meson test`; `cargo +nightly fmt --check` + `cargo clippy` + `cargo test`; `npm run build -w web` + `npx tsc --noEmit`; `make lint-commit` for a commit message. A gate that produces or consumes `build/` needs the candidate's own real `build/`.
-4. Check tests: each new test must fail on the defect it pins (reason it through or mutate locally, never commit the mutation); a green suite is not evidence if the assertion is vacuous.
-5. Rank findings, most severe first, at most ten. Each: file:line, the defect, the concrete failure scenario, blocking or not. Do not report style the linters already enforce, and do not restate conventions.
+3. Before the gate, invoke `$better-comment` in Review mode for the complete candidate. Require `Result: APPROVED`; propagate any `CHANGES REQUESTED` findings and do not approve the outer review.
+4. Run the gate once, from the candidate root, only for the layers touched: `gofmt -l` + `go vet` + `go test -count=1 <pkgs>`; `clang-format --dry-run` + `meson compile -C build` + `meson test`; `cargo +nightly fmt --check` + `cargo clippy` + `cargo test`; `npm run build -w web` + `npx tsc --noEmit`; `make lint-commit` for a commit message. A gate that produces or consumes `build/` needs the candidate's own real `build/`.
+5. Check tests: each new test must fail on the defect it pins (reason it through or mutate locally, never commit the mutation); a green suite is not evidence if the assertion is vacuous.
+6. Rank findings, most severe first, at most ten. Each: file:line, the defect, the concrete failure scenario, blocking or not. Do not report style the linters already enforce, and do not restate conventions.
 
 ## Verdict
 


### PR DESCRIPTION
## What

Add the `better-comment` skill for bounded source-comment authoring and read-only review. The skill classifies comments, preserves directive-like comments, enforces deterministic modes, and fails closed on blockers or review findings.

## Why

Keep useful rationale while removing comment narration and stale prose before code review. Integrate the pass into C, Go, Rust, and UI coding agents plus both direct and checklist-based reviewer workflows.

## Verification

- `make ai/agents`
- `make lint/agents`
- Frontmatter, symlink, whitelist, output-contract, and whitespace checks
- Independent skill audit: `APPROVED`
- Independent candidate review against `origin/main`: `APPROVED`
- Full runtime tests were not run; this change only adds agent skills and review configuration.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en