### PR TITLE
refactor(counters)!: drop the tag subcommands from the cli

### DIFF
--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -36,21 +36,27 @@ pub struct Cmd {
     pub verbose: u8,
 }
 
-#[derive(Debug, Clone, Parser, Default)]
+#[derive(Debug, Clone, clap::Args, Default)]
 pub struct ByTagsCmd {
     /// Counter name to show, as an exact name or a Rust regex pattern.
     #[arg(short, long = "name", value_name = "PATTERN")]
     pub names: Vec<String>,
+    /// Device name to filter by.
     #[arg(short, long)]
     pub device: Option<String>,
+    /// Pipeline name to filter by.
     #[arg(short, long)]
     pub pipeline: Option<String>,
+    /// Function name to filter by.
     #[arg(short, long)]
     pub function: Option<String>,
+    /// Chain name to filter by.
     #[arg(short, long)]
     pub chain: Option<String>,
+    /// Module type to filter by.
     #[arg(short = 't', long)]
     pub module_type: Option<String>,
+    /// Module name to filter by.
     #[arg(short = 'm', long)]
     pub module_name: Option<String>,
     /// Owner level to filter by (device, pipeline, function, chain, module,
@@ -95,18 +101,8 @@ impl From<ByTagsCmd> for CountersByTagsRequest {
     }
 }
 
-#[derive(Debug, Clone, Parser)]
+#[derive(Debug, Clone, clap::Subcommand)]
 pub enum ModeCmd {
-    /// Show device counters.
-    Device(DeviceCmd),
-    /// Show pipeline counters.
-    Pipeline(PipelineCmd),
-    /// Show function counters.
-    Function(FunctionCmd),
-    /// Show chain counters.
-    Chain(ChainCmd),
-    /// Show counters of module assigned to a pipeline.
-    Module(ModuleCmd),
     /// Show worker counters.
     Workers,
     /// Show port counters.
@@ -116,67 +112,10 @@ pub enum ModeCmd {
 impl ModeCmd {
     pub fn action(&self) -> &'static str {
         match self {
-            ModeCmd::Device(..) => "show device counters",
-            ModeCmd::Pipeline(..) => "show pipeline counters",
-            ModeCmd::Function(..) => "show function counters",
-            ModeCmd::Chain(..) => "show chain counters",
-            ModeCmd::Module(..) => "show module counters",
             ModeCmd::Workers => "show worker counters",
             ModeCmd::Ports => "show port counters",
         }
     }
-}
-
-#[derive(Debug, Clone, Parser)]
-pub struct DeviceCmd {
-    #[arg(short = 'd', long)]
-    pub device_name: String,
-}
-
-#[derive(Debug, Clone, Parser)]
-pub struct PipelineCmd {
-    #[arg(short = 'd', long)]
-    pub device_name: String,
-    #[arg(short = 'p', long)]
-    pub pipeline_name: String,
-}
-
-#[derive(Debug, Clone, Parser)]
-pub struct FunctionCmd {
-    #[arg(short = 'd', long)]
-    pub device_name: String,
-    #[arg(short = 'p', long)]
-    pub pipeline_name: String,
-    #[arg(short = 'f', long)]
-    pub function_name: String,
-}
-
-#[derive(Debug, Clone, Parser)]
-pub struct ChainCmd {
-    #[arg(short = 'd', long)]
-    pub device_name: String,
-    #[arg(short = 'p', long)]
-    pub pipeline_name: String,
-    #[arg(short = 'f', long)]
-    pub function_name: String,
-    #[arg(short = 'c', long)]
-    pub chain_name: String,
-}
-
-#[derive(Debug, Clone, Parser)]
-pub struct ModuleCmd {
-    #[arg(short = 'd', long)]
-    pub device_name: String,
-    #[arg(short = 'p', long)]
-    pub pipeline_name: String,
-    #[arg(short = 'f', long)]
-    pub function_name: String,
-    #[arg(short = 'c', long)]
-    pub chain_name: String,
-    #[arg(short = 't', long)]
-    pub module_type: String,
-    #[arg(short = 'm', long)]
-    pub module_name: String,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -223,9 +162,8 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                 },
             );
         }
-        mode => {
-            let request = tags_request(mode, cmd.by_tags);
-            let response = service.by_tags(request).await?;
+        None => {
+            let response = service.by_tags(cmd.by_tags.into()).await?;
             output::data(
                 || &response,
                 || {
@@ -243,53 +181,6 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 
     Ok(())
-}
-
-fn by_tags_request(tags: Vec<(&'static str, String)>) -> CountersByTagsRequest {
-    CountersByTagsRequest {
-        tags: tags
-            .into_iter()
-            .map(|(key, value)| CounterTag { key: key.to_string(), value })
-            .collect(),
-        query: Vec::new(),
-    }
-}
-
-fn tags_request(mode: Option<ModeCmd>, by_tags: ByTagsCmd) -> CountersByTagsRequest {
-    match mode {
-        None => by_tags.into(),
-        Some(ModeCmd::Device(cmd)) => {
-            by_tags_request(vec![("device", cmd.device_name), ("kind", "device".to_string())])
-        }
-        Some(ModeCmd::Pipeline(cmd)) => by_tags_request(vec![
-            ("device", cmd.device_name),
-            ("pipeline", cmd.pipeline_name),
-            ("kind", "pipeline".to_string()),
-        ]),
-        Some(ModeCmd::Function(cmd)) => by_tags_request(vec![
-            ("device", cmd.device_name),
-            ("pipeline", cmd.pipeline_name),
-            ("function", cmd.function_name),
-            ("kind", "function".to_string()),
-        ]),
-        Some(ModeCmd::Chain(cmd)) => by_tags_request(vec![
-            ("device", cmd.device_name),
-            ("pipeline", cmd.pipeline_name),
-            ("function", cmd.function_name),
-            ("chain", cmd.chain_name),
-            ("kind", "chain".to_string()),
-        ]),
-        Some(ModeCmd::Module(cmd)) => by_tags_request(vec![
-            ("device", cmd.device_name),
-            ("pipeline", cmd.pipeline_name),
-            ("function", cmd.function_name),
-            ("chain", cmd.chain_name),
-            ("module_type", cmd.module_type),
-            ("module_name", cmd.module_name),
-            ("kind", "module".to_string()),
-        ]),
-        Some(ModeCmd::Workers) | Some(ModeCmd::Ports) => unreachable!(),
-    }
 }
 
 pub struct CountersService {

--- a/scripts/monitor-throughput.py
+++ b/scripts/monitor-throughput.py
@@ -20,13 +20,14 @@ def run_yanet_command(args):
     Constructs and runs the shell command, returning the parsed JSON.
     """
     cmd = [
-        "yanet-cli-counters", "module",
-        "--device-name", args.device,
-        "--pipeline-name", args.pipeline,
-        "--function-name", args.function,
-        "--chain-name", args.chain,
+        "yanet-cli-counters",
+        "--device", args.device,
+        "--pipeline", args.pipeline,
+        "--function", args.function,
+        "--chain", args.chain,
         "--module-type", args.module_type,
         "--module-name", args.module_name,
+        "--kind", "module",
         "--format", "json"
     ]
 
@@ -48,7 +49,7 @@ def run_yanet_command(args):
 def extract_stats(data):
     """
     Sums the tx/rx packet and byte values of the module's counters across
-    every instance (worker) reported by `yanet-cli-counters module --format json`.
+    every instance (worker) reported by `yanet-cli-counters --format json`.
     """
     stats = {'tx': 0, 'rx': 0, 'tx_bytes': 0, 'rx_bytes': 0}
     packets_bytes = {'tx': ('tx', 'tx_bytes'), 'rx': ('rx', 'rx_bytes')}

--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -1303,47 +1302,6 @@ func (f *TestFramework) WaitForReady(timeout time.Duration) error {
 
 func (f *TestFramework) GetSocketPaths() []string {
 	return f.qemu.SocketPaths
-}
-
-// ValidateCounter queries a named counter via yanet-cli-counters and
-// compares its value against expect. Sums all instances for counters
-// with multiple instances. Returns an error if the counter is not found
-// or the value does not match.
-func (f *TestFramework) ValidateCounter(name string, expect uint64) error {
-	cmd := f.Paths.CLI("yanet-cli-counters") +
-		" pipeline --device-name kni0 --pipeline-name test"
-	output, err := f.ExecuteCommand(cmd)
-	if err != nil {
-		return fmt.Errorf("counters query failed: %w", err)
-	}
-
-	var resp struct {
-		Counters []struct {
-			Name      string `json:"name"`
-			Instances []struct {
-				Values []uint64 `json:"values"`
-			} `json:"instances"`
-		} `json:"counters"`
-	}
-	if err := json.Unmarshal([]byte(output), &resp); err != nil {
-		return fmt.Errorf("parse counters response: %w", err)
-	}
-
-	for _, c := range resp.Counters {
-		if c.Name == name {
-			var total uint64
-			for _, inst := range c.Instances {
-				for _, v := range inst.Values {
-					total += v
-				}
-			}
-			if total != expect {
-				return fmt.Errorf("counter %s: expected %d, got %d", name, expect, total)
-			}
-			return nil
-		}
-	}
-	return fmt.Errorf("counter %q not found", name)
 }
 
 // Run executes a subtest with the given name and function. This method wraps

--- a/tests/functional/main/decap_test.go
+++ b/tests/functional/main/decap_test.go
@@ -274,7 +274,7 @@ func testDecap(t *testing.T, fw *framework.TestFramework) {
 	})
 
 	fw.Run("Check_Yanet_State", func(fw *framework.TestFramework, t *testing.T) {
-		cmd := "/mnt/target/release/yanet-cli-counters pipeline --device-name kni0 --pipeline-name test"
+		cmd := "/mnt/target/release/yanet-cli-counters --device kni0 --pipeline test --kind pipeline"
 		output, err := fw.ExecuteCommand(cmd)
 		require.NoError(t, err, "Failed to execute command %s with output %s", cmd, output)
 	})


### PR DESCRIPTION
- Removes the `device`, `pipeline`, `function`, `chain` and `module` subcommands from `yanet-cli-counters`: each was exactly the flat filter flags plus an implied `kind` tag, with every tag mandatory and no `-n` pattern support, and combining them with the top-level filters silently discarded the filters.
- The flat flags with `--kind` cover every removed form; `workers` and `ports` stay as separate RPCs.
- Migrates `scripts/monitor-throughput.py` and the functional decap test to the flat flags and deletes the dead `ValidateCounter` framework helper that invoked a removed subcommand.
- The private playbooks are migrated in yanet-platform/yanet2-private#179, which works with both the current and the next CLI package.

Closes #2342.