### PR TITLE
fix(controlplane,cli): map pipeline and function mutation failures to grpc statuses

### DIFF
--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -217,8 +217,8 @@ impl FunctionService {
             }),
         };
 
-        // Update is an upsert on the function itself, so a NotFound here names a
-        // referenced chain module, not the function. Keep the backend message verbatim.
+        // Update is an upsert, so a resource-level NotFound names a referenced
+        // chain module, not the function. Keep the backend message verbatim.
         self.service
             .client()
             .update(request)

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -217,14 +217,13 @@ impl FunctionService {
             }),
         };
 
-        self.service.client().update(request).await.map_err(|status| {
-            NOT_FOUND.map(
-                status,
-                "update function",
-                self.service.endpoint(),
-                Some(&format!("function '{name}'", name = cmd.name)),
-            )
-        })?;
+        // Update is an upsert on the function itself, so a NotFound here names a
+        // referenced chain module, not the function. Keep the backend message verbatim.
+        self.service
+            .client()
+            .update(request)
+            .await
+            .map_err(self.service.status("update function"))?;
 
         Ok(())
     }

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -236,8 +236,8 @@ impl PipelineService {
             }),
         };
 
-        // Update is an upsert on the pipeline itself, so a NotFound here names a
-        // referenced function, not the pipeline. Keep the backend message verbatim.
+        // Update is an upsert, so a resource-level NotFound names a referenced
+        // function, not the pipeline. Keep the backend message verbatim.
         self.service
             .client()
             .update(request)

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -236,14 +236,13 @@ impl PipelineService {
             }),
         };
 
-        self.service.client().update(request).await.map_err(|status| {
-            NOT_FOUND.map(
-                status,
-                self.action,
-                self.service.endpoint(),
-                Some(&format!("pipeline '{pipeline_name}'")),
-            )
-        })?;
+        // Update is an upsert on the pipeline itself, so a NotFound here names a
+        // referenced function, not the pipeline. Keep the backend message verbatim.
+        self.service
+            .client()
+            .update(request)
+            .await
+            .map_err(self.service.status(self.action))?;
 
         Ok(())
     }

--- a/controlplane/builtin/function.go
+++ b/controlplane/builtin/function.go
@@ -2,7 +2,6 @@ package builtin
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/c2h5oh/datasize"
 	"go.uber.org/zap"
@@ -12,6 +11,7 @@ import (
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/controlplane/internal/agenterr"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
@@ -169,6 +169,9 @@ func (m *Function) Update(
 	if reqFunctionId == nil {
 		return nil, status.Error(codes.InvalidArgument, "function id is required")
 	}
+	if reqFunctionId.Name == "" {
+		return nil, status.Error(codes.InvalidArgument, "function name is required")
+	}
 
 	function := ffi.FunctionConfig{
 		Name: reqFunctionId.Name,
@@ -181,6 +184,9 @@ func (m *Function) Update(
 
 		modules := make([]ffi.ChainModuleConfig, 0, len(reqChain.Modules))
 		for _, reqChainModule := range reqChain.Modules {
+			if reqChainModule == nil {
+				return nil, status.Error(codes.InvalidArgument, "module id is required")
+			}
 			modules = append(modules, ffi.ChainModuleConfig{
 				Type: reqChainModule.Type,
 				Name: reqChainModule.Name,
@@ -200,12 +206,12 @@ func (m *Function) Update(
 
 	agent, err := m.shm.AgentAttach(functionAgentName, m.instanceID, functionAgentMemory)
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach to agent %q: %w", functionAgentName, err)
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	defer agent.Close()
 
 	if err := agent.UpdateFunction(function); err != nil {
-		return nil, fmt.Errorf("failed to update function: %w", err)
+		return nil, agenterr.ClassifyUpdate(err)
 	}
 
 	return &ynpb.UpdateFunctionResponse{}, nil
@@ -220,16 +226,19 @@ func (m *Function) Delete(
 	if reqId == nil {
 		return nil, status.Error(codes.InvalidArgument, "function id is required")
 	}
+	if reqId.Name == "" {
+		return nil, status.Error(codes.InvalidArgument, "function name is required")
+	}
 	functionName := reqId.Name
 
 	agent, err := m.shm.AgentAttach(functionAgentName, m.instanceID, functionAgentMemory)
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach to agent %q: %w", functionAgentName, err)
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	defer agent.Close()
 
 	if err := agent.DeleteFunction(functionName); err != nil {
-		return nil, fmt.Errorf("failed to delete function: %w", err)
+		return nil, agenterr.ClassifyDelete(err)
 	}
 
 	return &ynpb.DeleteFunctionResponse{}, nil

--- a/controlplane/builtin/function_test.go
+++ b/controlplane/builtin/function_test.go
@@ -31,12 +31,37 @@ func TestFunctionUpdateRejectsMissingMessages(t *testing.T) {
 			},
 		},
 		{
+			name: "empty function name",
+			request: &ynpb.UpdateFunctionRequest{
+				Function: &ynpb.Function{
+					Id: &commonpb.FunctionId{},
+				},
+			},
+		},
+		{
 			name: "missing chain",
 			request: &ynpb.UpdateFunctionRequest{
 				Function: &ynpb.Function{
 					Id: &commonpb.FunctionId{Name: "f"},
 					Chains: []*ynpb.FunctionChain{
 						{Weight: 1},
+					},
+				},
+			},
+		},
+		{
+			name: "nil module id in chain",
+			request: &ynpb.UpdateFunctionRequest{
+				Function: &ynpb.Function{
+					Id: &commonpb.FunctionId{Name: "f"},
+					Chains: []*ynpb.FunctionChain{
+						{
+							Weight: 1,
+							Chain: &ynpb.Chain{
+								Name:    "c",
+								Modules: []*commonpb.ModuleId{nil},
+							},
+						},
 					},
 				},
 			},
@@ -59,6 +84,17 @@ func TestFunctionDeleteRejectsMissingID(t *testing.T) {
 	svc := builtin.NewFunction(0, nil)
 
 	_, err := svc.Delete(t.Context(), &ynpb.DeleteFunctionRequest{})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Test_Function_Delete_EmptyName verifies that Delete rejects an id with
+// an empty name instead of deleting a function named "".
+func Test_Function_Delete_EmptyName(t *testing.T) {
+	svc := builtin.NewFunction(0, nil)
+
+	_, err := svc.Delete(t.Context(), &ynpb.DeleteFunctionRequest{
+		Id: &commonpb.FunctionId{},
+	})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 

--- a/controlplane/builtin/function_test.go
+++ b/controlplane/builtin/function_test.go
@@ -31,14 +31,6 @@ func TestFunctionUpdateRejectsMissingMessages(t *testing.T) {
 			},
 		},
 		{
-			name: "empty function name",
-			request: &ynpb.UpdateFunctionRequest{
-				Function: &ynpb.Function{
-					Id: &commonpb.FunctionId{},
-				},
-			},
-		},
-		{
 			name: "missing chain",
 			request: &ynpb.UpdateFunctionRequest{
 				Function: &ynpb.Function{
@@ -76,6 +68,19 @@ func TestFunctionUpdateRejectsMissingMessages(t *testing.T) {
 			require.Equal(t, codes.InvalidArgument, status.Code(err))
 		})
 	}
+}
+
+// Test_Function_Update_EmptyName verifies that Update rejects an id with
+// an empty name instead of creating a function named "".
+func Test_Function_Update_EmptyName(t *testing.T) {
+	svc := builtin.NewFunction(0, nil)
+
+	_, err := svc.Update(t.Context(), &ynpb.UpdateFunctionRequest{
+		Function: &ynpb.Function{
+			Id: &commonpb.FunctionId{},
+		},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 // TestFunctionDeleteRejectsMissingID verifies that Delete rejects a request

--- a/controlplane/builtin/pipeline.go
+++ b/controlplane/builtin/pipeline.go
@@ -2,7 +2,6 @@ package builtin
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/c2h5oh/datasize"
 	"go.uber.org/zap"
@@ -12,6 +11,7 @@ import (
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/controlplane/internal/agenterr"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
@@ -155,6 +155,9 @@ func (m *Pipeline) Update(
 	if reqPipelineId == nil {
 		return nil, status.Error(codes.InvalidArgument, "pipeline id is required")
 	}
+	if reqPipelineId.Name == "" {
+		return nil, status.Error(codes.InvalidArgument, "pipeline name is required")
+	}
 
 	pipeline := ffi.PipelineConfig{
 		Name:      reqPipelineId.Name,
@@ -162,17 +165,20 @@ func (m *Pipeline) Update(
 	}
 
 	for idx, reqFunctionId := range reqPipeline.Functions {
+		if reqFunctionId == nil {
+			return nil, status.Error(codes.InvalidArgument, "function id is required")
+		}
 		pipeline.Functions[idx] = reqFunctionId.Name
 	}
 
 	agent, err := m.shm.AgentAttach(agentName, m.instanceID, defaultAgentMemory)
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach to agent %q: %w", agentName, err)
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	defer agent.Close()
 
 	if err := agent.UpdatePipeline(pipeline); err != nil {
-		return nil, fmt.Errorf("failed to update function: %w", err)
+		return nil, agenterr.ClassifyUpdate(err)
 	}
 
 	return &ynpb.UpdatePipelineResponse{}, nil
@@ -187,16 +193,19 @@ func (m *Pipeline) Delete(
 	if reqId == nil {
 		return nil, status.Error(codes.InvalidArgument, "pipeline id is required")
 	}
+	if reqId.Name == "" {
+		return nil, status.Error(codes.InvalidArgument, "pipeline name is required")
+	}
 	pipelineName := reqId.Name
 
 	agent, err := m.shm.AgentAttach(agentName, m.instanceID, defaultAgentMemory)
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach to agent %q: %w", agentName, err)
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	defer agent.Close()
 
 	if err := agent.DeletePipeline(pipelineName); err != nil {
-		return nil, fmt.Errorf("failed to delete pipeline: %w", err)
+		return nil, agenterr.ClassifyDelete(err)
 	}
 
 	return &ynpb.DeletePipelineResponse{}, nil

--- a/controlplane/builtin/pipeline_test.go
+++ b/controlplane/builtin/pipeline_test.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/builtin"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
@@ -29,6 +30,23 @@ func TestPipelineUpdateRejectsMissingMessages(t *testing.T) {
 				Pipeline: &ynpb.Pipeline{},
 			},
 		},
+		{
+			name: "empty pipeline name",
+			request: &ynpb.UpdatePipelineRequest{
+				Pipeline: &ynpb.Pipeline{
+					Id: &commonpb.PipelineId{},
+				},
+			},
+		},
+		{
+			name: "nil function id in functions",
+			request: &ynpb.UpdatePipelineRequest{
+				Pipeline: &ynpb.Pipeline{
+					Id:        &commonpb.PipelineId{Name: "p"},
+					Functions: []*commonpb.FunctionId{nil},
+				},
+			},
+		},
 	}
 
 	svc := builtin.NewPipeline(0, nil)
@@ -47,6 +65,17 @@ func TestPipelineDeleteRejectsMissingID(t *testing.T) {
 	svc := builtin.NewPipeline(0, nil)
 
 	_, err := svc.Delete(t.Context(), &ynpb.DeletePipelineRequest{})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Test_Pipeline_Delete_EmptyName verifies that Delete rejects an id with
+// an empty name instead of deleting a pipeline named "".
+func Test_Pipeline_Delete_EmptyName(t *testing.T) {
+	svc := builtin.NewPipeline(0, nil)
+
+	_, err := svc.Delete(t.Context(), &ynpb.DeletePipelineRequest{
+		Id: &commonpb.PipelineId{},
+	})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 

--- a/controlplane/builtin/pipeline_test.go
+++ b/controlplane/builtin/pipeline_test.go
@@ -31,14 +31,6 @@ func TestPipelineUpdateRejectsMissingMessages(t *testing.T) {
 			},
 		},
 		{
-			name: "empty pipeline name",
-			request: &ynpb.UpdatePipelineRequest{
-				Pipeline: &ynpb.Pipeline{
-					Id: &commonpb.PipelineId{},
-				},
-			},
-		},
-		{
 			name: "nil function id in functions",
 			request: &ynpb.UpdatePipelineRequest{
 				Pipeline: &ynpb.Pipeline{
@@ -57,6 +49,19 @@ func TestPipelineUpdateRejectsMissingMessages(t *testing.T) {
 			require.Equal(t, codes.InvalidArgument, status.Code(err))
 		})
 	}
+}
+
+// Test_Pipeline_Update_EmptyName verifies that Update rejects an id with
+// an empty name instead of creating a pipeline named "".
+func Test_Pipeline_Update_EmptyName(t *testing.T) {
+	svc := builtin.NewPipeline(0, nil)
+
+	_, err := svc.Update(t.Context(), &ynpb.UpdatePipelineRequest{
+		Pipeline: &ynpb.Pipeline{
+			Id: &commonpb.PipelineId{},
+		},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 // TestPipelineDeleteRejectsMissingID verifies that Delete rejects a request

--- a/controlplane/internal/agenterr/agenterr.go
+++ b/controlplane/internal/agenterr/agenterr.go
@@ -1,0 +1,42 @@
+// Package agenterr classifies pipeline and function mutation failures
+// into gRPC statuses.
+//
+// No error code crosses the FFI boundary, only formatted text, so
+// classification anchors on that flat message instead of a code.
+package agenterr
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ClassifyDelete maps a Delete RPC's backend failure to a gRPC status.
+//
+// A trailing "not found" names the deleted entity itself; the same
+// wording continuing further names a live in-use refusal instead and
+// stays Internal.
+func ClassifyDelete(err error) error {
+	return classify(err, strings.HasSuffix(err.Error(), "' not found"))
+}
+
+// ClassifyUpdate maps an Update RPC's backend failure to a gRPC status.
+//
+// A pipeline update and a function update reach the same underlying
+// validation, so a missing referenced function or a missing chain
+// module both surface as NotFound regardless of which RPC ran; every
+// other failure stays Internal.
+func ClassifyUpdate(err error) error {
+	msg := err.Error()
+	notFound := strings.Contains(msg, "' not found for pipeline '") ||
+		strings.Contains(msg, "' not found in chain '")
+	return classify(err, notFound)
+}
+
+func classify(err error, notFound bool) error {
+	if notFound {
+		return status.Error(codes.NotFound, err.Error())
+	}
+	return status.Error(codes.Internal, err.Error())
+}

--- a/controlplane/internal/agenterr/agenterr_test.go
+++ b/controlplane/internal/agenterr/agenterr_test.go
@@ -1,0 +1,105 @@
+package agenterr_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/agenterr"
+)
+
+// Test_ClassifyDelete_Cases verifies that a missing-entity leaf maps to
+// NotFound and every other backend failure maps to Internal.
+//
+// An in-use refusal shares the same "not found" wording as a
+// missing-entity leaf but continues past it, so it must stay Internal;
+// both outcomes keep the message unchanged.
+func Test_ClassifyDelete_Cases(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		code codes.Code
+	}{
+		{
+			name: "missing pipeline",
+			msg:  `failed to delete pipeline "p": pipeline 'p' not found`,
+			code: codes.NotFound,
+		},
+		{
+			name: "missing function",
+			msg:  `failed to delete function "f": function 'f' not found`,
+			code: codes.NotFound,
+		},
+		{
+			name: "pipeline attached to a device",
+			msg:  `failed to delete pipeline "p": pipeline 'p' not found in device entry`,
+			code: codes.Internal,
+		},
+		{
+			name: "function still used by a pipeline",
+			msg:  `failed to delete function "f": function 'f' not found for pipeline 'p'`,
+			code: codes.Internal,
+		},
+		{
+			name: "registry delete failure",
+			msg:  `failed to delete function "f": failed to delete function from registry`,
+			code: codes.Internal,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := agenterr.ClassifyDelete(errors.New(test.msg))
+
+			require.Equal(t, test.code, status.Code(err))
+			require.Equal(t, test.msg, status.Convert(err).Message())
+		})
+	}
+}
+
+// Test_ClassifyUpdate_Cases verifies that a missing referenced entity
+// leaf maps to NotFound and every other backend failure maps to Internal.
+//
+// Both the missing-function and missing-chain-module leaves map to
+// NotFound regardless of which RPC's message prefix carries them; every
+// outcome keeps the message unchanged.
+func Test_ClassifyUpdate_Cases(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		code codes.Code
+	}{
+		{
+			name: "pipeline references missing function",
+			msg:  `failed to update pipelines: function 'f' not found for pipeline 'p'`,
+			code: codes.NotFound,
+		},
+		{
+			name: "function chain names missing module",
+			msg:  `failed to update functions: module 't:n' not found in chain 'c' of function 'f' in pipeline 'p'`,
+			code: codes.NotFound,
+		},
+		{
+			name: "pipeline update surfaces a chain-module leaf",
+			msg:  `failed to update pipelines: module 't:n' not found in chain 'c' of function 'f' in pipeline 'p'`,
+			code: codes.NotFound,
+		},
+		{
+			name: "allocation failure",
+			msg:  `failed to create pipeline config: failed to create ffi pipeline config`,
+			code: codes.Internal,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := agenterr.ClassifyUpdate(errors.New(test.msg))
+
+			require.Equal(t, test.code, status.Code(err))
+			require.Equal(t, test.msg, status.Convert(err).Message())
+		})
+	}
+}

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -524,6 +524,12 @@ cp_config_delete_function(
 	struct cp_config_gen *old_config_gen =
 		ADDR_OF(&cp_config->cp_config_gen);
 
+	uint64_t index;
+	if (cp_config_gen_lookup_function_index(old_config_gen, name, &index)) {
+		yanet_error_add(err, "function '%s' not found", name);
+		goto error_unlock;
+	}
+
 	struct cp_config_gen *new_config_gen =
 		cp_config_gen_new_from(cp_config, old_config_gen, err);
 	if (new_config_gen == NULL) {

--- a/lib/controlplane/config/zone.h
+++ b/lib/controlplane/config/zone.h
@@ -334,6 +334,11 @@ cp_config_gen_lookup_pipeline(
 );
 
 int
+cp_config_gen_lookup_function_index(
+	struct cp_config_gen *config_gen, const char *name, uint64_t *index
+);
+
+int
 cp_config_gen_lookup_pipeline_index(
 	struct cp_config_gen *config_gen, const char *name, uint64_t *index
 );


### PR DESCRIPTION
- Pipeline and function Update/Delete wrapped every backend failure in a plain error, so each surfaced as codes.Unknown, the CLI's not-found mapping (exit code 3) never fired for mutations, and messages arrived double-wrapped.
- A new internal package classifies agent mutation failures by anchoring on the C error text, since no error code crosses the FFI boundary: a missing entity maps to NotFound, everything else to Internal, keeping the single already-wrapped message.
- Deleting an entity that exists but is still referenced (a pipeline attached to a device, a function used by a pipeline) deliberately stays Internal, not NotFound.
- Both update RPCs share the same whole-graph validation on install, so both not-found leaves (missing referenced function, missing chain module) map to NotFound regardless of which RPC tripped them.
- The C-side delete of a function now pre-checks existence under the config lock and reports "function 'x' not found", mirroring its pipeline sibling, which previously reported only an opaque registry failure; the lookup helper's missing header prototype is added.
- Mutations also reject an empty entity name and nil repeated-field elements with InvalidArgument instead of panicking or writing an unnamed entity.
- The CLI update commands for pipeline and function no longer rewrite a NotFound as if the upserted target were missing: update is an upsert, so a NotFound names a missing referenced entity, and the backend message is kept verbatim (still exit code 3); delete and get keep the friendly rewrite.
- Known limitation carried over from the acl precedent: nothing couples the Go anchor strings to the C format strings, so a reword in the C layer would silently degrade the mapping to Internal; and an update of a pipeline not attached to any device still succeeds with a dangling function reference, as before.

Closes #2347.
