### PR TITLE
perf(acl): coalesce concurrent metrics scrapes into one shared-memory read

### DIFF
--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -3,6 +3,7 @@ package acl
 import (
 	"context"
 	"errors"
+	"slices"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -15,12 +16,16 @@ import (
 
 // metricsSource provides the module's metrics, filtered by tags.
 type metricsSource interface {
-	Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error)
-	RuleMetrics(req *aclpb.GetMetricsRulesRequest) ([]*commonpb.Metric, error)
+	Metrics(ctx context.Context, tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error)
+	RuleMetrics(ctx context.Context, req *aclpb.GetMetricsRulesRequest) ([]*commonpb.Metric, error)
 }
 
 type moduleCounterReader interface {
 	ModuleCounters(dataplaneConfig *ffi.DPConfig, position ffi.ModuleReference, counterNames []string) []ffi.CounterInfo
+}
+
+type countersByTagsReader interface {
+	CountersByTags(dataplaneConfig *ffi.DPConfig, tags []ffi.CounterTag, query []string) ([]ffi.CounterGroup, error)
 }
 
 // MetricsService exposes ACL module metrics over its own gRPC service.
@@ -38,7 +43,7 @@ func NewMetricsService(source metricsSource) *MetricsService {
 // GetMetrics returns a snapshot of ACL module metrics matching the
 // request's tags.
 func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetricsRequest) (*commonpb.GetMetricsResponse, error) {
-	all, err := m.source.Metrics(req.GetTags()...)
+	all, err := m.source.Metrics(ctx, req.GetTags()...)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,7 @@ func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetric
 
 // GetMetricsRules returns the per-rule counter metrics GetMetrics leaves out.
 func (m *MetricsService) GetMetricsRules(ctx context.Context, req *aclpb.GetMetricsRulesRequest) (*commonpb.GetMetricsResponse, error) {
-	all, err := m.source.RuleMetrics(req)
+	all, err := m.source.RuleMetrics(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -72,6 +77,10 @@ var aclStructuralCounters = []string{
 // Metrics returns ACL module metrics matching tags: per-pipeline packet
 // counters, ACL compilation info, and gRPC call metrics.
 //
+// Concurrent scrapes are coalesced into one shared collection of the
+// per-position packet-counter reads, and every concurrent caller
+// receives the same values filtered by its own tags.
+//
 // Per-rule counters are served by RuleMetrics and GetRulesCounters, not
 // here. Counter metrics are omitted when all worker values are zero to
 // reduce output noise.
@@ -86,25 +95,34 @@ var aclStructuralCounters = []string{
 //   - grpc_service:  fully-qualified gRPC service name (gRPC metrics)
 //   - grpc_method:   RPC name (gRPC metrics)
 //   - grpc_code:     gRPC status code string (grpc_server_handled_total only)
-func (m *ACLService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
-	all, err := m.collectDataplaneMetrics(tags)
+func (m *ACLService) Metrics(ctx context.Context, tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
+	collected, err := m.moduleMetricsFlight.Do(ctx, m.collectDataplaneMetrics)
 	if err != nil {
 		return nil, err
 	}
+
+	var grpcMetrics []*commonpb.Metric
 	if m.metrics != nil {
-		all = append(all, m.metrics.Collect()...)
+		grpcMetrics = m.metrics.Collect()
 	}
+	all := slices.Concat(collected, grpcMetrics)
 	return metrics.Filter(all, tags), nil
 }
 
 // RuleMetrics returns ACL per-rule counter metrics for the selected
 // positions: one packets and one bytes counter for every rule counter.
 //
+// One merged shared-memory read serves every selector: concurrent
+// scrapes are coalesced into it, and selection of each caller's
+// positions happens on its shared result.
+//
 // These are the counters Metrics leaves out, read from the runtime-kind
 // storages it never touches. An empty request field matches every value.
 // One read serves every position, and each metric's position comes from
-// the tags its counter group carries. Counter metrics are omitted when
-// all worker values are zero to reduce output noise.
+// the tags its counter group carries. A selector value the counter-tag
+// fields cannot carry is rejected as an invalid argument. Counter
+// metrics are omitted when all worker values are zero to reduce output
+// noise.
 //
 // Labels:
 //   - config:    ACL config name
@@ -113,16 +131,20 @@ func (m *ACLService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, e
 //   - function:  pipeline function name
 //   - chain:     pipeline chain name
 //   - counter:   rule counter name
-func (m *ACLService) RuleMetrics(req *aclpb.GetMetricsRulesRequest) ([]*commonpb.Metric, error) {
+func (m *ACLService) RuleMetrics(ctx context.Context, req *aclpb.GetMetricsRulesRequest) ([]*commonpb.Metric, error) {
 	dpConfig := m.backend.DPConfig()
 	if dpConfig == nil {
 		return []*commonpb.Metric{}, nil
 	}
 
-	groups, err := dpConfig.CountersByTags(ruleQueryTags(req), nil)
+	if err := validateRuleSelectors(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	groups, err := m.readRuleCounterGroups(ctx, dpConfig)
 	if err != nil {
-		if errors.Is(err, ffi.ErrInvalidTag) {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
 		}
 		return nil, status.Errorf(
 			codes.Internal, "failed to read rule counters: %v", err,
@@ -176,22 +198,56 @@ func (m *ACLService) RuleMetrics(req *aclpb.GetMetricsRulesRequest) ([]*commonpb
 	return result, nil
 }
 
-func ruleQueryTags(req *aclpb.GetMetricsRulesRequest) []ffi.CounterTag {
-	tags := []ffi.CounterTag{
-		{Key: "module_type", Value: moduleType},
-		{Key: "kind", Value: "runtime"},
-	}
+// DrainMetricsReads blocks until every in-flight metrics collection has
+// finished.
+//
+// A collection outlives the request handlers that joined it, so the
+// shared memory it reads may only be released after this returns.
+func (m *ACLService) DrainMetricsReads() {
+	m.moduleMetricsFlight.Drain()
+	m.ruleMetricsFlight.Drain()
+}
 
+// readRuleCounterGroups returns the per-rule counter groups both
+// rule-counter RPCs work on.
+//
+// The merged read carries no request selectors: every caller filters
+// the shared result on its own, so one shared-memory read of the family
+// is in flight at a time and releasing that memory is safe after the
+// drain.
+func (m *ACLService) readRuleCounterGroups(ctx context.Context, dpConfig *ffi.DPConfig) ([]ffi.CounterGroup, error) {
+	return m.ruleMetricsFlight.Do(ctx, func() ([]ffi.CounterGroup, error) {
+		if reader, ok := m.backend.(countersByTagsReader); ok {
+			return reader.CountersByTags(dpConfig, ruleCounterBaseTags(), nil)
+		}
+		return dpConfig.CountersByTags(ruleCounterBaseTags(), nil)
+	})
+}
+
+// validateRuleSelectors rejects request selectors the fixed-size
+// counter-tag fields cannot carry, before any shared-memory read.
+func validateRuleSelectors(req *aclpb.GetMetricsRulesRequest) error {
 	for _, selector := range requestSelectors(req) {
 		key, value := selector[0], selector[1]
 		if value == "" || value == "*" {
 			continue
 		}
 
-		tags = append(tags, ffi.CounterTag{Key: key, Value: value})
+		if err := ffi.ValidateTag(ffi.CounterTag{Key: key, Value: value}); err != nil {
+			return err
+		}
 	}
 
-	return tags
+	return nil
+}
+
+// ruleCounterBaseTags returns the fixed tag set every per-rule counter
+// read matches on: the module's own counters of the runtime kind.
+func ruleCounterBaseTags() []ffi.CounterTag {
+	return []ffi.CounterTag{
+		{Key: "module_type", Value: moduleType},
+		{Key: "kind", Value: "runtime"},
+	}
 }
 
 func locationSelected(location map[string]string, req *aclpb.GetMetricsRulesRequest) bool {
@@ -224,7 +280,7 @@ func groupLocation(tags []ffi.CounterTag) map[string]string {
 	return location
 }
 
-func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*commonpb.Metric, error) {
+func (m *ACLService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
 	snapshot := m.metricsState.load()
 
 	dpConfig := m.backend.DPConfig()
@@ -234,10 +290,7 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 
 	positions := dpConfig.AllModulePositions(moduleType)
 
-	names, read := metrics.Query(
-		tags,
-		metrics.WithStructuralCounters(aclStructuralCounters),
-	)
+	names := aclStructuralCounters
 
 	result := make([]*commonpb.Metric, 0)
 	gaugesEmitted := make(map[string]struct{})
@@ -253,20 +306,18 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 		}
 
 		var counters []ffi.CounterInfo
-		if read {
-			if counterReader, ok := m.backend.(moduleCounterReader); ok {
-				counters = counterReader.ModuleCounters(dpConfig, pos, names)
-			} else {
-				counters = dpConfig.ModuleCounters(
-					pos.Device,
-					pos.Pipeline,
-					pos.Function,
-					pos.Chain,
-					moduleType,
-					configName,
-					names,
-				)
-			}
+		if counterReader, ok := m.backend.(moduleCounterReader); ok {
+			counters = counterReader.ModuleCounters(dpConfig, pos, names)
+		} else {
+			counters = dpConfig.ModuleCounters(
+				pos.Device,
+				pos.Pipeline,
+				pos.Function,
+				pos.Chain,
+				moduleType,
+				configName,
+				names,
+			)
 		}
 
 		for _, counter := range counters {

--- a/modules/acl/controlplane/metrics_flight.go
+++ b/modules/acl/controlplane/metrics_flight.go
@@ -1,0 +1,97 @@
+package acl
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// metricsFlight coalesces concurrent collections of one metric family
+// into a single in-flight collection.
+//
+// A request arriving with nothing in progress starts the collection; a
+// request arriving while one is in progress waits for it instead of
+// starting its own, and every waiter of one collection receives the
+// identical values or the identical error. No stale snapshot is ever
+// served: a request arriving after a completed collection starts a new
+// one. A waiter whose context expires during the wait returns the
+// context error while the collection runs to completion for the other
+// waiters. A delivered result is shared by all waiters of its collection
+// and must be treated as read-only by every one of them. Releasing the
+// memory a collection still reads is only safe after a drain.
+type metricsFlight[T any] struct {
+	key string
+
+	group singleflight.Group
+
+	// mu guards current, the completion signal of the registered
+	// collection: nil while no collection is registered, a channel
+	// closed once the registered collection's read has finished. A
+	// request finding nil registers itself and forgets the group's key,
+	// so the delivery tail of a finished collection cannot absorb it as
+	// a waiter of values it did not collect.
+	mu      sync.Mutex
+	current chan struct{}
+}
+
+func newMetricsFlight[T any](key string) metricsFlight[T] {
+	return metricsFlight[T]{key: key}
+}
+
+// Do runs the collection at most once per in-flight request and hands
+// its result to every concurrent caller.
+//
+// The context bounds only the wait: a caller whose context expires
+// before the collection finishes is released with the context error,
+// and the collection itself runs to completion for its other waiters.
+func (m *metricsFlight[T]) Do(ctx context.Context, collect func() (T, error)) (T, error) {
+	m.mu.Lock()
+	if m.current == nil {
+		m.group.Forget(m.key)
+		m.current = make(chan struct{})
+	}
+	m.mu.Unlock()
+
+	channel := m.group.DoChan(m.key, func() (any, error) {
+		defer m.finishFlight()
+		return collect()
+	})
+
+	select {
+	case result := <-channel:
+		if result.Err != nil {
+			var zero T
+			return zero, result.Err
+		}
+		return result.Val.(T), nil
+	case <-ctx.Done():
+		var zero T
+		return zero, ctx.Err()
+	}
+}
+
+// Drain blocks until the in-flight collection has finished.
+//
+// A collection outlives the request handlers that joined it, so
+// releasing the memory its read still touches must wait for it.
+func (m *metricsFlight[T]) Drain() {
+	m.mu.Lock()
+	current := m.current
+	m.mu.Unlock()
+
+	if current != nil {
+		<-current
+	}
+}
+
+func (m *metricsFlight[T]) finishFlight() {
+	m.mu.Lock()
+	current := m.current
+	m.current = nil
+	m.mu.Unlock()
+
+	if current != nil {
+		close(current)
+	}
+}

--- a/modules/acl/controlplane/metrics_flight_test.go
+++ b/modules/acl/controlplane/metrics_flight_test.go
@@ -1,0 +1,773 @@
+package acl_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
+	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
+)
+
+// waiterContext signals through Parked when the waiter using it enters
+// the wait phase of a shared collection.
+//
+// The wait phase is entered only after the waiter has joined the
+// in-flight collection, so a test that releases the collection once
+// Parked has fired knows this waiter was served by that collection
+// rather than by a fresh one.
+type waiterContext struct {
+	context.Context
+
+	parkOnce sync.Once
+	parked   chan struct{}
+}
+
+func newWaiterContext(parent context.Context) *waiterContext {
+	return &waiterContext{Context: parent, parked: make(chan struct{})}
+}
+
+func (m *waiterContext) Done() <-chan struct{} {
+	m.parkOnce.Do(func() { close(m.parked) })
+	return m.Context.Done()
+}
+
+// Parked closes once the waiter has joined the in-flight collection.
+func (m *waiterContext) Parked() <-chan struct{} {
+	return m.parked
+}
+
+// readBlock gates one shared-memory read: the read announces itself and
+// then pauses until released.
+type readBlock struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+// blockingCounterSpyBackend pauses one module counter read of a scrape
+// and counts every read, so a test can prove that overlapping scrapes
+// shared a single flight of reads.
+type blockingCounterSpyBackend struct {
+	*fakeBackend
+
+	blockMu   sync.Mutex
+	nextBlock *readBlock
+	reads     int
+}
+
+func newBlockingCounterSpyBackend(dataplaneConfig *ffi.DPConfig) *blockingCounterSpyBackend {
+	backend := newFakeBackend()
+	backend.dpConfig = dataplaneConfig
+	return &blockingCounterSpyBackend{fakeBackend: backend}
+}
+
+// blockNextRead arms a one-shot pause for the next module counter read,
+// returning the read's entry signal and its release.
+func (m *blockingCounterSpyBackend) blockNextRead() (<-chan struct{}, func()) {
+	m.blockMu.Lock()
+	defer m.blockMu.Unlock()
+
+	block := &readBlock{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m.nextBlock = block
+
+	return block.entered, sync.OnceFunc(func() {
+		close(block.release)
+	})
+}
+
+// ModuleCounters pauses on the armed block, then returns a fixed
+// counter set for every position.
+func (m *blockingCounterSpyBackend) ModuleCounters(
+	dataplaneConfig *ffi.DPConfig,
+	position ffi.ModuleReference,
+	counterNames []string,
+) []ffi.CounterInfo {
+	m.blockMu.Lock()
+	m.reads++
+	block := m.nextBlock
+	m.nextBlock = nil
+	m.blockMu.Unlock()
+
+	if block != nil {
+		close(block.entered)
+		<-block.release
+	}
+
+	return []ffi.CounterInfo{
+		{Name: "rx", Values: [][]uint64{{1, 100}, {2, 200}}},
+		{Name: "tx", Values: [][]uint64{{3, 300}, {4, 400}}},
+		{Name: "drop", Values: [][]uint64{{5, 500}, {6, 600}}},
+		{Name: "pending_input", Values: [][]uint64{{7, 700}, {8, 800}}},
+		{Name: "pending_output", Values: [][]uint64{{9, 900}, {10, 1000}}},
+	}
+}
+
+// Reads returns the number of module counter reads observed so far.
+func (m *blockingCounterSpyBackend) Reads() int {
+	m.blockMu.Lock()
+	defer m.blockMu.Unlock()
+
+	return m.reads
+}
+
+// blockingRuleCounterBackend pauses rule-counter reads and feeds each
+// read from a test-supplied function of the read's ordinal, so a test
+// can pin sharing, freshness, and error delivery of the merged read.
+type blockingRuleCounterBackend struct {
+	*fakeBackend
+
+	blockMu   sync.Mutex
+	nextBlock *readBlock
+	reads     int
+	read      func(readIdx int) ([]ffi.CounterGroup, error)
+	lastTags  []ffi.CounterTag
+	lastQuery []string
+}
+
+func newBlockingRuleCounterBackend(
+	dataplaneConfig *ffi.DPConfig,
+	read func(readIdx int) ([]ffi.CounterGroup, error),
+) *blockingRuleCounterBackend {
+	backend := newFakeBackend()
+	backend.dpConfig = dataplaneConfig
+	return &blockingRuleCounterBackend{fakeBackend: backend, read: read}
+}
+
+// blockNextRead arms a one-shot pause for the next rule-counter read,
+// returning the read's entry signal and its release.
+func (m *blockingRuleCounterBackend) blockNextRead() (<-chan struct{}, func()) {
+	m.blockMu.Lock()
+	defer m.blockMu.Unlock()
+
+	block := &readBlock{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m.nextBlock = block
+
+	return block.entered, sync.OnceFunc(func() {
+		close(block.release)
+	})
+}
+
+// CountersByTags pauses on the armed block, then produces the data the
+// test assigned to this read's ordinal.
+func (m *blockingRuleCounterBackend) CountersByTags(
+	dataplaneConfig *ffi.DPConfig,
+	tags []ffi.CounterTag,
+	query []string,
+) ([]ffi.CounterGroup, error) {
+	m.blockMu.Lock()
+	readIdx := m.reads
+	m.reads++
+	m.lastTags = append([]ffi.CounterTag(nil), tags...)
+	m.lastQuery = append([]string(nil), query...)
+	block := m.nextBlock
+	m.nextBlock = nil
+	m.blockMu.Unlock()
+
+	if block != nil {
+		close(block.entered)
+		<-block.release
+	}
+
+	return m.read(readIdx)
+}
+
+// Reads returns the number of rule-counter reads observed so far.
+func (m *blockingRuleCounterBackend) Reads() int {
+	m.blockMu.Lock()
+	defer m.blockMu.Unlock()
+
+	return m.reads
+}
+
+// LastRead returns the tags and the name query of the most recent
+// rule-counter read.
+func (m *blockingRuleCounterBackend) LastRead() ([]ffi.CounterTag, []string) {
+	m.blockMu.Lock()
+	defer m.blockMu.Unlock()
+
+	return m.lastTags, m.lastQuery
+}
+
+// ruleCounterGroups builds two tagged rule-counter groups, one per
+// config name, whose counters carry the given nonzero packet and byte
+// totals so zero-suppression keeps every counter.
+func ruleCounterGroups(packets uint64) []ffi.CounterGroup {
+	return []ffi.CounterGroup{
+		{
+			Tags: []ffi.CounterTag{
+				{Key: "module_name", Value: "acl0"},
+				{Key: "device", Value: "port0"},
+				{Key: "pipeline", Value: "pipeline0"},
+				{Key: "function", Value: "function0"},
+				{Key: "chain", Value: "chain0"},
+			},
+			Counters: []ffi.CounterInfo{
+				{Name: "rule_a", Values: [][]uint64{{packets, packets * 10}}},
+			},
+		},
+		{
+			Tags: []ffi.CounterTag{
+				{Key: "module_name", Value: "acl1"},
+				{Key: "device", Value: "port1"},
+				{Key: "pipeline", Value: "pipeline1"},
+				{Key: "function", Value: "function1"},
+				{Key: "chain", Value: "chain1"},
+			},
+			Counters: []ffi.CounterInfo{
+				{Name: "rule_b", Values: [][]uint64{{packets, packets * 10}}},
+			},
+		},
+	}
+}
+
+// Test_ACLMetrics_ConcurrentScrapesShareOneCounterRead verifies that two
+// scrapes overlapping on the structural counter family share one flight
+// of position reads and receive equal metric sets.
+func Test_ACLMetrics_ConcurrentScrapesShareOneCounterRead(t *testing.T) {
+	_, agent := newMetricsSnapshotHarness(t)
+	backend := newBlockingCounterSpyBackend(agent.DPConfig())
+	service := acl.NewACLService(backend)
+
+	entered, release := backend.blockNextRead()
+	t.Cleanup(release)
+
+	var group errgroup.Group
+	var first, second []*commonpb.Metric
+	group.Go(func() error {
+		collected, err := service.Metrics(t.Context())
+		first = collected
+		return err
+	})
+
+	select {
+	case <-entered:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("first scrape did not reach the blocked counter read")
+	}
+
+	waiterCtx := newWaiterContext(t.Context())
+	group.Go(func() error {
+		collected, err := service.Metrics(waiterCtx)
+		second = collected
+		return err
+	})
+
+	select {
+	case <-waiterCtx.Parked():
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("second scrape did not join the in-flight collection")
+	}
+
+	release()
+	require.NoError(t, group.Wait())
+
+	require.Equal(t, first, second)
+	require.Equal(t, 5, backend.Reads())
+}
+
+// Test_ACLMetrics_ConcurrentRuleScrapesShareOneCounterRead verifies that
+// two rule scrapes with different selectors share one read and each
+// receives its own selection of the same values.
+func Test_ACLMetrics_ConcurrentRuleScrapesShareOneCounterRead(t *testing.T) {
+	_, agent := newMetricsSnapshotHarness(t)
+	backend := newBlockingRuleCounterBackend(agent.DPConfig(), func(readIdx int) ([]ffi.CounterGroup, error) {
+		return ruleCounterGroups(7), nil
+	})
+	service := acl.NewACLService(backend)
+
+	entered, release := backend.blockNextRead()
+	t.Cleanup(release)
+
+	var group errgroup.Group
+	var all, selected []*commonpb.Metric
+	group.Go(func() error {
+		collected, err := service.RuleMetrics(t.Context(), &aclpb.GetMetricsRulesRequest{})
+		all = collected
+		return err
+	})
+
+	select {
+	case <-entered:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("first rule scrape did not reach the blocked counter read")
+	}
+
+	waiterCtx := newWaiterContext(t.Context())
+	group.Go(func() error {
+		collected, err := service.RuleMetrics(waiterCtx, &aclpb.GetMetricsRulesRequest{Config: "acl0"})
+		selected = collected
+		return err
+	})
+
+	select {
+	case <-waiterCtx.Parked():
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("second rule scrape did not join the in-flight collection")
+	}
+
+	release()
+	require.NoError(t, group.Wait())
+
+	require.Equal(t, 1, backend.Reads())
+	tags, query := backend.LastRead()
+	require.Equal(t, []ffi.CounterTag{
+		{Key: "module_type", Value: "acl"},
+		{Key: "kind", Value: "runtime"},
+	}, tags)
+	require.Empty(t, query)
+
+	fullPackets := findMetricWithLabels(
+		all,
+		"acl_rule_packets",
+		map[string]string{"config": "acl0", "counter": "rule_a"},
+	)
+	require.NotNil(t, fullPackets, "unrestricted scrape must carry both configs")
+	selectedPackets := findMetricWithLabels(
+		selected,
+		"acl_rule_packets",
+		map[string]string{"config": "acl0", "counter": "rule_a"},
+	)
+	require.NotNil(t, selectedPackets)
+	require.Equal(t, fullPackets.GetCounter(), selectedPackets.GetCounter())
+	require.Nil(t, findMetricWithLabels(
+		selected,
+		"acl_rule_packets",
+		map[string]string{"config": "acl1", "counter": "rule_b"},
+	), "selected scrape must drop the unselected config")
+}
+
+// Test_ACLMetrics_RequestAfterCompletedFlightStartsNewRead verifies that
+// a rule scrape arriving after a completed flight starts a fresh read
+// instead of reusing the earlier result.
+func Test_ACLMetrics_RequestAfterCompletedFlightStartsNewRead(t *testing.T) {
+	_, agent := newMetricsSnapshotHarness(t)
+	backend := newBlockingRuleCounterBackend(agent.DPConfig(), func(readIdx int) ([]ffi.CounterGroup, error) {
+		return ruleCounterGroups(uint64(10 * (readIdx + 1))), nil
+	})
+	service := acl.NewACLService(backend)
+
+	first, err := service.RuleMetrics(t.Context(), &aclpb.GetMetricsRulesRequest{})
+	require.NoError(t, err)
+	second, err := service.RuleMetrics(t.Context(), &aclpb.GetMetricsRulesRequest{})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, backend.Reads())
+	firstPackets := findMetricWithLabels(
+		first,
+		"acl_rule_packets",
+		map[string]string{"config": "acl0", "counter": "rule_a"},
+	)
+	require.NotNil(t, firstPackets)
+	require.Equal(t, uint64(10), firstPackets.GetCounter())
+	secondPackets := findMetricWithLabels(
+		second,
+		"acl_rule_packets",
+		map[string]string{"config": "acl0", "counter": "rule_a"},
+	)
+	require.NotNil(t, secondPackets)
+	require.Equal(t, uint64(20), secondPackets.GetCounter())
+}
+
+// Test_ACLMetrics_ErrorReachesAllWaiters verifies that a failed merged
+// read reaches every overlapping scraper as the same internal error.
+func Test_ACLMetrics_ErrorReachesAllWaiters(t *testing.T) {
+	_, agent := newMetricsSnapshotHarness(t)
+	backend := newBlockingRuleCounterBackend(agent.DPConfig(), func(readIdx int) ([]ffi.CounterGroup, error) {
+		return nil, errors.New("counter read failed")
+	})
+	service := acl.NewACLService(backend)
+
+	entered, release := backend.blockNextRead()
+	t.Cleanup(release)
+
+	scraper := func(ctx context.Context) func() error {
+		return func() error {
+			_, err := service.RuleMetrics(ctx, &aclpb.GetMetricsRulesRequest{})
+			return err
+		}
+	}
+
+	var group errgroup.Group
+	failures := make(chan error, 2)
+	group.Go(func() error {
+		failures <- scraper(t.Context())()
+		return nil
+	})
+
+	select {
+	case <-entered:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("first rule scrape did not reach the blocked counter read")
+	}
+
+	waiterCtx := newWaiterContext(t.Context())
+	group.Go(func() error {
+		failures <- scraper(waiterCtx)()
+		return nil
+	})
+
+	select {
+	case <-waiterCtx.Parked():
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("second rule scrape did not join the in-flight collection")
+	}
+
+	release()
+	require.NoError(t, group.Wait())
+	close(failures)
+
+	require.Equal(t, 1, backend.Reads())
+	var firstErr, secondErr error
+	for failure := range failures {
+		if firstErr == nil {
+			firstErr = failure
+		} else {
+			secondErr = failure
+		}
+	}
+	require.Error(t, firstErr)
+	require.Error(t, secondErr)
+	require.Equal(t, codes.Internal, status.Code(firstErr))
+	require.Equal(t, codes.Internal, status.Code(secondErr))
+	require.Equal(t, firstErr.Error(), secondErr.Error())
+}
+
+// Test_ACLService_DrainMetricsReads_WaitsForInFlightCollection verifies
+// that draining blocks until a collection abandoned by a cancelled
+// waiter finishes, so the release waiting behind it cannot unmap memory
+// under the read.
+func Test_ACLService_DrainMetricsReads_WaitsForInFlightCollection(t *testing.T) {
+	_, agent := newMetricsSnapshotHarness(t)
+	backend := newBlockingRuleCounterBackend(agent.DPConfig(), func(readIdx int) ([]ffi.CounterGroup, error) {
+		return ruleCounterGroups(7), nil
+	})
+	service := acl.NewACLService(backend)
+
+	entered, release := backend.blockNextRead()
+	t.Cleanup(release)
+
+	type ruleResult struct {
+		metrics []*commonpb.Metric
+		err     error
+	}
+	leaderDone := make(chan ruleResult, 1)
+	go func() {
+		collected, err := service.RuleMetrics(t.Context(), &aclpb.GetMetricsRulesRequest{})
+		leaderDone <- ruleResult{metrics: collected, err: err}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("leader scrape did not reach the blocked counter read")
+	}
+
+	waiterParent, cancelWaiter := context.WithCancel(t.Context())
+	t.Cleanup(cancelWaiter)
+	waiterCtx := newWaiterContext(waiterParent)
+	waiterDone := make(chan error, 1)
+	go func() {
+		_, err := service.RuleMetrics(waiterCtx, &aclpb.GetMetricsRulesRequest{})
+		waiterDone <- err
+	}()
+
+	select {
+	case <-waiterCtx.Parked():
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("abandoned scraper did not join the in-flight collection")
+	}
+
+	cancelWaiter()
+	select {
+	case err := <-waiterDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("abandoned scraper did not return")
+	}
+
+	drainDone := make(chan struct{})
+	go func() {
+		service.DrainMetricsReads()
+		close(drainDone)
+	}()
+
+	select {
+	case <-drainDone:
+		t.Fatal("drain returned while the collection was still blocked")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+
+	select {
+	case <-drainDone:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("drain did not return after the collection finished")
+	}
+
+	var leader ruleResult
+	select {
+	case leader = <-leaderDone:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("leader scrape did not finish after the release")
+	}
+	require.NoError(t, leader.err)
+	require.Len(t, leader.metrics, 4)
+}
+
+// Test_ACLMetrics_CancelledWaiterDoesNotAbortFlight verifies that
+// cancelling one waiter neither aborts the shared read nor leaves its
+// result behind for the next scraper.
+func Test_ACLMetrics_CancelledWaiterDoesNotAbortFlight(t *testing.T) {
+	_, agent := newMetricsSnapshotHarness(t)
+	backend := newBlockingRuleCounterBackend(agent.DPConfig(), func(readIdx int) ([]ffi.CounterGroup, error) {
+		return ruleCounterGroups(7), nil
+	})
+	service := acl.NewACLService(backend)
+
+	entered, release := backend.blockNextRead()
+	t.Cleanup(release)
+
+	type ruleResult struct {
+		metrics []*commonpb.Metric
+		err     error
+	}
+	leaderDone := make(chan ruleResult, 1)
+	go func() {
+		collected, err := service.RuleMetrics(t.Context(), &aclpb.GetMetricsRulesRequest{})
+		leaderDone <- ruleResult{metrics: collected, err: err}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("leader scrape did not reach the blocked counter read")
+	}
+
+	waiterParent, cancelWaiter := context.WithCancel(t.Context())
+	t.Cleanup(cancelWaiter)
+	waiterCtx := newWaiterContext(waiterParent)
+	waiterDone := make(chan error, 1)
+	go func() {
+		_, err := service.RuleMetrics(waiterCtx, &aclpb.GetMetricsRulesRequest{})
+		waiterDone <- err
+	}()
+
+	select {
+	case <-waiterCtx.Parked():
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("cancellable scraper did not join the in-flight collection")
+	}
+
+	cancelWaiter()
+	select {
+	case err := <-waiterDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("cancelled scraper did not return")
+	}
+
+	release()
+
+	var leader ruleResult
+	select {
+	case leader = <-leaderDone:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("leader scrape did not finish after the release")
+	}
+	require.NoError(t, leader.err)
+	require.Len(t, leader.metrics, 4)
+	require.NotNil(t, findMetricWithLabels(
+		leader.metrics,
+		"acl_rule_packets",
+		map[string]string{"config": "acl0", "counter": "rule_a"},
+	), "leader scrape must receive the full result")
+
+	third, err := service.RuleMetrics(t.Context(), &aclpb.GetMetricsRulesRequest{})
+	require.NoError(t, err)
+	require.Equal(t, 2, backend.Reads())
+	require.NotNil(t, findMetricWithLabels(
+		third,
+		"acl_rule_packets",
+		map[string]string{"config": "acl0", "counter": "rule_a"},
+	), "post-completion scrape must run a fresh read")
+}
+
+// Test_ACLMetrics_RulesCountersShareRuleScrapeRead verifies that a
+// rules-counters request overlapping a rule scrape joins its in-flight
+// read instead of starting a second one, and filters the shared result
+// on its own.
+func Test_ACLMetrics_RulesCountersShareRuleScrapeRead(t *testing.T) {
+	_, agent := newMetricsSnapshotHarness(t)
+	backend := newBlockingRuleCounterBackend(agent.DPConfig(), func(readIdx int) ([]ffi.CounterGroup, error) {
+		return ruleCounterGroups(7), nil
+	})
+	service := acl.NewACLService(backend)
+
+	entered, release := backend.blockNextRead()
+	t.Cleanup(release)
+
+	var group errgroup.Group
+	rulesDone := make(chan []*commonpb.Metric, 1)
+	group.Go(func() error {
+		collected, err := service.RuleMetrics(t.Context(), &aclpb.GetMetricsRulesRequest{})
+		rulesDone <- collected
+		return err
+	})
+
+	select {
+	case <-entered:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("rule scrape did not reach the blocked counter read")
+	}
+
+	waiterCtx := newWaiterContext(t.Context())
+	countersDone := make(chan []*aclpb.RuleCounter, 1)
+	group.Go(func() error {
+		response, err := service.GetRulesCounters(waiterCtx, &aclpb.GetRulesCountersRequest{})
+		if err != nil {
+			return err
+		}
+		countersDone <- response.GetCounters()
+		return nil
+	})
+
+	select {
+	case <-waiterCtx.Parked():
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("rules-counters request did not join the in-flight read")
+	}
+
+	release()
+	require.NoError(t, group.Wait())
+
+	require.Equal(t, 1, backend.Reads())
+	tags, query := backend.LastRead()
+	require.Equal(t, []ffi.CounterTag{
+		{Key: "module_type", Value: "acl"},
+		{Key: "kind", Value: "runtime"},
+	}, tags)
+	require.Empty(t, query)
+
+	rules := <-rulesDone
+	require.NotNil(t, findMetricWithLabels(
+		rules,
+		"acl_rule_packets",
+		map[string]string{"config": "acl0", "counter": "rule_a"},
+	), "rule scrape must receive the full result")
+
+	counters := <-countersDone
+	require.Len(t, counters, 2)
+	first := counters[0]
+	require.Equal(t, "acl0", first.GetConfig())
+	require.Equal(t, "port0", first.GetDevice())
+	require.Equal(t, "pipeline0", first.GetPipeline())
+	require.Equal(t, "function0", first.GetFunction())
+	require.Equal(t, "chain0", first.GetChain())
+	require.Equal(t, "rule_a", first.GetCounter())
+	require.Equal(t, uint64(7), first.GetPackets())
+	require.Equal(t, uint64(70), first.GetBytes())
+}
+
+// Test_ACLMetrics_RuleMetricsRejectsUncarriableSelector verifies that a
+// selector value the counter-tag fields cannot carry is rejected as an
+// invalid argument before any shared-memory read.
+func Test_ACLMetrics_RuleMetricsRejectsUncarriableSelector(t *testing.T) {
+	_, agent := newMetricsSnapshotHarness(t)
+	backend := newBlockingRuleCounterBackend(agent.DPConfig(), func(readIdx int) ([]ffi.CounterGroup, error) {
+		return ruleCounterGroups(7), nil
+	})
+	service := acl.NewACLService(backend)
+
+	requests := map[string]*aclpb.GetMetricsRulesRequest{
+		"nul byte in config": {Config: "acl\x00"},
+		"overlong device":    {Device: strings.Repeat("a", 80)},
+	}
+	for name, request := range requests {
+		t.Run(name, func(t *testing.T) {
+			_, err := service.RuleMetrics(t.Context(), request)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+			require.Contains(t, err.Error(), "invalid counter tag")
+		})
+	}
+
+	require.Equal(t, 0, backend.Reads(), "rejected selectors must not reach the shared read")
+}
+
+// Test_ACLService_DrainMetricsReads_WaitsForRulesCounters verifies that
+// the drain also blocks behind a rules-counters request's shared read,
+// so the release waiting behind it cannot unmap memory under the read.
+func Test_ACLService_DrainMetricsReads_WaitsForRulesCounters(t *testing.T) {
+	_, agent := newMetricsSnapshotHarness(t)
+	backend := newBlockingRuleCounterBackend(agent.DPConfig(), func(readIdx int) ([]ffi.CounterGroup, error) {
+		return ruleCounterGroups(7), nil
+	})
+	service := acl.NewACLService(backend)
+
+	entered, release := backend.blockNextRead()
+	t.Cleanup(release)
+
+	type countersResult struct {
+		counters []*aclpb.RuleCounter
+		err      error
+	}
+	leaderDone := make(chan countersResult, 1)
+	go func() {
+		response, err := service.GetRulesCounters(t.Context(), &aclpb.GetRulesCountersRequest{})
+		var counters []*aclpb.RuleCounter
+		if err == nil {
+			counters = response.GetCounters()
+		}
+		leaderDone <- countersResult{counters: counters, err: err}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("rules-counters request did not reach the blocked counter read")
+	}
+
+	drainDone := make(chan struct{})
+	go func() {
+		service.DrainMetricsReads()
+		close(drainDone)
+	}()
+
+	select {
+	case <-drainDone:
+		t.Fatal("drain returned while the rules-counters read was still blocked")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+
+	select {
+	case <-drainDone:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("drain did not return after the rules-counters read finished")
+	}
+
+	select {
+	case leader := <-leaderDone:
+		require.NoError(t, leader.err)
+		require.Len(t, leader.counters, 2)
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("rules-counters request did not finish after the release")
+	}
+}

--- a/modules/acl/controlplane/metrics_test.go
+++ b/modules/acl/controlplane/metrics_test.go
@@ -1,6 +1,7 @@
 package acl_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -61,12 +62,12 @@ func (m *counterSpyBackend) CounterReads() []counterRead {
 	return append([]counterRead(nil), m.counterReads...)
 }
 
-func (m *spyMetricsSource) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
+func (m *spyMetricsSource) Metrics(ctx context.Context, tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
 	m.receivedTags = tags
 	return m.metrics, nil
 }
 
-func (m *spyMetricsSource) RuleMetrics(req *aclpb.GetMetricsRulesRequest) ([]*commonpb.Metric, error) {
+func (m *spyMetricsSource) RuleMetrics(ctx context.Context, req *aclpb.GetMetricsRulesRequest) ([]*commonpb.Metric, error) {
 	m.receivedRule = req
 	return m.ruleMetrics, nil
 }
@@ -89,7 +90,7 @@ func Test_ACLMetrics_UntaggedScrapeUsesBoundedGenericCounters(t *testing.T) {
 	})
 	service := acl.NewACLService(backend)
 
-	collected, err := service.Metrics()
+	collected, err := service.Metrics(t.Context())
 	require.NoError(t, err)
 
 	expectedQuery := []string{

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -124,5 +124,8 @@ func (m *ACLModule) UnaryServerInterceptors() []grpc.UnaryServerInterceptor {
 }
 
 func (m *ACLModule) Close() error {
+	// In-flight metric collections read the shared memory outside the
+	// drained request handlers; wait for them before releasing it.
+	m.aclService.DrainMetricsReads()
 	return errors.Join(m.agent.Close(), m.shm.Detach())
 }

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -222,6 +222,15 @@ type ACLService struct {
 
 	metricsState *aclMetricsState
 
+	// moduleMetricsFlight coalesces concurrent structural counter
+	// scrapes into one shared collection of per-position reads, run
+	// outside the service mutex like every shared-memory read.
+	moduleMetricsFlight metricsFlight[[]*commonpb.Metric]
+	// ruleMetricsFlight coalesces concurrent per-rule counter reads of
+	// both rule RPCs into one shared-memory read, equally outside the
+	// service mutex.
+	ruleMetricsFlight metricsFlight[[]ffi.CounterGroup]
+
 	// deferred holds superseded acl configs whose free was refused
 	// because a live configuration generation still referenced them.
 	// This service is their owner: it retries them on its next update,
@@ -239,10 +248,12 @@ func NewACLService(backend Backend, options ...Option) *ACLService {
 	}
 
 	m := &ACLService{
-		backend:      backend,
-		configs:      map[string]*configEntry{},
-		metricsState: newACLMetricsState(),
-		log:          opts.Log,
+		backend:             backend,
+		configs:             map[string]*configEntry{},
+		metricsState:        newACLMetricsState(),
+		moduleMetricsFlight: newMetricsFlight[[]*commonpb.Metric]("module_metrics"),
+		ruleMetricsFlight:   newMetricsFlight[[]ffi.CounterGroup]("rule_metrics"),
+		log:                 opts.Log,
 	}
 	if opts.Metrics != nil {
 		m.metrics = opts.Metrics(m.retention)
@@ -805,6 +816,8 @@ func (m *ACLService) DeleteConfig(
 // GetRulesCounters returns the per-rule counters of the named config, or of
 // every config when the request names none.
 //
+// The counters come from the same merged read the rule metrics scrape
+// uses, so the two requests never read the family concurrently.
 // Counters whose packets and bytes are both zero across all workers are
 // omitted, matching the metrics read.
 func (m *ACLService) GetRulesCounters(
@@ -827,55 +840,48 @@ func (m *ACLService) GetRulesCounters(
 		return &aclpb.GetRulesCountersResponse{}, nil
 	}
 
+	groups, err := m.readRuleCounterGroups(ctx, dpConfig)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		return nil, status.Errorf(
+			codes.Internal, "failed to read rule counters: %v", err,
+		)
+	}
+
 	result := make([]*aclpb.RuleCounter, 0)
-	for pos := range dpConfig.AllModulePositions(moduleType) {
-		if name != "" && pos.ModuleName != name {
+	for _, group := range groups {
+		location := groupLocation(group.Tags)
+		if name != "" && location["module_name"] != name {
 			continue
 		}
 
-		// Runtime-kind storages expand exactly the module's per-rule
-		// registries, so this read excludes the predefined module
-		// counters (rx, tx, acl_action_*, ...) by construction.
-		groups, err := dpConfig.CountersByTags([]ffi.CounterTag{
-			{Key: "device", Value: pos.Device},
-			{Key: "pipeline", Value: pos.Pipeline},
-			{Key: "function", Value: pos.Function},
-			{Key: "chain", Value: pos.Chain},
-			{Key: "module_type", Value: moduleType},
-			{Key: "module_name", Value: pos.ModuleName},
-			{Key: "kind", Value: "runtime"},
-		}, nil)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to read rule counters of config %q: %v", pos.ModuleName, err)
-		}
-
-		for _, group := range groups {
-			for _, counter := range group.Counters {
-				var packets, bytes uint64
-				for _, workerVals := range counter.Values {
-					if len(workerVals) > 0 {
-						packets += workerVals[0]
-					}
-					if len(workerVals) > 1 {
-						bytes += workerVals[1]
-					}
+		for _, counter := range group.Counters {
+			var packets, bytes uint64
+			for _, workerVals := range counter.Values {
+				if len(workerVals) > 0 {
+					packets += workerVals[0]
 				}
-
-				if packets == 0 && bytes == 0 {
-					continue
+				if len(workerVals) > 1 {
+					bytes += workerVals[1]
 				}
-
-				result = append(result, &aclpb.RuleCounter{
-					Config:   pos.ModuleName,
-					Device:   pos.Device,
-					Pipeline: pos.Pipeline,
-					Function: pos.Function,
-					Chain:    pos.Chain,
-					Counter:  counter.Name,
-					Packets:  packets,
-					Bytes:    bytes,
-				})
 			}
+
+			if packets == 0 && bytes == 0 {
+				continue
+			}
+
+			result = append(result, &aclpb.RuleCounter{
+				Config:   location["module_name"],
+				Device:   location["device"],
+				Pipeline: location["pipeline"],
+				Function: location["function"],
+				Chain:    location["chain"],
+				Counter:  counter.Name,
+				Packets:  packets,
+				Bytes:    bytes,
+			})
 		}
 	}
 

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -1306,7 +1306,7 @@ func TestMetrics_DoesNotWaitForUpdateConfig(t *testing.T) {
 	}
 	metricsDone := make(chan metricsResult, 1)
 	go func() {
-		collected, metricsErr := svc.Metrics()
+		collected, metricsErr := svc.Metrics(t.Context())
 		metricsDone <- metricsResult{count: len(collected), err: metricsErr}
 	}()
 
@@ -1347,7 +1347,7 @@ func TestMetricsSnapshotTracksConfigLifecycle(t *testing.T) {
 	}
 	metricsDone := make(chan metricsResult, 1)
 	go func() {
-		collected, metricsErr := svc.Metrics()
+		collected, metricsErr := svc.Metrics(t.Context())
 		metricsDone <- metricsResult{metrics: collected, err: metricsErr}
 	}()
 
@@ -1387,7 +1387,7 @@ func TestMetricsSnapshotTracksConfigLifecycle(t *testing.T) {
 	require.NotNil(t, ruleCount)
 	assert.Equal(t, float64(7), ruleCount.GetGauge())
 
-	afterDelete, err := svc.Metrics()
+	afterDelete, err := svc.Metrics(t.Context())
 	require.NoError(t, err)
 	assert.Nil(t, findMetricWithLabels(
 		afterDelete,
@@ -1437,7 +1437,7 @@ func TestMetricsSnapshotOrderingSurvivesConcurrentBarrage(t *testing.T) {
 		wantNames[name] = struct{}{}
 	}
 
-	collected, err := svc.Metrics()
+	collected, err := svc.Metrics(t.Context())
 	require.NoError(t, err)
 	gotNames := map[string]struct{}{}
 	for _, metric := range collected {

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -1203,7 +1203,7 @@ func TestACL_Counters(t *testing.T) {
 		ruleCounters := dataplaneut.RuleCounters(t, h, path, []string{"svc_counter"})
 		require.Len(t, ruleCounters, 1)
 
-		collected, err := svc.Metrics()
+		collected, err := svc.Metrics(t.Context())
 		require.NoError(t, err)
 		metricNames := make(map[string]struct{}, len(collected))
 		for _, metric := range collected {
@@ -1213,7 +1213,7 @@ func TestACL_Counters(t *testing.T) {
 		require.NotContains(t, metricNames, "acl_rule_bytes")
 		require.Contains(t, metricNames, "acl_action_allow_packets")
 
-		ruleMetrics, err := svc.RuleMetrics(&aclpb.GetMetricsRulesRequest{})
+		ruleMetrics, err := svc.RuleMetrics(t.Context(), &aclpb.GetMetricsRulesRequest{})
 		require.NoError(t, err)
 
 		byName := make(map[string]*commonpb.Metric, len(ruleMetrics))
@@ -1241,7 +1241,7 @@ func TestACL_Counters(t *testing.T) {
 		ruleMetricNames := func(req *aclpb.GetMetricsRulesRequest) []string {
 			t.Helper()
 
-			got, err := svc.RuleMetrics(req)
+			got, err := svc.RuleMetrics(t.Context(), req)
 			require.NoError(t, err)
 
 			names := make([]string, 0, len(got))


### PR DESCRIPTION
- At most one shared-memory read per metric family is in flight at a time: both rule RPCs (the rule metrics scrape and the rules-counters dump) share one merged read, concurrent requests join it and all receive the same result, and a request arriving after a completed read starts a fresh one.
- Rule-metrics selector pushdown is replaced by Go-side filtering on the shared result, with output identical to the pushed-down queries; a selector the fixed-size counter-tag fields cannot carry is still rejected as an invalid argument before any read.
- A cancelled waiter returns an error while the read completes for the remaining waiters; module close drains every in-flight read of both families before releasing the shared memory.
- Tagged module-metrics queries that previously skipped the counter read now always perform the shared position read once per scrape round.
- Closes #1924.
- #2403 tracks confirming the external scrape interval.