### PR TITLE
refactor(fwstate,dataplane,pdump): make fixed-width byte reads alias-safe

### DIFF
--- a/lib/dataplane/packet/mss.c
+++ b/lib/dataplane/packet/mss.c
@@ -159,17 +159,18 @@ static void
 clamp_mss_option(
 	struct rte_tcp_hdr *tcp, struct tcp_option *opt, uint16_t clamp_mss
 ) {
-	uint16_t *mss_ptr = (uint16_t *)opt->data;
-	uint16_t old_mss = rte_be_to_cpu_16(*mss_ptr);
-	if (old_mss <= clamp_mss) {
+	uint16_t old_mss_be;
+	memcpy(&old_mss_be, opt->data, sizeof(old_mss_be));
+	if (rte_be_to_cpu_16(old_mss_be) <= clamp_mss) {
 		return;
 	}
 
 	/* Incremental TCP checksum update per RFC 1624. */
 	uint16_t cksum = ~tcp->cksum;
-	cksum = csum_minus(cksum, *mss_ptr);
-	*mss_ptr = rte_cpu_to_be_16(clamp_mss);
-	cksum = csum_plus(cksum, *mss_ptr);
+	cksum = csum_minus(cksum, old_mss_be);
+	uint16_t new_mss_be = rte_cpu_to_be_16(clamp_mss);
+	memcpy(opt->data, &new_mss_be, sizeof(new_mss_be));
+	cksum = csum_plus(cksum, new_mss_be);
 	/* preserve all-ones checksum (RFC 1624). */
 	tcp->cksum = (cksum == 0xffff) ? cksum : ~cksum;
 }
@@ -196,7 +197,8 @@ write_into_mss_gap(struct rte_mbuf *mbuf, uint16_t offset, uint16_t mss) {
 		rte_pktmbuf_mtod_offset(mbuf, struct tcp_option *, offset);
 	opt->kind = TCP_OPTION_KIND_MSS;
 	opt->len = TCP_OPTION_MSS_LEN;
-	*(uint16_t *)opt->data = rte_cpu_to_be_16(mss);
+	uint16_t mss_be = rte_cpu_to_be_16(mss);
+	memcpy(opt->data, &mss_be, sizeof(mss_be));
 	return opt;
 }
 
@@ -207,10 +209,15 @@ write_into_mss_gap(struct rte_mbuf *mbuf, uint16_t offset, uint16_t mss) {
  */
 static void
 tcp_cksum_add_mss(struct rte_tcp_hdr *tcp, struct tcp_option *opt) {
+	uint16_t kind_and_len;
+	memcpy(&kind_and_len, opt, sizeof(kind_and_len));
+	uint16_t mss_be;
+	memcpy(&mss_be, opt->data, sizeof(mss_be));
+
 	uint16_t cksum = ~tcp->cksum;
 	cksum = csum_plus(cksum, TCP_DATA_OFF_ONE_WORD);
-	cksum = csum_plus(cksum, *(uint16_t *)opt);
-	cksum = csum_plus(cksum, *(uint16_t *)opt->data);
+	cksum = csum_plus(cksum, kind_and_len);
+	cksum = csum_plus(cksum, mss_be);
 	cksum = csum_plus(cksum, rte_cpu_to_be_16(TCP_OPTION_MSS_LEN));
 	/* preserve all-ones checksum (RFC 1624). */
 	tcp->cksum = (cksum == 0xffff) ? cksum : ~cksum;

--- a/lib/fwstate/fwmap.h
+++ b/lib/fwstate/fwmap.h
@@ -248,10 +248,18 @@ fwmap_rand_secure(void) {
 static inline bool
 fwmap_default_key_equal(const void *a, const void *b, size_t size) {
 	switch (size) {
-	case 4:
-		return memcmp(a, b, sizeof(uint32_t)) == 0;
-	case 8:
-		return memcmp(a, b, sizeof(uint64_t)) == 0;
+	case 4: {
+		uint32_t a_value, b_value;
+		memcpy(&a_value, a, sizeof(a_value));
+		memcpy(&b_value, b, sizeof(b_value));
+		return a_value == b_value;
+	}
+	case 8: {
+		uint64_t a_value, b_value;
+		memcpy(&a_value, a, sizeof(a_value));
+		memcpy(&b_value, b, sizeof(b_value));
+		return a_value == b_value;
+	}
 	default:
 		return memcmp(a, b, size) == 0;
 	}

--- a/lib/fwstate/fwmap.h
+++ b/lib/fwstate/fwmap.h
@@ -249,9 +249,9 @@ static inline bool
 fwmap_default_key_equal(const void *a, const void *b, size_t size) {
 	switch (size) {
 	case 4:
-		return *(uint32_t *)a == *(uint32_t *)b;
+		return memcmp(a, b, sizeof(uint32_t)) == 0;
 	case 8:
-		return *(uint64_t *)a == *(uint64_t *)b;
+		return memcmp(a, b, sizeof(uint64_t)) == 0;
 	default:
 		return memcmp(a, b, size) == 0;
 	}

--- a/lib/fwstate/ops.h
+++ b/lib/fwstate/ops.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "types.h"
 
@@ -128,14 +129,9 @@ fwmap_fw6_key_equal(const void *a, const void *b, size_t size) {
 	const struct fw6_state_key *k1 = (const struct fw6_state_key *)a;
 	const struct fw6_state_key *k2 = (const struct fw6_state_key *)b;
 
-	// Compare IPv6 addresses as two uint64_t values each
-	const uint64_t *src1 = (const uint64_t *)k1->src_addr;
-	const uint64_t *src2 = (const uint64_t *)k2->src_addr;
-	const uint64_t *dst1 = (const uint64_t *)k1->dst_addr;
-	const uint64_t *dst2 = (const uint64_t *)k2->dst_addr;
-
 	return k1->hdr.proto == k2->hdr.proto &&
 	       k1->hdr.src_port == k2->hdr.src_port &&
-	       k1->hdr.dst_port == k2->hdr.dst_port && src1[0] == src2[0] &&
-	       src1[1] == src2[1] && dst1[0] == dst2[0] && dst1[1] == dst2[1];
+	       k1->hdr.dst_port == k2->hdr.dst_port &&
+	       memcmp(k1->src_addr, k2->src_addr, sizeof(k1->src_addr)) == 0 &&
+	       memcmp(k1->dst_addr, k2->dst_addr, sizeof(k1->dst_addr)) == 0;
 }

--- a/lib/fwstate/types.h
+++ b/lib/fwstate/types.h
@@ -31,7 +31,6 @@ struct fw4_state_key {
 	uint32_t dst_addr;
 };
 
-// FIXME: ensure that during map allocations keys are aligned on u64 boundary
 struct fw6_state_key {
 	struct fw_state_key_hdr hdr;
 	uint8_t src_addr[16];

--- a/modules/pdump/dataplane/ring.h
+++ b/modules/pdump/dataplane/ring.h
@@ -74,13 +74,11 @@ pdump_ring_prepare(
 	// to free up space by discarding old messages.
 	while ((ring->write_idx - ring->readable_idx) >
 	       (ring->size - aligned_payload_size)) {
-		// Read the size of the message at readable_idx to know how much
-		// space to free. We can safely read uint32_t directly because
-		// all writes are aligned to 4-byte boundaries by
-		// pdump_ring_checkpoint, ensuring the total_len field is always
-		// properly aligned.
+		// Read the oldest message size to determine how much space to
+		// reclaim.
 		uint8_t *pos = ring_data + (ring->readable_idx & ring->mask);
-		uint32_t readable_slot_size = *(uint32_t *)pos;
+		uint32_t readable_slot_size;
+		memcpy(&readable_slot_size, pos, sizeof(readable_slot_size));
 		readable_slot_size = __ALIGN4RING(readable_slot_size);
 
 		if (unlikely(

--- a/modules/pdump/dataplane/ring.h
+++ b/modules/pdump/dataplane/ring.h
@@ -74,8 +74,6 @@ pdump_ring_prepare(
 	// to free up space by discarding old messages.
 	while ((ring->write_idx - ring->readable_idx) >
 	       (ring->size - aligned_payload_size)) {
-		// Read the oldest message size to determine how much space to
-		// reclaim.
 		uint8_t *pos = ring_data + (ring->readable_idx & ring->mask);
 		uint32_t readable_slot_size;
 		memcpy(&readable_slot_size, pos, sizeof(readable_slot_size));


### PR DESCRIPTION
- Replace the remaining fixed-width pointer dereferences over byte-oriented storage in firewall-state key comparison, TCP MSS handling, and the packet-dump ring with constant-size `memcmp` or `memcpy` operations.
- Preserve byte-for-byte comparison, network byte order, incremental checksum updates, and ring reclamation while removing alignment and effective-type assumptions.
- Closes #2281.