### PR TITLE
refactor(counters)!: read worker counters per worker id

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -35,10 +35,10 @@ struct counter_handle {
 	struct counter_tag *tags;
 	size_t tag_count;
 
-	// Per-instance snapshot arrays: values[i] holds size values for
-	// instance i, copied when the list was acquired, remaining valid and
-	// unchanged across controlplane updates until the list is freed.
-	uint64_t **values;
+	// The counter's value snapshot: size values copied when the list
+	// was acquired, remaining valid and unchanged across controlplane
+	// updates until the list is freed.
+	uint64_t *values;
 };
 
 // A list of counter handles whose single allocation also owns every
@@ -46,7 +46,6 @@ struct counter_handle {
 // region placed right after the handle array, so freeing the list
 // reclaims all of it.
 struct counter_handle_list {
-	uint64_t instance_count;
 	uint64_t count;
 	struct counter_handle counters[];
 };
@@ -74,8 +73,15 @@ yanet_counter_query_compile(
 void
 yanet_counter_query_free(struct counter_query *query);
 
+// Snapshot the worker counters of one worker, identified by its index
+// among the dataplane's workers.
+//
+// The returned list must be released with
+// yanet_counter_handle_list_free. Returns NULL when the index is out of
+// range or the allocation fails; the union across workers is the
+// caller's to build.
 struct counter_handle_list *
-yanet_get_worker_counters(struct dp_config *dp_config);
+yanet_get_worker_counters(struct dp_config *dp_config, uint64_t worker_idx);
 
 // Counters of a single DPDK port.
 //
@@ -127,29 +133,23 @@ struct counter_handle *
 yanet_get_counter(struct counter_handle_list *counters, uint64_t idx);
 
 uint64_t
-yanet_get_counter_value(
-	uint64_t **values, uint64_t value_idx, uint64_t worker_idx
-);
+yanet_get_counter_value(const uint64_t *values, uint64_t value_idx);
 
-// Copy all values for every instance of a counter into a flat caller-supplied
-// buffer in a single call.
+// Copy all values of a counter into a flat caller-supplied buffer in a
+// single call.
 //
-// values_out must have room for instance_count * size uint64 elements and is
-// filled instance-major: instance i occupies values_out[i*size .. i*size +
-// size). Performs the same reads as yanet_get_counter_value but batched into
-// one call, avoiding per-value CGO overhead when reading counters from Go.
+// values_out must have room for size uint64 elements. Performs the same
+// reads as the single-value accessor but batched into one call, avoiding
+// per-value CGO overhead when reading counters from Go.
 void
 yanet_get_counter_values(
-	uint64_t **values,
-	uint64_t size,
-	uint64_t instance_count,
-	uint64_t *values_out
+	const uint64_t *values, uint64_t size, uint64_t *values_out
 );
 
 // One worker's independently matched counter set.
 //
-// counters holds only that worker's snapshot: its instance_count is 1
-// and every handle's values are copied from that worker's own storages.
+// counters holds only that worker's snapshot: every handle's values are
+// copied from that worker's own storages.
 struct counter_worker_set {
 	uint64_t worker_idx;
 	struct counter_handle_list *counters;

--- a/controlplane/ffi/counter.go
+++ b/controlplane/ffi/counter.go
@@ -51,30 +51,22 @@ func (m CounterInfo) InstanceValues(instance int) []uint64 {
 	return m.Values[instance]
 }
 
-func decodeCounterHandle(
-	handle *C.struct_counter_handle,
-	instanceCount C.uint64_t,
-) CounterInfo {
+func decodeCounterHandle(handle *C.struct_counter_handle) CounterInfo {
 	size := int(handle.size)
-	instances := int(instanceCount)
 
-	values := make([][]uint64, instances)
-	if total := instances * size; total > 0 {
-		flat := make([]uint64, total)
+	var instance []uint64
+	if size > 0 {
+		instance = make([]uint64, size)
 		C.yanet_get_counter_values(
 			handle.values,
 			handle.size,
-			instanceCount,
-			(*C.uint64_t)(unsafe.Pointer(&flat[0])),
+			(*C.uint64_t)(unsafe.Pointer(&instance[0])),
 		)
-		for iidx := range instances {
-			values[iidx] = flat[iidx*size : (iidx+1)*size : (iidx+1)*size]
-		}
 	}
 
 	return CounterInfo{
 		Name:   C.GoString(&handle.name[0]),
-		Values: values,
+		Values: [][]uint64{instance},
 	}
 }
 
@@ -86,7 +78,7 @@ func (m *DPConfig) encodeCounters(
 	for cidx := C.uint64_t(0); cidx < counters.count; cidx++ {
 		handle := C.yanet_get_counter(counters, cidx)
 		if handle != nil {
-			res = append(res, decodeCounterHandle(handle, counters.instance_count))
+			res = append(res, decodeCounterHandle(handle))
 		}
 	}
 
@@ -240,15 +232,30 @@ func (m *DPConfig) ObjectCounters(
 }
 
 // RawWorkerCounters returns the worker counters, or nil when they cannot be read.
+//
+// The C API snapshots one worker at a time, so every worker is read
+// separately and the per-worker snapshots are merged into one list
+// spanning every worker: worker i's values land in instance slot i of
+// each counter.
 func (m *DPConfig) RawWorkerCounters() []CounterInfo {
-	counters := C.yanet_get_worker_counters(m.ptr)
-	defer C.yanet_counter_handle_list_free(counters)
-
-	if counters == nil {
-		return nil
+	workerCount := int(m.WorkerCount())
+	perWorker := make([][]CounterGroup, workerCount)
+	for idx := range workerCount {
+		counters := C.yanet_get_worker_counters(m.ptr, C.uint64_t(idx))
+		if counters == nil {
+			return nil
+		}
+		perWorker[idx] = []CounterGroup{{Counters: m.encodeCounters(counters)}}
+		C.yanet_counter_handle_list_free(counters)
 	}
 
-	return m.encodeCounters(counters)
+	// Every worker shares one untagged counter group, so the merge
+	// yields exactly one group carrying the worker-sharded counters.
+	groups := MergeWorkerCounterGroups(workerCount, perWorker)
+	if len(groups) == 0 {
+		return []CounterInfo{}
+	}
+	return groups[0].Counters
 }
 
 // CounterTag is a (key, value) predicate against a counter's tag set.
@@ -433,7 +440,8 @@ func decodeCounterGroups(counters *C.struct_counter_handle_list) []CounterGroup 
 		group := &groups[len(groups)-1]
 		group.Counters = append(
 			group.Counters,
-			decodeCounterHandle(handle, counters.instance_count))
+			decodeCounterHandle(handle),
+		)
 	}
 
 	return groups

--- a/controlplane/ffi/port.go
+++ b/controlplane/ffi/port.go
@@ -49,7 +49,6 @@ func (m *DPConfig) PortCounters() ([]PortGroup, error) {
 					Value: uint64(C.yanet_get_counter_value(
 						handle.values,
 						0,
-						0,
 					)),
 				},
 			)

--- a/lib/controlplane/agent/counters.c
+++ b/lib/controlplane/agent/counters.c
@@ -99,81 +99,43 @@ counter_tags_carve(
 	return dup;
 }
 
-// Size of one counter's share of a list's value region: the
-// worker-pointer array plus every worker's value block.
+// Size of one counter's share of a list's value region: the counter's
+// single value block.
 static bool
-counter_value_region_size(
-	uint64_t worker_count, uint64_t counter_size, size_t *out
-) {
-	if (worker_count == 0) {
-		*out = 0;
-		return true;
-	}
-	if (worker_count > SIZE_MAX / sizeof(uint64_t *)) {
+counter_value_region_size(uint64_t counter_size, size_t *out) {
+	if (counter_size > SIZE_MAX / sizeof(uint64_t)) {
 		return false;
 	}
-	size_t ptr_array = (size_t)worker_count * sizeof(uint64_t *);
-	size_t per_worker = (size_t)worker_count * sizeof(uint64_t);
-	if (counter_size > (SIZE_MAX - ptr_array) / per_worker) {
-		return false;
-	}
-	*out = ptr_array + per_worker * (size_t)counter_size;
+	*out = (size_t)counter_size * sizeof(uint64_t);
 	return true;
 }
 
-// Carve a counter's worker-pointer array and value blocks from the
-// cursor, advance the cursor past them, and point the handle at them.
+// Snapshot one already-described counter's values into a block carved
+// from the cursor and point the handle at it.
 //
-// The blocks come from the list's own zeroed allocation, so a worker
-// without a snapshot keeps a zeroed instance and a zero-size counter
-// keeps a NULL-filled pointer array.
-static uint64_t **
-counter_values_carve(
-	struct counter_handle *dst, uint8_t **cursor, uint64_t worker_count
-) {
-	size_t ptr_array_size = worker_count * sizeof(uint64_t *);
-	uint8_t *base = *cursor;
-	*cursor = base + ptr_array_size +
-		  worker_count * dst->size * sizeof(uint64_t);
-
-	uint64_t **values = (uint64_t **)base;
-	uint64_t *value_blocks = (uint64_t *)(base + ptr_array_size);
-	for (uint64_t w_idx = 0; w_idx < worker_count; ++w_idx) {
-		values[w_idx] = dst->size == 0
-					? NULL
-					: value_blocks + w_idx * dst->size;
-	}
-	dst->values = values;
-	return values;
-}
-
-// Snapshot one already-described counter's per-worker values into
-// blocks carved from the cursor.
-//
-// Each worker has its own single-instance storage. The caller gathers
-// one storage per worker into worker_storages (a plain C-pointer
-// array). These storages are dataplane-owned and outlive every
-// configuration generation, so no lock or generation pin is required
-// around this call.
+// The values come from a single-instance storage. Worker storages are
+// dataplane-owned and outlive every configuration generation, so no
+// lock or generation pin is required around this call. A zero-size
+// counter keeps the NULL block the zeroed allocation left behind.
 static void
 counter_handle_fill_values(
 	struct counter_handle *dst,
 	uint8_t **cursor,
-	struct counter_storage **worker_storages,
-	uint64_t worker_count,
+	struct counter_storage *storage,
 	uint64_t idx
 ) {
-	uint64_t **values = counter_values_carve(dst, cursor, worker_count);
-	for (uint64_t w_idx = 0; w_idx < worker_count; ++w_idx) {
-		if (dst->size == 0) {
-			continue;
-		}
-		struct counter_value_handle *handle =
-			counter_get_value_handle(idx, worker_storages[w_idx]);
-		memcpy(values[w_idx],
-		       counter_handle_get_value(handle),
-		       dst->size * sizeof(uint64_t));
+	if (dst->size == 0) {
+		return;
 	}
+	uint64_t *values = (uint64_t *)*cursor;
+	*cursor += dst->size * sizeof(uint64_t);
+	dst->values = values;
+
+	struct counter_value_handle *handle =
+		counter_get_value_handle(idx, storage);
+	memcpy(values,
+	       counter_handle_get_value(handle),
+	       dst->size * sizeof(uint64_t));
 }
 
 // Per-worker counter storages matching one tag predicate.
@@ -242,16 +204,13 @@ worker_counter_matches_collect(
 // Allocate a handle list sized for match_count handles plus a
 // values_size-byte value region, and zero all of it.
 //
-// Sets instance_count and count on success. The value region sits right
-// after the handle array and is carved sequentially by the fill pass;
-// the zeroing leaves every not-yet-carved handle with NULL tags and
-// values, and a later pass only overwrites what it fills in.
+// Sets count on success. The value region sits right after the handle
+// array and is carved sequentially by the fill pass; the zeroing
+// leaves every not-yet-carved handle with NULL tags and values, and a
+// later pass only overwrites what it fills in.
 static struct counter_handle_list *
 counter_handle_list_alloc(
-	uint64_t instance_count,
-	size_t match_count,
-	size_t values_size,
-	yanet_error **err
+	size_t match_count, size_t values_size, yanet_error **err
 ) {
 	size_t list_size = sizeof(struct counter_handle_list) +
 			   sizeof(struct counter_handle) * match_count;
@@ -266,7 +225,6 @@ counter_handle_list_alloc(
 		return NULL;
 	}
 	memset(list, 0, list_size);
-	list->instance_count = instance_count;
 	list->count = match_count;
 	return list;
 }
@@ -282,9 +240,9 @@ counter_handle_list_region(const struct counter_handle_list *list) {
 //
 // matches is that worker's NULL-terminated storage match array, or NULL
 // for a worker without an execution context. The resulting list carries
-// instance_count == 1 and values snapshotted from that worker's own
-// storages only. Handles of one storage share a tags copy and sit next
-// to each other, matching the list free path's sharing convention.
+// values snapshotted from that worker's own storages only. Handles of
+// one storage share a tags copy and sit next to each other, matching
+// the list free path's sharing convention.
 //
 // A sizing pass walks the matches first so the list's single allocation
 // covers everything the fill pass carves: every matched counter's value
@@ -298,7 +256,7 @@ worker_counter_list_build(
 	yanet_error **err
 ) {
 	if (matches == NULL) {
-		return counter_handle_list_alloc(1, 0, 0, err);
+		return counter_handle_list_alloc(0, 0, err);
 	}
 
 	size_t match_count = 0;
@@ -319,7 +277,7 @@ worker_counter_list_build(
 			}
 			size_t counter_region;
 			if (!counter_value_region_size(
-				    1, counters[idx].size, &counter_region
+				    counters[idx].size, &counter_region
 			    ) ||
 			    !counter_region_add(&region, counter_region)) {
 				yanet_error_add(
@@ -346,7 +304,7 @@ worker_counter_list_build(
 	}
 
 	struct counter_handle_list *list =
-		counter_handle_list_alloc(1, match_count, values_size, err);
+		counter_handle_list_alloc(match_count, values_size, err);
 	if (list == NULL) {
 		return NULL;
 	}
@@ -379,12 +337,7 @@ worker_counter_list_build(
 			dst->gen = src->gen;
 			dst->tags = storage_tags;
 			dst->tag_count = cp_storage->tag_count;
-			struct counter_storage *worker_storages[1] = {
-				storage,
-			};
-			counter_handle_fill_values(
-				dst, &cursor, worker_storages, 1, idx
-			);
+			counter_handle_fill_values(dst, &cursor, storage, idx);
 			++next;
 		}
 	}
@@ -507,34 +460,24 @@ yanet_get_counter(struct counter_handle_list *counters, uint64_t idx) {
 }
 
 uint64_t
-yanet_get_counter_value(
-	uint64_t **values, uint64_t value_idx, uint64_t worker_idx
-) {
-	return values[worker_idx][value_idx];
+yanet_get_counter_value(const uint64_t *values, uint64_t value_idx) {
+	return values[value_idx];
 }
 
 void
 yanet_get_counter_values(
-	uint64_t **values,
-	uint64_t size,
-	uint64_t instance_count,
-	uint64_t *values_out
+	const uint64_t *values, uint64_t size, uint64_t *values_out
 ) {
 	if (size == 0) {
 		return;
 	}
-	for (uint64_t iidx = 0; iidx < instance_count; ++iidx) {
-		memcpy(values_out + iidx * size,
-		       values[iidx],
-		       size * sizeof(uint64_t));
-	}
+	memcpy(values_out, values, size * sizeof(uint64_t));
 }
 
 static struct counter_handle_list *
 counter_handle_list_build(
 	struct counter_registry *counter_registry,
-	struct counter_storage **storages,
-	uint64_t worker_count
+	struct counter_storage *storage
 ) {
 	uint64_t count = counter_registry->count;
 
@@ -544,7 +487,7 @@ counter_handle_list_build(
 		for (uint64_t idx = 0; idx < count; ++idx) {
 			size_t region;
 			if (!counter_value_region_size(
-				    worker_count, counters[idx].size, &region
+				    counters[idx].size, &region
 			    ) ||
 			    !counter_region_add(&values_size, region)) {
 				return NULL;
@@ -552,26 +495,12 @@ counter_handle_list_build(
 		}
 	}
 
-	struct counter_handle_list *list = counter_handle_list_alloc(
-		worker_count, count, values_size, NULL
-	);
+	struct counter_handle_list *list =
+		counter_handle_list_alloc(count, values_size, NULL);
 	if (list == NULL) {
 		return NULL;
 	}
 	struct counter_handle *handlers = list->counters;
-
-	// storages holds one offset-pointer cell per worker; materialize a
-	// plain storage pointer per worker before handing them to the
-	// value fill, which indexes the array directly.
-	struct counter_storage **worker_storages =
-		malloc(worker_count * sizeof(*worker_storages));
-	if (worker_storages == NULL) {
-		yanet_counter_handle_list_free(list);
-		return NULL;
-	}
-	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
-		worker_storages[worker_idx] = ADDR_OF(storages + worker_idx);
-	}
 
 	uint8_t *cursor = counter_handle_list_region(list);
 	for (uint64_t idx = 0; idx < count; ++idx) {
@@ -580,21 +509,21 @@ counter_handle_list_build(
 		strtcpy(dst->name, counters[idx].name, sizeof(dst->name));
 		dst->size = counters[idx].size;
 		dst->gen = counters[idx].gen;
-		counter_handle_fill_values(
-			dst, &cursor, worker_storages, worker_count, idx
-		);
+		counter_handle_fill_values(dst, &cursor, storage, idx);
 	}
 
-	free(worker_storages);
 	return list;
 }
 
 struct counter_handle_list *
-yanet_get_worker_counters(struct dp_config *dp_config) {
+yanet_get_worker_counters(struct dp_config *dp_config, uint64_t worker_idx) {
+	if (worker_idx >= dp_config->worker_counter_storage_count) {
+		return NULL;
+	}
+	struct counter_storage **storages =
+		ADDR_OF(&dp_config->worker_counter_storages);
 	return counter_handle_list_build(
-		&dp_config->worker_counters,
-		ADDR_OF(&dp_config->worker_counter_storages),
-		dp_config->worker_counter_storage_count
+		&dp_config->worker_counters, ADDR_OF(storages + worker_idx)
 	);
 }
 
@@ -661,7 +590,7 @@ yanet_get_port_counters(struct dp_config *dp_config) {
 			pc->port_name,
 			sizeof(group->port_name));
 		group->counters = counter_handle_list_build(
-			&pc->registry, &pc->storage, 1
+			&pc->registry, ADDR_OF(&pc->storage)
 		);
 		if (group->counters == NULL) {
 			groups->port_count = idx;

--- a/lib/controlplane/tests/counter_workers_test.c
+++ b/lib/controlplane/tests/counter_workers_test.c
@@ -3,8 +3,10 @@
  *
  * Every worker's config_gen_ectx owns its own counter storage registry,
  * and those registries may hold different storages. The per-worker read
- * returns each worker's matched set independently; the cross-worker
- * union lives in the Go bindings.
+ * returns each worker's matched set independently; the union across
+ * workers lives in the Go bindings. The worker-counter read follows the
+ * same shape: each call snapshots one worker's own storage of the
+ * shared worker-counter registry, selected by the worker index.
  *
  * Divergence is produced by writing distinct values into the two workers'
  * pipeline storages and by registering an extra tagged storage in only
@@ -38,6 +40,8 @@
 #define CW_W1_INPUT 0x20
 #define CW_W1_EXTRA_0 0xAA
 #define CW_W1_EXTRA_1 0xBB
+#define CW_W0_WORKER 0x30
+#define CW_W1_WORKER 0x40
 
 static int
 install_empty_pipeline(
@@ -131,6 +135,34 @@ write_pipeline_counter(
 	TEST_ASSERT(
 		idx != COUNTER_INVALID,
 		"counter '%s' not found in the pipeline registry",
+		counter_name
+	);
+
+	uint64_t *values =
+		counter_handle_get_value(counter_get_value_handle(idx, storage)
+		);
+	values[0] = value;
+	return TEST_SUCCESS;
+}
+
+// Write value into the first slot of a counter named name in a worker's
+// own storage of the shared worker-counter registry, so the two workers
+// report different snapshots through the worker-counter read.
+static int
+write_worker_counter(
+	struct dp_config *dp_config,
+	uint64_t worker_idx,
+	const char *counter_name,
+	uint64_t value
+) {
+	struct counter_storage **storages =
+		ADDR_OF(&dp_config->worker_counter_storages);
+	struct counter_storage *storage = ADDR_OF(storages + worker_idx);
+
+	uint64_t idx = counter_index_by_name(storage, counter_name);
+	TEST_ASSERT(
+		idx != COUNTER_INVALID,
+		"counter '%s' not found in the worker counter registry",
 		counter_name
 	);
 
@@ -293,7 +325,6 @@ test_per_worker_sets(struct dp_config *dp_config) {
 	TEST_ASSERT_NOT_NULL(set1, "worker 1 set is missing");
 	TEST_ASSERT_EQUAL(0, set0->counters->count, "worker 0 matched");
 	TEST_ASSERT_EQUAL(1, set1->counters->count, "worker 1 match count");
-	TEST_ASSERT_EQUAL(1, set1->counters->instance_count, "instance count");
 
 	struct counter_handle *handle = yanet_get_counter(set1->counters, 0);
 	TEST_ASSERT_NOT_NULL(handle, "worker 1 set has no handle");
@@ -305,12 +336,12 @@ test_per_worker_sets(struct dp_config *dp_config) {
 	TEST_ASSERT_EQUAL(2, handle->size, "counter size");
 	TEST_ASSERT_EQUAL(
 		CW_W1_EXTRA_0,
-		yanet_get_counter_value(handle->values, 0, 0),
+		yanet_get_counter_value(handle->values, 0),
 		"worker 1 extra counter slot 0"
 	);
 	TEST_ASSERT_EQUAL(
 		CW_W1_EXTRA_1,
-		yanet_get_counter_value(handle->values, 1, 0),
+		yanet_get_counter_value(handle->values, 1),
 		"worker 1 extra counter slot 1"
 	);
 
@@ -363,13 +394,86 @@ test_per_worker_shared_counter(struct dp_config *dp_config) {
 		);
 		TEST_ASSERT_EQUAL(
 			expected[w_idx],
-			yanet_get_counter_value(handle->values, 0, 0),
+			yanet_get_counter_value(handle->values, 0),
 			"worker %lu input value",
 			(unsigned long)w_idx
 		);
 	}
 
 	yanet_counter_worker_set_list_free(sets);
+	return TEST_SUCCESS;
+}
+
+// Verifies that the worker-counter read snapshots only the named
+// worker's storage: each worker reports its own written value, every
+// worker carries the shared registry's full counter set, and an
+// out-of-range worker index is refused.
+static int
+test_worker_counters_per_worker(struct dp_config *dp_config) {
+	const uint64_t expected[CW_WORKER_COUNT] = {CW_W0_WORKER, CW_W1_WORKER};
+	for (uint64_t w_idx = 0; w_idx < CW_WORKER_COUNT; ++w_idx) {
+		TEST_ASSERT_SUCCESS(
+			write_worker_counter(
+				dp_config, w_idx, "iterations", expected[w_idx]
+			),
+			"failed to write worker %lu iterations counter",
+			(unsigned long)w_idx
+		);
+	}
+
+	uint64_t registry_count = 0;
+	for (uint64_t w_idx = 0; w_idx < CW_WORKER_COUNT; ++w_idx) {
+		struct counter_handle_list *list =
+			yanet_get_worker_counters(dp_config, w_idx);
+		TEST_ASSERT_NOT_NULL(
+			list,
+			"worker %lu counter read returned NULL",
+			(unsigned long)w_idx
+		);
+		if (w_idx == 0) {
+			registry_count = list->count;
+			TEST_ASSERT(
+				registry_count > 0,
+				"worker counter registry is empty"
+			);
+		} else {
+			TEST_ASSERT_EQUAL(
+				registry_count,
+				list->count,
+				"worker %lu counter count differs from worker "
+				"0",
+				(unsigned long)w_idx
+			);
+		}
+
+		struct counter_handle *handle = NULL;
+		for (size_t idx = 0; idx < list->count; ++idx) {
+			struct counter_handle *cur =
+				yanet_get_counter(list, idx);
+			if (cur != NULL &&
+			    strcmp(cur->name, "iterations") == 0) {
+				handle = cur;
+				break;
+			}
+		}
+		TEST_ASSERT_NOT_NULL(
+			handle,
+			"worker %lu read lacks the iterations counter",
+			(unsigned long)w_idx
+		);
+		TEST_ASSERT_EQUAL(
+			expected[w_idx],
+			yanet_get_counter_value(handle->values, 0),
+			"worker %lu iterations value",
+			(unsigned long)w_idx
+		);
+		yanet_counter_handle_list_free(list);
+	}
+
+	TEST_ASSERT_NULL(
+		yanet_get_worker_counters(dp_config, CW_WORKER_COUNT),
+		"out-of-range worker counter read must return NULL"
+	);
 	return TEST_SUCCESS;
 }
 
@@ -423,6 +527,9 @@ main(void) {
 	}
 	if (res == TEST_SUCCESS) {
 		res = test_per_worker_shared_counter(dp_config);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_worker_counters_per_worker(dp_config);
 	}
 
 	agent_detach(agent);

--- a/lib/controlplane/tests/counters_test.c
+++ b/lib/controlplane/tests/counters_test.c
@@ -152,7 +152,7 @@ test_value_snapshot_survives_removal(struct yanet_shm *shm) {
 	);
 
 	struct counter_handle *handle = yanet_get_counter(list, 0);
-	uint64_t before = yanet_get_counter_value(handle->values, 0, 0);
+	uint64_t before = yanet_get_counter_value(handle->values, 0);
 
 	// Re-install dev0 with no input pipeline: pipe0's counter storage is
 	// not respawned, so its value block's refcount drops to zero and the
@@ -162,17 +162,14 @@ test_value_snapshot_survives_removal(struct yanet_shm *shm) {
 		"failed to remove dev0's input pipeline"
 	);
 
-	uint64_t after = yanet_get_counter_value(handle->values, 0, 0);
+	uint64_t after = yanet_get_counter_value(handle->values, 0);
 	TEST_ASSERT_EQUAL(
 		after, before, "snapshot value changed after entity removal"
 	);
 
-	uint64_t *batched =
-		calloc(list->instance_count * handle->size, sizeof(uint64_t));
+	uint64_t *batched = calloc(handle->size, sizeof(uint64_t));
 	TEST_ASSERT_NOT_NULL(batched, "failed to allocate batched read buffer");
-	yanet_get_counter_values(
-		handle->values, handle->size, list->instance_count, batched
-	);
+	yanet_get_counter_values(handle->values, handle->size, batched);
 	TEST_ASSERT_EQUAL(
 		batched[0],
 		before,


### PR DESCRIPTION
- The worker counters read takes a worker index and snapshots only that worker's storage, refusing an out-of-range index.
- The counter handle list holds exactly one instance: the instance count is gone, the handle values are one flat block, and the per-worker tagged and per-port reads share the same single-storage build path.
- The Go bindings collect every worker's snapshot and merge them into the same worker-sharded view, keeping the Workers RPC and the worker metrics unchanged.

Closes #2409.
