### PR TITLE
feat(controlplane): make agent_resize grow an attached agent and expose it in Go

### DIFF
--- a/api/agent.h
+++ b/api/agent.h
@@ -108,18 +108,15 @@ agent_attach(
 uint64_t
 agent_memory_limit(struct agent *agent);
 
-// Grows an attached agent's shared memory to at least the given total size.
-//
-// The size is a total rather than an increment. A request for what the agent
-// already holds succeeds and changes nothing; a smaller one is rejected.
+// Grows an attached agent's shared memory by the given increment.
 //
 // @param agent Handle to the agent
-// @param new_size Total size the agent should reach, in bytes
+// @param size Number of bytes to add
 // @param err Error output parameter
 //
 // @return 0 on success, -1 on error.
 int
-agent_resize(struct agent *agent, uint64_t new_size, yanet_error **err);
+agent_extend(struct agent *agent, uint64_t size, yanet_error **err);
 
 // Returns number of dataplane instances in the specified shared memory segment.
 //

--- a/api/agent.h
+++ b/api/agent.h
@@ -100,10 +100,26 @@ agent_attach(
 	yanet_error **err
 );
 
-// Extend agent size.
+// Returns the memory limit of the agent.
+//
+// @param agent Handle to the agent
+//
+// @return Total size reserved for the agent, in bytes.
+uint64_t
+agent_memory_limit(struct agent *agent);
+
+// Grows an attached agent's shared memory to at least the given total size.
+//
+// The size is a total rather than an increment. A request for what the agent
+// already holds succeeds and changes nothing; a smaller one is rejected.
+//
+// @param agent Handle to the agent
+// @param new_size Total size the agent should reach, in bytes
+// @param err Error output parameter
+//
 // @return 0 on success, -1 on error.
 int
-agent_resize(struct agent *agent, size_t new_size, yanet_error **err);
+agent_resize(struct agent *agent, uint64_t new_size, yanet_error **err);
 
 // Returns number of dataplane instances in the specified shared memory segment.
 //

--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -18,10 +18,12 @@ package ffi
 //#include "api/agent.h"
 //#include "lib/controlplane/agent/agent.h"
 import "C"
+
 import (
 	"fmt"
 	"unsafe"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
 )
 
@@ -133,6 +135,31 @@ func (m *Agent) UpdateModules(modules []ModuleConfig) error {
 	}
 
 	return nil
+}
+
+// Resize grows the agent's shared memory to at least the given total size.
+//
+// The size is a total rather than an increment: asking for what the agent
+// already holds changes nothing, and asking for less fails. An agent that
+// draws memory straight from the controlplane pool cannot be grown.
+func (m *Agent) Resize(newSize datasize.ByteSize) error {
+	var cErr *C.yanet_error
+	rc := C.agent_resize(m.ptr, C.uint64_t(newSize), &cErr)
+	if rc != 0 {
+		return fmt.Errorf(
+			"failed to resize agent %q to %s: %w",
+			m.name,
+			newSize,
+			cerrors.FromC(unsafe.Pointer(cErr)),
+		)
+	}
+
+	return nil
+}
+
+// MemoryLimit reports the shared memory currently reserved for the agent.
+func (m *Agent) MemoryLimit() datasize.ByteSize {
+	return datasize.ByteSize(C.agent_memory_limit(m.ptr))
 }
 
 func (m *Agent) DPConfig() *DPConfig {

--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -137,19 +137,18 @@ func (m *Agent) UpdateModules(modules []ModuleConfig) error {
 	return nil
 }
 
-// Resize grows the agent's shared memory to at least the given total size.
+// Extend grows the agent's shared memory by the given size.
 //
-// The size is a total rather than an increment: asking for what the agent
-// already holds changes nothing, and asking for less fails. An agent that
-// draws memory straight from the controlplane pool cannot be grown.
-func (m *Agent) Resize(newSize datasize.ByteSize) error {
+// An agent that draws memory straight from the controlplane pool cannot be
+// grown.
+func (m *Agent) Extend(size datasize.ByteSize) error {
 	var cErr *C.yanet_error
-	rc := C.agent_resize(m.ptr, C.uint64_t(newSize), &cErr)
+	rc := C.agent_extend(m.ptr, C.uint64_t(size), &cErr)
 	if rc != 0 {
 		return fmt.Errorf(
-			"failed to resize agent %q to %s: %w",
+			"failed to extend agent %q by %s: %w",
 			m.name,
-			newSize,
+			size,
 			cerrors.FromC(unsafe.Pointer(cErr)),
 		)
 	}

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -340,7 +340,13 @@ unlock:
 
 uint64_t
 agent_memory_limit(struct agent *agent) {
-	return agent->memory_limit;
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	cp_config_lock(cp_config);
+	uint64_t memory_limit = agent->memory_limit;
+	cp_config_unlock(cp_config);
+
+	return memory_limit;
 }
 
 int

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1,5 +1,6 @@
 #include "agent.h"
 
+#include <assert.h>
 #include <linux/mman.h>
 #include <stdlib.h>
 #include <string.h>
@@ -20,7 +21,6 @@
 #include "lib/controlplane/config/cp_module.h"
 #include "lib/controlplane/config/cp_object.h"
 #include "lib/controlplane/config/zone.h"
-#include "lib/counters/counters.h"
 #include "lib/dataplane/config/zone.h"
 #include "lib/dataplane/pipeline/econtext.h"
 
@@ -114,6 +114,63 @@ dataplane_instance_worker_count(struct dp_config *dp_config) {
 static void
 agent_free_unused_agents_locked(struct agent *agent);
 
+static int
+allocate_arenas(
+	struct memory_context *memory_context,
+	struct agent_arena *arenas,
+	size_t arena_count,
+	uint64_t size,
+	yanet_error **err
+) {
+	(void)arena_count;
+	size_t added = 0;
+	uint64_t left = size;
+	while (left > 0) {
+		assert(added < arena_count);
+
+		uint64_t arena_size = left > MEMORY_BLOCK_ALLOCATOR_MAX_SIZE
+					      ? MEMORY_BLOCK_ALLOCATOR_MAX_SIZE
+					      : left;
+
+		void *arena = memory_balloc(memory_context, arena_size);
+		if (arena == NULL) {
+			yanet_error_add(
+				err, "failed to allocate memory for arena"
+			);
+			for (uint64_t idx = 0; idx < added; ++idx) {
+				struct agent_arena *reserved = &arenas[idx];
+				memory_bfree(
+					memory_context,
+					ADDR_OF(&reserved->data),
+					reserved->size
+				);
+			}
+			return -1;
+		}
+
+		SET_OFFSET_OF(&arenas[added].data, arena);
+		arenas[added].size = arena_size;
+		++added;
+
+		left -= arena_size;
+	}
+
+	return 0;
+}
+
+static size_t
+calculate_arena_count(uint64_t size) {
+	/*
+	 * FIXME: the code bellow tries to allocate memory_limit bytes
+	 * using max possible chunk size what breaks allocator encapsulation.
+	 * Alternative multi-alloc api should be implemented.
+	 */
+	if (size == 0) {
+		return 0;
+	}
+	return (size - 1) / MEMORY_BLOCK_ALLOCATOR_MAX_SIZE + 1;
+}
+
 struct agent *
 agent_attach(
 	struct yanet_shm *shm,
@@ -172,14 +229,7 @@ agent_attach(
 		&new_agent->block_allocator
 	);
 
-	/*
-	 * FIXME: the code bellow tries to allocate memory_limit bytes
-	 * using max possible chunk size what breaks allocator encapsulation.
-	 * Alternative multi-alloc api should be implemented.
-	 */
-	uint64_t arena_count =
-		(memory_limit + MEMORY_BLOCK_ALLOCATOR_MAX_SIZE - 1) /
-		MEMORY_BLOCK_ALLOCATOR_MAX_SIZE;
+	uint64_t arena_count = calculate_arena_count(memory_limit);
 	struct agent_arena *arenas = (struct agent_arena *)memory_balloc(
 		&cp_config->memory_context,
 		sizeof(struct agent_arena) * arena_count
@@ -192,32 +242,33 @@ agent_attach(
 	}
 
 	memset(arenas, 0, sizeof(struct agent_arena) * arena_count);
-	SET_OFFSET_OF(&new_agent->arenas, arenas);
 
-	while (new_agent->arena_count < arena_count) {
-		uint64_t arena_size =
-			memory_limit > MEMORY_BLOCK_ALLOCATOR_MAX_SIZE
-				? MEMORY_BLOCK_ALLOCATOR_MAX_SIZE
-				: memory_limit;
-
-		void *arena =
-			memory_balloc(&cp_config->memory_context, arena_size);
-		if (arena == NULL) {
-			yanet_error_add(
-				err, "failed to allocate memory for arena"
-			);
-			agent_cleanup(new_agent);
-			new_agent = NULL;
-			goto unlock;
-		}
-		block_allocator_put_arena(
-			&new_agent->block_allocator, arena, arena_size
+	if (allocate_arenas(
+		    &cp_config->memory_context,
+		    arenas,
+		    arena_count,
+		    memory_limit,
+		    err
+	    ) != 0) {
+		memory_bfree(
+			&cp_config->memory_context,
+			arenas,
+			sizeof(struct agent_arena) * arena_count
 		);
-		SET_OFFSET_OF(&arenas[new_agent->arena_count].data, arena);
-		arenas[new_agent->arena_count].size = arena_size;
-		new_agent->arena_count++;
+		agent_cleanup(new_agent);
+		new_agent = NULL;
+		goto unlock;
+	}
 
-		memory_limit -= arena_size;
+	SET_OFFSET_OF(&new_agent->arenas, arenas);
+	new_agent->arena_count = arena_count;
+
+	for (uint64_t arena_idx = 0; arena_idx < arena_count; ++arena_idx) {
+		block_allocator_put_arena(
+			&new_agent->block_allocator,
+			ADDR_OF(&arenas[arena_idx].data),
+			arenas[arena_idx].size
+		);
 	}
 
 	struct cp_agent_registry *old_registry =
@@ -287,94 +338,130 @@ unlock:
 	return new_agent;
 }
 
+uint64_t
+agent_memory_limit(struct agent *agent) {
+	return agent->memory_limit;
+}
+
 int
-agent_resize(struct agent *agent, size_t new_size, yanet_error **err) {
+agent_resize(struct agent *agent, uint64_t new_size, yanet_error **err) {
 	int ret = 0;
+
 	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+	struct memory_context *cp_memory_context = &cp_config->memory_context;
+
 	cp_config_lock(cp_config);
-	size_t need_arena_count =
-		(new_size + MEMORY_BLOCK_ALLOCATOR_MAX_SIZE - 1) /
-		MEMORY_BLOCK_ALLOCATOR_MAX_SIZE;
 
-	// TODO: handle case
-	// when need_arena_count == agent->arena_count == 1
-	// we need add one more arena in this case.
-
-	if (need_arena_count > agent->arena_count) {
-		struct agent_arena *arenas = memory_balloc(
-			&cp_config->memory_context,
-			need_arena_count * sizeof(struct agent_arena)
+	// An agent that draws straight from the controlplane pool owns no
+	// arena of its own and cannot be grown here.
+	//
+	// Built-in services are set up that way.
+	if (ADDR_OF(&agent->memory_context.block_allocator) !=
+	    &agent->block_allocator) {
+		yanet_error_add(
+			err,
+			"agent \"%s\" draws memory from the controlplane "
+			"pool and cannot be resized",
+			agent->name
 		);
-		if (arenas == NULL) {
-			yanet_error_add(err, "failed to allocate arenas array");
+		ret = -1;
+		goto unlock;
+	}
+
+	struct agent_arena *arenas = ADDR_OF(&agent->arenas);
+	uint64_t arena_count = agent->arena_count;
+
+	uint64_t current_size = 0;
+	for (uint64_t arena_idx = 0; arena_idx < arena_count; ++arena_idx) {
+		current_size += arenas[arena_idx].size;
+	}
+
+	// Shrinking is not offered.
+	if (new_size < current_size) {
+		yanet_error_add(
+			err,
+			"agent memory cannot shrink: %lu bytes requested, %lu "
+			"already reserved",
+			new_size,
+			current_size
+		);
+		ret = -1;
+		goto unlock;
+	}
+
+	uint64_t needed = new_size - current_size;
+	uint64_t misaligned = needed % MEMORY_BLOCK_ALLOCATOR_MIN_SIZE;
+	if (misaligned != 0) {
+		uint64_t pad = MEMORY_BLOCK_ALLOCATOR_MIN_SIZE - misaligned;
+		if (new_size > UINT64_MAX - pad) {
+			yanet_error_add(
+				err,
+				"agent memory cannot reach %lu bytes",
+				new_size
+			);
 			ret = -1;
 			goto unlock;
 		}
-		size_t need_alloc = need_arena_count - agent->arena_count;
-		size_t alloc;
-		for (alloc = 0; alloc < need_alloc; ++alloc) {
-			void *arena = memory_balloc(
-				&cp_config->memory_context,
-				MEMORY_BLOCK_ALLOCATOR_MAX_SIZE
-			);
-			if (arena == NULL) {
-				yanet_error_add(
-					err,
-					"failed to allocate arena of size %u "
-					"bytes",
-					MEMORY_BLOCK_ALLOCATOR_MAX_SIZE
-				);
-				for (size_t i = 0; i < alloc; ++i) {
-					memory_bfree(
-						&cp_config->memory_context,
-						ADDR_OF(&arenas[agent->arena_count +
-								i]
-								 .data),
-						MEMORY_BLOCK_ALLOCATOR_MAX_SIZE
-					);
-				}
-				memory_bfree(
-					&cp_config->memory_context,
-					arenas,
-					need_arena_count *
-						sizeof(struct agent_arena)
-				);
-				ret = -1;
-				goto unlock;
-			}
-			SET_OFFSET_OF(
-				&arenas[agent->arena_count + alloc].data, arena
-			);
-			arenas[agent->arena_count + alloc].size =
-				MEMORY_BLOCK_ALLOCATOR_MAX_SIZE;
-		}
-
-		// put arenas in allocator
-		for (size_t i = 0; i < need_alloc; ++i) {
-			void *arena =
-				ADDR_OF(&arenas[agent->arena_count + i].data);
-			block_allocator_put_arena(
-				&agent->block_allocator,
-				arena,
-				MEMORY_BLOCK_ALLOCATOR_MAX_SIZE
-			);
-		}
-
-		struct agent_arena *prev_arenas = ADDR_OF(&agent->arenas);
-		for (size_t i = 0; i < agent->arena_count; ++i) {
-			SET_OFFSET_OF(
-				&arenas[i].data, ADDR_OF(&prev_arenas[i].data)
-			);
-			arenas[i].size = prev_arenas[i].size;
-		}
-		SET_OFFSET_OF(&agent->arenas, arenas);
-		memory_bfree(
-			&cp_config->memory_context,
-			prev_arenas,
-			agent->arena_count * sizeof(struct agent_arena)
-		);
-		agent->arena_count = need_arena_count;
+		needed += pad;
 	}
+	if (needed == 0) {
+		goto unlock;
+	}
+
+	uint64_t added_count = calculate_arena_count(needed);
+	uint64_t new_arena_count = arena_count + added_count;
+
+	struct agent_arena *new_arenas = (struct agent_arena *)memory_balloc(
+		cp_memory_context, sizeof(struct agent_arena) * new_arena_count
+	);
+	if (new_arenas == NULL) {
+		yanet_error_add(err, "failed to allocate memory for arenas");
+		ret = -1;
+		goto unlock;
+	}
+	memset(new_arenas, 0, sizeof(struct agent_arena) * new_arena_count);
+
+	if (allocate_arenas(
+		    cp_memory_context,
+		    new_arenas + arena_count,
+		    added_count,
+		    needed,
+		    err
+	    ) != 0) {
+		memory_bfree(
+			cp_memory_context,
+			new_arenas,
+			sizeof(struct agent_arena) * new_arena_count
+		);
+		ret = -1;
+		goto unlock;
+	}
+
+	for (uint64_t arena_idx = 0; arena_idx < arena_count; ++arena_idx) {
+		EQUATE_OFFSET(
+			&new_arenas[arena_idx].data, &arenas[arena_idx].data
+		);
+		new_arenas[arena_idx].size = arenas[arena_idx].size;
+	}
+
+	SET_OFFSET_OF(&agent->arenas, new_arenas);
+	agent->arena_count = new_arena_count;
+	agent->memory_limit = current_size + needed;
+
+	for (uint64_t idx = 0; idx < added_count; ++idx) {
+		struct agent_arena *reserved = &new_arenas[arena_count + idx];
+		block_allocator_put_arena(
+			&agent->block_allocator,
+			ADDR_OF(&reserved->data),
+			reserved->size
+		);
+	}
+
+	memory_bfree(
+		cp_memory_context,
+		arenas,
+		sizeof(struct agent_arena) * arena_count
+	);
 
 unlock:
 	cp_config_unlock(cp_config);

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -344,7 +344,7 @@ agent_memory_limit(struct agent *agent) {
 }
 
 int
-agent_resize(struct agent *agent, uint64_t new_size, yanet_error **err) {
+agent_extend(struct agent *agent, uint64_t size, yanet_error **err) {
 	int ret = 0;
 
 	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
@@ -361,43 +361,20 @@ agent_resize(struct agent *agent, uint64_t new_size, yanet_error **err) {
 		yanet_error_add(
 			err,
 			"agent \"%s\" draws memory from the controlplane "
-			"pool and cannot be resized",
+			"pool and cannot be extended",
 			agent->name
 		);
 		ret = -1;
 		goto unlock;
 	}
 
-	struct agent_arena *arenas = ADDR_OF(&agent->arenas);
-	uint64_t arena_count = agent->arena_count;
-
-	uint64_t current_size = 0;
-	for (uint64_t arena_idx = 0; arena_idx < arena_count; ++arena_idx) {
-		current_size += arenas[arena_idx].size;
-	}
-
-	// Shrinking is not offered.
-	if (new_size < current_size) {
-		yanet_error_add(
-			err,
-			"agent memory cannot shrink: %lu bytes requested, %lu "
-			"already reserved",
-			new_size,
-			current_size
-		);
-		ret = -1;
-		goto unlock;
-	}
-
-	uint64_t needed = new_size - current_size;
+	uint64_t needed = size;
 	uint64_t misaligned = needed % MEMORY_BLOCK_ALLOCATOR_MIN_SIZE;
 	if (misaligned != 0) {
 		uint64_t pad = MEMORY_BLOCK_ALLOCATOR_MIN_SIZE - misaligned;
-		if (new_size > UINT64_MAX - pad) {
+		if (needed > UINT64_MAX - pad) {
 			yanet_error_add(
-				err,
-				"agent memory cannot reach %lu bytes",
-				new_size
+				err, "agent cannot grow by %lu bytes", size
 			);
 			ret = -1;
 			goto unlock;
@@ -407,6 +384,9 @@ agent_resize(struct agent *agent, uint64_t new_size, yanet_error **err) {
 	if (needed == 0) {
 		goto unlock;
 	}
+
+	struct agent_arena *arenas = ADDR_OF(&agent->arenas);
+	uint64_t arena_count = agent->arena_count;
 
 	uint64_t added_count = calculate_arena_count(needed);
 	uint64_t new_arena_count = arena_count + added_count;
@@ -446,7 +426,7 @@ agent_resize(struct agent *agent, uint64_t new_size, yanet_error **err) {
 
 	SET_OFFSET_OF(&agent->arenas, new_arenas);
 	agent->arena_count = new_arena_count;
-	agent->memory_limit = current_size + needed;
+	agent->memory_limit += needed;
 
 	for (uint64_t idx = 0; idx < added_count; ++idx) {
 		struct agent_arena *reserved = &new_arenas[arena_count + idx];

--- a/lib/controlplane/agent/agent_test.c
+++ b/lib/controlplane/agent/agent_test.c
@@ -6,6 +6,7 @@
 
 #include "api/agent.h"
 #include "api/counter.h"
+#include "common/memory.h"
 #include "common/memory_address.h"
 #include "common/test_assert.h"
 #include "lib/controlplane/agent/agent.h"
@@ -396,6 +397,225 @@ test_detach_initialised_segment_releases_mapping() {
 	return TEST_SUCCESS;
 }
 
+// Allocates zeroed storage for a resize test.
+static void *
+resize_storage_alloc(size_t size) {
+	return calloc(1, size);
+}
+
+static int
+resize_env_init(
+	void *storage, size_t cp_memory, struct cp_config **res_cp_config
+) {
+	struct dp_config *dp_config = NULL;
+	struct cp_config *cp_config = NULL;
+	if (dp_storage_init(
+		    0,
+		    0,
+		    storage,
+		    TEST_DP_MEMORY,
+		    cp_memory,
+		    &dp_config,
+		    &cp_config
+	    ) != 0) {
+		return -1;
+	}
+
+	struct agent *sys_agent =
+		dp_system_agent_new(cp_config, dp_config, "dataplane");
+	if (sys_agent == NULL) {
+		return -1;
+	}
+
+	yanet_error *err = NULL;
+	struct cp_config_gen *config_gen = cp_config_gen_new(sys_agent, &err);
+	if (config_gen == NULL) {
+		yanet_error_free(err);
+		return -1;
+	}
+	SET_OFFSET_OF(&cp_config->cp_config_gen, config_gen);
+
+	dp_config->instance_count = 1;
+	cp_config_unlock(cp_config);
+	dp_config_mark_ready(dp_config);
+
+	*res_cp_config = cp_config;
+	return 0;
+}
+
+static size_t
+cp_pool_free_size(struct cp_config *cp_config) {
+	return block_allocator_free_size(&cp_config->block_allocator);
+}
+
+static size_t
+agent_reserved_size(struct agent *agent) {
+	struct agent_arena *arenas = ADDR_OF(&agent->arenas);
+	size_t size = 0;
+	for (uint64_t idx = 0; idx < agent->arena_count; ++idx) {
+		size += arenas[idx].size;
+	}
+	return size;
+}
+
+static void
+resize_agent_release(struct agent *agent, struct cp_config *cp_config) {
+	cp_config_lock(cp_config);
+	agent_cleanup(agent);
+	cp_config_unlock(cp_config);
+}
+
+// Verify that growing an agent adds usable capacity, records the new arena
+// and publishes the new limit, all while staying inside a single chunk.
+static int
+test_resize_grows_agent_capacity_and_shrink_fails() {
+	void *storage = resize_storage_alloc(1 << 25);
+	TEST_ASSERT_NOT_NULL(storage, "storage allocation failed");
+
+	struct cp_config *cp_config = NULL;
+	int rc = resize_env_init(storage, 1 << 24, &cp_config);
+	TEST_ASSERT(rc == 0, "storage setup failed");
+
+	struct yanet_shm shm = {.base = storage, .size = 1 << 25};
+	yanet_error *err = NULL;
+	struct agent *agent = agent_attach(&shm, 0, "resize", 1 << 12, &err);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	TEST_ASSERT_EQUAL(
+		agent_reserved_size(agent),
+		(size_t)(1u << 12),
+		"attach must record the requested capacity"
+	);
+
+	void *block = memory_balloc(&agent->memory_context, 256);
+	TEST_ASSERT_NOT_NULL(block, "the attached capacity must be usable");
+	memory_bfree(&agent->memory_context, block, 256);
+
+	block = memory_balloc(&agent->memory_context, 1 << 13);
+	TEST_ASSERT_NULL(block, "agent allocated more memory than it has");
+
+	rc = agent_resize(agent, 1u << 20, &err);
+	TEST_ASSERT(rc == 0, "growing an attached agent must succeed");
+	TEST_ASSERT_NULL(err, "a successful resize must not set an error");
+
+	TEST_ASSERT_EQUAL(
+		agent_memory_limit(agent),
+		(uint64_t)(1u << 20),
+		"the reported limit must follow a successful resize"
+	);
+	TEST_ASSERT_EQUAL(
+		agent_reserved_size(agent),
+		(size_t)(1u << 20),
+		"the recorded arenas must add up to the new limit"
+	);
+
+	// The added memory is split along its own alignment, so the largest
+	// usable block stays well below the growth that was requested.
+	block = memory_balloc(&agent->memory_context, 1 << 14);
+	TEST_ASSERT_NOT_NULL(block, "the added capacity must be usable");
+	memory_bfree(&agent->memory_context, block, 1 << 14);
+
+	rc = agent_resize(agent, 1 << 19, &err);
+	TEST_ASSERT(rc != 0, "shrink is not supported");
+	TEST_ASSERT_NOT_NULL(err, "a rejected resize must set an error");
+	yanet_error_free(err);
+
+	resize_agent_release(agent, cp_config);
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+static int
+test_resize_rejects_borrowing_agent() {
+	void *storage = resize_storage_alloc(1 << 25);
+	TEST_ASSERT_NOT_NULL(storage, "storage allocation failed");
+
+	struct dp_config *dp_config = NULL;
+	struct cp_config *cp_config = NULL;
+	int rc = dp_storage_init(
+		0, 0, storage, TEST_DP_MEMORY, 1u << 22, &dp_config, &cp_config
+	);
+	TEST_ASSERT(rc == 0, "dp_storage_init failed");
+
+	struct agent *sys_agent =
+		dp_system_agent_new(cp_config, dp_config, "dataplane");
+	TEST_ASSERT_NOT_NULL(sys_agent, "dp_system_agent_new failed");
+	cp_config_unlock(cp_config);
+
+	yanet_error *err = NULL;
+	rc = agent_resize(sys_agent, 1u << 20, &err);
+	TEST_ASSERT(rc == -1, "a borrowing agent must not be resized");
+	TEST_ASSERT_NOT_NULL(err, "a rejected resize must set an error");
+	TEST_ASSERT_EQUAL(
+		sys_agent->arena_count,
+		(uint64_t)0,
+		"a rejected resize must not record an arena"
+	);
+	TEST_ASSERT_EQUAL(
+		sys_agent->memory_limit,
+		(uint64_t)0,
+		"a rejected resize must not move the limit"
+	);
+	yanet_error_free(err);
+
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verify that a request the controlplane pool cannot satisfy leaves the
+// agent, its capacity and its reported limit exactly as they were.
+static int
+test_resize_rolls_back_on_exhausted_pool() {
+	void *storage = resize_storage_alloc(1 << 25);
+	TEST_ASSERT_NOT_NULL(storage, "storage allocation failed");
+
+	struct cp_config *cp_config = NULL;
+	int rc = resize_env_init(storage, 1 << 19, &cp_config);
+	TEST_ASSERT(rc == 0, "storage setup failed");
+
+	struct yanet_shm shm = {.base = storage, .size = 1 << 25};
+	yanet_error *err = NULL;
+	struct agent *agent = agent_attach(&shm, 0, "resize", 4096, &err);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	uint64_t arena_count = agent->arena_count;
+	uint64_t memory_limit = agent->memory_limit;
+	size_t free_before = block_allocator_free_size(&agent->block_allocator);
+	size_t pool_before = cp_pool_free_size(cp_config);
+
+	rc = agent_resize(agent, 1 << 20, &err);
+	TEST_ASSERT(rc == -1, "an unsatisfiable resize must fail");
+	TEST_ASSERT_NOT_NULL(err, "a failed resize must set an error");
+	yanet_error_free(err);
+	err = NULL;
+
+	TEST_ASSERT_EQUAL(
+		agent->arena_count, arena_count, "no arena must be recorded"
+	);
+	TEST_ASSERT_EQUAL(
+		agent->memory_limit, memory_limit, "the limit must not move"
+	);
+	TEST_ASSERT_EQUAL(
+		block_allocator_free_size(&agent->block_allocator),
+		free_before,
+		"the capacity must not move"
+	);
+	TEST_ASSERT_EQUAL(
+		cp_pool_free_size(cp_config),
+		pool_before,
+		"a failed request must return everything it took"
+	);
+
+	// The agent must still be serviceable after the failure.
+	void *block = memory_balloc(&agent->memory_context, 256);
+	TEST_ASSERT_NOT_NULL(block, "the agent must survive a failed resize");
+	memory_bfree(&agent->memory_context, block, 256);
+
+	resize_agent_release(agent, cp_config);
+	free(storage);
+	return TEST_SUCCESS;
+}
+
 int
 main() {
 	log_enable_name("error");
@@ -483,6 +703,26 @@ main() {
 		++tests_failed;
 		LOG(ERROR,
 		    "test_detach_initialised_segment_releases_mapping failed");
+	}
+
+	++tests_count;
+	if (test_resize_grows_agent_capacity_and_shrink_fails() !=
+	    TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_resize_grows_agent_capacity_and_shrink_fails failed");
+	}
+
+	++tests_count;
+	if (test_resize_rejects_borrowing_agent() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR, "test_resize_rejects_borrowing_agent failed");
+	}
+
+	++tests_count;
+	if (test_resize_rolls_back_on_exhausted_pool() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR, "test_resize_rolls_back_on_exhausted_pool failed");
 	}
 
 	if (tests_failed != 0) {

--- a/lib/controlplane/agent/agent_test.c
+++ b/lib/controlplane/agent/agent_test.c
@@ -397,14 +397,14 @@ test_detach_initialised_segment_releases_mapping() {
 	return TEST_SUCCESS;
 }
 
-// Allocates zeroed storage for a resize test.
+// Allocates zeroed storage for an extend test.
 static void *
-resize_storage_alloc(size_t size) {
+extend_storage_alloc(size_t size) {
 	return calloc(1, size);
 }
 
 static int
-resize_env_init(
+extend_env_init(
 	void *storage, size_t cp_memory, struct cp_config **res_cp_config
 ) {
 	struct dp_config *dp_config = NULL;
@@ -459,7 +459,7 @@ agent_reserved_size(struct agent *agent) {
 }
 
 static void
-resize_agent_release(struct agent *agent, struct cp_config *cp_config) {
+extend_agent_release(struct agent *agent, struct cp_config *cp_config) {
 	cp_config_lock(cp_config);
 	agent_cleanup(agent);
 	cp_config_unlock(cp_config);
@@ -468,17 +468,17 @@ resize_agent_release(struct agent *agent, struct cp_config *cp_config) {
 // Verify that growing an agent adds usable capacity, records the new arena
 // and publishes the new limit, all while staying inside a single chunk.
 static int
-test_resize_grows_agent_capacity_and_shrink_fails() {
-	void *storage = resize_storage_alloc(1 << 25);
+test_extend_grows_agent_capacity() {
+	void *storage = extend_storage_alloc(1 << 25);
 	TEST_ASSERT_NOT_NULL(storage, "storage allocation failed");
 
 	struct cp_config *cp_config = NULL;
-	int rc = resize_env_init(storage, 1 << 24, &cp_config);
+	int rc = extend_env_init(storage, 1 << 24, &cp_config);
 	TEST_ASSERT(rc == 0, "storage setup failed");
 
 	struct yanet_shm shm = {.base = storage, .size = 1 << 25};
 	yanet_error *err = NULL;
-	struct agent *agent = agent_attach(&shm, 0, "resize", 1 << 12, &err);
+	struct agent *agent = agent_attach(&shm, 0, "extend", 1 << 12, &err);
 	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
 
 	TEST_ASSERT_EQUAL(
@@ -494,18 +494,18 @@ test_resize_grows_agent_capacity_and_shrink_fails() {
 	block = memory_balloc(&agent->memory_context, 1 << 13);
 	TEST_ASSERT_NULL(block, "agent allocated more memory than it has");
 
-	rc = agent_resize(agent, 1u << 20, &err);
+	rc = agent_extend(agent, 1u << 20, &err);
 	TEST_ASSERT(rc == 0, "growing an attached agent must succeed");
-	TEST_ASSERT_NULL(err, "a successful resize must not set an error");
+	TEST_ASSERT_NULL(err, "a successful extend must not set an error");
 
 	TEST_ASSERT_EQUAL(
 		agent_memory_limit(agent),
-		(uint64_t)(1u << 20),
-		"the reported limit must follow a successful resize"
+		(uint64_t)((1u << 12) + (1u << 20)),
+		"the reported limit must follow a successful extend"
 	);
 	TEST_ASSERT_EQUAL(
 		agent_reserved_size(agent),
-		(size_t)(1u << 20),
+		(size_t)((1u << 12) + (1u << 20)),
 		"the recorded arenas must add up to the new limit"
 	);
 
@@ -515,19 +515,14 @@ test_resize_grows_agent_capacity_and_shrink_fails() {
 	TEST_ASSERT_NOT_NULL(block, "the added capacity must be usable");
 	memory_bfree(&agent->memory_context, block, 1 << 14);
 
-	rc = agent_resize(agent, 1 << 19, &err);
-	TEST_ASSERT(rc != 0, "shrink is not supported");
-	TEST_ASSERT_NOT_NULL(err, "a rejected resize must set an error");
-	yanet_error_free(err);
-
-	resize_agent_release(agent, cp_config);
+	extend_agent_release(agent, cp_config);
 	free(storage);
 	return TEST_SUCCESS;
 }
 
 static int
-test_resize_rejects_borrowing_agent() {
-	void *storage = resize_storage_alloc(1 << 25);
+test_extend_rejects_borrowing_agent() {
+	void *storage = extend_storage_alloc(1 << 25);
 	TEST_ASSERT_NOT_NULL(storage, "storage allocation failed");
 
 	struct dp_config *dp_config = NULL;
@@ -543,18 +538,18 @@ test_resize_rejects_borrowing_agent() {
 	cp_config_unlock(cp_config);
 
 	yanet_error *err = NULL;
-	rc = agent_resize(sys_agent, 1u << 20, &err);
-	TEST_ASSERT(rc == -1, "a borrowing agent must not be resized");
-	TEST_ASSERT_NOT_NULL(err, "a rejected resize must set an error");
+	rc = agent_extend(sys_agent, 1u << 20, &err);
+	TEST_ASSERT(rc == -1, "a borrowing agent must not be extended");
+	TEST_ASSERT_NOT_NULL(err, "a rejected extend must set an error");
 	TEST_ASSERT_EQUAL(
 		sys_agent->arena_count,
 		(uint64_t)0,
-		"a rejected resize must not record an arena"
+		"a rejected extend must not record an arena"
 	);
 	TEST_ASSERT_EQUAL(
 		sys_agent->memory_limit,
 		(uint64_t)0,
-		"a rejected resize must not move the limit"
+		"a rejected extend must not move the limit"
 	);
 	yanet_error_free(err);
 
@@ -565,17 +560,17 @@ test_resize_rejects_borrowing_agent() {
 // Verify that a request the controlplane pool cannot satisfy leaves the
 // agent, its capacity and its reported limit exactly as they were.
 static int
-test_resize_rolls_back_on_exhausted_pool() {
-	void *storage = resize_storage_alloc(1 << 25);
+test_extend_rolls_back_on_exhausted_pool() {
+	void *storage = extend_storage_alloc(1 << 25);
 	TEST_ASSERT_NOT_NULL(storage, "storage allocation failed");
 
 	struct cp_config *cp_config = NULL;
-	int rc = resize_env_init(storage, 1 << 19, &cp_config);
+	int rc = extend_env_init(storage, 1 << 19, &cp_config);
 	TEST_ASSERT(rc == 0, "storage setup failed");
 
 	struct yanet_shm shm = {.base = storage, .size = 1 << 25};
 	yanet_error *err = NULL;
-	struct agent *agent = agent_attach(&shm, 0, "resize", 4096, &err);
+	struct agent *agent = agent_attach(&shm, 0, "extend", 4096, &err);
 	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
 
 	uint64_t arena_count = agent->arena_count;
@@ -583,9 +578,9 @@ test_resize_rolls_back_on_exhausted_pool() {
 	size_t free_before = block_allocator_free_size(&agent->block_allocator);
 	size_t pool_before = cp_pool_free_size(cp_config);
 
-	rc = agent_resize(agent, 1 << 20, &err);
-	TEST_ASSERT(rc == -1, "an unsatisfiable resize must fail");
-	TEST_ASSERT_NOT_NULL(err, "a failed resize must set an error");
+	rc = agent_extend(agent, 1 << 20, &err);
+	TEST_ASSERT(rc == -1, "an unsatisfiable extend must fail");
+	TEST_ASSERT_NOT_NULL(err, "a failed extend must set an error");
 	yanet_error_free(err);
 	err = NULL;
 
@@ -608,10 +603,10 @@ test_resize_rolls_back_on_exhausted_pool() {
 
 	// The agent must still be serviceable after the failure.
 	void *block = memory_balloc(&agent->memory_context, 256);
-	TEST_ASSERT_NOT_NULL(block, "the agent must survive a failed resize");
+	TEST_ASSERT_NOT_NULL(block, "the agent must survive a failed extend");
 	memory_bfree(&agent->memory_context, block, 256);
 
-	resize_agent_release(agent, cp_config);
+	extend_agent_release(agent, cp_config);
 	free(storage);
 	return TEST_SUCCESS;
 }
@@ -706,23 +701,21 @@ main() {
 	}
 
 	++tests_count;
-	if (test_resize_grows_agent_capacity_and_shrink_fails() !=
-	    TEST_SUCCESS) {
+	if (test_extend_grows_agent_capacity() != TEST_SUCCESS) {
 		++tests_failed;
-		LOG(ERROR,
-		    "test_resize_grows_agent_capacity_and_shrink_fails failed");
+		LOG(ERROR, "test_extend_grows_agent_capacity failed");
 	}
 
 	++tests_count;
-	if (test_resize_rejects_borrowing_agent() != TEST_SUCCESS) {
+	if (test_extend_rejects_borrowing_agent() != TEST_SUCCESS) {
 		++tests_failed;
-		LOG(ERROR, "test_resize_rejects_borrowing_agent failed");
+		LOG(ERROR, "test_extend_rejects_borrowing_agent failed");
 	}
 
 	++tests_count;
-	if (test_resize_rolls_back_on_exhausted_pool() != TEST_SUCCESS) {
+	if (test_extend_rolls_back_on_exhausted_pool() != TEST_SUCCESS) {
 		++tests_failed;
-		LOG(ERROR, "test_resize_rolls_back_on_exhausted_pool failed");
+		LOG(ERROR, "test_extend_rolls_back_on_exhausted_pool failed");
 	}
 
 	if (tests_failed != 0) {


### PR DESCRIPTION
- Treat the size passed to the resize entry point as a total rather than an increment, and document that contract in the public header.
- Allocate only the bytes that are missing instead of always taking full-size arenas, so a small grow no longer costs 64 MiB.
- Publish the new memory limit together with the recorded arenas, so agent inspection and `memory_arena_limit_bytes` follow a successful call.
- Handle a grow that stays inside the current arena count, which the previous code silently ignored.
- Reject a request below the current size: shrink is not supported.
- Reject an agent whose memory comes from the controlplane pool and that owns no arenas, such as a built-in service agent.
- Return everything already taken when an allocation fails part way, leaving the agent, its capacity and the controlplane pool untouched.
- Expose the operation as `Resize` in the control-plane binding, so a module can grow its agent at runtime.
- Cover growth, a rejected shrink, a rejected borrowing agent and the rollback path in the agent tests.

Closes #2285.
