### PR TITLE
feat(nat64)!: carry typed prefixes on the wire

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -33,6 +33,8 @@ breaking:
     # resolve state tables through named map objects).
     - modules/acl/controlplane/aclpb/v1/acl.proto
     - modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
+    # TODO: drop after the NAT64 prefix wire cutover in #2197 reaches main.
+    - modules/nat64/controlplane/nat64pb/v1/nat64.proto
     # ListEntries changes from a bidi stream to cursor-paginated unary calls
     # in the same cutover.
     - objects/fwstate/controlplane/fwstatemappb/v1/fwstatemap.proto

--- a/docs/proto-compatibility.md
+++ b/docs/proto-compatibility.md
@@ -106,6 +106,7 @@ The following entries in `buf.yaml` intentionally deviate from the defaults. Eac
 
 **`breaking.ignore`**
 - `modules/balancer2` — pre-v1 rewrite in flight; API shape is not yet stable. Remove this line from `buf.yaml` when balancer2 reaches v1.
+- `modules/nat64/controlplane/nat64pb/v1/nat64.proto` — the #2197 migration intentionally replaces all three NAT64 prefix byte fields with the shared family-typed IPv6 prefix message in one cutover. Remove this line after the new wire shape reaches `main`.
 - `operators/forward/operatorpb` and `operators/decap/operatorpb` — the readiness packages of the forward and decap operators were deleted on purpose: their wire route (`/operators.<name>.operatorpb.v1.ReadinessService/Ready`, `readinesspb` messages) is kept as a runtime service name registered by the static module operator, so callers that address the route by name (the announcer, the gateway proxy) are unaffected, and no generated client of these packages existed outside the operators themselves.
 
 **`lint.except`** — six identifier-naming rules are disabled globally because enforcing them would require renaming existing wire identifiers, which would itself be a breaking change:

--- a/modules/nat64/cli/build.rs
+++ b/modules/nat64/cli/build.rs
@@ -8,10 +8,6 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")
         .message_attribute(".", "#[derive(Serialize)]")
-        .field_attribute(
-            ".modules.nat64.controlplane.nat64pb.v1.Prefix.prefix",
-            "#[serde(serialize_with = \"crate::serialize_prefix\")]",
-        )
         .compile_protos(&["nat64pb/v1/nat64.proto"], &["../controlplane", "../../.."])?;
 
     Ok(())

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -99,7 +99,7 @@ pub struct AddPrefixCmd {
     /// The name of the config to operate on.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
-    /// IPv6 `/96` prefix (12 bytes) to be added.
+    /// IPv6 /96 prefix to add.
     #[arg(long, value_parser = parse_prefix)]
     pub prefix: Contiguous<Ipv6Network>,
 }
@@ -109,7 +109,7 @@ pub struct RemovePrefixCmd {
     /// The name of the config to operate on.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
-    /// IPv6 `/96` prefix (12 bytes) to be removed.
+    /// IPv6 /96 prefix to remove.
     #[arg(long, value_parser = parse_prefix)]
     pub prefix: Contiguous<Ipv6Network>,
 }
@@ -292,7 +292,7 @@ impl NAT64Service {
     pub async fn add_prefix(&mut self, cmd: AddPrefixCmd) -> Result<(), Error> {
         let request = AddPrefixRequest {
             name: cmd.config_name.clone(),
-            prefix: cmd.prefix.addr().octets()[..12].to_vec(),
+            prefix: Some(cmd.prefix.into()),
         };
         log::debug!("AddPrefixRequest: {request:?}");
         self.service
@@ -312,7 +312,7 @@ impl NAT64Service {
     pub async fn remove_prefix(&mut self, cmd: RemovePrefixCmd) -> Result<(), Error> {
         let request = RemovePrefixRequest {
             name: cmd.config_name.clone(),
-            prefix: cmd.prefix.addr().octets()[..12].to_vec(),
+            prefix: Some(cmd.prefix.into()),
         };
         log::debug!("RemovePrefixRequest: {request:?}");
         self.service
@@ -435,7 +435,7 @@ fn print_tree(resp: &ShowConfigResponse) {
         }
 
         for (idx, prefix) in config.prefixes.iter().enumerate() {
-            tree.add_empty_child(format!("{}: {}", idx, format_prefix(&prefix.prefix)));
+            tree.add_empty_child(format!("{}: {}", idx, prefix));
         }
         tree.end_child();
 
@@ -481,23 +481,6 @@ fn parse_prefix(value: &str) -> Result<Contiguous<Ipv6Network>, String> {
     Ok(prefix)
 }
 
-fn format_prefix(prefix: &[u8]) -> String {
-    if prefix.len() != 12 {
-        return "invalid".to_owned();
-    }
-
-    let mut octets = [0; 16];
-    octets[..12].copy_from_slice(prefix);
-    format!("{}/96", Ipv6Addr::from(octets))
-}
-
-fn serialize_prefix<S>(prefix: &[u8], serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.collect_str(&format_prefix(prefix))
-}
-
 /// Completion candidates for a `--name` argument: the nat64 configs the
 /// module currently knows.
 ///
@@ -530,22 +513,5 @@ mod test {
         let error = parse_prefix("2001:db8:1234:5678::/64").expect_err("/64 prefix rejected");
 
         assert!(error.contains("/96"));
-    }
-
-    #[test]
-    fn test_format_prefix_expands_wire_prefix_to_ipv6_96() {
-        let prefix = [0x20, 0x01, 0x0d, 0xb8, 0x12, 0x34, 0x56, 0x78, 0, 0, 0, 0];
-
-        assert_eq!("2001:db8:1234:5678::/96", format_prefix(&prefix));
-    }
-
-    #[test]
-    fn test_format_prefix_marks_short_wire_prefix_invalid() {
-        assert_eq!("invalid", format_prefix(&[0; 11]));
-    }
-
-    #[test]
-    fn test_format_prefix_marks_long_wire_prefix_invalid() {
-        assert_eq!("invalid", format_prefix(&[0; 13]));
     }
 }

--- a/modules/nat64/controlplane/nat64pb/v1/nat64.proto
+++ b/modules/nat64/controlplane/nat64pb/v1/nat64.proto
@@ -4,6 +4,7 @@ package modules.nat64.controlplane.nat64pb.v1;
 
 import "common/commonpb/v1/ipv4addr.proto";
 import "common/commonpb/v1/ipv6addr.proto";
+import "common/commonpb/v1/ipv6prefix.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb/v1;nat64pb";
 
@@ -48,11 +49,6 @@ message MTUConfig {
   uint32 ipv6_mtu = 2; // MTU value for IPv6
 }
 
-// Prefix represents a NAT64 prefix
-message Prefix {
-  bytes prefix = 1; // 12-byte IPv6 prefix
-}
-
 // Mapping represents an IPv4-IPv6 address mapping
 message Mapping {
   common.commonpb.v1.IPv4Address ipv4 = 1; // IPv4 host address
@@ -62,7 +58,8 @@ message Mapping {
 
 // Config represents configuration for a single dataplane instance
 message Config {
-  repeated Prefix prefixes = 1;
+  // NAT64 networks, which MUST use a /96 prefix length.
+  repeated common.commonpb.v1.IPv6Prefix prefixes = 1;
   repeated Mapping mappings = 2;
   MTUConfig mtu = 3;
   bool drop_unknown_prefix = 4;  // Drop packets with unknown prefix
@@ -75,7 +72,8 @@ message ShowConfigResponse { Config config = 1; }
 // AddPrefixRequest specifies a prefix to add
 message AddPrefixRequest {
   string name = 1;
-  bytes prefix = 2; // 12-byte IPv6 prefix
+  // NAT64 network, which MUST use a /96 prefix length.
+  common.commonpb.v1.IPv6Prefix prefix = 2;
 }
 
 message AddPrefixResponse {}
@@ -83,7 +81,8 @@ message AddPrefixResponse {}
 // RemovePrefixRequest specifies a prefix to remove
 message RemovePrefixRequest {
   string name = 1;
-  bytes prefix = 2; // 12-byte IPv6 prefix
+  // NAT64 network, which MUST use a /96 prefix length.
+  common.commonpb.v1.IPv6Prefix prefix = 2;
 }
 
 message RemovePrefixResponse {}

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"maps"
 	"math"
 	"net/netip"
@@ -114,6 +115,9 @@ type MTUConfig struct {
 }
 
 const (
+	nat64PrefixBits  = 96
+	nat64PrefixBytes = nat64PrefixBits / 8
+
 	defaultIPv4MTU uint32 = 1450
 	defaultIPv6MTU uint32 = 1280
 )
@@ -167,7 +171,7 @@ func (m *NAT64Service) ShowConfig(ctx context.Context, req *nat64pb.ShowConfigRe
 
 	cfg := inst.Config
 	response.Config = &nat64pb.Config{
-		Prefixes: make([]*nat64pb.Prefix, 0, len(cfg.Prefixes)),
+		Prefixes: make([]*commonpb.IPv6Prefix, 0, len(cfg.Prefixes)),
 		Mappings: make([]*nat64pb.Mapping, 0, len(cfg.Mappings)),
 		Mtu: &nat64pb.MTUConfig{
 			Ipv4Mtu: cfg.MTU.IPv4MTU,
@@ -178,9 +182,11 @@ func (m *NAT64Service) ShowConfig(ctx context.Context, req *nat64pb.ShowConfigRe
 	}
 
 	for _, prefix := range cfg.Prefixes {
-		response.Config.Prefixes = append(response.Config.Prefixes, &nat64pb.Prefix{
-			Prefix: slices.Clone(prefix),
-		})
+		wirePrefix, err := encodeNAT64Prefix(prefix)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to encode prefix: %v", err)
+		}
+		response.Config.Prefixes = append(response.Config.Prefixes, wirePrefix)
 	}
 
 	for _, mapping := range cfg.Mappings {
@@ -193,9 +199,11 @@ func (m *NAT64Service) ShowConfig(ctx context.Context, req *nat64pb.ShowConfigRe
 
 	return response, nil
 }
+
 func (m *NAT64Service) AddPrefix(ctx context.Context, req *nat64pb.AddPrefixRequest) (*nat64pb.AddPrefixResponse, error) {
-	if len(req.Prefix) != 12 {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid prefix length: got %d, want 12", len(req.Prefix))
+	prefix, err := decodeNAT64Prefix(req.GetPrefix())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	name := req.GetName()
@@ -207,7 +215,7 @@ func (m *NAT64Service) AddPrefix(ctx context.Context, req *nat64pb.AddPrefixRequ
 	defer m.mu.Unlock()
 
 	inst := m.instanceFor(name).Clone()
-	inst.Config.Prefixes = append(inst.Config.Prefixes, slices.Clone(req.Prefix))
+	inst.Config.Prefixes = append(inst.Config.Prefixes, prefix)
 
 	if err := m.updateModuleConfig(name, inst); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
@@ -217,8 +225,9 @@ func (m *NAT64Service) AddPrefix(ctx context.Context, req *nat64pb.AddPrefixRequ
 }
 
 func (m *NAT64Service) RemovePrefix(ctx context.Context, req *nat64pb.RemovePrefixRequest) (*nat64pb.RemovePrefixResponse, error) {
-	if len(req.Prefix) != 12 {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid prefix length: got %d, want 12", len(req.Prefix))
+	prefix, err := decodeNAT64Prefix(req.GetPrefix())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	name := req.GetName()
@@ -236,8 +245,8 @@ func (m *NAT64Service) RemovePrefix(ctx context.Context, req *nat64pb.RemovePref
 	next := inst.Clone()
 
 	removeIdx := -1
-	for idx, prefix := range next.Config.Prefixes {
-		if bytes.Equal(prefix, req.Prefix) {
+	for idx, storedPrefix := range next.Config.Prefixes {
+		if bytes.Equal(storedPrefix, prefix) {
 			removeIdx = idx
 			break
 		}
@@ -383,6 +392,44 @@ func (m *NAT64Service) SetDropUnknown(ctx context.Context, req *nat64pb.SetDropU
 	}
 
 	return &nat64pb.SetDropUnknownResponse{}, nil
+}
+
+func decodeNAT64Prefix(prefix *commonpb.IPv6Prefix) ([]byte, error) {
+	if prefix == nil {
+		return nil, fmt.Errorf("prefix is required")
+	}
+
+	network, err := prefix.ToPrefix()
+	if err != nil {
+		return nil, fmt.Errorf("invalid prefix: %w", err)
+	}
+	if network.Bits() != nat64PrefixBits {
+		return nil, fmt.Errorf(
+			"invalid prefix length: got %d, want %d",
+			network.Bits(),
+			nat64PrefixBits,
+		)
+	}
+
+	address := network.Addr().As16()
+	return slices.Clone(address[:nat64PrefixBytes]), nil
+}
+
+func encodeNAT64Prefix(prefix []byte) (*commonpb.IPv6Prefix, error) {
+	if len(prefix) != nat64PrefixBytes {
+		return nil, fmt.Errorf(
+			"invalid stored prefix length: got %d, want %d",
+			len(prefix),
+			nat64PrefixBytes,
+		)
+	}
+
+	var address [16]byte
+	copy(address[:], prefix)
+	return &commonpb.IPv6Prefix{
+		Addr:      commonpb.NewIPv6Address(address),
+		PrefixLen: nat64PrefixBits,
+	}, nil
 }
 
 func (m *NAT64Service) instanceFor(name string) config {

--- a/modules/nat64/controlplane/service_test.go
+++ b/modules/nat64/controlplane/service_test.go
@@ -41,14 +41,22 @@ func (m *mockBackend) UpdateModule(name string, cfg *NAT64Config) (ModuleHandle,
 	return handle, nil
 }
 
+func mustIPv6Prefix(t *testing.T, value string) *commonpb.IPv6Prefix {
+	t.Helper()
+
+	prefix, err := commonpb.NewIPv6PrefixFromPrefix(netip.MustParsePrefix(value))
+	require.NoError(t, err)
+	return prefix
+}
+
 // Test_NAT64Service_AddShowRemove verifies basic config lifecycle operations.
 func Test_NAT64Service_AddShowRemove(t *testing.T) {
 	backend := &mockBackend{}
 	service := NewNAT64Service(backend)
 	ctx := t.Context()
 
-	prefix0 := []byte{0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	prefix1 := []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0}
+	prefix0 := mustIPv6Prefix(t, "64:ff9b::/96")
+	prefix1 := mustIPv6Prefix(t, "2001:db8::/96")
 	ipv4 := netip.MustParseAddr("192.0.2.1")
 	ipv6 := netip.MustParseAddr("2001:db8::1")
 
@@ -79,7 +87,7 @@ func Test_NAT64Service_AddShowRemove(t *testing.T) {
 	show, err = service.ShowConfig(ctx, &nat64pb.ShowConfigRequest{Name: "nat64-0"})
 	require.NoError(t, err)
 	require.Len(t, show.GetConfig().GetPrefixes(), 1)
-	require.Equal(t, prefix1, show.GetConfig().GetPrefixes()[0].GetPrefix())
+	require.Equal(t, prefix1, show.GetConfig().GetPrefixes()[0])
 	require.Len(t, show.GetConfig().GetMappings(), 1)
 	require.Equal(t, uint32(0), show.GetConfig().GetMappings()[0].GetPrefixIndex())
 
@@ -118,11 +126,53 @@ func Test_NAT64Service_AddPrefixDefaultMTU(t *testing.T) {
 
 	_, err := service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{
 		Name:   "nat64-0",
-		Prefix: []byte{0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		Prefix: mustIPv6Prefix(t, "64:ff9b::/96"),
 	})
 	require.NoError(t, err)
 	require.Len(t, backend.configs, 1)
 	require.Equal(t, MTUConfig{IPv4MTU: 1450, IPv6MTU: 1280}, backend.configs[0].MTU)
+}
+
+// Test_NAT64Service_PrefixMutation_Invalid verifies that both mutations reject
+// missing, malformed, and non-/96 prefixes.
+func Test_NAT64Service_PrefixMutation_Invalid(t *testing.T) {
+	testCases := []struct {
+		name   string
+		prefix *commonpb.IPv6Prefix
+	}{
+		{name: "missing prefix"},
+		{name: "missing address", prefix: &commonpb.IPv6Prefix{PrefixLen: 96}},
+		{name: "non-96 prefix", prefix: mustIPv6Prefix(t, "2001:db8::/64")},
+		{
+			name: "overlong prefix",
+			prefix: &commonpb.IPv6Prefix{
+				Addr:      commonpb.NewIPv6Address([16]byte{}),
+				PrefixLen: 129,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			service := NewNAT64Service(&mockBackend{})
+
+			t.Run("add", func(t *testing.T) {
+				_, err := service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{
+					Name:   "nat64-0",
+					Prefix: testCase.prefix,
+				})
+				require.Equal(t, codes.InvalidArgument, status.Code(err))
+			})
+
+			t.Run("remove", func(t *testing.T) {
+				_, err := service.RemovePrefix(t.Context(), &nat64pb.RemovePrefixRequest{
+					Name:   "nat64-0",
+					Prefix: testCase.prefix,
+				})
+				require.Equal(t, codes.InvalidArgument, status.Code(err))
+			})
+		})
+	}
 }
 
 // Test_NAT64Service_SetDropUnknownDefaultMTU verifies default MTU is preserved.
@@ -163,8 +213,8 @@ func Test_NAT64Service_UpdateFailureAtomic(t *testing.T) {
 	service := NewNAT64Service(backend)
 	ctx := t.Context()
 
-	prefix0 := []byte{0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	prefix1 := []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0}
+	prefix0 := mustIPv6Prefix(t, "64:ff9b::/96")
+	prefix1 := mustIPv6Prefix(t, "2001:db8::/96")
 
 	_, err := service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{Name: "nat64-0", Prefix: prefix0})
 	require.NoError(t, err)
@@ -174,7 +224,7 @@ func Test_NAT64Service_UpdateFailureAtomic(t *testing.T) {
 	show, err := service.ShowConfig(ctx, &nat64pb.ShowConfigRequest{Name: "nat64-0"})
 	require.NoError(t, err)
 	require.Len(t, show.GetConfig().GetPrefixes(), 1)
-	require.Equal(t, prefix0, show.GetConfig().GetPrefixes()[0].GetPrefix())
+	require.Equal(t, prefix0, show.GetConfig().GetPrefixes()[0])
 	require.False(t, backend.handles[0].freed)
 }
 
@@ -201,7 +251,7 @@ func Test_NAT64Service_MappingAddressInvalid(t *testing.T) {
 	// InvalidArgument below can come only from the address checks.
 	_, err := service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{
 		Name:   "nat64-0",
-		Prefix: []byte{0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		Prefix: mustIPv6Prefix(t, "64:ff9b::/96"),
 	})
 	require.NoError(t, err)
 

--- a/modules/nat64/tests/functional/nat64_test.go
+++ b/modules/nat64/tests/functional/nat64_test.go
@@ -31,7 +31,7 @@ const (
 	nat64MemSize = 8 * datasize.MB
 )
 
-var nat64Prefix96 = [12]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0}
+var nat64Prefix96 = netip.MustParsePrefix("2001:db8::/96")
 
 func setupNAT64Harness(t *testing.T) (*dataplaneut.Harness, *nat64.NAT64Service) {
 	t.Helper()
@@ -104,9 +104,16 @@ func wireNAT64Pipeline(t *testing.T, agent *ffi.Agent, name string) {
 	require.NoError(t, err)
 }
 
-func mustAddPrefix(t *testing.T, svc *nat64.NAT64Service, name string, prefix [12]byte) {
+func mustAddPrefix(t *testing.T, svc *nat64.NAT64Service, name string, prefix netip.Prefix) {
 	t.Helper()
-	_, err := svc.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{Name: name, Prefix: prefix[:]})
+
+	wirePrefix, err := commonpb.NewIPv6PrefixFromPrefix(prefix)
+	require.NoError(t, err)
+
+	_, err = svc.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{
+		Name:   name,
+		Prefix: wirePrefix,
+	})
 	require.NoError(t, err)
 }
 
@@ -138,12 +145,11 @@ func parseOneOutput(t *testing.T, result *dataplaneut.Result) gopacket.Packet {
 	return xpacket.ParseEtherPacket(result.Output[0].RawData)
 }
 
-func mappedV6(prefix [12]byte, ip4 netip.Addr) net.IP {
+func mappedV6(prefix netip.Prefix, ip4 netip.Addr) net.IP {
+	out := prefix.Masked().Addr().As16()
 	ip4b := ip4.As4()
-	out := make([]byte, 16)
-	copy(out[:12], prefix[:])
 	copy(out[12:], ip4b[:])
-	return out
+	return out[:]
 }
 
 func packetWithIPv6RawExt(


### PR DESCRIPTION
- Replace all NAT64 prefix byte fields with the shared family-typed IPv6 prefix message in one wire cutover.
- Preserve strict /96 validation while keeping the dataplane's 12-byte representation behind the control-plane adapter.
- Reuse commonpb CIDR rendering and serialization in the Rust CLI.
- Exclude only the NAT64 protobuf file from Buf breaking until the new baseline reaches main.

Refs #2197.