### PR TITLE
perf(worker): replace per-tick device scans with rlist worklist

### DIFF
--- a/common/rlist.h
+++ b/common/rlist.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// Intrusive circular doubly-linked list, list_head style.
+//
+// A member embeds a node and is reached back through the node; a head is
+// a plain node that points at itself when empty. Insertion appends at
+// the tail, so first-out order matches insertion order.
+struct rlist {
+	struct rlist *prev;
+	struct rlist *next;
+};
+
+static inline void
+rlist_init(struct rlist *head) {
+	head->prev = head;
+	head->next = head;
+}
+
+static inline void
+rlist_remove(struct rlist *node) {
+	node->prev->next = node->next;
+	node->next->prev = node->prev;
+}
+
+static inline void
+rlist_add(struct rlist *head, struct rlist *node) {
+	node->prev = head->prev;
+	node->next = head;
+	head->prev->next = node;
+	head->prev = node;
+}
+
+static inline struct rlist *
+rlist_first(struct rlist *head) {
+	return head->next;
+}
+
+static inline int
+rlist_empty(struct rlist *head) {
+	return head->next == head;
+}

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -112,8 +112,9 @@ worker_read(
 			*(worker->dp_worker->drop_count) += 1;
 			continue;
 		}
-		packet_front_input(
-			&ADDR_OF(&device_ectx->input_pipelines)->schedule,
+		device_entry_ectx_schedule(
+			config_gen_ectx,
+			ADDR_OF(&device_ectx->input_pipelines),
 			packet
 		);
 	}

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -1336,6 +1336,8 @@ device_ectx_create(
 		goto error;
 	}
 	SET_OFFSET_OF(&device_ectx->input_pipelines, input);
+	SET_OFFSET_OF(&input->device_ectx, device_ectx);
+	input->direction = device_entry_direction_input;
 
 	struct device_entry_ectx *output = device_entry_ectx_create(
 		cp_config_gen,
@@ -1351,6 +1353,8 @@ device_ectx_create(
 		goto error;
 	}
 	SET_OFFSET_OF(&device_ectx->output_pipelines, output);
+	SET_OFFSET_OF(&output->device_ectx, device_ectx);
+	output->direction = device_entry_direction_output;
 
 	return device_ectx;
 

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/rlist.h"
 #include "lib/counters/counters.h"
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/pipeline/econtext.h"
@@ -44,6 +45,91 @@ device_entry_ectx_count_recirc_drop(
 	counter[1] += rte_pktmbuf_pkt_len(packet_to_mbuf(packet));
 }
 
+// Advance the generation's worklists to the start of a worker tick.
+//
+// Must run on the owning worker before any packet is scheduled in the
+// tick. Once the lists are built, a tick start only flips the roles,
+// which turns the processed list into the to-execute list with no
+// per-node work; the first build walks the devices once and links every
+// input entry before every output entry, mirroring the historical phase
+// order of the full sweep. The freshly built list is the active one for
+// the current tick, so the build path must not flip.
+static inline void
+config_gen_ectx_schedules_prepare(struct config_gen_ectx *config_gen_ectx) {
+	if (config_gen_ectx->schedules_ready) {
+		config_gen_ectx->schedule_active ^= 1;
+		return;
+	}
+
+	rlist_init(&config_gen_ectx->schedule_lists[0]);
+	rlist_init(&config_gen_ectx->schedule_lists[1]);
+
+	for (uint64_t pass = 0; pass < 2; ++pass) {
+		for (uint64_t idx = 0; idx < config_gen_ectx->device_count;
+		     ++idx) {
+			struct device_ectx *device_ectx =
+				config_gen_ectx_get_device(
+					config_gen_ectx, idx
+				);
+			if (device_ectx == NULL) {
+				continue;
+			}
+
+			struct device_entry_ectx *device_entry_ectx;
+			if (pass == 0) {
+				device_entry_ectx =
+					ADDR_OF(&device_ectx->input_pipelines);
+			} else {
+				device_entry_ectx =
+					ADDR_OF(&device_ectx->output_pipelines);
+			}
+
+			rlist_add(
+				&config_gen_ectx->schedule_lists[0],
+				&device_entry_ectx->schedule_node
+			);
+			device_entry_ectx->schedule_list = 0;
+		}
+	}
+
+	config_gen_ectx->schedule_active = 0;
+	config_gen_ectx->schedules_ready = 1;
+}
+
+// Schedule a packet onto a device entry's input list, moving the entry
+// onto the active worklist when needed.
+//
+// An entry parked on the processed list after running this tick is
+// moved back to the active list so it runs again, reproducing the
+// recirculation semantics; an entry already queued for this tick is
+// left where it is. Before the lists are built the packet is only
+// placed on the entry's schedule and the first full sweep picks it up.
+static inline void
+device_entry_ectx_schedule(
+	struct config_gen_ectx *config_gen_ectx,
+	struct device_entry_ectx *device_entry_ectx,
+	struct packet *packet
+) {
+	if (!config_gen_ectx->schedules_ready) {
+		packet_front_input(&device_entry_ectx->schedule, packet);
+		return;
+	}
+
+	if (device_entry_ectx->schedule_list !=
+	    config_gen_ectx->schedule_active) {
+		rlist_remove(&device_entry_ectx->schedule_node);
+		rlist_add(
+			&config_gen_ectx->schedule_lists
+				 [config_gen_ectx->schedule_active],
+			&device_entry_ectx->schedule_node
+		);
+		device_entry_ectx->schedule_list =
+			config_gen_ectx->schedule_active;
+	}
+
+	packet_front_input(&device_entry_ectx->schedule, packet);
+}
+
 // Route a packet to its target device's input entry, counting it as
 // pending_input on the originating schedule.
 //
@@ -82,7 +168,7 @@ module_ectx_route_input(
 		packet_front_drop(packet_front, packet);
 		return;
 	}
-	packet_front_input(&entry_ectx->schedule, packet);
+	device_entry_ectx_schedule(config_gen_ectx, entry_ectx, packet);
 }
 
 // Route a packet to its target device's output entry, counting it as
@@ -122,7 +208,7 @@ module_ectx_route_output(
 		packet_front_drop(packet_front, packet);
 		return;
 	}
-	packet_front_input(&entry_ectx->schedule, packet);
+	device_entry_ectx_schedule(config_gen_ectx, entry_ectx, packet);
 }
 
 // Build one execution context per worker.

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -44,11 +44,11 @@ _Static_assert(
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct device_entry_ectx) == 216,
+	sizeof(struct device_entry_ectx) == 248,
 	"struct device_entry_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct config_gen_ectx) == 176,
+	sizeof(struct config_gen_ectx) == 216,
 	"struct config_gen_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 20
+#define YANET_MODULE_ABI_VERSION 21
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include "common/memory_address.h"
+#include "common/rlist.h"
 #include "lib/dataplane/device/device.h"
 #include "lib/dataplane/module/module.h"
 #include "lib/dataplane/module/packet_front.h"
@@ -142,8 +143,26 @@ struct pipeline_ectx {
 	struct function_ectx *functions[];
 };
 
+enum device_entry_direction {
+	device_entry_direction_input,
+	device_entry_direction_output,
+};
+
 struct device_entry_ectx {
 	device_handler handler;
+
+	// Worker-side worklist membership and round dispatch.
+	//
+	// The node links this entry into one of the generation's two
+	// worklists and the direction selects input or output processing;
+	// the back reference reaches the owning device without an array
+	// walk (an offset pointer filled by the control plane, as is the
+	// direction). List links are the owning worker's business only.
+	struct rlist schedule_node;
+	uint8_t schedule_list;
+	uint8_t direction;
+	struct device_ectx *device_ectx;
+
 	struct counter_value_handle *counter_packet_rx;
 	struct counter_value_handle *counter_packet_entry;
 	struct counter_value_handle *counter_packet_tx;
@@ -200,6 +219,22 @@ struct config_gen_ectx {
 	// end of every worker round, so the worker loop reuses it in place
 	// instead of reinitializing a fresh front on each iteration.
 	struct packet_front packet_front;
+
+	// Two device-entry worklists whose roles swap every tick; the
+	// active one is the to-execute list.
+	//
+	// Every entry is linked into exactly one: the active list holds
+	// entries still to execute this tick, the other the processed
+	// ones. Tick start flips the roles, turning the whole processed
+	// list back into the to-execute list at constant cost, so every
+	// entry still runs at least once per tick; a packet routed to a
+	// processed entry moves it back so it runs again within the tick.
+	// Links are raw pointers built only by the owning worker, which
+	// also raises the ready flag on first build; the control plane
+	// leaves all three fields zeroed.
+	struct rlist schedule_lists[2];
+	uint8_t schedule_active;
+	uint8_t schedules_ready;
 
 	uint64_t device_count;
 	struct device_ectx *devices[];

--- a/lib/dataplane/worker/pipeline_round.c
+++ b/lib/dataplane/worker/pipeline_round.c
@@ -1,5 +1,6 @@
 #include "pipeline_round.h"
 
+#include "common/container_of.h"
 #include "lib/controlplane/config/econtext.h"
 #include "lib/controlplane/config/zone.h"
 #include "lib/dataplane/config/zone.h"
@@ -16,73 +17,50 @@ worker_pipeline_round(
 ) {
 	(void)cp_config_gen;
 
-	uint64_t device_count = config_gen_ectx->device_count;
+	struct rlist *active_head =
+		&config_gen_ectx
+			 ->schedule_lists[config_gen_ectx->schedule_active];
+	struct rlist *inactive_head =
+		&config_gen_ectx
+			 ->schedule_lists[config_gen_ectx->schedule_active ^ 1];
 
 	/*
-	 * Force a full traversal on the first iteration.
+	 * Every entry executes at least once per tick.
 	 *
-	 * Every device, and through it every pipeline, function, chain and
-	 * module, runs once per tick even when no packets arrived, so periodic
-	 * work has a chance to make progress. Later iterations only revisit
-	 * devices whose input or output entry received packets, whether
-	 * straight from RX or routed in by a module.
+	 * Tick preparation hands over a list that still holds every
+	 * entry, so all of them run even when no packets arrived and
+	 * periodic work has a chance to make progress. Within the tick,
+	 * an entry re-enters the list only when a packet is routed onto
+	 * it, and the round ends once that quiesces.
 	 */
-	int force_poll = 1;
+	while (!rlist_empty(active_head)) {
+		struct rlist *node = rlist_first(active_head);
 
-	while (1) {
-		if (!force_poll) {
-			int has_work = 0;
-			for (uint64_t idx = 0; idx < device_count; ++idx) {
-				struct device_ectx *device_ectx =
-					config_gen_ectx_get_device(
-						config_gen_ectx, idx
-					);
-				if (device_ectx == NULL) {
-					continue;
-				}
-				if (packet_list_first(
-					    &ADDR_OF(&device_ectx
-							      ->input_pipelines)
-						     ->schedule.input
-				    ) != NULL ||
-				    packet_list_first(
-					    &ADDR_OF(&device_ectx
-							      ->output_pipelines
-					    )
-						     ->schedule.input
-				    ) != NULL) {
-					has_work = 1;
-					break;
-				}
-			}
-			if (!has_work) {
-				break;
-			}
-		}
+		/*
+		 * Park the entry before executing it: a packet routed
+		 * into it while it runs moves it back onto the active
+		 * list so it runs again this tick.
+		 */
+		rlist_remove(node);
+		rlist_add(inactive_head, node);
 
-		for (uint64_t idx = 0; idx < device_count; ++idx) {
-			struct device_ectx *device_ectx =
-				config_gen_ectx_get_device(
-					config_gen_ectx, idx
-				);
-			if (device_ectx == NULL) {
-				continue;
-			}
+		struct device_entry_ectx *device_entry_ectx = container_of(
+			node, struct device_entry_ectx, schedule_node
+		);
+		device_entry_ectx->schedule_list =
+			config_gen_ectx->schedule_active ^ 1;
 
-			struct packet_front *schedule =
-				&ADDR_OF(&device_ectx->input_pipelines)
-					 ->schedule;
+		struct device_ectx *device_ectx =
+			ADDR_OF(&device_entry_ectx->device_ectx);
+		struct packet_front *schedule = &device_entry_ectx->schedule;
 
-			if (!force_poll &&
-			    packet_list_first(&schedule->input) == NULL) {
-				continue;
-			}
+		// Detach the batch so redirects land in the reusable
+		// inbox.
+		struct packet_front active = *schedule;
+		packet_front_init(schedule);
 
-			// Detach the batch so redirects land in the reusable
-			// inbox.
-			struct packet_front active = *schedule;
-			packet_front_init(schedule);
-
+		if (device_entry_ectx->direction ==
+		    device_entry_direction_input) {
 			device_ectx_process_input(
 				dp_worker, device_ectx, &active
 			);
@@ -94,40 +72,12 @@ worker_pipeline_round(
 			 * routed into a device entry by a module.
 			 */
 			packet_front_drop_output(&active);
-
-			packet_front_merge(packet_front, &active);
-		}
-
-		for (uint64_t idx = 0; idx < device_count; ++idx) {
-			struct device_ectx *device_ectx =
-				config_gen_ectx_get_device(
-					config_gen_ectx, idx
-				);
-			if (device_ectx == NULL) {
-				continue;
-			}
-
-			struct packet_front *schedule =
-				&ADDR_OF(&device_ectx->output_pipelines)
-					 ->schedule;
-
-			if (!force_poll &&
-			    packet_list_first(&schedule->input) == NULL) {
-				continue;
-			}
-
-			// Detach the batch so redirects land in the reusable
-			// inbox.
-			struct packet_front active = *schedule;
-			packet_front_init(schedule);
-
+		} else {
 			device_ectx_process_output(
 				dp_worker, device_ectx, &active
 			);
-
-			packet_front_merge(packet_front, &active);
 		}
 
-		force_poll = 0;
+		packet_front_merge(packet_front, &active);
 	}
 }

--- a/lib/dataplane/worker/round.h
+++ b/lib/dataplane/worker/round.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/memory_address.h"
+#include "lib/controlplane/config/econtext.h"
 #include "lib/controlplane/config/zone.h"
 #include "lib/dataplane/config/zone.h"
 
@@ -32,6 +33,12 @@ worker_round_prepare(
 		&dp_worker->gen, round.cp_config_gen->gen, __ATOMIC_RELEASE
 	);
 	*dp_worker->iterations += 1;
+
+	// Flip or first-build the worklists before any packet of this tick
+	// is scheduled onto them.
+	if (round.config_gen_ectx != NULL) {
+		config_gen_ectx_schedules_prepare(round.config_gen_ectx);
+	}
 
 	return round;
 }

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -526,8 +526,9 @@ dataplane_ut_run(
 			packet_front_drop(&packet_front, packet);
 			continue;
 		}
-		packet_front_input(
-			&ADDR_OF(&device_ectx->input_pipelines)->schedule,
+		device_entry_ectx_schedule(
+			config_gen_ectx,
+			ADDR_OF(&device_ectx->input_pipelines),
 			packet
 		);
 	}


### PR DESCRIPTION
- Drive the worker pipeline round from an intrusive rlist worklist over the device entries instead of rescanning the whole device array every tick.
- Executed entries park on an inactive list and a tick-start role flip restores the once-per-tick full poll at constant cost, so periodic module work keeps progressing.
- Packets routed onto an entry (RX read, module input and output routing, the unit-test harness) move it back to the active list, preserving the round's fixpoint semantics.
- The schedule bookkeeping lives in the generation execution context; module ABI version bumps to 21 for the shared-memory layout change.
- Closes #2294.