### PR TITLE
refactor(operator,route): turn the function applier into an actuator

### DIFF
--- a/common/go/operator/function.go
+++ b/common/go/operator/function.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -11,73 +12,73 @@ import (
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
-// FunctionApplier publishes a fixed function definition to a gateway.
-type FunctionApplier struct {
-	client   ynpb.FunctionServiceClient
-	function *ynpb.Function
-	compare  functionCompare
+// FunctionActuator publishes network functions to a gateway, leaving alone
+// the ones the gateway already holds.
+type FunctionActuator struct {
+	client  ynpb.FunctionServiceClient
+	compare functionCompare
+	log     *zap.Logger
 }
 
-// NewFunctionApplier returns a FunctionApplier that will publish function to
-// client on each Apply call.
-func NewFunctionApplier(
+// NewFunctionActuator returns a FunctionActuator publishing through client.
+func NewFunctionActuator(
 	client ynpb.FunctionServiceClient,
-	function *ynpb.Function,
-	options ...FunctionApplierOption,
-) *FunctionApplier {
-	opts := newFunctionApplierOptions()
+	options ...FunctionActuatorOption,
+) *FunctionActuator {
+	opts := newFunctionActuatorOptions()
 	for _, o := range options {
 		o(opts)
 	}
 
-	return &FunctionApplier{
-		client:   client,
-		function: function,
-		compare:  opts.Compare,
+	return &FunctionActuator{
+		client:  client,
+		compare: opts.Compare,
+		log:     opts.Log,
 	}
 }
 
-// Name returns the function identifier the applier publishes.
-func (m *FunctionApplier) Name() string {
-	return m.function.GetId().GetName()
-}
-
-// Apply publishes the captured definition to the gateway, or returns true
-// if the gateway is already correctly configured.
-func (m *FunctionApplier) Apply(ctx context.Context) (bool, error) {
-	if len(m.function.GetChains()) == 0 {
-		return false, fmt.Errorf("function %q has no chains", m.Name())
+// Apply publishes function to the gateway unless it already holds it.
+func (m *FunctionActuator) Apply(ctx context.Context, function *ynpb.Function) error {
+	name := function.GetId().GetName()
+	if len(function.GetChains()) == 0 {
+		return fmt.Errorf("function %q has no chains", name)
 	}
 
-	ok, err := m.alreadyCorrect(ctx)
+	ok, err := m.alreadyCorrect(ctx, function)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if ok {
-		return true, nil
+		m.log.Debug("function already correct, skipped", zap.String("function", name))
+		return nil
 	}
 
-	req := &ynpb.UpdateFunctionRequest{Function: m.function}
+	req := &ynpb.UpdateFunctionRequest{Function: function}
 	if _, err := m.client.Update(ctx, req); err != nil {
-		return false, fmt.Errorf("failed to update function %q: %w", m.Name(), err)
+		return fmt.Errorf("failed to update function %q: %w", name, err)
 	}
+	m.log.Info("updated function", zap.String("function", name))
 
-	return false, nil
+	return nil
 }
 
-// alreadyCorrect reports whether the gateway already holds the wanted function.
-func (m *FunctionApplier) alreadyCorrect(ctx context.Context) (bool, error) {
+// Close is a no-op, the client's connection belongs to the caller.
+func (m *FunctionActuator) Close() error {
+	return nil
+}
+
+// alreadyCorrect reports whether the gateway already holds function.
+func (m *FunctionActuator) alreadyCorrect(ctx context.Context, function *ynpb.Function) (bool, error) {
+	name := function.GetId().GetName()
 	resp, err := m.client.Get(ctx, &ynpb.GetFunctionRequest{
-		Id: &commonpb.FunctionId{
-			Name: m.Name(),
-		},
+		Id: &commonpb.FunctionId{Name: name},
 	})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
 			return false, nil
 		}
-		return false, fmt.Errorf("failed to get function %q: %w", m.Name(), err)
+		return false, fmt.Errorf("failed to get function %q: %w", name, err)
 	}
 
-	return m.compare(resp.GetFunction(), m.function), nil
+	return m.compare(resp.GetFunction(), function), nil
 }

--- a/common/go/operator/function_test.go
+++ b/common/go/operator/function_test.go
@@ -69,26 +69,26 @@ func makeGetResp(modules ...*commonpb.ModuleId) *ynpb.GetFunctionResponse {
 	}
 }
 
-var functionApplierSpecModules = []*commonpb.ModuleId{
+var functionActuatorSpecModules = []*commonpb.ModuleId{
 	{
 		Type: "forward",
 		Name: "fwd0",
 	},
 }
 
-// functionApplierSpec builds the single-chain function the legacy cases
+// functionActuatorSpec builds the single-chain function the legacy cases
 // publish, one forward module under the default chain.
-func functionApplierSpec() *ynpb.Function {
+func functionActuatorSpec() *ynpb.Function {
 	return &ynpb.Function{
 		Id: &commonpb.FunctionId{Name: "fn:test"},
 		Chains: []*ynpb.FunctionChain{{
-			Chain:  &ynpb.Chain{Name: "default", Modules: functionApplierSpecModules},
+			Chain:  &ynpb.Chain{Name: "default", Modules: functionActuatorSpecModules},
 			Weight: 1,
 		}},
 	}
 }
 
-func Test_FunctionApplier_Basic(t *testing.T) {
+func Test_FunctionActuator_Basic(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: makeGetResp(
 			&commonpb.ModuleId{
@@ -98,26 +98,22 @@ func Test_FunctionApplier_Basic(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c).Apply(t.Context(), functionActuatorSpec())
 	require.NoError(t, err)
-	require.True(t, skipped)
 	require.Equal(t, 0, c.updates)
 }
 
-func Test_FunctionApplier_GetErrorAbortsWithoutUpdateDefaultStrategy(t *testing.T) {
+func Test_FunctionActuator_GetErrorAbortsWithoutUpdateDefaultStrategy(t *testing.T) {
 	c := &fakeFunctionClient{
 		getErr: errors.New("not found"),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c).Apply(t.Context(), functionActuatorSpec())
 	require.Error(t, err)
-	require.False(t, skipped)
 	require.Equal(t, 0, c.updates)
 }
 
-func Test_FunctionApplier_PdumpPresentExactStrategyNotSkipped(t *testing.T) {
+func Test_FunctionActuator_PdumpPresentExactStrategyNotSkipped(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: makeGetResp(
 			&commonpb.ModuleId{
@@ -131,26 +127,22 @@ func Test_FunctionApplier_PdumpPresentExactStrategyNotSkipped(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c).Apply(t.Context(), functionActuatorSpec())
 	require.NoError(t, err)
-	require.False(t, skipped)
 	require.Equal(t, 1, c.updates)
 }
 
-func Test_FunctionApplier_GetErrorAbortsWithoutUpdate(t *testing.T) {
+func Test_FunctionActuator_GetErrorAbortsWithoutUpdate(t *testing.T) {
 	c := &fakeFunctionClient{
 		getErr: errors.New("not found"),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c, WithIgnorePDump()).Apply(t.Context(), functionActuatorSpec())
 	require.Error(t, err)
-	require.False(t, skipped)
 	require.Equal(t, 0, c.updates)
 }
 
-func Test_FunctionApplier_ChainMissingNotSkipped(t *testing.T) {
+func Test_FunctionActuator_ChainMissingNotSkipped(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: &ynpb.GetFunctionResponse{
 			Function: &ynpb.Function{
@@ -158,7 +150,7 @@ func Test_FunctionApplier_ChainMissingNotSkipped(t *testing.T) {
 				Chains: []*ynpb.FunctionChain{{
 					Chain: &ynpb.Chain{
 						Name:    "other",
-						Modules: functionApplierSpecModules,
+						Modules: functionActuatorSpecModules,
 					},
 					Weight: 1,
 				}},
@@ -166,14 +158,12 @@ func Test_FunctionApplier_ChainMissingNotSkipped(t *testing.T) {
 		},
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c).Apply(t.Context(), functionActuatorSpec())
 	require.NoError(t, err)
-	require.False(t, skipped)
 	require.Equal(t, 1, c.updates)
 }
 
-func Test_FunctionApplier_ChainMatchesExactlyNoPdumpSkipped(t *testing.T) {
+func Test_FunctionActuator_ChainMatchesExactlyNoPdumpSkipped(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: makeGetResp(
 			&commonpb.ModuleId{
@@ -183,14 +173,12 @@ func Test_FunctionApplier_ChainMatchesExactlyNoPdumpSkipped(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c, WithIgnorePDump()).Apply(t.Context(), functionActuatorSpec())
 	require.NoError(t, err)
-	require.True(t, skipped)
 	require.Equal(t, 0, c.updates)
 }
 
-func Test_FunctionApplier_PdumpBeforeAndAfterMatchingSurvivorsSkipped(t *testing.T) {
+func Test_FunctionActuator_PdumpBeforeAndAfterMatchingSurvivorsSkipped(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: makeGetResp(
 			&commonpb.ModuleId{
@@ -208,14 +196,12 @@ func Test_FunctionApplier_PdumpBeforeAndAfterMatchingSurvivorsSkipped(t *testing
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c, WithIgnorePDump()).Apply(t.Context(), functionActuatorSpec())
 	require.NoError(t, err)
-	require.True(t, skipped)
 	require.Equal(t, 0, c.updates)
 }
 
-func Test_FunctionApplier_PdumpBetweenModulesAndAtStartSkipped(t *testing.T) {
+func Test_FunctionActuator_PdumpBetweenModulesAndAtStartSkipped(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: makeGetResp(
 			&commonpb.ModuleId{
@@ -229,14 +215,12 @@ func Test_FunctionApplier_PdumpBetweenModulesAndAtStartSkipped(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c, WithIgnorePDump()).Apply(t.Context(), functionActuatorSpec())
 	require.NoError(t, err)
-	require.True(t, skipped)
 	require.Equal(t, 0, c.updates)
 }
 
-func Test_FunctionApplier_WrongModuleTypeNotSkipped(t *testing.T) {
+func Test_FunctionActuator_WrongModuleTypeNotSkipped(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: makeGetResp(&commonpb.ModuleId{
 			Type: "route",
@@ -244,14 +228,12 @@ func Test_FunctionApplier_WrongModuleTypeNotSkipped(t *testing.T) {
 		}),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c, WithIgnorePDump()).Apply(t.Context(), functionActuatorSpec())
 	require.NoError(t, err)
-	require.False(t, skipped)
 	require.Equal(t, 1, c.updates)
 }
 
-func Test_FunctionApplier_CorrectTypeWrongOrderNotSkipped(t *testing.T) {
+func Test_FunctionActuator_CorrectTypeWrongOrderNotSkipped(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: &ynpb.GetFunctionResponse{
 			Function: &ynpb.Function{
@@ -270,14 +252,12 @@ func Test_FunctionApplier_CorrectTypeWrongOrderNotSkipped(t *testing.T) {
 		},
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c, WithIgnorePDump()).Apply(t.Context(), functionActuatorSpec())
 	require.NoError(t, err)
-	require.False(t, skipped)
 	require.Equal(t, 1, c.updates)
 }
 
-func Test_FunctionApplier_ExtraNonPdumpModuleNotSkipped(t *testing.T) {
+func Test_FunctionActuator_ExtraNonPdumpModuleNotSkipped(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: makeGetResp(
 			&commonpb.ModuleId{
@@ -291,14 +271,12 @@ func Test_FunctionApplier_ExtraNonPdumpModuleNotSkipped(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c, WithIgnorePDump()).Apply(t.Context(), functionActuatorSpec())
 	require.NoError(t, err)
-	require.False(t, skipped)
 	require.Equal(t, 1, c.updates)
 }
 
-func Test_FunctionApplier_ForwardWithWrongNameNotSkipped(t *testing.T) {
+func Test_FunctionActuator_ForwardWithWrongNameNotSkipped(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: makeGetResp(
 			&commonpb.ModuleId{
@@ -308,14 +286,12 @@ func Test_FunctionApplier_ForwardWithWrongNameNotSkipped(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c, WithIgnorePDump()).Apply(t.Context(), functionActuatorSpec())
 	require.NoError(t, err)
-	require.False(t, skipped)
 	require.Equal(t, 1, c.updates)
 }
 
-func Test_FunctionApplier_PdumpxPrefixNotFilteredNotSkipped(t *testing.T) {
+func Test_FunctionActuator_PdumpxPrefixNotFilteredNotSkipped(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: makeGetResp(
 			&commonpb.ModuleId{
@@ -329,10 +305,8 @@ func Test_FunctionApplier_PdumpxPrefixNotFilteredNotSkipped(t *testing.T) {
 		),
 	}
 
-	skipped, err := NewFunctionApplier(c, functionApplierSpec(), WithIgnorePDump()).
-		Apply(t.Context())
+	err := NewFunctionActuator(c, WithIgnorePDump()).Apply(t.Context(), functionActuatorSpec())
 	require.NoError(t, err)
-	require.False(t, skipped)
 	require.Equal(t, 1, c.updates)
 }
 
@@ -363,50 +337,48 @@ func functionDefinition() *ynpb.Function {
 	}
 }
 
-// Test_FunctionApplier_MatchingDefinitionSkipped verifies that a
+// Test_FunctionActuator_MatchingDefinitionSkipped verifies that a
 // gateway holding the same chains, weights and modules is left alone.
-func Test_FunctionApplier_MatchingDefinitionSkipped(t *testing.T) {
+func Test_FunctionActuator_MatchingDefinitionSkipped(t *testing.T) {
 	c := &fakeFunctionClient{
 		getResp: &ynpb.GetFunctionResponse{Function: functionDefinition()},
 	}
 
-	skipped, err := NewFunctionApplier(c, functionDefinition()).Apply(t.Context())
+	err := NewFunctionActuator(c).Apply(t.Context(), functionDefinition())
 	require.NoError(t, err)
-	require.True(t, skipped)
 	require.Equal(t, 0, c.updates)
 }
 
-// Test_FunctionApplier_ChainOrderMatters verifies that chains in another
+// Test_FunctionActuator_ChainOrderMatters verifies that chains in another
 // order count as drift, as the order decides which packets each chain gets.
-func Test_FunctionApplier_ChainOrderMatters(t *testing.T) {
+func Test_FunctionActuator_ChainOrderMatters(t *testing.T) {
 	reordered := functionDefinition()
 	reordered.Chains[0], reordered.Chains[1] = reordered.Chains[1], reordered.Chains[0]
 	c := &fakeFunctionClient{
 		getResp: &ynpb.GetFunctionResponse{Function: reordered},
 	}
 
-	skipped, err := NewFunctionApplier(c, functionDefinition()).Apply(t.Context())
+	err := NewFunctionActuator(c).Apply(t.Context(), functionDefinition())
 	require.NoError(t, err)
-	require.False(t, skipped)
 	require.Equal(t, 1, c.updates)
 }
 
-// Test_FunctionApplier_RejectsChainlessDefinition verifies that a definition
+// Test_FunctionActuator_RejectsChainlessDefinition verifies that a definition
 // without chains is refused before it can reach the gateway.
-func Test_FunctionApplier_RejectsChainlessDefinition(t *testing.T) {
+func Test_FunctionActuator_RejectsChainlessDefinition(t *testing.T) {
 	c := &fakeFunctionClient{}
 	definition := functionDefinition()
 	definition.Chains = nil
 
-	_, err := NewFunctionApplier(c, definition).Apply(t.Context())
+	err := NewFunctionActuator(c).Apply(t.Context(), definition)
 
 	require.ErrorContains(t, err, "has no chains")
 	require.Equal(t, 0, c.updates)
 }
 
-// Test_FunctionApplier_Drift verifies that each way the gateway can drift
+// Test_FunctionActuator_Drift verifies that each way the gateway can drift
 // from the definition triggers an update under either comparison strategy.
-func Test_FunctionApplier_Drift(t *testing.T) {
+func Test_FunctionActuator_Drift(t *testing.T) {
 	cases := []struct {
 		name  string
 		drift func(current *ynpb.Function)
@@ -460,7 +432,7 @@ func Test_FunctionApplier_Drift(t *testing.T) {
 			t.Run(fmt.Sprintf("%s/ignore pdump %t", tc.name, ignorePdump), func(t *testing.T) {
 				current := functionDefinition()
 				tc.drift(current)
-				var options []FunctionApplierOption
+				var options []FunctionActuatorOption
 				if ignorePdump {
 					options = append(options, WithIgnorePDump())
 					chain := current.Chains[0].Chain
@@ -470,34 +442,32 @@ func Test_FunctionApplier_Drift(t *testing.T) {
 					getResp: &ynpb.GetFunctionResponse{Function: current},
 				}
 
-				skipped, err := NewFunctionApplier(c, functionDefinition(), options...).
-					Apply(t.Context())
+				err := NewFunctionActuator(c, options...).Apply(t.Context(), functionDefinition())
 				require.NoError(t, err)
-				require.False(t, skipped)
 				require.Equal(t, 1, c.updates)
 			})
 		}
 	}
 }
 
-// Test_FunctionApplier_PdumpInDefinition verifies that a definition carrying
+// Test_FunctionActuator_PdumpInDefinition verifies that a definition carrying
 // pdump itself is skipped when pdump is ignored and updated otherwise.
-func Test_FunctionApplier_PdumpInDefinition(t *testing.T) {
+func Test_FunctionActuator_PdumpInDefinition(t *testing.T) {
 	cases := []struct {
 		name        string
-		options     []FunctionApplierOption
+		options     []FunctionActuatorOption
 		gateway     []*commonpb.ModuleId
 		wantUpdates int
 	}{
 		{
 			name:        "ignored, gateway lacks pdump",
-			options:     []FunctionApplierOption{WithIgnorePDump()},
+			options:     []FunctionActuatorOption{WithIgnorePDump()},
 			gateway:     []*commonpb.ModuleId{{Type: "forward", Name: "fwd0"}},
 			wantUpdates: 0,
 		},
 		{
 			name:    "ignored, gateway holds another pdump",
-			options: []FunctionApplierOption{WithIgnorePDump()},
+			options: []FunctionActuatorOption{WithIgnorePDump()},
 			gateway: []*commonpb.ModuleId{
 				{Type: "forward", Name: "fwd0"},
 				{Type: "pdump", Name: "pd1"},
@@ -513,33 +483,30 @@ func Test_FunctionApplier_PdumpInDefinition(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			definition := functionApplierSpec()
+			definition := functionActuatorSpec()
 			definition.Chains[0].Chain.Modules = []*commonpb.ModuleId{
 				{Type: "pdump", Name: "pd0"},
 				{Type: "forward", Name: "fwd0"},
 			}
 			c := &fakeFunctionClient{getResp: makeGetResp(tc.gateway...)}
 
-			skipped, err := NewFunctionApplier(c, definition, tc.options...).
-				Apply(t.Context())
+			err := NewFunctionActuator(c, tc.options...).Apply(t.Context(), definition)
 			require.NoError(t, err)
-			require.Equal(t, tc.wantUpdates == 0, skipped)
 			require.Equal(t, tc.wantUpdates, c.updates)
 		})
 	}
 }
 
-// Test_FunctionApplier_AbsentFunctionPublished verifies that a
+// Test_FunctionActuator_AbsentFunctionPublished verifies that a
 // function the gateway does not know is published as is.
-func Test_FunctionApplier_AbsentFunctionPublished(t *testing.T) {
+func Test_FunctionActuator_AbsentFunctionPublished(t *testing.T) {
 	c := &fakeFunctionClient{
 		getErr: status.Error(codes.NotFound, "no such function"),
 	}
 	definition := functionDefinition()
 
-	skipped, err := NewFunctionApplier(c, definition).Apply(t.Context())
+	err := NewFunctionActuator(c).Apply(t.Context(), definition)
 	require.NoError(t, err)
-	require.False(t, skipped)
 	require.Equal(t, 1, c.updates)
 	require.True(t, proto.Equal(definition, c.lastUpdate.GetFunction()), "got %v", c.lastUpdate)
 }

--- a/common/go/operator/options.go
+++ b/common/go/operator/options.go
@@ -184,24 +184,34 @@ func WithReconcilerMetrics(metrics ReconcilerMetricsObserver) ReconcilerOption {
 	}
 }
 
-type functionApplierOptions struct {
+type functionActuatorOptions struct {
 	// Compare decides whether the gateway already holds the wanted function.
 	Compare functionCompare
+	// Log receives the outcome of every Apply.
+	Log *zap.Logger
 }
 
-func newFunctionApplierOptions() *functionApplierOptions {
-	return &functionApplierOptions{
+func newFunctionActuatorOptions() *functionActuatorOptions {
+	return &functionActuatorOptions{
 		Compare: (*ynpb.Function).Equal,
+		Log:     zap.NewNop(),
 	}
 }
 
-// FunctionApplierOption configures NewFunctionApplier.
-type FunctionApplierOption func(*functionApplierOptions)
+// FunctionActuatorOption configures NewFunctionActuator.
+type FunctionActuatorOption func(*functionActuatorOptions)
+
+// WithFunctionLog sets the logger for the function actuator.
+func WithFunctionLog(log *zap.Logger) FunctionActuatorOption {
+	return func(o *functionActuatorOptions) {
+		o.Log = log
+	}
+}
 
 // WithIgnorePDump leaves pdump modules on both sides out of the check
 // whether the gateway already holds the wanted function.
-func WithIgnorePDump() FunctionApplierOption {
-	return func(o *functionApplierOptions) {
+func WithIgnorePDump() FunctionActuatorOption {
+	return func(o *functionActuatorOptions) {
 		o.Compare = compareFunctionsIgnorePdump
 	}
 }

--- a/common/go/operator/static.go
+++ b/common/go/operator/static.go
@@ -292,22 +292,14 @@ func (m *staticGatewayActuator) Apply(ctx context.Context, targets []StaticTarge
 		if target.Function == nil {
 			continue
 		}
-		var options []FunctionApplierOption
+		options := []FunctionActuatorOption{WithFunctionLog(m.log)}
 		if target.IgnorePdump {
 			options = append(options, WithIgnorePDump())
 		}
-		applier := NewFunctionApplier(m.functions, target.Function, options...)
-		skipped, e := applier.Apply(ctx)
-		if e != nil {
+		if e := NewFunctionActuator(m.functions, options...).Apply(ctx, target.Function); e != nil {
 			err = errors.Join(err, fmt.Errorf(
-				"failed to update function %q on gateway %q: %w", applier.Name(), m.name, e,
+				"failed to update function %q on gateway %q: %w", target.Function.GetId().GetName(), m.name, e,
 			))
-			continue
-		}
-		if skipped {
-			m.log.Debug("function already correct, skipped", zap.String("function", applier.Name()))
-		} else {
-			m.log.Info("updated function", zap.String("function", applier.Name()))
 		}
 	}
 

--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -20,13 +20,14 @@ import (
 // GatewayActuator applies route-operator state to a single Gateway via
 // the route module's UpdateFIB unary RPC.
 type GatewayActuator struct {
-	name        string
-	conn        *grpc.ClientConn
-	routes      routepb.RouteServiceClient
-	funcApplier *operator.FunctionApplier
-	devices     []string
-	onFIBBuilt  func(module string, stats FIBBuildStats)
-	log         *zap.Logger
+	name             string
+	conn             *grpc.ClientConn
+	routes           routepb.RouteServiceClient
+	function         *ynpb.Function
+	functionActuator *operator.FunctionActuator
+	devices          []string
+	onFIBBuilt       func(module string, stats FIBBuildStats)
+	log              *zap.Logger
 }
 
 // NewGatewayActuator dials the Gateway endpoint and returns a
@@ -68,26 +69,21 @@ func NewGatewayActuator(
 		}},
 	}
 
-	var applierOptions []operator.FunctionApplierOption
+	log := opts.Log.With(zap.String("gateway", cfg.Name))
+	actuatorOptions := []operator.FunctionActuatorOption{operator.WithFunctionLog(log)}
 	if fn.IgnorePdump {
-		applierOptions = append(applierOptions, operator.WithIgnorePDump())
+		actuatorOptions = append(actuatorOptions, operator.WithIgnorePDump())
 	}
 
 	return &GatewayActuator{
-		name:   cfg.Name,
-		conn:   conn,
-		routes: routepb.NewRouteServiceClient(conn),
-		funcApplier: operator.NewFunctionApplier(
-			ynpb.NewFunctionServiceClient(conn),
-			function,
-			applierOptions...,
-		),
-		devices:    opts.Devices,
-		onFIBBuilt: opts.OnFIBBuilt,
-		log: opts.Log.With(
-			zap.String("gateway", cfg.Name),
-			zap.String("function", fn.Name.Unwrap()),
-		),
+		name:             cfg.Name,
+		conn:             conn,
+		routes:           routepb.NewRouteServiceClient(conn),
+		function:         function,
+		functionActuator: operator.NewFunctionActuator(ynpb.NewFunctionServiceClient(conn), actuatorOptions...),
+		devices:          opts.Devices,
+		onFIBBuilt:       opts.OnFIBBuilt,
+		log:              log.With(zap.String("function", fn.Name.Unwrap())),
 	}, nil
 }
 
@@ -125,15 +121,8 @@ func (m *GatewayActuator) Apply(ctx context.Context, snapshot RouteSnapshot) err
 // applyFunction publishes the operator's single network-function definition to
 // the gateway.
 func (m *GatewayActuator) applyFunction(ctx context.Context) error {
-	skipped, err := m.funcApplier.Apply(ctx)
-	if err != nil {
+	if err := m.functionActuator.Apply(ctx, m.function); err != nil {
 		return fmt.Errorf("failed to update function on gateway %q: %w", m.name, err)
-	}
-
-	if skipped {
-		m.log.Debug("function already correct, skipped")
-	} else {
-		m.log.Info("updated function")
 	}
 
 	return nil


### PR DESCRIPTION
- Replace FunctionApplier with FunctionActuator implementing Actuator over a network function, so the function is passed to Apply instead of being captured at construction and a reconcile loop can drive it directly.
- Log the already-correct and updated outcomes inside the actuator, so the static module operator and the route actuator stop duplicating them.
- Drop the skipped result, the callers only wrap the error with the function and gateway names.
