### PR TITLE
refactor(acl,fwstate,cli): drop per-module metrics subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3346,7 +3346,6 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
- "tabled",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/cli/core/src/metrics.rs
+++ b/cli/core/src/metrics.rs
@@ -1,19 +1,10 @@
-//! Shared metrics rendering for module CLIs.
+//! Shared metrics domain types for module CLIs.
 //!
-//! Free functions read a wire `Metric`'s kind and label values without
-//! converting it, so a caller can filter protobuf messages and keep them on
-//! the machine-readable output path. The domain `Metric` type serves human
-//! display, with helpers that format gauge and histogram values and render
-//! the `GRPC CALLS` / `GRPC HANDLING LATENCIES` sections. Per-module counter
-//! grouping stays in each CLI, since label sets and grouping keys differ.
-
-use std::collections::HashMap;
+//! The domain `Metric` mirrors the wire message for display code. Grouping
+//! and rendering stay in each CLI, since label sets and grouping keys differ.
 
 use commonpb::pb::metric::Value;
 use serde::Serialize;
-use tabled::Tabled;
-
-use crate::display::print_table_from_entries;
 
 #[derive(Serialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -119,38 +110,6 @@ pub fn proto_kind(m: &commonpb::pb::Metric) -> Kind {
     }
 }
 
-/// Returns the first label value matching `key` on a wire metric.
-pub fn proto_label_value<'a>(m: &'a commonpb::pb::Metric, key: &str) -> Option<&'a str> {
-    m.labels.iter().find(|l| l.name == key).map(|l| l.value.as_str())
-}
-
-/// Computes the p-th percentile bucket label for a histogram whose upper
-/// bounds are in seconds.
-pub fn histogram_percentile(buckets: &[Bucket], total: u64, p: f64) -> String {
-    if total == 0 || buckets.is_empty() {
-        return "-".to_string();
-    }
-    let target = ((total as f64 * p / 100.0).ceil() as u64).max(1);
-    let mut cumulative: u64 = 0;
-    for (i, b) in buckets.iter().enumerate() {
-        cumulative = cumulative.saturating_add(b.count);
-        if cumulative >= target {
-            return if b.upper_bound.is_infinite() {
-                // Report the last finite bound as the lower edge of the
-                // overflow bucket. When the +Inf bucket is the very first one
-                // there is no finite predecessor to reference.
-                match buckets[..i].iter().rev().find(|bucket| bucket.upper_bound.is_finite()) {
-                    Some(prev) => format!(">{:.3}s", prev.upper_bound),
-                    None => "+Inf".to_string(),
-                }
-            } else {
-                format!("≤{:.3}s", b.upper_bound)
-            };
-        }
-    }
-    "-".to_string()
-}
-
 /// Formats `n` with thousands separators, e.g. `1234567` -> `1,234,567`.
 pub fn format_number(n: u64) -> String {
     let s = n.to_string();
@@ -164,181 +123,9 @@ pub fn format_number(n: u64) -> String {
     result.chars().rev().collect()
 }
 
-/// Formats a gauge `value` for `name`, picking a unit from the metric name's
-/// suffix.
-///
-/// `_ns` names scale through ns/µs/ms/s, `_bytes` names scale through
-/// B/KiB/MiB/GiB, anything else falls back to `format_number`.
-pub fn format_gauge_value(name: &str, value: f64) -> String {
-    if name.ends_with("_ns") {
-        if value < 1_000.0 {
-            format!("{:.0}ns", value)
-        } else if value < 1_000_000.0 {
-            format!("{:.2}µs", value / 1_000.0)
-        } else if value < 1_000_000_000.0 {
-            format!("{:.2}ms", value / 1_000_000.0)
-        } else {
-            format!("{:.2}s", value / 1_000_000_000.0)
-        }
-    } else if name.ends_with("_bytes") {
-        if value < 1024.0 {
-            format!("{:.0} B", value)
-        } else if value < 1024.0 * 1024.0 {
-            format!("{:.2} KiB", value / 1024.0)
-        } else if value < 1024.0 * 1024.0 * 1024.0 {
-            format!("{:.2} MiB", value / (1024.0 * 1024.0))
-        } else {
-            format!("{:.2} GiB", value / (1024.0 * 1024.0 * 1024.0))
-        }
-    } else {
-        format_number(value as u64)
-    }
-}
-
-/// Turns a `snake_case` metric name into a `Title Case` display name, after
-/// stripping `prefix` (e.g. `"acl_"` or `"fwstate_"`) if present.
-pub fn metric_display_name(name: &str, prefix: &str) -> String {
-    let stripped = name.strip_prefix(prefix).unwrap_or(name);
-    stripped
-        .split('_')
-        .map(|word| {
-            let mut c = word.chars();
-            match c.next() {
-                None => String::new(),
-                Some(first) => first.to_uppercase().collect::<String>() + c.as_str(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-#[derive(Tabled)]
-pub struct GaugeRow {
-    #[tabled(rename = "Metric")]
-    pub metric: String,
-    #[tabled(rename = "Value")]
-    pub value: String,
-}
-
-#[derive(Tabled)]
-struct GrpcCallRow {
-    #[tabled(rename = "Method")]
-    method: String,
-    #[tabled(rename = "Code")]
-    code: String,
-    #[tabled(rename = "Handled")]
-    handled: String,
-}
-
-#[derive(Tabled)]
-struct GrpcLatRow {
-    #[tabled(rename = "Method")]
-    method: String,
-    #[tabled(rename = "Total Calls")]
-    total: String,
-    #[tabled(rename = "P50")]
-    p50: String,
-    #[tabled(rename = "P95")]
-    p95: String,
-    #[tabled(rename = "P99")]
-    p99: String,
-}
-
-/// Prints the `GRPC CALLS` and `GRPC HANDLING LATENCIES` sections shared by
-/// every module's `metrics` subcommand.
-///
-/// `grpc_counters` are the `grpc_*` metrics of `Kind::Counter` and
-/// `grpc_histograms` the `grpc_*` metrics of `Kind::Histogram`; callers
-/// collect these while walking their full metric list, since the split
-/// between gRPC metrics and module-specific metrics differs per module.
-pub fn print_grpc_metrics(grpc_counters: &[&Metric], grpc_histograms: &[&Metric]) {
-    if !grpc_counters.is_empty() {
-        // Collect started counts keyed by grpc_method.
-        let mut started: HashMap<String, u64> = HashMap::new();
-        // Collect handled counts keyed by (grpc_method, grpc_code), preserving order.
-        let mut handled_keys: Vec<(String, String)> = Vec::new();
-        let mut handled: HashMap<(String, String), u64> = HashMap::new();
-
-        for m in grpc_counters {
-            let method = m.label_value("grpc_method").unwrap_or("").to_string();
-            if m.name == "grpc_server_started_total" {
-                let count = m.value.unwrap_or(0.0) as u64;
-                *started.entry(method).or_default() += count;
-            } else if m.name == "grpc_server_handled_total" {
-                let code = m.label_value("grpc_code").unwrap_or("").to_string();
-                let key = (method, code);
-                if !handled.contains_key(&key) {
-                    handled_keys.push(key.clone());
-                }
-                *handled.entry(key).or_default() += m.value.unwrap_or(0.0) as u64;
-            }
-        }
-
-        if !handled_keys.is_empty() || !started.is_empty() {
-            println!();
-            println!("GRPC CALLS");
-            println!();
-        }
-
-        if !handled_keys.is_empty() {
-            let rows: Vec<GrpcCallRow> = handled_keys
-                .iter()
-                .map(|(method, code)| GrpcCallRow {
-                    method: method.clone(),
-                    code: code.clone(),
-                    handled: format_number(handled[&(method.clone(), code.clone())]),
-                })
-                .collect();
-            print_table_from_entries(rows);
-        }
-
-        if !started.is_empty() {
-            println!();
-            let mut started_methods: Vec<&String> = started.keys().collect();
-            started_methods.sort();
-            for method in started_methods {
-                println!("  started  {method}: {}", format_number(started[method]));
-            }
-        }
-    }
-
-    if !grpc_histograms.is_empty() {
-        println!();
-        println!("GRPC HANDLING LATENCIES");
-        println!();
-        let rows: Vec<GrpcLatRow> = grpc_histograms
-            .iter()
-            .map(|m| {
-                let method = m.label_value("grpc_method").unwrap_or("unknown").to_string();
-                match &m.histogram {
-                    Some(h) => GrpcLatRow {
-                        method,
-                        total: format_number(h.total_count),
-                        p50: histogram_percentile(&h.buckets, h.total_count, 50.0),
-                        p95: histogram_percentile(&h.buckets, h.total_count, 95.0),
-                        p99: histogram_percentile(&h.buckets, h.total_count, 99.0),
-                    },
-                    None => GrpcLatRow {
-                        method,
-                        total: "-".into(),
-                        p50: "-".into(),
-                        p95: "-".into(),
-                        p99: "-".into(),
-                    },
-                }
-            })
-            .collect();
-        print_table_from_entries(rows);
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-
-    fn bucket(upper_bound: f64, count: u64) -> Bucket {
-        Bucket { upper_bound, count }
-    }
 
     #[test]
     fn proto_kind_matches_from_proto_mapping() {
@@ -364,35 +151,5 @@ mod test {
             assert!(proto_kind(&m) == expected);
             assert!(Metric::from_proto(m).kind == expected);
         }
-    }
-
-    #[test]
-    fn percentile_empty_or_zero_total() {
-        assert_eq!("-", histogram_percentile(&[], 0, 50.0));
-        assert_eq!("-", histogram_percentile(&[bucket(1.0, 0)], 0, 50.0));
-    }
-
-    #[test]
-    fn percentile_finite_bucket() {
-        let buckets = [bucket(0.001, 5), bucket(0.01, 5), bucket(f64::INFINITY, 0)];
-        // total=10, p50 => target=5, cumulative reaches 5 in the first bucket.
-        assert_eq!("≤0.001s", histogram_percentile(&buckets, 10, 50.0));
-        // p95 => target=ceil(9.5)=10, reached in the second bucket.
-        assert_eq!("≤0.010s", histogram_percentile(&buckets, 10, 95.0));
-    }
-
-    #[test]
-    fn percentile_overflow_reports_last_finite_bound() {
-        let buckets = [bucket(0.001, 1), bucket(0.01, 1), bucket(f64::INFINITY, 8)];
-        // p99 => target=ceil(9.9)=10, only reached in the +Inf bucket.
-        assert_eq!(">0.010s", histogram_percentile(&buckets, 10, 99.0));
-    }
-
-    #[test]
-    fn percentile_single_infinite_bucket() {
-        // A histogram with only the +Inf bucket has no finite predecessor;
-        // it must not panic and should fall back to "+Inf".
-        let buckets = [bucket(f64::INFINITY, 4)];
-        assert_eq!("+Inf", histogram_percentile(&buckets, 4, 50.0));
     }
 }

--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -16,8 +16,6 @@ pub enum ModeCmd {
     Update(UpdateCmd),
     /// Show ACL config rules
     Show(ShowCmd),
-    /// Show ACL metrics
-    Metrics(MetricsCmd),
     /// Show per-rule ACL counter metrics
     MetricsRules(MetricsRulesCmd),
     /// Show per-rule ACL counters
@@ -72,53 +70,6 @@ pub struct ShowCmd {
     /// ACL config name
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
-}
-
-#[derive(Debug, Clone, clap::ValueEnum)]
-pub enum MetricName {
-    /// Packet counters (acl_*_packets)
-    Packets,
-    /// Byte counters (acl_*_bytes)
-    Bytes,
-    /// Action outcome counters: allow, deny, count, check_state, create_state,
-    /// unknown
-    Action,
-    /// State-table counters: check_state, create_state, state_miss
-    State,
-    /// Compiled filter rule counts per protocol
-    FilterRuleCount,
-    /// Compilation time and memory usage
-    Compilation,
-    /// gRPC handler call latency histograms
-    Handler,
-}
-
-impl MetricName {
-    pub fn as_filter(&self) -> &'static str {
-        match self {
-            Self::Packets => "packets",
-            Self::Bytes => "bytes",
-            Self::Action => "action",
-            Self::State => "state",
-            Self::FilterRuleCount => "filter_rule_count",
-            Self::Compilation => "compilation",
-            Self::Handler => "handler",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Parser, Default)]
-pub struct MetricsCmd {
-    /// Server-side tag filter, e.g. --tag config=my-acl --tag device=eth0.
-    ///
-    /// An empty value requires the label to be absent, `*` requires it to be
-    /// present with any value, and any other value requires an exact match.
-    /// Mirrors the counters `CounterTag` semantics.
-    #[arg(long = "tag", short = 't', value_name = "NAME=VALUE")]
-    pub tags: Vec<String>,
-    /// Show only metrics matching this category
-    #[arg(long, short, value_enum)]
-    pub name: Option<MetricName>,
 }
 
 #[derive(Debug, Clone, Parser, Default)]

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -5,8 +5,8 @@ use aclpb::{
     DeleteConfigRequest, GetMetricsRulesRequest, GetRulesCountersRequest, ListConfigsRequest, ShowConfigRequest,
     UpdateConfigRequest, acl_service_client::AclServiceClient, metrics_service_client::MetricsServiceClient,
 };
-use args::{DeleteCmd, MetricsCmd, MetricsRulesCmd, ModeCmd, RuleCountersCmd, ShowCmd, UpdateCmd};
-use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
+use args::{DeleteCmd, MetricsRulesCmd, ModeCmd, RuleCountersCmd, ShowCmd, UpdateCmd};
+use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
 use serde::{Deserialize, Serialize};
 use tabled::Tabled;
@@ -14,16 +14,14 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
     completion,
-    display::print_table_from_entries,
     errors::Error,
-    metrics::{self, GaugeRow, Kind, Metric},
+    metrics,
     output::{self, CommonFormat},
 };
 
 mod args;
 
 use ::commonpb::pb as commonpb;
-use commonpb::{GetMetricsRequest, MetricTag};
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod aclpb {
@@ -191,134 +189,6 @@ fn print_rule_metrics_table(metrics: &[commonpb::Metric]) {
         print_counter_table(pending);
         println!();
     }
-}
-
-fn print_metrics_table(metrics: &[Metric]) {
-    struct CounterPair {
-        display: String,
-        packets: Option<u64>,
-        bytes: Option<u64>,
-    }
-
-    let mut location_keys: Vec<String> = Vec::new();
-    let mut location_map: HashMap<String, Vec<&Metric>> = HashMap::new();
-    let mut gauge_keys: Vec<String> = Vec::new();
-    let mut gauge_map: HashMap<String, Vec<&Metric>> = HashMap::new();
-    let mut grpc_counters: Vec<&Metric> = Vec::new();
-    let mut grpc_histograms: Vec<&Metric> = Vec::new();
-
-    for m in metrics {
-        if m.name.starts_with("grpc_") {
-            match m.kind {
-                Kind::Counter => grpc_counters.push(m),
-                Kind::Histogram => grpc_histograms.push(m),
-                _ => {}
-            }
-            continue;
-        }
-
-        match m.kind {
-            Kind::Histogram => {}
-            Kind::Gauge => {
-                let cfg = m.label_value("config").unwrap_or("global").to_string();
-                if !gauge_map.contains_key(&cfg) {
-                    gauge_keys.push(cfg.clone());
-                }
-                gauge_map.entry(cfg).or_default().push(m);
-            }
-            Kind::Counter => {
-                let key = format!(
-                    "{}\0{}\0{}\0{}\0{}",
-                    m.label_value("config").unwrap_or(""),
-                    m.label_value("device").unwrap_or(""),
-                    m.label_value("pipeline").unwrap_or(""),
-                    m.label_value("function").unwrap_or(""),
-                    m.label_value("chain").unwrap_or(""),
-                );
-                if !location_map.contains_key(&key) {
-                    location_keys.push(key.clone());
-                }
-                location_map.entry(key).or_default().push(m);
-            }
-            Kind::Unknown => {}
-        }
-    }
-
-    for (loc_idx, key) in location_keys.iter().enumerate() {
-        if loc_idx > 0 {
-            println!();
-        }
-        let counters = &location_map[key];
-        let parts: Vec<&str> = key.split('\0').collect();
-        let (cfg, device, pipeline, function, chain) = (parts[0], parts[1], parts[2], parts[3], parts[4]);
-        println!("ACL COUNTERS  config={cfg} device={device} pipeline={pipeline} function={function} chain={chain}");
-        println!();
-
-        let std_counters: Vec<&&Metric> = counters.iter().filter(|m| m.label_value("counter").is_none()).collect();
-
-        let mut pair_order: Vec<String> = Vec::new();
-        let mut pair_map: HashMap<String, CounterPair> = HashMap::new();
-
-        for m in &std_counters {
-            let val = m.value.unwrap_or(0.0) as u64;
-            let stripped = m.name.strip_prefix("acl_").unwrap_or(&m.name);
-            if let Some(base) = stripped.strip_suffix("_packets") {
-                let pair = pair_map.entry(base.to_string()).or_insert_with(|| {
-                    pair_order.push(base.to_string());
-                    CounterPair {
-                        display: metrics::metric_display_name(base, "acl_"),
-                        packets: None,
-                        bytes: None,
-                    }
-                });
-                pair.packets = Some(val);
-            } else if let Some(base) = stripped.strip_suffix("_bytes") {
-                let pair = pair_map.entry(base.to_string()).or_insert_with(|| {
-                    pair_order.push(base.to_string());
-                    CounterPair {
-                        display: metrics::metric_display_name(base, "acl_"),
-                        packets: None,
-                        bytes: None,
-                    }
-                });
-                pair.bytes = Some(val);
-            }
-        }
-
-        if !pair_order.is_empty() {
-            let rows: Vec<CounterRow> = pair_order
-                .iter()
-                .map(|k| {
-                    let p = &pair_map[k];
-                    CounterRow {
-                        counter: p.display.clone(),
-                        packets: p.packets.map(metrics::format_number).unwrap_or_else(|| "-".into()),
-                        bytes: p.bytes.map(metrics::format_number).unwrap_or_else(|| "-".into()),
-                    }
-                })
-                .collect();
-            print_counter_table(rows);
-        }
-
-        println!();
-    }
-
-    for cfg in &gauge_keys {
-        let gauges = &gauge_map[cfg];
-        println!("ACL CONFIG INFO  config={cfg}");
-        println!();
-        let rows: Vec<GaugeRow> = gauges
-            .iter()
-            .map(|m| GaugeRow {
-                metric: metrics::metric_display_name(&m.name, "acl_"),
-                value: metrics::format_gauge_value(&m.name, m.value.unwrap_or(0.0)),
-            })
-            .collect();
-        print_table_from_entries(rows);
-        println!();
-    }
-
-    metrics::print_grpc_metrics(&grpc_counters, &grpc_histograms);
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -645,47 +515,6 @@ impl ACLService {
         Ok(())
     }
 
-    pub async fn metrics(&mut self, cmd: MetricsCmd) -> Result<(), Error> {
-        let tags = cmd
-            .tags
-            .iter()
-            .map(|entry| parse_tag(entry))
-            .collect::<Result<Vec<_>, String>>()
-            .map_err(|message| Error::invalid_argument("metrics", self.metrics.endpoint(), message))?;
-
-        let response = self
-            .metrics
-            .client()
-            .get_metrics(GetMetricsRequest { tags })
-            .await
-            .map_err(self.metrics.status("metrics"))?
-            .into_inner();
-
-        let metrics: Vec<commonpb::Metric> = response
-            .metrics
-            .into_iter()
-            .filter(|m| cmd.name.as_ref().is_none_or(|f| m.name.contains(f.as_filter())))
-            .collect();
-
-        output::data(
-            || &metrics,
-            || {
-                if metrics.is_empty() {
-                    match cmd.name.as_ref().and_then(ValueEnum::to_possible_value) {
-                        Some(name) => output::empty(format_args!("No ACL metrics found for '{}'.", name.get_name())),
-                        None => output::empty(format_args!("No ACL metrics found.")),
-                    }
-                    return;
-                }
-
-                let metrics: Vec<Metric> = metrics.iter().cloned().map(Metric::from_proto).collect();
-                print_metrics_table(&metrics)
-            },
-        );
-
-        Ok(())
-    }
-
     pub async fn metrics_rules(&mut self, cmd: MetricsRulesCmd) -> Result<(), Error> {
         let request = GetMetricsRulesRequest {
             config: cmd.config.clone().unwrap_or_default(),
@@ -724,21 +553,6 @@ impl ACLService {
     }
 }
 
-/// Parses a `NAME=VALUE` tag entry into a [`MetricTag`].
-///
-/// An entry without `=` is bad input — the message is turned into an
-/// invalid-argument [`Error`] once at the call site.
-fn parse_tag(entry: &str) -> Result<MetricTag, String> {
-    let Some((name, value)) = entry.split_once('=') else {
-        return Err(format!("invalid --tag \"{entry}\": expected NAME=VALUE"));
-    };
-
-    Ok(MetricTag {
-        name: name.to_string(),
-        value: value.to_string(),
-    })
-}
-
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let mut service = ACLService::new(&cmd.connection).await?;
     match cmd.mode {
@@ -746,7 +560,6 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
         ModeCmd::Update(cmd) => service.update_config(cmd).await,
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::Metrics(cmd) => service.metrics(cmd).await,
         ModeCmd::MetricsRules(cmd) => service.metrics_rules(cmd).await,
         ModeCmd::RuleCounters(cmd) => service.rule_counters(cmd).await,
     }
@@ -892,28 +705,5 @@ rules:
         assert_eq!(2, rule.sources6.len());
         assert_eq!(1, rule.destinations4.len());
         assert_eq!(1, rule.destinations6.len());
-    }
-
-    #[test]
-    fn a_tag_entry_splits_on_the_first_equals() {
-        let tag = parse_tag("config=my-acl").expect("a well-formed tag must parse");
-
-        assert_eq!("config", tag.name);
-        assert_eq!("my-acl", tag.value);
-    }
-
-    #[test]
-    fn an_empty_tag_value_requires_the_label_absent() {
-        let tag = parse_tag("config=").expect("an empty value must parse");
-
-        assert_eq!("config", tag.name);
-        assert_eq!("", tag.value);
-    }
-
-    #[test]
-    fn a_tag_entry_without_equals_is_rejected() {
-        let err = parse_tag("config").expect_err("a bare tag name must be rejected");
-
-        assert!(err.contains("NAME=VALUE"));
     }
 }

--- a/modules/fwstate/cli/Cargo.toml
+++ b/modules/fwstate/cli/Cargo.toml
@@ -23,7 +23,6 @@ tonic = { version = "0.13", features = ["gzip"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 humantime = "2"
-tabled = { version = "0.18", features = ["ansi"] }
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -2,8 +2,6 @@ use core::{net::Ipv6Addr, time::Duration};
 
 use clap::Parser;
 use clap_complete::engine::ArgValueCandidates;
-use commonpb::pb::Metric;
-use ync::metrics::{self, Kind};
 
 /// Parse duration from string (e.g., "60s", "5m", "1h")
 fn parse_duration(s: &str) -> Result<Duration, String> {
@@ -21,8 +19,6 @@ pub enum ModeCmd {
     Update(UpdateCmd),
     /// Show fwstate configuration
     Show(ShowCmd),
-    /// Show fwstate metrics
-    Metrics(MetricsCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -94,36 +90,4 @@ pub struct UpdateCmd {
     /// Omitted or zero keeps the currently configured window.
     #[arg(long, value_parser = parse_duration)]
     pub sync_suppress_timeout: Option<Duration>,
-}
-
-#[derive(Debug, Clone, clap::ValueEnum)]
-pub enum MetricName {
-    /// Dataplane packet/byte counters (fwstate_*_packets, fwstate_*_bytes)
-    Counters,
-    /// Sync-related counters (fwstate_sync_*)
-    Sync,
-    /// gRPC server metrics: call counts and handling latency histograms
-    Grpc,
-}
-
-impl MetricName {
-    /// Returns true when the metric belongs to this category.
-    pub fn matches(&self, m: &Metric) -> bool {
-        let kind = metrics::proto_kind(m);
-        match self {
-            Self::Counters => kind == Kind::Counter && m.name.starts_with("fwstate_"),
-            Self::Sync => kind == Kind::Counter && m.name.starts_with("fwstate_sync_"),
-            Self::Grpc => m.name.starts_with("grpc_"),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Parser, Default)]
-pub struct MetricsCmd {
-    /// Label filter, e.g. --label config=my-fwstate
-    #[arg(long = "label", short = 'l', value_name = "KEY=VALUE")]
-    pub labels: Vec<String>,
-    /// Show only metrics matching this category
-    #[arg(long, short, value_enum)]
-    pub name: Option<MetricName>,
 }

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -1,22 +1,18 @@
 use core::net::IpAddr;
-use std::collections::HashMap;
 
-use args::{DeleteCmd, MetricsCmd, ModeCmd, ShowCmd, UpdateCmd};
-use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
+use args::{DeleteCmd, ModeCmd, ShowCmd, UpdateCmd};
+use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
-use commonpb::pb::{GetMetricsRequest, IpAddress, Metric as ProtoMetric};
+use commonpb::pb::IpAddress;
 use fwstatepb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, ShowConfigResponse, UpdateConfigRequest,
-    fw_state_service_client::FwStateServiceClient, metrics_service_client::MetricsServiceClient,
+    fw_state_service_client::FwStateServiceClient,
 };
-use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
     completion,
-    display::print_table_from_entries,
     errors::Error,
-    metrics::{self, Kind, Metric},
     output::{self, CommonFormat},
 };
 
@@ -31,9 +27,6 @@ pub mod fwstatepb {
 
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.fwstate.controlplane.fwstatepb.v1.FWStateService";
-
-/// The fully-qualified gRPC service name for the metrics service.
-const METRICS_SERVICE_NAME: &str = "modules.fwstate.controlplane.fwstatepb.v1.MetricsService";
 
 /// FWState module CLI.
 #[derive(Debug, Clone, Parser)]
@@ -75,7 +68,6 @@ fn merged_map_names(current: &ShowConfigResponse, cmd: &UpdateCmd) -> Result<(St
 
 pub struct FWStateService {
     service: Service<FwStateServiceClient<LayeredChannel>>,
-    metrics: Service<MetricsServiceClient<LayeredChannel>>,
 }
 
 impl FWStateService {
@@ -86,12 +78,7 @@ impl FWStateService {
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
         });
-        let metrics = Service::new(&conn, METRICS_SERVICE_NAME, |channel| {
-            MetricsServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        });
-        Ok(Self { service, metrics })
+        Ok(Self { service })
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
@@ -247,279 +234,6 @@ impl FWStateService {
 
         Ok(())
     }
-
-    pub async fn metrics(&mut self, cmd: MetricsCmd) -> Result<(), Error> {
-        let response = self
-            .metrics
-            .client()
-            .get_metrics(GetMetricsRequest::default())
-            .await
-            .map_err(self.metrics.status("metrics"))?
-            .into_inner();
-        let mut label_filters: Vec<(&str, &str)> = Vec::with_capacity(cmd.labels.len());
-        for s in &cmd.labels {
-            match s.split_once('=') {
-                Some(kv) => label_filters.push(kv),
-                None => {
-                    return Err(self
-                        .metrics
-                        .invalid("metrics", format!("invalid label filter {s:?}, expected KEY=VALUE")));
-                }
-            }
-        }
-
-        let metrics: Vec<ProtoMetric> = response
-            .metrics
-            .into_iter()
-            .filter(|m| {
-                if let Some(ref f) = cmd.name
-                    && !f.matches(m)
-                {
-                    return false;
-                }
-                label_filters
-                    .iter()
-                    .all(|(k, v)| metrics::proto_label_value(m, k) == Some(v))
-            })
-            .collect();
-
-        output::data(
-            || &metrics,
-            || {
-                if metrics.is_empty() {
-                    match cmd.name.as_ref().and_then(ValueEnum::to_possible_value) {
-                        Some(name) => {
-                            output::empty(format_args!("No FWState metrics found for '{}'.", name.get_name()))
-                        }
-                        None => output::empty(format_args!("No FWState metrics found.")),
-                    }
-                    return;
-                }
-
-                let metrics: Vec<Metric> = metrics.iter().cloned().map(Metric::from_proto).collect();
-                print_metrics_table(&metrics)
-            },
-        );
-
-        Ok(())
-    }
-}
-
-#[derive(Tabled)]
-struct CounterRow {
-    #[tabled(rename = "Counter")]
-    counter: String,
-    #[tabled(rename = "Packets")]
-    packets: String,
-    #[tabled(rename = "Bytes")]
-    bytes: String,
-    #[tabled(rename = "Entries")]
-    entries: String,
-}
-
-#[derive(Tabled)]
-struct GaugeRow {
-    #[tabled(rename = "Map")]
-    map: String,
-    #[tabled(rename = "AF")]
-    af: String,
-    #[tabled(rename = "Index size")]
-    index_size: String,
-    #[tabled(rename = "Extra buckets")]
-    extra_buckets: String,
-    #[tabled(rename = "Max chain")]
-    max_chain: String,
-    #[tabled(rename = "Layers")]
-    layers: String,
-    #[tabled(rename = "Elements")]
-    elements: String,
-    #[tabled(rename = "Max deadline TTL")]
-    max_deadline_ttl: String,
-    #[tabled(rename = "Memory")]
-    memory: String,
-}
-
-fn print_metrics_table(metrics: &[Metric]) {
-    struct CounterPair {
-        display: String,
-        packets: Option<u64>,
-        bytes: Option<u64>,
-        entries: Option<u64>,
-    }
-
-    let mut counter_keys: Vec<String> = Vec::new();
-    let mut counter_map: HashMap<String, Vec<&Metric>> = HashMap::new();
-    let mut map_gauges: HashMap<(String, String), HashMap<String, u64>> = HashMap::new();
-    let mut map_gauge_order: Vec<(String, String)> = Vec::new();
-    let mut grpc_counters: Vec<&Metric> = Vec::new();
-    let mut grpc_histograms: Vec<&Metric> = Vec::new();
-
-    for m in metrics {
-        if m.name.starts_with("grpc_") {
-            match m.kind {
-                Kind::Counter => grpc_counters.push(m),
-                Kind::Histogram => grpc_histograms.push(m),
-                _ => {}
-            }
-            continue;
-        }
-
-        // State-map gauges (fwstate_total_elements and siblings) carry a
-        // map name and an address family; collect them per map for the
-        // gauge section below.
-        if m.kind == Kind::Gauge && m.label_value("map").is_some() {
-            let key = (
-                m.label_value("map").unwrap_or_default().to_string(),
-                m.label_value("af").unwrap_or_default().to_string(),
-            );
-            let entry = map_gauges.entry(key.clone()).or_insert_with(|| {
-                map_gauge_order.push(key);
-                HashMap::new()
-            });
-            entry.insert(m.name.clone(), m.value.unwrap_or(0.0) as u64);
-            continue;
-        }
-
-        if m.kind == Kind::Counter {
-            let key = format!(
-                "{}\0{}\0{}\0{}\0{}",
-                m.label_value("config").unwrap_or(""),
-                m.label_value("device").unwrap_or(""),
-                m.label_value("pipeline").unwrap_or(""),
-                m.label_value("function").unwrap_or(""),
-                m.label_value("chain").unwrap_or(""),
-            );
-            if !counter_map.contains_key(&key) {
-                counter_keys.push(key.clone());
-            }
-            counter_map.entry(key).or_default().push(m);
-        }
-    }
-
-    for key in &counter_keys {
-        let counters = &counter_map[key];
-        let parts: Vec<&str> = key.split('\0').collect();
-        let (config, device, pipeline, function, chain) = (parts[0], parts[1], parts[2], parts[3], parts[4]);
-        println!(
-            "FWSTATE COUNTERS  config={config} device={device} pipeline={pipeline} function={function} chain={chain}"
-        );
-        println!();
-
-        let mut pair_order: Vec<String> = Vec::new();
-        let mut pair_map: HashMap<String, CounterPair> = HashMap::new();
-
-        // Generic counters (the default arm of emitCounterMetrics) are all
-        // exported under the shared names fwstate_counter_packets /
-        // fwstate_counter_bytes and distinguished only by the "counter" label.
-        // After stripping the fwstate_ prefix and the _packets/_bytes suffix
-        // they all collapse to the same base "counter", so the pair key must
-        // include the "counter" label value to keep them as separate rows
-        // instead of overwriting each other (last write wins). Dedicated
-        // counters carry no "counter" label, so the suffix is empty and their
-        // base is unaffected.
-        for m in counters {
-            let val = m.value.unwrap_or(0.0) as u64;
-            let stripped = m.name.strip_prefix("fwstate_").unwrap_or(&m.name);
-            let counter_label = m.label_value("counter").unwrap_or("");
-
-            // Determine the semantic suffix and the base name shared by the
-            // packets/bytes series of the same counter. The pair key and the
-            // display name must be built from the base (suffix stripped),
-            // otherwise fwstate_rx_packets and fwstate_rx_bytes get different
-            // keys and end up on two separate rows instead of one.
-            let (base, is_packets, is_bytes) = if let Some(b) = stripped.strip_suffix("_packets") {
-                (b, true, false)
-            } else if let Some(b) = stripped.strip_suffix("_bytes") {
-                (b, false, true)
-            } else {
-                (stripped, false, false)
-            };
-
-            let display = if counter_label.is_empty() {
-                metrics::metric_display_name(base, "fwstate_")
-            } else {
-                metrics::metric_display_name(counter_label, "fwstate_")
-            };
-            let pair_key = format!("{base}\0{counter_label}");
-
-            let pair = pair_map.entry(pair_key.clone()).or_insert_with(|| {
-                pair_order.push(pair_key.clone());
-                CounterPair {
-                    display,
-                    packets: None,
-                    bytes: None,
-                    entries: None,
-                }
-            });
-
-            if is_packets {
-                pair.packets = Some(val);
-            } else if is_bytes {
-                pair.bytes = Some(val);
-            } else {
-                // State-table entry counters (e.g. sync insert counters) and
-                // any unsuffixed counter count frames/items, not
-                // packets/bytes; render under Entries.
-                pair.entries = Some(val);
-            }
-        }
-
-        let rows: Vec<CounterRow> = pair_order
-            .iter()
-            .map(|pair_key| {
-                let p = &pair_map[pair_key];
-                CounterRow {
-                    counter: p.display.clone(),
-                    packets: p.packets.map(metrics::format_number).unwrap_or_else(|| "-".into()),
-                    bytes: p.bytes.map(metrics::format_number).unwrap_or_else(|| "-".into()),
-                    entries: p.entries.map(metrics::format_number).unwrap_or_else(|| "-".into()),
-                }
-            })
-            .collect();
-        print_table_from_entries(rows);
-        println!();
-    }
-
-    if !map_gauge_order.is_empty() {
-        let rows: Vec<GaugeRow> = map_gauge_order
-            .into_iter()
-            .map(|(map, af)| {
-                let gauges = &map_gauges[&(map.clone(), af.clone())];
-                let get = |name: &str| gauges.get(name).copied();
-                GaugeRow {
-                    map,
-                    af,
-                    index_size: get("fwstate_index_size")
-                        .map(metrics::format_number)
-                        .unwrap_or_else(|| "-".into()),
-                    extra_buckets: get("fwstate_extra_bucket_count")
-                        .map(metrics::format_number)
-                        .unwrap_or_else(|| "-".into()),
-                    max_chain: get("fwstate_max_chain_length")
-                        .map(metrics::format_number)
-                        .unwrap_or_else(|| "-".into()),
-                    layers: get("fwstate_layer_count")
-                        .map(metrics::format_number)
-                        .unwrap_or_else(|| "-".into()),
-                    elements: get("fwstate_total_elements")
-                        .map(metrics::format_number)
-                        .unwrap_or_else(|| "-".into()),
-                    max_deadline_ttl: get("fwstate_max_deadline_ns")
-                        .map(metrics::format_number)
-                        .unwrap_or_else(|| "-".into()),
-                    memory: get("fwstate_memory_bytes")
-                        .map(metrics::format_number)
-                        .unwrap_or_else(|| "-".into()),
-                }
-            })
-            .collect();
-        println!("FWSTATE STATE MAPS");
-        println!();
-        print_table_from_entries(rows);
-        println!();
-    }
-
-    metrics::print_grpc_metrics(&grpc_counters, &grpc_histograms);
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
@@ -530,7 +244,6 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
         ModeCmd::Update(cmd) => service.update_config(cmd).await,
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::Metrics(cmd) => service.metrics(cmd).await,
     }
 }
 


### PR DESCRIPTION
- Removes `yanet-cli-acl metrics` and `yanet-cli-fwstate metrics`: both duplicated the generic `yanet-cli metrics` probe over the same `GetMetrics` RPC with divergent filters and rendering, and the acl `--name handler` / `--name compilation` categories could never match their metrics.
- The metric-name category filters (acl `--name packets|bytes|action|state|filter-rule-count|compilation|handler`, fwstate `--name counters|sync|grpc`) go with the commands; the generic probe filters server-side with `--tag NAME=VALUE`.
- Keeps `yanet-cli-acl metrics-rules` (a distinct RPC with structured filters) and `yanet-cli-balancer2 metrics` (its `GetMetrics` sits on the `Balancer` service, which the generic probe cannot discover).
- Prunes the `ync::metrics` helpers that served only the removed commands, keeping the shared domain types the remaining consumers use.
- Drops the fwstate CLI's now-unused MetricsService client and `tabled` dependency.

Closes #2349.
