### PR TITLE
feat(agents): add the code-cli skill

### DIFF
--- a/.agents/conventions/rust.md
+++ b/.agents/conventions/rust.md
@@ -7,11 +7,11 @@ Loaded on demand by the agent writing or reviewing Rust; this is the single sour
 - **`cargo fmt --all` also formats local path dependencies**, so it reaches outside the crate you think you are formatting. Scope it deliberately when the workspace pulls in path deps from another tree.
 - Proto compilation needs `protobuf-compiler` in CI.
 - **Proto crates**: tonic-include crates expose `pub mod pb`, never `pub mod <crate>`; consume shared `common/rust/` crates through `extern_path`.
+- **CLI crates**: the `code-cli` skill (`.agents/skills/code-cli/`) owns every CLI-specific rule — binary shape, arguments, output, errors, tests. Load it before touching `cli/`, `modules|devices|objects|operators/*/cli/` or `common/rust`.
 - **Orphan rule**: never implement a foreign trait for a foreign type. Give the CLI a local enum/wrapper, implement the foreign trait there, then `From<Local> for Foreign`; free functions are not a substitute.
 - **Visibility**: avoid `pub(crate)`; items are `pub` or private. Conceptual type API methods are `pub`, even in binaries.
 - **Wire vs domain types**: parse and check invariants in the domain type; wire types get `From<Domain>` and use `TryFrom` only when fallible. Confirm module-specific validation (ACL permits non-contiguous masks, forward/decap do not) before generalising.
 - **`Display`/`Serialize`**: own types implement `Display`; `Serialize` uses `serializer.collect_str(self)`. Never blanket-derive `Serialize` for a proto module with a manual implementation.
-- **`--format json` serializes the wire message itself.** A struct mirroring an in-crate `include_proto!` type holds only impls that type could carry — serialize the proto and `impl Tabled`/`Serialize` on it, computed cells and all. A local row is right only where the orphan rule above blocks that, for a wire type from a shared proto crate, or for a document schema that also parses a config file. Fix an unusable derived shape on the wire type via `impl Serialize`/`Display` or a `serialize_with` attribute in `build.rs`, owner-approved as the exception.
 - **`fmt` imports**: `use core::fmt::{self, Display, Formatter};` with explicit `Result<(), fmt::Error>` (not `fmt::Result` alias).
 - **`clippy::std_instead_of_core`** is deny-level via `[workspace.lints.clippy]` + per-crate `[lints] workspace = true`; prefer `core::` for anything `core` provides (`error::Error`, `fmt`, `net`, `str::FromStr`, `time::Duration`, `mem`, `iter`, `ops`).
 - **Escape hatches** are `#[allow(clippy::std_instead_of_core)]` on an enclosing item (function or module), never the `use` itself — clippy's `useless_attribute` rejects that: tonic's client codegen emits `std::` paths we do not control, and `core_io`-gated items (`io::ErrorKind`, `io::Cursor`) are still unstable in `core`.
@@ -21,5 +21,4 @@ Loaded on demand by the agent writing or reviewing Rust; this is the single sour
 - **`assert_eq!` order**: expected first, actual second: `assert_eq!(expected, actual)`.
 - **Style**: prefer shadowing to `_str`, destructure `self` rather than `self.0`, put bounds in `where`, and import types directly.
 - **Struct literals**: follow declaration order, including generated protos; rustfmt/clippy do not check this.
-- **Empty CLI results**: use `output::empty`/`empty_with_hint`, never bare printing or call-site format guards. The primitive owns the stderr marker, `No <subject> found.` register, and non-TTY/serializing suppression.
 - **Tests**: follow `.agents/conventions/tests.md` (naming `fn test_<what_to_test>_<case>`, one-brief `verifies that` doc comment, self-describing `#[case]` names). Reference: `modules/pdump/cli/src/printer.rs`.

--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: code-cli
+description: >-
+  How a yanet CLI binary (yanet-cli-*) is written: the clap derive shape,
+  typed arguments, the ync framework (connection, output, errors, exit codes,
+  completion), the verb and flag dictionary, human and JSON rendering and the
+  test policy. Load before creating or changing anything under cli/,
+  modules|devices|objects|operators/*/cli/ or common/rust, and when reviewing
+  such a diff.
+---
+
+# code-cli
+
+A CLI is a thin, typed front for one gRPC service: clap proves the form of
+every argument before a connection exists, the service owns every invariant,
+`ync` owns connection, output, errors and completion. `references/new-crate.md`
+has the manifest, `build.rs`, skeleton and registration steps for a new binary.
+
+## Shape
+
+- One crate per binary `yanet-cli-<suffix>`. `yanet-cli device <x>` and
+  `yanet-cli operator <x>` dispatch to `yanet-cli-device-<x>` /
+  `yanet-cli-operator-<x>` by name; the dispatcher needs no registration.
+- `Cmd`: `#[derive(Debug, Clone, Parser)]`, `#[command(version, about)]`,
+  `#[command(flatten_help = true)]`, fields `#[clap(subcommand)] mode: ModeCmd`,
+  `#[command(flatten)] connection: ConnectionArgs`, `--format`
+  (`CommonFormat`, `default_value = "human"`, `global = true`, doc
+  `Output format.`) and `-v` (`ArgAction::Count`, `global = true`, doc
+  `Be verbose: shows debug log lines and raw gRPC error details.`).
+- `fn main()` is synchronous: `CompleteEnv::with_factory(Cmd::command).complete();
+  start();`. `#[tokio::main(flavor = "current_thread")] async fn start()` parses,
+  calls `ync::init(cmd.verbose, cmd.format)` and ends with
+  `if let Err(err) = run(cmd).await { output::failure(&err);
+  std::process::exit(err.exit_code()); }`. Completion never runs inside the
+  runtime.
+- `run(cmd)` builds the service object once and matches `cmd.mode`; every
+  handler returns `Result<(), Error>`.
+- `const SERVICE_NAME: &str = "<proto package>.<Service>";` with the doc
+  `/// The fully-qualified gRPC service name used in error messages.`. One
+  service: `Service::connect(&cmd.connection, SERVICE_NAME, |channel|
+  Client::new(channel).send_compressed(Gzip).accept_compressed(Gzip)).await?`.
+  Several: `Connection::connect(&cmd.connection).await?` once, then
+  `Service::new(&connection, NAME, build)` per client.
+- Every RPC: `self.service.client().<rpc>(request).await
+  .map_err(self.service.status("<verb>"))?.into_inner()`.
+- Generated code: `#[allow(clippy::all, clippy::std_instead_of_core,
+  non_snake_case)] pub mod <x>pb { tonic::include_proto!("…"); }`; shared
+  protos come through `extern_path` to `::commonpb::pb`.
+
+## Arguments
+
+- The parser proves the form: typed fields, `required = true` on a `Vec<T>`
+  payload, `conflicts_with` for exclusive flags, `value_parser!(u16).range(..)`,
+  `ValueEnum` for closed sets. A bad value exits 2 before any connection. No
+  parsing in handlers, no `String` for a value that has a type.
+- Type ladder, in order: `core`/`std` (`IpAddr`, `Ipv4Addr`, `Ipv6Addr`, `u16`
+  for ports, `PathBuf`), then `netip` (`IpNetwork`, `Contiguous<IpNetwork>` for
+  prefixes, `MacAddr`), then `common/rust` types with `FromStr`
+  (`commonpb::pb::DevicePipeline`). Inside a crate only `ValueEnum` enums and
+  clap arg groups. A `value_parser = <fn>` that constrains an existing type (a
+  range, a fixed prefix length) is fine. A new `FromStr` type anywhere, in the
+  crate or in `common/rust`, is a decision for the owner: stop and ask before
+  writing it.
+- Wire values are made when the request is built (`IpAddress::from(addr)`,
+  `MacAddress::from(mac)`), never parsed from text there.
+- Positional arguments carry the key of an element only (`insert <prefix>
+  --via …`, `remove <next-hop>…`, `table create <name>`); everything else is a
+  flag.
+- Flags: `--name/-n` is the config name and nothing else; `--file/-f` an input
+  document; `--category` a metric category (`--rules`/`--name` migrate under
+  #2373); `-4/-6` family filters, mutually exclusive (nat64's address pair
+  excepted); `--endpoint` and `--auth` exist only through `ConnectionArgs`. A
+  short flag has one meaning across all binaries and never shadows the global
+  `-v`, so no auto `short` on a subcommand flag.
+- Verbs: configs `list / show / update` (upsert) `/ delete`; elements inside a
+  config `insert` (upsert by key), `add` (strict or idempotent add to a set),
+  `remove`; scalars `set-<x>`; the whole object `flush`. A rename keeps the old
+  spelling as a hidden `alias` for a release.
+- Every command and argument has a one-sentence doc comment ending in a
+  period; `about` comes from the `Cmd` doc.
+- An argument naming an existing object carries `add =
+  ArgValueCandidates::new(<fn>)`, the function built on
+  `completion::candidates(Cmd::command, build, async move |mut client| …)` (a
+  genuine `async move` closure). Never on a `value_delimiter` argument, never
+  on the new name of a `create`.
+
+## Boundary with the service
+
+The CLI checks presence, type, range and exclusivity. The configuration
+itself, an empty config, a refcount, a duplicate key, a missing element on
+remove, is the service's decision, relayed as its status. No confirmations,
+no `--yes`, no `--dry-run`.
+
+## Output
+
+- Data leaves through `output::data(|| payload, || render)`. The JSON payload
+  is the wire message or one of its fields, never a mirror struct. Human
+  rendering is the closure.
+- Lists: sort, then `display::print_table_from_entries(rows)` with `impl
+  Tabled for <wire type>` (`LENGTH`, `fields` with `Cow::Borrowed` for `&str`
+  and `Cow::Owned` for computed cells, `headers`). A local row struct only
+  where the orphan rule blocks that (a type from a shared proto crate) or for
+  a document schema that also parses a file. A single object is a key/value
+  block, nested lists as sub-tables. Never a pretty-printed JSON, YAML or tree
+  dump in human mode.
+- Empty results: inside the render closure, `output::empty(…)` or
+  `output::empty_with_hint(…, "create one with '<full command>'")` and an
+  early return; never bare printing or a call-site guard. The primitive owns
+  the marker and stays silent under JSON and on a non-TTY stdout.
+- Mutations: `output::success("<verb>", format_args!("<Sentence>."))`.
+- Colour and glyphs only via `output::is_colored()`, `output::dim`,
+  `output::paint_dim`; no `colored` dependency in a CLI crate (#2377).
+- An unusable derived JSON shape (an enum as a number) is fixed on the wire
+  type: `field_attribute` in `build.rs` adds `#[serde(serialize_with = "…")]`,
+  the function lives in `main.rs`, the exception is owner-approved.
+- Ages, durations, sizes: `ync::humanfmt`; metrics: `ync::metrics`.
+
+## Errors and exit codes
+
+- Exit codes come only from `err.exit_code()`: 0 ok, 1 invalid argument, auth
+  or RPC error, 2 usage (clap), 3 not found or service not registered, 4
+  connection or unavailable. No command invents a code (`ready` exiting 2 for
+  "not ready" is legacy until #2354).
+- A local rejection is `self.service.invalid("<verb>", message)` or
+  `Error::invalid_argument(verb, endpoint, message)`; a command addressing an
+  existing object maps its status through `NotFoundMapper::new(SERVICE_NAME,
+  "<resource>")` and `.map(status, verb, endpoint, resource)`, so a missing
+  object reads `<resource> not found` and exits 3. Hints via `.with_hint(…)`.
+
+## Tests
+
+Test the crate's own logic only: its formatters, a request mapping that merges
+or branches, a file loader. Nothing that exercises clap (`debug_assert`,
+`try_parse_from` for required, typed or conflicting arguments), `std` or
+`netip` parsing, a JSON shape or human text; such tests already merged are
+not a precedent and go when their crate is next changed. `fn
+test_<what>_<case>` in `mod test`.
+
+## Never
+
+- Parse or validate after connecting.
+- `String`, `Option<String>` or `Vec<String>` for an address, MAC, prefix or
+  pipeline.
+- A `Vec<T>` payload without `required = true`.
+- Accept `--format` and ignore it, or `println!` a JSON document.
+- `CompleteEnv` inside a tokio runtime.
+- Swallow a stream or writer error and exit 0.
+- Heuristics over a library error: take the root of the `source()` chain or
+  the library's own rendering.

--- a/.agents/skills/code-cli/references/new-crate.md
+++ b/.agents/skills/code-cli/references/new-crate.md
@@ -1,0 +1,369 @@
+# New CLI crate
+
+Everything a new `yanet-cli-<suffix>` binary needs, in the order it is
+written. `<x>` is the module, device or operator name, `<x>pb` its proto
+package crate name (`decappb`, `operatorpb`, …).
+
+## Directory
+
+```
+<owner>/<x>/cli/
+  Cargo.toml
+  build.rs
+  src/main.rs
+```
+
+`<owner>` is `modules`, `devices`, `objects` or `operators`; a core binary
+lives in `cli/modules/<x>/`.
+
+## Cargo.toml
+
+```toml
+[package]
+name = "yanet-cli-<suffix>"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+rust-version = "1.88"
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "yanet-cli-<suffix>"
+path = "src/main.rs"
+
+[dependencies]
+commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
+ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
+netip = "0.3"
+prost = "0.13"
+serde = { version = "1", features = ["derive"] }
+tabled = { version = "0.18", features = ["ansi"] }
+tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
+tonic = { version = "0.13", features = ["gzip"] }
+
+[build-dependencies]
+tonic-build = "0.13"
+```
+
+Add a dependency only when the code uses it; `netip` and `tabled` are
+listed because almost every binary parses an address or prints a table.
+
+## build.rs
+
+```rust
+use core::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let root = "../../..";
+    let proto = "<owner>/<x>/controlplane/<x>pb/v1/<x>.proto";
+    println!("cargo:rerun-if-changed={root}/{proto}");
+
+    tonic_build::configure()
+        .emit_rerun_if_changed(false)
+        .build_server(false)
+        .message_attribute(".", "#[derive(serde::Serialize)]")
+        // One line per enum field that must render by its proto name.
+        .field_attribute(".<package>.<Message>.<field>", "#[serde(serialize_with = \"crate::serialize_<field>\")]")
+        .extern_path(".common.commonpb.v1", "::commonpb::pb")
+        .compile_protos(&[format!("{root}/{proto}")], &[root])?;
+
+    Ok(())
+}
+```
+
+Shared packages (`common.commonpb.v1`, `common.filterpb.v1`) are always
+`extern_path`ed to their crate; never compile them twice.
+
+## src/main.rs
+
+```rust
+//! CLI for YANET <x>.
+
+use std::borrow::Cow;
+
+use clap::{ArgAction, CommandFactory, Parser};
+use clap_complete::{
+    CompleteEnv,
+    engine::{ArgValueCandidates, CompletionCandidate},
+};
+use tabled::Tabled;
+use tonic::codec::CompressionEncoding;
+use ync::{
+    client::{ConnectionArgs, LayeredChannel, Service},
+    completion,
+    display::print_table_from_entries,
+    errors::{Error, NotFoundMapper},
+    output::{self, CommonFormat},
+};
+
+use crate::<x>pb::{
+    Config, DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
+    <x>_service_client::<X>ServiceClient,
+};
+
+#[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
+pub mod <x>pb {
+    tonic::include_proto!("<proto package>");
+}
+
+/// The fully-qualified gRPC service name used in error messages.
+const SERVICE_NAME: &str = "<proto package>.<X>Service";
+
+/// Maps a genuine "config not found" status into a friendly message.
+const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "config");
+
+/// <X> CLI.
+#[derive(Debug, Clone, Parser)]
+#[command(version, about)]
+#[command(flatten_help = true)]
+pub struct Cmd {
+    #[clap(subcommand)]
+    pub mode: ModeCmd,
+    #[command(flatten)]
+    pub connection: ConnectionArgs,
+    /// Output format.
+    #[arg(long, default_value = "human", global = true)]
+    pub format: CommonFormat,
+    /// Be verbose: shows debug log lines and raw gRPC error details.
+    #[clap(short, action = ArgAction::Count, global = true)]
+    pub verbose: u8,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub enum ModeCmd {
+    /// List configs.
+    List,
+    /// Show a config.
+    Show(ShowCmd),
+    /// Create or replace a config.
+    Update(UpdateCmd),
+    /// Delete a config.
+    Delete(DeleteCmd),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct ShowCmd {
+    /// Name of the <x> config to operate on.
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
+    pub config_name: String,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct UpdateCmd {
+    /// Name of the <x> config to operate on.
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
+    pub config_name: String,
+    /// Prefixes to install.
+    #[arg(long = "prefix", short = 'p', required = true)]
+    pub prefixes: Vec<netip::Contiguous<netip::IpNetwork>>,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct DeleteCmd {
+    /// Name of the <x> config to operate on.
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
+    pub config_name: String,
+}
+
+fn main() {
+    CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
+    let cmd = Cmd::parse();
+    ync::init(cmd.verbose, cmd.format);
+
+    if let Err(err) = run(cmd).await {
+        output::failure(&err);
+        std::process::exit(err.exit_code());
+    }
+}
+
+async fn run(cmd: Cmd) -> Result<(), Error> {
+    let mut service = <X>Service::new(&cmd.connection).await?;
+
+    match cmd.mode {
+        ModeCmd::List => service.list_configs().await,
+        ModeCmd::Show(args) => service.show_config(args).await,
+        ModeCmd::Update(args) => service.update_config(args).await,
+        ModeCmd::Delete(args) => service.delete_config(args).await,
+    }
+}
+
+pub struct <X>Service {
+    service: Service<<X>ServiceClient<LayeredChannel>>,
+}
+
+impl <X>Service {
+    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
+        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+            <X>ServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        })
+        .await?;
+
+        Ok(Self { service })
+    }
+
+    pub async fn list_configs(&mut self) -> Result<(), Error> {
+        let response = self
+            .service
+            .client()
+            .list_configs(ListConfigsRequest {})
+            .await
+            .map_err(self.service.status("list"))?
+            .into_inner();
+
+        output::data(
+            || &response.configs,
+            || {
+                if response.configs.is_empty() {
+                    output::empty_with_hint(
+                        format_args!("No configs found."),
+                        format_args!("create one with 'yanet-cli-<suffix> update --name <name> …'"),
+                    );
+                    return;
+                }
+
+                let mut entries: Vec<&Config> = response.configs.iter().collect();
+                entries.sort_by(|a, b| a.name.cmp(&b.name));
+                print_table_from_entries(entries);
+            },
+        );
+
+        Ok(())
+    }
+
+    pub async fn show_config(&mut self, cmd: ShowCmd) -> Result<(), Error> {
+        let request = ShowConfigRequest { name: cmd.config_name.clone() };
+
+        let response = self
+            .service
+            .client()
+            .show_config(request)
+            .await
+            .map_err(|status| NOT_FOUND.map(status, "show", self.service.endpoint(), Some(&cmd.config_name)))?
+            .into_inner();
+
+        output::data(
+            || &response,
+            || {
+                println!("name:     {}", response.name);
+                println!("prefixes: {}", response.prefixes.len());
+            },
+        );
+
+        Ok(())
+    }
+
+    pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
+        let request = UpdateConfigRequest {
+            name: cmd.config_name.clone(),
+            prefixes: cmd.prefixes.iter().map(|prefix| prefix.clone().into()).collect(),
+        };
+
+        self.service
+            .client()
+            .update_config(request)
+            .await
+            .map_err(self.service.status("update"))?;
+
+        output::success("update", format_args!("Updated config {}.", cmd.config_name));
+
+        Ok(())
+    }
+
+    pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
+        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+
+        self.service
+            .client()
+            .delete_config(request)
+            .await
+            .map_err(|status| NOT_FOUND.map(status, "delete", self.service.endpoint(), Some(&cmd.config_name)))?;
+
+        output::success("delete", format_args!("Deleted config {}.", cmd.config_name));
+
+        Ok(())
+    }
+}
+
+impl Tabled for Config {
+    const LENGTH: usize = 2;
+
+    fn fields(&self) -> Vec<Cow<'_, str>> {
+        vec![
+            Cow::Borrowed(self.name.as_str()),
+            Cow::Owned(self.prefixes.len().to_string()),
+        ]
+    }
+
+    fn headers() -> Vec<Cow<'static, str>> {
+        vec![Cow::Borrowed("NAME"), Cow::Borrowed("PREFIXES")]
+    }
+}
+
+/// Completion candidates for a config-name argument: the configs the
+/// service currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn config_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            <X>ServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| {
+            Ok(client
+                .list_configs(ListConfigsRequest {})
+                .await?
+                .into_inner()
+                .configs
+                .into_iter()
+                .map(|config| config.name)
+                .collect())
+        },
+    )
+}
+```
+
+Several services behind one binary: `Connection::connect(connection).await?`
+once, then `Service::new(&connection, NAME, build)` for each client, all
+kept in the service struct.
+
+## Registration
+
+Three files move together; missing the last two builds green and never
+installs the binary.
+
+1. Root `Cargo.toml`: add the crate path to `[workspace] members`.
+2. Root `Makefile`: add the suffix (`<x>`, `device-<x>`, `operator-<x>`) to
+   `CLI_MODULES`; a `cli/modules/<x>` crate goes to `CLI_CORE_MODULES`.
+3. `debian/yanet2-cli.install`: add `usr/bin/yanet-cli-<suffix>`.
+
+Shell completions need nothing: the packaging script emits
+`COMPLETE=bash <bin>` for every installed `yanet-cli-*`.
+
+## Gates before review
+
+```bash
+cargo +nightly-2026-08-28 fmt -p yanet-cli-<suffix>
+cargo clippy -p yanet-cli-<suffix> --all-targets
+cargo build --release -p yanet-cli-<suffix>
+cargo test -p yanet-cli-<suffix>
+```
+
+Then run the binary against a closed port (`--endpoint grpc://127.0.0.1:1`):
+a malformed argument must exit 2 with clap's message, a valid one must reach
+`connect failed` and exit 4; `--help` must describe every flag; `--format json`
+must print the wire message.

--- a/.agents/skills/review-change/SKILL.md
+++ b/.agents/skills/review-change/SKILL.md
@@ -31,6 +31,7 @@ still a review finding; do not switch to Author mode in this gate.
 - **Missing integration**: three-place registrations (CLI, page, module), generated code (`*.pb.go`, charters), meson/Cargo/npm manifests, docs that now lie.
 - **Tests that cannot fail**: derived oracles, unset modes, assertions on the setup rather than the behaviour; a benchmark not exercising the claimed path.
 - **Non-code changes**: execute instructions and configs mentally against the cases they name and the default they leave unnamed; a rule's restatements elsewhere go stale.
+- **CLI surface**: a diff under `cli/`, `modules|devices|objects|operators/*/cli/` or `common/rust` is checked against the `code-cli` skill — binary shape, typed arguments, verb and flag dictionary, output, errors and test policy.
 
 ## Findings
 

--- a/.claude/skills/code-cli
+++ b/.claude/skills/code-cli
@@ -1,0 +1,1 @@
+../../.agents/skills/code-cli

--- a/.gitignore
+++ b/.gitignore
@@ -160,12 +160,14 @@ deploy/packages/
 .agents/skills/*
 !.agents/skills/autopilot
 !.agents/skills/better-comment
+!.agents/skills/code-cli
 !.agents/skills/issue-create
 !.agents/skills/review-change
 !.agents/skills/ship-pr
 .claude/skills/*
 !.claude/skills/autopilot
 !.claude/skills/better-comment
+!.claude/skills/code-cli
 !.claude/skills/issue-create
 !.claude/skills/review-change
 !.claude/skills/ship-pr

--- a/.rulesync/subagents/coder-rust.md
+++ b/.rulesync/subagents/coder-rust.md
@@ -16,16 +16,16 @@ codexcli:
   model: gpt-5.6-luna
   model_reasoning_effort: xhigh
 ---
-You write Rust for the YANET2 CLIs (`AGENTS.md` → Rust CLI for the workspace shape and the three registration surfaces; `.agents/conventions/rust.md` before writing Rust).
+You write Rust for the YANET2 CLIs (`AGENTS.md` → Rust CLI for the workspace shape and the three registration surfaces; `.agents/conventions/rust.md` before writing Rust; the `code-cli` skill before touching a CLI crate).
 
 ## Scope
 
-`cli/`, `modules/*/cli/`, `operators/*/cli/`, `common/rust/`, root `Cargo.toml`, `build.rs` files. You do not touch C, Go, TypeScript, proto or meson files — say what they need and stop.
+`cli/`, `modules|devices|objects|operators/*/cli/`, `common/rust/`, root `Cargo.toml`, `build.rs` files. You do not touch C, Go, TypeScript, proto or meson files — say what they need and stop.
 
 ## Working
 
 - `cd` into the worktree root the brief names first; confirm `git rev-parse --show-toplevel` and `git branch --show-current` before writing.
-- Read `cli/core/src/` and two module CLIs (`modules/route/cli/`, `modules/forward/cli/`) before adding a pattern; match existing code.
+- Load the `code-cli` skill before adding a pattern: it is the norm, and an existing crate that differs from it is behind, not a precedent.
 - A new CLI is registered in root `Cargo.toml` members, root `Makefile` (`CLI_CORE_MODULES`/`CLI_MODULES`) and `debian/yanet2-cli.install`; a private CLI is a standalone workspace.
 - Minimal means minimal: no renames, no reformatting outside the change. Stop and report when the change needs a proto or Go change, or ~40 tool calls have not converged.
 


### PR DESCRIPTION
- Add the `code-cli` skill: how a yanet CLI binary is written — the clap derive shape, typed arguments and their type ladder, the ync connection, output, error and completion contracts, the verb and flag dictionary, human and JSON rendering, exit codes and the test policy — with a new-crate reference holding the manifest, build script, skeleton and registration steps.
- Move the CLI-specific rules out of the Rust conventions into the skill and point the Rust charter and the review checklist at it.
- Whitelist the new public skill in `.gitignore` alongside the existing ones.
