### PR TITLE
chore(hooks): forbid direct commits on the main branch

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# Rejects commits on the main branch: work lands through feature branches
+# and pull requests, so the trunk stays a fast-forward of origin/main.
+branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+if [ "$branch" = "main" ]; then
+	echo "committing to main is not allowed; create a branch, or bypass with 'git commit --no-verify'" >&2
+	exit 1
+fi
+
 # Rejects commits that violate one of this repository's Go style
 # conventions in CLAUDE.md: the options-pattern rule for loggers,
 # call-site encapsulation (reaching into a private field or method


### PR DESCRIPTION
- Reject commits attempted directly on the local main branch in the pre-commit hook, pointing at a feature branch instead.
- Keeps the trunk a fast-forward of origin/main, matching the branch-and-pull-request flow the repository already enforces in review.