### PR TITLE
feat(cli): connect and request timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,6 +3096,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_logger",
+ "socket2 0.5.10",
  "ssh-key",
  "tabled",
  "terminal_size",

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -37,3 +37,8 @@ humantime = "2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }
+tokio = { version = "1", features = ["macros", "test-util"] }
+socket2 = "0.5"

--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -21,6 +21,8 @@
 //!     .accept_compressed(CompressionEncoding::Gzip);
 //! ```
 
+use core::time::Duration;
+
 use http::uri::PathAndQuery;
 use prost::Message;
 use tonic::{
@@ -34,13 +36,14 @@ use tower::Layer;
 use crate::{
     auth::{self, interceptor::AuthService, AuthArgs},
     errors::{root_cause, Error},
+    timeout::{TimeoutLayer, TimeoutService},
 };
 
 /// Channel type with all interceptors applied.
 ///
 /// Use this as the type parameter for tonic-generated clients, e.g.
 /// `MyServiceClient<LayeredChannel>`.
-pub type LayeredChannel = AuthService<Channel>;
+pub type LayeredChannel = TimeoutService<AuthService<Channel>>;
 
 /// Common CLI arguments for gRPC connection.
 ///
@@ -53,6 +56,24 @@ pub struct ConnectionArgs {
     /// Authentication options.
     #[command(flatten)]
     pub auth: AuthArgs,
+    /// Time budget in seconds for connecting and for each request.
+    ///
+    /// Long-lived streams are bounded only while being established.
+    #[arg(long, global = true, env = "YANET_TIMEOUT", value_name = "SECONDS", value_parser = parse_timeout)]
+    pub timeout: Option<Duration>,
+}
+
+/// Parses a positive, possibly fractional, number of seconds.
+fn parse_timeout(value: &str) -> Result<Duration, String> {
+    let seconds: f64 = value
+        .parse()
+        .map_err(|_| "expected a positive number of seconds".to_owned())?;
+
+    if !seconds.is_finite() || seconds <= 0.0 {
+        return Err("expected a positive number of seconds".to_owned());
+    }
+
+    Duration::try_from_secs_f64(seconds).map_err(|err| err.to_string())
 }
 
 /// Error type for connection establishment.
@@ -64,14 +85,31 @@ pub enum ConnectionError {
     InvalidUri(#[from] http::uri::InvalidUri),
     #[error("auth error: {0}")]
     Auth(#[from] auth::AuthError),
+    #[error("connect timed out after {}s", .0.as_secs_f64())]
+    Timeout(Duration),
 }
 
 /// Connect to the endpoint with all interceptors pre-applied.
+///
+/// When `args.timeout` is set, it bounds channel establishment and auth
+/// setup together, then rides along as the per-request budget of the
+/// returned channel.
 pub async fn connect(args: &ConnectionArgs) -> Result<LayeredChannel, ConnectionError> {
-    let channel = Channel::from_shared(args.endpoint.clone())?.connect().await?;
-    let auth = auth::create_layer(&args.auth).await?;
+    let establish = async {
+        let channel = Channel::from_shared(args.endpoint.clone())?.connect().await?;
+        let auth = auth::create_layer(&args.auth).await?;
 
-    Ok(auth.layer(channel))
+        Ok::<_, ConnectionError>(auth.layer(channel))
+    };
+
+    let auth_service = match args.timeout {
+        Some(budget) => tokio::time::timeout(budget, establish)
+            .await
+            .map_err(|_| ConnectionError::Timeout(budget))??,
+        None => establish.await?,
+    };
+
+    Ok(TimeoutLayer::new(args.timeout).layer(auth_service))
 }
 
 /// An established, authenticated channel to one endpoint.
@@ -356,10 +394,58 @@ where
 
 #[cfg(test)]
 mod test {
+    use core::{net::SocketAddr, time::Duration};
+    use std::net::{TcpListener, TcpStream};
+
+    use socket2::{Domain, Socket, Type};
     use tonic::Status;
 
-    use super::Service;
-    use crate::errors::ErrorKind;
+    use super::{parse_timeout, Connection, ConnectionArgs, Service};
+    use crate::{
+        auth::{AuthArgs, AuthMethod},
+        errors::ErrorKind,
+    };
+
+    #[test]
+    fn test_parse_timeout_accepts_whole_and_fractional_seconds() {
+        assert_eq!(Duration::from_secs(3), parse_timeout("3").unwrap());
+        assert_eq!(Duration::from_millis(500), parse_timeout("0.5").unwrap());
+    }
+
+    #[test]
+    fn test_parse_timeout_rejects_non_positive_and_non_numeric() {
+        for input in ["0", "-1", "nan", "inf", "abc"] {
+            assert!(parse_timeout(input).is_err(), "expected {input} to be rejected");
+        }
+    }
+
+    /// Verifies that a connect wedged before the TCP handshake completes
+    /// fails within the budget as a connection error naming it.
+    #[tokio::test]
+    async fn test_connect_tcp_handshake_never_completing_times_out() {
+        // A backlog of 0 holds exactly one pending connection on Linux.
+        // With that slot taken, further SYNs are silently dropped.
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+        socket
+            .bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
+            .unwrap();
+        socket.listen(0).unwrap();
+        let listener: TcpListener = socket.into();
+        let port = listener.local_addr().unwrap().port();
+        let _plugged = TcpStream::connect(("127.0.0.1", port)).unwrap();
+
+        let args = ConnectionArgs {
+            endpoint: format!("grpc://127.0.0.1:{port}"),
+            auth: AuthArgs { auth: AuthMethod::None },
+            timeout: Some(Duration::from_millis(200)),
+        };
+
+        let err = Connection::connect(&args).await.err().unwrap();
+
+        assert_eq!(ErrorKind::Connection, err.kind());
+        assert_eq!(4, err.exit_code());
+        assert_eq!("connect timed out after 0.2s", err.message());
+    }
 
     #[test]
     fn status_maps_grpc_code() {

--- a/cli/core/src/errors.rs
+++ b/cli/core/src/errors.rs
@@ -136,6 +136,10 @@ impl Error {
                 Some("check the --endpoint URL format (expected: grpc://host:port or unix:///path)".to_owned()),
             ),
             ConnectionError::Auth(..) => (ErrorKind::Auth, None),
+            ConnectionError::Timeout(..) => (
+                ErrorKind::Connection,
+                Some("verify the endpoint is reachable and the gateway is up".to_owned()),
+            ),
         };
 
         Self {

--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod humanfmt;
 pub mod logging;
 pub mod metrics;
 pub mod output;
+pub mod timeout;
 
 mod signal;
 

--- a/cli/core/src/timeout.rs
+++ b/cli/core/src/timeout.rs
@@ -1,0 +1,133 @@
+//! Tower middleware bounding one request to a fixed time budget.
+
+use core::{
+    error::Error,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use tonic::Status;
+use tower::{Layer, Service};
+
+type BoxError = Box<dyn Error + Send + Sync>;
+
+/// Tower layer that wraps a service with a per-request time budget.
+///
+/// `None` leaves the wrapped service untouched.
+#[derive(Clone, Copy)]
+pub struct TimeoutLayer {
+    budget: Option<Duration>,
+}
+
+impl TimeoutLayer {
+    /// Create a layer enforcing `budget` on every request, or none at all.
+    pub fn new(budget: Option<Duration>) -> Self {
+        Self { budget }
+    }
+}
+
+impl<S> Layer<S> for TimeoutLayer {
+    type Service = TimeoutService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TimeoutService { inner, budget: self.budget }
+    }
+}
+
+/// Tower service that fails a request still pending after its time budget.
+#[derive(Clone)]
+pub struct TimeoutService<S> {
+    inner: S,
+    budget: Option<Duration>,
+}
+
+impl<S, B> Service<http::Request<B>> for TimeoutService<S>
+where
+    S: Service<http::Request<B>> + Clone + Send + 'static,
+    S::Future: Send,
+    S::Response: Send,
+    S::Error: Into<BoxError> + Send,
+    B: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, request: http::Request<B>) -> Self::Future {
+        // Standard Tower pattern: clone and swap to get an owned service
+        // for the async block.
+        let clone = self.inner.clone();
+        let mut inner = core::mem::replace(&mut self.inner, clone);
+        let budget = self.budget;
+
+        Box::pin(async move {
+            let Some(budget) = budget else {
+                return inner.call(request).await.map_err(Into::into);
+            };
+
+            tokio::select! {
+                result = inner.call(request) => result.map_err(Into::into),
+                () = tokio::time::sleep(budget) => {
+                    let message = format!("request timed out after {}s", budget.as_secs_f64());
+                    Err(Box::new(Status::unavailable(message)) as BoxError)
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::{convert::Infallible, time::Duration};
+
+    use tonic::{Code, Status};
+    use tower::{service_fn, Layer, Service, ServiceExt};
+
+    use super::TimeoutLayer;
+
+    /// Verifies that a service still pending after its budget fails with an
+    /// `Unavailable` status naming the budget.
+    #[tokio::test(start_paused = true)]
+    async fn test_call_pending_past_budget_reports_unavailable() {
+        let inner =
+            service_fn(|_: http::Request<()>| core::future::pending::<Result<http::Response<()>, Infallible>>());
+        let mut service = TimeoutLayer::new(Some(Duration::from_secs(1))).layer(inner);
+
+        let err = service
+            .ready()
+            .await
+            .unwrap()
+            .call(http::Request::new(()))
+            .await
+            .unwrap_err();
+
+        let status = err.downcast_ref::<Status>().expect("error is a tonic Status");
+
+        assert_eq!(Code::Unavailable, status.code());
+        assert_eq!("request timed out after 1s", status.message());
+    }
+
+    /// Verifies that a `None` budget passes a ready response through
+    /// unchanged.
+    #[tokio::test]
+    async fn test_call_without_budget_passes_response_through() {
+        let inner = service_fn(|_: http::Request<()>| async { Ok::<_, Infallible>(http::Response::new(())) });
+        let mut service = TimeoutLayer::new(None).layer(inner);
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call(http::Request::new(()))
+            .await
+            .unwrap();
+
+        assert_eq!((), *response.body());
+    }
+}

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -730,6 +730,7 @@ entries:
         let connection = ConnectionArgs {
             endpoint: format!("grpc://127.0.0.1:{port}"),
             auth: AuthArgs { auth: AuthMethod::None },
+            timeout: None,
         };
 
         let err = RouteService::new(&connection).await.err().unwrap();


### PR DESCRIPTION
- Every yanet CLI binary gains a global `--timeout` flag taking a possibly fractional number of seconds, with a `YANET_TIMEOUT` environment override.
- By agreement with the owner there is no separate `--connect-timeout` and no default budget: without the flag the behaviour stays as today, with no deadline at all.
- The budget bounds connection establishment including the auth-layer setup, and each request at the channel layer: a unary call and stream establishment are bounded, while an established server stream is never cut.
- A timed-out connect is reported as a connection error and a timed-out request as unavailable, both exit with code 4 and name the configured budget in the message.
- The issue's carve-out for CLIs building a channel by hand is stale: every binary reaches the wire through `ync::client::connect`, so the flag is honoured everywhere without per-crate changes.
- Closes #2350.