### PR TITLE
fix(pdump): report a failed capture from the cli

### DIFF
--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -21,8 +21,6 @@
 //!     .accept_compressed(CompressionEncoding::Gzip);
 //! ```
 
-use core::error::Error as StdError;
-
 use http::uri::PathAndQuery;
 use prost::Message;
 use tonic::{
@@ -35,7 +33,7 @@ use tower::Layer;
 
 use crate::{
     auth::{self, interceptor::AuthService, AuthArgs},
-    errors::Error,
+    errors::{root_cause, Error},
 };
 
 /// Channel type with all interceptors applied.
@@ -66,16 +64,6 @@ pub enum ConnectionError {
     InvalidUri(#[from] http::uri::InvalidUri),
     #[error("auth error: {0}")]
     Auth(#[from] auth::AuthError),
-}
-
-/// Returns the innermost cause, the one text that explains a transport
-/// failure.
-fn root_cause(mut err: &dyn StdError) -> &dyn StdError {
-    while let Some(source) = err.source() {
-        err = source;
-    }
-
-    err
 }
 
 /// Connect to the endpoint with all interceptors pre-applied.

--- a/cli/core/src/errors.rs
+++ b/cli/core/src/errors.rs
@@ -269,6 +269,18 @@ fn map_code(status: &Status) -> ErrorKind {
     }
 }
 
+/// Returns the innermost cause, the one text that explains a failure whose
+/// wrappers only label the layer they come from.
+pub fn root_cause<'a>(err: &'a (dyn core::error::Error + 'static)) -> &'a (dyn core::error::Error + 'static) {
+    let mut err = err;
+
+    while let Some(source) = err.source() {
+        err = source;
+    }
+
+    err
+}
+
 /// Build a default hint for the given error kind.
 fn default_hint(kind: ErrorKind) -> Option<String> {
     match kind {

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -15,11 +15,11 @@ use tonic::{Status, codec::CompressionEncoding};
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    errors::Error,
+    errors::{Error, ErrorKind},
     output::{self, CommonFormat},
 };
 
-use crate::pdumppb::SetConfigRequest;
+use crate::{pdumppb::SetConfigRequest, writer::PdumpWriter};
 
 mod args;
 mod dump_mode;
@@ -235,44 +235,75 @@ impl PdumpService {
             .into_inner();
         log::debug!("read_data successfully acquired data stream for {}", cmd.config_name,);
 
+        // Register before the first byte is written, so that a closed output
+        // reaches the writer instead of the default SIGPIPE disposition.
+        let mut sig_pipe = unix::signal(SignalKind::pipe()).expect("failed to register SIGPIPE handler");
+
+        // Opened once the capture is granted, so that a rejected request
+        // leaves an existing file alone.
+        let output = cmd.output.clone().unwrap_or_else(|| "-".to_owned());
+        let dump_writer = PdumpWriter::new(cmd.dump_format, &output, config.snaplen).map_err(|err| {
+            self.service
+                .invalid("read", format!("cannot write to '{output}': {err}"))
+        })?;
+
         reader_set.spawn(writer::pdump_stream_reader(stream, tx.clone(), done.clone()));
         drop(tx);
 
         // Spawn outside the reader_set to get unpinable join handler.
-        let mut write_jh = tokio::task::spawn_blocking(move || {
-            let output = cmd.output.unwrap_or("-".to_string());
-            writer::pdump_write(vec![config], rx, cmd.num, cmd.dump_format, &output)
-        });
+        let mut write_jh = tokio::task::spawn_blocking(move || writer::pdump_write(dump_writer, rx, cmd.num));
 
-        let mut sig_pipe = unix::signal(SignalKind::pipe()).expect("failed to register SIGPIPE handler");
-
+        let mut finished = None;
         tokio::select! {
             _ = sig_pipe.recv() => {
-                log::warn!("writer pipe closed; initiating shutdown...");
+                log::debug!("the output pipe is closed, stopping the capture");
                 cancellation_token.cancel();
             }
             _ = tokio::signal::ctrl_c() => {
-                log::warn!("interrupted...");
+                log::debug!("interrupted, stopping the capture");
                 cancellation_token.cancel();
             }
             res = &mut write_jh => {
-                log::warn!("writer task finished, initiating shutdown...");
-                match res {
-                    Ok(()) => log::debug!("writer task completed successfully."),
-                    Err(e) => log::warn!("writer task failed: {e}"),
-                }
+                log::debug!("the writer finished, stopping the capture");
                 cancellation_token.cancel();
+                finished = Some(res);
             }
         }
 
-        // Wait for all reader tasks to gracefully finish.
+        // A capture stopped by a signal leaves the writer running, so wait for
+        // it to drain the channel and flush before reporting anything.
+        let written = match finished {
+            Some(res) => res,
+            None => (&mut write_jh).await,
+        };
+
+        let mut result = match written {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(err)) => Err(self.write_failed(err.to_string())),
+            Err(err) => Err(self.write_failed(format!("the writer task failed: {err}"))),
+        };
+
         while let Some(res) = reader_set.join_next().await {
-            if let Err(e) = res {
-                log::warn!("reader task failed during shutdown: {e}");
+            let failure = match res {
+                Ok(Ok(())) => continue,
+                Ok(Err(status)) => (self.service.status("read"))(status),
+                Err(err) => self.write_failed(format!("the reader task failed: {err}")),
+            };
+
+            if result.is_ok() {
+                result = Err(failure);
+            } else {
+                log::debug!("the capture also failed to read the stream: {}", failure.message());
             }
         }
 
-        Ok(())
+        result
+    }
+
+    /// Reports a failure of the local capture pipeline, which has no gRPC
+    /// status of its own.
+    fn write_failed(&self, message: String) -> Error {
+        Error::new(ErrorKind::Rpc, "read", self.service.endpoint(), message)
     }
 }
 

--- a/modules/pdump/cli/src/writer.rs
+++ b/modules/pdump/cli/src/writer.rs
@@ -18,7 +18,8 @@ use pcap_file::{
 };
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tonic::codec::Streaming;
+use tonic::{Status, codec::Streaming};
+use ync::errors::root_cause;
 
 use crate::{args::DumpOutputFormat, pdumppb, printer};
 
@@ -52,29 +53,29 @@ impl io::Write for PdumpOutput {
     }
 }
 
-struct Text {
+pub struct Text {
     inner: PdumpOutput,
     pretty: bool,
     base_ts: Option<u64>,
 }
 
-struct Pcap {
+pub struct Pcap {
     inner: PcapWriter<PdumpOutput>,
 }
 
-struct PcapNg {
+pub struct PcapNg {
     inner: PcapNgWriter<PdumpOutput>,
     interface_id: u32,
 }
 
-enum PdumpWriter {
+pub enum PdumpWriter {
     Text(Text),
     Pcap(Pcap),
     PcapNg(PcapNg),
 }
 
 impl PdumpWriter {
-    fn new(fmt: DumpOutputFormat, dst: &str, snaplen: u32) -> Result<Self, Box<dyn Error>> {
+    pub fn new(fmt: DumpOutputFormat, dst: &str, snaplen: u32) -> Result<Self, Box<dyn Error>> {
         let output = PdumpOutput::new(dst)?;
 
         let writer = match fmt {
@@ -191,73 +192,139 @@ impl PdumpWriter {
     }
 }
 
+/// Failure of the capture's writing side, carried out of the blocking task.
+pub type WriteError = Box<dyn Error + Send + Sync>;
+
+/// Writes captured records until a limit, the stream or a failure ends the
+/// capture, always flushing. An output that goes away is not a failure.
 pub fn pdump_write(
-    config: Vec<pdumppb::Config>,
+    mut writer: PdumpWriter,
     mut rx: mpsc::Receiver<pdumppb::Record>,
     packet_limit: Option<u64>,
-    fmt: DumpOutputFormat,
-    dst: &str,
-) {
-    let max_snaplen = config.iter().fold(0, |sl, e| sl.max(e.snaplen));
-    let mut writer = match PdumpWriter::new(fmt, dst, max_snaplen) {
-        Ok(w) => w,
-        Err(e) => {
-            log::error!("failed to create pdump writer at '{dst}': {e}");
-            return;
-        }
-    };
+) -> Result<(), WriteError> {
     let mut count = 0;
-    loop {
+    let captured = loop {
         if let Some(limit) = packet_limit
             && count >= limit
         {
             log::debug!("stopping writer because the packet capture limit has been reached: {limit}");
 
-            break;
+            break Ok(());
         }
 
         let Some(rec) = rx.blocking_recv() else {
-            break;
+            break Ok(());
         };
 
-        if let Err(e) = writer.write(rec) {
-            log::error!("failed to write record: {e}");
-            break;
+        if let Err(err) = writer.write(rec) {
+            if is_broken_pipe(err.as_ref()) {
+                log::debug!("the output is closed, stopping the capture");
+
+                break Ok(());
+            }
+
+            break Err(WriteError::from(format!(
+                "failed to write record: {}",
+                root_cause(err.as_ref())
+            )));
         };
 
         count += 1;
-    }
-    _ = writer.flush().map_err(|e| {
-        log::error!("failed to flush writer: {e}");
-    });
+    };
+
+    let flushed = match writer.flush() {
+        Ok(()) => Ok(()),
+        Err(err) if is_broken_pipe(err.as_ref()) => Ok(()),
+        Err(err) => Err(WriteError::from(format!(
+            "failed to flush the output: {}",
+            root_cause(err.as_ref())
+        ))),
+    };
+
+    captured.and(flushed)
 }
 
+/// Reports whether the output went away, which ends a capture piped into a
+/// consumer that stopped reading.
+///
+/// The pcap writers render every failure as one fixed text, so the cause
+/// chain decides.
+fn is_broken_pipe(err: &(dyn Error + 'static)) -> bool {
+    root_cause(err)
+        .downcast_ref::<io::Error>()
+        .is_some_and(|err| err.kind() == io::ErrorKind::BrokenPipe)
+}
+
+/// Forwards records to the writer until the stream ends or the capture is
+/// cancelled. A closed channel is a finished writer, not a failure.
 pub async fn pdump_stream_reader(
     mut stream: Streaming<pdumppb::Record>,
     tx: mpsc::Sender<pdumppb::Record>,
     done: CancellationToken,
-) {
+) -> Result<(), Status> {
     loop {
         tokio::select! {
             biased;
             _ = done.cancelled() => {
-                return;
+                return Ok(());
             }
             message = stream.message() => {
                 match message {
-                    Err(e) => {
-                        log::warn!("error on gRPC stream: {e}");
-                        return;
-                    }
-                    Ok(None) => return,
+                    Err(status) => return Err(status),
+                    Ok(None) => return Ok(()),
                     Ok(Some(rec)) => {
-                        if let Err(e) = tx.send(rec).await {
-                            log::warn!("failed to send Record to pdump writer via mpsc channel: {e}");
-                            return;
+                        if let Err(err) = tx.send(rec).await {
+                            log::debug!("pdump writer is gone, stopping the reader: {err}");
+                            return Ok(());
                         };
                     }
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_pdump_write_reports_an_output_that_cannot_take_records() {
+        let writer = PdumpWriter::new(DumpOutputFormat::Text, "/dev/full", 65535).expect("must open");
+        let (tx, rx) = mpsc::channel(1);
+        tx.try_send(pdumppb::Record {
+            meta: Some(pdumppb::RecordMeta::default()),
+            data: Vec::new(),
+        })
+        .expect("must accept the record");
+        drop(tx);
+
+        let err = pdump_write(writer, rx, None).expect_err("a full output must fail the capture");
+
+        assert!(err.to_string().starts_with("failed to write record: "), "{err}");
+    }
+
+    #[test]
+    fn test_broken_pipe_is_recognised_through_a_wrapper() {
+        let piped = pcap_file::PcapError::IoError(io::Error::from(io::ErrorKind::BrokenPipe));
+        let full = pcap_file::PcapError::IoError(io::Error::from(io::ErrorKind::StorageFull));
+
+        assert!(is_broken_pipe(&piped));
+        assert!(!is_broken_pipe(&full));
+    }
+
+    /// Verifies that a record the writer cannot encode ends the capture with
+    /// an error instead of a log line.
+    #[test]
+    fn test_pdump_write_reports_a_failed_record() {
+        let writer = PdumpWriter::new(DumpOutputFormat::Pcap, "/dev/null", 65535).expect("must open");
+        let (tx, rx) = mpsc::channel(1);
+        tx.try_send(pdumppb::Record { meta: None, data: Vec::new() })
+            .expect("must accept the record");
+        drop(tx);
+
+        let err = pdump_write(writer, rx, None).expect_err("a record without metadata must fail the capture");
+
+        assert_eq!("failed to write record: pdump record missing metadata", err.to_string());
     }
 }


### PR DESCRIPTION
- Report a failed capture: a record that cannot be encoded or written and a stream error each end `pdump read` with an error report and a non-zero exit instead of a log line.
- Open the output once the capture is granted, so a destination that cannot be written fails as a usage error and a rejected request leaves an existing file alone.
- Keep a closed output a normal end: a capture piped into a consumer that stops reading still exits successfully.
- Wait for the writer after a signal or a limit, so the file is flushed before the command exits, and drop the warning from the normal completion path.
- Share the root-cause helper through the cli core, so a failure reports the operating system error rather than a wrapper's fixed text.
- The shared helper spells out its error type rather than importing a short name, because the error module already uses that name for the CLI error.

Closes #2339.
