### PR TITLE
feat(common,forward,mirror,web)!: carry forward and mirror modes by name in json

### DIFF
--- a/common/go/xproto/enum.go
+++ b/common/go/xproto/enum.go
@@ -1,0 +1,89 @@
+// Package xproto holds protobuf helpers shared by the Go control plane.
+//
+// Generated enums carry no JSON form of their own, so the helpers here give
+// them one: the declared name on output, a name or a number on input.
+package xproto
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// Enum is the shape of every generated enum type: an int32 that knows its
+// descriptor.
+type Enum interface {
+	~int32
+	protoreflect.Enum
+}
+
+// MarshalEnumJSON renders an enum value as its declared name, or as the bare
+// number when no name is declared for it.
+//
+// The number form keeps a value from a newer peer round-tripping through a
+// binary that does not know it yet, which is what UnmarshalEnumJSON accepts
+// in turn.
+func MarshalEnumJSON[E Enum](value E) ([]byte, error) {
+	if declared := value.Descriptor().Values().ByNumber(value.Number()); declared != nil {
+		return json.Marshal(string(declared.Name()))
+	}
+	return json.Marshal(int32(value))
+}
+
+// UnmarshalEnumJSON reads an enum value written as its declared name or as
+// a number into target.
+//
+// A name must match a declared value exactly. Any number in the int32 range
+// is accepted, as proto3 enums are open, so a value unknown to this binary
+// is preserved rather than rejected. A JSON null leaves target untouched,
+// the convention encoding/json expects from an unmarshaler.
+func UnmarshalEnumJSON[E Enum](data []byte, target *E) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var raw any
+	if err := decoder.Decode(&raw); err != nil {
+		return err
+	}
+
+	descriptor := E(0).Descriptor()
+	switch value := raw.(type) {
+	case string:
+		declared := descriptor.Values().ByName(protoreflect.Name(value))
+		if declared == nil {
+			return fmt.Errorf(
+				"%q is not a value of %s, want one of %s",
+				value, descriptor.FullName(), strings.Join(enumNames(descriptor), ", "),
+			)
+		}
+		*target = E(declared.Number())
+		return nil
+	case json.Number:
+		number, err := strconv.ParseInt(value.String(), 10, 32)
+		if err != nil {
+			return fmt.Errorf("%s is not a valid number for %s", value, descriptor.FullName())
+		}
+		*target = E(number)
+		return nil
+	default:
+		return fmt.Errorf(
+			"expected a name or a number for %s, got %s", descriptor.FullName(), bytes.TrimSpace(data),
+		)
+	}
+}
+
+func enumNames(descriptor protoreflect.EnumDescriptor) []string {
+	values := descriptor.Values()
+	names := make([]string, values.Len())
+	for idx := range values.Len() {
+		names[idx] = string(values.Get(idx).Name())
+	}
+	return names
+}

--- a/common/go/xproto/enum_test.go
+++ b/common/go/xproto/enum_test.go
@@ -30,11 +30,11 @@ func Test_UnmarshalEnumJSON_Spellings(t *testing.T) {
 		want    filterpb.FragmentKind
 		wantErr string
 	}{
-		{name: "declared name", input: `"Frag"`, want: filterpb.FragmentKind_Frag},
-		{name: "declared number", input: `2`, want: filterpb.FragmentKind_Frag},
+		{name: "declared name", input: `"None"`, want: filterpb.FragmentKind_None},
+		{name: "declared number", input: `1`, want: filterpb.FragmentKind_None},
 		{name: "undeclared number is kept", input: `7`, want: filterpb.FragmentKind(7)},
-		{name: "null leaves the value", input: `null`, want: filterpb.FragmentKind_None},
-		{name: "wrong letter case", input: `"frag"`, wantErr: "want one of Any, None, Frag"},
+		{name: "null leaves the seeded value", input: `null`, want: filterpb.FragmentKind_Frag},
+		{name: "wrong letter case", input: `"none"`, wantErr: "want one of Any, None, Frag"},
 		{name: "fraction", input: `2.5`, wantErr: "not a valid number"},
 		{name: "out of int32 range", input: `4294967296`, wantErr: "not a valid number"},
 		{name: "boolean", input: `true`, wantErr: "expected a name or a number"},
@@ -43,7 +43,9 @@ func Test_UnmarshalEnumJSON_Spellings(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			kind := filterpb.FragmentKind_None
+			// Seeded with a nonzero value that no case decodes to, so a decode
+			// that resets or ignores the target is caught either way.
+			kind := filterpb.FragmentKind_Frag
 			err := xproto.UnmarshalEnumJSON([]byte(tc.input), &kind)
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)

--- a/common/go/xproto/enum_test.go
+++ b/common/go/xproto/enum_test.go
@@ -1,0 +1,56 @@
+package xproto_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/xproto"
+)
+
+// verifies that a declared value renders as its name and an undeclared one
+// as its number, so both survive a round trip through a peer.
+func Test_MarshalEnumJSON_NameOrNumber(t *testing.T) {
+	declared, err := xproto.MarshalEnumJSON(filterpb.FragmentKind_Frag)
+	require.NoError(t, err)
+	require.JSONEq(t, `"Frag"`, string(declared))
+
+	undeclared, err := xproto.MarshalEnumJSON(filterpb.FragmentKind(7))
+	require.NoError(t, err)
+	require.JSONEq(t, `7`, string(undeclared))
+}
+
+// verifies that each accepted spelling lands on the intended value and each
+// rejected one names the reason.
+func Test_UnmarshalEnumJSON_Spellings(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    filterpb.FragmentKind
+		wantErr string
+	}{
+		{name: "declared name", input: `"Frag"`, want: filterpb.FragmentKind_Frag},
+		{name: "declared number", input: `2`, want: filterpb.FragmentKind_Frag},
+		{name: "undeclared number is kept", input: `7`, want: filterpb.FragmentKind(7)},
+		{name: "null leaves the value", input: `null`, want: filterpb.FragmentKind_None},
+		{name: "wrong letter case", input: `"frag"`, wantErr: "want one of Any, None, Frag"},
+		{name: "fraction", input: `2.5`, wantErr: "not a valid number"},
+		{name: "out of int32 range", input: `4294967296`, wantErr: "not a valid number"},
+		{name: "boolean", input: `true`, wantErr: "expected a name or a number"},
+		{name: "object", input: `{"kind": 2}`, wantErr: "expected a name or a number"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kind := filterpb.FragmentKind_None
+			err := xproto.UnmarshalEnumJSON([]byte(tc.input), &kind)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, kind)
+		})
+	}
+}

--- a/modules/forward/controlplane/forwardpb/v1/forward.go
+++ b/modules/forward/controlplane/forwardpb/v1/forward.go
@@ -1,0 +1,14 @@
+package forwardpb
+
+import "github.com/yanet-platform/yanet2/common/go/xproto"
+
+// MarshalJSON renders the mode by its declared name, or by its number when
+// the value is not declared.
+func (m ForwardMode) MarshalJSON() ([]byte, error) {
+	return xproto.MarshalEnumJSON(m)
+}
+
+// UnmarshalJSON accepts the declared name or the number.
+func (m *ForwardMode) UnmarshalJSON(data []byte) error {
+	return xproto.UnmarshalEnumJSON(data, m)
+}

--- a/modules/forward/controlplane/forwardpb/v1/forward_test.go
+++ b/modules/forward/controlplane/forwardpb/v1/forward_test.go
@@ -1,0 +1,28 @@
+package forwardpb_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
+)
+
+// verifies that a mode travels by name on the JSON wire, that the zero mode
+// stays omitted, and that both a name and an older client's number read back.
+func Test_ForwardMode_JSONRoundTrip(t *testing.T) {
+	encoded, err := json.Marshal(&forwardpb.Action{Target: "eth0", Mode: forwardpb.ForwardMode_OUT})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"target": "eth0", "mode": "OUT"}`, string(encoded))
+
+	zero, err := json.Marshal(&forwardpb.Action{Target: "eth0", Mode: forwardpb.ForwardMode_NONE})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"target": "eth0"}`, string(zero))
+
+	for _, input := range []string{`{"mode": "IN"}`, `{"mode": 1}`} {
+		action := &forwardpb.Action{}
+		require.NoError(t, json.Unmarshal([]byte(input), action), input)
+		require.Equal(t, forwardpb.ForwardMode_IN, action.GetMode(), input)
+	}
+}

--- a/modules/forward/web/SaveDiffModal.tsx
+++ b/modules/forward/web/SaveDiffModal.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import type { Rule } from '@yanet/core/api/forward';
-import { ForwardMode, FORWARD_MODE_LABELS } from '@yanet/core/api/forward';
+import { FORWARD_MODE_LABELS, parseForwardMode } from '@yanet/core/api/forward';
 import { dumpYamlDoc } from '@yanet/core/utils';
 import { SaveDiffModal as SharedSaveDiffModal } from '@yanet/core/components';
 import { effectiveCounterName } from './hooks';
@@ -43,7 +43,7 @@ export const rulesToDiffYaml = (rules: Rule[], showEffectiveCounter = false): st
         if (devices.length > 0) {
             entry['devices'] = devices;
         }
-        entry['mode'] = FORWARD_MODE_LABELS[r.action?.mode ?? ForwardMode.NONE] ?? 'NONE';
+        entry['mode'] = FORWARD_MODE_LABELS[parseForwardMode(r.action?.mode)];
 
         return entry;
     });

--- a/modules/forward/web/hooks.test.ts
+++ b/modules/forward/web/hooks.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { effectiveCounterName } from './hooks';
+import { effectiveCounterName, rulesToNgItems } from './hooks';
+import { ForwardMode } from '@yanet/core/api/forward';
 
 describe('effectiveCounterName', () => {
     it('returns the explicit counter name verbatim when set', () => {
@@ -12,5 +13,17 @@ describe('effectiveCounterName', () => {
 
     it('materialises the literal to_ when both counter and target are empty', () => {
         expect(effectiveCounterName('', '')).toBe('to_');
+    });
+});
+
+describe('rulesToNgItems', () => {
+    it('reads a numeric mode from an older gateway as the named mode', () => {
+        const [item] = rulesToNgItems([{ action: { target: 'eth0', mode: 2 } }]);
+        expect(item.mode).toBe(ForwardMode.OUT);
+    });
+
+    it('reads a named mode as itself', () => {
+        const [item] = rulesToNgItems([{ action: { target: 'eth0', mode: ForwardMode.IN } }]);
+        expect(item.mode).toBe(ForwardMode.IN);
     });
 });

--- a/modules/forward/web/hooks.ts
+++ b/modules/forward/web/hooks.ts
@@ -1,5 +1,5 @@
 import type { Rule, VlanRange } from '@yanet/core/api/forward';
-import { ForwardMode } from '@yanet/core/api/forward';
+import { parseForwardMode } from '@yanet/core/api/forward';
 import { formatRange, parseRangesRaw, partitionCidrsToTyped } from '@yanet/core/utils';
 import type { RuleItem, RuleDraft } from './types';
 
@@ -37,7 +37,7 @@ export const rulesToNgItems = (rules: Rule[]): RuleItem[] => {
         const isAllVlans = computeIsAllVlans(rule.vlan_ranges);
         const sourceCidrs = [...(rule.sources4 || []), ...(rule.sources6 || [])];
         const dstCidrs = [...(rule.destinations4 || []), ...(rule.destinations6 || [])];
-        const mode = rule.action?.mode ?? ForwardMode.NONE;
+        const mode = parseForwardMode(rule.action?.mode);
 
         return {
             id: `ng-rule-${index}`,

--- a/modules/mirror/controlplane/mirrorpb/v1/mirror.go
+++ b/modules/mirror/controlplane/mirrorpb/v1/mirror.go
@@ -1,0 +1,14 @@
+package mirrorpb
+
+import "github.com/yanet-platform/yanet2/common/go/xproto"
+
+// MarshalJSON renders the mode by its declared name, or by its number when
+// the value is not declared.
+func (m MirrorMode) MarshalJSON() ([]byte, error) {
+	return xproto.MarshalEnumJSON(m)
+}
+
+// UnmarshalJSON accepts the declared name or the number.
+func (m *MirrorMode) UnmarshalJSON(data []byte) error {
+	return xproto.UnmarshalEnumJSON(data, m)
+}

--- a/modules/mirror/controlplane/mirrorpb/v1/mirror_test.go
+++ b/modules/mirror/controlplane/mirrorpb/v1/mirror_test.go
@@ -1,0 +1,28 @@
+package mirrorpb_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mirrorpb "github.com/yanet-platform/yanet2/modules/mirror/controlplane/mirrorpb/v1"
+)
+
+// verifies that a mode travels by name on the JSON wire, that the zero mode
+// stays omitted, and that both a name and an older client's number read back.
+func Test_MirrorMode_JSONRoundTrip(t *testing.T) {
+	encoded, err := json.Marshal(&mirrorpb.Action{Target: "eth0", Mode: mirrorpb.MirrorMode_OUT})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"target": "eth0", "mode": "OUT"}`, string(encoded))
+
+	zero, err := json.Marshal(&mirrorpb.Action{Target: "eth0", Mode: mirrorpb.MirrorMode_NONE})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"target": "eth0"}`, string(zero))
+
+	for _, input := range []string{`{"mode": "IN"}`, `{"mode": 1}`} {
+		action := &mirrorpb.Action{}
+		require.NoError(t, json.Unmarshal([]byte(input), action), input)
+		require.Equal(t, mirrorpb.MirrorMode_IN, action.GetMode(), input)
+	}
+}

--- a/web/src/core/api/forward.test.ts
+++ b/web/src/core/api/forward.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { ForwardMode, parseForwardMode } from './forward';
+
+describe('parseForwardMode', () => {
+    it('passes a named mode through unchanged', () => {
+        expect(parseForwardMode(ForwardMode.OUT)).toBe(ForwardMode.OUT);
+    });
+
+    it('maps a declared number from an older gateway to its name', () => {
+        expect(parseForwardMode(1)).toBe(ForwardMode.IN);
+        expect(parseForwardMode(2)).toBe(ForwardMode.OUT);
+    });
+
+    it('reads an undeclared number and an absent mode as NONE', () => {
+        expect(parseForwardMode(7)).toBe(ForwardMode.NONE);
+        expect(parseForwardMode(undefined)).toBe(ForwardMode.NONE);
+    });
+
+    it('reads a name this build does not declare as NONE', () => {
+        expect(parseForwardMode('LOOPBACK' as ForwardMode)).toBe(ForwardMode.NONE);
+    });
+});

--- a/web/src/core/api/forward.ts
+++ b/web/src/core/api/forward.ts
@@ -5,10 +5,12 @@ import { createService, type CallOptions } from './client';
 import type { Device, VlanRange, ListConfigsResponse } from './shared';
 export type { Device, VlanRange, ListConfigsResponse };
 
+// The gateway serializes a declared mode by its proto name. A gateway that
+// predates that form, or a value this build does not know, sends a number.
 export enum ForwardMode {
-    NONE = 0,
-    IN = 1,
-    OUT = 2,
+    NONE = 'NONE',
+    IN = 'IN',
+    OUT = 'OUT',
 }
 
 export const FORWARD_MODE_LABELS: Record<ForwardMode, string> = {
@@ -17,9 +19,29 @@ export const FORWARD_MODE_LABELS: Record<ForwardMode, string> = {
     [ForwardMode.OUT]: 'OUT',
 };
 
+const FORWARD_MODE_BY_NUMBER: Record<number, ForwardMode> = {
+    0: ForwardMode.NONE,
+    1: ForwardMode.IN,
+    2: ForwardMode.OUT,
+};
+
+/**
+ * Reads a mode off the wire in either spelling.
+ *
+ * A name or a declared number maps to the mode. Anything else, including a
+ * value this build does not know, reads as NONE, the same fallback the page
+ * used before names existed.
+ */
+export const parseForwardMode = (value: ForwardMode | number | undefined): ForwardMode => {
+    if (typeof value === 'number') {
+        return FORWARD_MODE_BY_NUMBER[value] ?? ForwardMode.NONE;
+    }
+    return value !== undefined && value in FORWARD_MODE_LABELS ? value : ForwardMode.NONE;
+};
+
 export interface Action {
     target?: string;
-    mode?: ForwardMode;
+    mode?: ForwardMode | number;
     counter?: string;
 }
 


### PR DESCRIPTION
- Add generic JSON helpers for protobuf enums: a declared value is written by its name, an undeclared one by its number, and both spellings are read back.
- Give ForwardMode and MirrorMode a JSON form through those helpers, so the gateway HTTP proxy and the upcoming YAML config loader share one spelling.
- Switch the web ForwardMode enum to string values and read a numeric mode from an older gateway through one parser.
- Breaking for HTTP clients: `mode` now arrives as a name; a UI built from this change writing to a gateway without it gets HTTP 400 on UpdateConfig, which is accepted because the UI ships with its gateway.
