### PR TITLE
fix(operator,ynpb): compare the whole function on apply

### DIFF
--- a/common/go/operator/function.go
+++ b/common/go/operator/function.go
@@ -11,34 +11,11 @@ import (
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
-// chainModulesCompare reports whether the modules the gateway holds satisfy
-// the wanted module list for a single chain.
-type chainModulesCompare func(gateway, want []*commonpb.ModuleId) bool
-
-func compareChainModulesExact(gateway, want []*commonpb.ModuleId) bool {
-	if len(gateway) != len(want) {
-		return false
-	}
-
-	for idx, module := range gateway {
-		if module.GetType() != want[idx].GetType() || module.GetName() != want[idx].GetName() {
-			return false
-		}
-	}
-
-	return true
-}
-
-func compareChainModulesIgnorePdump(gateway, want []*commonpb.ModuleId) bool {
-	survivors := filterPdump(gateway)
-	return compareChainModulesExact(survivors, want)
-}
-
 // FunctionApplier publishes a fixed function definition to a gateway.
 type FunctionApplier struct {
-	client         ynpb.FunctionServiceClient
-	function       *ynpb.Function
-	compareModules chainModulesCompare
+	client   ynpb.FunctionServiceClient
+	function *ynpb.Function
+	compare  functionCompare
 }
 
 // NewFunctionApplier returns a FunctionApplier that will publish function to
@@ -53,15 +30,10 @@ func NewFunctionApplier(
 		o(opts)
 	}
 
-	compare := compareChainModulesExact
-	if opts.IgnorePdump {
-		compare = compareChainModulesIgnorePdump
-	}
-
 	return &FunctionApplier{
-		client:         client,
-		function:       function,
-		compareModules: compare,
+		client:   client,
+		function: function,
+		compare:  opts.Compare,
 	}
 }
 
@@ -93,8 +65,7 @@ func (m *FunctionApplier) Apply(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-// alreadyCorrect reports whether the gateway holds the wanted chains in the
-// wanted order, each with the wanted weight and modules.
+// alreadyCorrect reports whether the gateway already holds the wanted function.
 func (m *FunctionApplier) alreadyCorrect(ctx context.Context) (bool, error) {
 	resp, err := m.client.Get(ctx, &ynpb.GetFunctionRequest{
 		Id: &commonpb.FunctionId{
@@ -108,32 +79,5 @@ func (m *FunctionApplier) alreadyCorrect(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("failed to get function %q: %w", m.Name(), err)
 	}
 
-	gateway := resp.GetFunction().GetChains()
-	want := m.function.GetChains()
-	if len(gateway) != len(want) {
-		return false, nil
-	}
-	for idx, chain := range gateway {
-		if chain.GetChain().GetName() != want[idx].GetChain().GetName() ||
-			chain.GetWeight() != want[idx].GetWeight() {
-			return false, nil
-		}
-		if !m.compareModules(chain.GetChain().GetModules(), want[idx].GetChain().GetModules()) {
-			return false, nil
-		}
-	}
-
-	return true, nil
-}
-
-// filterPdump returns a new slice containing only the modules whose type is
-// not exactly "pdump".
-func filterPdump(modules []*commonpb.ModuleId) []*commonpb.ModuleId {
-	out := make([]*commonpb.ModuleId, 0, len(modules))
-	for _, mod := range modules {
-		if mod.GetType() != "pdump" {
-			out = append(out, mod)
-		}
-	}
-	return out
+	return m.compare(resp.GetFunction(), m.function), nil
 }

--- a/common/go/operator/function_test.go
+++ b/common/go/operator/function_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -142,7 +143,7 @@ func Test_FunctionApplier_GetErrorAbortsWithoutUpdate(t *testing.T) {
 		getErr: errors.New("not found"),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePdump(true)).
+	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
 		Apply(t.Context())
 	require.Error(t, err)
 	require.False(t, skipped)
@@ -182,7 +183,7 @@ func Test_FunctionApplier_ChainMatchesExactlyNoPdumpSkipped(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePdump(true)).
+	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
 		Apply(t.Context())
 	require.NoError(t, err)
 	require.True(t, skipped)
@@ -207,7 +208,7 @@ func Test_FunctionApplier_PdumpBeforeAndAfterMatchingSurvivorsSkipped(t *testing
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePdump(true)).
+	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
 		Apply(t.Context())
 	require.NoError(t, err)
 	require.True(t, skipped)
@@ -228,7 +229,7 @@ func Test_FunctionApplier_PdumpBetweenModulesAndAtStartSkipped(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePdump(true)).
+	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
 		Apply(t.Context())
 	require.NoError(t, err)
 	require.True(t, skipped)
@@ -243,7 +244,7 @@ func Test_FunctionApplier_WrongModuleTypeNotSkipped(t *testing.T) {
 		}),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePdump(true)).
+	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
 		Apply(t.Context())
 	require.NoError(t, err)
 	require.False(t, skipped)
@@ -269,7 +270,7 @@ func Test_FunctionApplier_CorrectTypeWrongOrderNotSkipped(t *testing.T) {
 		},
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePdump(true)).
+	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
 		Apply(t.Context())
 	require.NoError(t, err)
 	require.False(t, skipped)
@@ -290,7 +291,7 @@ func Test_FunctionApplier_ExtraNonPdumpModuleNotSkipped(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePdump(true)).
+	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
 		Apply(t.Context())
 	require.NoError(t, err)
 	require.False(t, skipped)
@@ -307,7 +308,7 @@ func Test_FunctionApplier_ForwardWithWrongNameNotSkipped(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePdump(true)).
+	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
 		Apply(t.Context())
 	require.NoError(t, err)
 	require.False(t, skipped)
@@ -328,7 +329,7 @@ func Test_FunctionApplier_PdumpxPrefixNotFilteredNotSkipped(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePdump(true)).
+	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
 		Apply(t.Context())
 	require.NoError(t, err)
 	require.False(t, skipped)
@@ -403,8 +404,8 @@ func Test_FunctionApplier_RejectsChainlessDefinition(t *testing.T) {
 	require.Equal(t, 0, c.updates)
 }
 
-// Test_FunctionApplier_Drift verifies that each way the gateway
-// can drift from the definition triggers an update.
+// Test_FunctionApplier_Drift verifies that each way the gateway can drift
+// from the definition triggers an update under either comparison strategy.
 func Test_FunctionApplier_Drift(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -455,17 +456,75 @@ func Test_FunctionApplier_Drift(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			current := functionDefinition()
-			tc.drift(current)
-			c := &fakeFunctionClient{
-				getResp: &ynpb.GetFunctionResponse{Function: current},
-			}
+		for _, ignorePdump := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/ignore pdump %t", tc.name, ignorePdump), func(t *testing.T) {
+				current := functionDefinition()
+				tc.drift(current)
+				var options []FunctionApplierOption
+				if ignorePdump {
+					options = append(options, WithIgnorePDump())
+					chain := current.Chains[0].Chain
+					chain.Modules = append([]*commonpb.ModuleId{{Type: "pdump", Name: "pd0"}}, chain.Modules...)
+				}
+				c := &fakeFunctionClient{
+					getResp: &ynpb.GetFunctionResponse{Function: current},
+				}
 
-			skipped, err := NewFunctionApplier(c, functionDefinition()).Apply(t.Context())
+				skipped, err := NewFunctionApplier(c, functionDefinition(), options...).
+					Apply(t.Context())
+				require.NoError(t, err)
+				require.False(t, skipped)
+				require.Equal(t, 1, c.updates)
+			})
+		}
+	}
+}
+
+// Test_FunctionApplier_PdumpInDefinition verifies that a definition carrying
+// pdump itself is skipped when pdump is ignored and updated otherwise.
+func Test_FunctionApplier_PdumpInDefinition(t *testing.T) {
+	cases := []struct {
+		name        string
+		options     []FunctionApplierOption
+		gateway     []*commonpb.ModuleId
+		wantUpdates int
+	}{
+		{
+			name:        "ignored, gateway lacks pdump",
+			options:     []FunctionApplierOption{WithIgnorePDump()},
+			gateway:     []*commonpb.ModuleId{{Type: "forward", Name: "fwd0"}},
+			wantUpdates: 0,
+		},
+		{
+			name:    "ignored, gateway holds another pdump",
+			options: []FunctionApplierOption{WithIgnorePDump()},
+			gateway: []*commonpb.ModuleId{
+				{Type: "forward", Name: "fwd0"},
+				{Type: "pdump", Name: "pd1"},
+			},
+			wantUpdates: 0,
+		},
+		{
+			name:        "exact, gateway lacks pdump",
+			gateway:     []*commonpb.ModuleId{{Type: "forward", Name: "fwd0"}},
+			wantUpdates: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			definition := functionApplierSpec()
+			definition.Chains[0].Chain.Modules = []*commonpb.ModuleId{
+				{Type: "pdump", Name: "pd0"},
+				{Type: "forward", Name: "fwd0"},
+			}
+			c := &fakeFunctionClient{getResp: makeGetResp(tc.gateway...)}
+
+			skipped, err := NewFunctionApplier(c, definition, tc.options...).
+				Apply(t.Context())
 			require.NoError(t, err)
-			require.False(t, skipped)
-			require.Equal(t, 1, c.updates)
+			require.Equal(t, tc.wantUpdates == 0, skipped)
+			require.Equal(t, tc.wantUpdates, c.updates)
 		})
 	}
 }

--- a/common/go/operator/options.go
+++ b/common/go/operator/options.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 type grpcServerOption struct {
@@ -184,20 +185,33 @@ func WithReconcilerMetrics(metrics ReconcilerMetricsObserver) ReconcilerOption {
 }
 
 type functionApplierOptions struct {
-	IgnorePdump bool
+	// Compare decides whether the gateway already holds the wanted function.
+	Compare functionCompare
 }
 
 func newFunctionApplierOptions() *functionApplierOptions {
-	return &functionApplierOptions{}
+	return &functionApplierOptions{
+		Compare: (*ynpb.Function).Equal,
+	}
 }
 
 // FunctionApplierOption configures NewFunctionApplier.
 type FunctionApplierOption func(*functionApplierOptions)
 
-// WithIgnorePdump, when enabled, hides pdump modules on the gateway from the
-// check whether a chain already carries the wanted modules.
-func WithIgnorePdump(enabled bool) FunctionApplierOption {
+// WithIgnorePDump leaves pdump modules on both sides out of the check
+// whether the gateway already holds the wanted function.
+func WithIgnorePDump() FunctionApplierOption {
 	return func(o *functionApplierOptions) {
-		o.IgnorePdump = enabled
+		o.Compare = compareFunctionsIgnorePdump
 	}
+}
+
+// functionCompare reports whether the function satisfies the wanted
+// definition.
+type functionCompare func(have, want *ynpb.Function) bool
+
+// compareFunctionsIgnorePdump leaves pdump modules on both sides out of the
+// comparison, so a definition carrying pdump itself does not drift forever.
+func compareFunctionsIgnorePdump(have, want *ynpb.Function) bool {
+	return have.WithoutModules("pdump").Equal(want.WithoutModules("pdump"))
 }

--- a/common/go/operator/static.go
+++ b/common/go/operator/static.go
@@ -31,7 +31,7 @@ type StaticTarget struct {
 	Request proto.Message
 	// Function is published after the config, nil when the target owns none.
 	Function *ynpb.Function
-	// IgnorePdump leaves pdump modules on the gateway out of the function
+	// IgnorePdump leaves pdump modules on both sides out of the function
 	// comparison.
 	IgnorePdump bool
 }
@@ -292,7 +292,11 @@ func (m *staticGatewayActuator) Apply(ctx context.Context, targets []StaticTarge
 		if target.Function == nil {
 			continue
 		}
-		applier := NewFunctionApplier(m.functions, target.Function, WithIgnorePdump(target.IgnorePdump))
+		var options []FunctionApplierOption
+		if target.IgnorePdump {
+			options = append(options, WithIgnorePDump())
+		}
+		applier := NewFunctionApplier(m.functions, target.Function, options...)
 		skipped, e := applier.Apply(ctx)
 		if e != nil {
 			err = errors.Join(err, fmt.Errorf(

--- a/controlplane/ynpb/v1/function.go
+++ b/controlplane/ynpb/v1/function.go
@@ -1,0 +1,30 @@
+package ynpb
+
+import (
+	"slices"
+
+	"google.golang.org/protobuf/proto"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+)
+
+// Equal reports whether both functions carry the same definition.
+func (m *Function) Equal(other *Function) bool {
+	return proto.Equal(m, other)
+}
+
+// WithoutModules returns a deep copy of the function with the modules of
+// the given type dropped from every chain.
+//
+// A nil function yields nil.
+func (m *Function) WithoutModules(moduleType string) *Function {
+	function := proto.Clone(m).(*Function)
+	for _, chain := range function.GetChains() {
+		if chain := chain.GetChain(); chain != nil {
+			chain.Modules = slices.DeleteFunc(chain.Modules, func(module *commonpb.ModuleId) bool {
+				return module.GetType() == moduleType
+			})
+		}
+	}
+	return function
+}

--- a/controlplane/ynpb/v1/function_test.go
+++ b/controlplane/ynpb/v1/function_test.go
@@ -1,0 +1,67 @@
+package ynpb_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// Test_Function_WithoutModules_DropsExactTypeFromEveryChain verifies that
+// only exact type matches leave each chain and the original stays untouched.
+func Test_Function_WithoutModules_DropsExactTypeFromEveryChain(t *testing.T) {
+	function := &ynpb.Function{
+		Id: &commonpb.FunctionId{Name: "fn"},
+		Chains: []*ynpb.FunctionChain{
+			{
+				Chain: &ynpb.Chain{
+					Name: "default",
+					Modules: []*commonpb.ModuleId{
+						{Type: "pdump", Name: "pd0"},
+						{Type: "forward", Name: "fwd0"},
+						{Type: "pdumpx", Name: "pdx0"},
+					},
+				},
+				Weight: 3,
+			},
+			{
+				Chain:  &ynpb.Chain{Name: "tap", Modules: []*commonpb.ModuleId{{Type: "pdump", Name: "pd1"}}},
+				Weight: 1,
+			},
+			{Weight: 1},
+		},
+	}
+	original := proto.Clone(function).(*ynpb.Function)
+
+	got := function.WithoutModules("pdump")
+
+	require.True(t, function.Equal(original), "original mutated: %v", function)
+	require.True(t, got.Equal(&ynpb.Function{
+		Id: &commonpb.FunctionId{Name: "fn"},
+		Chains: []*ynpb.FunctionChain{
+			{
+				Chain: &ynpb.Chain{
+					Name: "default",
+					Modules: []*commonpb.ModuleId{
+						{Type: "forward", Name: "fwd0"},
+						{Type: "pdumpx", Name: "pdx0"},
+					},
+				},
+				Weight: 3,
+			},
+			{Chain: &ynpb.Chain{Name: "tap"}, Weight: 1},
+			{Weight: 1},
+		},
+	}), "got %v", got)
+}
+
+// Test_Function_WithoutModules_Nil verifies that a nil function stays nil
+// instead of panicking.
+func Test_Function_WithoutModules_Nil(t *testing.T) {
+	var function *ynpb.Function
+
+	require.Nil(t, function.WithoutModules("pdump"))
+}

--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -68,6 +68,11 @@ func NewGatewayActuator(
 		}},
 	}
 
+	var applierOptions []operator.FunctionApplierOption
+	if fn.IgnorePdump {
+		applierOptions = append(applierOptions, operator.WithIgnorePDump())
+	}
+
 	return &GatewayActuator{
 		name:   cfg.Name,
 		conn:   conn,
@@ -75,7 +80,7 @@ func NewGatewayActuator(
 		funcApplier: operator.NewFunctionApplier(
 			ynpb.NewFunctionServiceClient(conn),
 			function,
-			operator.WithIgnorePdump(fn.IgnorePdump),
+			applierOptions...,
 		),
 		devices:    opts.Devices,
 		onFIBBuilt: opts.OnFIBBuilt,


### PR DESCRIPTION
- Add Function.Equal and Function.WithoutModules beside the generated ynpb code.
- Decide whether a gateway already holds the wanted function by comparing the whole definition, so weights, chain names and any future field take part instead of a hand-maintained field list.
- Keep the comparison a strategy chosen by the applier options, exact by default.
- Leave pdump modules out on both sides when they are ignored, so a definition carrying pdump itself is no longer republished on every apply.
