### PR TITLE
feat(unrdup): delete a config through the service and cli

### DIFF
--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -14,13 +14,13 @@ use filterpb::pb::IpNet;
 use serde::{Deserialize, Serialize};
 use tonic::codec::CompressionEncoding;
 use unrduppb::{
-    Config, Endpoint, ListConfigsRequest, Protocol, Service, ShowConfigRequest, UpdateConfigRequest,
-    unrdup_service_client::UnrdupServiceClient,
+    Config, DeleteConfigRequest, Endpoint, ListConfigsRequest, Protocol, Service, ShowConfigRequest,
+    UpdateConfigRequest, unrdup_service_client::UnrdupServiceClient,
 };
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
     completion,
-    errors::Error,
+    errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
 };
 
@@ -52,6 +52,8 @@ pub enum ModeCmd {
     List,
     Show(ShowConfigCmd),
     Update(UpdateConfigCmd),
+    /// Delete an unrdup module config.
+    Delete(DeleteConfigCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -69,6 +71,13 @@ pub struct UpdateConfigCmd {
     /// Path to the YAML file describing the whole configuration.
     #[arg(long = "config", short = 'c')]
     pub config_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct DeleteConfigCmd {
+    /// Unrdup module name to delete.
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
+    pub config_name: String,
 }
 
 /// Transport a virtual service serves.
@@ -218,6 +227,9 @@ fn addr_to_proto(addr: IpAddr) -> IpAddress {
 
 const SERVICE_NAME: &str = "modules.unrdup.controlplane.unrduppb.v1.UnrdupService";
 
+/// Maps a genuine "config not found" status into a friendly message.
+const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
+
 fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
     start();
@@ -241,6 +253,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::List => service.list_configs().await,
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
         ModeCmd::Update(cmd) => service.update_config(cmd).await,
+        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
     }
 }
 
@@ -352,6 +365,29 @@ impl UnrdupService {
         log::debug!("update config response: {response:?}");
 
         output::success("update", format_args!("Updated {}.", cmd.config_name));
+
+        Ok(())
+    }
+
+    pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
+        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+        log::trace!("delete config request: {request:?}");
+        let response = self
+            .client
+            .delete_config(request)
+            .await
+            .map_err(|status| {
+                NOT_FOUND.map(
+                    status,
+                    "delete",
+                    self.endpoint.clone(),
+                    Some(&format!("config '{}'", cmd.config_name)),
+                )
+            })?
+            .into_inner();
+        log::debug!("delete config response: {response:?}");
+
+        output::success("delete", format_args!("Deleted unrdup {}.", cmd.config_name));
 
         Ok(())
     }

--- a/modules/unrdup/controlplane/backend.go
+++ b/modules/unrdup/controlplane/backend.go
@@ -8,6 +8,9 @@ import (
 	"github.com/yanet-platform/yanet2/modules/unrdup/bindings/go/cunrdup"
 )
 
+// moduleType identifies the unrdup module to the shared-memory agent.
+const moduleType = "unrdup"
+
 type backend struct {
 	agent *ffi.Agent
 }
@@ -46,4 +49,8 @@ func (m *backend) UpdateModule(
 	}
 
 	return module, nil
+}
+
+func (m *backend) DeleteModule(name string) error {
+	return m.agent.DeleteModuleConfig(moduleType, name)
 }

--- a/modules/unrdup/controlplane/service.go
+++ b/modules/unrdup/controlplane/service.go
@@ -55,6 +55,8 @@ type Backend interface {
 		sources []xnetip.Network,
 		services []cunrdup.Service,
 	) (ModuleHandle, error)
+	// DeleteModule removes a module config.
+	DeleteModule(name string) error
 }
 
 type UnrdupService struct {
@@ -197,4 +199,39 @@ func (m *UnrdupService) UpdateConfig(
 	m.configs[name] = updated
 
 	return &unrduppb.UpdateConfigResponse{}, nil
+}
+
+// DeleteConfig removes the named config if it is not referenced by any
+// pipeline.
+func (m *UnrdupService) DeleteConfig(
+	ctx context.Context,
+	request *unrduppb.DeleteConfigRequest,
+) (*unrduppb.DeleteConfigResponse, error) {
+	name := request.GetName()
+	if name == "" {
+		return nil, errConfigNameRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	current, ok := m.configs[name]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "config %q is not found", name)
+	}
+
+	if err := m.backend.DeleteModule(name); err != nil {
+		return nil, status.Errorf(
+			codes.Internal, "failed to delete config %q: %s", name, err,
+		)
+	}
+
+	// The delete retired the generation holding the published module.
+	// Retry the deferred ones, then retire this one.
+	m.reclaimDeferred()
+	m.parkOrFree(current.Module)
+
+	delete(m.configs, name)
+
+	return &unrduppb.DeleteConfigResponse{}, nil
 }

--- a/modules/unrdup/controlplane/service_test.go
+++ b/modules/unrdup/controlplane/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yanet-platform/xnetip"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/unrdup/bindings/go/cunrdup"
 	unrdup "github.com/yanet-platform/yanet2/modules/unrdup/controlplane"
 	"github.com/yanet-platform/yanet2/modules/unrdup/controlplane/unrduppb/v1"
@@ -22,11 +23,28 @@ import (
 var errBackendFailure = errors.New("backend failure")
 
 type fakeHandle struct {
-	freed bool
+	freed     bool
+	freeCalls int
 }
 
 func (m *fakeHandle) Free() error {
 	m.freed = true
+	m.freeCalls++
+	return nil
+}
+
+// refusingOnceHandle refuses its first Free with ffi.ErrStillReferenced, then succeeds.
+type refusingOnceHandle struct {
+	numCalls int
+	freed    int
+}
+
+func (m *refusingOnceHandle) Free() error {
+	m.numCalls++
+	if m.numCalls == 1 {
+		return ffi.ErrStillReferenced
+	}
+	m.freed++
 	return nil
 }
 
@@ -36,6 +54,15 @@ type fakeBackend struct {
 	handles  []*fakeHandle
 	sources  []xnetip.Network
 	services []cunrdup.Service
+
+	// nextHandle, when set, is returned by the next successful update
+	// instead of a fresh handle, and is cleared once used.
+	nextHandle unrdup.ModuleHandle
+
+	// deleteErr, when set, is returned by every delete until cleared,
+	// modeling a config still referenced by a live generation.
+	deleteErr   error
+	deletedName string
 }
 
 func (m *fakeBackend) UpdateModule(
@@ -51,10 +78,21 @@ func (m *fakeBackend) UpdateModule(
 	m.sources = sources
 	m.services = services
 
+	if m.nextHandle != nil {
+		handle := m.nextHandle
+		m.nextHandle = nil
+		return handle, nil
+	}
+
 	handle := &fakeHandle{}
 	m.handles = append(m.handles, handle)
 
 	return handle, nil
+}
+
+func (m *fakeBackend) DeleteModule(name string) error {
+	m.deletedName = name
+	return m.deleteErr
 }
 
 func ipAddr(addr string) *commonpb.IPAddress {
@@ -510,4 +548,113 @@ func TestListConfigsEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Empty(t, response.GetConfigs())
+}
+
+// Test_UnrdupService_DeleteConfig_RequiresName verifies that deleting
+// without a name returns InvalidArgument.
+func Test_UnrdupService_DeleteConfig_RequiresName(t *testing.T) {
+	service := unrdup.NewUnrdupService(&fakeBackend{})
+
+	resp, err := service.DeleteConfig(t.Context(), &unrduppb.DeleteConfigRequest{})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Test_UnrdupService_DeleteConfig_MissingConfig verifies that deleting a
+// config that was never created returns NotFound.
+func Test_UnrdupService_DeleteConfig_MissingConfig(t *testing.T) {
+	service := unrdup.NewUnrdupService(&fakeBackend{})
+
+	resp, err := service.DeleteConfig(t.Context(), &unrduppb.DeleteConfigRequest{
+		Name: "unrdup0",
+	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// Test_UnrdupService_DeleteConfig_RemovesConfig verifies that deleting an
+// unreferenced config removes it from ListConfigs and from ShowConfig.
+func Test_UnrdupService_DeleteConfig_RemovesConfig(t *testing.T) {
+	backend := &fakeBackend{}
+	service := unrdup.NewUnrdupService(backend)
+	ctx := t.Context()
+
+	_, err := service.UpdateConfig(ctx, &unrduppb.UpdateConfigRequest{
+		Name:   "unrdup0",
+		Config: validConfig(),
+	})
+	require.NoError(t, err)
+	require.Len(t, backend.handles, 1)
+	handle := backend.handles[0]
+
+	resp, err := service.DeleteConfig(ctx, &unrduppb.DeleteConfigRequest{Name: "unrdup0"})
+	require.NotNil(t, resp)
+	require.NoError(t, err)
+	require.Equal(t, "unrdup0", backend.deletedName)
+	require.Equal(t, 1, handle.freeCalls)
+
+	list, err := service.ListConfigs(ctx, &unrduppb.ListConfigsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, list.GetConfigs())
+
+	show, err := service.ShowConfig(ctx, &unrduppb.ShowConfigRequest{Name: "unrdup0"})
+	require.Nil(t, show)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// Test_UnrdupService_DeleteConfig_Referenced verifies that a backend
+// refusal surfaces as Internal and leaves the config in place.
+func Test_UnrdupService_DeleteConfig_Referenced(t *testing.T) {
+	backend := &fakeBackend{deleteErr: errBackendFailure}
+	service := unrdup.NewUnrdupService(backend)
+	ctx := t.Context()
+
+	_, err := service.UpdateConfig(ctx, &unrduppb.UpdateConfigRequest{
+		Name:   "unrdup0",
+		Config: validConfig(),
+	})
+	require.NoError(t, err)
+
+	resp, err := service.DeleteConfig(ctx, &unrduppb.DeleteConfigRequest{Name: "unrdup0"})
+	require.Nil(t, resp)
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.Equal(t, "unrdup0", backend.deletedName)
+
+	list, err := service.ListConfigs(ctx, &unrduppb.ListConfigsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"unrdup0"}, list.GetConfigs())
+
+	show, err := service.ShowConfig(ctx, &unrduppb.ShowConfigRequest{Name: "unrdup0"})
+	require.NoError(t, err)
+	require.NotNil(t, show)
+}
+
+// Test_UnrdupService_DeleteConfig_ParksThenReclaims verifies that a handle
+// refused on delete is parked and reclaimed by the next successful update.
+func Test_UnrdupService_DeleteConfig_ParksThenReclaims(t *testing.T) {
+	backend := &fakeBackend{}
+	service := unrdup.NewUnrdupService(backend)
+	ctx := t.Context()
+
+	parked := &refusingOnceHandle{}
+	backend.nextHandle = parked
+
+	_, err := service.UpdateConfig(ctx, &unrduppb.UpdateConfigRequest{
+		Name:   "unrdup0",
+		Config: validConfig(),
+	})
+	require.NoError(t, err)
+
+	resp, err := service.DeleteConfig(ctx, &unrduppb.DeleteConfigRequest{Name: "unrdup0"})
+	require.NotNil(t, resp)
+	require.NoError(t, err)
+	require.Equal(t, 0, parked.freed)
+
+	// A later successful update reclaims deferred handles first.
+	_, err = service.UpdateConfig(ctx, &unrduppb.UpdateConfigRequest{
+		Name:   "unrdup1",
+		Config: validConfig(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, parked.freed)
 }

--- a/modules/unrdup/controlplane/unrduppb/v1/unrdup.proto
+++ b/modules/unrdup/controlplane/unrduppb/v1/unrdup.proto
@@ -17,6 +17,10 @@ service UnrdupService {
 
   // UpdateConfig replaces the whole configuration.
   rpc UpdateConfig(UpdateConfigRequest) returns (UpdateConfigResponse);
+
+  // DeleteConfig removes the named config when it is no longer referenced
+  // by any pipeline.
+  rpc DeleteConfig(DeleteConfigRequest) returns (DeleteConfigResponse) {}
 }
 
 // Protocol of a served transport endpoint.
@@ -65,3 +69,9 @@ message UpdateConfigRequest {
 }
 
 message UpdateConfigResponse {}
+
+// DeleteConfigRequest names the config to delete.
+message DeleteConfigRequest { string name = 1; }
+
+// DeleteConfigResponse is the response to a DeleteConfig call.
+message DeleteConfigResponse {}


### PR DESCRIPTION
- Add a DeleteConfig RPC to UnrdupService and serve it with the standard guarded path: a missing config returns NotFound, a config still referenced by a live generation is refused with the dataplane's error relayed, and an unreferenced config is removed from ListConfigs with its shared-memory handle released or parked for reclaim.
- Add `yanet-cli-unrdup delete --name` with completion of the config name; a missing config renders a friendly not-found error and exits 3.
- Cover the empty-name, missing, unreferenced, referenced and park-then-reclaim cases in the service tests; the external test package pins the park-then-reclaim contract through observable handle release counts.
- Assumption: DeleteConfigResponse is empty rather than the always-true `bool deleted` of the older modules, matching the decap precedent of #2411.
- Assumption: a referenced-config refusal is relayed as Internal carrying the C error text, as in the peer modules; a typed still-referenced status would need a bindings change out of this scope.
- Assumption: the CLI keeps its existing raw-client connection idiom; only the delete verb maps through a not-found mapper, and no unit tests are added because the verb has no crate-own logic.
- Closes #2386.