### PR TITLE
feat(route): delete a fib config through the service and cli

### DIFF
--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -15,12 +15,15 @@ use clap_complete::{
 use tonic::codec::CompressionEncoding;
 use yanet_cli_route::{
     fib::render::print_fib,
-    routepb::{self, route_service_client::RouteServiceClient, ListConfigsRequest, ShowFibRequest, UpdateFibRequest},
+    routepb::{
+        self, route_service_client::RouteServiceClient, DeleteConfigRequest, ListConfigsRequest, ShowFibRequest,
+        UpdateFibRequest,
+    },
 };
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    errors::Error,
+    errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
 };
 
@@ -142,6 +145,8 @@ pub enum FibAction {
     Show(FibShowCmd),
     /// Replace the FIB atomically with entries from a YAML file.
     Update(FibUpdateCmd),
+    /// Delete a route module config.
+    Delete(FibDeleteCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -152,6 +157,13 @@ pub struct FibUpdateCmd {
     /// Path to the FIB YAML file.
     #[arg(required = true, long = "rules", value_name = "PATH")]
     pub rules: PathBuf,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct FibDeleteCmd {
+    /// Route module config name.
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
+    pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -169,6 +181,9 @@ pub struct FibShowCmd {
 
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.route.controlplane.routepb.v1.RouteService";
+
+/// Rewrites a genuine missing-config `NotFound` into a friendly message.
+const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
 fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
@@ -210,6 +225,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
             FibAction::List => service.list_fibs().await,
             FibAction::Show(cmd) => service.show_fib(cmd).await,
             FibAction::Update(cmd) => service.update_fib(cmd).await,
+            FibAction::Delete(cmd) => service.delete_fib(cmd).await,
         },
     }
 }
@@ -247,6 +263,22 @@ impl RouteService {
             "update",
             format_args!("Updated FIB '{}' ({} entries).", cmd.config_name, entry_count),
         );
+        Ok(())
+    }
+
+    pub async fn delete_fib(&mut self, cmd: FibDeleteCmd) -> Result<(), Error> {
+        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+
+        self.service.client().delete_config(request).await.map_err(|status| {
+            NOT_FOUND.map(
+                status,
+                "delete",
+                self.service.endpoint(),
+                Some(&format!("config '{}'", cmd.config_name)),
+            )
+        })?;
+
+        output::success("delete", format_args!("Deleted FIB '{}'.", cmd.config_name));
         Ok(())
     }
 

--- a/modules/route/controlplane/routepb/v1/route.proto
+++ b/modules/route/controlplane/routepb/v1/route.proto
@@ -13,7 +13,7 @@ service RouteService {
   // module.
   rpc ListConfigs(ListConfigsRequest) returns (ListConfigsResponse);
 
-  // DeleteConfig deletes a route configuration.
+  // DeleteConfig deletes a route configuration if it is not referenced by any pipeline.
   rpc DeleteConfig(DeleteConfigRequest) returns (DeleteConfigResponse);
 
   // ShowFIB returns the current Forwarding Information Base entries

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -270,7 +270,7 @@ func (m *RouteService) DeleteConfig(
 
 	entry, ok := m.configs[name]
 	if !ok {
-		return &routepb.DeleteConfigResponse{}, nil
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
 	if err := m.backend.DeleteModule(name); err != nil {

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -456,6 +456,16 @@ func TestShowFIBUnknownConfig(t *testing.T) {
 	require.Equal(t, codes.NotFound, status.Code(err))
 }
 
+// TestDeleteConfigUnknownConfig verifies that DeleteConfig reports NotFound
+// for a config name that was never registered.
+func TestDeleteConfigUnknownConfig(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	_, err := service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "missing"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
 // TestShowFIBEmptyConfig verifies that a registered config with no FIB
 // entries still returns a normal empty success.
 func TestShowFIBEmptyConfig(t *testing.T) {


### PR DESCRIPTION
- Adds a `fib delete --name` subcommand to `yanet-cli-route` over the existing `RouteService.DeleteConfig` RPC, with config-name completion, a friendly not-found error (exit 3) and pass-through of the server's refusal of a referenced config (exit 1).
- Changes the service to return NotFound instead of silent success for an unknown name, matching the forward and acl services. No caller of this RPC exists in the public or the private tree, so the change is not observable by running systems.
- The issue scoped only the CLI crate, but the exit-3-on-missing acceptance is only reachable when the service reports NotFound, hence the service-side alignment in the same change.
- The not-found mapping on the CLI side is covered by the shared error library's own tests and the new service-level NotFound test; per-crate mapper tests were dropped in review as duplicates of those.
- Documents the referenced-config constraint on the DeleteConfig RPC the way the sibling modules do.

Closes #2360.