### PR TITLE
refactor(counters)!: fold same-storage counters into tagged groups

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -32,8 +32,6 @@ struct counter_handle {
 	char name[COUNTER_NAME_LEN];
 	uint64_t size;
 	uint64_t gen;
-	struct counter_tag *tags;
-	size_t tag_count;
 
 	// The counter's value snapshot: size values copied when the list
 	// was acquired, remaining valid and unchanged across controlplane
@@ -42,12 +40,34 @@ struct counter_handle {
 };
 
 // A list of counter handles whose single allocation also owns every
-// handle's tag array and value blocks: they are carved out of a value
-// region placed right after the handle array, so freeing the list
-// reclaims all of it.
+// handle's value block: it is carved out of a region placed right
+// after the handle array, so freeing the list reclaims all of it.
 struct counter_handle_list {
 	uint64_t count;
 	struct counter_handle counters[];
+};
+
+// The matched counters of one counter storage, folded into one block.
+//
+// Every counter of a storage carries the same tags, so the block
+// states the storage's tag names and values once instead of repeating
+// them per counter; its counters sit in registry order.
+struct counter_group {
+	uint64_t count;
+	struct counter_tag *tags;
+	size_t tag_count;
+	struct counter_handle *counters;
+};
+
+// One worker's matched storages, one group per storage in match order.
+//
+// The list's single allocation also owns every group's handle array,
+// tag-array copy and value block: they are carved out of a region
+// placed right after the group array, so freeing the list reclaims
+// all of it.
+struct counter_group_list {
+	uint64_t group_count;
+	struct counter_group groups[];
 };
 
 // A counter-name filter, applied to every counter a read walks.
@@ -148,11 +168,12 @@ yanet_get_counter_values(
 
 // One worker's independently matched counter set.
 //
-// counters holds only that worker's snapshot: every handle's values are
-// copied from that worker's own storages.
+// The set holds only that worker's snapshot: one group per matched
+// storage, every counter value copied from that worker's own storages.
+// The set list owns every group list; releasing it releases them all.
 struct counter_worker_set {
 	uint64_t worker_idx;
-	struct counter_handle_list *counters;
+	struct counter_group_list *groups;
 };
 
 // Per-worker counter sets, one entry per dataplane worker in index
@@ -172,6 +193,11 @@ struct counter_worker_set_list {
 // Each worker's counter storage registry is matched independently, so
 // the sets may differ from worker to worker; the union across workers
 // is the caller's to build.
+//
+// The counters of one storage are folded into a single counter_group
+// carrying that storage's tag names and values once, not once per
+// counter; a storage whose counters all fail the name query yields no
+// group at all.
 //
 // Each counter_tag is a predicate against the counter's tags, with the
 // check encoded in value: an empty string requires the tag to be
@@ -214,7 +240,17 @@ yanet_get_counter_worker_set(
 	struct counter_worker_set_list *sets, uint64_t worker_idx
 );
 
-// Release a per-worker set list. No-op on NULL.
+// Return the group at idx of a worker's group list, or NULL when out
+// of range.
+struct counter_group *
+yanet_get_counter_group(struct counter_group_list *groups, uint64_t idx);
+
+// Return the counter at idx of a group, or NULL when out of range.
+struct counter_handle *
+yanet_get_group_counter(struct counter_group *group, uint64_t idx);
+
+// Release a per-worker set list, and with it every group list it
+// holds. No-op on NULL.
 void
 yanet_counter_worker_set_list_free(struct counter_worker_set_list *sets);
 

--- a/controlplane/ffi/counter.go
+++ b/controlplane/ffi/counter.go
@@ -413,38 +413,42 @@ func (m *DPConfig) CountersByTags(
 		if set == nil {
 			return nil, fmt.Errorf("counter set for worker %d is missing", idx)
 		}
-		perWorker[idx] = decodeCounterGroups(set.counters)
+		perWorker[idx] = decodeCounterGroups(set.groups)
 	}
 
 	return MergeWorkerCounterGroups(workerCount, perWorker), nil
 }
 
-// decodeCounterGroups splits one handle list into groups of counters
-// sharing the same tag set. Consecutive handles of one storage share the
-// tags pointer, which marks the group boundary. A nil list decodes to no
-// groups.
-func decodeCounterGroups(counters *C.struct_counter_handle_list) []CounterGroup {
-	groups := make([]CounterGroup, 0)
-	if counters == nil {
-		return groups
+// decodeCounterGroups decodes one worker's group list. The C read
+// already folds every storage's counters into a group stating that
+// storage's tags once, so decoding is a direct walk. A nil list decodes
+// to no groups.
+func decodeCounterGroups(groups *C.struct_counter_group_list) []CounterGroup {
+	out := make([]CounterGroup, 0)
+	if groups == nil {
+		return out
 	}
 
-	for idx := C.uint64_t(0); idx < counters.count; idx++ {
-		handle := C.yanet_get_counter(counters, idx)
-
-		if idx == 0 || C.yanet_get_counter(counters, idx-1).tags != handle.tags {
-			tags := decodeCounterTags(handle.tags, handle.tag_count)
-			groups = append(groups, CounterGroup{Tags: tags})
+	for gidx := C.uint64_t(0); gidx < groups.group_count; gidx++ {
+		group := C.yanet_get_counter_group(groups, gidx)
+		if group == nil {
+			break
 		}
 
-		group := &groups[len(groups)-1]
-		group.Counters = append(
-			group.Counters,
-			decodeCounterHandle(handle),
-		)
+		counters := make([]CounterInfo, 0, group.count)
+		for cidx := C.uint64_t(0); cidx < group.count; cidx++ {
+			if handle := C.yanet_get_group_counter(group, cidx); handle != nil {
+				counters = append(counters, decodeCounterHandle(handle))
+			}
+		}
+
+		out = append(out, CounterGroup{
+			Tags:     decodeCounterTags(group.tags, group.tag_count),
+			Counters: counters,
+		})
 	}
 
-	return groups
+	return out
 }
 
 // counterGroupKey builds a canonical identity of a tag set, independent

--- a/lib/controlplane/agent/counters.c
+++ b/lib/controlplane/agent/counters.c
@@ -87,6 +87,16 @@ counter_tag_region_size(size_t tag_count, size_t *out) {
 	return true;
 }
 
+// Size of one group's handle array.
+static bool
+counter_handle_region_size(size_t handle_count, size_t *out) {
+	if (handle_count > SIZE_MAX / sizeof(struct counter_handle)) {
+		return false;
+	}
+	*out = handle_count * sizeof(struct counter_handle);
+	return true;
+}
+
 // Carve a tag-array copy from the cursor and fill it in, advancing the
 // cursor past it.
 static struct counter_tag *
@@ -206,8 +216,8 @@ worker_counter_matches_collect(
 //
 // Sets count on success. The value region sits right after the handle
 // array and is carved sequentially by the fill pass; the zeroing
-// leaves every not-yet-carved handle with NULL tags and values, and a
-// later pass only overwrites what it fills in.
+// leaves every not-yet-carved handle with NULL values, and a later
+// pass only overwrites what it fills in.
 static struct counter_handle_list *
 counter_handle_list_alloc(
 	size_t match_count, size_t values_size, yanet_error **err
@@ -236,31 +246,82 @@ counter_handle_list_region(const struct counter_handle_list *list) {
 	return (uint8_t *)(list->counters + list->count);
 }
 
-// Build one worker's handle list from its matching storages.
+// Allocate a group list sized for group_count groups plus a
+// region_size-byte carve region, and zero all of it.
 //
-// matches is that worker's NULL-terminated storage match array, or NULL
-// for a worker without an execution context. The resulting list carries
-// values snapshotted from that worker's own storages only. Handles of
-// one storage share a tags copy and sit next to each other, matching
-// the list free path's sharing convention.
+// Sets group_count on success. The region sits right after the group
+// array and is carved sequentially by the fill pass; the zeroing
+// leaves every not-yet-carved handle with NULL values, and a later
+// pass only overwrites what it fills in.
+static struct counter_group_list *
+counter_group_list_alloc(
+	size_t group_count, size_t region_size, yanet_error **err
+) {
+	size_t list_size = sizeof(struct counter_group_list) +
+			   sizeof(struct counter_group) * group_count;
+	if (!counter_region_add(&list_size, region_size)) {
+		yanet_error_add(err, "counter list size overflow");
+		return NULL;
+	}
+	struct counter_group_list *list =
+		(struct counter_group_list *)malloc(list_size);
+	if (list == NULL) {
+		yanet_error_add(err, "malloc failed");
+		return NULL;
+	}
+	memset(list, 0, list_size);
+	list->group_count = group_count;
+	return list;
+}
+
+// The first byte of a group list's carve region: right past the group
+// array. The carve cursor starts here.
+static uint8_t *
+counter_group_list_region(const struct counter_group_list *list) {
+	return (uint8_t *)(list->groups + list->group_count);
+}
+
+// Build one worker's group list from its matching storages.
 //
-// A sizing pass walks the matches first so the list's single allocation
-// covers everything the fill pass carves: every matched counter's value
-// block and one tag copy per storage with a match. The generation pin
-// held by the caller keeps the registries from changing between the two
-// walks.
-static struct counter_handle_list *
-worker_counter_list_build(
+// matches is that worker's NULL-terminated storage match array, or
+// NULL for a worker without an execution context. Every matched
+// storage with at least one name-matching counter becomes one group
+// stating the storage's tags once, holding its matched handles with
+// values snapshotted from that worker's own storage only.
+//
+// The sizing pass records each storage's match count so the fill pass
+// never re-runs the name matcher to reconstruct it; the generation pin
+// held by the caller keeps the registries from changing between walks.
+static struct counter_group_list *
+worker_counter_group_list_build(
 	struct cp_counter_storage **matches,
 	const struct counter_pattern_set *names,
 	yanet_error **err
 ) {
 	if (matches == NULL) {
-		return counter_handle_list_alloc(0, 0, err);
+		return counter_group_list_alloc(0, 0, err);
 	}
 
-	size_t match_count = 0;
-	size_t values_size = 0;
+	size_t storage_count = 0;
+	for (size_t i = 0; matches[i] != NULL; ++i) {
+		++storage_count;
+	}
+
+	size_t *match_counts = NULL;
+	if (storage_count != 0) {
+		if (storage_count > SIZE_MAX / sizeof(*match_counts)) {
+			yanet_error_add(err, "counter list size overflow");
+			return NULL;
+		}
+		match_counts = malloc(storage_count * sizeof(*match_counts));
+		if (match_counts == NULL) {
+			yanet_error_add(err, "malloc failed");
+			return NULL;
+		}
+	}
+
+	size_t group_count = 0;
+	size_t region_size = 0;
 	for (size_t i = 0; matches[i] != NULL; ++i) {
 		struct cp_counter_storage *cp_storage = matches[i];
 		struct counter_storage *storage = ADDR_OF(&cp_storage->storage);
@@ -283,64 +344,86 @@ worker_counter_list_build(
 				yanet_error_add(
 					err, "counter list size overflow"
 				);
+				free(match_counts);
 				return NULL;
 			}
 			++storage_matches;
 		}
+
+		match_counts[i] = storage_matches;
 		if (storage_matches == 0) {
 			continue;
 		}
-		match_count += storage_matches;
 
+		size_t handles_region;
 		size_t tags_region;
-		if (!counter_tag_region_size(
+		if (!counter_handle_region_size(
+			    storage_matches, &handles_region
+		    ) ||
+		    !counter_tag_region_size(
 			    cp_storage->tag_count, &tags_region
 		    ) ||
-		    !counter_region_add(&values_size, region) ||
-		    !counter_region_add(&values_size, tags_region)) {
+		    !counter_region_add(&region, handles_region) ||
+		    !counter_region_add(&region, tags_region) ||
+		    !counter_region_add(&region_size, region)) {
 			yanet_error_add(err, "counter list size overflow");
+			free(match_counts);
 			return NULL;
 		}
+		++group_count;
 	}
 
-	struct counter_handle_list *list =
-		counter_handle_list_alloc(match_count, values_size, err);
-	if (list == NULL) {
-		return NULL;
-	}
-
-	uint8_t *cursor = counter_handle_list_region(list);
-	size_t next = 0;
-	for (size_t i = 0; matches[i] != NULL; ++i) {
-		struct cp_counter_storage *cp_storage = matches[i];
-		struct counter_storage *storage = ADDR_OF(&cp_storage->storage);
-		struct counter_registry *registry = ADDR_OF(&storage->registry);
-		struct counter *counters = ADDR_OF(&registry->names);
-		struct counter_tag *storage_tags = NULL;
-		for (uint64_t idx = 0; idx < registry->count; ++idx) {
-			if (!counter_pattern_set_match(
-				    names, counters[idx].name
-			    )) {
+	struct counter_group_list *list =
+		counter_group_list_alloc(group_count, region_size, err);
+	if (list != NULL) {
+		uint8_t *cursor = counter_group_list_region(list);
+		size_t next_group = 0;
+		for (size_t i = 0; matches[i] != NULL; ++i) {
+			size_t storage_matches = match_counts[i];
+			if (storage_matches == 0) {
 				continue;
 			}
-			if (storage_tags == NULL) {
-				storage_tags = counter_tags_carve(
-					&cursor,
-					cp_storage->tags,
-					cp_storage->tag_count
+
+			struct cp_counter_storage *cp_storage = matches[i];
+			struct counter_storage *storage =
+				ADDR_OF(&cp_storage->storage);
+			struct counter_registry *registry =
+				ADDR_OF(&storage->registry);
+			struct counter *counters = ADDR_OF(&registry->names);
+
+			struct counter_group *group = &list->groups[next_group];
+			group->count = storage_matches;
+			group->tags = counter_tags_carve(
+				&cursor, cp_storage->tags, cp_storage->tag_count
+			);
+			group->tag_count = cp_storage->tag_count;
+			group->counters = (struct counter_handle *)cursor;
+			cursor += storage_matches * sizeof(*group->counters);
+
+			size_t next = 0;
+			for (uint64_t idx = 0; idx < registry->count; ++idx) {
+				if (!counter_pattern_set_match(
+					    names, counters[idx].name
+				    )) {
+					continue;
+				}
+				struct counter_handle *dst =
+					&group->counters[next];
+				const struct counter *src = &counters[idx];
+				strtcpy(dst->name, src->name, sizeof(dst->name)
 				);
+				dst->size = src->size;
+				dst->gen = src->gen;
+				counter_handle_fill_values(
+					dst, &cursor, storage, idx
+				);
+				++next;
 			}
-			struct counter_handle *dst = &list->counters[next];
-			const struct counter *src = &counters[idx];
-			strtcpy(dst->name, src->name, sizeof(dst->name));
-			dst->size = src->size;
-			dst->gen = src->gen;
-			dst->tags = storage_tags;
-			dst->tag_count = cp_storage->tag_count;
-			counter_handle_fill_values(dst, &cursor, storage, idx);
-			++next;
+			++next_group;
 		}
 	}
+
+	free(match_counts);
 	return list;
 }
 
@@ -367,10 +450,10 @@ counter_worker_set_list_build(
 
 	for (uint64_t w_idx = 0; w_idx < matches->worker_count; ++w_idx) {
 		sets->sets[w_idx].worker_idx = w_idx;
-		sets->sets[w_idx].counters = worker_counter_list_build(
+		sets->sets[w_idx].groups = worker_counter_group_list_build(
 			matches->by_worker[w_idx], names, err
 		);
-		if (sets->sets[w_idx].counters == NULL) {
+		if (sets->sets[w_idx].groups == NULL) {
 			yanet_counter_worker_set_list_free(sets);
 			return NULL;
 		}
@@ -440,15 +523,44 @@ yanet_get_counter_worker_set(
 	return sets->sets + worker_idx;
 }
 
+// Release a group list owned by a worker set. No-op on NULL.
+//
+// The list's single allocation owns every group's handle array,
+// tag-array copy and value block: they are carved out of its region,
+// so one free reclaims all of it.
+static void
+counter_group_list_free(struct counter_group_list *groups) {
+	if (groups == NULL) {
+		return;
+	}
+	free(groups);
+}
+
 void
 yanet_counter_worker_set_list_free(struct counter_worker_set_list *sets) {
 	if (sets == NULL) {
 		return;
 	}
 	for (uint64_t w_idx = 0; w_idx < sets->worker_count; ++w_idx) {
-		yanet_counter_handle_list_free(sets->sets[w_idx].counters);
+		counter_group_list_free(sets->sets[w_idx].groups);
 	}
 	free(sets);
+}
+
+struct counter_group *
+yanet_get_counter_group(struct counter_group_list *groups, uint64_t idx) {
+	if (groups == NULL || idx >= groups->group_count) {
+		return NULL;
+	}
+	return groups->groups + idx;
+}
+
+struct counter_handle *
+yanet_get_group_counter(struct counter_group *group, uint64_t idx) {
+	if (group == NULL || idx >= group->count) {
+		return NULL;
+	}
+	return group->counters + idx;
 }
 
 struct counter_handle *
@@ -628,8 +740,8 @@ yanet_counter_handle_list_free(struct counter_handle_list *counters) {
 	if (counters == NULL) {
 		return;
 	}
-	// The list's single allocation owns every handle's tag array and
-	// value block: they are carved out of its value region, so one
-	// free reclaims all of it.
+	// The list's single allocation owns every handle's value block:
+	// it is carved out of its value region, so one free reclaims all
+	// of it.
 	free(counters);
 }

--- a/lib/controlplane/tests/counter_workers_test.c
+++ b/lib/controlplane/tests/counter_workers_test.c
@@ -323,11 +323,33 @@ test_per_worker_sets(struct dp_config *dp_config) {
 	struct counter_worker_set *set1 = yanet_get_counter_worker_set(sets, 1);
 	TEST_ASSERT_NOT_NULL(set0, "worker 0 set is missing");
 	TEST_ASSERT_NOT_NULL(set1, "worker 1 set is missing");
-	TEST_ASSERT_EQUAL(0, set0->counters->count, "worker 0 matched");
-	TEST_ASSERT_EQUAL(1, set1->counters->count, "worker 1 match count");
+	TEST_ASSERT_EQUAL(0, set0->groups->group_count, "worker 0 matched");
+	TEST_ASSERT_EQUAL(
+		1, set1->groups->group_count, "worker 1 matched group count"
+	);
 
-	struct counter_handle *handle = yanet_get_counter(set1->counters, 0);
-	TEST_ASSERT_NOT_NULL(handle, "worker 1 set has no handle");
+	struct counter_group *group = yanet_get_counter_group(set1->groups, 0);
+	TEST_ASSERT_NOT_NULL(group, "worker 1 set has no group");
+	TEST_ASSERT_EQUAL(1, group->count, "worker 1 match count");
+
+	// The whole storage folds into one block stating its tags once:
+	// every registered tag is there, in the group and not per handle.
+	TEST_ASSERT_EQUAL(3, group->tag_count, "worker 1 group tag count");
+	int seen_object_name = 0;
+	for (size_t i = 0; i < group->tag_count; ++i) {
+		if (strcmp(group->tags[i].key, "object_name") == 0) {
+			TEST_ASSERT(
+				strcmp(group->tags[i].value, "w1") == 0,
+				"object_name tag value is '%s', expected 'w1'",
+				group->tags[i].value
+			);
+			seen_object_name = 1;
+		}
+	}
+	TEST_ASSERT(seen_object_name, "object_name tag missing from group");
+
+	struct counter_handle *handle = yanet_get_group_counter(group, 0);
+	TEST_ASSERT_NOT_NULL(handle, "worker 1 group has no handle");
 	TEST_ASSERT(
 		strcmp(handle->name, "w1_only") == 0,
 		"counter name is '%s', expected 'w1_only'",
@@ -378,13 +400,44 @@ test_per_worker_shared_counter(struct dp_config *dp_config) {
 			yanet_get_counter_worker_set(sets, w_idx);
 		TEST_ASSERT_NOT_NULL(set, "worker set is missing");
 
+		// The pipeline storage carries several counters, and they
+		// all fold into one block stating the storage's tags once.
+		TEST_ASSERT_EQUAL(
+			1,
+			set->groups->group_count,
+			"worker %lu pipeline storage group count",
+			(unsigned long)w_idx
+		);
+		struct counter_group *only_group =
+			yanet_get_counter_group(set->groups, 0);
+		TEST_ASSERT_NOT_NULL(
+			only_group,
+			"worker %lu has no group",
+			(unsigned long)w_idx
+		);
+		TEST_ASSERT(
+			only_group->count > 1,
+			"the pipeline storage must fold several counters "
+			"into one group"
+		);
+
 		struct counter_handle *handle = NULL;
-		for (size_t idx = 0; idx < set->counters->count; ++idx) {
-			struct counter_handle *cur =
-				yanet_get_counter(set->counters, idx);
-			if (cur != NULL && strcmp(cur->name, "input") == 0) {
-				handle = cur;
+		for (uint64_t g_idx = 0;
+		     g_idx < set->groups->group_count && handle == NULL;
+		     ++g_idx) {
+			struct counter_group *group =
+				yanet_get_counter_group(set->groups, g_idx);
+			if (group == NULL) {
 				break;
+			}
+			for (uint64_t idx = 0; idx < group->count; ++idx) {
+				struct counter_handle *cur =
+					yanet_get_group_counter(group, idx);
+				if (cur != NULL &&
+				    strcmp(cur->name, "input") == 0) {
+					handle = cur;
+					break;
+				}
 			}
 		}
 		TEST_ASSERT_NOT_NULL(

--- a/lib/controlplane/tests/counters_lock_test.c
+++ b/lib/controlplane/tests/counters_lock_test.c
@@ -108,6 +108,17 @@ now_ns(void) {
 	return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
 }
 
+// Total matched counters across a worker set's groups, one storage per
+// group.
+static uint64_t
+worker_set_counter_count(const struct counter_worker_set *set) {
+	uint64_t total = 0;
+	for (uint64_t idx = 0; idx < set->groups->group_count; ++idx) {
+		total += set->groups->groups[idx].count;
+	}
+	return total;
+}
+
 // Verifies that a large tagged counter read releases the config lock long
 // before it returns, instead of holding it across matching, allocation
 // and the whole per-counter value-copy pass.
@@ -220,7 +231,7 @@ test_lock_released_during_value_copy(struct yanet_shm *shm) {
 		yanet_get_counter_worker_set(args.sets, 0);
 	TEST_ASSERT_NOT_NULL(final_set, "worker 0 set is missing");
 	TEST_ASSERT_EQUAL(
-		final_set->counters->count,
+		worker_set_counter_count(final_set),
 		(uint64_t)LOCK_TEST_PIPELINE_COUNT *
 			LOCK_TEST_COUNTERS_PER_PIPELINE,
 		"unexpected matched counter count"
@@ -268,7 +279,8 @@ race_reader_thread(void *arg) {
 		struct counter_worker_set *set0 =
 			sets != NULL ? yanet_get_counter_worker_set(sets, 0)
 				     : NULL;
-		if (set0 == NULL || set0->counters->count != expected_matches) {
+		if (set0 == NULL ||
+		    worker_set_counter_count(set0) != expected_matches) {
 			yanet_counter_worker_set_list_free(sets);
 			atomic_store_explicit(
 				&state->reader_failed,

--- a/lib/controlplane/tests/counters_test.c
+++ b/lib/controlplane/tests/counters_test.c
@@ -145,13 +145,16 @@ test_value_snapshot_survives_removal(struct yanet_shm *shm) {
 	struct counter_worker_set *pipeline_set =
 		yanet_get_counter_worker_set(pipeline_sets, 0);
 	TEST_ASSERT_NOT_NULL(pipeline_set, "worker 0 set is missing");
-	struct counter_handle_list *list = pipeline_set->counters;
+	struct counter_group_list *groups = pipeline_set->groups;
 	TEST_ASSERT(
-		list->count > 0,
+		groups->group_count > 0,
 		"no pipeline counter storage matched dev0/pipe0"
 	);
 
-	struct counter_handle *handle = yanet_get_counter(list, 0);
+	struct counter_group *group = yanet_get_counter_group(groups, 0);
+	TEST_ASSERT_NOT_NULL(group, "worker 0 has no counter group");
+	struct counter_handle *handle = yanet_get_group_counter(group, 0);
+	TEST_ASSERT_NOT_NULL(handle, "worker 0 group has no handle");
 	uint64_t before = yanet_get_counter_value(handle->values, 0);
 
 	// Re-install dev0 with no input pipeline: pipe0's counter storage is
@@ -182,7 +185,7 @@ test_value_snapshot_survives_removal(struct yanet_shm *shm) {
 	return TEST_SUCCESS;
 }
 
-// Verifies that a counter_handle's tag strings stay readable and correct
+// Verifies that a counter group's tag strings stay readable and correct
 // after a controlplane generation swap frees the arena they were
 // originally borrowed from.
 static int
@@ -215,15 +218,17 @@ test_tag_strings_survive_generation_swap(struct yanet_shm *shm) {
 	struct counter_worker_set *device_set =
 		yanet_get_counter_worker_set(device_sets, 0);
 	TEST_ASSERT_NOT_NULL(device_set, "worker 0 set is missing");
-	struct counter_handle_list *list = device_set->counters;
-	TEST_ASSERT(list->count > 0, "no counter storage matched dev0");
+	struct counter_group_list *groups = device_set->groups;
+	TEST_ASSERT(groups->group_count > 0, "no counter storage matched dev0");
 
-	struct counter_handle *handle = yanet_get_counter(list, 0);
-	TEST_ASSERT(handle->tag_count > 0, "handle has no tags to verify");
+	struct counter_group *group = yanet_get_counter_group(groups, 0);
+	TEST_ASSERT_NOT_NULL(group, "worker 0 has no counter group");
+	TEST_ASSERT(group->count > 0, "group carries no matched counters");
+	TEST_ASSERT(group->tag_count > 0, "group has no tags to verify");
 
 	// Trigger: any controlplane update installs a new generation and
-	// synchronously frees the old one, which pre-fix left handle->tags
-	// pointing into freed shm.
+	// synchronously frees the old one, which pre-fix left the group's
+	// tags pointing into freed shm.
 	int rc = cp_config_update_modules(dp_config, cp_config, 0, NULL, &err);
 	TEST_ASSERT_SUCCESS(
 		rc,
@@ -232,12 +237,12 @@ test_tag_strings_survive_generation_swap(struct yanet_shm *shm) {
 	);
 
 	int found = 0;
-	for (size_t i = 0; i < handle->tag_count; ++i) {
-		if (strcmp(handle->tags[i].key, "device") == 0) {
+	for (size_t i = 0; i < group->tag_count; ++i) {
+		if (strcmp(group->tags[i].key, "device") == 0) {
 			TEST_ASSERT(
-				strcmp(handle->tags[i].value, "dev0") == 0,
+				strcmp(group->tags[i].value, "dev0") == 0,
 				"device tag value mismatch after swap: got %s",
-				handle->tags[i].value
+				group->tags[i].value
 			);
 			found = 1;
 		}

--- a/tests/counters/query_test.go
+++ b/tests/counters/query_test.go
@@ -162,6 +162,54 @@ func TestCountersByTagsAcceptsLongExactNameList(t *testing.T) {
 	)
 }
 
+// Test_CountersByTags_FoldsStoragesIntoGroups verifies that every
+// matched storage's counters come back folded into one group stating
+// that storage's tags once, so the surface's storage count fixes the
+// group count and no two groups share a storage.
+func Test_CountersByTags_FoldsStoragesIntoGroups(t *testing.T) {
+	dp := installQuerySurface(t)
+
+	groups, err := dp.CountersByTags(nil, nil)
+	require.NoError(t, err)
+
+	require.Len(t, groups, queryPipelineCount+1,
+		"every storage must fold into exactly one group",
+	)
+
+	pipelines := map[string]struct{}{}
+	devices := 0
+	for _, group := range groups {
+		require.NotEmpty(t, group.Tags,
+			"a group must state its storage's tags",
+		)
+		require.NotEmpty(t, group.Counters)
+
+		switch tagValue(group.Tags, "kind") {
+		case "pipeline":
+			pipelines[tagValue(group.Tags, "pipeline")] = struct{}{}
+		case "device":
+			devices++
+		}
+	}
+	require.Len(t, pipelines, queryPipelineCount,
+		"each pipeline storage must appear as its own group",
+	)
+	require.Equal(t, 1, devices,
+		"the device storage must appear as its own group",
+	)
+}
+
+// tagValue returns the value a tag set carries for key, or an empty
+// string when the key is absent.
+func tagValue(tags []ffi.CounterTag, key string) string {
+	for _, tag := range tags {
+		if tag.Key == key {
+			return tag.Value
+		}
+	}
+	return ""
+}
+
 // A query the matcher refuses fails the call rather than returning nothing.
 func TestCountersByTagsRejectsBadQuery(t *testing.T) {
 	dp := installQuerySurface(t)


### PR DESCRIPTION
- The tag-based read returns one group per matched counter storage, stating each storage's tag names and values once for all of its counters instead of repeating them on every handle.
- The counter handle carries counter data only, and the go bindings walk the explicit groups instead of inferring boundaries from shared tag pointers.
- Worker-counter and port-counter reads keep the plain handle list, which no longer carries per-handle tags.