### PR TITLE
feat(dscp): delete a config through the service and cli

### DIFF
--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -5,8 +5,8 @@ use clap_complete::{
 };
 use commonpb::partition_prefixes;
 use dscppb::{
-    AddPrefixesRequest, DscpConfig, RemovePrefixesRequest, SetDscpMarkingRequest, ShowConfigRequest,
-    ShowConfigResponse, dscp_service_client::DscpServiceClient,
+    AddPrefixesRequest, DeleteConfigRequest, DscpConfig, RemovePrefixesRequest, SetDscpMarkingRequest,
+    ShowConfigRequest, ShowConfigResponse, dscp_service_client::DscpServiceClient,
 };
 use netip::{Contiguous, IpNetwork};
 use ptree::TreeBuilder;
@@ -14,7 +14,7 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    errors::Error,
+    errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
 };
 
@@ -51,6 +51,8 @@ pub enum ModeCmd {
     PrefixAdd(AddPrefixesCmd),
     PrefixRemove(RemovePrefixesCmd),
     SetMarking(SetDscpMarkingCmd),
+    /// Delete a dscp module config.
+    Delete(DeleteConfigCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -94,8 +96,18 @@ pub struct SetDscpMarkingCmd {
     pub mark: u32,
 }
 
+#[derive(Debug, Clone, Parser)]
+pub struct DeleteConfigCmd {
+    /// DSCP module name to delete.
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
+    pub config_name: String,
+}
+
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.dscp.controlplane.dscppb.v1.DscpService";
+
+/// Maps a genuine "config not found" status into a friendly message.
+const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
 fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
@@ -122,6 +134,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::PrefixAdd(cmd) => service.add_prefixes(cmd).await,
         ModeCmd::PrefixRemove(cmd) => service.remove_prefixes(cmd).await,
         ModeCmd::SetMarking(cmd) => service.set_dscp_marking(cmd).await,
+        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
     }
 }
 
@@ -283,6 +296,30 @@ impl DscpService {
         log::debug!("SetDscpMarkingResponse: {response:?}");
 
         output::success("set-marking", format_args!("Set DSCP marking on {}.", cmd.config_name));
+
+        Ok(())
+    }
+
+    pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
+        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+        log::trace!("DeleteConfigRequest: {request:?}");
+        let response = self
+            .service
+            .client()
+            .delete_config(request)
+            .await
+            .map_err(|status| {
+                NOT_FOUND.map(
+                    status,
+                    "delete",
+                    self.service.endpoint(),
+                    Some(&format!("config '{}'", cmd.config_name)),
+                )
+            })?
+            .into_inner();
+        log::debug!("DeleteConfigResponse: {response:?}");
+
+        output::success("delete", format_args!("Deleted dscp {}.", cmd.config_name));
 
         Ok(())
     }

--- a/modules/dscp/controlplane/backend.go
+++ b/modules/dscp/controlplane/backend.go
@@ -8,6 +8,9 @@ import (
 	"github.com/yanet-platform/yanet2/modules/dscp/bindings/go/cdscp"
 )
 
+// moduleType identifies the dscp module to the shared-memory agent.
+const moduleType = "dscp"
+
 // backend is the real Backend implementation backed by shared memory.
 type backend struct {
 	agent *ffi.Agent
@@ -55,4 +58,8 @@ func (m *backend) UpdateModule(
 	}
 
 	return module, nil
+}
+
+func (m *backend) DeleteModule(name string) error {
+	return m.agent.DeleteModuleConfig(moduleType, name)
 }

--- a/modules/dscp/controlplane/dscppb/v1/dscp.go
+++ b/modules/dscp/controlplane/dscppb/v1/dscp.go
@@ -36,6 +36,15 @@ func (m *RemovePrefixesRequest) Validate() error {
 	return nil
 }
 
+// Validate checks that the request names the config to delete.
+func (m *DeleteConfigRequest) Validate() error {
+	if m.Name == "" {
+		return errConfigNameRequired
+	}
+
+	return nil
+}
+
 func (m *SetDscpMarkingRequest) Validate() error {
 	if m.Name == "" {
 		return errConfigNameRequired

--- a/modules/dscp/controlplane/dscppb/v1/dscp.proto
+++ b/modules/dscp/controlplane/dscppb/v1/dscp.proto
@@ -22,6 +22,9 @@ service DscpService {
   rpc RemovePrefixes(RemovePrefixesRequest) returns (RemovePrefixesResponse);
   // SetDscpMarking sets the DSCP marking configuration.
   rpc SetDscpMarking(SetDscpMarkingRequest) returns (SetDscpMarkingResponse);
+  // DeleteConfig removes the named config when it is no longer referenced
+  // by any pipeline.
+  rpc DeleteConfig(DeleteConfigRequest) returns (DeleteConfigResponse) {}
 }
 
 message Config {
@@ -73,3 +76,9 @@ message SetDscpMarkingRequest {
   DscpConfig dscp_config = 2;
 }
 message SetDscpMarkingResponse {}
+
+// DeleteConfigRequest names the config to delete.
+message DeleteConfigRequest { string name = 1; }
+
+// DeleteConfigResponse is the response to a DeleteConfig call.
+message DeleteConfigResponse {}

--- a/modules/dscp/controlplane/service.go
+++ b/modules/dscp/controlplane/service.go
@@ -26,6 +26,8 @@ type Backend interface {
 	// UpdateModule creates a module config, applies mutations, and publishes it
 	// to the dataplane.
 	UpdateModule(name string, prefixes []netip.Prefix, flag uint8, mark uint8) (ModuleHandle, error)
+	// DeleteModule removes a module config.
+	DeleteModule(name string) error
 }
 
 type DscpService struct {
@@ -273,6 +275,43 @@ func (m *DscpService) SetDscpMarking(
 	}
 
 	return &dscppb.SetDscpMarkingResponse{}, nil
+}
+
+// DeleteConfig removes the named config if it is not referenced by any
+// pipeline.
+func (m *DscpService) DeleteConfig(
+	ctx context.Context,
+	request *dscppb.DeleteConfigRequest,
+) (*dscppb.DeleteConfigResponse, error) {
+	if err := request.Validate(); err != nil {
+		return nil, err
+	}
+
+	name := request.GetName()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.configs[name]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "config not found")
+	}
+
+	if err := m.backend.DeleteModule(name); err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to delete module config %q: %v", name, err,
+		)
+	}
+
+	// The delete retired the generation holding the published module.
+	// Retry the deferred ones, then retire this one.
+	m.reclaimDeferred()
+	m.parkOrFree(entry.Module)
+
+	delete(m.configs, name)
+
+	return &dscppb.DeleteConfigResponse{}, nil
 }
 
 func (m *DscpService) updateModuleConfig(name string, cfg *config) error {

--- a/modules/dscp/controlplane/service_test.go
+++ b/modules/dscp/controlplane/service_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/netip"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/dscp/controlplane/dscppb/v1"
 )
 
@@ -61,14 +63,35 @@ func prefixStrings[T interface{ ToPrefix() (netip.Prefix, error) }](t *testing.T
 	return prefixes
 }
 
+// mockModuleHandle counts Free calls so tests can assert a release happened.
 type mockModuleHandle struct {
+	freed atomic.Int64
 }
 
 func (m *mockModuleHandle) Free() error {
+	m.freed.Add(1)
 	return nil
 }
 
-type mockBackend struct{}
+// refusingOnceHandle refuses its first Free with ffi.ErrStillReferenced, then succeeds.
+type refusingOnceHandle struct {
+	numCalls atomic.Int64
+	freed    atomic.Int64
+}
+
+func (m *refusingOnceHandle) Free() error {
+	if m.numCalls.Add(1) == 1 {
+		return ffi.ErrStillReferenced
+	}
+	m.freed.Add(1)
+	return nil
+}
+
+// mockBackend records the last handle it minted and the name it last saw in DeleteModule.
+type mockBackend struct {
+	lastHandle  atomic.Pointer[mockModuleHandle]
+	deletedName string
+}
 
 func (m *mockBackend) UpdateModule(
 	name string,
@@ -76,12 +99,50 @@ func (m *mockBackend) UpdateModule(
 	flag uint8,
 	mark uint8,
 ) (ModuleHandle, error) {
-	return &mockModuleHandle{}, nil
+	handle := &mockModuleHandle{}
+	m.lastHandle.Store(handle)
+	return handle, nil
+}
+
+func (m *mockBackend) DeleteModule(name string) error {
+	m.deletedName = name
+	return nil
 }
 
 func newTestService(t *testing.T) *DscpService {
 	t.Helper()
 	return NewDscpService(&mockBackend{})
+}
+
+// refusingDeleteBackend updates like mockBackend but refuses every delete,
+// modeling a config still referenced by a live generation.
+type refusingDeleteBackend struct {
+	mockBackend
+}
+
+func (m *refusingDeleteBackend) DeleteModule(name string) error {
+	m.deletedName = name
+	return errBackendFailure
+}
+
+// parkingBackend refuses to release the first handle it mints, then releases
+// normally, so that handle must be parked before it can be reclaimed.
+type parkingBackend struct {
+	mockBackend
+	numCalls atomic.Int64
+	first    refusingOnceHandle
+}
+
+func (m *parkingBackend) UpdateModule(
+	name string,
+	prefixes []netip.Prefix,
+	flag uint8,
+	mark uint8,
+) (ModuleHandle, error) {
+	if m.numCalls.Add(1) == 1 {
+		return &m.first, nil
+	}
+	return &mockModuleHandle{}, nil
 }
 
 type flakyBackend struct {
@@ -105,6 +166,10 @@ func (m *flakyBackend) UpdateModule(
 	}
 
 	return m.backend.UpdateModule(name, prefixes, flag, mark)
+}
+
+func (m *flakyBackend) DeleteModule(name string) error {
+	return nil
 }
 
 // Test_DscpService_ListShowAddRemoveSetMarking verifies that prefix mutations
@@ -217,6 +282,12 @@ func Test_DscpService_RequestValidation(t *testing.T) {
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
 
+	t.Run("DeleteConfigInvalidName", func(t *testing.T) {
+		response, err := service.DeleteConfig(ctx, &dscppb.DeleteConfigRequest{Name: ""})
+		require.Nil(t, response)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
 	t.Run("SetDscpMarkingNoDSCPConfig", func(t *testing.T) {
 		response, err := service.SetDscpMarking(ctx, &dscppb.SetDscpMarkingRequest{
 			Name: "dscp0",
@@ -295,6 +366,107 @@ func Test_DscpService_NoUpdateOnFailure(t *testing.T) {
 	require.NotNil(t, response)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"10.0.0.0/24"}, prefixStrings(t, response.Config.Prefixes4))
+}
+
+// Test_DscpService_DeleteConfig_MissingConfig verifies that deleting a
+// config that was never created returns NotFound.
+func Test_DscpService_DeleteConfig_MissingConfig(t *testing.T) {
+	t.Parallel()
+	service := newTestService(t)
+
+	response, err := service.DeleteConfig(t.Context(), &dscppb.DeleteConfigRequest{Name: "dscp0"})
+	require.Nil(t, response)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// Test_DscpService_DeleteConfig_RemovesConfig verifies that deleting an
+// unreferenced config removes it from ListConfigs and from Show.
+func Test_DscpService_DeleteConfig_RemovesConfig(t *testing.T) {
+	t.Parallel()
+	backend := &mockBackend{}
+	service := NewDscpService(backend)
+	ctx := t.Context()
+
+	_, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
+		Name:      "dscp0",
+		Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
+	})
+	require.NoError(t, err)
+
+	handle := backend.lastHandle.Load()
+	require.NotNil(t, handle)
+
+	response, err := service.DeleteConfig(ctx, &dscppb.DeleteConfigRequest{Name: "dscp0"})
+	require.NotNil(t, response)
+	require.NoError(t, err)
+	assert.Equal(t, "dscp0", backend.deletedName)
+	assert.Equal(t, int64(1), handle.freed.Load())
+
+	list, err := service.ListConfigs(ctx, &dscppb.ListConfigsRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, list.Configs)
+
+	show, err := service.ShowConfig(ctx, &dscppb.ShowConfigRequest{Name: "dscp0"})
+	require.Nil(t, show)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// Test_DscpService_DeleteConfig_Referenced verifies that a backend refusal
+// surfaces as Internal and leaves the config in place.
+func Test_DscpService_DeleteConfig_Referenced(t *testing.T) {
+	t.Parallel()
+	backend := &refusingDeleteBackend{}
+	service := NewDscpService(backend)
+	ctx := t.Context()
+
+	_, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
+		Name:      "dscp0",
+		Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
+	})
+	require.NoError(t, err)
+
+	response, err := service.DeleteConfig(ctx, &dscppb.DeleteConfigRequest{Name: "dscp0"})
+	require.Nil(t, response)
+	require.Equal(t, codes.Internal, status.Code(err))
+	assert.Equal(t, "dscp0", backend.deletedName)
+
+	list, err := service.ListConfigs(ctx, &dscppb.ListConfigsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dscp0"}, list.Configs)
+
+	show, err := service.ShowConfig(ctx, &dscppb.ShowConfigRequest{Name: "dscp0"})
+	require.NotNil(t, show)
+	require.NoError(t, err)
+}
+
+// Test_DscpService_DeleteConfig_ParksThenReclaims verifies that a handle
+// refused on delete is parked and reclaimed by the next successful update.
+func Test_DscpService_DeleteConfig_ParksThenReclaims(t *testing.T) {
+	t.Parallel()
+	backend := &parkingBackend{}
+	service := NewDscpService(backend)
+	ctx := t.Context()
+
+	_, err := service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
+		Name:      "dscp0",
+		Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
+	})
+	require.NoError(t, err)
+
+	response, err := service.DeleteConfig(ctx, &dscppb.DeleteConfigRequest{Name: "dscp0"})
+	require.NotNil(t, response)
+	require.NoError(t, err)
+	require.Len(t, service.deferred, 1)
+	assert.Equal(t, int64(0), backend.first.freed.Load())
+
+	// A later successful update reclaims deferred handles first.
+	_, err = service.AddPrefixes(ctx, &dscppb.AddPrefixesRequest{
+		Name:      "dscp1",
+		Prefixes4: mustPrefixes4(t, "10.0.1.0/24"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, service.deferred)
+	assert.Equal(t, int64(1), backend.first.freed.Load())
 }
 
 // Test_DscpService_ConcurrentAccess verifies that concurrent mutations and


### PR DESCRIPTION
- Add a DeleteConfig RPC to DscpService and serve it with the standard guarded path: a missing config returns NotFound, a config still referenced by a live generation is refused with the dataplane's error relayed, and an unreferenced config is removed from ListConfigs with its shared-memory handle released or parked for reclaim.
- Add `yanet-cli-dscp delete --name` with completion of the config name; a missing config renders a friendly not-found error and exits 3.
- Cover the empty-name, missing, unreferenced, referenced and park-then-reclaim cases in the service tests, with mocks that pin the handle release.
- Assumption: DeleteConfigResponse is empty rather than the always-true `bool deleted` of the older modules, matching the decap precedent of #2411.
- Assumption: the name-required check follows the module's own request Validate idiom instead of an inline guard.
- Assumption: a referenced-config refusal is relayed as Internal carrying the C error text, as in the peer modules; a typed still-referenced status would need a bindings change out of this scope.
- Assumption: the CLI gains no unit tests because the verb adds no crate-own logic, per the repo test policy.
- Closes #2384.