### PR TITLE
feat(controlplane): grow an agent's shared memory at runtime

### DIFF
--- a/api/agent.h
+++ b/api/agent.h
@@ -119,6 +119,30 @@ agent_memory_limit(struct agent *agent);
 int
 agent_extend(struct agent *agent, uint64_t size, yanet_error **err);
 
+// Grows the shared memory of a named agent and reports its new size.
+//
+// Finding the agent and growing it happen under one hold of the
+// configuration lock, so a concurrent re-attach of the same name cannot
+// retire the agent midway.
+//
+// @param shm Handle to shared memory segment
+// @param instance_idx Index of the dataplane instance
+// @param name Name the agent was attached under
+// @param size Number of bytes to add
+// @param memory_limit Receives the total size reserved for the agent
+// @param err Error output parameter
+//
+// @return 0 on success, 1 if no agent goes by that name, -1 on error.
+int
+yanet_shm_extend_agent(
+	struct yanet_shm *shm,
+	uint32_t instance_idx,
+	const char *name,
+	uint64_t size,
+	uint64_t *memory_limit,
+	yanet_error **err
+);
+
 // Returns number of dataplane instances in the specified shared memory segment.
 //
 // @param shm Handle to the shared memory segment.

--- a/bindings/go/cerrors/cgo.go
+++ b/bindings/go/cerrors/cgo.go
@@ -36,6 +36,9 @@ const (
 	Busy Kind = C.YANET_ERROR_BUSY
 	// InvalidArgument: the request is wrong regardless of the system state.
 	InvalidArgument Kind = C.YANET_ERROR_INVALID_ARGUMENT
+	// ResourceExhausted: the pool the operation draws from has no room
+	// left for the request.
+	ResourceExhausted Kind = C.YANET_ERROR_RESOURCE_EXHAUSTED
 )
 
 func (m Kind) Error() string {
@@ -48,6 +51,8 @@ func (m Kind) Error() string {
 		return "busy"
 	case InvalidArgument:
 		return "invalid argument"
+	case ResourceExhausted:
+		return "resource exhausted"
 	}
 	return "unknown error kind"
 }

--- a/controlplane/builtin/memory.go
+++ b/controlplane/builtin/memory.go
@@ -2,8 +2,12 @@ package builtin
 
 import (
 	"context"
+	"errors"
 
+	"github.com/c2h5oh/datasize"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -11,7 +15,7 @@ import (
 )
 
 // Memory is an in-process gRPC service for reporting per-agent
-// shared-memory arena utilization.
+// shared-memory arena utilization and for growing an agent's arena.
 type Memory struct {
 	ynpb.UnimplementedMemoryServiceServer
 
@@ -64,6 +68,43 @@ func (m *Memory) ListArenas(
 	}
 
 	return &ynpb.ListArenasResponse{Arenas: arenas}, nil
+}
+
+// ExtendAgent grows the arena of a live agent by the requested size.
+//
+// The size is a lower bound: the allocator rounds it up to its own
+// granularity, so the reported limit may exceed what was asked for.
+func (m *Memory) ExtendAgent(
+	ctx context.Context,
+	request *ynpb.ExtendAgentRequest,
+) (*ynpb.ExtendAgentResponse, error) {
+	name := request.GetAgent()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "agent name is required")
+	}
+
+	size := datasize.ByteSize(request.GetSize())
+	if size == 0 {
+		return nil, status.Error(codes.InvalidArgument, "size must be positive")
+	}
+
+	if !m.shm.DataplaneReady(m.instanceID) {
+		return nil, status.Error(codes.Unavailable, "dataplane instance is not ready")
+	}
+
+	memoryLimit, err := m.shm.ExtendAgent(m.instanceID, name, size)
+	switch {
+	case errors.Is(err, ffi.ErrAgentNotFound):
+		return nil, status.Errorf(codes.NotFound, "agent %q is not attached", name)
+	case errors.Is(err, ffi.ErrResourceExhausted):
+		return nil, status.Error(codes.ResourceExhausted, err.Error())
+	case err != nil:
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &ynpb.ExtendAgentResponse{
+		MemoryLimit: uint64(memoryLimit),
+	}, nil
 }
 
 // Collect returns arena occupancy and memory-context attribution gauges

--- a/controlplane/ffi/errors.go
+++ b/controlplane/ffi/errors.go
@@ -29,4 +29,7 @@ const (
 	// ErrInvalidArgument: the request is wrong regardless of the system
 	// state.
 	ErrInvalidArgument = cerrors.InvalidArgument
+	// ErrResourceExhausted: the pool the operation draws from has no room
+	// left for the request.
+	ErrResourceExhausted = cerrors.ResourceExhausted
 )

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -14,6 +14,7 @@ package ffi
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"iter"
 	"unsafe"
@@ -112,6 +113,50 @@ func (m *SharedMemory) AgentAttach(
 	}
 
 	return &Agent{name: name, ptr: ptr}, nil
+}
+
+// ErrAgentNotFound reports that no agent is attached under the requested
+// name.
+var ErrAgentNotFound = errors.New("agent is not attached")
+
+// ExtendAgent grows the shared memory of the agent attached under the given
+// name and reports the size it holds afterwards.
+//
+// The size is a lower bound, because the allocator rounds it up to its own
+// granularity. Finding the agent and growing it happen under one hold of the
+// configuration lock, so a re-attach of the same name cannot retire the agent
+// midway. Reports ErrAgentNotFound when no agent goes by that name.
+func (m *SharedMemory) ExtendAgent(
+	instanceIdx uint32,
+	name string,
+	size datasize.ByteSize,
+) (datasize.ByteSize, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var memoryLimit C.uint64_t
+	var cErr *C.yanet_error
+	rc := C.yanet_shm_extend_agent(
+		m.ptr,
+		C.uint32_t(instanceIdx),
+		cName,
+		C.uint64_t(size),
+		&memoryLimit,
+		&cErr,
+	)
+	switch {
+	case rc > 0:
+		return 0, ErrAgentNotFound
+	case rc < 0:
+		return 0, fmt.Errorf(
+			"failed to extend agent %q by %s: %w",
+			name,
+			size,
+			cerrors.FromC(unsafe.Pointer(cErr)),
+		)
+	}
+
+	return datasize.ByteSize(memoryLimit), nil
 }
 
 // DPConfig represents a handle to dataplane configuration.

--- a/controlplane/ynpb/v1/memory.proto
+++ b/controlplane/ynpb/v1/memory.proto
@@ -4,14 +4,17 @@ package controlplane.ynpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
-// MemoryService reports per-agent shared-memory arena utilization.
-//
-// It is the read side of a planned arena grow/shrink API: the sizing
-// decisions that API will make depend on the occupancy this service
-// already exposes.
+// MemoryService reports per-agent shared-memory arena utilization and
+// grows an agent's arena on demand.
 service MemoryService {
   // ListArenas returns arena utilization for every agent generation.
   rpc ListArenas(ListArenasRequest) returns (ListArenasResponse);
+  // ExtendAgent grows the arena of a live agent.
+  //
+  // The request carries an increment rather than a target, so calling it
+  // twice grows twice. A caller that retries after a timeout must read
+  // the arena back before deciding to repeat itself.
+  rpc ExtendAgent(ExtendAgentRequest) returns (ExtendAgentResponse);
 }
 
 message ListArenasRequest {}
@@ -30,4 +33,19 @@ message ArenaInfo {
   uint64 free_bytes = 5;
   // retired is true for a superseded generation still holding its arena.
   bool retired = 6;
+}
+
+// ExtendAgentRequest asks for more arena space for one live agent.
+message ExtendAgentRequest {
+  string agent = 1;
+  // size is the number of bytes to add, rounded up to the allocator's
+  // granularity.
+  uint64 size = 2;
+}
+
+// ExtendAgentResponse reports the agent's arena after the growth.
+message ExtendAgentResponse {
+  // memory_limit is the arena size the agent holds now, which may exceed
+  // what was asked for once the rounding is applied.
+  uint64 memory_limit = 1;
 }

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -93,6 +93,16 @@ agent_dp_config_ready(struct yanet_shm *shm, uint32_t instance_idx) {
 	       DP_CONFIG_READY_MAGIC;
 }
 
+static struct cp_config *
+shm_cp_config(struct yanet_shm *shm, uint32_t instance_idx) {
+	if (!agent_dp_config_ready(shm, instance_idx)) {
+		return NULL;
+	}
+
+	struct dp_config *dp_config = yanet_shm_dp_config(shm, instance_idx);
+	return ADDR_OF(&dp_config->cp_config);
+}
+
 uint32_t
 yanet_shm_instance_count(struct yanet_shm *shm) {
 	struct dp_config *dp_config = yanet_shm_dp_config(shm, 0);
@@ -171,8 +181,10 @@ allocate_arenas(
 
 		void *arena = memory_balloc(memory_context, arena_size);
 		if (arena == NULL) {
-			yanet_error_add(
-				err, "failed to allocate memory for arena"
+			yanet_error_add_kind(
+				err,
+				YANET_ERROR_RESOURCE_EXHAUSTED,
+				"failed to allocate memory for arena"
 			);
 			for (uint64_t idx = 0; idx < added; ++idx) {
 				struct agent_arena *reserved = &arenas[idx];
@@ -395,14 +407,10 @@ agent_memory_limit(struct agent *agent) {
 	return memory_limit;
 }
 
-int
-agent_extend(struct agent *agent, uint64_t size, yanet_error **err) {
-	int ret = 0;
-
+static int
+agent_extend_locked(struct agent *agent, uint64_t size, yanet_error **err) {
 	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
 	struct memory_context *cp_memory_context = &cp_config->memory_context;
-
-	cp_config_lock(cp_config);
 
 	// An agent that draws straight from the controlplane pool owns no
 	// arena of its own and cannot be grown here.
@@ -416,8 +424,7 @@ agent_extend(struct agent *agent, uint64_t size, yanet_error **err) {
 			"pool and cannot be extended",
 			agent->name
 		);
-		ret = -1;
-		goto unlock;
+		return -1;
 	}
 
 	uint64_t needed = size;
@@ -428,13 +435,12 @@ agent_extend(struct agent *agent, uint64_t size, yanet_error **err) {
 			yanet_error_add(
 				err, "agent cannot grow by %lu bytes", size
 			);
-			ret = -1;
-			goto unlock;
+			return -1;
 		}
 		needed += pad;
 	}
 	if (needed == 0) {
-		goto unlock;
+		return 0;
 	}
 
 	struct agent_arena *arenas = ADDR_OF(&agent->arenas);
@@ -447,9 +453,12 @@ agent_extend(struct agent *agent, uint64_t size, yanet_error **err) {
 		cp_memory_context, sizeof(struct agent_arena) * new_arena_count
 	);
 	if (new_arenas == NULL) {
-		yanet_error_add(err, "failed to allocate memory for arenas");
-		ret = -1;
-		goto unlock;
+		yanet_error_add_kind(
+			err,
+			YANET_ERROR_RESOURCE_EXHAUSTED,
+			"failed to allocate memory for arenas"
+		);
+		return -1;
 	}
 	memset(new_arenas, 0, sizeof(struct agent_arena) * new_arena_count);
 
@@ -465,8 +474,7 @@ agent_extend(struct agent *agent, uint64_t size, yanet_error **err) {
 			new_arenas,
 			sizeof(struct agent_arena) * new_arena_count
 		);
-		ret = -1;
-		goto unlock;
+		return -1;
 	}
 
 	for (uint64_t arena_idx = 0; arena_idx < arena_count; ++arena_idx) {
@@ -495,7 +503,15 @@ agent_extend(struct agent *agent, uint64_t size, yanet_error **err) {
 		sizeof(struct agent_arena) * arena_count
 	);
 
-unlock:
+	return 0;
+}
+
+int
+agent_extend(struct agent *agent, uint64_t size, yanet_error **err) {
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	cp_config_lock(cp_config);
+	int ret = agent_extend_locked(agent, size, err);
 	cp_config_unlock(cp_config);
 
 	return ret;
@@ -1808,4 +1824,54 @@ set_prev:
 	}
 
 	return 0;
+}
+
+static struct agent *
+find_agent_locked(struct cp_config *cp_config, const char *name) {
+	struct cp_agent_registry *registry =
+		ADDR_OF(&cp_config->agent_registry);
+	for (uint64_t agent_idx = 0; agent_idx < registry->count; ++agent_idx) {
+		struct agent *agent = ADDR_OF(&registry->agents[agent_idx]);
+		if (!strncmp(agent->name, name, sizeof(agent->name))) {
+			return agent;
+		}
+	}
+
+	return NULL;
+}
+
+int
+yanet_shm_extend_agent(
+	struct yanet_shm *shm,
+	uint32_t instance_idx,
+	const char *name,
+	uint64_t size,
+	uint64_t *memory_limit,
+	yanet_error **err
+) {
+	struct cp_config *cp_config = shm_cp_config(shm, instance_idx);
+	if (cp_config == NULL) {
+		yanet_error_add(
+			err,
+			"dataplane shared memory instance %u is not yet "
+			"initialised",
+			instance_idx
+		);
+		return -1;
+	}
+
+	cp_config_lock(cp_config);
+
+	int ret = 1;
+	struct agent *agent = find_agent_locked(cp_config, name);
+	if (agent != NULL) {
+		ret = agent_extend_locked(agent, size, err);
+		if (ret == 0) {
+			*memory_limit = agent->memory_limit;
+		}
+	}
+
+	cp_config_unlock(cp_config);
+
+	return ret;
 }

--- a/lib/controlplane/agent/agent_test.c
+++ b/lib/controlplane/agent/agent_test.c
@@ -773,6 +773,11 @@ test_extend_rolls_back_on_exhausted_pool() {
 	rc = agent_extend(agent, 1 << 20, &err);
 	TEST_ASSERT(rc == -1, "an unsatisfiable extend must fail");
 	TEST_ASSERT_NOT_NULL(err, "a failed extend must set an error");
+	TEST_ASSERT_EQUAL(
+		yanet_error_kind(err),
+		YANET_ERROR_RESOURCE_EXHAUSTED,
+		"a pool with no room left must say so"
+	);
 	yanet_error_free(err);
 	err = NULL;
 
@@ -824,6 +829,94 @@ test_attach_name_too_long_is_refused() {
 	TEST_ASSERT_NOT_NULL(err, "a refused attach must set an error");
 
 	yanet_error_free(err);
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verify that a growth lands on the agent it names and leaves every other
+// agent's memory untouched.
+static int
+test_extend_agent_grows_the_named_agent() {
+	void *storage = extend_storage_alloc(1 << 25);
+	TEST_ASSERT_NOT_NULL(storage, "storage allocation failed");
+
+	struct cp_config *cp_config = NULL;
+	int rc = extend_env_init(storage, 1 << 24, &cp_config);
+	TEST_ASSERT(rc == 0, "storage setup failed");
+
+	struct yanet_shm shm = {.base = storage, .size = 1 << 25};
+	yanet_error *err = NULL;
+	struct agent *first = agent_attach(&shm, 0, "first", 1 << 12, &err);
+	TEST_ASSERT_NOT_NULL(first, "agent_attach failed");
+	struct agent *second = agent_attach(&shm, 0, "second", 1 << 12, &err);
+	TEST_ASSERT_NOT_NULL(second, "agent_attach failed");
+
+	uint64_t memory_limit = 0;
+	rc = yanet_shm_extend_agent(
+		&shm, 0, "second", 1u << 20, &memory_limit, &err
+	);
+	TEST_ASSERT(rc == 0, "growing an attached agent must succeed");
+	TEST_ASSERT_NULL(err, "a successful growth must not set an error");
+
+	TEST_ASSERT_EQUAL(
+		second->memory_limit,
+		(uint64_t)((1u << 12) + (1u << 20)),
+		"the named agent must be the one that grew"
+	);
+	TEST_ASSERT_EQUAL(
+		first->memory_limit,
+		(uint64_t)(1u << 12),
+		"an agent nobody named must keep its memory"
+	);
+
+	extend_agent_release(first, cp_config);
+	extend_agent_release(second, cp_config);
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verify that a growth refuses an instance the dataplane has not finished
+// initialising, so an early caller gets an error instead of a fault.
+static int
+test_extend_agent_gates_on_readiness() {
+	void *storage = extend_storage_alloc(1 << 25);
+	TEST_ASSERT_NOT_NULL(storage, "storage allocation failed");
+
+	struct yanet_shm shm = {.base = storage, .size = 1 << 25};
+	yanet_error *err = NULL;
+	uint64_t memory_limit = 0;
+	int rc = yanet_shm_extend_agent(
+		&shm, 0, "any", 1u << 20, &memory_limit, &err
+	);
+	TEST_ASSERT(rc == -1, "a zeroed instance must not be grown");
+	TEST_ASSERT_NOT_NULL(err, "a refused growth must set an error");
+	yanet_error_free(err);
+	err = NULL;
+
+	struct cp_config *cp_config = NULL;
+	rc = extend_env_init(storage, 1 << 24, &cp_config);
+	TEST_ASSERT(rc == 0, "storage setup failed");
+
+	struct agent *agent = agent_attach(&shm, 0, "ready", 1 << 12, &err);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	rc = yanet_shm_extend_agent(
+		&shm, 1, "ready", 1u << 20, &memory_limit, &err
+	);
+	TEST_ASSERT(
+		rc == -1,
+		"an index past the published instance count must not be grown"
+	);
+	TEST_ASSERT_NOT_NULL(err, "a refused growth must set an error");
+	yanet_error_free(err);
+
+	TEST_ASSERT_EQUAL(
+		agent->memory_limit,
+		(uint64_t)(1u << 12),
+		"a refused growth must not move any agent's memory"
+	);
+
+	extend_agent_release(agent, cp_config);
 	free(storage);
 	return TEST_SUCCESS;
 }
@@ -969,6 +1062,18 @@ main() {
 		LOG(ERROR,
 		    "test_current_time_does_not_regress_when_a_worker_stops "
 		    "failed");
+	}
+
+	++tests_count;
+	if (test_extend_agent_grows_the_named_agent() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR, "test_extend_agent_grows_the_named_agent failed");
+	}
+
+	++tests_count;
+	if (test_extend_agent_gates_on_readiness() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR, "test_extend_agent_gates_on_readiness failed");
 	}
 
 	if (tests_failed != 0) {

--- a/lib/errors/errors.h
+++ b/lib/errors/errors.h
@@ -31,6 +31,8 @@ enum yanet_error_kind {
 	YANET_ERROR_BUSY,
 	// The request is wrong regardless of the system state.
 	YANET_ERROR_INVALID_ARGUMENT,
+	// The pool the operation draws from has no room left for the request.
+	YANET_ERROR_RESOURCE_EXHAUSTED,
 };
 
 // Frees the whole chain.


### PR DESCRIPTION
- Adds `MemoryService.ExtendAgent`, which grows a named agent's shared memory without restarting the process that attached it and reports the size the arena reached.
- Adds `yanet_shm_extend_agent`, which resolves the agent and grows it under one hold of the configuration lock: looking the agent up, releasing the lock and growing the borrowed pointer afterwards is a use-after-free, because a re-attach of the same name reclaims the previous generation as soon as its loaded counts reach zero, and the pipeline and function services re-attach on every update and delete.
- Splits `agent_extend` into a `_locked` body the fused entry point reuses, since the configuration lock is not recursive and asserts on re-entry.
- Looks an agent up by the name it is registered under, assuming one agent per name. A name of 80 bytes or more breaks that assumption today, because attaching stores a truncated name but compares the untruncated one and so appends a second entry instead of superseding the first; that is an existing defect in attach, which already gets a truncation signal it ignores, and it is fixed separately.
- Maps a controlplane pool that cannot back the request to `ResourceExhausted` through a new `agenterr.ClassifyExtend`, and an instance the dataplane has not finished initialising to `Unavailable` rather than to a missing agent.
- Deliberately exposes no Go binding for a bare agent lookup: any borrowed agent pointer handed across the lock release is the use-after-free above, so `yanet_shm_extend_agent` is the whole surface.
- The request carries an increment rather than a target, so it is not idempotent; that is documented on the RPC and left for the resize design in #1906 to revisit.
- Relates to #1906. The CLI for this RPC is #2432 and ships separately.