### PR TITLE
fix(controlplane,dataplane): separate config lock cache line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ RULESYNC_GENERATE_ARGS := generate --targets claudecode,codexcli,opencode --feat
 
 # Compile database consumed by lint/clang-syntax.
 COMPILE_DB ?= build/compile_commands.json
+RTE_CONFIG ?= build/subprojects/dpdk/rte_build_config.h
+YANET_CACHE_LINE_CPPFLAG = -DYANET_CACHE_LINE_SIZE=$$(awk '$$2 == "RTE_CACHE_LINE_SIZE" { print $$3; exit }' "$(RTE_CONFIG)")
 
 # Default PREFIX for debian packaging
 PREFIX ?= /usr
@@ -335,7 +337,7 @@ test:
 	$(MAKE) test-only
 
 test-only: dataplane
-	go test -count=1 $$(go list ./... | grep -v '^github.com/yanet-platform/yanet2/tests/functional/main')
+	CGO_CPPFLAGS="$(strip $(CGO_CPPFLAGS) $(YANET_CACHE_LINE_CPPFLAG))" go test -count=1 $$(go list ./... | grep -v '^github.com/yanet-platform/yanet2/tests/functional/main')
 	meson test -C build
 
 test-asan:
@@ -352,7 +354,7 @@ test-asan-only:
 # Set as a default only, mirroring the same if-absent condition meson uses for
 # its own injection: without it, a recoverable diagnostic would go unseen and
 # the package would still pass.
-	CGO_CFLAGS="-fsanitize=address,undefined" CGO_LDFLAGS="-fsanitize=address,undefined" UBSAN_OPTIONS="$${UBSAN_OPTIONS:-halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1}" go test -count=1 $$(go list ./... | grep -v '^github.com/yanet-platform/yanet2/tests/functional/main')
+	CGO_CPPFLAGS="$(strip $(CGO_CPPFLAGS) $(YANET_CACHE_LINE_CPPFLAG))" CGO_CFLAGS="-fsanitize=address,undefined" CGO_LDFLAGS="-fsanitize=address,undefined" UBSAN_OPTIONS="$${UBSAN_OPTIONS:-halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1}" go test -count=1 $$(go list ./... | grep -v '^github.com/yanet-platform/yanet2/tests/functional/main')
 	meson test -C build
 
 test-tsan:
@@ -375,7 +377,7 @@ test-functional:
 bench:
 	$(MAKE) go-cache-clean
 	$(MAKE) dataplane
-	go test -run='^$$' -bench=. -benchmem ./bindings/go/dataplane_ut/... ./modules/acl/tests/functional/...
+	CGO_CPPFLAGS="$(strip $(CGO_CPPFLAGS) $(YANET_CACHE_LINE_CPPFLAG))" go test -run='^$$' -bench=. -benchmem ./bindings/go/dataplane_ut/... ./modules/acl/tests/functional/...
 
 fuzz:
 	@if [ -d build ] && ! meson introspect build --buildoptions | jq -er '.[] | select(.name=="fuzzing") | .value' | grep -q enabled; then \

--- a/common/cache.h
+++ b/common/cache.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#ifndef YANET_CACHE_LINE_SIZE
+// Standalone common-code builds do not include the DPDK configuration.
+#define YANET_CACHE_LINE_SIZE 64
+#endif

--- a/common/data_pipe.h
+++ b/common/data_pipe.h
@@ -3,10 +3,7 @@
 #include <stdatomic.h>
 #include <stdlib.h>
 
-// TODO: move to project constants, since cache line size is not always 64.
-#ifndef DATA_PIPE_CACHE_LINE_SIZE
-#define DATA_PIPE_CACHE_LINE_SIZE 64
-#endif
+#include "common/cache.h"
 
 // Lock-free SPSC ring buffer.
 //
@@ -54,10 +51,8 @@
 // Memory layout
 // =============
 //
-// w_pos and f_pos are placed in the same cache line (both accessed by the
-// producer).
-// r_pos is DATA_PIPE_CACHE_LINE_SIZE bytes away on a separate cache line to
-// avoid false sharing with the consumer.
+// The producer's write and free positions share a cache line. The consumer's
+// read position is one cache line away to avoid false sharing.
 //
 //
 // Callback pattern
@@ -98,14 +93,14 @@ data_pipe_init(struct data_pipe *pipe, size_t size) {
 	if (pipe->data == NULL) {
 		return -1;
 	}
-	pipe->w_pos = (_Atomic size_t *)malloc(2 * DATA_PIPE_CACHE_LINE_SIZE);
+	pipe->w_pos = (_Atomic size_t *)malloc(2 * YANET_CACHE_LINE_SIZE);
 	if (pipe->w_pos == NULL) {
 		free(pipe->data);
 		return -1;
 	}
 	pipe->f_pos = pipe->w_pos + 1;
-	pipe->r_pos = (_Atomic size_t *)((char *)pipe->w_pos +
-					 DATA_PIPE_CACHE_LINE_SIZE);
+	pipe->r_pos =
+		(_Atomic size_t *)((char *)pipe->w_pos + YANET_CACHE_LINE_SIZE);
 
 	atomic_store_explicit(pipe->w_pos, 0, memory_order_relaxed);
 	atomic_store_explicit(pipe->f_pos, 0, memory_order_relaxed);

--- a/lib/controlplane/config/zone.h
+++ b/lib/controlplane/config/zone.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include <sys/types.h>
 
+#include "common/cache.h"
 #include "common/memory.h"
 
 #include "lib/counters/counters.h"
@@ -110,6 +112,12 @@ struct cp_config {
 	 */
 	pid_t config_lock;
 
+	// Keep lock ownership writes away from the published generation.
+	//
+	// Every dataplane worker reads the generation once per round, so lock
+	// contention must not invalidate the same cache line.
+	uint8_t _config_lock_pad[YANET_CACHE_LINE_SIZE - sizeof(pid_t)];
+
 	/*
 	 * Relative pointer to the current active packet processing
 	 * configuration.
@@ -122,6 +130,13 @@ struct cp_config {
 	 */
 	struct cp_agent_registry *agent_registry;
 };
+
+_Static_assert(
+	offsetof(struct cp_config, cp_config_gen) -
+			offsetof(struct cp_config, config_lock) >=
+		YANET_CACHE_LINE_SIZE,
+	"config lock and generation publication must use separate cache lines"
+);
 
 /*
  * Try to lock controlplane configuration.

--- a/meson.build
+++ b/meson.build
@@ -139,16 +139,6 @@ if get_option('fuzzing').enabled()
   yanet_cgo_ldflags += cgo_flags
 endif
 
-# gRPC-only operators never touch shared memory and link no cgo.
-#
-# Building them with cgo disabled turns a stray import of a module control
-# plane or of the FFI bindings into a loud build failure; with cgo on it
-# would silently restore the cgo link, which meson cannot see and which
-# then fails only as an ordering-dependent "cannot find -l<lib>" error.
-# Because it snapshots the Go build environment above, it must stay
-# below the last assignment to that environment.
-yanet_go_nocgo_env = yanet_go_env + {'CGO_ENABLED': '0'}
-
 yanet_rootdir = include_directories('.')
 
 # Initialize fuzzing targets dictionary
@@ -182,6 +172,23 @@ libdpdk = subproject(
 )
 
 libdpdk_dep = libdpdk.get_variable('dpdk_dep')
+
+yanet_cache_line_size = libdpdk.get_variable('dpdk_conf').get('RTE_CACHE_LINE_SIZE')
+yanet_cache_line_arg = '-DYANET_CACHE_LINE_SIZE=' + yanet_cache_line_size.to_string()
+yanet_project_args += yanet_cache_line_arg
+yanet_go_env += {
+  'CGO_CPPFLAGS': yanet_cache_line_arg,
+}
+
+# gRPC-only operators never touch shared memory and link no cgo.
+#
+# Building them with cgo disabled turns a stray import of a module control
+# plane or of the FFI bindings into a loud build failure; with cgo on it
+# would silently restore the cgo link, which meson cannot see and which
+# then fails only as an ordering-dependent "cannot find -l<lib>" error.
+# Because it snapshots the Go build environment above, it must stay
+# below the last assignment to that environment.
+yanet_go_nocgo_env = yanet_go_env + {'CGO_ENABLED': '0'}
 
 # Taking only the include directories strips the compile args carried
 # by dpdk_dep, including -include rte_config.h, so it has to be


### PR DESCRIPTION
- Derives one overridable cache-line constant from the configured DPDK build and passes it consistently to C and cgo.
- Places configuration-lock ownership writes at least one cache line away from the generation pointer read by workers.
- Enforces the separation at compile time without changing lock or publication semantics.
- Provides an independently measurable hardware candidate for #2308.