### PR TITLE
feat(common,acl,fwstate): add the agent extend endpoint

### DIFF
--- a/common/commonpb/meson.build
+++ b/common/commonpb/meson.build
@@ -4,6 +4,7 @@ root_dir = meson.project_source_root()
 common_proto_files = [
     join_paths(common_proto_dir, 'v1', 'target.proto'),
     join_paths(common_proto_dir, 'v1', 'metric.proto'),
+    join_paths(common_proto_dir, 'v1', 'extend.proto'),
     join_paths(common_proto_dir, 'v1', 'macaddr.proto'),
     join_paths(common_proto_dir, 'v1', 'ipaddr.proto'),
     join_paths(common_proto_dir, 'v1', 'ipv4addr.proto'),
@@ -25,6 +26,7 @@ common_protoc_gen = custom_target(
     output: [
         'target.pb.go',
         'metric.pb.go',
+        'extend.pb.go',
         'macaddr.pb.go',
         'ipaddr.pb.go',
         'ipv4addr.pb.go',

--- a/common/commonpb/v1/extend.proto
+++ b/common/commonpb/v1/extend.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package common.commonpb.v1;
+
+option go_package = "github.com/yanet-platform/yanet2/common/commonpb/v1;commonpb";
+
+// Request to grow the agent memory a module was started with, without
+// restarting it.
+message ExtendRequest {
+  // How much memory to add, in bytes.
+  uint64 size = 1;
+}
+
+message ExtendResponse {
+  // The memory the agent holds once the call returns, in bytes. At least
+  // the increment above what it held, since the allocator hands out whole
+  // blocks.
+  uint64 memory_limit = 1;
+}

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -24,12 +24,15 @@ const SERDE_MESSAGES: &[&str] = &[
     ".common.commonpb.v1.Label",
     ".common.commonpb.v1.Histogram",
     ".common.commonpb.v1.Bucket",
+    ".common.commonpb.v1.ExtendRequest",
+    ".common.commonpb.v1.ExtendResponse",
     ".common.commonpb.v1.IPRange",
 ];
 
 pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=common/commonpb/v1/target.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/metric.proto");
+    println!("cargo:rerun-if-changed=common/commonpb/v1/extend.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/macaddr.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipaddr.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipv4addr.proto");
@@ -62,6 +65,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         &[
             "common/commonpb/v1/target.proto",
             "common/commonpb/v1/metric.proto",
+            "common/commonpb/v1/extend.proto",
             "common/commonpb/v1/macaddr.proto",
             "common/commonpb/v1/ipaddr.proto",
             "common/commonpb/v1/ipv4addr.proto",

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -6,6 +6,7 @@ import "common/filterpb/v1/filter.proto";
 import "common/commonpb/v1/ipv4network.proto";
 import "common/commonpb/v1/ipv6network.proto";
 import "common/commonpb/v1/metric.proto";
+import "common/commonpb/v1/extend.proto";
 import "common/commonpb/v1/ipaddr.proto";
 import "common/commonpb/v1/macaddr.proto";
 
@@ -24,6 +25,14 @@ service ACLService {
   rpc ListConfigs(ListConfigsRequest) returns (ListConfigsResponse);
   // Returns per-rule counters of ACL configurations
   rpc GetRulesCounters(GetRulesCountersRequest) returns (GetRulesCountersResponse);
+}
+
+// ExtendService grows the memory of the agent this module writes its
+// configurations into.
+service ExtendService {
+  // Extend grows the agent by the requested size and reports the limit
+  // it reached.
+  rpc Extend(common.commonpb.v1.ExtendRequest) returns (common.commonpb.v1.ExtendResponse);
 }
 
 // MetricsService exposes ACL module metrics.

--- a/modules/acl/controlplane/extend.go
+++ b/modules/acl/controlplane/extend.go
@@ -1,0 +1,70 @@
+package acl
+
+import (
+	"context"
+
+	"github.com/c2h5oh/datasize"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
+)
+
+// ExtendService grows the ACL agent under the module's own service name,
+// which is what makes a call reach this module's agent and not another's.
+type ExtendService struct {
+	aclpb.UnimplementedExtendServiceServer
+
+	agent *ffi.Agent
+	log   *zap.Logger
+}
+
+func NewExtendService(agent *ffi.Agent, options ...Option) *ExtendService {
+	opts := newOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	return &ExtendService{
+		agent: agent,
+		log:   opts.Log,
+	}
+}
+
+// Extend grows the agent by the requested size and reports the limit it
+// reached, leaving the module on its current configuration when refused.
+func (m *ExtendService) Extend(
+	ctx context.Context,
+	req *commonpb.ExtendRequest,
+) (*commonpb.ExtendResponse, error) {
+	size := datasize.ByteSize(req.GetSize())
+	if size == 0 {
+		return nil, status.Error(codes.InvalidArgument, "requested size is required")
+	}
+
+	if err := m.agent.Extend(size); err != nil {
+		m.log.Error("failed to grow agent memory",
+			zap.Stringer("requested", size),
+			zap.Error(err),
+		)
+
+		return nil, status.Errorf(
+			codes.ResourceExhausted,
+			"failed to grow agent memory by %s: %v",
+			size,
+			err,
+		)
+	}
+
+	limit := m.agent.MemoryLimit()
+
+	m.log.Info("grew agent memory",
+		zap.Stringer("requested", size),
+		zap.Stringer("memory_limit", limit),
+	)
+
+	return &commonpb.ExtendResponse{MemoryLimit: uint64(limit)}, nil
+}

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -46,6 +46,7 @@ type ACLModule struct {
 	agent          *ffi.Agent
 	aclService     *ACLService
 	metricsService *MetricsService
+	extendService  *ExtendService
 }
 
 // NewACLModule creates a new ACL module instance.
@@ -85,12 +86,15 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 
 	metricsService := NewMetricsService(aclService)
 
+	extendService := NewExtendService(agent, WithLog(log))
+
 	return &ACLModule{
 		cfg:            cfg,
 		shm:            shm,
 		agent:          agent,
 		aclService:     aclService,
 		metricsService: metricsService,
+		extendService:  extendService,
 	}, nil
 }
 
@@ -106,12 +110,14 @@ func (m *ACLModule) ServicesNames() []string {
 	return []string{
 		serviceName,
 		aclpb.MetricsService_ServiceDesc.ServiceName,
+		aclpb.ExtendService_ServiceDesc.ServiceName,
 	}
 }
 
 func (m *ACLModule) RegisterService(server *grpc.Server) {
 	aclpb.RegisterACLServiceServer(server, m.aclService)
 	aclpb.RegisterMetricsServiceServer(server, m.metricsService)
+	aclpb.RegisterExtendServiceServer(server, m.extendService)
 }
 
 // UnaryServerInterceptors returns the gRPC unary interceptors for this module.

--- a/modules/fwstate/controlplane/extend.go
+++ b/modules/fwstate/controlplane/extend.go
@@ -1,0 +1,71 @@
+package fwstate
+
+import (
+	"context"
+
+	"github.com/c2h5oh/datasize"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	fwstatepb "github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
+)
+
+// ExtendService grows the FWState agent under the module's own service
+// name, which is what makes a call reach this module's agent and not
+// another's.
+type ExtendService struct {
+	fwstatepb.UnimplementedExtendServiceServer
+
+	agent *ffi.Agent
+	log   *zap.Logger
+}
+
+func NewExtendService(agent *ffi.Agent, options ...Option) *ExtendService {
+	opts := newOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	return &ExtendService{
+		agent: agent,
+		log:   opts.Log,
+	}
+}
+
+// Extend grows the agent by the requested size and reports the limit it
+// reached, leaving the module on its current configuration when refused.
+func (m *ExtendService) Extend(
+	ctx context.Context,
+	req *commonpb.ExtendRequest,
+) (*commonpb.ExtendResponse, error) {
+	size := datasize.ByteSize(req.GetSize())
+	if size == 0 {
+		return nil, status.Error(codes.InvalidArgument, "requested size is required")
+	}
+
+	if err := m.agent.Extend(size); err != nil {
+		m.log.Error("failed to grow agent memory",
+			zap.Stringer("requested", size),
+			zap.Error(err),
+		)
+
+		return nil, status.Errorf(
+			codes.ResourceExhausted,
+			"failed to grow agent memory by %s: %v",
+			size,
+			err,
+		)
+	}
+
+	limit := m.agent.MemoryLimit()
+
+	m.log.Info("grew agent memory",
+		zap.Stringer("requested", size),
+		zap.Stringer("memory_limit", limit),
+	)
+
+	return &commonpb.ExtendResponse{MemoryLimit: uint64(limit)}, nil
+}

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
@@ -5,6 +5,7 @@ package modules.fwstate.controlplane.fwstatepb.v1;
 import "common/commonpb/v1/ipaddr.proto";
 import "common/commonpb/v1/macaddr.proto";
 import "common/commonpb/v1/metric.proto";
+import "common/commonpb/v1/extend.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1;fwstatepb";
 
@@ -18,6 +19,14 @@ service FWStateService {
   rpc ShowConfig(ShowConfigRequest) returns (ShowConfigResponse);
   // List all FWState configurations across instances
   rpc ListConfigs(ListConfigsRequest) returns (ListConfigsResponse);
+}
+
+// ExtendService grows the memory of the agent this module writes its
+// configurations into.
+service ExtendService {
+  // Extend grows the agent by the requested size and reports the limit
+  // it reached.
+  rpc Extend(common.commonpb.v1.ExtendRequest) returns (common.commonpb.v1.ExtendResponse);
 }
 
 // MetricsService exposes FWState module metrics.

--- a/modules/fwstate/controlplane/mod.go
+++ b/modules/fwstate/controlplane/mod.go
@@ -26,6 +26,7 @@ type FWStateModule struct {
 	agent                 *ffi.Agent
 	fwstateService        *FWStateService
 	fwstateMetricsService *MetricsService
+	fwstateExtendService  *ExtendService
 	mapService            *fwstatemap.FWStateMapService
 }
 
@@ -76,12 +77,17 @@ func NewFWStateModule(cfg *Config, options ...Option) (*FWStateModule, error) {
 	// reachable through the module's metrics RPC.
 	fwstateMetricsService := NewMetricsService(fwstateService, mapService)
 
+	// The extend endpoint grows the one agent all three services above
+	// write into.
+	fwstateExtendService := NewExtendService(agent, WithLog(log))
+
 	return &FWStateModule{
 		cfg:                   cfg,
 		shm:                   shm,
 		agent:                 agent,
 		fwstateService:        fwstateService,
 		fwstateMetricsService: fwstateMetricsService,
+		fwstateExtendService:  fwstateExtendService,
 		mapService:            mapService,
 	}, nil
 }
@@ -98,6 +104,7 @@ func (m *FWStateModule) ServicesNames() []string {
 	return []string{
 		FWStateServiceName,
 		FWStateMetricsServiceName,
+		FWStateExtendServiceName,
 		fwstatemap.ServiceName,
 	}
 }
@@ -105,6 +112,7 @@ func (m *FWStateModule) ServicesNames() []string {
 func (m *FWStateModule) RegisterService(server *grpc.Server) {
 	fwstatepb.RegisterFWStateServiceServer(server, m.fwstateService)
 	fwstatepb.RegisterMetricsServiceServer(server, m.fwstateMetricsService)
+	fwstatepb.RegisterExtendServiceServer(server, m.fwstateExtendService)
 	m.mapService.Register(server)
 }
 

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -83,7 +83,8 @@ func NewMetricsFactory(extra ...grpcmetrics.Option) grpcmetrics.Factory {
 	opts = append(opts, grpcmetrics.WithServiceFilter(
 		func(service string) bool {
 			return service == FWStateServiceName ||
-				service == FWStateMetricsServiceName
+				service == FWStateMetricsServiceName ||
+				service == FWStateExtendServiceName
 		},
 	))
 	opts = append(opts, extra...)
@@ -99,15 +100,16 @@ const (
 	maxSyncPort uint32 = 65535
 )
 
-// FWStateServiceName and MetricsServiceName are the fully-qualified gRPC
-// service names exposed by this module, derived from the generated service
-// descriptors so they cannot drift from the proto definitions.
+// The fully-qualified gRPC service names exposed by this module, derived
+// from the generated service descriptors so they cannot drift from the
+// proto definitions.
 //
 // They are used to scope the module's [grpcmetrics.ServerMetrics] to its own
 // services when several modules share a single [grpc.Server].
 var (
 	FWStateServiceName        = fwstatepb.FWStateService_ServiceDesc.ServiceName
 	FWStateMetricsServiceName = fwstatepb.MetricsService_ServiceDesc.ServiceName
+	FWStateExtendServiceName  = fwstatepb.ExtendService_ServiceDesc.ServiceName
 )
 
 // Mutation phases report a goroutine before Lock, after Lock succeeds, and


### PR DESCRIPTION
Define the extend request and response once in common, beside the shared metric messages, so every module reuses the same wire types.
Serve the endpoint from ACL and FWState under each module's own service name, since the gateway routes by service name and one shared name could not tell the two agents apart.
Take an increment rather than a total, matching the operation underneath, so a repeated call grows the agent again instead of settling on a size.
Report the limit the agent reached, which is at least the increment above what it held, since the allocator hands out whole blocks.
Leave config updates unserialized against a grow: the arena data is never moved or freed, the block allocator guards its own free lists, and every reader of the agent's arena list already runs under the config lock.
Closes #2286.
