### PR TITLE
feat(nat64): delete a config through the service and cli

### DIFF
--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -6,9 +6,9 @@ use clap_complete::{
     CompleteEnv,
 };
 use nat64pb::{
-    nat64_service_client::Nat64ServiceClient, AddMappingRequest, AddPrefixRequest, ListConfigsRequest,
-    RemoveMappingRequest, RemovePrefixRequest, SetDropUnknownRequest, SetMtuRequest, ShowConfigRequest,
-    ShowConfigResponse,
+    nat64_service_client::Nat64ServiceClient, AddMappingRequest, AddPrefixRequest, DeleteConfigRequest,
+    ListConfigsRequest, RemoveMappingRequest, RemovePrefixRequest, SetDropUnknownRequest, SetMtuRequest,
+    ShowConfigRequest, ShowConfigResponse,
 };
 use netip::{Contiguous, Ipv6Network};
 use ptree::TreeBuilder;
@@ -55,6 +55,8 @@ pub enum ModeCmd {
     List,
     /// Show current configuration
     Show(ShowConfigCmd),
+    /// Delete a nat64 module config.
+    Delete(DeleteConfigCmd),
     /// Manage NAT64 prefixes
     Prefix {
         #[clap(subcommand)]
@@ -90,6 +92,13 @@ pub enum MappingCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
     /// The name of the config to operate on.
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
+    pub config_name: String,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct DeleteConfigCmd {
+    /// The name of the config to delete.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
 }
@@ -189,6 +198,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
+        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
         ModeCmd::Prefix { cmd } => match cmd {
             PrefixCmd::Add(cmd) => service.add_prefix(cmd).await,
             PrefixCmd::Remove(cmd) => service.remove_prefix(cmd).await,
@@ -285,6 +295,30 @@ impl NAT64Service {
                 print_tree(&response);
             },
         );
+
+        Ok(())
+    }
+
+    pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
+        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+        log::trace!("delete config request: {request:?}");
+        let response = self
+            .service
+            .client()
+            .delete_config(request)
+            .await
+            .map_err(|status| {
+                NOT_FOUND.map(
+                    status,
+                    "delete",
+                    self.service.endpoint(),
+                    Some(&format!("config '{}'", cmd.config_name)),
+                )
+            })?
+            .into_inner();
+        log::debug!("delete config response: {response:?}");
+
+        output::success("delete", format_args!("Deleted nat64 {}.", cmd.config_name));
 
         Ok(())
     }

--- a/modules/nat64/controlplane/backend.go
+++ b/modules/nat64/controlplane/backend.go
@@ -15,7 +15,12 @@ var _ ModuleHandle = (*cnat64.ModuleConfig)(nil)
 
 type Backend interface {
 	UpdateModule(name string, config *NAT64Config) (ModuleHandle, error)
+	// DeleteModule removes a module config.
+	DeleteModule(name string) error
 }
+
+// moduleType identifies the nat64 module to the shared-memory agent.
+const moduleType = "nat64"
 
 type backend struct {
 	agent *ffi.Agent
@@ -73,4 +78,8 @@ func (m *backend) UpdateModule(name string, config *NAT64Config) (ModuleHandle, 
 	}
 
 	return module, nil
+}
+
+func (m *backend) DeleteModule(name string) error {
+	return m.agent.DeleteModuleConfig(moduleType, name)
 }

--- a/modules/nat64/controlplane/nat64pb/v1/nat64.proto
+++ b/modules/nat64/controlplane/nat64pb/v1/nat64.proto
@@ -33,6 +33,10 @@ service NAT64Service {
   // SetDropUnknown sets drop_unknown_prefix and drop_unknown_mapping
   // flags
   rpc SetDropUnknown(SetDropUnknownRequest) returns (SetDropUnknownResponse) {}
+
+  // DeleteConfig removes the named config when it is no longer referenced
+  // by any pipeline.
+  rpc DeleteConfig(DeleteConfigRequest) returns (DeleteConfigResponse) {}
 }
 
 message ListConfigsRequest {}
@@ -121,3 +125,9 @@ message SetDropUnknownRequest {
 }
 
 message SetDropUnknownResponse {}
+
+// DeleteConfigRequest names the config to delete.
+message DeleteConfigRequest { string name = 1; }
+
+// DeleteConfigResponse is the response to a DeleteConfig call.
+message DeleteConfigResponse {}

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -432,6 +432,36 @@ func encodeNAT64Prefix(prefix []byte) (*commonpb.IPv6Prefix, error) {
 	}, nil
 }
 
+// DeleteConfig removes the named config when it is no longer referenced
+// by any pipeline.
+func (m *NAT64Service) DeleteConfig(ctx context.Context, req *nat64pb.DeleteConfigRequest) (*nat64pb.DeleteConfigResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "module config name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	inst, ok := m.configs[name]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "config not found")
+	}
+
+	if err := m.backend.DeleteModule(name); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to delete module config: %v", err)
+	}
+
+	// The delete retired the generation holding the published module.
+	// Retry the deferred ones, then retire this one.
+	m.reclaimDeferred()
+	m.parkOrFree(inst.Module)
+
+	delete(m.configs, name)
+
+	return &nat64pb.DeleteConfigResponse{}, nil
+}
+
 func (m *NAT64Service) instanceFor(name string) config {
 	inst, ok := m.configs[name]
 	if !ok {

--- a/modules/nat64/controlplane/service_test.go
+++ b/modules/nat64/controlplane/service_test.go
@@ -3,6 +3,7 @@ package nat64
 import (
 	"errors"
 	"net/netip"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,24 +11,42 @@ import (
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	nat64pb "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb/v1"
 )
 
 var errInjectedBackend = errors.New("injected backend failure")
 
 type mockHandle struct {
-	freed bool
+	freed      bool
+	freedCount atomic.Int64
 }
 
 func (m *mockHandle) Free() error {
 	m.freed = true
+	m.freedCount.Add(1)
+	return nil
+}
+
+// refusingOnceHandle refuses its first Free with ffi.ErrStillReferenced, then succeeds.
+type refusingOnceHandle struct {
+	numCalls atomic.Int64
+	freed    atomic.Int64
+}
+
+func (m *refusingOnceHandle) Free() error {
+	if m.numCalls.Add(1) == 1 {
+		return ffi.ErrStillReferenced
+	}
+	m.freed.Add(1)
 	return nil
 }
 
 type mockBackend struct {
-	configs []NAT64Config
-	handles []*mockHandle
-	failAt  int
+	configs     []NAT64Config
+	handles     []*mockHandle
+	failAt      int
+	deletedName string
 }
 
 func (m *mockBackend) UpdateModule(name string, cfg *NAT64Config) (ModuleHandle, error) {
@@ -47,6 +66,37 @@ func mustIPv6Prefix(t *testing.T, value string) *commonpb.IPv6Prefix {
 	prefix, err := commonpb.NewIPv6PrefixFromPrefix(netip.MustParsePrefix(value))
 	require.NoError(t, err)
 	return prefix
+}
+
+func (m *mockBackend) DeleteModule(name string) error {
+	m.deletedName = name
+	return nil
+}
+
+// refusingDeleteBackend updates like mockBackend but refuses every delete,
+// modeling a config still referenced by a live generation.
+type refusingDeleteBackend struct {
+	mockBackend
+}
+
+func (m *refusingDeleteBackend) DeleteModule(name string) error {
+	m.deletedName = name
+	return errInjectedBackend
+}
+
+// parkingBackend updates like mockBackend but refuses to release the first
+// handle it mints, so that handle must be parked before it can be reclaimed.
+type parkingBackend struct {
+	mockBackend
+	numCalls atomic.Int64
+	first    refusingOnceHandle
+}
+
+func (m *parkingBackend) UpdateModule(name string, cfg *NAT64Config) (ModuleHandle, error) {
+	if m.numCalls.Add(1) == 1 {
+		return &m.first, nil
+	}
+	return m.mockBackend.UpdateModule(name, cfg)
 }
 
 // Test_NAT64Service_AddShowRemove verifies basic config lifecycle operations.
@@ -271,4 +321,111 @@ func Test_NAT64Service_MappingAddressInvalid(t *testing.T) {
 	// Only the prefix update reached the backend: no mapping landed.
 	require.Len(t, backend.configs, 1)
 	require.Empty(t, backend.configs[0].Mappings)
+}
+
+// Test_NAT64Service_DeleteConfig_InvalidName verifies that deleting a
+// config with an empty name is rejected.
+func Test_NAT64Service_DeleteConfig_InvalidName(t *testing.T) {
+	service := NewNAT64Service(&mockBackend{})
+	ctx := t.Context()
+
+	resp, err := service.DeleteConfig(ctx, &nat64pb.DeleteConfigRequest{})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Test_NAT64Service_DeleteConfig_MissingConfig verifies that deleting a
+// config that was never created returns NotFound.
+func Test_NAT64Service_DeleteConfig_MissingConfig(t *testing.T) {
+	service := NewNAT64Service(&mockBackend{})
+	ctx := t.Context()
+
+	resp, err := service.DeleteConfig(ctx, &nat64pb.DeleteConfigRequest{Name: "nat64-0"})
+	require.Nil(t, resp)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// Test_NAT64Service_DeleteConfig_RemovesConfig verifies that deleting an
+// unreferenced config removes it from ListConfigs and from Show.
+func Test_NAT64Service_DeleteConfig_RemovesConfig(t *testing.T) {
+	backend := &mockBackend{}
+	service := NewNAT64Service(backend)
+	ctx := t.Context()
+
+	_, err := service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{
+		Name:   "nat64-0",
+		Prefix: mustIPv6Prefix(t, "64:ff9b::/96"),
+	})
+	require.NoError(t, err)
+	handle := backend.handles[0]
+
+	resp, err := service.DeleteConfig(ctx, &nat64pb.DeleteConfigRequest{Name: "nat64-0"})
+	require.NotNil(t, resp)
+	require.NoError(t, err)
+	require.Equal(t, "nat64-0", backend.deletedName)
+	require.Equal(t, int64(1), handle.freedCount.Load())
+
+	list, err := service.ListConfigs(ctx, &nat64pb.ListConfigsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, list.Configs)
+
+	show, err := service.ShowConfig(ctx, &nat64pb.ShowConfigRequest{Name: "nat64-0"})
+	require.Nil(t, show)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// Test_NAT64Service_DeleteConfig_Referenced verifies that a backend refusal
+// surfaces as Internal and leaves the config in place.
+func Test_NAT64Service_DeleteConfig_Referenced(t *testing.T) {
+	backend := &refusingDeleteBackend{}
+	service := NewNAT64Service(backend)
+	ctx := t.Context()
+
+	_, err := service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{
+		Name:   "nat64-0",
+		Prefix: mustIPv6Prefix(t, "64:ff9b::/96"),
+	})
+	require.NoError(t, err)
+
+	resp, err := service.DeleteConfig(ctx, &nat64pb.DeleteConfigRequest{Name: "nat64-0"})
+	require.Nil(t, resp)
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.Equal(t, "nat64-0", backend.deletedName)
+
+	list, err := service.ListConfigs(ctx, &nat64pb.ListConfigsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"nat64-0"}, list.Configs)
+
+	show, err := service.ShowConfig(ctx, &nat64pb.ShowConfigRequest{Name: "nat64-0"})
+	require.NotNil(t, show)
+	require.NoError(t, err)
+}
+
+// Test_NAT64Service_DeleteConfig_ParksThenReclaims verifies a handle whose
+// release is refused at delete time is parked, then reclaimed on the next update.
+func Test_NAT64Service_DeleteConfig_ParksThenReclaims(t *testing.T) {
+	backend := &parkingBackend{}
+	service := NewNAT64Service(backend)
+	ctx := t.Context()
+
+	_, err := service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{
+		Name:   "nat64-0",
+		Prefix: mustIPv6Prefix(t, "64:ff9b::/96"),
+	})
+	require.NoError(t, err)
+
+	resp, err := service.DeleteConfig(ctx, &nat64pb.DeleteConfigRequest{Name: "nat64-0"})
+	require.NotNil(t, resp)
+	require.NoError(t, err)
+	require.Len(t, service.deferred, 1)
+	require.Equal(t, int64(0), backend.first.freed.Load())
+
+	// A later successful update reclaims deferred handles first.
+	_, err = service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{
+		Name:   "nat64-1",
+		Prefix: mustIPv6Prefix(t, "64:ff9b::/96"),
+	})
+	require.NoError(t, err)
+	require.Empty(t, service.deferred)
+	require.Equal(t, int64(1), backend.first.freed.Load())
 }


### PR DESCRIPTION
- Add a DeleteConfig RPC to NAT64Service and serve it with the standard guarded path: a missing config returns NotFound, a config still referenced by a live generation is refused with the dataplane's error relayed, and an unreferenced config is removed from ListConfigs with its shared-memory handle released or parked for reclaim.
- Add `yanet-cli-nat64 delete --name` with completion of the config name; a missing config renders a friendly not-found error and exits 3.
- Cover the empty-name, missing, unreferenced, referenced and park-then-reclaim cases in the service tests, creating configs through the module's element-wise add calls.
- Assumption: DeleteConfigResponse is empty rather than the always-true `bool deleted` of the older modules, matching the decap precedent of #2411.
- Assumption: a referenced-config refusal is relayed as Internal carrying the C error text, as in the peer modules; a typed still-referenced status would need a bindings change out of this scope.
- Assumption: the CLI gains no unit tests because the verb adds no crate-own logic, per the repo test policy.
- Closes #2385.