### PR TITLE
fix(cli): validate module update arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3115,6 +3115,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "log",
+ "netip",
  "prost",
  "prost-types",
  "ptree",

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -78,7 +78,7 @@ pub struct UpdateCmd {
     #[arg(short, long, add = ArgValueCandidates::new(pipeline_candidates))]
     pub name: String,
     /// Pipeline functions.
-    #[arg(long, value_delimiter = ',')]
+    #[arg(long, required = true, num_args = 0.., value_delimiter = ',')]
     pub functions: Vec<String>,
 }
 

--- a/modules/acl/cli/Cargo.toml
+++ b/modules/acl/cli/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
+netip = "0.3"
 log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }

--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -1,7 +1,9 @@
+use core::net::Ipv6Addr;
 use std::path::PathBuf;
 
 use clap::Parser;
 use clap_complete::engine::ArgValueCandidates;
+use netip::MacAddr;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Parser)]
@@ -48,21 +50,21 @@ pub struct UpdateCmd {
     /// Destination MAC address of emitted state-sync frames
     /// (e.g., "00:11:22:33:44:55")
     #[arg(long)]
-    pub dst_ether: Option<String>,
+    pub dst_ether: Option<MacAddr>,
     /// Multicast IPv6 destination of emitted state-sync frames
     /// (e.g., "ff02::1")
     #[arg(long)]
-    pub dst_addr_multicast: Option<String>,
+    pub dst_addr_multicast: Option<Ipv6Addr>,
     /// Multicast port of emitted state-sync frames
     #[arg(long)]
-    pub port_multicast: Option<u32>,
+    pub port_multicast: Option<u16>,
     /// Unicast IPv6 destination of emitted state-sync frames
     /// (e.g., "2001:db8::2")
     #[arg(long)]
-    pub dst_addr_unicast: Option<String>,
+    pub dst_addr_unicast: Option<Ipv6Addr>,
     /// Unicast port of emitted state-sync frames
     #[arg(long)]
-    pub port_unicast: Option<u32>,
+    pub port_unicast: Option<u16>,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -1,4 +1,4 @@
-use core::net::Ipv6Addr;
+use core::net::IpAddr;
 use std::{collections::HashMap, fs::File, path::Path};
 
 use aclpb::{
@@ -359,12 +359,6 @@ struct ShowConfig {
     sync_config: Option<aclpb::SyncConfig>,
 }
 
-/// Parse an IPv6 address string into the proto message.
-fn parse_ipv6(s: &str) -> Result<commonpb::IpAddress, String> {
-    let addr: Ipv6Addr = s.parse().map_err(|err: core::net::AddrParseError| err.to_string())?;
-    Ok(commonpb::IpAddress { addr: addr.octets().to_vec() })
-}
-
 /// ACL module CLI.
 #[derive(Debug, Clone, Parser)]
 #[command(version, about)]
@@ -501,11 +495,7 @@ impl ACLService {
     ///
     /// The YAML section is the base; every flag that was passed overrides
     /// its field. A config with neither source carries no sync config.
-    fn merge_sync_config(
-        &self,
-        base: Option<aclpb::SyncConfig>,
-        cmd: &UpdateCmd,
-    ) -> Result<Option<aclpb::SyncConfig>, String> {
+    fn merge_sync_config(&self, base: Option<aclpb::SyncConfig>, cmd: &UpdateCmd) -> Option<aclpb::SyncConfig> {
         let mut sync = match base {
             Some(base) => base,
             None => {
@@ -515,33 +505,29 @@ impl ACLService {
                     && cmd.dst_addr_unicast.is_none()
                     && cmd.port_unicast.is_none();
                 if no_flags {
-                    return Ok(None);
+                    return None;
                 }
                 aclpb::SyncConfig::default()
             }
         };
 
-        if let Some(ref dst_ether) = cmd.dst_ether {
-            sync.dst_ether = Some(
-                dst_ether
-                    .parse()
-                    .map_err(|err: Box<dyn core::error::Error>| err.to_string())?,
-            );
+        if let Some(dst_ether) = cmd.dst_ether {
+            sync.dst_ether = Some(commonpb::MacAddress::from(dst_ether));
         }
-        if let Some(ref dst_addr_multicast) = cmd.dst_addr_multicast {
-            sync.dst_addr_multicast = Some(parse_ipv6(dst_addr_multicast)?);
+        if let Some(dst_addr_multicast) = cmd.dst_addr_multicast {
+            sync.dst_addr_multicast = Some(commonpb::IpAddress::from(IpAddr::V6(dst_addr_multicast)));
         }
         if let Some(port_multicast) = cmd.port_multicast {
-            sync.port_multicast = port_multicast;
+            sync.port_multicast = u32::from(port_multicast);
         }
-        if let Some(ref dst_addr_unicast) = cmd.dst_addr_unicast {
-            sync.dst_addr_unicast = Some(parse_ipv6(dst_addr_unicast)?);
+        if let Some(dst_addr_unicast) = cmd.dst_addr_unicast {
+            sync.dst_addr_unicast = Some(commonpb::IpAddress::from(IpAddr::V6(dst_addr_unicast)));
         }
         if let Some(port_unicast) = cmd.port_unicast {
-            sync.port_unicast = port_unicast;
+            sync.port_unicast = u32::from(port_unicast);
         }
 
-        Ok(Some(sync))
+        Some(sync)
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
@@ -567,9 +553,7 @@ impl ACLService {
             .clone()
             .or(config.fwtable_name_v6.clone())
             .unwrap_or_default();
-        let sync_config = self
-            .merge_sync_config(config.sync_config, &cmd)
-            .map_err(|err| self.service.invalid("update", err))?;
+        let sync_config = self.merge_sync_config(config.sync_config, &cmd);
 
         let request = UpdateConfigRequest {
             name: cmd.config_name.clone(),

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -62,7 +62,7 @@ pub struct UpdateConfigCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Prefixes in the full desired set, replacing the current one entirely.
-    #[arg(long, short)]
+    #[arg(long, short, required = true, num_args = 0..)]
     pub prefixes: Vec<Contiguous<IpNetwork>>,
 }
 

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -1,4 +1,4 @@
-use core::time::Duration;
+use core::{net::Ipv6Addr, time::Duration};
 
 use clap::Parser;
 use clap_complete::engine::ArgValueCandidates;
@@ -55,15 +55,15 @@ pub struct UpdateCmd {
 
     /// Source IPv6 address (e.g., "2001:db8::1")
     #[arg(long)]
-    pub src_addr: Option<String>,
+    pub src_addr: Option<Ipv6Addr>,
 
     /// Multicast IPv6 address (e.g., "ff02::1")
     #[arg(long)]
-    pub dst_addr_multicast: Option<String>,
+    pub dst_addr_multicast: Option<Ipv6Addr>,
 
     /// Multicast port
     #[arg(long)]
-    pub port_multicast: Option<u32>,
+    pub port_multicast: Option<u16>,
 
     /// TCP SYN-ACK timeout (e.g., "60s", "5m", "1h")
     #[arg(long, value_parser = parse_duration)]

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -1,4 +1,4 @@
-use core::net::Ipv6Addr;
+use core::net::IpAddr;
 use std::collections::HashMap;
 
 use args::{DeleteCmd, MetricsCmd, ModeCmd, ShowCmd, UpdateCmd};
@@ -50,12 +50,6 @@ pub struct Cmd {
     /// Log verbosity level.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
-}
-
-/// Parse IPv6 address string into an `IpAddress` proto message.
-fn parse_ipv6(s: &str) -> Result<IpAddress, String> {
-    let addr = s.parse::<Ipv6Addr>().map_err(|err| err.to_string())?;
-    Ok(IpAddress { addr: addr.octets().to_vec() })
 }
 
 /// Merges the linked map object names an update should carry.
@@ -195,17 +189,16 @@ impl FWStateService {
         };
 
         // Update only the fields that were provided
-        if let Some(ref src_addr) = cmd.src_addr {
-            sync_config.src_addr = Some(parse_ipv6(src_addr).map_err(|err| self.service.invalid("update", err))?);
+        if let Some(src_addr) = cmd.src_addr {
+            sync_config.src_addr = Some(IpAddress::from(IpAddr::V6(src_addr)));
         }
 
-        if let Some(ref dst_addr_multicast) = cmd.dst_addr_multicast {
-            sync_config.dst_addr_multicast =
-                Some(parse_ipv6(dst_addr_multicast).map_err(|err| self.service.invalid("update", err))?);
+        if let Some(dst_addr_multicast) = cmd.dst_addr_multicast {
+            sync_config.dst_addr_multicast = Some(IpAddress::from(IpAddr::V6(dst_addr_multicast)));
         }
 
         if let Some(port_multicast) = cmd.port_multicast {
-            sync_config.port_multicast = port_multicast;
+            sync_config.port_multicast = u32::from(port_multicast);
         }
 
         // Convert timeouts from Duration to nanoseconds if provided

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -93,7 +93,7 @@ pub struct RouteUpdateCmd {
     #[arg(long = "dst")]
     pub dst_addr: IpAddr,
     /// The MPLS Label to encapsulate packets into.
-    #[arg(long = "label")]
+    #[arg(long = "label", value_parser = clap::value_parser!(u32).range(0..=1_048_575))]
     pub mpls_label: u32,
     /// The IP address of the tunnel source.
     #[arg(long = "src")]
@@ -118,7 +118,7 @@ pub struct RouteWithdrawCmd {
     #[arg(long = "dst")]
     pub dst_addr: IpAddr,
     /// The MPLS Label to encapsulate packets into.
-    #[arg(long = "label")]
+    #[arg(long = "label", value_parser = clap::value_parser!(u32).range(0..=1_048_575))]
     pub mpls_label: u32,
 }
 

--- a/scripts/setup-example.sh
+++ b/scripts/setup-example.sh
@@ -13,7 +13,7 @@ repo_root=${script_dir%/scripts}
 
 yanet-cli-forward update --name=forward0 --rules "$repo_root/forward.yaml"
 
-yanet-cli-pipeline update --name=dummy
+yanet-cli-pipeline update --name=dummy --functions
 
 yanet-cli-function update --name=virt --chains chain0:10=forward:forward0
 yanet-cli-pipeline update --name=virt --functions virt

--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -167,7 +167,7 @@ func (f *TestFramework) CommonConfigCommands() []string {
 
 		p.CLI("yanet-cli-pipeline") + " update --name=bootstrap --functions virt",
 		p.CLI("yanet-cli-pipeline") + " update --name=test --functions test",
-		p.CLI("yanet-cli-pipeline") + " update --name=dummy",
+		p.CLI("yanet-cli-pipeline") + " update --name=dummy --functions",
 
 		p.CLI("yanet-cli-device-plain") + " update --name=01:00.0 --input test:1 --output dummy:1",
 		p.CLI("yanet-cli-device-plain") + " update --name=virtio_user_kni0 --input bootstrap:1 --output dummy:1",

--- a/tests/functional/main/pipeline_test.go
+++ b/tests/functional/main/pipeline_test.go
@@ -16,7 +16,7 @@ func restoreBaselinePipelineCommands(fw *framework.TestFramework) []string {
 		p.CLI("yanet-cli-function") + " update --name=test --chains chain2:1=forward:forward0,route:route0",
 		p.CLI("yanet-cli-pipeline") + " update --name=bootstrap --functions virt",
 		p.CLI("yanet-cli-pipeline") + " update --name=test --functions test",
-		p.CLI("yanet-cli-pipeline") + " update --name=dummy",
+		p.CLI("yanet-cli-pipeline") + " update --name=dummy --functions",
 		p.CLI("yanet-cli-device-plain") + " update --name=01:00.0 --input test:1 --output dummy:1",
 		p.CLI("yanet-cli-device-plain") + " update --name=virtio_user_kni0 --input bootstrap:1 --output dummy:1",
 	}

--- a/tests/packaging/packaging_test.go
+++ b/tests/packaging/packaging_test.go
@@ -236,7 +236,7 @@ func Test_SetupExampleUsesSourceTreeForwardFlow(t *testing.T) {
 	require.NoError(t, err)
 	expected := strings.Join([]string{
 		"yanet-cli-forward\tupdate\t--name=forward0\t--rules\t" + resolvedForwardPath,
-		"yanet-cli-pipeline\tupdate\t--name=dummy",
+		"yanet-cli-pipeline\tupdate\t--name=dummy\t--functions",
 		"yanet-cli-function\tupdate\t--name=virt\t--chains\tchain0:10=forward:forward0",
 		"yanet-cli-pipeline\tupdate\t--name=virt\t--functions\tvirt",
 		"yanet-cli-device-plain\tupdate\t--name=virtio_user_kni0\t--input\tvirt:1\t--output\tdummy:1",


### PR DESCRIPTION
- Reject incomplete whole-set updates and malformed labels, ports, and addresses before establishing a gRPC connection.
- Preserve the existing protobuf shapes by widening typed `u16` ports losslessly to their `uint32` wire fields.
- Treat ACL synchronization IPv6 and MAC flags as part of the issue address-validation scope because they used the same post-connection parsing path.
- Apply the 20-bit label bound to both route updates and withdrawals because both populate the same MPLS wire field, while leaving label semantics to the service.
- Treat payload-flag presence, rather than the semantics of an explicitly empty set, as the CLI boundary described by the issue.
- Add no clap parsing tests, following the issue explicit owner decision for declarative constraints.

Closes #2341.