### PR TITLE
perf(dataplane): hand remote packets to another worker a burst at a time

### DIFF
--- a/bindings/go/dataplane_ut/tx_pipe.go
+++ b/bindings/go/dataplane_ut/tx_pipe.go
@@ -58,6 +58,63 @@ func (m *TxPipeFixture) Push(mbuf *TxPipeMbuf) error {
 	return nil
 }
 
+// TxPipeBatchSize mirrors the pipe's batch capacity, the most one Flush can
+// hold.
+const TxPipeBatchSize = 32
+
+// PushBulk pushes a batch onto the fixture's pipe in one call, returning how
+// many were accepted and the mbufs that did not enter the pipe.
+//
+// A short return is a normal outcome: the pipe or its deferred-free ring ran
+// out of room, or a chain's segments disagreed on a refcount and was refused
+// on its own. The rejected mbufs remain the caller's.
+func (m *TxPipeFixture) PushBulk(mbufs []*TxPipeMbuf) (int, []*TxPipeMbuf) {
+	if len(mbufs) == 0 {
+		return 0, nil
+	}
+
+	ptrs := make([]*C.struct_rte_mbuf, len(mbufs))
+	for idx, mbuf := range mbufs {
+		ptrs[idx] = mbuf.ptr
+	}
+
+	rejected := make([]*C.struct_rte_mbuf, len(mbufs))
+	var count C.size_t
+
+	pushed := int(C.dataplane_ut_tx_pipe_push_bulk(
+		m.ptr, &ptrs[0], C.size_t(len(ptrs)), &rejected[0], &count,
+	))
+
+	out := make([]*TxPipeMbuf, int(count))
+	for idx := range out {
+		out[idx] = &TxPipeMbuf{ptr: rejected[idx]}
+	}
+
+	return pushed, out
+}
+
+// Stage adds one mbuf to the pipe's pending batch, reporting false when the
+// batch is already full and owes a Flush.
+func (m *TxPipeFixture) Stage(mbuf *TxPipeMbuf) bool {
+	return C.dataplane_ut_tx_pipe_stage(m.ptr, mbuf.ptr) == 0
+}
+
+// Flush hands the staged batch to the pipe, returning how many it accepted
+// and the mbufs it refused, which never entered the pipe.
+func (m *TxPipeFixture) Flush() (int, []*TxPipeMbuf) {
+	rejected := make([]*C.struct_rte_mbuf, TxPipeBatchSize)
+	var count C.size_t
+
+	pushed := int(C.dataplane_ut_tx_pipe_flush(m.ptr, &rejected[0], &count))
+
+	out := make([]*TxPipeMbuf, int(count))
+	for idx := range out {
+		out[idx] = &TxPipeMbuf{ptr: rejected[idx]}
+	}
+
+	return pushed, out
+}
+
 // Drain pops the fixture's pipe, handing at most accept mbufs of each popped
 // burst to a stub transmit and freeing whatever it did not accept — the same
 // rejected-tail path a short real NIC tx_burst would take.
@@ -127,4 +184,9 @@ func (m *TxPipeMbuf) AddRefcnt(delta int16) {
 // double-frees it.
 func (m *TxPipeMbuf) CompleteSegment() {
 	C.dataplane_ut_tx_pipe_complete_segment(m.ptr)
+}
+
+// Same reports whether both handles refer to one mbuf.
+func (m *TxPipeMbuf) Same(other *TxPipeMbuf) bool {
+	return m.ptr == other.ptr
 }

--- a/bindings/go/dataplane_ut/tx_stage.go
+++ b/bindings/go/dataplane_ut/tx_stage.go
@@ -1,0 +1,153 @@
+package dataplaneut
+
+/*
+#include <stdlib.h>
+#include "lib/dataplane_ut/tx_stage.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// TxStageFixture drives the worker's remote staging path over a connection
+// table of real pipes, without a NIC.
+type TxStageFixture struct {
+	ptr *C.struct_dataplane_ut_tx_stage
+
+	deviceCount    int
+	pipesPerDevice int
+}
+
+// TxStagePacket is one packet offered to the staging path.
+type TxStagePacket struct {
+	ptr *C.struct_packet
+}
+
+// NewTxStageFixture builds a connection table of deviceCount devices, each
+// with pipesPerDevice pipes.
+func NewTxStageFixture(deviceCount, pipesPerDevice int) (*TxStageFixture, error) {
+	const maxPipes = 1 << 20
+
+	if deviceCount < 0 || pipesPerDevice < 0 {
+		return nil, fmt.Errorf(
+			"negative dimensions: %d devices, %d pipes each",
+			deviceCount, pipesPerDevice,
+		)
+	}
+	if deviceCount > maxPipes || pipesPerDevice > maxPipes ||
+		deviceCount*pipesPerDevice > maxPipes {
+		return nil, fmt.Errorf(
+			"dimensions too large: %d devices, %d pipes each",
+			deviceCount, pipesPerDevice,
+		)
+	}
+
+	ptr := C.dataplane_ut_tx_stage_new(
+		C.uint32_t(deviceCount), C.uint32_t(pipesPerDevice),
+	)
+	if ptr == nil {
+		return nil, fmt.Errorf("failed to build a tx stage fixture")
+	}
+
+	return &TxStageFixture{
+		ptr:            ptr,
+		deviceCount:    deviceCount,
+		pipesPerDevice: pipesPerDevice,
+	}, nil
+}
+
+// Free releases the fixture and everything it owns.
+func (m *TxStageFixture) Free() {
+	if m.ptr != nil {
+		C.dataplane_ut_tx_stage_free(m.ptr)
+		m.ptr = nil
+	}
+	runtime.KeepAlive(m)
+}
+
+// Packet takes a packet from the mock pool addressed to a device and carrying
+// a flow hash.
+func (m *TxStageFixture) Packet(txDeviceID uint16, hash uint32) (*TxStagePacket, error) {
+	ptr := C.dataplane_ut_tx_stage_packet(
+		m.ptr, C.uint16_t(txDeviceID), C.uint32_t(hash),
+	)
+	if ptr == nil {
+		return nil, fmt.Errorf("mock pool exhausted")
+	}
+
+	return &TxStagePacket{ptr: ptr}, nil
+}
+
+// Offer hands one packet to the staging path.
+func (m *TxStageFixture) Offer(packet *TxStagePacket) {
+	C.dataplane_ut_tx_stage_offer(m.ptr, packet.ptr)
+}
+
+// Flush hands every pipe's held packets to their consumers.
+func (m *TxStageFixture) Flush() {
+	C.dataplane_ut_tx_stage_flush(m.ptr)
+}
+
+// checkPipe rejects coordinates outside the table before they reach C, where
+// they would index the connection array unchecked.
+func (m *TxStageFixture) checkPipe(device, pipe int) {
+	if device < 0 || device >= m.deviceCount {
+		panic(fmt.Sprintf(
+			"device %d out of range [0,%d)", device, m.deviceCount,
+		))
+	}
+	if pipe < 0 || pipe >= m.pipesPerDevice {
+		panic(fmt.Sprintf(
+			"pipe %d out of range [0,%d)", pipe, m.pipesPerDevice,
+		))
+	}
+}
+
+// Held reports how many packets a pipe is currently holding.
+func (m *TxStageFixture) Held(device, pipe int) int {
+	m.checkPipe(device, pipe)
+
+	return int(C.dataplane_ut_tx_stage_held(
+		m.ptr, C.uint32_t(device), C.uint32_t(pipe),
+	))
+}
+
+// Placed reports how many packets a pipe has handed to its consumer.
+func (m *TxStageFixture) Placed(device, pipe int) int {
+	m.checkPipe(device, pipe)
+
+	return int(C.dataplane_ut_tx_stage_placed(
+		m.ptr, C.uint32_t(device), C.uint32_t(pipe),
+	))
+}
+
+// TxCount reports the remote transmit counter.
+func (m *TxStageFixture) TxCount() int {
+	return int(C.dataplane_ut_tx_stage_tx_count(m.ptr))
+}
+
+// TxDrops reports the remote drop counter.
+func (m *TxStageFixture) TxDrops() int {
+	return int(C.dataplane_ut_tx_stage_tx_drops(m.ptr))
+}
+
+// Failed returns the failure list in the order packets joined it.
+func (m *TxStageFixture) Failed() []*TxStagePacket {
+	count := int(C.dataplane_ut_tx_stage_failed_count(m.ptr))
+
+	out := make([]*TxStagePacket, count)
+	for idx := range out {
+		out[idx] = &TxStagePacket{
+			ptr: C.dataplane_ut_tx_stage_failed_at(m.ptr, C.size_t(idx)),
+		}
+	}
+
+	return out
+}
+
+// Same reports whether both handles refer to one packet.
+func (m *TxStagePacket) Same(other *TxStagePacket) bool {
+	return m.ptr == other.ptr
+}

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -141,25 +141,6 @@ worker_tx_transmit_cb(struct rte_mbuf **mbufs, size_t count, void *data) {
 	return written;
 }
 
-/*
- * FIXME: the function below sends a packet to a different worker
- * using corresponding data pipe so the routine name might be confusing.
- */
-static int
-worker_send_to_port(struct dataplane_worker *worker, struct packet *packet) {
-	struct worker_tx_connection *tx_conn =
-		worker->write_ctx.tx_connections + packet->tx_device_id;
-
-	if (!tx_conn->count) {
-		return -1;
-	}
-
-	struct worker_tx_pipe *tx_pipe =
-		tx_conn->pipes + packet->hash % tx_conn->count;
-
-	return worker_tx_pipe_push(tx_pipe, packet_to_mbuf(packet));
-}
-
 static void
 worker_collect_from_port(struct dataplane_worker *worker) {
 	for (uint32_t conn_idx = 0; conn_idx < worker->dataplane->device_count;
@@ -200,8 +181,6 @@ static void
 worker_write(
 	struct dataplane_worker *worker, struct packet_front *packet_front
 ) {
-	struct dp_config *dp_config = worker->instance->dp_config;
-
 	struct packet_list failed;
 	packet_list_init(&failed);
 
@@ -225,28 +204,32 @@ worker_write(
 			to_write = 0;
 		}
 
-		if (packet->tx_device_id >=
-		    dp_config->dp_topology.device_count) {
-			packet_list_add(&failed, packet);
-			continue;
-		}
-
 		if (packet->tx_device_id == worker->device_id) {
 			mbufs[to_write] = packet_to_mbuf(packet);
 			++to_write;
 		} else {
-			if (worker_send_to_port(worker, packet)) {
-				*(worker->dp_worker->remote_tx_drops) += 1;
-				packet_list_add(&failed, packet);
-			} else {
-				*(worker->dp_worker->remote_tx_count) += 1;
-			}
+			worker_tx_stage(
+				worker->write_ctx.tx_connections,
+				worker->dataplane->device_count,
+				worker->dp_worker,
+				packet,
+				&failed
+			);
 		}
 	}
 
 	if (to_write > 0) {
 		worker_submit_burst(worker, mbufs, to_write, &failed);
 	}
+
+	// Batches staged above cross to their consumers here, before the round
+	// ends and their packets are discarded.
+	worker_tx_flush_all(
+		worker->write_ctx.tx_connections,
+		worker->dataplane->device_count,
+		worker->dp_worker,
+		&failed
+	);
 
 	// Move failures back to the output list, restoring counters.
 	struct packet *failed_packet;

--- a/dataplane/worker.h
+++ b/dataplane/worker.h
@@ -9,7 +9,7 @@
 
 #include "common/data_pipe.h"
 #include "lib/dataplane/packet/packet.h"
-#include "lib/dataplane/worker/tx_pipe.h"
+#include "lib/dataplane/worker/tx_stage.h"
 
 struct dataplane;
 struct dataplane_instance;
@@ -18,11 +18,6 @@ struct dp_worker;
 
 struct worker_read_ctx {
 	uint16_t read_size;
-};
-
-struct worker_tx_connection {
-	uint32_t count;
-	struct worker_tx_pipe *pipes;
 };
 
 struct worker_write_ctx {

--- a/lib/dataplane/worker/meson.build
+++ b/lib/dataplane/worker/meson.build
@@ -15,6 +15,7 @@ sources = files(
   'worker.c',
   'counters.c',
   'tx_pipe.c',
+  'tx_stage.c',
 )
 
 lib_worker_dp = static_library(

--- a/lib/dataplane/worker/tx_pipe.c
+++ b/lib/dataplane/worker/tx_pipe.c
@@ -8,45 +8,86 @@
 
 struct worker_push_ctx {
 	struct worker_tx_pipe *tx_pipe;
-	struct rte_mbuf *mbuf;
+	struct rte_mbuf **mbufs;
+	size_t count;
+	size_t cursor;
+	struct rte_mbuf **rejected;
+	size_t *rejected_count;
 };
 
+// Pin every segment of one chain, recording the refcount they shared
+// beforehand.
+//
+// Every segment must start from one baseline, the value reclaim checks each
+// against: one above it never sinks back down and wedges the pipe, one below
+// it already reads as reclaimable while still in flight. Walked by hand
+// rather than pinning the chain blind, which offers no unwind on mismatch.
+// Returns false with every pin already taken undone.
+static bool
+worker_pin_chain(struct rte_mbuf *mbuf, uint64_t *ref_cnt) {
+	uint64_t baseline = rte_mbuf_refcnt_read(mbuf);
+
+	struct rte_mbuf *seg = mbuf;
+	do {
+		if (rte_mbuf_refcnt_read(seg) != baseline) {
+			for (struct rte_mbuf *pinned = mbuf; pinned != seg;
+			     pinned = pinned->next) {
+				rte_mbuf_refcnt_update(pinned, -1);
+			}
+			return false;
+		}
+		rte_mbuf_refcnt_update(seg, 1);
+	} while ((seg = seg->next) != NULL);
+
+	*ref_cnt = baseline;
+	return true;
+}
+
+// Fill as much of the offered run of ring slots as the batch and the
+// deferred-free ring allow.
+//
+// A chain that cannot be pinned is set aside and the walk carries on, so one
+// bad chain costs itself a place in the batch and nothing more.
 static size_t
 worker_connection_push_cb(void **item, size_t count, void *data) {
 	struct worker_push_ctx *push_ctx = (struct worker_push_ctx *)data;
 	struct worker_tx_pipe *tx_pipe = push_ctx->tx_pipe;
 
-	if (count > 0) {
-		// Every segment must share one ref_cnt, the baseline
-		// worker_pending_mbuf_ready checks each segment against: one
-		// above it never sinks back down and wedges the pipe, one
-		// below it already reads as reclaimable while still in flight.
-		// Walked by hand rather than rte_pktmbuf_refcnt_update,
-		// which pins every segment blind with no unwind on mismatch.
-		uint64_t ref_cnt = rte_mbuf_refcnt_read(push_ctx->mbuf);
-		struct rte_mbuf *seg = push_ctx->mbuf;
-		do {
-			if (rte_mbuf_refcnt_read(seg) != ref_cnt) {
-				for (struct rte_mbuf *pinned = push_ctx->mbuf;
-				     pinned != seg;
-				     pinned = pinned->next) {
-					rte_mbuf_refcnt_update(pinned, -1);
-				}
-				return 0;
-			}
-			rte_mbuf_refcnt_update(seg, 1);
-		} while ((seg = seg->next) != NULL);
+	// Backpressure: never outrun the deferred-free ring, which has to hold
+	// every pushed mbuf until its consumer-side tx completes.
+	uint64_t capacity = (uint64_t)tx_pipe->pending_mask + 1;
+	uint64_t in_flight = tx_pipe->pending_stop - tx_pipe->pending_start;
+	uint64_t pending_free = in_flight < capacity ? capacity - in_flight : 0;
 
-		memcpy(item, &push_ctx->mbuf, sizeof(struct rte_mbuf *));
+	size_t limit = count;
+	if (limit > pending_free) {
+		limit = pending_free;
+	}
+
+	size_t written = 0;
+	while (written < limit && push_ctx->cursor < push_ctx->count) {
+		struct rte_mbuf *mbuf = push_ctx->mbufs[push_ctx->cursor];
+
+		uint64_t ref_cnt;
+		if (!worker_pin_chain(mbuf, &ref_cnt)) {
+			push_ctx->rejected[(*push_ctx->rejected_count)++] =
+				mbuf;
+			++push_ctx->cursor;
+			continue;
+		}
+
+		memcpy(item + written, &mbuf, sizeof(struct rte_mbuf *));
 
 		uint32_t ofs = tx_pipe->pending_stop & tx_pipe->pending_mask;
-		tx_pipe->pending_mbufs[ofs].mbuf = push_ctx->mbuf;
+		tx_pipe->pending_mbufs[ofs].mbuf = mbuf;
 		tx_pipe->pending_mbufs[ofs].ref_cnt = ref_cnt;
 		++tx_pipe->pending_stop;
 
-		return 1;
+		++written;
+		++push_ctx->cursor;
 	}
-	return 0;
+
+	return written;
 }
 
 static size_t
@@ -75,6 +116,7 @@ worker_tx_pipe_init(struct worker_tx_pipe *tx_pipe) {
 	tx_pipe->pending_mask = pending_capacity - 1;
 	tx_pipe->pending_start = 0;
 	tx_pipe->pending_stop = 0;
+	tx_pipe->batch_count = 0;
 
 	return 0;
 }
@@ -85,26 +127,79 @@ worker_tx_pipe_fini(struct worker_tx_pipe *tx_pipe) {
 	data_pipe_fini(&tx_pipe->pipe);
 }
 
-int
-worker_tx_pipe_push(struct worker_tx_pipe *tx_pipe, struct rte_mbuf *mbuf) {
-	// Backpressure: drop when this pipe's pending ring is full.
-	if (tx_pipe->pending_stop - tx_pipe->pending_start >
-	    tx_pipe->pending_mask) {
-		return -1;
-	}
+size_t
+worker_tx_pipe_push_bulk(
+	struct worker_tx_pipe *tx_pipe,
+	struct rte_mbuf **mbufs,
+	size_t count,
+	struct rte_mbuf **rejected,
+	size_t *rejected_count
+) {
+	*rejected_count = 0;
 
 	struct worker_push_ctx push_ctx = {
 		.tx_pipe = tx_pipe,
-		.mbuf = mbuf,
+		.mbufs = mbufs,
+		.count = count,
+		.cursor = 0,
+		.rejected = rejected,
+		.rejected_count = rejected_count,
 	};
 
-	if (data_pipe_item_push(
-		    &tx_pipe->pipe, worker_connection_push_cb, &push_ctx
-	    ) != 1) {
-		return -1;
+	// A batch straddling the ring's wrap needs a second round trip to
+	// place its tail, since only the slots before the boundary are offered.
+	//
+	// Progress is how far through the batch the walk got, not how many it
+	// placed, since setting a chain aside advances without placing
+	// anything.
+	size_t pushed = 0;
+	while (push_ctx.cursor < count) {
+		size_t before = push_ctx.cursor;
+
+		pushed += data_pipe_item_push(
+			&tx_pipe->pipe, worker_connection_push_cb, &push_ctx
+		);
+
+		if (push_ctx.cursor == before) {
+			break;
+		}
 	}
 
-	return 0;
+	// Whatever the pipe had no room for never entered it and stays the
+	// caller's, collected in the order the batch was given.
+	for (size_t idx = push_ctx.cursor; idx < count; ++idx) {
+		rejected[(*rejected_count)++] = mbufs[idx];
+	}
+
+	return pushed;
+}
+
+bool
+worker_tx_pipe_stage(struct worker_tx_pipe *tx_pipe, struct rte_mbuf *mbuf) {
+	if (tx_pipe->batch_count == WORKER_TX_BATCH_SIZE) {
+		return false;
+	}
+
+	tx_pipe->batch[tx_pipe->batch_count++] = mbuf;
+	return true;
+}
+
+size_t
+worker_tx_pipe_flush(
+	struct worker_tx_pipe *tx_pipe,
+	struct rte_mbuf **rejected,
+	size_t *rejected_count
+) {
+	size_t pushed = worker_tx_pipe_push_bulk(
+		tx_pipe,
+		tx_pipe->batch,
+		tx_pipe->batch_count,
+		rejected,
+		rejected_count
+	);
+
+	tx_pipe->batch_count = 0;
+	return pushed;
 }
 
 // True once every segment has sunk back to ref_cnt: the consumer freed

--- a/lib/dataplane/worker/tx_pipe.h
+++ b/lib/dataplane/worker/tx_pipe.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -7,6 +8,13 @@
 
 // log2 of the per-connection SPSC data pipe capacity.
 #define WORKER_TX_PIPE_SIZE 10
+
+// How many mbufs one flush hands the pipe at most.
+//
+// Sized to the worker's own tx burst so a full burst bound for one pipe
+// crosses to its consumer in a single ring round trip.
+#define WORKER_TX_BATCH_SIZE 32
+
 // The per-pipe deferred-free ring holds 2^(WORKER_TX_PIPE_SIZE + this)
 // mbufs, sized above the pipe capacity to absorb consumer-side NIC tx
 // backlog before backpressure drops further packets.
@@ -29,6 +37,14 @@ struct worker_tx_pipe {
 	uint32_t pending_mask;
 	uint64_t pending_start;
 	uint64_t pending_stop;
+
+	// Mbufs accumulated since the last flush.
+	//
+	// Held here rather than by the producer so the batch travels with the
+	// pipe it is bound for, across the reallocation that grows the
+	// producer's pipe array as the topology is wired up.
+	struct rte_mbuf *batch[WORKER_TX_BATCH_SIZE];
+	uint16_t batch_count;
 };
 
 // Initialize the pipe and its deferred-free ring.
@@ -41,13 +57,41 @@ worker_tx_pipe_init(struct worker_tx_pipe *tx_pipe);
 void
 worker_tx_pipe_fini(struct worker_tx_pipe *tx_pipe);
 
-// Push mbuf onto the pipe for the consumer to transmit.
+// Add mbuf to the pipe's pending batch.
 //
-// Returns 0 on success, -1 if the pipe or its deferred-free ring is
-// full, or if the chain's segments don't share one refcount to record
-// as the reclaim baseline.
-int
-worker_tx_pipe_push(struct worker_tx_pipe *tx_pipe, struct rte_mbuf *mbuf);
+// Returns false when the batch is already full, which means the caller owes
+// the pipe a flush before it can stage anything more.
+bool
+worker_tx_pipe_stage(struct worker_tx_pipe *tx_pipe, struct rte_mbuf *mbuf);
+
+// Hand the staged batch to the pipe and empty it.
+//
+// Returns how many the pipe accepted and collects the rest, which never
+// entered the pipe and stay the caller's to dispose of. The collecting array
+// needs room for a whole batch.
+size_t
+worker_tx_pipe_flush(
+	struct worker_tx_pipe *tx_pipe,
+	struct rte_mbuf **rejected,
+	size_t *rejected_count
+);
+
+// Hand a batch to the consumer in far fewer ring round trips than one per
+// mbuf.
+//
+// Returns how many were accepted, and collects the rest in the order they
+// were given, so the two together always account for the whole batch; the
+// collecting array needs room for all of them. A chain whose segments do not
+// share one refcount is refused on its own, and the rest of the batch is
+// unaffected.
+size_t
+worker_tx_pipe_push_bulk(
+	struct worker_tx_pipe *tx_pipe,
+	struct rte_mbuf **mbufs,
+	size_t count,
+	struct rte_mbuf **rejected,
+	size_t *rejected_count
+);
 
 // Reclaim consumed pipe slots and release mbufs whose consumer-side NIC tx
 // has completed.

--- a/lib/dataplane/worker/tx_stage.c
+++ b/lib/dataplane/worker/tx_stage.c
@@ -1,0 +1,82 @@
+#include "tx_stage.h"
+
+#include "lib/dataplane/config/zone.h"
+#include "lib/dataplane/packet/data.h"
+
+// Hand one pipe's held packets over and account for the outcome.
+static void
+worker_tx_flush_pipe(
+	struct worker_tx_pipe *tx_pipe,
+	struct dp_worker *dp_worker,
+	struct packet_list *failed
+) {
+	if (tx_pipe->batch_count == 0) {
+		return;
+	}
+
+	struct rte_mbuf *rejected[WORKER_TX_BATCH_SIZE];
+	size_t rejected_count = 0;
+	size_t pushed =
+		worker_tx_pipe_flush(tx_pipe, rejected, &rejected_count);
+
+	*(dp_worker->remote_tx_count) += pushed;
+	*(dp_worker->remote_tx_drops) += rejected_count;
+
+	for (size_t idx = 0; idx < rejected_count; ++idx) {
+		packet_list_add(failed, mbuf_to_packet(rejected[idx]));
+	}
+}
+
+void
+worker_tx_stage(
+	struct worker_tx_connection *connections,
+	uint32_t device_count,
+	struct dp_worker *dp_worker,
+	struct packet *packet,
+	struct packet_list *failed
+) {
+	// A device this worker has no connections for is not a transmit
+	// failure, so it joins the failures without counting one.
+	if (packet->tx_device_id >= device_count) {
+		packet_list_add(failed, packet);
+		return;
+	}
+
+	struct worker_tx_connection *connection =
+		connections + packet->tx_device_id;
+	if (!connection->count) {
+		*(dp_worker->remote_tx_drops) += 1;
+		packet_list_add(failed, packet);
+		return;
+	}
+
+	struct worker_tx_pipe *tx_pipe =
+		connection->pipes + packet->hash % connection->count;
+
+	// A full pipe goes now so this packet has somewhere to land; the rest
+	// leave together at the end of the round.
+	if (!worker_tx_pipe_stage(tx_pipe, packet_to_mbuf(packet))) {
+		worker_tx_flush_pipe(tx_pipe, dp_worker, failed);
+		worker_tx_pipe_stage(tx_pipe, packet_to_mbuf(packet));
+	}
+}
+
+void
+worker_tx_flush_all(
+	struct worker_tx_connection *connections,
+	uint32_t device_count,
+	struct dp_worker *dp_worker,
+	struct packet_list *failed
+) {
+	for (uint32_t conn_idx = 0; conn_idx < device_count; ++conn_idx) {
+		struct worker_tx_connection *connection =
+			connections + conn_idx;
+
+		for (uint32_t pipe_idx = 0; pipe_idx < connection->count;
+		     ++pipe_idx) {
+			worker_tx_flush_pipe(
+				connection->pipes + pipe_idx, dp_worker, failed
+			);
+		}
+	}
+}

--- a/lib/dataplane/worker/tx_stage.h
+++ b/lib/dataplane/worker/tx_stage.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "lib/dataplane/packet/packet.h"
+#include "lib/dataplane/worker/tx_pipe.h"
+
+struct dp_worker;
+
+// One worker's pipes toward a single destination device.
+//
+// A packet is spread across them by its flow hash, so every packet of a flow
+// reaches the same consumer and cannot be reordered against its own.
+struct worker_tx_connection {
+	uint32_t count;
+	struct worker_tx_pipe *pipes;
+};
+
+// Hold a packet bound for another worker until the round ends.
+//
+// Packets accumulate on the pipe their flow hashes to, so a whole burst
+// crosses to its consumer together rather than one packet at a time. A packet
+// addressed to a device this worker cannot reach, and any the pipe later
+// refuses, joins the caller's failure list, which the round discards.
+// Recovering a refused packet reads it back from the buffer it carries, so it
+// must live at the head of that buffer — where the pipeline puts it.
+void
+worker_tx_stage(
+	struct worker_tx_connection *connections,
+	uint32_t device_count,
+	struct dp_worker *dp_worker,
+	struct packet *packet,
+	struct packet_list *failed
+);
+
+// Hand every pipe's held packets to their consumers.
+//
+// Must run before the round ends, or packets staged during it would wait for
+// traffic that may never come.
+void
+worker_tx_flush_all(
+	struct worker_tx_connection *connections,
+	uint32_t device_count,
+	struct dp_worker *dp_worker,
+	struct packet_list *failed
+);

--- a/lib/dataplane_ut/mempool.h
+++ b/lib/dataplane_ut/mempool.h
@@ -21,9 +21,57 @@ test_pool_free(struct rte_mempool *mp) {
 	rte_panic("unimplemented: pool's internal data free");
 }
 
+// Objects handed out and not yet returned, so the pool can release whatever a
+// test left behind.
+//
+// Every object is a separate allocation, and only a return frees one, so a
+// test that deliberately ends holding objects would otherwise leak them all.
+struct test_pool_live {
+	void **objects;
+	size_t count;
+	size_t capacity;
+};
+
+static inline struct test_pool_live *
+test_pool_live_of(const struct rte_mempool *mp) {
+	return (struct test_pool_live *)((size_t *)mp->pool_data + 2);
+}
+
+static inline void
+test_pool_live_add(struct rte_mempool *mp, void *obj) {
+	struct test_pool_live *live = test_pool_live_of(mp);
+
+	if (live->count == live->capacity) {
+		size_t capacity = live->capacity ? live->capacity * 2 : 64;
+		void **grown = (void **)realloc(
+			live->objects, capacity * sizeof(void *)
+		);
+		if (grown == NULL) {
+			rte_panic("failed to grow the live-object table");
+		}
+		live->objects = grown;
+		live->capacity = capacity;
+	}
+
+	live->objects[live->count++] = obj;
+}
+
+static inline void
+test_pool_live_remove(struct rte_mempool *mp, void *obj) {
+	struct test_pool_live *live = test_pool_live_of(mp);
+
+	for (size_t idx = live->count; idx-- > 0;) {
+		if (live->objects[idx] == obj) {
+			live->objects[idx] = live->objects[--live->count];
+			return;
+		}
+	}
+}
+
 static int
 test_pool_enqueue(struct rte_mempool *mp, void *const *obj_table, unsigned n) {
 	for (unsigned idx = 0; idx < n; idx++) {
+		test_pool_live_remove(mp, obj_table[idx]);
 		free((char *)obj_table[idx] - mp->header_size);
 	}
 	*(size_t *)mp->pool_data -= n;
@@ -50,6 +98,7 @@ test_pool_dequeue(struct rte_mempool *mp, void **obj_table, unsigned n) {
 			(rte_iova_t)(uintptr_t)((char *)ptr + mp->header_size);
 
 		obj_table[idx] = (char *)ptr + mp->header_size;
+		test_pool_live_add(mp, obj_table[idx]);
 
 		rte_pktmbuf_init(mp, NULL, obj_table[idx], 0);
 	}
@@ -78,14 +127,18 @@ test_mempool_create(void) {
 	rte_mempool_ops_table.num_ops = 0;
 	rte_mempool_register_ops(&test_pool_ops);
 
-	// The outstanding-object counter and poison flag live right after the
-	// private data, inside this same allocation, so every caller's plain
-	// free(mp) stays correct instead of leaking separately-allocated state.
+	// The outstanding-object counter, the poison flag and the live-object
+	// table live right after the private data.
+	//
+	// The table's entries are allocated separately because their number is
+	// not known in advance, so the pool must be released through its own
+	// teardown rather than a plain free.
 	size_t private_data_size = sizeof(struct rte_pktmbuf_pool_private);
 	struct rte_mempool *mp =
 		calloc(1,
 		       sizeof(struct rte_mempool) + private_data_size +
-			       2 * sizeof(size_t));
+			       2 * sizeof(size_t) +
+			       sizeof(struct test_pool_live));
 	mp->flags |= RTE_MEMPOOL_F_POOL_CREATED;
 	mp->socket_id = 0;
 	mp->cache_size = 0;
@@ -104,6 +157,14 @@ test_mempool_create(void) {
 // Release resources allocated by test_mempool_create().
 static inline void
 test_mempool_free(struct rte_mempool *mp) {
+	// Release whatever a test finished holding. Only a return frees an
+	// object, so anything still live here would otherwise leak.
+	struct test_pool_live *live = test_pool_live_of(mp);
+	for (size_t idx = 0; idx < live->count; ++idx) {
+		free((char *)live->objects[idx] - mp->header_size);
+	}
+	free(live->objects);
+
 	// Do NOT call rte_mempool_free — the test pool is not a real DPDK
 	// pool and has no backing memory to tear down that way.
 	free(mp);

--- a/lib/dataplane_ut/meson.build
+++ b/lib/dataplane_ut/meson.build
@@ -14,6 +14,7 @@ dependencies = [
 sources = files(
   'dataplane_ut.c',
   'tx_pipe.c',
+  'tx_stage.c',
 )
 
 lib_dataplane_ut = static_library(

--- a/lib/dataplane_ut/tx_pipe.c
+++ b/lib/dataplane_ut/tx_pipe.c
@@ -84,7 +84,45 @@ int
 dataplane_ut_tx_pipe_push(
 	struct dataplane_ut_tx_pipe *fixture, struct rte_mbuf *mbuf
 ) {
-	return worker_tx_pipe_push(&fixture->tx_pipe, mbuf);
+	struct rte_mbuf *rejected[1];
+	size_t rejected_count = 0;
+
+	return worker_tx_pipe_push_bulk(
+		       &fixture->tx_pipe, &mbuf, 1, rejected, &rejected_count
+	       ) == 1
+		       ? 0
+		       : -1;
+}
+
+int
+dataplane_ut_tx_pipe_stage(
+	struct dataplane_ut_tx_pipe *fixture, struct rte_mbuf *mbuf
+) {
+	return worker_tx_pipe_stage(&fixture->tx_pipe, mbuf) ? 0 : -1;
+}
+
+size_t
+dataplane_ut_tx_pipe_flush(
+	struct dataplane_ut_tx_pipe *fixture,
+	struct rte_mbuf **rejected,
+	size_t *rejected_count
+) {
+	return worker_tx_pipe_flush(
+		&fixture->tx_pipe, rejected, rejected_count
+	);
+}
+
+size_t
+dataplane_ut_tx_pipe_push_bulk(
+	struct dataplane_ut_tx_pipe *fixture,
+	struct rte_mbuf **mbufs,
+	size_t count,
+	struct rte_mbuf **rejected,
+	size_t *rejected_count
+) {
+	return worker_tx_pipe_push_bulk(
+		&fixture->tx_pipe, mbufs, count, rejected, rejected_count
+	);
 }
 
 struct dataplane_ut_tx_pipe_transmit_ctx {

--- a/lib/dataplane_ut/tx_pipe.h
+++ b/lib/dataplane_ut/tx_pipe.h
@@ -25,12 +25,43 @@ dataplane_ut_tx_pipe_alloc_mbuf(
 	struct dataplane_ut_tx_pipe *fixture, size_t seg_count
 );
 
-// Push mbuf onto the fixture's pipe via worker_tx_pipe_push.
+// Push one mbuf onto the fixture's pipe as a single-element batch.
 //
 // Returns 0 on success, -1 if the pipe or its deferred-free ring is full.
 int
 dataplane_ut_tx_pipe_push(
 	struct dataplane_ut_tx_pipe *fixture, struct rte_mbuf *mbuf
+);
+
+// Stage one mbuf on the fixture's pipe via worker_tx_pipe_stage.
+//
+// Returns 0 when staged, -1 when the batch is already full.
+int
+dataplane_ut_tx_pipe_stage(
+	struct dataplane_ut_tx_pipe *fixture, struct rte_mbuf *mbuf
+);
+
+// Flush the fixture's staged batch via worker_tx_pipe_flush.
+//
+// Returns how many the pipe accepted and fills rejected, which must have
+// room for a whole batch.
+size_t
+dataplane_ut_tx_pipe_flush(
+	struct dataplane_ut_tx_pipe *fixture,
+	struct rte_mbuf **rejected,
+	size_t *rejected_count
+);
+
+// Push a batch onto the fixture's pipe via worker_tx_pipe_push_bulk.
+//
+// Returns how many were accepted; the rest stay the caller's.
+size_t
+dataplane_ut_tx_pipe_push_bulk(
+	struct dataplane_ut_tx_pipe *fixture,
+	struct rte_mbuf **mbufs,
+	size_t count,
+	struct rte_mbuf **rejected,
+	size_t *rejected_count
 );
 
 // Drain the fixture's pipe via worker_tx_pipe_drain, transmitting only the

--- a/lib/dataplane_ut/tx_stage.c
+++ b/lib/dataplane_ut/tx_stage.c
@@ -1,0 +1,197 @@
+#include "tx_stage.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <rte_mbuf.h>
+
+#include "lib/dataplane/config/zone.h"
+#include "lib/dataplane/packet/data.h"
+#include "lib/dataplane/packet/packet.h"
+#include "lib/dataplane/worker/tx_stage.h"
+#include "lib/dataplane_ut/mempool.h"
+
+struct dataplane_ut_tx_stage {
+	struct rte_mempool *mempool;
+
+	struct worker_tx_connection *connections;
+	struct worker_tx_pipe *pipes;
+	uint32_t device_count;
+	uint32_t pipes_per_device;
+
+	struct dp_worker dp_worker;
+	uint64_t tx_count;
+	uint64_t tx_drops;
+
+	struct packet_list failed;
+};
+
+struct dataplane_ut_tx_stage *
+dataplane_ut_tx_stage_new(uint32_t device_count, uint32_t pipes_per_device) {
+	struct dataplane_ut_tx_stage *fixture =
+		(struct dataplane_ut_tx_stage *)calloc(1, sizeof(*fixture));
+	if (fixture == NULL) {
+		return NULL;
+	}
+
+	fixture->mempool = test_mempool_create();
+	if (fixture->mempool == NULL) {
+		free(fixture);
+		return NULL;
+	}
+
+	fixture->device_count = device_count;
+	fixture->pipes_per_device = pipes_per_device;
+	fixture->connections = (struct worker_tx_connection *)calloc(
+		device_count, sizeof(struct worker_tx_connection)
+	);
+	fixture->pipes = (struct worker_tx_pipe *)calloc(
+		(size_t)device_count * pipes_per_device + 1,
+		sizeof(struct worker_tx_pipe)
+	);
+	if (fixture->connections == NULL || fixture->pipes == NULL) {
+		dataplane_ut_tx_stage_free(fixture);
+		return NULL;
+	}
+
+	// Count pipes as they come up, never before: a failed pipe leaves its
+	// own storage released, so teardown must not visit it.
+	for (uint32_t device = 0; device < device_count; ++device) {
+		fixture->connections[device].count = 0;
+		fixture->connections[device].pipes =
+			fixture->pipes + (size_t)device * pipes_per_device;
+
+		for (uint32_t pipe = 0; pipe < pipes_per_device; ++pipe) {
+			if (worker_tx_pipe_init(
+				    fixture->connections[device].pipes + pipe
+			    )) {
+				dataplane_ut_tx_stage_free(fixture);
+				return NULL;
+			}
+			++fixture->connections[device].count;
+		}
+	}
+
+	fixture->dp_worker.remote_tx_count = &fixture->tx_count;
+	fixture->dp_worker.remote_tx_drops = &fixture->tx_drops;
+	packet_list_init(&fixture->failed);
+
+	return fixture;
+}
+
+void
+dataplane_ut_tx_stage_free(struct dataplane_ut_tx_stage *fixture) {
+	if (fixture == NULL) {
+		return;
+	}
+
+	if (fixture->pipes != NULL && fixture->connections != NULL) {
+		for (uint32_t device = 0; device < fixture->device_count;
+		     ++device) {
+			for (uint32_t pipe = 0;
+			     pipe < fixture->connections[device].count;
+			     ++pipe) {
+				worker_tx_pipe_fini(
+					fixture->connections[device].pipes +
+					pipe
+				);
+			}
+		}
+	}
+
+	free(fixture->pipes);
+	free(fixture->connections);
+	if (fixture->mempool != NULL) {
+		test_mempool_free(fixture->mempool);
+	}
+	free(fixture);
+}
+
+struct packet *
+dataplane_ut_tx_stage_packet(
+	struct dataplane_ut_tx_stage *fixture,
+	uint16_t tx_device_id,
+	uint32_t hash
+) {
+	struct rte_mbuf *mbuf = rte_pktmbuf_alloc(fixture->mempool);
+	if (mbuf == NULL) {
+		return NULL;
+	}
+
+	struct packet *packet = mbuf_to_packet(mbuf);
+	memset(packet, 0, sizeof(*packet));
+	packet->mbuf = mbuf;
+	packet->tx_device_id = tx_device_id;
+	packet->hash = hash;
+
+	return packet;
+}
+
+void
+dataplane_ut_tx_stage_offer(
+	struct dataplane_ut_tx_stage *fixture, struct packet *packet
+) {
+	worker_tx_stage(
+		fixture->connections,
+		fixture->device_count,
+		&fixture->dp_worker,
+		packet,
+		&fixture->failed
+	);
+}
+
+void
+dataplane_ut_tx_stage_flush(struct dataplane_ut_tx_stage *fixture) {
+	worker_tx_flush_all(
+		fixture->connections,
+		fixture->device_count,
+		&fixture->dp_worker,
+		&fixture->failed
+	);
+}
+
+uint32_t
+dataplane_ut_tx_stage_held(
+	struct dataplane_ut_tx_stage *fixture, uint32_t device, uint32_t pipe
+) {
+	return fixture->connections[device].pipes[pipe].batch_count;
+}
+
+uint64_t
+dataplane_ut_tx_stage_placed(
+	struct dataplane_ut_tx_stage *fixture, uint32_t device, uint32_t pipe
+) {
+	return fixture->connections[device].pipes[pipe].pending_stop;
+}
+
+uint64_t
+dataplane_ut_tx_stage_tx_count(struct dataplane_ut_tx_stage *fixture) {
+	return fixture->tx_count;
+}
+
+uint64_t
+dataplane_ut_tx_stage_tx_drops(struct dataplane_ut_tx_stage *fixture) {
+	return fixture->tx_drops;
+}
+
+size_t
+dataplane_ut_tx_stage_failed_count(struct dataplane_ut_tx_stage *fixture) {
+	size_t count = 0;
+	for (struct packet *packet = packet_list_first(&fixture->failed);
+	     packet != NULL;
+	     packet = packet->next) {
+		++count;
+	}
+	return count;
+}
+
+struct packet *
+dataplane_ut_tx_stage_failed_at(
+	struct dataplane_ut_tx_stage *fixture, size_t idx
+) {
+	struct packet *packet = packet_list_first(&fixture->failed);
+	while (packet != NULL && idx-- > 0) {
+		packet = packet->next;
+	}
+	return packet;
+}

--- a/lib/dataplane_ut/tx_stage.h
+++ b/lib/dataplane_ut/tx_stage.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct dataplane_ut_tx_stage;
+struct packet;
+
+// Construct a fixture owning a connection table and a mock mempool.
+//
+// Every device is given the same number of pipes; a device with none stands
+// for one this worker cannot reach. Returns NULL on allocation failure.
+struct dataplane_ut_tx_stage *
+dataplane_ut_tx_stage_new(uint32_t device_count, uint32_t pipes_per_device);
+
+// Tear down a fixture previously returned by dataplane_ut_tx_stage_new.
+// NULL-safe.
+void
+dataplane_ut_tx_stage_free(struct dataplane_ut_tx_stage *fixture);
+
+// Take a packet from the mock pool, addressed to a device and carrying a
+// flow hash. Returns NULL on exhaustion.
+struct packet *
+dataplane_ut_tx_stage_packet(
+	struct dataplane_ut_tx_stage *fixture,
+	uint16_t tx_device_id,
+	uint32_t hash
+);
+
+// Offer one packet to the staging path.
+void
+dataplane_ut_tx_stage_offer(
+	struct dataplane_ut_tx_stage *fixture, struct packet *packet
+);
+
+// Hand every pipe's held packets to their consumers.
+void
+dataplane_ut_tx_stage_flush(struct dataplane_ut_tx_stage *fixture);
+
+// How many packets a given pipe is currently holding.
+//
+// The coordinates must be within the table the fixture was built with.
+uint32_t
+dataplane_ut_tx_stage_held(
+	struct dataplane_ut_tx_stage *fixture, uint32_t device, uint32_t pipe
+);
+
+// How many packets a given pipe has placed with its consumer.
+uint64_t
+dataplane_ut_tx_stage_placed(
+	struct dataplane_ut_tx_stage *fixture, uint32_t device, uint32_t pipe
+);
+
+// Counters the staging path maintains.
+uint64_t
+dataplane_ut_tx_stage_tx_count(struct dataplane_ut_tx_stage *fixture);
+uint64_t
+dataplane_ut_tx_stage_tx_drops(struct dataplane_ut_tx_stage *fixture);
+
+// The failure list, in the order packets joined it.
+size_t
+dataplane_ut_tx_stage_failed_count(struct dataplane_ut_tx_stage *fixture);
+struct packet *
+dataplane_ut_tx_stage_failed_at(
+	struct dataplane_ut_tx_stage *fixture, size_t idx
+);

--- a/lib/tests/dataplane/worker_clone_test.c
+++ b/lib/tests/dataplane/worker_clone_test.c
@@ -390,7 +390,7 @@ main(void) {
 		}
 	}
 
-	free(pool);
+	test_mempool_free(pool);
 
 	if (failed == 0) {
 		LOG(INFO, "all %zu worker_clone tests passed", total);

--- a/tests/worker/tx_pipe_test.go
+++ b/tests/worker/tx_pipe_test.go
@@ -288,3 +288,305 @@ func TestPushRejectsMismatchOnLaterTailSegment(t *testing.T) {
 	require.Equal(t, 0, fixture.Outstanding(),
 		"the recovered chain must be back in the pool exactly once")
 }
+
+// allocBatch allocates count mbufs of segCount segments each, failing the
+// test if the mock pool cannot satisfy them.
+func allocBatch(t *testing.T, fixture *dataplaneut.TxPipeFixture, count, segCount int) []*dataplaneut.TxPipeMbuf {
+	t.Helper()
+
+	mbufs := make([]*dataplaneut.TxPipeMbuf, count)
+	for idx := range mbufs {
+		mbuf, err := fixture.AllocMbuf(segCount)
+		require.NoError(t, err)
+		mbufs[idx] = mbuf
+	}
+
+	return mbufs
+}
+
+// TestPushBulkWholeBatchReclaimReturnsEveryMbufToPool verifies that a batch
+// pushed in one call behaves exactly as the same mbufs pushed one at a time:
+// every one survives to the drain, and a single Reclaim after their
+// completions returns all of them to the pool exactly once.
+func TestPushBulkWholeBatchReclaimReturnsEveryMbufToPool(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	const batch = 8
+	mbufs := allocBatch(t, fixture, batch, 1)
+	require.Equal(t, batch, fixture.Outstanding())
+
+	pushed, rejected := fixture.PushBulk(mbufs)
+	require.Equal(t, batch, pushed, "an empty pipe must accept the whole batch in one call")
+	require.Empty(t, rejected)
+
+	fixture.Drain(batch)
+	require.Equal(t, batch, fixture.Outstanding(),
+		"accepted mbufs must survive drain until NIC completion")
+
+	for _, mbuf := range mbufs {
+		mbuf.Complete()
+	}
+	fixture.Reclaim()
+
+	require.Equal(t, 0, fixture.Outstanding())
+}
+
+// TestPushBulkMultiSegmentChainsReclaimReturnsEverySegment verifies that a
+// batch of chained mbufs pins and releases every segment, not just each
+// chain's head.
+func TestPushBulkMultiSegmentChainsReclaimReturnsEverySegment(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	const batch, segments = 4, 3
+	mbufs := allocBatch(t, fixture, batch, segments)
+	require.Equal(t, batch*segments, fixture.Outstanding())
+
+	pushed, _ := fixture.PushBulk(mbufs)
+	require.Equal(t, batch, pushed)
+
+	fixture.Drain(batch)
+	for _, mbuf := range mbufs {
+		mbuf.Complete()
+	}
+	fixture.Reclaim()
+
+	require.Equal(t, 0, fixture.Outstanding(),
+		"every segment of every chain must return to the pool exactly once")
+}
+
+// TestPushBulkPartialDrainAcceptBalancesBothOutcomes verifies that when a
+// drain accepts only a prefix of a bulk-pushed batch, the rejected remainder
+// is freed by the drain while the accepted prefix waits for completion, and
+// one Reclaim balances both.
+func TestPushBulkPartialDrainAcceptBalancesBothOutcomes(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	const batch, accept = 6, 2
+	mbufs := allocBatch(t, fixture, batch, 1)
+
+	pushed, _ := fixture.PushBulk(mbufs)
+	require.Equal(t, batch, pushed)
+
+	fixture.Drain(accept)
+	for _, mbuf := range mbufs[:accept] {
+		mbuf.Complete()
+	}
+	fixture.Reclaim()
+
+	require.Equal(t, 0, fixture.Outstanding(),
+		"accepted and rejected halves of one batch must both settle")
+}
+
+// TestPushBulkRefusesMismatchedChainAloneAndPlacesTheRest verifies that a
+// chain whose segments disagree on a refcount is refused on its own while
+// every other mbuf in the batch is still placed.
+//
+// A refused packet is requeued ahead of the ones behind it, so the pipe only
+// keeps moving while a refusal stays confined to the chain that caused it.
+func TestPushBulkRefusesMismatchedChainAloneAndPlacesTheRest(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	const batch, offender = 5, 2
+	mbufs := allocBatch(t, fixture, batch, 3)
+
+	// Lift one tail segment above its chain's baseline so the pin walk
+	// refuses that chain.
+	mbufs[offender].Segment(1).AddRefcnt(1)
+	before := mbufs[offender].Segment(1).Refcnt()
+
+	pushed, rejected := fixture.PushBulk(mbufs)
+	require.Equal(t, batch-1, pushed,
+		"every chain but the mismatched one must be placed")
+	require.Len(t, rejected, 1)
+	require.True(t, rejected[0].Same(mbufs[offender]),
+		"the mismatched chain is the one refused")
+	require.Equal(t, before, mbufs[offender].Segment(1).Refcnt(),
+		"the mismatched chain's pins must be fully unwound")
+
+	fixture.Drain(batch - 1)
+	for idx, mbuf := range mbufs {
+		if idx != offender {
+			mbuf.Complete()
+		}
+	}
+	fixture.Reclaim()
+
+	require.Equal(t, 3, fixture.Outstanding(),
+		"only the refused chain's segments stay the caller's")
+}
+
+// TestPushBulkMismatchedHeadDoesNotBlockTheBatch verifies that a mismatched
+// chain at the head of a batch does not hold up the mbufs behind it.
+//
+// The head is the position that decides it: an offender further along leaves
+// the packets before it already placed, so only a leading one shows whether a
+// refusal stays confined to its own chain.
+func TestPushBulkMismatchedHeadDoesNotBlockTheBatch(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	mbufs := allocBatch(t, fixture, 3, 2)
+	mbufs[0].Segment(1).AddRefcnt(1)
+
+	pushed, rejected := fixture.PushBulk(mbufs)
+	require.Equal(t, 2, pushed,
+		"the two sound chains must be placed despite leading with a bad one")
+	require.Len(t, rejected, 1)
+	require.True(t, rejected[0].Same(mbufs[0]))
+}
+
+// settleBatch drains, completes and reclaims a whole batch, leaving the pipe
+// empty but its ring positions advanced.
+func settleBatch(t *testing.T, fixture *dataplaneut.TxPipeFixture, mbufs []*dataplaneut.TxPipeMbuf) {
+	t.Helper()
+
+	fixture.Drain(len(mbufs))
+	for _, mbuf := range mbufs {
+		mbuf.Complete()
+	}
+	fixture.Reclaim()
+}
+
+// TestPushBulkSpansRingWrap verifies that a batch straddling the ring
+// buffer's wrap point is placed whole rather than truncated at the boundary.
+//
+// The ring offers only the slots left before its buffer wraps, so placing a
+// batch that crosses the boundary takes a second round trip.
+func TestPushBulkSpansRingWrap(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	// Advance the ring positions two thirds of the way round, so the next
+	// batch cannot be contiguous.
+	const offset = 700
+	offsetMbufs := allocBatch(t, fixture, offset, 1)
+	pushedOffset, _ := fixture.PushBulk(offsetMbufs)
+	require.Equal(t, offset, pushedOffset)
+	settleBatch(t, fixture, offsetMbufs)
+	require.Equal(t, 0, fixture.Outstanding())
+
+	const batch = 600
+	mbufs := allocBatch(t, fixture, batch, 1)
+	pushed, rejected := fixture.PushBulk(mbufs)
+	require.Equal(t, batch, pushed, "a batch spanning the wrap must be placed in full")
+	require.Empty(t, rejected)
+
+	settleBatch(t, fixture, mbufs)
+	require.Equal(t, 0, fixture.Outstanding())
+}
+
+// TestPushBulkStopsWhenRingIsFull verifies that a batch larger than the ring
+// is truncated to what fits, leaving the remainder with the caller.
+func TestPushBulkStopsWhenRingIsFull(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	const ringSlots = 1 << 10
+	const batch = ringSlots + 64
+	mbufs := allocBatch(t, fixture, batch, 1)
+
+	pushed, rejected := fixture.PushBulk(mbufs)
+	require.Equal(t, ringSlots, pushed, "the ring must cap the batch at its slot count")
+	require.Len(t, rejected, batch-ringSlots,
+		"everything the ring had no room for comes back to the caller")
+
+	settleBatch(t, fixture, mbufs[:ringSlots])
+	require.Equal(t, batch-ringSlots, fixture.Outstanding(),
+		"the mbufs that never entered the pipe stay the caller's")
+}
+
+// TestPushBulkStopsWhenDeferredFreeRingIsFull verifies that the deferred-free
+// ring, not just the pipe, bounds a batch.
+//
+// Reclaim frees pipe slots as soon as the consumer has popped them, but an
+// mbuf's deferred-free entry lives until its tx completes. Refilling the pipe
+// without completing anything therefore backs up against the deferred-free
+// ring, which is deliberately larger than the pipe — so only a batch that
+// outlasts several pipe-fulls reaches this limit.
+func TestPushBulkStopsWhenDeferredFreeRingIsFull(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	const ringSlots = 1 << 10
+	const pendingSlots = ringSlots << 2
+
+	var inFlight []*dataplaneut.TxPipeMbuf
+	for len(inFlight) < pendingSlots {
+		mbufs := allocBatch(t, fixture, ringSlots, 1)
+		pushed, _ := fixture.PushBulk(mbufs)
+		require.Equal(t, ringSlots, pushed)
+
+		// Pop and reclaim without completing: pipe slots come back,
+		// deferred-free entries do not.
+		fixture.Drain(ringSlots)
+		fixture.Reclaim()
+		inFlight = append(inFlight, mbufs...)
+	}
+
+	overflow := allocBatch(t, fixture, 16, 1)
+	pushed, rejected := fixture.PushBulk(overflow)
+	require.Equal(t, 0, pushed, "a full deferred-free ring must refuse the whole batch")
+	require.Len(t, rejected, len(overflow))
+
+	for _, mbuf := range inFlight {
+		mbuf.Complete()
+	}
+	fixture.Reclaim()
+	require.Equal(t, len(overflow), fixture.Outstanding(),
+		"only the refused batch may remain outstanding")
+}
+
+// TestStageFillsBatchThenRefuses verifies that staging stops accepting once
+// the batch is full and resumes after a flush empties it.
+func TestStageFillsBatchThenRefuses(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	mbufs := allocBatch(t, fixture, dataplaneut.TxPipeBatchSize+1, 1)
+	for idx, mbuf := range mbufs[:dataplaneut.TxPipeBatchSize] {
+		require.True(t, fixture.Stage(mbuf), "mbuf %d must stage", idx)
+	}
+	require.False(t, fixture.Stage(mbufs[dataplaneut.TxPipeBatchSize]),
+		"a full batch must refuse further staging")
+
+	pushed, rejected := fixture.Flush()
+	require.Equal(t, dataplaneut.TxPipeBatchSize, pushed)
+	require.Empty(t, rejected)
+
+	require.True(t, fixture.Stage(mbufs[dataplaneut.TxPipeBatchSize]),
+		"a flushed batch must accept staging again")
+
+	pushed, rejected = fixture.Flush()
+	require.Equal(t, 1, pushed)
+	require.Empty(t, rejected)
+
+	settleBatch(t, fixture, mbufs)
+	require.Equal(t, 0, fixture.Outstanding())
+}
+
+// TestFlushReturnsRejectedRemainderInOrder verifies that when the pipe cannot
+// take the whole staged batch, the refused mbufs come back to the caller in
+// the order they were staged, so the caller can requeue them without
+// reordering a flow.
+func TestFlushReturnsRejectedRemainderInOrder(t *testing.T) {
+	fixture := newTxPipeFixture(t)
+
+	// Fill the ring so nothing staged afterwards can be accepted.
+	const ringSlots = 1 << 10
+	filler := allocBatch(t, fixture, ringSlots, 1)
+	pushedFiller, _ := fixture.PushBulk(filler)
+	require.Equal(t, ringSlots, pushedFiller)
+
+	const staged = 4
+	mbufs := allocBatch(t, fixture, staged, 1)
+	for _, mbuf := range mbufs {
+		require.True(t, fixture.Stage(mbuf))
+	}
+
+	pushed, rejected := fixture.Flush()
+	require.Equal(t, 0, pushed, "a full pipe must accept nothing")
+	require.Len(t, rejected, staged)
+	for idx := range mbufs {
+		require.True(t, rejected[idx].Same(mbufs[idx]),
+			"rejected mbuf %d must be the one staged at that position", idx)
+	}
+
+	settleBatch(t, fixture, filler)
+	require.Equal(t, staged, fixture.Outstanding(),
+		"the refused mbufs never entered the pipe and are still the caller's")
+}

--- a/tests/worker/tx_stage_test.go
+++ b/tests/worker/tx_stage_test.go
@@ -1,0 +1,187 @@
+// Package worker_test also covers the worker's remote staging path in
+// lib/dataplane/worker/tx_stage.c, reached through the
+// lib/dataplane_ut/tx_stage.h fixture.
+//
+// A pass confirms packets bound for another worker reach the pipe their flow
+// hashes to, cross in bursts, and that anything a pipe cannot take rejoins the
+// caller's failure list, which the round discards.
+package worker_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+)
+
+// newTxStageFixture constructs a staging fixture and registers its teardown.
+func newTxStageFixture(t *testing.T, devices, pipesPerDevice int) *dataplaneut.TxStageFixture {
+	t.Helper()
+
+	fixture, err := dataplaneut.NewTxStageFixture(devices, pipesPerDevice)
+	require.NoError(t, err)
+	t.Cleanup(fixture.Free)
+
+	return fixture
+}
+
+// offer takes a packet addressed to a device with a flow hash and offers it to
+// the staging path, returning it so a test can identify it later.
+func offer(t *testing.T, fixture *dataplaneut.TxStageFixture, device uint16, hash uint32) *dataplaneut.TxStagePacket {
+	t.Helper()
+
+	packet, err := fixture.Packet(device, hash)
+	require.NoError(t, err)
+	fixture.Offer(packet)
+
+	return packet
+}
+
+// TestStageHoldsPacketsUntilFlush verifies that a staged packet waits on its
+// pipe until the round ends, then crosses in one go.
+func TestStageHoldsPacketsUntilFlush(t *testing.T) {
+	fixture := newTxStageFixture(t, 2, 1)
+
+	const held = 5
+	for range held {
+		offer(t, fixture, 1, 0)
+	}
+
+	require.Equal(t, held, fixture.Held(1, 0), "packets must wait for the flush")
+	require.Equal(t, 0, fixture.Placed(1, 0))
+	require.Equal(t, 0, fixture.TxCount())
+
+	fixture.Flush()
+
+	require.Equal(t, 0, fixture.Held(1, 0))
+	require.Equal(t, held, fixture.Placed(1, 0), "the whole burst must cross at once")
+	require.Equal(t, held, fixture.TxCount())
+	require.Empty(t, fixture.Failed())
+}
+
+// TestStageRoutesByDestinationDevice verifies that packets are held on the
+// connection for the device they are addressed to.
+func TestStageRoutesByDestinationDevice(t *testing.T) {
+	fixture := newTxStageFixture(t, 3, 1)
+
+	offer(t, fixture, 0, 0)
+	offer(t, fixture, 2, 0)
+	offer(t, fixture, 2, 0)
+
+	require.Equal(t, 1, fixture.Held(0, 0))
+	require.Equal(t, 0, fixture.Held(1, 0))
+	require.Equal(t, 2, fixture.Held(2, 0))
+}
+
+// TestStageSpreadsFlowsAcrossPipes verifies that a device served by several
+// pipes has its packets spread by flow hash, and that one flow always lands on
+// one pipe so it cannot be reordered against itself.
+func TestStageSpreadsFlowsAcrossPipes(t *testing.T) {
+	const pipes = 4
+	fixture := newTxStageFixture(t, 1, pipes)
+
+	for hash := range uint32(pipes) {
+		offer(t, fixture, 0, hash)
+	}
+	for pipe := range pipes {
+		require.Equal(t, 1, fixture.Held(0, pipe),
+			"each flow must land on its own pipe")
+	}
+
+	// One flow repeated stays on the pipe it first chose.
+	for range 3 {
+		offer(t, fixture, 0, 2)
+	}
+	require.Equal(t, 4, fixture.Held(0, 2))
+}
+
+// TestStageFlushesAFullPipeMidRound verifies that a pipe holding a full batch
+// hands it over immediately, so the packet in hand has somewhere to land.
+func TestStageFlushesAFullPipeMidRound(t *testing.T) {
+	fixture := newTxStageFixture(t, 1, 1)
+
+	batch := dataplaneut.TxPipeBatchSize
+	for range batch {
+		offer(t, fixture, 0, 0)
+	}
+	require.Equal(t, batch, fixture.Held(0, 0))
+	require.Equal(t, 0, fixture.Placed(0, 0))
+
+	offer(t, fixture, 0, 0)
+
+	require.Equal(t, batch, fixture.Placed(0, 0),
+		"the full batch must cross to make room")
+	require.Equal(t, 1, fixture.Held(0, 0),
+		"the packet in hand takes the emptied batch")
+	require.Equal(t, batch, fixture.TxCount())
+}
+
+// TestStageRequeuesPacketsForAnUnreachableDevice verifies that a device this
+// worker has no pipes to hands its packets to the failure list, counted as
+// remote drops.
+func TestStageRequeuesPacketsForAnUnreachableDevice(t *testing.T) {
+	fixture := newTxStageFixture(t, 2, 0)
+
+	first := offer(t, fixture, 0, 0)
+	second := offer(t, fixture, 1, 0)
+
+	failed := fixture.Failed()
+	require.Len(t, failed, 2)
+	require.True(t, failed[0].Same(first), "the failure list keeps offer order")
+	require.True(t, failed[1].Same(second))
+	require.Equal(t, 2, fixture.TxDrops())
+	require.Equal(t, 0, fixture.TxCount())
+}
+
+// TestStageRequeuesAnOutOfRangeDeviceUncounted verifies that a packet
+// addressed beyond the connection table is sent back without being counted as
+// a transmit drop, which is reserved for a device that exists but could not
+// take it.
+//
+// The first id past the end is the one that matters: it is the id a bound one
+// too wide would let through, and the only one that would then be read from
+// beyond the table.
+func TestStageRequeuesAnOutOfRangeDeviceUncounted(t *testing.T) {
+	const devices = 2
+	fixture := newTxStageFixture(t, devices, 1)
+
+	justPast := offer(t, fixture, devices, 0)
+	wellPast := offer(t, fixture, devices+16, 0)
+
+	failed := fixture.Failed()
+	require.Len(t, failed, 2)
+	require.True(t, failed[0].Same(justPast),
+		"the first id past the end must be refused")
+	require.True(t, failed[1].Same(wellPast))
+	require.Equal(t, 0, fixture.TxDrops(), "an unknown device is not a transmit drop")
+}
+
+// TestStageRequeuesWhatAPipeRefuses verifies that packets a full pipe cannot
+// take rejoin the failure list in the order they were offered.
+func TestStageRequeuesWhatAPipeRefuses(t *testing.T) {
+	fixture := newTxStageFixture(t, 1, 1)
+
+	// A pipe holds one ring's worth; keep going until it must refuse.
+	const ringSlots = 1 << 10
+	const offered = ringSlots + dataplaneut.TxPipeBatchSize
+
+	packets := make([]*dataplaneut.TxStagePacket, 0, offered)
+	for range offered {
+		packets = append(packets, offer(t, fixture, 0, 0))
+	}
+	fixture.Flush()
+
+	failed := fixture.Failed()
+	require.NotEmpty(t, failed, "a pipe that ran out of room must send packets back")
+	require.Equal(t, offered, fixture.TxCount()+fixture.TxDrops(),
+		"every offered packet is either placed or counted as a drop")
+	require.Equal(t, len(failed), fixture.TxDrops())
+
+	// The refused packets are a suffix of what was offered, in order.
+	first := offered - len(failed)
+	for idx, packet := range failed {
+		require.True(t, packet.Same(packets[first+idx]),
+			"refused packet %d is out of order", idx)
+	}
+}


### PR DESCRIPTION
Packets bound for another worker crossed the tx pipe one at a time. The write
position the consumer polls migrates between the two cores' caches on every
store, so that cost was paid per packet rather than per burst.

- Accumulate packets destined for another worker on the pipe their flow hash
  selects, and hand each batch across in one ring round trip when the round
  ends. A batch that fills mid-round goes early so the packet in hand has
  somewhere to land.
- Refuse a chain whose segments disagree on a refcount on its own, leaving the
  rest of the batch unaffected. Accepted and refused mbufs together always
  account for the whole batch, and the refused keep the order they were given.
- Bound each batch by both the pipe and the deferred-free ring, and place a
  batch that straddles the ring's wrap in a second round trip rather than
  truncating it at the boundary.
- Move the remote dispatch out of the dataplane binary into a unit the test
  harness can link, taking the connection table and worker counters rather than
  the whole worker. It reaches no port, so it needs no device to drive it.
- Bound the destination device once, against the count that sizes the
  connection table. The previous check used the topology's count, which could
  read past the table when the two disagreed.
- Add fixtures and regression tests for both layers: batch handover, chained
  mbufs, partial accept, a refused chain at the head and mid-batch, the ring
  wrap, both backpressure limits, flow-hash spread, the mid-round flush, and
  the requeue paths.

Measured on bare metal with a throwaway harness, comparing against the
original pre-batching push:
145 -> 66 cycles/packet at a burst of 32, about 2.2x, against a ~4% penalty for
a single packet. Producer side only.

Closes #1871.