### PR TITLE
fix(filter): make the fixed-width network key reads safe under strict aliasing

### DIFF
--- a/common/network.h
+++ b/common/network.h
@@ -57,6 +57,19 @@ struct net {
 	};
 };
 
+// Word views over address and mask bytes, safe under strict aliasing and
+// at any byte offset.
+//
+// The byte arrays have no word type of their own and no alignment
+// guarantee, so a plain integer pointer cast over them is undefined
+// behaviour. These types may alias anything and carry byte alignment,
+// which costs nothing on targets with unaligned loads and makes strict
+// alignment targets read byte by byte.
+typedef uint32_t __attribute__((__may_alias__, __aligned__(1))) net4_word;
+typedef uint64_t __attribute__((__may_alias__, __aligned__(1))) net6_half;
+_Static_assert(_Alignof(net4_word) == 1, "net4_word must have byte alignment");
+_Static_assert(_Alignof(net6_half) == 1, "net6_half must have byte alignment");
+
 enum ip_family {
 	ip_family_ip4,
 	ip_family_ip6,

--- a/lib/filter/compiler/net4.c
+++ b/lib/filter/compiler/net4.c
@@ -38,11 +38,11 @@ net4_collect_values(
 	uint32_t *values = ADDR_OF(&range_index->values);
 
 	for (struct net4 *net4 = start; net4 < start + count; ++net4) {
-		if (*(uint32_t *)net4->mask == 0x00000000) {
+		if (*(const net4_word *)net4->mask == 0x00000000) {
 			continue;
 		}
-		uint32_t to =
-			*(uint32_t *)net4->addr | ~*(uint32_t *)net4->mask;
+		uint32_t to = *(const net4_word *)net4->addr |
+			      ~*(const net4_word *)net4->mask;
 		filter_key_inc(4, (uint8_t *)&to);
 
 		uint32_t start =
@@ -74,8 +74,8 @@ net4_collect_registry(
 	struct value_registry *registry
 ) {
 	for (struct net4 *net4 = start; net4 < start + count; ++net4) {
-		uint32_t addr = *(uint32_t *)net4->addr;
-		uint32_t mask = *(uint32_t *)net4->mask;
+		uint32_t addr = *(const net4_word *)net4->addr;
+		uint32_t mask = *(const net4_word *)net4->mask;
 		uint32_t to = addr | ~mask;
 		if (lpm4_collect_values(
 			    lpm,
@@ -124,11 +124,11 @@ collect_net4_values(
 
 		for (struct net4 *net4 = nets; net4 < nets + net_count;
 		     ++net4) {
+			uint32_t mask = *(const net4_word *)net4->mask;
 			if (range4_collector_add(
 				    &collector,
 				    net4->addr,
-				    __builtin_popcountll(*(uint32_t *)net4->mask
-				    )
+				    __builtin_popcountll(mask)
 			    )) {
 				goto error_collector;
 			}

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -94,10 +94,11 @@ collect_net6_range(
 			uint8_t *mask;
 			get_part(&net6, &addr, &mask);
 
+			uint64_t mask_bits = *(const net6_half *)mask;
 			if (range8_collector_add(
 				    &collector,
 				    addr,
-				    __builtin_popcountll(*(uint64_t *)mask)
+				    __builtin_popcountll(mask_bits)
 			    )) {
 				goto error_collector;
 			}
@@ -156,11 +157,12 @@ net6_part_range_index_bound(
 	uint32_t *stop
 ) {
 	uint8_t next[8];
-	*(uint64_t *)next = *(uint64_t *)addr | ~*(uint64_t *)mask;
+	*(net6_half *)next =
+		*(const net6_half *)addr | ~*(const net6_half *)mask;
 	filter_key_inc(8, next);
 	*start = radix_lookup(&range_index->radix, 8, addr);
 	*stop = range_index->count;
-	if (*(uint64_t *)next != 0) {
+	if (*(const net6_half *)next != 0) {
 		*stop = radix_lookup(&range_index->radix, 8, next);
 	}
 }
@@ -230,8 +232,8 @@ touch_network_ranges(
 			struct net6 net6 = all_nets[values[idx]];
 
 			// Skip `any` network
-			if (*(uint64_t *)net6.mask == 0 &&
-			    *(uint64_t *)(net6.mask + 8) == 0) {
+			if (*(const net6_half *)net6.mask == 0 &&
+			    *(const net6_half *)(net6.mask + 8) == 0) {
 				continue;
 			}
 


### PR DESCRIPTION
- The net4 and net6 compilers read network addresses and masks through plain fixed-width pointer casts over byte arrays, which is undefined behaviour under strict aliasing and a misaligned access whenever a rule hands the bytes over at an odd address.
- The reads now go through word types that may alias anything and carry byte alignment, so the compiler keeps the loads honest on every target at no cost where unaligned loads are native, and the structure layout stays untouched.
