### PR TITLE
build(nix): add reproducible development shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,46 @@ YANET employs a multi-language approach to leverage the strengths of different p
 - Ninja build system.
 - GCC/Clang.
 
+### Nix development shell
+
+On a machine with Nix installed, the repository provides the build tools and
+libraries except Rust, which is managed separately with `rustup`:
+
+Install Nix with `sh <(curl -L https://nixos.org/nix/install) --daemon` if it is not already available.
+See the [official Nix installation documentation](https://nixos.org/download/) for platform-specific options.
+
+```bash
+nix develop
+git submodule update --init --recursive
+meson setup build
+```
+
+`flake.lock` pins the environment. The flake does not select a Nix store path:
+each machine uses its own Nix configuration, so a standard `/nix` store and an
+administrator-configured external-disk store both work without repository
+changes.
+
+QEMU is included in the development shell. KVM is optional acceleration; the
+functional-test harness falls back to QEMU TCG when `/dev/kvm` is unavailable.
+To use KVM on Linux, add the current user to its group and log in again:
+
+```bash
+sudo usermod -aG kvm "$(id -un)"
+test -r /dev/kvm && test -w /dev/kvm
+```
+
+The host or VM platform must expose `/dev/kvm`; group membership cannot create
+the device. Functional tests configure hugepages inside the guest. Host
+hugepages are needed only when running the dataplane directly on the host.
+
+On x86-64, build the release artifacts with `make all`, then run
+`make test-functional`. The test harness stages Nix-built executables so they
+run with the guest system loader; the guest does not need `/nix/store`.
+Functional tests from aarch64 hosts are not yet supported.
+
+See the [Nix development workflow](docs/nix-develop-workflow.md) for everyday
+commands and store cleanup behaviour.
+
 ### Build Instructions
 
 1. Clone the repository:

--- a/docs/nix-develop-workflow.md
+++ b/docs/nix-develop-workflow.md
@@ -1,0 +1,87 @@
+# Nix development workflow
+
+Install Nix once by following the [official installation guide](https://nixos.org/download/).
+Install the stable Rust toolchain, Clippy, rust-analyzer, and nightly rustfmt
+with [rustup](https://rustup.rs/):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+rustup toolchain install stable --component clippy --component rust-analyzer
+rustup default stable
+rustup toolchain install nightly --component rustfmt
+```
+
+The installer adds Cargo to `PATH` for future login shells. Source
+`$HOME/.cargo/env` as above, or log in again before running `rustup`.
+
+Rust is intentionally kept outside the Nix shell so that normal rustup commands
+such as `cargo +nightly fmt` work unchanged. Then enter the project environment
+from the repository root:
+
+```bash
+nix develop
+```
+
+The first invocation downloads the versions pinned by `flake.lock`. Inside the
+shell, initialize and configure the project once:
+
+```bash
+git submodule update --init --recursive
+meson setup build
+```
+
+GCC is the default compiler, matching CI. Clang 19 is also available; use a
+separate build directory because Meson fixes the compiler at setup time:
+
+```bash
+CC=clang CXX=clang++ meson setup build-clang
+meson compile -C build-clang
+meson test -C build-clang
+```
+
+Use the regular project commands afterwards, for example:
+
+```bash
+meson compile -C build
+make test
+cargo build --workspace
+npm ci
+npm run build -w web
+```
+
+Go itself comes from Nix, but its module cache and installed tools remain in
+the normal writable user directories. `go install example.org/tool@version`
+writes the binary to `$GOBIN`, or to `$(go env GOPATH)/bin` when `$GOBIN` is
+unset. Add that directory to the host `PATH` if it is not already there. A tool
+also listed in `flake.nix` takes precedence inside `nix develop`.
+
+Run a single command without entering an interactive shell when convenient:
+
+```bash
+nix develop --command meson compile -C build
+nix develop --command make test
+```
+
+Leave an interactive development shell with `exit`. The tools are not installed
+globally; they remain in `/nix/store` and become available through `nix develop`.
+`nix store gc` may remove an unused development-shell closure, in which case the
+next `nix develop` downloads it again.
+
+QEMU is included in the shell. KVM is optional acceleration; the functional
+tests fall back to QEMU TCG when `/dev/kvm` is unavailable. To use KVM, grant
+access on the Linux host:
+
+```bash
+sudo usermod -aG kvm "$(id -un)"
+test -r /dev/kvm && test -w /dev/kvm
+```
+
+Log in again after changing group membership. Functional tests configure
+hugepages inside the guest; host hugepages and other DPDK settings are needed
+when running the dataplane directly on the host.
+
+On x86-64, build the release artifacts with `make all`, then run
+`make test-functional`. The test harness stages Nix-built executables so they
+run with the guest system loader; the guest does not need `/nix/store`.
+Functional tests from aarch64 hosts are not yet supported.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "toolpkgs": "toolpkgs"
+      }
+    },
+    "toolpkgs": {
+      "locked": {
+        "lastModified": 1787631388,
+        "narHash": "sha256-vMiXptXarfSdJb1Gkc+FYVOAibuBRj7qxGa8z68q1Uw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac6b2166e7a9375683b8e98f860f273222337b16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "ac6b2166e7a9",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "YANET2 development shell";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  inputs.toolpkgs.url = "github:NixOS/nixpkgs/ac6b2166e7a9";
+
+  outputs = { nixpkgs, toolpkgs, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+    in {
+      devShells = nixpkgs.lib.genAttrs systems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          tools = import toolpkgs { inherit system; };
+          python = pkgs.python3.withPackages (ps: [ ps.pyelftools ]);
+        in {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              bison
+              buf
+              ccache
+              cdrtools
+              cmake
+              flex
+              gcc
+              git
+              gh
+              gnumake
+              tools.go
+              tools.golangci-lint
+              gopls
+              jq
+              meson
+              ninja
+              nodejs_22
+              pkg-config
+              protobuf
+              tools.protoc-gen-go
+              tools.protoc-gen-go-grpc
+              python
+              qemu
+              shellcheck
+              typescript-language-server
+              wget
+              llvmPackages_19.clang
+              llvmPackages_19.clang-tools
+            ];
+
+            buildInputs = with pkgs; [
+              libpcap
+              libyaml
+              numactl
+              rdma-core
+            ];
+
+            # Some OOM tests intentionally compile with -O0 and -Werror.
+            hardeningDisable = [ "fortify" ];
+            LIBCLANG_PATH = "${pkgs.llvmPackages_19.libclang.lib}/lib";
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ];
+            PYTHONPATH = "${python}/${python.sitePackages}";
+            shellHook = ''export CC=gcc CXX=g++'';
+          };
+        });
+    };
+}


### PR DESCRIPTION
Setting up a YANET development environment currently requires contributors to install and align a large set of system dependencies by hand. The exact setup varies between distributions and can easily drift from the toolchain expected by the project. This PR adds a pinned Nix development shell so contributors can get a consistent environment with a single command without installing the entire toolchain globally.

Making the regular build work inside Nix is not enough: the same environment must also support the functional test suite. Nix-built executables normally expect their dynamic loader under `/nix/store`, but the Ubuntu test VM deliberately has no Nix installation. The functional test harness now prepares guest-local copies of those executables so they can run with the loader already provided by Ubuntu, without exposing the host Nix store to the VM.

  - Provides reproducible development shells for x86-64 and aarch64 Linux with the required build, lint, editor, and QEMU tooling.
  - Keeps Rust managed by rustup so the existing stable and nightly Cargo workflows continue to work.
  - Documents shell activation, PATH refresh after rustup installation, custom Nix stores, KVM and TCG operation, hugepages, and functional-test limitations.
  - Makes `make test-functional` work from the x86-64 Nix shell without installing Nix or mounting `/nix/store` inside the guest.
  - Leaves aarch64 functional-test support out of scope for a follow-up.
