### PR TITLE
fix(cli): make the route family flags mutually exclusive

### DIFF
--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -157,7 +157,7 @@ pub struct FibUpdateCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct FibShowCmd {
     /// Show only IPv4 FIB entries.
-    #[arg(long, short = '4')]
+    #[arg(long, short = '4', conflicts_with = "ipv6")]
     pub ipv4: bool,
     /// Show only IPv6 FIB entries.
     #[arg(long, short = '6')]

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -75,7 +75,7 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RouteShowCmd {
     /// Show only IPv4 routes.
-    #[arg(long, short = '4')]
+    #[arg(long, short = '4', conflicts_with = "ipv6")]
     pub ipv4: bool,
     /// Show only IPv6 routes.
     #[arg(long, short = '6')]


### PR DESCRIPTION
- Make `--ipv4` and `--ipv6` mutually exclusive in `route fib show` and `operator route show`, so combining them is a usage error instead of an empty listing.

Closes #2346.
