### PR TITLE
refactor(counters)!: chunk the registry names array

### DIFF
--- a/lib/controlplane/agent/counters.c
+++ b/lib/controlplane/agent/counters.c
@@ -335,19 +335,17 @@ worker_counter_list_build(
 		struct cp_counter_storage *cp_storage = matches[i];
 		struct counter_storage *storage = ADDR_OF(&cp_storage->storage);
 		struct counter_registry *registry = ADDR_OF(&storage->registry);
-		struct counter *counters = ADDR_OF(&registry->names);
-
 		size_t storage_matches = 0;
 		size_t region = 0;
 		for (uint64_t idx = 0; idx < registry->count; ++idx) {
-			if (!counter_pattern_set_match(
-				    names, counters[idx].name
-			    )) {
+			struct counter *counter =
+				counter_registry_entry(registry, idx);
+			if (!counter_pattern_set_match(names, counter->name)) {
 				continue;
 			}
 			size_t counter_region;
 			if (!counter_value_region_size(
-				    1, counters[idx].size, &counter_region
+				    1, counter->size, &counter_region
 			    ) ||
 			    !counter_region_add(&region, counter_region)) {
 				yanet_error_add(
@@ -385,12 +383,11 @@ worker_counter_list_build(
 		struct cp_counter_storage *cp_storage = matches[i];
 		struct counter_storage *storage = ADDR_OF(&cp_storage->storage);
 		struct counter_registry *registry = ADDR_OF(&storage->registry);
-		struct counter *counters = ADDR_OF(&registry->names);
 		struct counter_tag *storage_tags = NULL;
 		for (uint64_t idx = 0; idx < registry->count; ++idx) {
-			if (!counter_pattern_set_match(
-				    names, counters[idx].name
-			    )) {
+			struct counter *counter =
+				counter_registry_entry(registry, idx);
+			if (!counter_pattern_set_match(names, counter->name)) {
 				continue;
 			}
 			if (storage_tags == NULL) {
@@ -401,7 +398,7 @@ worker_counter_list_build(
 				);
 			}
 			struct counter_handle *dst = &list->counters[next];
-			const struct counter *src = &counters[idx];
+			const struct counter *src = counter;
 			strtcpy(dst->name, src->name, sizeof(dst->name));
 			dst->size = src->size;
 			dst->gen = src->gen;
@@ -1053,16 +1050,15 @@ counter_handle_list_build(
 	uint64_t count = counter_registry->count;
 
 	size_t values_size = 0;
-	{
-		struct counter *counters = ADDR_OF(&counter_registry->names);
-		for (uint64_t idx = 0; idx < count; ++idx) {
-			size_t region;
-			if (!counter_value_region_size(
-				    worker_count, counters[idx].size, &region
-			    ) ||
-			    !counter_region_add(&values_size, region)) {
-				return NULL;
-			}
+	for (uint64_t idx = 0; idx < count; ++idx) {
+		struct counter *counter =
+			counter_registry_entry(counter_registry, idx);
+		size_t region;
+		if (!counter_value_region_size(
+			    worker_count, counter->size, &region
+		    ) ||
+		    !counter_region_add(&values_size, region)) {
+			return NULL;
 		}
 	}
 
@@ -1089,11 +1085,12 @@ counter_handle_list_build(
 
 	uint8_t *cursor = counter_handle_list_region(list);
 	for (uint64_t idx = 0; idx < count; ++idx) {
-		struct counter *counters = ADDR_OF(&counter_registry->names);
+		struct counter *counter =
+			counter_registry_entry(counter_registry, idx);
 		struct counter_handle *dst = &handlers[idx];
-		strtcpy(dst->name, counters[idx].name, sizeof(dst->name));
-		dst->size = counters[idx].size;
-		dst->gen = counters[idx].gen;
+		strtcpy(dst->name, counter->name, sizeof(dst->name));
+		dst->size = counter->size;
+		dst->gen = counter->gen;
 		counter_handle_fill_values(
 			dst, &cursor, worker_storages, worker_count, idx
 		);

--- a/lib/controlplane/tests/counter_workers_test.c
+++ b/lib/controlplane/tests/counter_workers_test.c
@@ -103,9 +103,9 @@ install_device(
 static uint64_t
 counter_index_by_name(struct counter_storage *storage, const char *name) {
 	struct counter_registry *registry = ADDR_OF(&storage->registry);
-	struct counter *counters = ADDR_OF(&registry->names);
 	for (uint64_t idx = 0; idx < registry->count; ++idx) {
-		if (strcmp(counters[idx].name, name) == 0) {
+		if (strcmp(counter_registry_entry(registry, idx)->name, name) ==
+		    0) {
 			return idx;
 		}
 	}

--- a/lib/counters/counters.c
+++ b/lib/counters/counters.c
@@ -21,7 +21,8 @@ counter_registry_init(
 	registry->capacity = 0;
 	registry->gen = gen;
 
-	SET_OFFSET_OF(&registry->names, NULL);
+	SET_OFFSET_OF(&registry->dirs, NULL);
+	registry->dir_page_count = 0;
 
 	if (str_index_init(&registry->str_index, memory_context)) {
 		return -1;
@@ -34,12 +35,38 @@ void
 counter_registry_fini(struct counter_registry *registry) {
 	struct memory_context *memory_context =
 		ADDR_OF(&registry->memory_context);
-	struct counter *names = ADDR_OF(&registry->names);
-	if (names != NULL) {
+	struct counter ***dirs = ADDR_OF(&registry->dirs);
+	if (dirs != NULL) {
+		uint64_t chunk_slots =
+			registry->capacity / COUNTER_REGISTRY_CHUNK;
+		for (uint64_t page_idx = 0; page_idx < registry->dir_page_count;
+		     ++page_idx) {
+			struct counter **page = ADDR_OF(dirs + page_idx);
+			uint64_t page_first_slot =
+				page_idx * COUNTER_REGISTRY_DIR_SLOTS;
+			for (uint64_t slot = 0;
+			     slot < COUNTER_REGISTRY_DIR_SLOTS &&
+			     page_first_slot + slot < chunk_slots;
+			     ++slot) {
+				memory_bfree(
+					memory_context,
+					ADDR_OF(page + slot),
+					sizeof(struct counter) *
+						COUNTER_REGISTRY_CHUNK
+				);
+			}
+			memory_bfree(
+				memory_context,
+				page,
+				sizeof(struct counter *) *
+					COUNTER_REGISTRY_DIR_SLOTS
+			);
+		}
+
 		memory_bfree(
 			memory_context,
-			names,
-			sizeof(struct counter) * registry->capacity
+			dirs,
+			sizeof(struct counter **) * registry->dir_page_count
 		);
 	}
 
@@ -51,11 +78,9 @@ counter_registry_fini(struct counter_registry *registry) {
 
 static inline const char *
 counter_registry_read_index(uint32_t index, const void *data) {
-	const struct counter_registry *registry =
-		(struct counter_registry *)data;
+	struct counter_registry *registry = (struct counter_registry *)data;
 
-	struct counter *names = ADDR_OF(&registry->names);
-	return names[index].name;
+	return counter_registry_entry(registry, index)->name;
 }
 
 uint64_t
@@ -77,54 +102,101 @@ counter_registry_lookup_index(
 	return (uint64_t)-1;
 }
 
+// Grows the registry by one chunk of entries.
+//
+// The only entry allocation on this path is the fixed-size chunk itself:
+// growth never copies the existing entries and never holds old and new
+// storage live at once, so the transient arena demand is one chunk no
+// matter how large the registry already is.
 static int
-counter_registry_expand(
-	struct counter_registry *registry,
-	uint64_t new_capacity,
-	yanet_error **err
-) {
-	uint64_t old_capacity = registry->capacity;
-	if (new_capacity < registry->capacity) {
-		yanet_error_add(
-			err,
-			"requested capacity (%lu) is smaller than current "
-			"capacity (%lu)",
-			new_capacity,
-			registry->capacity
-		);
-		return -1;
-	}
-	if (new_capacity == registry->capacity) {
-		return 0;
-	}
-
+counter_registry_grow(struct counter_registry *registry, yanet_error **err) {
 	struct memory_context *memory_context =
 		ADDR_OF(&registry->memory_context);
 
-	struct counter *new_names = (struct counter *)memory_balloc(
-		memory_context, sizeof(struct counter) * new_capacity
+	struct counter *chunk = (struct counter *)memory_balloc(
+		memory_context, sizeof(struct counter) * COUNTER_REGISTRY_CHUNK
 	);
-	if (new_names == NULL) {
+	if (chunk == NULL) {
 		yanet_error_add(err, "failed to allocate counter names");
 		return -1;
 	}
+	memset(chunk, 0, sizeof(struct counter) * COUNTER_REGISTRY_CHUNK);
 
-	struct counter *names = ADDR_OF(&registry->names);
+	uint64_t slot = registry->capacity / COUNTER_REGISTRY_CHUNK;
 
-	/*
-	 * FIXME: copying is not efficient here so names and links should be
-	 * turned into chunked arrays.
-	 */
-	if (old_capacity > 0) {
-		memcpy(new_names, names, sizeof(struct counter) * old_capacity);
+	// A fresh directory page is needed whenever the current page runs
+	// out of slots. Page cells hold self-relative pointers, so the
+	// pages array cannot grow through realloc-copy: a copied cell would
+	// resolve against its new address instead of the one it was set
+	// for. The pages array is re-housed with EQUATE_OFFSET and stays a
+	// handful of pointers: one page covers 65,536 counters.
+	if (slot % COUNTER_REGISTRY_DIR_SLOTS == 0) {
+		struct counter **page = (struct counter **)memory_balloc(
+			memory_context,
+			sizeof(struct counter *) * COUNTER_REGISTRY_DIR_SLOTS
+		);
+		if (page == NULL) {
+			memory_bfree(
+				memory_context,
+				chunk,
+				sizeof(struct counter) * COUNTER_REGISTRY_CHUNK
+			);
+			yanet_error_add(
+				err, "failed to allocate counter directory"
+			);
+			return -1;
+		}
+		memset(page,
+		       0,
+		       sizeof(struct counter *) * COUNTER_REGISTRY_DIR_SLOTS);
+
+		uint64_t new_page_count = registry->dir_page_count + 1;
+		struct counter ***new_dirs = (struct counter ***)memory_balloc(
+			memory_context,
+			sizeof(struct counter **) * new_page_count
+		);
+		if (new_dirs == NULL) {
+			memory_bfree(
+				memory_context,
+				page,
+				sizeof(struct counter *) *
+					COUNTER_REGISTRY_DIR_SLOTS
+			);
+			memory_bfree(
+				memory_context,
+				chunk,
+				sizeof(struct counter) * COUNTER_REGISTRY_CHUNK
+			);
+			yanet_error_add(
+				err, "failed to grow counter directory array"
+			);
+			return -1;
+		}
+
+		struct counter ***dirs = ADDR_OF(&registry->dirs);
+		for (uint64_t idx = 0; idx < registry->dir_page_count; ++idx) {
+			EQUATE_OFFSET(new_dirs + idx, dirs + idx);
+		}
+		if (dirs != NULL) {
+			memory_bfree(
+				memory_context,
+				dirs,
+				sizeof(struct counter **) *
+					registry->dir_page_count
+			);
+		}
+
+		registry->dir_page_count = new_page_count;
+		SET_OFFSET_OF(&registry->dirs, new_dirs);
+		SET_OFFSET_OF(new_dirs + new_page_count - 1, page);
 	}
 
-	SET_OFFSET_OF(&registry->names, new_names);
-	registry->capacity = new_capacity;
+	struct counter ***dirs = ADDR_OF(&registry->dirs);
+	struct counter **page =
+		ADDR_OF(dirs + slot / COUNTER_REGISTRY_DIR_SLOTS);
+	SET_OFFSET_OF(page + slot % COUNTER_REGISTRY_DIR_SLOTS, chunk);
 
-	memory_bfree(
-		memory_context, names, sizeof(struct counter) * old_capacity
-	);
+	registry->capacity += COUNTER_REGISTRY_CHUNK;
 
 	return 0;
 }
@@ -142,11 +214,7 @@ counter_registry_insert(
 	}
 
 	if (registry->count >= registry->capacity) {
-		uint64_t new_capacity = registry->capacity * 2;
-		if (new_capacity == 0) {
-			new_capacity = 8;
-		}
-		if (counter_registry_expand(registry, new_capacity, err)) {
+		if (counter_registry_grow(registry, err)) {
 			yanet_error_add(
 				err, "failed to expand counter registry"
 			);
@@ -166,9 +234,8 @@ counter_registry_insert(
 		return -1;
 	}
 
-	struct counter *names = ADDR_OF(&registry->names);
-
-	struct counter *new_name = names + registry->count;
+	struct counter *new_name =
+		counter_registry_entry(registry, registry->count);
 
 	strtcpy(new_name->name, name, COUNTER_NAME_LEN);
 	new_name->size = size;
@@ -208,7 +275,7 @@ counter_registry_register(
 	uint64_t idx = counter_registry_lookup_index(registry, name);
 
 	if (idx != (uint64_t)-1) {
-		struct counter *name = ADDR_OF(&registry->names) + idx;
+		struct counter *name = counter_registry_entry(registry, idx);
 		name->gen = registry->gen;
 		if (name->size != size) {
 			yanet_error_add(
@@ -239,7 +306,7 @@ counter_registry_link(
 
 		for (uint64_t src_idx = 0; src_idx < src->count; ++src_idx) {
 			struct counter *src_name =
-				ADDR_OF(&src->names) + src_idx;
+				counter_registry_entry(src, src_idx);
 
 			// Skip outdated counters
 			if (src_name->gen != src->gen) {
@@ -259,7 +326,7 @@ counter_registry_link(
 				);
 			} else {
 				struct counter *dst_name =
-					ADDR_OF(&dst->names) + dst_idx;
+					counter_registry_entry(dst, dst_idx);
 				if (dst_name->size != src_name->size) {
 					yanet_error_add(
 						err,
@@ -274,12 +341,12 @@ counter_registry_link(
 			}
 
 			struct counter *dst_name =
-				ADDR_OF(&dst->names) + dst_idx;
+				counter_registry_entry(dst, dst_idx);
 			dst_name->offset = src_name->offset;
 		}
 	}
 	for (uint64_t dst_idx = 0; dst_idx < dst->count; ++dst_idx) {
-		struct counter *dst_name = ADDR_OF(&dst->names) + dst_idx;
+		struct counter *dst_name = counter_registry_entry(dst, dst_idx);
 
 		if (dst_name->offset != (uint64_t)-1) {
 			continue;
@@ -438,7 +505,8 @@ counter_storage_spawn(
 	}
 
 	for (uint64_t idx = 0; idx < counter_registry->count; ++idx) {
-		struct counter *name = ADDR_OF(&counter_registry->names) + idx;
+		struct counter *name =
+			counter_registry_entry(counter_registry, idx);
 
 		uint64_t pool_idx = uint64_log_up(name->size);
 

--- a/lib/counters/counters.h
+++ b/lib/counters/counters.h
@@ -15,7 +15,10 @@
 #define CP_PIPELINE_NAME_LEN 80
 #endif
 
-#define COUNTER_NAME_LEN 128
+// The name field leaves room for the three uint64_t fields of struct
+// counter, so one entry is exactly 128 bytes: two cache lines, and a
+// power-of-two entry count packs a chunk without padding.
+#define COUNTER_NAME_LEN (128 - 8 - 8 - 8)
 #define COUNTER_INVALID (uint64_t)-1
 
 struct counter {
@@ -25,6 +28,34 @@ struct counter {
 	uint64_t offset;
 };
 
+_Static_assert(
+	sizeof(struct counter) == 128,
+	"counter entry must stay exactly 128 bytes"
+);
+
+// Entries per registry chunk: 64 entries pack into one 8 KiB allocator
+// class, so a chunk request never fragments a higher class and growth
+// caps the arena's largest registry demand at one small page whatever
+// the counter count.
+#define COUNTER_REGISTRY_CHUNK 64
+
+// Chunk-pointer slots per directory page, also one 8 KiB allocator class.
+//
+// A flat pointer array indexed by chunk would itself cross the one-chunk
+// bound at 65,536 counters (1,025 pointers), so chunk pointers live in
+// fixed directory pages instead: growth adds at most one entry chunk or
+// one directory page, never a larger block.
+#define COUNTER_REGISTRY_DIR_SLOTS 1024
+
+_Static_assert(
+	COUNTER_REGISTRY_CHUNK * sizeof(struct counter) == 8192,
+	"registry chunk must pack exactly into the 8 KiB allocator class"
+);
+_Static_assert(
+	COUNTER_REGISTRY_DIR_SLOTS * sizeof(struct counter *) == 8192,
+	"registry directory page must pack exactly into the 8 KiB class"
+);
+
 struct counter_registry {
 	struct memory_context *memory_context;
 	uint64_t gen;
@@ -32,9 +63,33 @@ struct counter_registry {
 	uint64_t count;
 	uint64_t counts[COUNTER_POOL_SIZE];
 
-	struct counter *names;
+	// Chunked names storage: entry idx lives in chunk slot
+	// idx / COUNTER_REGISTRY_CHUNK of the chunk pointed at by directory
+	// page (idx / COUNTER_REGISTRY_CHUNK) / COUNTER_REGISTRY_DIR_SLOTS,
+	// slot (idx / COUNTER_REGISTRY_CHUNK) %
+	// COUNTER_REGISTRY_DIR_SLOTS. capacity counts entries and is always
+	// a multiple of COUNTER_REGISTRY_CHUNK; dir_page_count is the
+	// allocated length of the pages array, which stays a handful of
+	// pointers for any realistic registry. All pointers are
+	// shared-memory relative.
+	struct counter ***dirs;
+	uint64_t dir_page_count;
 	struct str_index str_index;
 };
+
+// Entry idx of registry, chunk- and directory-resolved.
+//
+// Valid for idx < registry->count only: the chunk slots beyond the last
+// allocated chunk are never materialized.
+static inline struct counter *
+counter_registry_entry(struct counter_registry *registry, uint64_t idx) {
+	uint64_t slot = idx / COUNTER_REGISTRY_CHUNK;
+	struct counter ***dirs = ADDR_OF(&registry->dirs);
+	struct counter **page =
+		ADDR_OF(dirs + slot / COUNTER_REGISTRY_DIR_SLOTS);
+	return ADDR_OF(page + slot % COUNTER_REGISTRY_DIR_SLOTS) +
+	       idx % COUNTER_REGISTRY_CHUNK;
+}
 
 int
 counter_registry_init(
@@ -53,6 +108,12 @@ counter_registry_register(
 
 void
 counter_registry_fini(struct counter_registry *registry);
+
+// Index of the registered name, or (uint64_t)-1 when absent.
+uint64_t
+counter_registry_lookup_index(
+	struct counter_registry *registry, const char *name
+);
 
 int
 counter_registry_link(

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -24,7 +24,7 @@ _Static_assert(
 	"struct module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct dp_config) == 1184,
+	sizeof(struct dp_config) == 1192,
 	"struct dp_config size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
@@ -36,7 +36,7 @@ _Static_assert(
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct cp_module) == 544,
+	sizeof(struct cp_module) == 552,
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane_ut/tests/worker_counters_test.c
+++ b/lib/dataplane_ut/tests/worker_counters_test.c
@@ -17,9 +17,10 @@
 // not rely on the same lookup that registration uses.
 static uint64_t
 lookup_id(struct counter_registry *registry, const char *name) {
-	struct counter *names = ADDR_OF(&registry->names);
 	for (uint64_t idx = 0; idx < registry->count; ++idx) {
-		if (strncmp(names[idx].name, name, COUNTER_NAME_LEN) == 0) {
+		if (strncmp(counter_registry_entry(registry, idx)->name,
+			    name,
+			    COUNTER_NAME_LEN) == 0) {
 			return idx;
 		}
 	}

--- a/modules/forward/controlplane/service_test.go
+++ b/modules/forward/controlplane/service_test.go
@@ -236,7 +236,7 @@ func TestUpdateConfigEmptyCounterEmptyTarget(t *testing.T) {
 // long enough to overflow the counter-name limit still applies, with the
 // counter cut to exactly that limit.
 //
-// The expected length (127) is asserted as a literal, not derived from
+// The expected length (103) is asserted as a literal, not derived from
 // cforward.CounterNameMaxLen, so an off-by-one in that constant would not
 // make this test pass vacuously.
 func TestUpdateConfigMaterializesEmptyCounterLongTarget(t *testing.T) {
@@ -256,7 +256,7 @@ func TestUpdateConfigMaterializesEmptyCounterLongTarget(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, backend.rules, 1)
-	require.Len(t, backend.rules[0].Counter, 127)
+	require.Len(t, backend.rules[0].Counter, 103)
 	require.True(t, strings.HasPrefix(backend.rules[0].Counter, "to_aaa"))
 
 	response, err := svc.ShowConfig(t.Context(), &forwardpb.ShowConfigRequest{Name: "config"})

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -457,7 +457,7 @@ func TestForward_EmptyCounterLongTargetRegistersInCounterRegistry(t *testing.T) 
 
 	wantCounter := response.GetRules()[0].GetAction().GetCounter()
 	require.NotEmpty(t, wantCounter)
-	require.Len(t, wantCounter, 127, "materialised counter must be cut to the registry's usable limit")
+	require.Len(t, wantCounter, 103, "materialised counter must be cut to the registry's usable limit")
 
 	wireForwardPipeline(t, agent, "port0", "test", nil)
 

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -573,7 +573,7 @@ fib_iter_nexthop_counter_name(const struct fib_iter *it, uint64_t nexthop_idx) {
 		ADDR_OF(registries + config->routes_registry_idx);
 	struct counter_registry *registry = &entry->registry;
 	if (r->counter_id < registry->count) {
-		return ADDR_OF(&registry->names)[r->counter_id].name;
+		return counter_registry_entry(registry, r->counter_id)->name;
 	}
 	return "";
 }

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -579,19 +579,19 @@ func TestUpdateFIBRejectsOverlongCounter(t *testing.T) {
 	backend := newFakeBackend()
 	service := route.NewRouteService(backend)
 
-	okEntry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "nexthop_"+strings.Repeat("a", 127-len("nexthop_"))))
+	okEntry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "nexthop_"+strings.Repeat("a", 103-len("nexthop_"))))
 	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
 		ModuleName: "cfg",
 		Entries:    []*routepb.FIBEntry{okEntry},
 	})
-	require.NoError(t, err, "a 127-byte counter name must be accepted")
+	require.NoError(t, err, "a 103-byte counter name must be accepted")
 
-	tooLongEntry := testFIBEntry(t, "10.0.0.1/32", testNexthop("eth0", "nexthop_"+strings.Repeat("a", 128-len("nexthop_"))))
+	tooLongEntry := testFIBEntry(t, "10.0.0.1/32", testNexthop("eth0", "nexthop_"+strings.Repeat("a", 104-len("nexthop_"))))
 	_, err = service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
 		ModuleName: "cfg",
 		Entries:    []*routepb.FIBEntry{tooLongEntry},
 	})
-	require.Equal(t, codes.InvalidArgument, status.Code(err), "a 128-byte counter name must be rejected")
+	require.Equal(t, codes.InvalidArgument, status.Code(err), "a 104-byte counter name must be rejected")
 }
 
 // TestUpdateFIBRejectsCounterWithNULByte verifies that a counter name

--- a/modules/route/tests/route_api_test.c
+++ b/modules/route/tests/route_api_test.c
@@ -26,19 +26,31 @@
 #include <string.h>
 
 /*
- * 16 KB: enough for cp_module_init's small allocations (empirically < 8 KB),
- * but well below the 32 KB lpm_init page-chunk request.
+ * Enough for cp_module_init's small allocations plus one registry names
+ * chunk (a 32 KB-class block since the registry moved to chunked
+ * storage), but below fitting the LPM page-chunk request next to them.
+ * The sanitizer build pays a red zone per allocation on top, measured to
+ * cross the 64 KB boundary, so each mode picks its own limit.
  */
-#define ROUTE_TEST_MEMORY_LIMIT (16u * 1024u)
+#ifdef HAVE_ASAN
+#define ROUTE_TEST_MEMORY_LIMIT (72u * 1024u)
+#else
+#define ROUTE_TEST_MEMORY_LIMIT (56u * 1024u)
+#endif
 
 /*
- * 40800 bytes, found empirically: enough for construction plus one
- * routing table's own setup, but too little for the second table to also
- * succeed. This size reaches data setup's own error path instead of the
- * shared type teardown, verifying that path frees the first table
- * exactly once.
+ * Module smalls, one registry names chunk, and the first routing table's
+ * own setup, but too little for the second table to also succeed. This
+ * reaches data setup's own error path instead of the shared type
+ * teardown, verifying that path frees the first table exactly once. The
+ * sanitizer build pays a red zone per allocation and a class bump on
+ * boundary-exact blocks, so each mode picks its own limit.
  */
-#define ROUTE_TEST_SECOND_LPM_LIMIT (40800u)
+#ifdef HAVE_ASAN
+#define ROUTE_TEST_SECOND_LPM_LIMIT (160u * 1024u)
+#else
+#define ROUTE_TEST_SECOND_LPM_LIMIT (72u * 1024u)
+#endif
 
 static int
 run_test(struct yanet_shm *shm) {

--- a/modules/route/web/validation.test.ts
+++ b/modules/route/web/validation.test.ts
@@ -41,18 +41,18 @@ describe('validateRow counter field', () => {
         expect(validateRow({ ...baseRow, counter: 'my-counter' }).counter).not.toBeNull();
     });
 
-    it('rejects a counter longer than 127 bytes', () => {
-        const tooLong = 'nexthop_' + 'a'.repeat(127);
+    it('rejects a counter longer than 103 bytes', () => {
+        const tooLong = 'nexthop_' + 'a'.repeat(103);
         expect(validateRow({ ...baseRow, counter: tooLong }).counter).not.toBeNull();
     });
 
-    it('rejects a counter at exactly 128 bytes', () => {
-        const atLimit = 'nexthop_' + 'a'.repeat(128 - 'nexthop_'.length);
+    it('rejects a counter at exactly 104 bytes', () => {
+        const atLimit = 'nexthop_' + 'a'.repeat(104 - 'nexthop_'.length);
         expect(validateRow({ ...baseRow, counter: atLimit }).counter).not.toBeNull();
     });
 
-    it('accepts a counter at exactly 127 bytes', () => {
-        const exact = 'nexthop_' + 'a'.repeat(127 - 'nexthop_'.length);
+    it('accepts a counter at exactly 103 bytes', () => {
+        const exact = 'nexthop_' + 'a'.repeat(103 - 'nexthop_'.length);
         expect(validateRow({ ...baseRow, counter: exact }).counter).toBeNull();
     });
 });

--- a/modules/route/web/validation.ts
+++ b/modules/route/web/validation.ts
@@ -2,7 +2,10 @@ import type { FIBRowItem, FIBRowErrors } from './types';
 import { normalizeIPRange } from '@yanet/core/utils/netip';
 import { rowHasError as sharedRowHasError, countInvalidRows as sharedCountInvalidRows } from '@yanet/core/utils';
 
-const MAX_COUNTER_NAME_BYTES = 127;
+// Mirrors the registry-side counter-name limit: COUNTER_NAME_LEN is
+// 128 minus the three uint64_t fields of struct counter, leaving 103
+// usable bytes (see lib/counters/counters.h).
+const MAX_COUNTER_NAME_BYTES = 103;
 
 /** Returns true if the row's from/to parse as a valid, non-reversed IP range. */
 export const isValidRange = (row: Pick<FIBRowItem, 'from' | 'to'>): boolean =>
@@ -20,7 +23,7 @@ export const isValidDevice = (s: string): boolean =>
 const counterError = (s: string): string | null => {
     if (!s) return null;
     if (!s.startsWith('nexthop_')) return 'Must start with nexthop_';
-    if (new TextEncoder().encode(s).length > MAX_COUNTER_NAME_BYTES) return 'Too long (max 127 bytes)';
+    if (new TextEncoder().encode(s).length > MAX_COUNTER_NAME_BYTES) return 'Too long (max 103 bytes)';
     return null;
 };
 

--- a/tests/controlplane/cp_module_counter_registry_test.c
+++ b/tests/controlplane/cp_module_counter_registry_test.c
@@ -31,9 +31,14 @@
 #include <unistd.h>
 
 #define ARENA_BUFFER_SIZE MEMORY_BLOCK_ALLOCATOR_MAX_ALIGN
-#define FULL_ARENA_SIZE (64u * 1024u)
+// One registry chunk ties itself to the allocator's 32 KiB class, so the
+// sweep must span module smalls, the first chunk, and the second
+// registry's chunk to hit every growth outcome. The full arena must also
+// fit the spawned storage pages, whose per-allocation redzones under the
+// sanitizer build add up, hence the headroom.
+#define FULL_ARENA_SIZE (128u * 1024u)
 #define SWEEP_MIN_ARENA_SIZE 256u
-#define SWEEP_MAX_ARENA_SIZE (16u * 1024u)
+#define SWEEP_MAX_ARENA_SIZE (80u * 1024u)
 #define SWEEP_STEP 8u
 
 // Builds a module whose runtime registry allocations come from a fresh


### PR DESCRIPTION
Replace the counter registry's doubling-copy names array with fixed-size chunks, cutting the arena's largest single contiguous allocation demand and its 1.5x growth transient.

- Growth allocates exactly one chunk of entries plus a tiny re-housed pointer array: the registry never asks the arena for a block larger than one chunk, byte-tied to the 32 KiB allocator class, and never holds old and new storage live at once.
- The chunk pointer array grows with EQUATE_OFFSET rather than realloc-copy, because the slots are self-relative pointers that would otherwise resolve against their old addresses.
- The registry struct grows by eight bytes, so the dataplane plugin size tripwires move and YANET_MODULE_ABI_VERSION bumps to 20.
- A probe-shimmed build of the registry sources backs a new acceptance test: registering counters across several chunk boundaries never allocates more than one chunk, lookups and linking keep resolving, and fini returns every arena byte.
- Tight-arena tests recalibrate their limits to the new one-chunk floor, with comments explaining the sizing.

The dataplane packet path is unaffected: workers increment counters through handles resolved at config activation, and the value pages were already chunked.

Closes #1742.