### PR TITLE
fix(route-mpls): accept a withdraw without a source address

### DIFF
--- a/modules/route-mpls/controlplane/routemplspb/v1/routempls.proto
+++ b/modules/route-mpls/controlplane/routemplspb/v1/routempls.proto
@@ -36,6 +36,8 @@ message UpdateConfigRequest {
 message UpdateEvent {
   oneof event {
     Rule update = 1;
+    // Matches by prefix, destination_ip, and label only. Every other
+    // nexthop field is ignored.
     Rule withdraw = 2;
   }
 }

--- a/modules/route-mpls/controlplane/service.go
+++ b/modules/route-mpls/controlplane/service.go
@@ -415,7 +415,7 @@ func (m *RouteMPLSService) UpdateConfig(
 				return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
 			}
 
-			nextHop, err := makeNextHop(w.Nexthop)
+			nextHop, err := makeWithdrawNextHop(w.Nexthop)
 			if err != nil {
 				return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop: %v", err)
 			}
@@ -462,6 +462,20 @@ func makeNextHop(nexthop *routemplspb.NextHop) (NextHop, error) {
 		MPLSLabel:   nexthop.Label,
 		Weight:      nexthop.Weight,
 		Counter:     nexthop.Counter,
+	}, nil
+}
+
+// makeWithdrawNextHop parses only the destination and label, the sole
+// fields a withdraw is matched by. Other nexthop fields are ignored.
+func makeWithdrawNextHop(nexthop *routemplspb.NextHop) (NextHop, error) {
+	destination, err := nexthop.GetDestinationIp().ToAddr()
+	if err != nil {
+		return NextHop{}, fmt.Errorf("invalid destination_ip (bytes=%x): %w", nexthop.GetDestinationIp().GetAddr(), err)
+	}
+
+	return NextHop{
+		Destination: destination,
+		MPLSLabel:   nexthop.GetLabel(),
 	}, nil
 }
 

--- a/modules/route-mpls/controlplane/service_test.go
+++ b/modules/route-mpls/controlplane/service_test.go
@@ -176,6 +176,124 @@ func Test_RouteMPLSService_UpdateConfig_UpdateAndWithdraw(t *testing.T) {
 	assert.Len(t, show.Rules, 1)
 }
 
+// Test_RouteMPLSService_UpdateConfig_WithdrawWithoutSourceIP verifies that a
+// withdraw with source, weight, and counter unset still removes the nexthop.
+func Test_RouteMPLSService_UpdateConfig_WithdrawWithoutSourceIP(t *testing.T) {
+	service := newTestService(t)
+	ctx := t.Context()
+
+	_, err := service.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
+		Name:  "mpls0",
+		Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
+	})
+	require.NoError(t, err)
+
+	prefix, err := commonpb.NewIPPrefixFromPrefix(netip.MustParsePrefix("10.0.0.0/24"))
+	require.NoError(t, err)
+
+	_, err = service.UpdateConfig(ctx, &routemplspb.UpdateConfigRequest{
+		Name: "mpls0",
+		Updates: []*routemplspb.UpdateEvent{
+			{Event: &routemplspb.UpdateEvent_Withdraw{
+				Withdraw: &routemplspb.Rule{
+					Prefix: prefix,
+					Nexthop: &routemplspb.NextHop{
+						Kind:          routemplspb.ActionKind_ACTION_KIND_TUNNEL,
+						Label:         100,
+						SourceIp:      nil,
+						DestinationIp: commonpb.NewIPAddressFromAddr(netip.MustParseAddr("203.0.113.1")),
+						Weight:        0,
+						Counter:       "",
+					},
+				},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	show, err := service.ShowConfig(ctx, &routemplspb.ShowConfigRequest{Name: "mpls0"})
+	require.NoError(t, err)
+	assert.Empty(t, show.Rules)
+}
+
+// Test_RouteMPLSService_UpdateConfig_WithdrawWithDifferentSourceIP verifies
+// that a withdraw matches by destination and label alone, ignoring source IP.
+func Test_RouteMPLSService_UpdateConfig_WithdrawWithDifferentSourceIP(t *testing.T) {
+	service := newTestService(t)
+	ctx := t.Context()
+
+	_, err := service.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
+		Name:  "mpls0",
+		Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
+	})
+	require.NoError(t, err)
+
+	withdraw := makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)
+	withdraw.Nexthop.SourceIp = commonpb.NewIPAddressFromAddr(netip.MustParseAddr("198.51.100.9"))
+
+	_, err = service.UpdateConfig(ctx, &routemplspb.UpdateConfigRequest{
+		Name: "mpls0",
+		Updates: []*routemplspb.UpdateEvent{
+			{Event: &routemplspb.UpdateEvent_Withdraw{Withdraw: withdraw}},
+		},
+	})
+	require.NoError(t, err)
+
+	show, err := service.ShowConfig(ctx, &routemplspb.ShowConfigRequest{Name: "mpls0"})
+	require.NoError(t, err)
+	assert.Empty(t, show.Rules)
+}
+
+// Test_RouteMPLSService_UpdateConfig_WithdrawInvalidDestination verifies
+// that a withdraw with no usable destination is rejected, not ignored.
+func Test_RouteMPLSService_UpdateConfig_WithdrawInvalidDestination(t *testing.T) {
+	cases := []struct {
+		name    string
+		nexthop *routemplspb.NextHop
+	}{
+		{
+			name:    "nil nexthop",
+			nexthop: nil,
+		},
+		{
+			name: "missing destination_ip",
+			nexthop: &routemplspb.NextHop{
+				Label: 100,
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			service := newTestService(t)
+			ctx := t.Context()
+
+			_, err := service.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
+				Name:  "mpls0",
+				Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
+			})
+			require.NoError(t, err)
+
+			prefix, err := commonpb.NewIPPrefixFromPrefix(netip.MustParsePrefix("10.0.0.0/24"))
+			require.NoError(t, err)
+
+			response, err := service.UpdateConfig(ctx, &routemplspb.UpdateConfigRequest{
+				Name: "mpls0",
+				Updates: []*routemplspb.UpdateEvent{
+					{Event: &routemplspb.UpdateEvent_Withdraw{
+						Withdraw: &routemplspb.Rule{
+							Prefix:  prefix,
+							Nexthop: testCase.nexthop,
+						},
+					}},
+				},
+			})
+			require.Nil(t, response)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
 func Test_RouteMPLSService_ShowConfig_NotFound(t *testing.T) {
 	svc := newTestService(t)
 


### PR DESCRIPTION
- Withdraw events in `UpdateConfig` no longer require `source_ip`: a new `makeWithdrawNextHop` parses only `destination_ip` and `label`, the fields a withdraw is matched by, so the CLI's withdraw (which sends `source_ip` unset) now works.
- Regression tests cover the exact CLI wire shape, a withdraw whose source disagrees with the stored nexthop still removing it, and a missing or nil destination rejected as `InvalidArgument`.
- The withdraw match contract is documented on the proto field: a withdraw is identified by `(prefix, destination_ip, label)`, every other nexthop field is deliberately ignored even when present, so bird-adapter's full-nexthop withdraws keep working unchanged.
- The "succeeds against a running control plane" acceptance was validated by driving the real `yanet-cli-route-mpls` binary (create, update, withdraw, show) against an in-process `RouteMPLSService`, not a full stand.

Closes #2335.
