### PR TITLE
feat(decap): delete a config through the service and cli

### DIFF
--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -5,7 +5,7 @@ use clap_complete::{
 };
 use commonpb::partition_prefixes;
 use decappb::{
-    ListConfigsRequest, ShowConfigRequest, ShowConfigResponse, UpdateConfigRequest,
+    DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, ShowConfigResponse, UpdateConfigRequest,
     decap_service_client::DecapServiceClient,
 };
 use netip::{Contiguous, IpNetwork};
@@ -14,7 +14,7 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    errors::Error,
+    errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
 };
 
@@ -47,6 +47,8 @@ pub enum ModeCmd {
     List,
     Show(ShowConfigCmd),
     Update(UpdateConfigCmd),
+    /// Delete a decap module config.
+    Delete(DeleteConfigCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -66,8 +68,18 @@ pub struct UpdateConfigCmd {
     pub prefixes: Vec<Contiguous<IpNetwork>>,
 }
 
+#[derive(Debug, Clone, Parser)]
+pub struct DeleteConfigCmd {
+    /// Decap module name to delete.
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
+    pub config_name: String,
+}
+
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.decap.controlplane.decappb.v1.DecapService";
+
+/// Maps a genuine "config not found" status into a friendly message.
+const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
 fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
@@ -92,6 +104,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::List => service.list_configs().await,
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
         ModeCmd::Update(cmd) => service.update_config(cmd).await,
+        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
     }
 }
 
@@ -193,6 +206,30 @@ impl DecapService {
         log::debug!("update config response: {response:?}");
 
         output::success("update", format_args!("Updated decap {}.", cmd.config_name));
+
+        Ok(())
+    }
+
+    pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
+        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+        log::trace!("delete config request: {request:?}");
+        let response = self
+            .service
+            .client()
+            .delete_config(request)
+            .await
+            .map_err(|status| {
+                NOT_FOUND.map(
+                    status,
+                    "delete",
+                    self.service.endpoint(),
+                    Some(&format!("config '{}'", cmd.config_name)),
+                )
+            })?
+            .into_inner();
+        log::debug!("delete config response: {response:?}");
+
+        output::success("delete", format_args!("Deleted decap {}.", cmd.config_name));
 
         Ok(())
     }

--- a/modules/decap/controlplane/backend.go
+++ b/modules/decap/controlplane/backend.go
@@ -8,6 +8,9 @@ import (
 	"github.com/yanet-platform/yanet2/modules/decap/bindings/go/cdecap"
 )
 
+// moduleType identifies the decap module to the shared-memory agent.
+const moduleType = "decap"
+
 // backend is the real Backend implementation backed by shared memory.
 type backend struct {
 	agent *ffi.Agent
@@ -45,4 +48,8 @@ func (m *backend) UpdateModule(name string, prefixes []netip.Prefix) (ModuleHand
 	}
 
 	return mod, nil
+}
+
+func (m *backend) DeleteModule(name string) error {
+	return m.agent.DeleteModuleConfig(moduleType, name)
 }

--- a/modules/decap/controlplane/decappb/v1/decap.proto
+++ b/modules/decap/controlplane/decappb/v1/decap.proto
@@ -18,6 +18,10 @@ service DecapService {
 
   // UpdateConfig atomically replaces the whole prefix set of the named config.
   rpc UpdateConfig(UpdateConfigRequest) returns (UpdateConfigResponse) {}
+
+  // DeleteConfig removes the named config when it is no longer referenced
+  // by any pipeline.
+  rpc DeleteConfig(DeleteConfigRequest) returns (DeleteConfigResponse) {}
 }
 
 message ListConfigsRequest {}
@@ -43,3 +47,9 @@ message UpdateConfigRequest {
 
 // UpdateConfigResponse is the response to an UpdateConfig call.
 message UpdateConfigResponse {}
+
+// DeleteConfigRequest names the config to delete.
+message DeleteConfigRequest { string name = 1; }
+
+// DeleteConfigResponse is the response to a DeleteConfig call.
+message DeleteConfigResponse {}

--- a/modules/decap/controlplane/service.go
+++ b/modules/decap/controlplane/service.go
@@ -32,6 +32,8 @@ type Backend interface {
 	// UpdateModule creates a module config, adds prefixes, and publishes
 	// it to the dataplane.
 	UpdateModule(name string, prefixes []netip.Prefix) (ModuleHandle, error)
+	// DeleteModule removes a module config.
+	DeleteModule(name string) error
 }
 
 type config struct {
@@ -154,6 +156,42 @@ func (m *DecapService) UpdateConfig(
 	}
 
 	return &decappb.UpdateConfigResponse{}, nil
+}
+
+// DeleteConfig removes the named config if it is not referenced by any
+// pipeline.
+func (m *DecapService) DeleteConfig(
+	ctx context.Context,
+	req *decappb.DeleteConfigRequest,
+) (*decappb.DeleteConfigResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, errConfigNameRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.configs[name]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "no config found")
+	}
+
+	if err := m.backend.DeleteModule(name); err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to delete module config %q: %v", name, err,
+		)
+	}
+
+	// The delete retired the generation holding the published module.
+	// Retry the deferred ones, then retire this one.
+	m.reclaimDeferred()
+	m.parkOrFree(entry.Module)
+
+	delete(m.configs, name)
+
+	return &decappb.DeleteConfigResponse{}, nil
 }
 
 func comparePrefixes(first, second netip.Prefix) int {

--- a/modules/decap/controlplane/service_test.go
+++ b/modules/decap/controlplane/service_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
 
@@ -59,24 +60,82 @@ func prefixStrings[T interface{ ToPrefix() (netip.Prefix, error) }](t *testing.T
 
 var errInjectedBackend = errors.New("injected backend failure")
 
-type mockModuleHandle struct{}
+// mockModuleHandle counts Free calls so tests can assert a release happened.
+type mockModuleHandle struct {
+	freed atomic.Int64
+}
 
 func (m *mockModuleHandle) Free() error {
+	m.freed.Add(1)
 	return nil
 }
 
-type mockBackend struct{}
+// refusingOnceHandle refuses its first Free with ffi.ErrStillReferenced, then succeeds.
+type refusingOnceHandle struct {
+	numCalls atomic.Int64
+	freed    atomic.Int64
+}
+
+func (m *refusingOnceHandle) Free() error {
+	if m.numCalls.Add(1) == 1 {
+		return ffi.ErrStillReferenced
+	}
+	m.freed.Add(1)
+	return nil
+}
+
+// mockBackend records the last handle it minted and the name it last saw in DeleteModule.
+type mockBackend struct {
+	lastHandle  atomic.Pointer[mockModuleHandle]
+	deletedName string
+}
 
 func (m *mockBackend) UpdateModule(
 	name string,
 	prefixes []netip.Prefix,
 ) (ModuleHandle, error) {
-	return &mockModuleHandle{}, nil
+	handle := &mockModuleHandle{}
+	m.lastHandle.Store(handle)
+	return handle, nil
+}
+
+func (m *mockBackend) DeleteModule(name string) error {
+	m.deletedName = name
+	return nil
 }
 
 func newTestService(t *testing.T) *DecapService {
 	t.Helper()
 	return NewDecapService(&mockBackend{})
+}
+
+// refusingDeleteBackend updates like mockBackend but refuses every delete,
+// modeling a config still referenced by a live generation.
+type refusingDeleteBackend struct {
+	mockBackend
+}
+
+func (m *refusingDeleteBackend) DeleteModule(name string) error {
+	m.deletedName = name
+	return errInjectedBackend
+}
+
+// parkingBackend refuses to release the first handle it mints, then releases
+// normally, so that handle must be parked before it can be reclaimed.
+type parkingBackend struct {
+	mockBackend
+	numCalls atomic.Int64
+	first    refusingOnceHandle
+}
+
+func (m *parkingBackend) UpdateModule(
+	name string,
+	prefixes []netip.Prefix,
+) (ModuleHandle, error) {
+	if m.numCalls.Add(1) == 1 {
+		return &m.first, nil
+	}
+	return &mockModuleHandle{}, nil
 }
 
 // flakyBackend succeeds on the first UpdateModule call and fails thereafter.
@@ -92,6 +151,10 @@ func (m *flakyBackend) UpdateModule(
 		return nil, errInjectedBackend
 	}
 	return &mockModuleHandle{}, nil
+}
+
+func (m *flakyBackend) DeleteModule(name string) error {
+	return nil
 }
 
 func Test_DecapService_UpdateAndShow(t *testing.T) {
@@ -177,6 +240,12 @@ func Test_DecapService_EmptyConfigName(t *testing.T) {
 		require.Nil(t, resp)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
+
+	t.Run("DeleteConfig", func(t *testing.T) {
+		resp, err := svc.DeleteConfig(ctx, &decappb.DeleteConfigRequest{})
+		require.Nil(t, resp)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
 }
 
 func Test_DecapService_InvalidPrefix(t *testing.T) {
@@ -244,6 +313,103 @@ func Test_DecapService_UpdateFailureAtomic(t *testing.T) {
 	require.NotNil(t, show)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff([]string{"10.0.0.0/24"}, prefixStrings(t, show.Prefixes4)))
+}
+
+// Test_DecapService_DeleteConfig_MissingConfig verifies that deleting a
+// config that was never created returns NotFound.
+func Test_DecapService_DeleteConfig_MissingConfig(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.DeleteConfig(t.Context(), &decappb.DeleteConfigRequest{Name: "decap0"})
+	require.Nil(t, resp)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// Test_DecapService_DeleteConfig_RemovesConfig verifies that deleting an
+// unreferenced config removes it from ListConfigs and from Show.
+func Test_DecapService_DeleteConfig_RemovesConfig(t *testing.T) {
+	backend := &mockBackend{}
+	svc := NewDecapService(backend)
+	ctx := t.Context()
+
+	_, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
+		Name:      "decap0",
+		Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
+	})
+	require.NoError(t, err)
+
+	handle := backend.lastHandle.Load()
+	require.NotNil(t, handle)
+
+	resp, err := svc.DeleteConfig(ctx, &decappb.DeleteConfigRequest{Name: "decap0"})
+	require.NotNil(t, resp)
+	require.NoError(t, err)
+	assert.Equal(t, "decap0", backend.deletedName)
+	assert.Equal(t, int64(1), handle.freed.Load())
+
+	list, err := svc.ListConfigs(ctx, &decappb.ListConfigsRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, list.Configs)
+
+	show, err := svc.ShowConfig(ctx, &decappb.ShowConfigRequest{Name: "decap0"})
+	require.Nil(t, show)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// Test_DecapService_DeleteConfig_Referenced verifies that a backend refusal
+// surfaces as Internal and leaves the config in place.
+func Test_DecapService_DeleteConfig_Referenced(t *testing.T) {
+	backend := &refusingDeleteBackend{}
+	svc := NewDecapService(backend)
+	ctx := t.Context()
+
+	_, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
+		Name:      "decap0",
+		Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
+	})
+	require.NoError(t, err)
+
+	resp, err := svc.DeleteConfig(ctx, &decappb.DeleteConfigRequest{Name: "decap0"})
+	require.Nil(t, resp)
+	require.Equal(t, codes.Internal, status.Code(err))
+	assert.Equal(t, "decap0", backend.deletedName)
+
+	list, err := svc.ListConfigs(ctx, &decappb.ListConfigsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"decap0"}, list.Configs)
+
+	show, err := svc.ShowConfig(ctx, &decappb.ShowConfigRequest{Name: "decap0"})
+	require.NotNil(t, show)
+	require.NoError(t, err)
+}
+
+// Test_DecapService_DeleteConfig_ParksThenReclaims verifies that a handle
+// refused on delete is parked and reclaimed by the next successful update.
+func Test_DecapService_DeleteConfig_ParksThenReclaims(t *testing.T) {
+	backend := &parkingBackend{}
+	svc := NewDecapService(backend)
+	ctx := t.Context()
+
+	_, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
+		Name:      "decap0",
+		Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
+	})
+	require.NoError(t, err)
+
+	resp, err := svc.DeleteConfig(ctx, &decappb.DeleteConfigRequest{Name: "decap0"})
+	require.NotNil(t, resp)
+	require.NoError(t, err)
+	require.Len(t, svc.deferred, 1)
+	assert.Equal(t, int64(0), backend.first.freed.Load())
+
+	// A later successful update reclaims deferred handles first.
+	_, err = svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
+		Name:      "decap1",
+		Prefixes4: mustPrefixes4(t, "10.0.1.0/24"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, svc.deferred)
+	assert.Equal(t, int64(1), backend.first.freed.Load())
 }
 
 func Test_DecapService_DeduplicatePrefixes(t *testing.T) {


### PR DESCRIPTION
- Add a DeleteConfig RPC to DecapService and serve it with the standard guarded path: a missing config returns NotFound, a config still referenced by a live generation is refused with the dataplane's error relayed, and an unreferenced config is removed from ListConfigs with its shared-memory handle released or parked for reclaim.
- Add `yanet-cli-decap delete --name` with completion of the config name; a missing config renders a friendly not-found error and exits 3.
- Cover the empty-name, missing, unreferenced, referenced and park-then-reclaim cases in the service tests, with mocks that pin the handle release.
- Assumption: DeleteConfigResponse is empty rather than the always-true `bool deleted` of the older modules, which the CLI ops review flagged as meaningless.
- Assumption: a referenced-config refusal is relayed as Internal carrying the C error text, matching the peer modules; the FFI flattens the C error chain into a string, so a typed still-referenced status would need a bindings change out of this scope.
- Assumption: the CLI gains no unit tests because the verb adds no crate-own logic, and the repo test policy forbids clap and status-mapping tautology tests.
- Closes #2383.