### PR TITLE
feat(operator): apply a full function definition

### DIFF
--- a/common/go/operator/function.go
+++ b/common/go/operator/function.go
@@ -11,31 +11,17 @@ import (
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
-// FunctionChainSpec is the desired single-chain function definition that
-// FunctionApplier publishes.
-type FunctionChainSpec struct {
-	// Name is the function identifier (Function.Id.Name).
-	Name string
-	// Chain is the chain name (Chain.Name).
-	Chain string
-	// Weight is the chain weight (FunctionChain.Weight).
-	Weight uint64
-	// Modules is the ordered list of module IDs for the chain.
-	Modules []*commonpb.ModuleId
-}
+// chainModulesCompare reports whether the modules the gateway holds satisfy
+// the wanted module list for a single chain.
+type chainModulesCompare func(gateway, want []*commonpb.ModuleId) bool
 
-// chainModulesCompare reports whether current modules satisfy the desired
-// module list for a single chain.
-type chainModulesCompare func(current, want []*commonpb.ModuleId) bool
-
-func compareChainModulesExact(current, want []*commonpb.ModuleId) bool {
-	if len(current) != len(want) {
+func compareChainModulesExact(gateway, want []*commonpb.ModuleId) bool {
+	if len(gateway) != len(want) {
 		return false
 	}
 
-	for idx, mod := range current {
-		spec := want[idx]
-		if mod.GetType() != spec.GetType() || mod.GetName() != spec.GetName() {
+	for idx, module := range gateway {
+		if module.GetType() != want[idx].GetType() || module.GetName() != want[idx].GetName() {
 			return false
 		}
 	}
@@ -51,15 +37,15 @@ func compareChainModulesIgnorePdump(gateway, want []*commonpb.ModuleId) bool {
 // FunctionApplier publishes a fixed function definition to a gateway.
 type FunctionApplier struct {
 	client         ynpb.FunctionServiceClient
-	spec           FunctionChainSpec
+	function       *ynpb.Function
 	compareModules chainModulesCompare
 }
 
-// NewFunctionApplier returns a FunctionApplier that will publish spec to
+// NewFunctionApplier returns a FunctionApplier that will publish function to
 // client on each Apply call.
 func NewFunctionApplier(
 	client ynpb.FunctionServiceClient,
-	spec FunctionChainSpec,
+	function *ynpb.Function,
 	options ...FunctionApplierOption,
 ) *FunctionApplier {
 	opts := newFunctionApplierOptions()
@@ -74,19 +60,23 @@ func NewFunctionApplier(
 
 	return &FunctionApplier{
 		client:         client,
-		spec:           spec,
+		function:       function,
 		compareModules: compare,
 	}
 }
 
 // Name returns the function identifier the applier publishes.
 func (m *FunctionApplier) Name() string {
-	return m.spec.Name
+	return m.function.GetId().GetName()
 }
 
-// Apply publishes the captured spec to the gateway, or returns true
+// Apply publishes the captured definition to the gateway, or returns true
 // if the gateway is already correctly configured.
 func (m *FunctionApplier) Apply(ctx context.Context) (bool, error) {
+	if len(m.function.GetChains()) == 0 {
+		return false, fmt.Errorf("function %q has no chains", m.Name())
+	}
+
 	ok, err := m.alreadyCorrect(ctx)
 	if err != nil {
 		return false, err
@@ -95,53 +85,45 @@ func (m *FunctionApplier) Apply(ctx context.Context) (bool, error) {
 		return true, nil
 	}
 
-	req := &ynpb.UpdateFunctionRequest{
-		Function: &ynpb.Function{
-			Id: &commonpb.FunctionId{
-				Name: m.spec.Name,
-			},
-			Chains: []*ynpb.FunctionChain{{
-				Chain: &ynpb.Chain{
-					Name:    m.spec.Chain,
-					Modules: m.spec.Modules,
-				},
-				Weight: m.spec.Weight,
-			}},
-		},
-	}
+	req := &ynpb.UpdateFunctionRequest{Function: m.function}
 	if _, err := m.client.Update(ctx, req); err != nil {
-		return false, fmt.Errorf("failed to update function %q: %w", m.spec.Name, err)
+		return false, fmt.Errorf("failed to update function %q: %w", m.Name(), err)
 	}
 
 	return false, nil
 }
 
+// alreadyCorrect reports whether the gateway holds the wanted chains in the
+// wanted order, each with the wanted weight and modules.
 func (m *FunctionApplier) alreadyCorrect(ctx context.Context) (bool, error) {
 	resp, err := m.client.Get(ctx, &ynpb.GetFunctionRequest{
 		Id: &commonpb.FunctionId{
-			Name: m.spec.Name,
+			Name: m.Name(),
 		},
 	})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
 			return false, nil
 		}
-		return false, fmt.Errorf("failed to get function %q: %w", m.spec.Name, err)
+		return false, fmt.Errorf("failed to get function %q: %w", m.Name(), err)
 	}
 
-	for _, fc := range resp.GetFunction().GetChains() {
-		if fc.GetChain().GetName() != m.spec.Chain {
-			continue
-		}
-
-		if m.compareModules(fc.GetChain().GetModules(), m.spec.Modules) {
-			return true, nil
-		}
-
+	gateway := resp.GetFunction().GetChains()
+	want := m.function.GetChains()
+	if len(gateway) != len(want) {
 		return false, nil
 	}
+	for idx, chain := range gateway {
+		if chain.GetChain().GetName() != want[idx].GetChain().GetName() ||
+			chain.GetWeight() != want[idx].GetWeight() {
+			return false, nil
+		}
+		if !m.compareModules(chain.GetChain().GetModules(), want[idx].GetChain().GetModules()) {
+			return false, nil
+		}
+	}
 
-	return false, nil
+	return true, nil
 }
 
 // filterPdump returns a new slice containing only the modules whose type is

--- a/common/go/operator/function_test.go
+++ b/common/go/operator/function_test.go
@@ -7,15 +7,19 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 type fakeFunctionClient struct {
-	getResp *ynpb.GetFunctionResponse
-	getErr  error
-	updates int
+	getResp    *ynpb.GetFunctionResponse
+	getErr     error
+	updates    int
+	lastUpdate *ynpb.UpdateFunctionRequest
 }
 
 func (m *fakeFunctionClient) List(
@@ -36,10 +40,11 @@ func (m *fakeFunctionClient) Get(
 
 func (m *fakeFunctionClient) Update(
 	_ context.Context,
-	_ *ynpb.UpdateFunctionRequest,
+	req *ynpb.UpdateFunctionRequest,
 	_ ...grpc.CallOption,
 ) (*ynpb.UpdateFunctionResponse, error) {
 	m.updates++
+	m.lastUpdate = req
 	return &ynpb.UpdateFunctionResponse{}, nil
 }
 
@@ -70,12 +75,15 @@ var functionApplierSpecModules = []*commonpb.ModuleId{
 	},
 }
 
-func functionApplierSpec() FunctionChainSpec {
-	return FunctionChainSpec{
-		Name:    "fn:test",
-		Chain:   "default",
-		Weight:  1,
-		Modules: functionApplierSpecModules,
+// functionApplierSpec builds the single-chain function the legacy cases
+// publish, one forward module under the default chain.
+func functionApplierSpec() *ynpb.Function {
+	return &ynpb.Function{
+		Id: &commonpb.FunctionId{Name: "fn:test"},
+		Chains: []*ynpb.FunctionChain{{
+			Chain:  &ynpb.Chain{Name: "default", Modules: functionApplierSpecModules},
+			Weight: 1,
+		}},
 	}
 }
 
@@ -325,4 +333,154 @@ func Test_FunctionApplier_PdumpxPrefixNotFilteredNotSkipped(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, skipped)
 	require.Equal(t, 1, c.updates)
+}
+
+// functionDefinition builds a two-chain definition, one chain holding two
+// modules, so weight, chain set and module order are all in play.
+func functionDefinition() *ynpb.Function {
+	return &ynpb.Function{
+		Id: &commonpb.FunctionId{Name: "fn:acl"},
+		Chains: []*ynpb.FunctionChain{
+			{
+				Chain: &ynpb.Chain{
+					Name: "default",
+					Modules: []*commonpb.ModuleId{
+						{Type: "acl", Name: "acl-in"},
+						{Type: "fwstate", Name: "fwstate0"},
+					},
+				},
+				Weight: 3,
+			},
+			{
+				Chain: &ynpb.Chain{
+					Name:    "bypass",
+					Modules: []*commonpb.ModuleId{{Type: "forward", Name: "bypass"}},
+				},
+				Weight: 1,
+			},
+		},
+	}
+}
+
+// Test_FunctionApplier_MatchingDefinitionSkipped verifies that a
+// gateway holding the same chains, weights and modules is left alone.
+func Test_FunctionApplier_MatchingDefinitionSkipped(t *testing.T) {
+	c := &fakeFunctionClient{
+		getResp: &ynpb.GetFunctionResponse{Function: functionDefinition()},
+	}
+
+	skipped, err := NewFunctionApplier(c, functionDefinition()).Apply(t.Context())
+	require.NoError(t, err)
+	require.True(t, skipped)
+	require.Equal(t, 0, c.updates)
+}
+
+// Test_FunctionApplier_ChainOrderMatters verifies that chains in another
+// order count as drift, as the order decides which packets each chain gets.
+func Test_FunctionApplier_ChainOrderMatters(t *testing.T) {
+	reordered := functionDefinition()
+	reordered.Chains[0], reordered.Chains[1] = reordered.Chains[1], reordered.Chains[0]
+	c := &fakeFunctionClient{
+		getResp: &ynpb.GetFunctionResponse{Function: reordered},
+	}
+
+	skipped, err := NewFunctionApplier(c, functionDefinition()).Apply(t.Context())
+	require.NoError(t, err)
+	require.False(t, skipped)
+	require.Equal(t, 1, c.updates)
+}
+
+// Test_FunctionApplier_RejectsChainlessDefinition verifies that a definition
+// without chains is refused before it can reach the gateway.
+func Test_FunctionApplier_RejectsChainlessDefinition(t *testing.T) {
+	c := &fakeFunctionClient{}
+	definition := functionDefinition()
+	definition.Chains = nil
+
+	_, err := NewFunctionApplier(c, definition).Apply(t.Context())
+
+	require.ErrorContains(t, err, "has no chains")
+	require.Equal(t, 0, c.updates)
+}
+
+// Test_FunctionApplier_Drift verifies that each way the gateway
+// can drift from the definition triggers an update.
+func Test_FunctionApplier_Drift(t *testing.T) {
+	cases := []struct {
+		name  string
+		drift func(current *ynpb.Function)
+	}{
+		{
+			name:  "weight changed",
+			drift: func(current *ynpb.Function) { current.Chains[0].Weight = 1 },
+		},
+		{
+			name: "extra chain",
+			drift: func(current *ynpb.Function) {
+				current.Chains = append(current.Chains, &ynpb.FunctionChain{
+					Chain:  &ynpb.Chain{Name: "extra"},
+					Weight: 1,
+				})
+			},
+		},
+		{
+			name:  "missing chain",
+			drift: func(current *ynpb.Function) { current.Chains = current.Chains[:1] },
+		},
+		{
+			name: "chain renamed",
+			drift: func(current *ynpb.Function) {
+				current.Chains[1].Chain.Name = "fallback"
+			},
+		},
+		{
+			name: "module order swapped",
+			drift: func(current *ynpb.Function) {
+				modules := current.Chains[0].Chain.Modules
+				modules[0], modules[1] = modules[1], modules[0]
+			},
+		},
+		{
+			name: "module dropped",
+			drift: func(current *ynpb.Function) {
+				current.Chains[0].Chain.Modules = current.Chains[0].Chain.Modules[:1]
+			},
+		},
+		{
+			name: "chain duplicated in place of another",
+			drift: func(current *ynpb.Function) {
+				current.Chains[1] = current.Chains[0]
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			current := functionDefinition()
+			tc.drift(current)
+			c := &fakeFunctionClient{
+				getResp: &ynpb.GetFunctionResponse{Function: current},
+			}
+
+			skipped, err := NewFunctionApplier(c, functionDefinition()).Apply(t.Context())
+			require.NoError(t, err)
+			require.False(t, skipped)
+			require.Equal(t, 1, c.updates)
+		})
+	}
+}
+
+// Test_FunctionApplier_AbsentFunctionPublished verifies that a
+// function the gateway does not know is published as is.
+func Test_FunctionApplier_AbsentFunctionPublished(t *testing.T) {
+	c := &fakeFunctionClient{
+		getErr: status.Error(codes.NotFound, "no such function"),
+	}
+	definition := functionDefinition()
+
+	skipped, err := NewFunctionApplier(c, definition).Apply(t.Context())
+	require.NoError(t, err)
+	require.False(t, skipped)
+	require.Equal(t, 1, c.updates)
+	require.True(t, proto.Equal(definition, c.lastUpdate.GetFunction()), "got %v", c.lastUpdate)
 }

--- a/common/go/operator/options.go
+++ b/common/go/operator/options.go
@@ -194,9 +194,8 @@ func newFunctionApplierOptions() *functionApplierOptions {
 // FunctionApplierOption configures NewFunctionApplier.
 type FunctionApplierOption func(*functionApplierOptions)
 
-// WithIgnorePdump sets the chain-modules comparison strategy: when enabled,
-// pdump modules on the gateway are ignored when checking whether the chain
-// already matches spec.Modules.
+// WithIgnorePdump, when enabled, hides pdump modules on the gateway from the
+// check whether a chain already carries the wanted modules.
 func WithIgnorePdump(enabled bool) FunctionApplierOption {
 	return func(o *functionApplierOptions) {
 		o.IgnorePdump = enabled

--- a/operators/decap/internal/operator/actuator_gateway.go
+++ b/operators/decap/internal/operator/actuator_gateway.go
@@ -49,18 +49,22 @@ func NewGatewayActuator(
 	fnClient := ynpb.NewFunctionServiceClient(conn)
 	appliers := make([]*operator.FunctionApplier, 0, len(functions))
 	for _, fn := range functions {
-		spec := operator.FunctionChainSpec{
-			Name:   fn.Name.Unwrap(),
-			Chain:  fn.Chain.Unwrap(),
-			Weight: fn.Weight,
-			Modules: []*commonpb.ModuleId{{
-				Type: "decap",
-				Name: fn.Module.Unwrap(),
+		function := &ynpb.Function{
+			Id: &commonpb.FunctionId{Name: fn.Name.Unwrap()},
+			Chains: []*ynpb.FunctionChain{{
+				Chain: &ynpb.Chain{
+					Name: fn.Chain.Unwrap(),
+					Modules: []*commonpb.ModuleId{{
+						Type: "decap",
+						Name: fn.Module.Unwrap(),
+					}},
+				},
+				Weight: fn.Weight.Unwrap(),
 			}},
 		}
 		appliers = append(appliers, operator.NewFunctionApplier(
 			fnClient,
-			spec,
+			function,
 			operator.WithIgnorePdump(fn.IgnorePdump),
 		))
 	}

--- a/operators/decap/internal/operator/cfg.go
+++ b/operators/decap/internal/operator/cfg.go
@@ -98,7 +98,7 @@ type FunctionConfig struct {
 	// Chain is the chain name (e.g. "default").
 	Chain xcfg.NonEmptyString `yaml:"chain"`
 	// Weight is the chain weight inside the function.
-	Weight uint64 `yaml:"weight"`
+	Weight xcfg.Required[uint64] `yaml:"weight"`
 	// Module is the decap module config name this function targets
 	// (e.g. "decap0").
 	Module xcfg.NonEmptyString `yaml:"module"`

--- a/operators/decap/internal/operator/cfg_test.go
+++ b/operators/decap/internal/operator/cfg_test.go
@@ -116,7 +116,7 @@ func validConfig() *Config {
 			{
 				Name:         xcfg.MustNonEmptyString("fn:decap"),
 				Chain:        xcfg.MustNonEmptyString("default"),
-				Weight:       1,
+				Weight:       xcfg.NewRequired(uint64(1)),
 				Module:       xcfg.MustNonEmptyString("decap0"),
 				PrefixesFile: xcfg.MustNonEmptyString("/etc/yanet2/decap.d/default.yaml"),
 			},
@@ -160,7 +160,7 @@ func TestConfigValidate(t *testing.T) {
 				cfg.Functions = append(cfg.Functions, FunctionConfig{
 					Name:         xcfg.MustNonEmptyString("fn:decap"),
 					Chain:        xcfg.MustNonEmptyString("default"),
-					Weight:       1,
+					Weight:       xcfg.NewRequired(uint64(1)),
 					Module:       xcfg.MustNonEmptyString("other-module"),
 					PrefixesFile: xcfg.MustNonEmptyString("/etc/yanet2/decap.d/other.yaml"),
 				})
@@ -175,7 +175,7 @@ func TestConfigValidate(t *testing.T) {
 				cfg.Functions = append(cfg.Functions, FunctionConfig{
 					Name:         xcfg.MustNonEmptyString("fn:decap-other"),
 					Chain:        xcfg.MustNonEmptyString("default"),
-					Weight:       1,
+					Weight:       xcfg.NewRequired(uint64(1)),
 					Module:       xcfg.MustNonEmptyString("decap0"),
 					PrefixesFile: xcfg.MustNonEmptyString("/etc/yanet2/decap.d/other.yaml"),
 				})
@@ -225,4 +225,43 @@ func Test_ReadinessScopeSpecs_GatewaysUseNominalReconcileInterval(t *testing.T) 
 		"config:gw0": 10 * time.Second,
 		"config:gw1": 10 * time.Second,
 	}, intervalsByName)
+}
+
+// Test_Decode_WeightMustBeSpelled verifies that an omitted weight is refused
+// at load time, while an explicit zero, a disabled chain, is accepted.
+func Test_Decode_WeightMustBeSpelled(t *testing.T) {
+	cases := []struct {
+		name    string
+		weight  string
+		wantErr bool
+	}{
+		{name: "omitted weight", weight: "", wantErr: true},
+		{name: "explicit zero", weight: "    weight: 0\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := `
+gateways:
+  - name: numa0
+    endpoint: "[::1]:8080"
+functions:
+  - name: fn:decap
+    chain: default
+    module: decap0
+    prefixes_file: /etc/yanet2/decap.d/default.yaml
+` + tc.weight
+			cfg := DefaultConfig()
+			err := xcfg.Decode([]byte(input), cfg)
+
+			if tc.wantErr {
+				var pathErr *xcfg.PathError
+				require.ErrorAs(t, err, &pathErr)
+				require.Contains(t, pathErr.Path, "functions[0].weight")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, uint64(0), cfg.Functions[0].Weight.Unwrap())
+		})
+	}
 }

--- a/operators/forward/internal/operator/actuator_gateway.go
+++ b/operators/forward/internal/operator/actuator_gateway.go
@@ -49,18 +49,22 @@ func NewGatewayActuator(
 	fnClient := ynpb.NewFunctionServiceClient(conn)
 	appliers := make([]*operator.FunctionApplier, 0, len(functions))
 	for _, fn := range functions {
-		spec := operator.FunctionChainSpec{
-			Name:   fn.Name.Unwrap(),
-			Chain:  fn.Chain.Unwrap(),
-			Weight: fn.Weight,
-			Modules: []*commonpb.ModuleId{{
-				Type: "forward",
-				Name: fn.Module.Unwrap(),
+		function := &ynpb.Function{
+			Id: &commonpb.FunctionId{Name: fn.Name.Unwrap()},
+			Chains: []*ynpb.FunctionChain{{
+				Chain: &ynpb.Chain{
+					Name: fn.Chain.Unwrap(),
+					Modules: []*commonpb.ModuleId{{
+						Type: "forward",
+						Name: fn.Module.Unwrap(),
+					}},
+				},
+				Weight: fn.Weight.Unwrap(),
 			}},
 		}
 		appliers = append(appliers, operator.NewFunctionApplier(
 			fnClient,
-			spec,
+			function,
 			operator.WithIgnorePdump(fn.IgnorePdump),
 		))
 	}

--- a/operators/forward/internal/operator/cfg.go
+++ b/operators/forward/internal/operator/cfg.go
@@ -97,7 +97,7 @@ type FunctionConfig struct {
 	// Chain is the chain name (e.g. "default").
 	Chain xcfg.NonEmptyString `yaml:"chain"`
 	// Weight is the chain weight inside the function.
-	Weight uint64 `yaml:"weight"`
+	Weight xcfg.Required[uint64] `yaml:"weight"`
 	// Module is the forward module config name this function targets
 	// (e.g. "vlan-phy").
 	Module xcfg.NonEmptyString `yaml:"module"`

--- a/operators/forward/internal/operator/cfg_test.go
+++ b/operators/forward/internal/operator/cfg_test.go
@@ -88,7 +88,7 @@ func validConfig() *Config {
 			{
 				Name:      xcfg.MustNonEmptyString("fn:forward-vlan-phy"),
 				Chain:     xcfg.MustNonEmptyString("default"),
-				Weight:    1,
+				Weight:    xcfg.NewRequired(uint64(1)),
 				Module:    xcfg.MustNonEmptyString("vlan-phy"),
 				RulesFile: xcfg.MustNonEmptyString("/etc/yanet2/forward.d/vlan-phy-default.yaml"),
 			},
@@ -132,7 +132,7 @@ func TestConfigValidate(t *testing.T) {
 				cfg.Functions = append(cfg.Functions, FunctionConfig{
 					Name:      xcfg.MustNonEmptyString("fn:forward-vlan-phy"),
 					Chain:     xcfg.MustNonEmptyString("default"),
-					Weight:    1,
+					Weight:    xcfg.NewRequired(uint64(1)),
 					Module:    xcfg.MustNonEmptyString("other-module"),
 					RulesFile: xcfg.MustNonEmptyString("/etc/yanet2/forward.d/other.yaml"),
 				})
@@ -147,7 +147,7 @@ func TestConfigValidate(t *testing.T) {
 				cfg.Functions = append(cfg.Functions, FunctionConfig{
 					Name:      xcfg.MustNonEmptyString("fn:forward-other"),
 					Chain:     xcfg.MustNonEmptyString("default"),
-					Weight:    1,
+					Weight:    xcfg.NewRequired(uint64(1)),
 					Module:    xcfg.MustNonEmptyString("vlan-phy"),
 					RulesFile: xcfg.MustNonEmptyString("/etc/yanet2/forward.d/other.yaml"),
 				})
@@ -197,4 +197,43 @@ func Test_ReadinessScopeSpecs_GatewaysUseNominalReconcileInterval(t *testing.T) 
 		"config:gw0": 10 * time.Second,
 		"config:gw1": 10 * time.Second,
 	}, intervalsByName)
+}
+
+// Test_Decode_WeightMustBeSpelled verifies that an omitted weight is refused
+// at load time, while an explicit zero, a disabled chain, is accepted.
+func Test_Decode_WeightMustBeSpelled(t *testing.T) {
+	cases := []struct {
+		name    string
+		weight  string
+		wantErr bool
+	}{
+		{name: "omitted weight", weight: "", wantErr: true},
+		{name: "explicit zero", weight: "    weight: 0\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := `
+gateways:
+  - name: numa0
+    endpoint: "[::1]:8080"
+functions:
+  - name: fn:forward-vlan-phy
+    chain: default
+    module: vlan-phy
+    rules_file: /etc/yanet2/forward.d/vlan-phy-default.yaml
+` + tc.weight
+			cfg := DefaultConfig()
+			err := xcfg.Decode([]byte(input), cfg)
+
+			if tc.wantErr {
+				var pathErr *xcfg.PathError
+				require.ErrorAs(t, err, &pathErr)
+				require.Contains(t, pathErr.Path, "functions[0].weight")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, uint64(0), cfg.Functions[0].Weight.Unwrap())
+		})
+	}
 }

--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -54,13 +54,17 @@ func NewGatewayActuator(
 	}
 
 	fn := opts.Function
-	spec := operator.FunctionChainSpec{
-		Name:   fn.Name.Unwrap(),
-		Chain:  fn.Chain.Unwrap(),
-		Weight: fn.Weight,
-		Modules: []*commonpb.ModuleId{{
-			Type: "route",
-			Name: fn.Module.Unwrap(),
+	function := &ynpb.Function{
+		Id: &commonpb.FunctionId{Name: fn.Name.Unwrap()},
+		Chains: []*ynpb.FunctionChain{{
+			Chain: &ynpb.Chain{
+				Name: fn.Chain.Unwrap(),
+				Modules: []*commonpb.ModuleId{{
+					Type: "route",
+					Name: fn.Module.Unwrap(),
+				}},
+			},
+			Weight: fn.Weight,
 		}},
 	}
 
@@ -70,7 +74,7 @@ func NewGatewayActuator(
 		routes: routepb.NewRouteServiceClient(conn),
 		funcApplier: operator.NewFunctionApplier(
 			ynpb.NewFunctionServiceClient(conn),
-			spec,
+			function,
 			operator.WithIgnorePdump(fn.IgnorePdump),
 		),
 		devices:    opts.Devices,


### PR DESCRIPTION
- The function applier now takes a whole function definition, several chains with their weights, and treats the gateway as correct only when it holds exactly those chains in the declared order, since the order decides which packets each chain receives, with pdump modules optionally ignored.
- The single-chain spec is gone: the route, forward and decap operators build their one-chain function themselves, and a changed weight or an extra chain on the gateway now counts as drift for them too.
- A forward or decap function must now spell its weight: a config that omits the key refuses to start instead of silently disabling the chain, while an explicit zero still disables it on purpose.
- A definition without chains is refused before it reaches the gateway, where it would drop every packet of the function.
- Groundwork for the generic operator, whose config carries a function definition verbatim.
