### PR TITLE
refactor(controlplane): pin registry refcount serialization to the config lock

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -511,24 +511,6 @@ dataplane_init(
 		instance->dp_config->packet_recirc_limit =
 			config->packet_recirc_limit;
 
-		// System agent for this instance.
-		//
-		// Owns the phy devices created in cp_config_gen_new
-		// and lives in shm so their parent_memory_context offsets
-		// remain valid in every process that maps the same shm region.
-		//
-		// FIXME: not paired with a free: released only when shm is torn
-		// down.
-		struct agent *agent = dp_system_agent_new(
-			instance->cp_config, instance->dp_config, "dataplane"
-		);
-		if (agent == NULL) {
-			LOG(ERROR,
-			    "failed to allocate system agent for instance %u",
-			    instance_idx);
-			return -1;
-		}
-
 		struct dp_port *ports = dp_topology_alloc_devices(
 			instance->dp_config, config->device_count
 		);
@@ -623,6 +605,27 @@ dataplane_init(
 			}
 		}
 
+		// System agent for this instance.
+		//
+		// Owns the phy devices created in cp_config_gen_new
+		// and lives in shm so their parent_memory_context offsets
+		// remain valid in every process that maps the same shm region.
+		//
+		// FIXME: not paired with a free: released only when shm is torn
+		// down.
+		cp_config_lock(instance->cp_config);
+
+		struct agent *agent = dp_system_agent_new(
+			instance->cp_config, instance->dp_config, "dataplane"
+		);
+		if (agent == NULL) {
+			LOG(ERROR,
+			    "failed to allocate system agent for instance %u",
+			    instance_idx);
+			cp_config_unlock(instance->cp_config);
+			return -1;
+		}
+
 		struct cp_config_gen *cp_config_gen =
 			cp_config_gen_new(agent, &err);
 		if (cp_config_gen == NULL) {
@@ -630,11 +633,13 @@ dataplane_init(
 			    "failed to create cp_config_gen: %s",
 			    yanet_error_message(err));
 			yanet_error_free(err);
+			cp_config_unlock(instance->cp_config);
 			return -1;
 		}
 		SET_OFFSET_OF(
 			&instance->cp_config->cp_config_gen, cp_config_gen
 		);
+		cp_config_unlock(instance->cp_config);
 
 		instance_offset += instance_size;
 	}
@@ -842,7 +847,6 @@ dataplane_init(
 			}
 		}
 
-		cp_config_unlock(cp_config);
 		dp_config_mark_ready(dp_config);
 	}
 

--- a/lib/controlplane/agent/agent_test.c
+++ b/lib/controlplane/agent/agent_test.c
@@ -47,7 +47,7 @@ test_attach_zeroed_segment_returns_error() {
 	return TEST_SUCCESS;
 }
 
-// Verify that the readiness sequence (dp_storage_init -> cp_config_unlock ->
+// Verify that the readiness sequence (dp_storage_init ->
 // dp_config_mark_ready) leaves ready_magic set and the cp_config offset
 // pointer navigable. This confirms the attach gate will open for a correctly
 // initialised segment.
@@ -69,7 +69,7 @@ test_initialised_segment_magic_and_cp_config_valid() {
 	);
 	TEST_ASSERT(rc == 0, "dp_storage_init failed");
 
-	cp_config_unlock(cp_config);
+	(void)cp_config;
 	dp_config_mark_ready(dp_config);
 
 	// The release store in dp_config_mark_ready must be visible once we
@@ -113,7 +113,7 @@ test_ready_predicate_zeroed_segment_returns_false() {
 }
 
 // Verify that agent_dp_config_ready returns 1 after the full readiness
-// sequence: dp_storage_init -> cp_config_unlock -> dp_config_mark_ready.
+// sequence: dp_storage_init -> dp_config_mark_ready.
 // Also sets instance_count so the instance_idx bound check in the predicate
 // passes.
 static int
@@ -135,7 +135,7 @@ test_ready_predicate_initialised_segment_returns_true() {
 	TEST_ASSERT(rc == 0, "dp_storage_init failed");
 
 	dp_config->instance_count = 1;
-	cp_config_unlock(cp_config);
+	(void)cp_config;
 	dp_config_mark_ready(dp_config);
 
 	struct yanet_shm shm = {.base = storage, .size = TEST_STORAGE_SIZE};
@@ -151,8 +151,8 @@ test_ready_predicate_initialised_segment_returns_true() {
 
 // Verify that agent_attach succeeds on a fully initialised segment. This
 // proves the attach gate opens once the instance is marked ready. Mirrors
-// the dataplane init sequence: dp_storage_init, system agent, cp_config_gen,
-// unlock, mark_ready.
+// the dataplane init sequence: dp_storage_init, system agent and
+// cp_config_gen under the configuration lock, mark_ready.
 static int
 test_attach_initialised_segment_succeeds() {
 	void *storage = calloc(1, TEST_STORAGE_SIZE);
@@ -173,6 +173,7 @@ test_attach_initialised_segment_succeeds() {
 
 	// A system agent and cp_config_gen are required before agent_attach
 	// can succeed — agent_attach reads cp_config_gen->gen after locking.
+	cp_config_lock(cp_config);
 	struct agent *sys_agent =
 		dp_system_agent_new(cp_config, dp_config, "dataplane");
 	TEST_ASSERT_NOT_NULL(sys_agent, "dp_system_agent_new failed");
@@ -182,9 +183,9 @@ test_attach_initialised_segment_succeeds() {
 		cp_config_gen_new(sys_agent, &setup_err);
 	TEST_ASSERT_NOT_NULL(cp_config_gen, "cp_config_gen_new failed");
 	SET_OFFSET_OF(&cp_config->cp_config_gen, cp_config_gen);
+	cp_config_unlock(cp_config);
 
 	dp_config->instance_count = 1;
-	cp_config_unlock(cp_config);
 	dp_config_mark_ready(dp_config);
 
 	struct yanet_shm shm = {.base = storage, .size = TEST_STORAGE_SIZE};
@@ -381,7 +382,6 @@ test_detach_initialised_segment_releases_mapping() {
 	);
 	TEST_ASSERT(rc == 0, "dp_storage_init failed");
 	dp_config->instance_count = 1;
-	cp_config_unlock(cp_config);
 	dp_config_mark_ready(dp_config);
 
 	uint8_t *base = (uint8_t *)dp_config;
@@ -421,6 +421,8 @@ extend_env_init(
 		return -1;
 	}
 
+	cp_config_lock(cp_config);
+
 	struct agent *sys_agent =
 		dp_system_agent_new(cp_config, dp_config, "dataplane");
 	if (sys_agent == NULL) {
@@ -434,9 +436,9 @@ extend_env_init(
 		return -1;
 	}
 	SET_OFFSET_OF(&cp_config->cp_config_gen, config_gen);
+	cp_config_unlock(cp_config);
 
 	dp_config->instance_count = 1;
-	cp_config_unlock(cp_config);
 	dp_config_mark_ready(dp_config);
 
 	*res_cp_config = cp_config;
@@ -532,6 +534,7 @@ test_extend_rejects_borrowing_agent() {
 	);
 	TEST_ASSERT(rc == 0, "dp_storage_init failed");
 
+	cp_config_lock(cp_config);
 	struct agent *sys_agent =
 		dp_system_agent_new(cp_config, dp_config, "dataplane");
 	TEST_ASSERT_NOT_NULL(sys_agent, "dp_system_agent_new failed");

--- a/lib/controlplane/config/config_lock.h
+++ b/lib/controlplane/config/config_lock.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <assert.h>
+
+struct cp_config;
+
+// Configuration whose lock the calling thread holds, if any;
+// maintained by the lock, try-lock and unlock routines. A thread locks
+// at most one configuration at a time, which the lock routines assert.
+extern __thread struct cp_config *cp_config_locked_by_thread;
+
+// Abort in debug builds unless the calling thread holds the lock of
+// this configuration.
+//
+// The shared lock word stores a process id and cannot tell threads or
+// instances apart, so the check reads the per-thread record; a sibling
+// thread holding the lock, or another instance's lock, does not
+// satisfy it. A configuration of NULL matches a held record of none,
+// which keeps ownerless test registries exempt from the check.
+static inline void
+cp_config_assert_locked(const struct cp_config *cp_config) {
+	(void)cp_config;
+	assert(cp_config_locked_by_thread == cp_config);
+}

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -418,10 +418,13 @@ cp_device_fini(struct cp_device *self) {
 int
 cp_device_registry_init(
 	struct memory_context *memory_context,
+	struct cp_config *owner,
 	struct cp_device_registry *new_device_registry,
 	yanet_error **err
 ) {
-	if (registry_init(memory_context, &new_device_registry->registry, 8)) {
+	if (registry_init(
+		    memory_context, owner, &new_device_registry->registry, 8
+	    )) {
 		yanet_error_add(err, "failed to initialize device registry");
 		return -1;
 	}

--- a/lib/controlplane/config/cp_device.h
+++ b/lib/controlplane/config/cp_device.h
@@ -149,6 +149,7 @@ struct cp_device_registry {
 int
 cp_device_registry_init(
 	struct memory_context *memory_context,
+	struct cp_config *owner,
 	struct cp_device_registry *registry,
 	yanet_error **err
 );

--- a/lib/controlplane/config/cp_function.c
+++ b/lib/controlplane/config/cp_function.c
@@ -201,11 +201,12 @@ cp_function_fini(struct cp_function *self) {
 int
 cp_function_registry_init(
 	struct memory_context *memory_context,
+	struct cp_config *owner,
 	struct cp_function_registry *new_function_registry,
 	yanet_error **err
 ) {
 	if (registry_init(
-		    memory_context, &new_function_registry->registry, 8
+		    memory_context, owner, &new_function_registry->registry, 8
 	    )) {
 		yanet_error_add(err, "failed to initialize function registry");
 		return -1;

--- a/lib/controlplane/config/cp_function.h
+++ b/lib/controlplane/config/cp_function.h
@@ -105,6 +105,7 @@ struct cp_function_registry {
 int
 cp_function_registry_init(
 	struct memory_context *memory_context,
+	struct cp_config *owner,
 	struct cp_function_registry *registry,
 	yanet_error **err
 );

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -427,10 +427,13 @@ cp_module_try_destroy(struct cp_module *cp_module, yanet_error **err) {
 int
 cp_module_registry_init(
 	struct memory_context *memory_context,
+	struct cp_config *owner,
 	struct cp_module_registry *new_module_registry,
 	yanet_error **err
 ) {
-	if (registry_init(memory_context, &new_module_registry->registry, 8)) {
+	if (registry_init(
+		    memory_context, owner, &new_module_registry->registry, 8
+	    )) {
 		yanet_error_add(err, "failed to initialize module registry");
 		return -1;
 	}

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -222,6 +222,8 @@ struct cp_module_registry {
  * specified memory context.
  *
  * @param memory_context Memory context for registry allocations
+ * @param owner Configuration whose lock guards the reference counts;
+ * NULL exempts the registry from the lock check
  * @param registry Pointer to the registry structure to initialize
  * @param err Error output parameter
  * @return 0 on success, negative error code on failure
@@ -229,6 +231,7 @@ struct cp_module_registry {
 int
 cp_module_registry_init(
 	struct memory_context *memory_context,
+	struct cp_config *owner,
 	struct cp_module_registry *registry,
 	yanet_error **err
 );

--- a/lib/controlplane/config/cp_object.c
+++ b/lib/controlplane/config/cp_object.c
@@ -86,10 +86,11 @@ cp_object_fini(struct cp_object *self) {
 int
 cp_object_registry_init(
 	struct memory_context *memory_context,
+	struct cp_config *owner,
 	struct cp_object_registry *new_registry,
 	yanet_error **err
 ) {
-	if (registry_init(memory_context, &new_registry->registry, 8)) {
+	if (registry_init(memory_context, owner, &new_registry->registry, 8)) {
 		yanet_error_add(err, "failed to initialize object registry");
 		return -1;
 	}

--- a/lib/controlplane/config/cp_object.h
+++ b/lib/controlplane/config/cp_object.h
@@ -105,6 +105,7 @@ struct cp_object_cmp_data {
 int
 cp_object_registry_init(
 	struct memory_context *memory_context,
+	struct cp_config *owner,
 	struct cp_object_registry *registry,
 	yanet_error **err
 );

--- a/lib/controlplane/config/cp_pipeline.c
+++ b/lib/controlplane/config/cp_pipeline.c
@@ -169,11 +169,12 @@ cp_pipeline_fini(struct cp_pipeline *self) {
 int
 cp_pipeline_registry_init(
 	struct memory_context *memory_context,
+	struct cp_config *owner,
 	struct cp_pipeline_registry *new_pipeline_registry,
 	yanet_error **err
 ) {
 	if (registry_init(
-		    memory_context, &new_pipeline_registry->registry, 8
+		    memory_context, owner, &new_pipeline_registry->registry, 8
 	    )) {
 		yanet_error_add(err, "failed to initialize pipeline registry");
 		return -1;

--- a/lib/controlplane/config/cp_pipeline.h
+++ b/lib/controlplane/config/cp_pipeline.h
@@ -95,6 +95,7 @@ struct cp_pipeline_registry {
 int
 cp_pipeline_registry_init(
 	struct memory_context *memory_context,
+	struct cp_config *owner,
 	struct cp_pipeline_registry *registry,
 	yanet_error **err
 );

--- a/lib/controlplane/config/registry.h
+++ b/lib/controlplane/config/registry.h
@@ -2,6 +2,8 @@
 
 #include "common/memory.h"
 
+#include "lib/controlplane/config/config_lock.h"
+
 struct registry_item {
 	uint64_t refcnt;
 	// Set by registry_item_mark_destroying once an owner won the right
@@ -18,8 +20,16 @@ registry_item_init(struct registry_item *item) {
 	item->destroying = 0;
 }
 
+// Take one reference for a registry slot; like every registry
+// mutation this must run under the control-plane configuration lock
+// (cp_config_lock) of the owning configuration.
+//
+// Checked in debug builds against the owner: a caller outside that
+// lock loses updates and leaks the counted item. An owner of NULL
+// exempts ownerless test registries.
 static inline void
-registry_item_ref(struct registry_item *item) {
+registry_item_ref(struct registry_item *item, const struct cp_config *owner) {
+	cp_config_assert_locked(owner);
 	item->refcnt += 1;
 }
 
@@ -40,16 +50,21 @@ registry_item_is_destroying(const struct registry_item *item) {
 typedef void (*registry_item_free_func)(struct registry_item *item, void *data);
 
 // Drop one reference. A NULL free_func makes the zero transition a no-op:
-// the item stays alive, dangling, and only its owner may destroy it. Every
-// mutation of a registry or its items' reference counts runs under the
-// configuration lock, so an owner reading the count under that lock sees a
-// value no concurrent registry operation can still change.
+// the item stays alive, dangling, and only its owner may destroy it.
+//
+// Every mutation of a registry or its items' reference counts runs under
+// the control-plane configuration lock (cp_config_lock) of the owning
+// configuration, checked in debug builds, so an owner reading the count
+// under that lock sees a value no concurrent registry operation can
+// still change.
 static inline void
 registry_item_unref(
 	struct registry_item *item,
+	const struct cp_config *owner,
 	registry_item_free_func free_func,
 	void *free_func_data
 ) {
+	cp_config_assert_locked(owner);
 	item->refcnt -= 1;
 	if (!item->refcnt && free_func != NULL) {
 		free_func(item, free_func_data);
@@ -58,6 +73,9 @@ registry_item_unref(
 
 struct registry {
 	struct memory_context *memory_context;
+	// Configuration whose lock must be held for every reference-count
+	// mutation; NULL exempts ownerless test registries.
+	struct cp_config *owner;
 	uint64_t capacity;
 	struct registry_item **items;
 };
@@ -87,10 +105,12 @@ registry_set(
 static inline int
 registry_init(
 	struct memory_context *memory_context,
+	struct cp_config *owner,
 	struct registry *registry,
 	uint64_t capacity
 ) {
 	SET_OFFSET_OF(&registry->memory_context, memory_context);
+	SET_OFFSET_OF(&registry->owner, owner);
 	registry->capacity = capacity;
 
 	struct registry_item **items = (struct registry_item **)memory_balloc(
@@ -124,6 +144,7 @@ registry_fini(
 
 	struct memory_context *memory_context =
 		ADDR_OF(&registry->memory_context);
+	struct cp_config *owner = ADDR_OF(&registry->owner);
 
 	for (uint64_t idx = 0; idx < registry->capacity; ++idx) {
 		struct registry_item *item = registry_get(registry, idx);
@@ -131,7 +152,9 @@ registry_fini(
 			continue;
 		}
 
-		registry_item_unref(item, item_free_func, item_free_func_data);
+		registry_item_unref(
+			item, owner, item_free_func, item_free_func_data
+		);
 	}
 
 	memory_bfree(
@@ -150,7 +173,10 @@ registry_copy(
 	struct registry *old_registry
 ) {
 	if (registry_init(
-		    memory_context, new_registry, old_registry->capacity
+		    memory_context,
+		    ADDR_OF(&old_registry->owner),
+		    new_registry,
+		    old_registry->capacity
 	    )) {
 		return -1;
 	}
@@ -159,7 +185,7 @@ registry_copy(
 		struct registry_item *item = registry_get(old_registry, idx);
 
 		if (item != NULL) {
-			registry_item_ref(item);
+			registry_item_ref(item, ADDR_OF(&old_registry->owner));
 		}
 
 		registry_set(new_registry, idx, item);
@@ -253,7 +279,7 @@ registry_insert(struct registry *registry, struct registry_item *new_item) {
 	}
 
 	registry_set(registry, index, new_item);
-	registry_item_ref(new_item);
+	registry_item_ref(new_item, ADDR_OF(&registry->owner));
 
 	return 0;
 }
@@ -287,14 +313,17 @@ registry_replace(
 
 	struct registry_item *old_item = registry_get(registry, index);
 	if (new_item != NULL) {
-		registry_item_ref(new_item);
+		registry_item_ref(new_item, ADDR_OF(&registry->owner));
 	}
 
 	registry_set(registry, index, new_item);
 
 	if (old_item != NULL) {
 		registry_item_unref(
-			old_item, item_free_func, item_free_func_data
+			old_item,
+			ADDR_OF(&registry->owner),
+			item_free_func,
+			item_free_func_data
 		);
 	}
 

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -18,22 +18,37 @@
 
 #include "lib/controlplane/agent/agent.h"
 
+__thread struct cp_config *cp_config_locked_by_thread = NULL;
+
 bool
 cp_config_try_lock(struct cp_config *cp_config) {
+	// A thread locks at most one configuration at a time; acquiring a
+	// second one, or the same one again, is a discipline violation.
+	assert(cp_config_locked_by_thread == NULL);
+
 	pid_t pid = getpid();
 	pid_t zero = 0;
-	return __atomic_compare_exchange_n(
-		&cp_config->config_lock,
-		&zero,
-		pid,
-		false,
-		__ATOMIC_ACQUIRE,
-		__ATOMIC_RELAXED
-	);
+	if (__atomic_compare_exchange_n(
+		    &cp_config->config_lock,
+		    &zero,
+		    pid,
+		    false,
+		    __ATOMIC_ACQUIRE,
+		    __ATOMIC_RELAXED
+	    )) {
+		cp_config_locked_by_thread = cp_config;
+		return true;
+	}
+
+	return false;
 }
 
 void
 cp_config_lock(struct cp_config *cp_config) {
+	// A thread locks at most one configuration at a time; acquiring a
+	// second one, or the same one again, is a discipline violation.
+	assert(cp_config_locked_by_thread == NULL);
+
 	pid_t pid = getpid();
 	int spins = 0;
 	for (;;) {
@@ -46,6 +61,7 @@ cp_config_lock(struct cp_config *cp_config) {
 			    __ATOMIC_ACQUIRE,
 			    __ATOMIC_RELAXED
 		    )) {
+			cp_config_locked_by_thread = cp_config;
 			return;
 		}
 
@@ -61,11 +77,17 @@ cp_config_lock(struct cp_config *cp_config) {
 	}
 }
 
-bool
+void
 cp_config_unlock(struct cp_config *cp_config) {
+	// Abort in debug builds when the calling thread does not own the
+	// acquisition: releasing on another thread's behalf would leave
+	// that thread's record stale, letting a later unlocked mutation
+	// pass the debug assert.
+	assert(cp_config_locked_by_thread == cp_config);
+
 	pid_t pid = getpid();
 	pid_t zero = 0;
-	return __atomic_compare_exchange_n(
+	__atomic_compare_exchange_n(
 		&cp_config->config_lock,
 		&pid,
 		zero,
@@ -73,6 +95,7 @@ cp_config_unlock(struct cp_config *cp_config) {
 		__ATOMIC_RELEASE,
 		__ATOMIC_RELAXED
 	);
+	cp_config_locked_by_thread = NULL;
 }
 
 static inline void
@@ -86,6 +109,8 @@ cp_config_gen_new_from(
 	struct cp_config_gen *old_config_gen,
 	yanet_error **err
 ) {
+	cp_config_assert_locked(cp_config);
+
 	struct cp_config_gen *new_config_gen =
 		(struct cp_config_gen *)memory_balloc(
 			&cp_config->memory_context, sizeof(struct cp_config_gen)
@@ -221,6 +246,8 @@ void
 cp_config_gen_release(
 	struct cp_config *cp_config, struct cp_config_gen *config_gen
 ) {
+	cp_config_assert_locked(cp_config);
+
 	if (--config_gen->refcnt == 0) {
 		cp_config_gen_free(cp_config, config_gen);
 	}
@@ -305,6 +332,7 @@ cp_config_delete_module(
 	if (cp_config_gen_install(dp_config, cp_config, new_config_gen, err)) {
 		goto error_free;
 	}
+	cp_config_assert_locked(cp_config);
 	cp_config_unlock(cp_config);
 
 	return 0;
@@ -1001,6 +1029,7 @@ cp_config_gen_new(struct agent *agent, yanet_error **err) {
 
 	if (cp_module_registry_init(
 		    &cp_config->memory_context,
+		    cp_config,
 		    &cp_config_gen->module_registry,
 		    err
 	    )) {
@@ -1010,6 +1039,7 @@ cp_config_gen_new(struct agent *agent, yanet_error **err) {
 
 	if (cp_function_registry_init(
 		    &cp_config->memory_context,
+		    cp_config,
 		    &cp_config_gen->function_registry,
 		    err
 	    )) {
@@ -1019,6 +1049,7 @@ cp_config_gen_new(struct agent *agent, yanet_error **err) {
 
 	if (cp_pipeline_registry_init(
 		    &cp_config->memory_context,
+		    cp_config,
 		    &cp_config_gen->pipeline_registry,
 		    err
 	    )) {
@@ -1028,6 +1059,7 @@ cp_config_gen_new(struct agent *agent, yanet_error **err) {
 
 	if (cp_device_registry_init(
 		    &cp_config->memory_context,
+		    cp_config,
 		    &cp_config_gen->device_registry,
 		    err
 	    )) {
@@ -1037,6 +1069,7 @@ cp_config_gen_new(struct agent *agent, yanet_error **err) {
 
 	if (cp_object_registry_init(
 		    &cp_config->memory_context,
+		    cp_config,
 		    &cp_config_gen->object_registry,
 		    err
 	    )) {

--- a/lib/controlplane/config/zone.h
+++ b/lib/controlplane/config/zone.h
@@ -13,6 +13,7 @@
 
 #include "lib/dataplane/config/zone.h"
 
+#include "lib/controlplane/config/config_lock.h"
 #include "lib/controlplane/config/cp_chain.h"
 #include "lib/controlplane/config/cp_device.h"
 #include "lib/controlplane/config/cp_function.h"
@@ -154,10 +155,10 @@ cp_config_lock(struct cp_config *cp_config);
 
 /*
  * Unlock controplane configuration.
- * The function returns false in case when controplane was not locked
- * by the current process.
+ * Aborts in debug builds when the current thread does not hold this
+ * configuration's lock.
  */
-bool
+void
 cp_config_unlock(struct cp_config *cp_config);
 
 /*
@@ -260,6 +261,7 @@ cp_config_gen_new(struct agent *agent, yanet_error **err);
 // current during that window.
 static inline struct cp_config_gen *
 cp_config_gen_acquire(struct cp_config *cp_config) {
+	cp_config_assert_locked(cp_config);
 	struct cp_config_gen *config_gen = ADDR_OF(&cp_config->cp_config_gen);
 	config_gen->refcnt += 1;
 	return config_gen;

--- a/lib/controlplane/tests/cp_object_test.c
+++ b/lib/controlplane/tests/cp_object_test.c
@@ -119,7 +119,7 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 	struct cp_object_registry registry;
 	TEST_ASSERT_SUCCESS(
 		cp_object_registry_init(
-			&agent->memory_context, &registry, &err
+			&agent->memory_context, NULL, &registry, &err
 		),
 		"object registry init failed: %s",
 		err ? yanet_error_message(err) : "?"
@@ -416,7 +416,7 @@ test_cp_object_attach_gate(struct yanet_shm *shm) {
 	struct cp_object_registry registry;
 	TEST_ASSERT_SUCCESS(
 		cp_object_registry_init(
-			&agent1->memory_context, &registry, &err
+			&agent1->memory_context, NULL, &registry, &err
 		),
 		"object registry init failed: %s",
 		err ? yanet_error_message(err) : "?"

--- a/lib/controlplane/tests/dangling_devices_test.c
+++ b/lib/controlplane/tests/dangling_devices_test.c
@@ -61,7 +61,9 @@ test_referenced_free_eagain_then_destroy(struct yanet_shm *shm) {
 	// exactly like an install would take.
 	struct cp_device_registry reg;
 	TEST_ASSERT_SUCCESS(
-		cp_device_registry_init(&agent->memory_context, &reg, &err),
+		cp_device_registry_init(
+			&agent->memory_context, NULL, &reg, &err
+		),
 		"cp_device_registry_init failed"
 	);
 	TEST_ASSERT_SUCCESS(
@@ -133,7 +135,9 @@ test_typed_destroy_is_per_owner(struct yanet_shm *shm) {
 
 	struct cp_device_registry reg;
 	TEST_ASSERT_SUCCESS(
-		cp_device_registry_init(&agent->memory_context, &reg, &err),
+		cp_device_registry_init(
+			&agent->memory_context, NULL, &reg, &err
+		),
 		"cp_device_registry_init failed"
 	);
 	TEST_ASSERT_SUCCESS(

--- a/lib/controlplane/tests/dangling_modules_test.c
+++ b/lib/controlplane/tests/dangling_modules_test.c
@@ -93,7 +93,9 @@ test_referenced_free_eagain_then_destroy(struct yanet_shm *shm) {
 	// exactly like an install would take.
 	struct cp_module_registry reg;
 	TEST_ASSERT_SUCCESS(
-		cp_module_registry_init(&agent->memory_context, &reg, &err),
+		cp_module_registry_init(
+			&agent->memory_context, NULL, &reg, &err
+		),
 		"cp_module_registry_init failed"
 	);
 	TEST_ASSERT_SUCCESS(
@@ -153,7 +155,9 @@ test_typed_destroy_is_per_owner(struct yanet_shm *shm) {
 
 	struct cp_module_registry reg;
 	TEST_ASSERT_SUCCESS(
-		cp_module_registry_init(&agent->memory_context, &reg, &err),
+		cp_module_registry_init(
+			&agent->memory_context, NULL, &reg, &err
+		),
 		"cp_module_registry_init failed"
 	);
 	TEST_ASSERT_SUCCESS(

--- a/lib/controlplane/tests/dangling_objects_test.c
+++ b/lib/controlplane/tests/dangling_objects_test.c
@@ -58,7 +58,9 @@ test_referenced_free_eagain_then_destroy(struct yanet_shm *shm) {
 	// exactly like an install would take.
 	struct cp_object_registry reg;
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_init(&agent->memory_context, &reg, &err),
+		cp_object_registry_init(
+			&agent->memory_context, NULL, &reg, &err
+		),
 		"cp_object_registry_init failed"
 	);
 	TEST_ASSERT_SUCCESS(
@@ -136,7 +138,9 @@ test_typed_destroy_is_per_owner(struct yanet_shm *shm) {
 
 	struct cp_object_registry reg;
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_init(&agent->memory_context, &reg, &err),
+		cp_object_registry_init(
+			&agent->memory_context, NULL, &reg, &err
+		),
 		"cp_object_registry_init failed"
 	);
 	TEST_ASSERT_SUCCESS(

--- a/lib/dataplane/config/bootstrap.c
+++ b/lib/dataplane/config/bootstrap.c
@@ -47,6 +47,10 @@ dp_storage_init(
 	struct cp_config *cp_config =
 		(struct cp_config *)((uintptr_t)storage + dp_memory);
 
+	// The lock is taken and released inside this routine: callers pair
+	// their own control-plane mutations themselves. Nobody else can
+	// reach the zone before readiness is published, so the pair is
+	// uncontended discipline rather than exclusion.
 	cp_config_lock(cp_config);
 
 	block_allocator_init(&cp_config->block_allocator);
@@ -82,6 +86,8 @@ dp_storage_init(
 
 	SET_OFFSET_OF(&dp_config->cp_config, cp_config);
 	SET_OFFSET_OF(&cp_config->dp_config, dp_config);
+
+	cp_config_unlock(cp_config);
 
 	*res_dp_config = dp_config;
 	*res_cp_config = cp_config;

--- a/lib/dataplane/config/bootstrap.h
+++ b/lib/dataplane/config/bootstrap.h
@@ -11,7 +11,9 @@ struct cp_config;
 //
 // On success *res_dp_config and *res_cp_config point into storage and
 // are mutually navigable via offset pointers. Caller owns storage.
-// Returns 0 on success, -1 on failure.
+// The control-plane zone's lock is taken and released inside this
+// routine; callers pair their own lock around any further control-plane
+// mutations. Returns 0 on success, -1 on failure.
 int
 dp_storage_init(
 	uint32_t numa_idx,
@@ -25,7 +27,8 @@ dp_storage_init(
 
 // Publish the readiness marker for this instance.
 //
-// Call this after releasing cp_config, once the instance is fully initialised
-// and ready for attach.
+// Call this only after every control-plane mutation is complete and no
+// lock is held, once the instance is fully initialised and ready for
+// attach.
 void
 dp_config_mark_ready(struct dp_config *dp_config);

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -195,21 +195,6 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		ut->dp_config->object_count = cfg->objects_to_load_count;
 	}
 
-	// Allocate the system agent inside cp_config memory so that its
-	// offset pointers remain valid across all processes that map the
-	// same arena. A stack agent would mix shm-relative offsets with
-	// process-local addresses and produce SIGBUS on cross-process
-	// dereference.
-	struct agent *agent = dp_system_agent_new(
-		ut->cp_config, ut->dp_config, "dataplane_ut"
-	);
-	if (agent == NULL) {
-		LOG(ERROR, "dataplane_ut_new: failed to allocate system agent");
-		dataplane_ut_free(ut);
-		return NULL;
-	}
-	ut->agent = agent;
-
 	// Populate dp_topology with the logical port names from cfg.
 	if (cfg->device_count > 0) {
 		struct dp_port *ports = dp_topology_alloc_devices(
@@ -228,6 +213,24 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		}
 	}
 
+	// Allocate the system agent inside cp_config memory so that its
+	// offset pointers remain valid across all processes that map the
+	// same arena. A stack agent would mix shm-relative offsets with
+	// process-local addresses and produce SIGBUS on cross-process
+	// dereference.
+	cp_config_lock(ut->cp_config);
+
+	struct agent *agent = dp_system_agent_new(
+		ut->cp_config, ut->dp_config, "dataplane_ut"
+	);
+	if (agent == NULL) {
+		LOG(ERROR, "dataplane_ut_new: failed to allocate system agent");
+		cp_config_unlock(ut->cp_config);
+		dataplane_ut_free(ut);
+		return NULL;
+	}
+	ut->agent = agent;
+
 	// Create the initial cp_config_gen so agents can register modules
 	// and pipelines.
 	yanet_error *err = NULL;
@@ -237,10 +240,12 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		    "dataplane_ut_new: cp_config_gen_new failed: %s",
 		    yanet_error_message(err));
 		yanet_error_free(err);
+		cp_config_unlock(ut->cp_config);
 		dataplane_ut_free(ut);
 		return NULL;
 	}
 	SET_OFFSET_OF(&ut->cp_config->cp_config_gen, cp_config_gen);
+	cp_config_unlock(ut->cp_config);
 
 	counter_registry_init(
 		&ut->dp_config->worker_counters,
@@ -268,7 +273,6 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		return NULL;
 	}
 
-	cp_config_unlock(ut->cp_config);
 	dp_config_mark_ready(ut->dp_config);
 
 	// Create the mock mempool now so step 2 can allocate mbufs.

--- a/modules/fwstate/tests/dataplane/harness.c
+++ b/modules/fwstate/tests/dataplane/harness.c
@@ -92,7 +92,10 @@ fwstate_test_agent_new(struct memory_context *parent, const char *name) {
 
 	yanet_error *err = NULL;
 	if (cp_object_registry_init(
-		    &agent->memory_context, &config_gen->object_registry, &err
+		    &agent->memory_context,
+		    cp_config,
+		    &config_gen->object_registry,
+		    &err
 	    )) {
 		yanet_error_free(err);
 		return NULL;
@@ -294,6 +297,8 @@ fwstate_test_register_object(struct agent *agent, struct cp_object *cp_object) {
 	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
 	struct cp_config_gen *config_gen = ADDR_OF(&cp_config->cp_config_gen);
 
+	cp_config_lock(cp_config);
+
 	yanet_error *err = NULL;
 	if (cp_object_registry_upsert(
 		    &config_gen->object_registry,
@@ -303,8 +308,11 @@ fwstate_test_register_object(struct agent *agent, struct cp_object *cp_object) {
 		    &err
 	    )) {
 		yanet_error_free(err);
+		cp_config_unlock(cp_config);
 		return -1;
 	}
+
+	cp_config_unlock(cp_config);
 	return 0;
 }
 

--- a/tests/controlplane/agent_memory_tree_test.c
+++ b/tests/controlplane/agent_memory_tree_test.c
@@ -36,6 +36,8 @@ test_memory_tree_exported(void) {
 	int rc = dp_storage_init(0, 0, storage, DP_MEMORY, CP_MEMORY, &dp, &cp);
 	TEST_ASSERT(rc == 0, "dp_storage_init failed");
 
+	cp_config_lock(cp);
+
 	struct agent *sys = dp_system_agent_new(cp, dp, "dataplane");
 	TEST_ASSERT_NOT_NULL(sys, "dp_system_agent_new failed");
 
@@ -203,6 +205,8 @@ test_memory_tree_after_fini(void) {
 	struct cp_config *cp = NULL;
 	int rc = dp_storage_init(0, 0, storage, DP_MEMORY, CP_MEMORY, &dp, &cp);
 	TEST_ASSERT(rc == 0, "dp_storage_init failed");
+
+	cp_config_lock(cp);
 
 	struct agent *sys = dp_system_agent_new(cp, dp, "dataplane");
 	TEST_ASSERT_NOT_NULL(sys, "dp_system_agent_new failed");

--- a/tests/controlplane/config_gen_test.c
+++ b/tests/controlplane/config_gen_test.c
@@ -71,7 +71,9 @@ main(void) {
 	SET_OFFSET_OF(&agent.cp_config, cp);
 
 	yanet_error *err = NULL;
+	cp_config_lock(cp);
 	struct cp_config_gen *gen = cp_config_gen_new(&agent, &err);
+	cp_config_unlock(cp);
 	TEST_ASSERT_NOT_NULL(gen, "cp_config_gen_new failed");
 
 	// Reproduce the worker's code path:


### PR DESCRIPTION
Registry reference counts are plain counters whose safety rests on every mutation running under the configuration lock, and nothing enforced that; a future caller reaching the primitives from an unlocked context would silently leak an agent arena.

- Give every registry an owning configuration reference and make the take and drop reference primitives assert that owner's lock in debug builds, so the serialization contract is checked at the primitive itself for all five registry types; ownerless standalone test registries are exempt.
- Extract the per-thread lock record and its assert into a dedicated header so the registry primitives can check it without include cycles.
- The lock discipline is one configuration lock per thread, taken and released inside the same routine: acquisition asserts the thread holds none, release asserts the calling thread owns this configuration, and the shared lock word's process-granular owner is never trusted for either check.
- Storage bootstrap pairs its lock internally instead of returning it held; the dataplane startup locks per instance around its own control-plane mutations instead of holding every instance until the readiness loop; generation construction runs under its caller's lock.
- The check immediately caught a real pre-existing defect: the fwstate dataplane test harness registered objects into the object registry without the lock, which now takes it.
- Reject an atomic reference count: the destroy-marking and free-on-zero protocol depends on observing the count at zero under the same lock, which an atomic counter alone cannot provide, so it would mask the lost update while leaving the real race in place.
- The registry layout change and the new thread-local extern need a Go cache clean on pulls, as with any header-level change to this library.

Closes #1994.