### PR TITLE
Support for proper testing of chains with several outputs

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -207,10 +207,44 @@ type Config struct {
 	Workers []WorkerSpec
 }
 
+// OutputPacket is a parsed output packet paired with the egress device the
+// dataplane resolved for it.
+//
+// DeviceID is the packet's tx_device_id, indexing Config.Devices. The real
+// worker picks its transmit ring from that same field, so it is the egress
+// device a test must assert on to tell a fan-out apart from two copies
+// leaving through one device.
+type OutputPacket struct {
+	*framework.PacketInfo
+	DeviceID uint16
+}
+
+// RawPacket holds one packet's raw first-segment bytes and its device id.
+type RawPacket struct {
+	Data []byte
+	// DeviceID is tx_device_id. On a dropped packet it is the last target
+	// resolved before the drop rather than an egress.
+	DeviceID uint16
+}
+
 // Result of one pipeline round.
+//
+// Drop carries no device id because a dropped packet never egressed.
 type Result struct {
-	Output []*framework.PacketInfo
+	Output []OutputPacket
 	Drop   []*framework.PacketInfo
+}
+
+// OutputOn returns the output packets the dataplane sent to deviceID, in
+// round order.
+func (m *Result) OutputOn(deviceID uint16) []OutputPacket {
+	var on []OutputPacket
+	for idx := range m.Output {
+		if m.Output[idx].DeviceID == deviceID {
+			on = append(on, m.Output[idx])
+		}
+	}
+	return on
 }
 
 // RawResult holds the raw first-segment bytes of each output and drop packet
@@ -219,8 +253,20 @@ type Result struct {
 // Use this when the packets under test cannot be decoded by gopacket (e.g.
 // malformed or multi-segment packets that are passed through as-is).
 type RawResult struct {
-	Output [][]byte
-	Drop   [][]byte
+	Output []RawPacket
+	Drop   []RawPacket
+}
+
+// OutputOn returns the raw output packets the dataplane sent to deviceID, in
+// round order.
+func (m *RawResult) OutputOn(deviceID uint16) []RawPacket {
+	var on []RawPacket
+	for idx := range m.Output {
+		if m.Output[idx].DeviceID == deviceID {
+			on = append(on, m.Output[idx])
+		}
+	}
+	return on
 }
 
 // Harness is a handle to an in-process dataplane harness.
@@ -392,13 +438,40 @@ func (m *Harness) AdvanceTime(d time.Duration) time.Time {
 
 // HandlePackets runs packets through worker 0 for one pipeline round.
 func (m *Harness) HandlePackets(packets ...gopacket.Packet) (*Result, error) {
-	return m.handlePackets(0, nil, packets...)
+	return m.handlePackets(0, 0, 0, nil, packets...)
 }
 
 // HandlePacketsOnWorker runs packets through the given worker index for one
 // pipeline round.
 func (m *Harness) HandlePacketsOnWorker(worker int, packets ...gopacket.Packet) (*Result, error) {
-	return m.handlePackets(worker, nil, packets...)
+	return m.handlePackets(worker, 0, 0, nil, packets...)
+}
+
+// HandlePacketsOnDevice runs packets through the given worker for one pipeline
+// round, stamping rxDeviceID as both the ingress and egress device of every
+// input packet.
+//
+// This mirrors the real dataplane's ingress stamp, where the polling worker's
+// own device becomes the packet's rx and tx device (see dataplane/worker.c).
+// HandlePackets pins every packet to device 0, so a test that needs
+// device-keyed module behavior on parsed packets uses this instead.
+func (m *Harness) HandlePacketsOnDevice(
+	worker int,
+	rxDeviceID uint16,
+	packets ...gopacket.Packet,
+) (*Result, error) {
+	// The round dispatch indexes per-device scheduling arrays by the packet
+	// device id, so an id outside the registered topology would corrupt
+	// memory on the C side.
+	if int(rxDeviceID) >= m.deviceCount {
+		return nil, fmt.Errorf(
+			"device id %d exceeds topology device count %d",
+			rxDeviceID,
+			m.deviceCount,
+		)
+	}
+
+	return m.handlePackets(worker, rxDeviceID, rxDeviceID, nil, packets...)
 }
 
 // HandlePacketsWithHashes runs one pipeline round with caller-supplied per-packet hash values.
@@ -419,7 +492,7 @@ func (m *Harness) HandlePacketsWithHashes(
 			len(packets),
 		)
 	}
-	return m.handlePackets(0, hashes, packets...)
+	return m.handlePackets(0, 0, 0, hashes, packets...)
 }
 
 // HandleSegmentedPackets runs one pipeline round on worker 0 where each input
@@ -506,21 +579,37 @@ func (m *Harness) handleSegmentedPackets(
 	output := (*dataplane.PacketList)(unsafe.Pointer(&result.output))
 	drop := (*dataplane.PacketList)(unsafe.Pointer(&result.drop))
 
-	rawBytes := func(list *dataplane.PacketList) [][]byte {
+	rawPackets := func(list *dataplane.PacketList) []RawPacket {
 		data := list.Data()
-		out := make([][]byte, 0, len(data))
+		out := make([]RawPacket, 0, len(data))
 		for idx := range data {
 			b := make([]byte, len(data[idx].Payload))
 			copy(b, data[idx].Payload)
-			out = append(out, b)
+			out = append(out, RawPacket{
+				Data:     b,
+				DeviceID: data[idx].TxDeviceId,
+			})
 		}
 		return out
 	}
 
 	return &RawResult{
-		Output: rawBytes(output),
-		Drop:   rawBytes(drop),
+		Output: rawPackets(output),
+		Drop:   rawPackets(drop),
 	}, nil
+}
+
+// outputPackets parses each packet in list and pairs it with the egress device
+// the round resolved for it.
+func outputPackets(list *dataplane.PacketList) []OutputPacket {
+	out := make([]OutputPacket, 0, list.Count())
+	for pkt := list.First(); pkt != nil; pkt = pkt.Next() {
+		out = append(out, OutputPacket{
+			PacketInfo: pkt.Info(),
+			DeviceID:   pkt.Data().TxDeviceId,
+		})
+	}
+	return out
 }
 
 // handlePackets is the shared implementation for all HandlePackets variants.
@@ -529,6 +618,7 @@ func (m *Harness) handleSegmentedPackets(
 // then runs one pipeline round on the given worker index.
 func (m *Harness) handlePackets(
 	worker int,
+	txDeviceID, rxDeviceID uint16,
 	hashes []uint32,
 	packets ...gopacket.Packet,
 ) (*Result, error) {
@@ -550,8 +640,8 @@ func (m *Harness) handlePackets(
 	for idx := range payloads {
 		data = append(data, dataplane.PacketData{
 			Payload:    payloads[idx],
-			TxDeviceId: 0,
-			RxDeviceId: 0,
+			TxDeviceId: txDeviceID,
+			RxDeviceId: rxDeviceID,
 		})
 	}
 
@@ -586,7 +676,7 @@ func (m *Harness) handlePackets(
 	drop := (*dataplane.PacketList)(unsafe.Pointer(&result.drop))
 
 	return &Result{
-		Output: output.Info(),
+		Output: outputPackets(output),
 		Drop:   drop.Info(),
 	}, nil
 }

--- a/bindings/go/dataplane_ut/dataplane_ut_test.go
+++ b/bindings/go/dataplane_ut/dataplane_ut_test.go
@@ -332,3 +332,171 @@ func TestHandleSegmentedPacketsOnDevice_ForwardDeviceScopedRule(t *testing.T) {
 	assert.Equal(t, []uint64{0, 0}, counters[0].Values[0], "worker 0 never ran the round")
 	assert.Equal(t, []uint64{1, uint64(len(payload))}, counters[0].Values[1], "worker 1 ran the matching round")
 }
+
+// TestHandlePacketsOnDevice_InvalidDeviceID verifies that
+// HandlePacketsOnDevice rejects an rxDeviceID at or beyond the harness's
+// registered device count instead of stamping a packet that would index the
+// C-side per-device scheduling arrays out of bounds.
+func TestHandlePacketsOnDevice_InvalidDeviceID(t *testing.T) {
+	cfg := Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB * 4),
+		WorkerCount: 1,
+	}
+
+	h, err := NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	result, err := h.HandlePacketsOnDevice(0, 5)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds topology device count")
+	require.Nil(t, result)
+}
+
+// TestHandlePacketsOnDevice_InvalidWorker verifies that HandlePacketsOnDevice
+// rejects a worker index at or beyond the harness's registered worker count
+// instead of indexing the C-side worker array out of bounds.
+func TestHandlePacketsOnDevice_InvalidWorker(t *testing.T) {
+	cfg := Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB * 4),
+		WorkerCount: 1,
+	}
+
+	h, err := NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	result, err := h.HandlePacketsOnDevice(3, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds topology worker count")
+	require.Nil(t, result)
+}
+
+// TestHandlePacketsOnDevice_EgressDeviceID verifies that OutputPacket.DeviceID
+// carries the egress device the round resolved rather than the ingress one,
+// and that HandlePacketsOnDevice actually chooses that ingress device.
+//
+// Two crossed forward rules — port0 ingress redirected out through port1 and
+// port1 ingress out through port0 — let the same packet bytes leave through
+// opposite devices depending only on the injected ingress device. A harness
+// that discarded tx_device_id, or an entrypoint that still pinned every packet
+// to device 0, could not produce both answers.
+func TestHandlePacketsOnDevice_EgressDeviceID(t *testing.T) {
+	const (
+		port0 uint16 = 0
+		port1 uint16 = 1
+	)
+
+	cfg := Config{
+		CPMemory:      uint64(datasize.MB * 64),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   2,
+		Devices:       []string{"port0", "port1"},
+		Modules:       []string{"forward"},
+		DevicesToLoad: []string{"plain"},
+		Workers: []WorkerSpec{
+			{DeviceID: 0, QueueID: 0},
+			{DeviceID: 1, QueueID: 0},
+		},
+	}
+	h, err := NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	shm := h.SharedMemory()
+	agent, err := shm.AgentAttach("egress-device-test", 0, datasize.MB*16)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	backend := forward.NewBackend(agent)
+	moduleHandle, err := backend.UpdateModule("cross", []cforward.ForwardRule{
+		{
+			Target:  "port1",
+			Mode:    cforward.ModeOut,
+			Counter: "port0_to_port1",
+			Devices: filter.Devices{{Name: "port0"}},
+		},
+		{
+			Target:  "port0",
+			Mode:    cforward.ModeOut,
+			Counter: "port1_to_port0",
+			Devices: filter.Devices{{Name: "port1"}},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(moduleHandle.Free)
+
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: "cross",
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name:    "cross_chain",
+				Modules: []ffi.ChainModuleConfig{{Type: "forward", Name: "cross"}},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "cross",
+		Functions: []string{"cross"},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "sink"}))
+
+	// Both devices carry the same input pipeline, so which rule matches is
+	// decided purely by the injected ingress device, and both carry an
+	// output pipeline so either egress can complete.
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{
+		{
+			Name:   "port0",
+			Input:  []ffi.DevicePipelineConfig{{Name: "cross", Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "sink", Weight: 1}},
+		},
+		{
+			Name:   "port1",
+			Input:  []ffi.DevicePipelineConfig{{Name: "cross", Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "sink", Weight: 1}},
+		},
+	}))
+
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip4 := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolICMPv4,
+		SrcIP:    net.ParseIP("1.2.3.4"),
+		DstIP:    net.ParseIP("10.0.0.5"),
+	}
+	icmp := layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
+	}
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+
+	fromPort0, err := h.HandlePacketsOnDevice(0, port0, pkt)
+	require.NoError(t, err)
+	require.Len(t, fromPort0.Output, 1)
+	assert.Empty(t, fromPort0.Drop)
+	assert.Equal(t, port1, fromPort0.Output[0].DeviceID, "ingress port0 must egress on port1")
+	assert.Len(t, fromPort0.OutputOn(port1), 1)
+	assert.Empty(t, fromPort0.OutputOn(port0))
+
+	fromPort1, err := h.HandlePacketsOnDevice(1, port1, pkt)
+	require.NoError(t, err)
+	require.Len(t, fromPort1.Output, 1)
+	assert.Empty(t, fromPort1.Drop)
+	assert.Equal(t, port0, fromPort1.Output[0].DeviceID, "ingress port1 must egress on port0")
+	assert.Len(t, fromPort1.OutputOn(port0), 1)
+	assert.Empty(t, fromPort1.OutputOn(port1))
+
+	// HandlePackets pins the ingress to device 0, so it must agree with the
+	// explicit port0 injection above.
+	pinned, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Len(t, pinned.Output, 1)
+	assert.Equal(t, port1, pinned.Output[0].DeviceID)
+}

--- a/modules/acl/tests/functional/acl_net6_share_test.go
+++ b/modules/acl/tests/functional/acl_net6_share_test.go
@@ -271,8 +271,8 @@ func collectNet6ShareVerdicts(
 	require.NoError(t, err)
 
 	verdicts := make(map[string]string, len(packets))
-	for _, info := range result.Output {
-		verdicts[net6SharePacketKey(info)] = "output"
+	for _, out := range result.Output {
+		verdicts[net6SharePacketKey(out.PacketInfo)] = "output"
 	}
 	for _, info := range result.Drop {
 		verdicts[net6SharePacketKey(info)] = "drop"

--- a/modules/mirror/tests/functional/mirror_test.go
+++ b/modules/mirror/tests/functional/mirror_test.go
@@ -30,6 +30,13 @@ const (
 	mirMemSize = 16 * datasize.MB
 )
 
+// Egress device ids the fan-out assertions use, indexing the devices slice
+// passed to setupMirrorHarness.
+const (
+	mirPort0 uint16 = 0
+	mirPort1 uint16 = 1
+)
+
 // setupMirrorHarness builds a dataplane harness with the mirror module
 // loaded and attaches a control-plane agent.
 //
@@ -345,9 +352,14 @@ func TestMirror_ModeOut_IPv4(t *testing.T) {
 
 	result, err := h.HandlePackets(pkt)
 	require.NoError(t, err)
-	// The packet is queued via pending_output -> device_ectx_process_output on
-	// port1 -> dummy output pipeline -> packet_front.output.
-	require.Len(t, result.Output, 2, "re-routed ModeOut packet plus its mirror copy must reach output")
+	// The clone is queued via pending_output -> device_ectx_process_output on
+	// port1 -> dummy output pipeline -> packet_front.output, while the original
+	// keeps its ingress device and leaves through port0's sink. Asserting per
+	// device is what separates a real fan-out from both copies leaving through
+	// one device.
+	require.Len(t, result.Output, 2, "the original and its mirror copy must both reach output")
+	require.Len(t, result.OutputOn(mirPort0), 1, "the original must egress on port0")
+	require.Len(t, result.OutputOn(mirPort1), 1, "the mirror copy must egress on port1")
 	require.Empty(t, result.Drop, "ModeOut packet with valid device must not be dropped")
 	require.Zero(t, h.OutstandingMbufs())
 
@@ -389,9 +401,12 @@ func TestMirror_ModeIn_IPv4(t *testing.T) {
 
 	result, err := h.HandlePackets(pkt)
 	require.NoError(t, err)
-	// The packet traverses: pending_input -> device_ectx_process_input on
-	// port1 -> dummy_extra_in_port1 pipeline -> packet_front.output.
-	require.Len(t, result.Output, 2, "re-routed ModeIn packet plus its mirror copy must reach output")
+	// The clone traverses: pending_input -> device_ectx_process_input on port1
+	// -> sink_in_port1 pipeline -> packet_front.output, while the original
+	// keeps its ingress device and leaves through port0's sink.
+	require.Len(t, result.Output, 2, "the original and its mirror copy must both reach output")
+	require.Len(t, result.OutputOn(mirPort0), 1, "the original must egress on port0")
+	require.Len(t, result.OutputOn(mirPort1), 1, "the mirror copy must egress on port1")
 	require.Empty(t, result.Drop, "ModeIn packet with valid device must not be dropped")
 
 	path := dataplaneut.CounterPath{

--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -53,12 +53,19 @@ endif
 # falling back to the preyanet snapshot only when baseline fails.
 test: prepare-vm
 	@echo "Running all functional tests..."
-	go test -count=1 -v ./main/...
+	go test -count=1 -v ./main/... ./multidev/...
 
 # Run main functional tests
 test-main: prepare-vm
 	@echo "Running main functional tests..."
 	go test -count=1 -v -failfast ./main/...
+
+# Run the multi-device functional tests.
+# This package boots its own VM pool, so the first run bakes a second
+# baseline template overlay.
+test-multidev: prepare-vm
+	@echo "Running multi-device functional tests..."
+	go test -count=1 -v -failfast ./multidev/...
 
 # Run specific test
 test-run:

--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -659,6 +659,153 @@ func (f *TestFramework) SendPacketAndCaptureAll(inputIfaceIndex int, outputIface
 	return outputClient.ReceiveAllPackets(timeout, outputDumpPath)
 }
 
+// SendPacketAndCaptureByIface sends packet once on inputIface and captures what
+// each interface in outputIfaces received, keyed by interface index.
+//
+// This is what distinguishes a real fan-out from a single copy: the one-output
+// Send methods observe a single interface per send, so telling the two apart
+// with them means re-sending the packet.
+func (f *TestFramework) SendPacketAndCaptureByIface(
+	inputIface int,
+	outputIfaces []int,
+	packet []byte,
+	timeout time.Duration,
+) (map[int][][]byte, error) {
+	return f.SendPacketsAndCaptureByIface(inputIface, outputIfaces, [][]byte{packet}, timeout)
+}
+
+// SendPacketsAndCaptureByIface sends every packet in one write on inputIface,
+// then captures what each interface in outputIfaces received, keyed by
+// interface index.
+//
+// Every output socket is connected and drained before the send, so a copy
+// delivered to an interface the test does not primarily expect is observed
+// rather than mistaken for stale traffic. The captures run concurrently, so the
+// call costs about timeout regardless of how many interfaces are watched.
+// An interface that received nothing is absent from the result.
+//
+// outputIfaces must not repeat an index: ReceiveAllPackets does not hold the
+// client's connection mutex, so two readers on one socket would interleave
+// reads of the same stream.
+func (f *TestFramework) SendPacketsAndCaptureByIface(
+	inputIface int,
+	outputIfaces []int,
+	packets [][]byte,
+	timeout time.Duration,
+) (map[int][][]byte, error) {
+	f.log.Infof(
+		"Sending %d packet(s) on interface %d and capturing on interfaces %v",
+		len(packets), inputIface, outputIfaces,
+	)
+
+	outputClients := make(map[int]*SocketClient, len(outputIfaces))
+	for _, iface := range outputIfaces {
+		if _, dup := outputClients[iface]; dup {
+			return nil, fmt.Errorf("output interface %d listed more than once", iface)
+		}
+
+		client, err := f.GetSocketClient(iface)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get socket client for interface %d: %w", iface, err)
+		}
+		if err := client.Connect(); err != nil {
+			return nil, fmt.Errorf("failed to connect to socket for interface %d: %w", iface, err)
+		}
+		outputClients[iface] = client
+	}
+
+	inputClient, err := f.GetSocketClient(inputIface)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get input socket client: %w", err)
+	}
+	if err := inputClient.Connect(); err != nil {
+		return nil, fmt.Errorf("failed to connect to input socket: %w", err)
+	}
+
+	// Drain stale packets left by a previous test from every watched
+	// interface before sending. A short deadline flushes already-buffered
+	// data without blocking for new traffic.
+	for iface, client := range outputClients {
+		_, _ = client.ReceiveAllPackets(50*time.Millisecond, f.getIfaceDumpPath(iface))
+	}
+
+	inputDumpPath, _ := f.getDumpFilePaths()
+	if err := inputClient.SendPackets(packets, inputDumpPath); err != nil {
+		return nil, fmt.Errorf("failed to send packets: %w", err)
+	}
+
+	type capture struct {
+		iface   int
+		packets [][]byte
+		err     error
+	}
+
+	results := make(chan capture, len(outputClients))
+	var wg sync.WaitGroup
+	for iface, client := range outputClients {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			received, err := client.ReceiveAllPackets(timeout, f.getIfaceDumpPath(iface))
+			results <- capture{iface: iface, packets: received, err: err}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	captured := make(map[int][][]byte, len(outputClients))
+	for result := range results {
+		if result.err != nil {
+			return nil, fmt.Errorf(
+				"failed to capture on interface %d: %w", result.iface, result.err,
+			)
+		}
+		if len(result.packets) > 0 {
+			captured[result.iface] = result.packets
+		}
+	}
+
+	return captured, nil
+}
+
+// SendPacketAndParseByIface is SendPacketAndCaptureByIface with every captured
+// packet parsed.
+func (f *TestFramework) SendPacketAndParseByIface(
+	inputIface int,
+	outputIfaces []int,
+	packet []byte,
+	timeout time.Duration,
+) (map[int][]*PacketInfo, error) {
+	inputPacketInfo, err := f.PacketParser.ParsePacket(packet)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse input packet: %w", err)
+	}
+	f.log.Debugf("Sending packet: %s", inputPacketInfo.String())
+
+	captured, err := f.SendPacketAndCaptureByIface(inputIface, outputIfaces, packet, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed := make(map[int][]*PacketInfo, len(captured))
+	for iface, packets := range captured {
+		infos := make([]*PacketInfo, 0, len(packets))
+		for idx, data := range packets {
+			info, err := f.PacketParser.ParsePacket(data)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"failed to parse packet %d captured on interface %d: %w", idx, iface, err,
+				)
+			}
+			f.log.Debugf("Received packet %d on interface %d: %s", idx, iface, info.String())
+			infos = append(infos, info)
+		}
+		parsed[iface] = infos
+	}
+
+	return parsed, nil
+}
+
 // SendPacketAndParse sends a network packet, captures the response, and parses both
 // the input and output packets into structured PacketInfo objects. This high-level
 // method provides comprehensive packet analysis for detailed testing scenarios.
@@ -935,6 +1082,20 @@ func (f *TestFramework) getDumpFilePaths() (string, string) {
 	outputDumpPath := filepath.Join(f.qemu.WorkDir, fmt.Sprintf("%s.out.dump", f.testName))
 
 	return inputDumpPath, outputDumpPath
+}
+
+// getIfaceDumpPath returns the dump file path for one captured interface.
+// If debug is disabled or testName is empty, returns an empty string.
+//
+// The multi-interface capture methods key their dumps by interface rather than
+// sharing getDumpFilePaths' single output path, so concurrent captures do not
+// interleave into one file.
+func (f *TestFramework) getIfaceDumpPath(iface int) string {
+	if !IsDebugEnabled() || f.testName == "" {
+		return ""
+	}
+
+	return filepath.Join(f.qemu.WorkDir, fmt.Sprintf("%s.out%d.dump", f.testName, iface))
 }
 
 // StartYANET initializes and launches the complete YANET network processing stack

--- a/tests/functional/framework/harness.go
+++ b/tests/functional/framework/harness.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,14 +31,67 @@ func baselineTemplatePath(qemuImage, baselineTag string) string {
 // each name listed in Modules. Leaving both empty produces a configuration
 // that relies solely on the modules statically linked into the dataplane
 // binary.
+// ExtraDevices declares further ports alongside the baseline 01:00.0 and
+// virtio_user_kni0 pair, so a test can assert which device a packet egressed
+// on. Naming the guest's second NIC ("02:00.0") is what makes it reachable at
+// all: it is bound to vfio-pci at boot but undeclared by default, so nothing
+// can be routed there.
+//
+// Each extra device adds a busy-poll worker on core 0, which the guest's two
+// cores already share, so this belongs to a test package with its own
+// BaselineTag rather than the default baseline.
 type DataplaneOptions struct {
 	PluginDir         string
 	Modules           []string
 	PacketRecircLimit uint16
+	ExtraDevices      []string
+}
+
+// dataplaneDeviceBlock renders one entry of the dataplane `devices:` list,
+// using the same mac, mtu and single-worker shape every functional-test device
+// shares.
+func dataplaneDeviceBlock(portName string) string {
+	return `    - port_name: ` + portName + `
+      mac_addr: 52:54:00:6b:ff:a5
+      mtu: 7000
+      max_lro_packet_size: 7200
+      rss_hash: 0
+      workers:
+        - core_id: 0
+          instance_id: 0
+          rx_queue_len: 1024
+          tx_queue_len: 1024
+          num_mbufs: 2048
+`
+}
+
+// dataplaneConnections renders a `connections:` entry for every ordered pair of
+// distinct devices.
+//
+// A packet whose tx_device_id names a device other than the polling worker's
+// own is handed over a tx pipe, and with no connection between the two the
+// worker has nowhere to put it: the packet is dropped and remote_tx_drops is
+// incremented (see dataplane/worker.c). Cross-device egress therefore needs
+// the pairing declared, not just the device.
+func dataplaneConnections(devices []string) string {
+	var connections strings.Builder
+	for _, src := range devices {
+		for _, dst := range devices {
+			if src == dst {
+				continue
+			}
+			connections.WriteString(`    - src_device: ` + src + `
+      dst_device: ` + dst + `
+`)
+		}
+	}
+
+	return connections.String()
 }
 
 // DataplaneConfig returns the baseline dataplane YAML used by functional
-// tests, optionally requesting runtime module plugins via opts.
+// tests, optionally requesting runtime module plugins or extra devices via
+// opts.
 func DataplaneConfig(opts DataplaneOptions) string {
 	plugins := ""
 	cpMemory := "134217728"
@@ -58,6 +112,13 @@ func DataplaneConfig(opts DataplaneOptions) string {
 		cpMemory = "167772160"
 	}
 
+	deviceNames := append([]string{"01:00.0", "virtio_user_kni0"}, opts.ExtraDevices...)
+
+	var devices strings.Builder
+	for _, name := range deviceNames {
+		devices.WriteString(dataplaneDeviceBlock(name))
+	}
+
 	// The cp_memory value defaults to 128 MiB, matching the built-in main pool.
 	//
 	// The plugin-loading configuration bumps it to 160 MiB to carry headroom
@@ -74,34 +135,8 @@ dataplane:
       cp_memory: ` + cpMemory + `
       numa_id: 0
   devices:
-    - port_name: 01:00.0
-      mac_addr: 52:54:00:6b:ff:a5
-      mtu: 7000
-      max_lro_packet_size: 7200
-      rss_hash: 0
-      workers:
-        - core_id: 0
-          instance_id: 0
-          rx_queue_len: 1024
-          tx_queue_len: 1024
-          num_mbufs: 2048
-    - port_name: virtio_user_kni0
-      mac_addr: 52:54:00:6b:ff:a5
-      mtu: 7000
-      max_lro_packet_size: 7200
-      rss_hash: 0
-      workers:
-        - core_id: 0
-          instance_id: 0
-          rx_queue_len: 1024
-          tx_queue_len: 1024
-          num_mbufs: 2048
-  connections:
-    - src_device: 01:00.0
-      dst_device: virtio_user_kni0
-    - src_device: virtio_user_kni0
-      dst_device: 01:00.0
-`
+` + devices.String() + `  connections:
+` + dataplaneConnections(deviceNames)
 }
 
 // DefaultControlplaneConfig returns the baseline controlplane YAML used by

--- a/tests/functional/framework/harness_default_config_test.go
+++ b/tests/functional/framework/harness_default_config_test.go
@@ -4,11 +4,85 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 	"github.com/yanet-platform/yanet2/controlplane/yncp"
 	"github.com/yanet-platform/yanet2/tests/functional/framework"
 )
+
+// dataplaneYAML mirrors the parts of the dataplane configuration these tests
+// assert on. The dataplane itself parses this YAML in C, so there is no shared
+// Go schema to decode into.
+type dataplaneYAML struct {
+	Dataplane struct {
+		Devices []struct {
+			PortName string `yaml:"port_name"`
+			Workers  []struct {
+				CoreID int `yaml:"core_id"`
+			} `yaml:"workers"`
+		} `yaml:"devices"`
+		Connections []struct {
+			SrcDevice string `yaml:"src_device"`
+			DstDevice string `yaml:"dst_device"`
+		} `yaml:"connections"`
+	} `yaml:"dataplane"`
+}
+
+func decodeDataplaneConfig(t *testing.T, opts framework.DataplaneOptions) dataplaneYAML {
+	t.Helper()
+
+	var cfg dataplaneYAML
+	require.NoError(t, yaml.Unmarshal([]byte(framework.DataplaneConfig(opts)), &cfg))
+
+	return cfg
+}
+
+// TestDataplaneConfig_DefaultDevices pins the baseline device set and its
+// connection pairing, the shape every test package sharing the default
+// baseline snapshot boots with.
+func TestDataplaneConfig_DefaultDevices(t *testing.T) {
+	cfg := decodeDataplaneConfig(t, framework.DataplaneOptions{})
+
+	require.Len(t, cfg.Dataplane.Devices, 2)
+	require.Equal(t, "01:00.0", cfg.Dataplane.Devices[0].PortName)
+	require.Equal(t, "virtio_user_kni0", cfg.Dataplane.Devices[1].PortName)
+	require.Len(t, cfg.Dataplane.Connections, 2)
+}
+
+// TestDataplaneConfig_ExtraDevices verifies that an extra device is declared
+// and connected in both directions to every other device.
+//
+// The connection half is what the assertion is really for: an extra device
+// with no connection to the port a worker polls silently drops every packet
+// routed to it and increments remote_tx_drops, which reads as a broken test
+// rather than a missing pairing.
+func TestDataplaneConfig_ExtraDevices(t *testing.T) {
+	cfg := decodeDataplaneConfig(t, framework.DataplaneOptions{
+		ExtraDevices: []string{"02:00.0"},
+	})
+
+	names := make([]string, 0, len(cfg.Dataplane.Devices))
+	for _, device := range cfg.Dataplane.Devices {
+		names = append(names, device.PortName)
+		require.Len(t, device.Workers, 1, "device %q must declare exactly one worker", device.PortName)
+	}
+	require.Equal(t, []string{"01:00.0", "virtio_user_kni0", "02:00.0"}, names)
+
+	pairs := make(map[string]bool, len(cfg.Dataplane.Connections))
+	for _, connection := range cfg.Dataplane.Connections {
+		pairs[connection.SrcDevice+"->"+connection.DstDevice] = true
+	}
+	require.Len(t, pairs, len(cfg.Dataplane.Connections), "connections must not repeat a pair")
+	for _, src := range names {
+		for _, dst := range names {
+			if src == dst {
+				continue
+			}
+			require.True(t, pairs[src+"->"+dst], "missing connection %s -> %s", src, dst)
+		}
+	}
+}
 
 // TestDefaultControlplaneConfig_NoUnknownKeys guards the functional harness's
 // baseline controlplane YAML against a key that matches no field in

--- a/tests/functional/multidev/framework_test.go
+++ b/tests/functional/multidev/framework_test.go
@@ -1,0 +1,84 @@
+// Package multidev holds the functional tests that need more than one egress
+// device.
+//
+// It boots its own VM pool rather than joining tests/functional/main: the extra
+// device adds a third busy-poll worker to the guest's two cores, and baking it
+// into the shared baseline would change the timing of every existing test.
+package multidev
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/yanet-platform/yanet2/tests/functional/framework"
+)
+
+// secondDevice is the guest's second NIC. QEMU wires it as a unix-stream
+// netdev reachable at socket interface index 1, and the guest binds it to
+// vfio-pci at boot, but the default dataplane configuration never declares it.
+const secondDevice = "02:00.0"
+
+// Socket interface indices, matching the QEMU netdev order: index 0 is the
+// 01:00.0 port every functional test sends on, index 1 is secondDevice.
+const (
+	iface0 = 0
+	iface1 = 1
+)
+
+// harness owns the baseline VM pool shared by every test in this package.
+var harness *framework.Harness
+
+// withBootedVM acquires a VM from the pool and restores it to a working YANET
+// state, trying the baseline snapshot first and falling back to a fresh
+// StartYANET only when that restore fails.
+func withBootedVM(t *testing.T, fn func(fw *framework.TestFramework)) {
+	t.Helper()
+	if harness == nil {
+		t.Fatal("VM pool is not initialized")
+	}
+	harness.WithBootedVM(t, fn)
+}
+
+// TestMain is the entry point for running tests in this package.
+func TestMain(m *testing.M) {
+	os.Exit(testMainWrapper(m))
+}
+
+// testMainWrapper builds the baseline VM pool via the framework harness, runs
+// the package's tests, and tears the pool down on exit.
+func testMainWrapper(m *testing.M) (code int) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, "testMainWrapper recovered panic: %v\n", r)
+			code = 1
+		}
+	}()
+
+	// BaselineTag keeps this pool's cached baseline overlay separate from the
+	// shared one, which SetupHarness requires for any custom YAML.
+	h, cleanup, err := framework.SetupHarness(framework.HarnessConfig{
+		PoolName:    "multidev",
+		BaselineTag: "multidev",
+		Dataplane: framework.DataplaneConfig(framework.DataplaneOptions{
+			ExtraDevices: []string{secondDevice},
+		}),
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set up functional-test harness: %v\n", err)
+		return 1
+	}
+	defer cleanup()
+
+	harness = h
+
+	defer func() {
+		if err := h.Shutdown(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to shut down VM pool: %v\n", err)
+			code = 12
+		}
+		harness = nil
+	}()
+
+	return m.Run()
+}

--- a/tests/functional/multidev/multidev_test.go
+++ b/tests/functional/multidev/multidev_test.go
@@ -1,0 +1,187 @@
+package multidev
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/yanet-platform/yanet2/tests/functional/framework"
+)
+
+// routeCfgName is the route module config these tests drive. It matches the
+// name the baseline configuration wires into the "test" function chain.
+const routeCfgName = "route0"
+
+// splitPrefix is routed out secondDevice while everything else keeps the
+// baseline nexthop on 01:00.0, so one send proves both the presence on the
+// intended interface and the absence on the other.
+const splitPrefix = "198.51.100.0/24"
+
+// captureTimeout bounds each interface's idle-based capture. The captures run
+// concurrently, so this is the cost of the whole call rather than per
+// interface.
+const captureTimeout = 200 * time.Millisecond
+
+// nexthop names the device a prefix is routed out of.
+type nexthop struct {
+	prefix string
+	device string
+}
+
+// fibConfig builds a route FIB YAML mapping each prefix to a nexthop on the
+// named device.
+//
+// Order matters and the argument is a slice for that reason: the FIB installs
+// each entry as an address range and a later range overwrites an earlier one it
+// covers, so a default route listed after a more specific prefix erases it.
+// List least specific first.
+//
+// The MAC pair is swapped relative to the framework's canonical SrcMAC/DstMAC
+// so egressing packets carry the host's expected destination MAC, which is
+// also what the capture path filters on.
+func fibConfig(t *testing.T, nexthops []nexthop) string {
+	t.Helper()
+
+	type fibRangeYAML struct {
+		Start string `yaml:"start"`
+		End   string `yaml:"end"`
+	}
+	type fibNexthopYAML struct {
+		DstMAC string `yaml:"dst_mac"`
+		SrcMAC string `yaml:"src_mac"`
+		Device string `yaml:"device"`
+	}
+	type fibEntryYAML struct {
+		Range    fibRangeYAML     `yaml:"range"`
+		Nexthops []fibNexthopYAML `yaml:"nexthops"`
+	}
+	type fibConfigYAML struct {
+		Entries []fibEntryYAML `yaml:"entries"`
+	}
+
+	cfg := fibConfigYAML{Entries: make([]fibEntryYAML, 0, len(nexthops))}
+	for _, hop := range nexthops {
+		start, end, err := framework.PrefixRange(hop.prefix)
+		require.NoError(t, err, "failed to parse prefix %q", hop.prefix)
+
+		cfg.Entries = append(cfg.Entries, fibEntryYAML{
+			Range: fibRangeYAML{Start: start, End: end},
+			Nexthops: []fibNexthopYAML{{
+				DstMAC: framework.SrcMAC,
+				SrcMAC: framework.DstMAC,
+				Device: hop.device,
+			}},
+		})
+	}
+
+	body, err := yaml.Marshal(&cfg)
+	require.NoError(t, err, "failed to marshal FIB config")
+
+	return string(body)
+}
+
+// configureSplitRouting registers secondDevice with the control plane and
+// installs a FIB that sends splitPrefix out of it while the default route
+// keeps using 01:00.0.
+//
+// Registering the device is not optional: the dataplane declares 02:00.0, but
+// until it carries pipelines the round has no execution context for it and
+// drops everything addressed there.
+func configureSplitRouting(t *testing.T, fw *framework.TestFramework) {
+	t.Helper()
+
+	fib := fibConfig(t, []nexthop{
+		{prefix: "0.0.0.0/0", device: "01:00.0"},
+		{prefix: splitPrefix, device: secondDevice},
+	})
+	require.NoError(t, fw.CreateConfigFile("multidev-fib.yaml", fib),
+		"failed to write FIB config")
+
+	commands := []string{
+		framework.CLIDevicePlain + " update --name=" + secondDevice +
+			" --input bootstrap:1 --output dummy:1",
+		framework.CLIRoute + " fib update --name=" + routeCfgName +
+			" --rules /mnt/config/multidev-fib.yaml",
+	}
+	_, err := fw.ExecuteCommands(commands...)
+	require.NoError(t, err, "failed to configure split routing")
+}
+
+// TestMultiDeviceRoute verifies that a nexthop on the second device egresses
+// there and nowhere else, observed from a single send.
+//
+// Both interfaces are captured per send, so the "absent from the other
+// interface" half is a real observation rather than the second send the
+// one-output Send methods would need. Two destinations sent through the same
+// pipeline separate a working per-device demux from a dataplane that simply
+// sends everything one way.
+func TestMultiDeviceRoute(t *testing.T) {
+	t.Parallel()
+	withBootedVM(t, func(fw *framework.TestFramework) {
+		fw.Run("Configure_Split_Routing", func(fw *framework.TestFramework, t *testing.T) {
+			configureSplitRouting(t, fw)
+		})
+
+		fw.Run("Route_To_Second_Device", func(fw *framework.TestFramework, t *testing.T) {
+			packet := framework.CreateTCPIPv4Packet(
+				net.ParseIP("192.0.2.100"),
+				net.ParseIP("198.51.100.10"),
+				[]byte("second device"),
+				nil,
+			)
+
+			captured, err := fw.SendPacketAndParseByIface(
+				iface0, []int{iface0, iface1}, packet, captureTimeout,
+			)
+			require.NoError(t, err, "failed to send and capture")
+
+			require.Len(t, captured[iface1], 1, "packet must egress on the second device")
+			require.Equal(t, "198.51.100.10", captured[iface1][0].DstIP.String())
+			require.Empty(t, captured[iface0], "packet must not also egress on 01:00.0")
+		})
+
+		fw.Run("Default_Route_Stays_On_First_Device", func(fw *framework.TestFramework, t *testing.T) {
+			packet := framework.CreateTCPIPv4Packet(
+				net.ParseIP("192.0.2.100"),
+				net.ParseIP("203.0.113.200"),
+				[]byte("first device"),
+				nil,
+			)
+
+			captured, err := fw.SendPacketAndParseByIface(
+				iface0, []int{iface0, iface1}, packet, captureTimeout,
+			)
+			require.NoError(t, err, "failed to send and capture")
+
+			require.Len(t, captured[iface0], 1, "packet must egress on 01:00.0")
+			require.Equal(t, "203.0.113.200", captured[iface0][0].DstIP.String())
+			require.Empty(t, captured[iface1], "packet must not leak to the second device")
+		})
+	})
+}
+
+// TestMultiDeviceCaptureRejectsDuplicateIface guards the capture API's one
+// reader per socket rule: ReceiveAllPackets does not hold the client's
+// connection mutex, so two goroutines reading one socket would interleave
+// reads of the same stream and split frames between them.
+func TestMultiDeviceCaptureRejectsDuplicateIface(t *testing.T) {
+	t.Parallel()
+	withBootedVM(t, func(fw *framework.TestFramework) {
+		fw.Run("Duplicate_Output_Iface", func(fw *framework.TestFramework, t *testing.T) {
+			packet := framework.CreateTCPIPv4Packet(
+				net.ParseIP("192.0.2.100"),
+				net.ParseIP("203.0.113.200"),
+				nil,
+				nil,
+			)
+
+			_, err := fw.SendPacketAndCaptureByIface(
+				iface0, []int{iface0, iface0}, packet, captureTimeout,
+			)
+			require.ErrorContains(t, err, "listed more than once")
+		})
+	})
+}


### PR DESCRIPTION
Currently tests can only use single output device. Which means that chains with multiple outputs cannot be tested properly.

Say, tests for 'mirror' module check that two packets arrived, but they can't verify that second packet went from another device, so if 'mirror' module has bug in routing, it won't be caught.

This change adds support for multi-device tests both to unit and function tests. Separate VM with two devices is used to not touch existing tests which doesn't require it.