### PR TITLE
chore(agents): move issue start bookkeeping into a script

### DIFF
--- a/.agents/scripts/issue-start.sh
+++ b/.agents/scripts/issue-start.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Start work on an issue: assign the caller and set the board Status to
+# In Progress on the managed planning boards.
+#
+# Idempotent. All node IDs are discovered live, never hardcoded.
+set -euo pipefail
+
+usage() {
+	echo "usage: ${0##*/} <owner>/<repo> <issue-number>" >&2
+	exit 64
+}
+
+[[ $# -eq 2 ]] || usage
+repo=$1
+number=$2
+[[ $repo =~ ^[^/]+/[^/]+$ ]] || usage
+[[ $number =~ ^[0-9]+$ ]] || usage
+owner=${repo%%/*}
+name=${repo#*/}
+
+# The planning boards issue-create manages. Projects outside this set are
+# never mutated.
+managed_boards=" 7 8 9 10 11 "
+
+viewer=$(gh api graphql -f query='{viewer{login}}' -q .data.viewer.login)
+
+issue_json=$(gh api graphql \
+	-f query='query($owner:String!,$name:String!,$number:Int!){
+	  repository(owner:$owner,name:$name){
+	    issue(number:$number){
+	      state
+	      assignees(first:10){nodes{login}}
+	      projectItems(first:20){nodes{
+	        id
+	        fieldValueByName(name:"Status"){
+	          ... on ProjectV2ItemFieldSingleSelectValue { name }
+	        }
+	        project{
+	          id number title
+	          field(name:"Status"){
+	            ... on ProjectV2SingleSelectField { id options { id name } }
+	          }
+	        }
+	      }}
+	    }
+	  }
+	}' -f owner="$owner" -f name="$name" -F number="$number")
+
+state=$(jq -r .data.repository.issue.state <<<"$issue_json")
+if [[ $state != OPEN ]]; then
+	echo "error: issue #$number in $repo is $state" >&2
+	exit 1
+fi
+
+mapfile -t assignees < <(jq -r '.data.repository.issue.assignees.nodes[].login' <<<"$issue_json")
+for login in "${assignees[@]}"; do
+	if [[ $login != "$viewer" ]]; then
+		echo "error: issue #$number is assigned to $login, not $viewer" >&2
+		exit 1
+	fi
+done
+
+if [[ ${#assignees[@]} -eq 0 ]]; then
+	gh issue edit "$number" --repo "$repo" --add-assignee "@me" >/dev/null
+	echo "issue #$number: assigned $viewer"
+else
+	echo "issue #$number: already assigned to $viewer"
+fi
+
+on_board=0
+while IFS=$'\t' read -r item_id project_id project_number title field_id option_id current; do
+	[[ $managed_boards == *" $project_number "* ]] || continue
+	on_board=1
+	if [[ $current == "In Progress" ]]; then
+		echo "board #$project_number ($title): already In Progress"
+		continue
+	fi
+	if [[ -z $field_id || -z $option_id ]]; then
+		echo "warning: board #$project_number ($title) has no Status field with an In Progress option" >&2
+		continue
+	fi
+	gh api graphql \
+		-f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!){
+		  updateProjectV2ItemFieldValue(input:{
+		    projectId:$projectId,itemId:$itemId,fieldId:$fieldId,
+		    value:{singleSelectOptionId:$optionId}
+		  }){clientMutationId}
+		}' -f projectId="$project_id" -f itemId="$item_id" \
+		-f fieldId="$field_id" -f optionId="$option_id" >/dev/null
+	echo "board #$project_number ($title): ${current:-unset} -> In Progress"
+done < <(jq -r '.data.repository.issue.projectItems.nodes[] |
+	[.id, .project.id, (.project.number|tostring), .project.title,
+	 (.project.field.id // ""),
+	 ((.project.field.options // []) | map(select(.name=="In Progress")) | .[0].id // ""),
+	 (.fieldValueByName.name // "")] | @tsv' <<<"$issue_json")
+
+if [[ $on_board -eq 0 ]]; then
+	echo "warning: issue #$number is on no managed board; status unchanged" >&2
+fi

--- a/.agents/skills/autopilot/SKILL.md
+++ b/.agents/skills/autopilot/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 
 # autopilot
 
-Take issue `<n>` (plus optional instructions) to merged `main` without asking for decisions along the way, and stop cleanly with one question when a decision is not yours. `ship-pr` is the publish runbook — invoke it, never restate it. `planner` owns issue lifecycle writes (`start`, `close`, `ingest`); you own the engineering and write no code yourself.
+Take issue `<n>` (plus optional instructions) to merged `main` without asking for decisions along the way, and stop cleanly with one question when a decision is not yours. `ship-pr` is the publish runbook — invoke it, never restate it. `planner` owns issue lifecycle writes (`close`, `ingest`); you own the engineering and write no code yourself.
 
 ## Non-negotiables
 
@@ -27,7 +27,7 @@ Ambiguous number (both repos hold it, no repo named) · issue closed or is a PR 
 
 ## Pipeline
 
-0. **Admit.** Resolve `<n>` (`gh issue view <n> --repo yanet-platform/yanet2` then `yanet2-private`); check the hard stops and the assignee, allowing no assignee or `@me` and stopping for any other assignee; `planner start <n>`.
+0. **Admit.** Resolve `<n>` (`gh issue view <n> --repo yanet-platform/yanet2` then `yanet2-private`); check the hard stops and the assignee, allowing no assignee or `@me` and stopping for any other assignee; `.agents/scripts/issue-start.sh <owner>/<repo> <n>`.
 1. **Understand.** Read the code the issue touches; send `fast-explorer` for bounded facts. A reported defect goes to `bug-hunter confirm` first; a speedup deliverable goes to `performance-engineer` for a baseline first. Decompose into file-scoped briefs in layer order — C API, proto + Go, Rust CLI, web UI — naming every shared surface and its consumers (defining grep, generated and gitignored trees included).
 2. **Worktree.** `AGENTS.md` → Worktrees; seed what the gates need (its own `build/` if a gate produces or consumes it, `node_modules` for web).
 3. **Delegate.** One brief = one coherent change; each names the worktree's absolute root, the property to reach, the files in scope, the gate, and where to stop and report. Sequential when briefs share files, parallel otherwise.

--- a/.rulesync/subagents/planner.md
+++ b/.rulesync/subagents/planner.md
@@ -48,8 +48,10 @@ prefer low effort and unblocking value.
   or report its admission stop.
 - `triage <n>` — pass an existing issue through `issue-create triage` without
   changing its lifecycle.
-- `start <n>` — assign `@me` and set In Progress. `close <n>` — close completed
-  with a comment naming the PR, or not_planned with the reason.
+- `start <n>` — resolve the repository, stopping when both repositories hold
+  `<n>` and none was named, then run
+  `.agents/scripts/issue-start.sh <owner>/<repo> <n>`. `close <n>` — close
+  completed with a comment naming the PR, or not_planned with the reason.
 - `scan <scope>` — bounded evidence-backed code/GitHub discovery producing
   candidates through `draft`; create only when the user separately said file/create.
 


### PR DESCRIPTION
- Add `.agents/scripts/issue-start.sh`: assigns the caller and sets In Progress on the managed boards, idempotently, discovering all node IDs live.
- Autopilot admission and the planner `start` mode call the script instead of restating the bookkeeping.