### PR TITLE
fix(test-functional): use guest-local cli paths in snapshots

### DIFF
--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -878,14 +878,14 @@ func (f *TestFramework) ResetConnections() {
 //	    t.Logf("Output: %s", output)
 //	})
 func (f *TestFramework) ExecuteCommand(command string) (string, error) {
-	return f.cli.ExecuteCommand(command)
+	return f.cli.ExecuteCommand(f.resolveCLIPaths(command))
 }
 
 // ExecuteCommandWithTimeout executes a single CLI command with a custom
 // timeout. Use this for operations that may take longer than the default
 // 30s, such as copying large binaries on slow emulated VMs.
 func (f *TestFramework) ExecuteCommandWithTimeout(command string, timeout time.Duration) (string, error) {
-	return f.cli.ExecuteCommandWithTimeout(command, timeout)
+	return f.cli.ExecuteCommandWithTimeout(f.resolveCLIPaths(command), timeout)
 }
 
 // ExecuteCommands executes multiple CLI commands sequentially within the QEMU
@@ -915,13 +915,28 @@ func (f *TestFramework) ExecuteCommandWithTimeout(command string, timeout time.D
 //	    t.Logf("Outputs: %v", outputs)
 //	})
 func (f *TestFramework) ExecuteCommands(commands ...string) ([]string, error) {
-	return f.cli.ExecuteCommands(commands...)
+	return f.cli.ExecuteCommands(f.resolveCLICommands(commands)...)
 }
 
 // ExecuteCommandsSeparately runs every command to completion regardless of
 // individual failures, pairing each output with its own error.
 func (f *TestFramework) ExecuteCommandsSeparately(commands ...string) ([]string, []error) {
-	return f.cli.ExecuteCommandsSeparately(commands...)
+	return f.cli.ExecuteCommandsSeparately(f.resolveCLICommands(commands)...)
+}
+
+func (f *TestFramework) resolveCLIPaths(command string) string {
+	if !f.Paths.LocalMode {
+		return command
+	}
+	return strings.ReplaceAll(command, CLIBasePath+"/", f.Paths.CLIBase+"/")
+}
+
+func (f *TestFramework) resolveCLICommands(commands []string) []string {
+	resolved := make([]string, len(commands))
+	for i, command := range commands {
+		resolved[i] = f.resolveCLIPaths(command)
+	}
+	return resolved
 }
 
 // getDumpFilePaths returns dump file paths for a test.

--- a/tests/functional/framework/pool_test.go
+++ b/tests/functional/framework/pool_test.go
@@ -64,3 +64,19 @@ func TestConfigureTemplateSetsGuestPathsForSelectedSnapshot(t *testing.T) {
 		})
 	}
 }
+
+// Test_ResolveCLIPaths_GuestStorageMode verifies that snapshot-backed guests
+// use copied CLIs while booted guests use the shared mount.
+func Test_ResolveCLIPaths_GuestStorageMode(t *testing.T) {
+	command := "/mnt/target/release/yanet-cli-route list"
+
+	local := &TestFramework{Paths: LocalGuestPaths()}
+	if got, want := local.resolveCLIPaths(command), "/tmp/yanet/cli/yanet-cli-route list"; got != want {
+		t.Errorf("resolveCLIPaths() = %q, want %q", got, want)
+	}
+
+	mounted := &TestFramework{Paths: DefaultGuestPaths()}
+	if got := mounted.resolveCLIPaths(command); got != command {
+		t.Errorf("resolveCLIPaths() = %q, want %q", got, command)
+	}
+}

--- a/tests/functional/main/framework_test.go
+++ b/tests/functional/main/framework_test.go
@@ -235,6 +235,12 @@ func testFrameworkSuite(t *testing.T, fw *framework.TestFramework) {
 			})
 		}
 
+		fw.Run("yanet-cli_dispatches_sibling", func(fw *framework.TestFramework, t *testing.T) {
+			output, err := fw.ExecuteCommand(framework.CLIGeneric + " route --help")
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+		})
+
 		// Check main YANET components
 		fw.Run("yanet_components", func(fw *framework.TestFramework, t *testing.T) {
 			components := []string{


### PR DESCRIPTION
- Ensure snapshot-backed VMs use the CLI binaries stored with the snapshot instead of potentially newer binaries from the host-mounted build directory.
- Keep booted single-VM guests on the shared target mount.
- Verify that the generic CLI can dispatch to sibling module binaries from guest-local storage.