### PR TITLE
fix(test): keep unix socket paths short

### DIFF
--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -115,8 +115,12 @@ func NewTestListener(t *testing.T) net.Listener {
 	return listener
 }
 
-// newTestUnixSocketPath returns a unique short filesystem path for a Unix
-// socket, independent of TMPDIR and the test name.
+// newTestUnixSocketPath returns a unique path short enough for Unix socket
+// limits, independent of the configured temporary root and test name.
+//
+// Cleanup preserves the prior testing.TempDir behavior and runs after both
+// success and ordinary test failure. The directory contains only the socket
+// entry, not diagnostic state worth preserving after the test.
 func newTestUnixSocketPath(t *testing.T) string {
 	t.Helper()
 

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -3,6 +3,7 @@ package gateway_test
 import (
 	"context"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -112,6 +113,20 @@ func NewTestListener(t *testing.T) net.Listener {
 	t.Cleanup(func() { _ = listener.Close() })
 
 	return listener
+}
+
+// newTestUnixSocketPath returns a unique short filesystem path for a Unix
+// socket, independent of TMPDIR and the test name.
+func newTestUnixSocketPath(t *testing.T) string {
+	t.Helper()
+
+	directory, err := os.MkdirTemp("/tmp", "y2-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(directory))
+	})
+
+	return filepath.Join(directory, "s")
 }
 
 // blockingReadinessService is a fake Service whose Watch handler blocks on
@@ -409,7 +424,7 @@ func TestServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
 		_ = gatewayGroup.Wait()
 	})
 
-	backendAddr := filepath.Join(t.TempDir(), "runner.sock")
+	backendAddr := newTestUnixSocketPath(t)
 	runner := gateway.NewServiceRunner(
 		&blockingReadinessService{endpoint: backendAddr},
 		gatewayListener.Addr().String(),

--- a/controlplane/gateway/readiness_test.go
+++ b/controlplane/gateway/readiness_test.go
@@ -2,7 +2,6 @@ package gateway_test
 
 import (
 	"context"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -183,7 +182,7 @@ func Test_GatewayRun_ReadinessDrainLatchesLateReady(t *testing.T) {
 
 	listener := NewTestListener(t)
 	service := &readinessLatchService{
-		endpoint: filepath.Join(t.TempDir(), "readiness-latch.sock"),
+		endpoint: newTestUnixSocketPath(t),
 	}
 	gw, err := gateway.NewGateway(
 		gateway.DefaultConfig(),

--- a/tests/functional/framework/socket_client_test.go
+++ b/tests/functional/framework/socket_client_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"io"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -175,7 +176,7 @@ func TestReplyBudget_ExhaustedStillCollectsReply(t *testing.T) {
 func newTestClient(t *testing.T, handle func(conn net.Conn)) *framework.SocketClient {
 	t.Helper()
 
-	socketPath := filepath.Join(t.TempDir(), "socket.sock")
+	socketPath := newTestUnixSocketPath(t)
 	listener, err := net.Listen("unix", socketPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { listener.Close() })
@@ -195,6 +196,20 @@ func newTestClient(t *testing.T, handle func(conn net.Conn)) *framework.SocketCl
 	t.Cleanup(func() { client.Close() })
 
 	return client
+}
+
+// newTestUnixSocketPath returns a unique short filesystem path for a Unix
+// socket, independent of TMPDIR and the test name.
+func newTestUnixSocketPath(t *testing.T) string {
+	t.Helper()
+
+	directory, err := os.MkdirTemp("/tmp", "y2-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(directory))
+	})
+
+	return filepath.Join(directory, "s")
 }
 
 // buildReplyFrame constructs a minimal Ethernet frame addressed to

--- a/tests/functional/framework/socket_client_test.go
+++ b/tests/functional/framework/socket_client_test.go
@@ -198,8 +198,12 @@ func newTestClient(t *testing.T, handle func(conn net.Conn)) *framework.SocketCl
 	return client
 }
 
-// newTestUnixSocketPath returns a unique short filesystem path for a Unix
-// socket, independent of TMPDIR and the test name.
+// newTestUnixSocketPath returns a unique path short enough for Unix socket
+// limits, independent of the configured temporary root and test name.
+//
+// Cleanup preserves the prior testing.TempDir behavior and runs after both
+// success and ordinary test failure. The directory contains only the socket
+// entry, not diagnostic state worth preserving after the test.
 func newTestUnixSocketPath(t *testing.T) string {
 	t.Helper()
 


### PR DESCRIPTION
- Create gateway and functional-framework Unix socket fixtures in short private directories under `/tmp`, preventing `sockaddr_un` path overflows when `TMPDIR` contains a long Nix or worktree path.
- Remove the temporary directories through test cleanup while keeping production behavior and host configuration unchanged.