### PR TITLE
fix(functional): require kvm device access

### DIFF
--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -13,8 +13,8 @@ ifeq ($(UNAME_S),Darwin)
 	QEMU_ACCEL :=
 else
 	MKISOFS := mkisofs -output
-	# Check if KVM is available
-	KVM_AVAILABLE := $(shell [ -r /dev/kvm ] && echo "yes" || echo "no")
+	# QEMU needs both read and write access to initialize KVM.
+	KVM_AVAILABLE := $(shell [ -e /dev/kvm ] && (exec 3<>/dev/kvm) 2>/dev/null && echo "yes" || echo "no")
 	ifeq ($(KVM_AVAILABLE),yes)
 		QEMU_ACCEL := -enable-kvm
 	else

--- a/tests/functional/framework/qemu.go
+++ b/tests/functional/framework/qemu.go
@@ -1244,12 +1244,18 @@ func copyFile(src, dst string) error {
 	return out.Sync()
 }
 
-// isKVMEnabled checks if KVM is available on the system.
+// isKVMEnabled reports whether QEMU can open the KVM device.
 func isKVMEnabled() bool {
-	if _, err := os.Stat("/dev/kvm"); err == nil {
-		return true
+	return isKVMDeviceAccessible("/dev/kvm")
+}
+
+func isKVMDeviceAccessible(path string) bool {
+	device, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return false
 	}
-	return false
+	defer device.Close()
+	return true
 }
 
 // existingVMPattern builds the pgrep -f pattern that detects a real QEMU

--- a/tests/functional/framework/qemu_test.go
+++ b/tests/functional/framework/qemu_test.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -155,4 +156,18 @@ func Test_CheckForExistingVMRun_RunnerErrorIsPropagated(t *testing.T) {
 		strings.Contains(err.Error(), "executable file not found"),
 		"underlying pgrep error must be wrapped, not swallowed",
 	)
+}
+
+// verifies that an existing path without read-write device access disables KVM.
+func Test_KVMDeviceAccessible_ReadWriteAccessRequired(t *testing.T) {
+	require.False(t, isKVMDeviceAccessible(t.TempDir()))
+}
+
+// verifies that a path openable for reading and writing enables KVM.
+func Test_KVMDeviceAccessible_ReadWriteAccessAvailable(t *testing.T) {
+	device, err := os.CreateTemp(t.TempDir(), "kvm-device-")
+	require.NoError(t, err)
+	require.NoError(t, device.Close())
+
+	require.True(t, isKVMDeviceAccessible(device.Name()))
 }


### PR DESCRIPTION
Verify that `/dev/kvm` can be opened read-write before enabling QEMU hardware acceleration.
Fall back to TCG when the KVM device exists but is inaccessible.
Cover accessible and inaccessible device paths with regression tests.