### PR TITLE
feat(cli): list and grow agent shared memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,7 +3188,10 @@ dependencies = [
 name = "yanet-cli-common"
 version = "0.1.0"
 dependencies = [
+ "bytesize",
  "clap",
+ "clap_complete",
+ "tabled",
  "tonic",
  "yanet-cli",
  "yanet-ynpb",

--- a/cli/modules/common/Cargo.toml
+++ b/cli/modules/common/Cargo.toml
@@ -13,4 +13,7 @@ workspace = true
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tonic = { version = "0.14", features = ["gzip"] }
+bytesize = "2"
+tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }

--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -1,18 +1,34 @@
-//! CLI for YANET "logging" core module.
+//! CLI for the YANET core services.
 
-use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+use bytesize::ByteSize;
+use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
+use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, Service},
+    client::{ConnectionArgs, LayeredChannel, Service},
+    completion,
+    display::print_table_from_entries,
     errors::Error,
     output::{self, CommonFormat},
 };
-use ynpb::pb::{GetLevelRequest, UpdateLevelRequest, logging_client::LoggingClient};
+use ynpb::pb::{
+    ArenaInfo, ExtendAgentRequest, GetLevelRequest, ListArenasRequest, UpdateLevelRequest,
+    logging_client::LoggingClient, memory_service_client::MemoryServiceClient,
+};
 
 const LOGGING_SERVICE: &str = "controlplane.ynpb.v1.Logging";
 
-/// Manages the log level of the control plane process (`yanet-controlplane`),
-/// covering its Go logger and the hosted C libraries but not the dataplane.
+const MEMORY_SERVICE: &str = "controlplane.ynpb.v1.MemoryService";
+
+fn memory_client(channel: LayeredChannel) -> MemoryServiceClient<LayeredChannel> {
+    MemoryServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
+/// Manages the control plane process (`yanet-controlplane`): its log level and
+/// the shared memory its agents run on.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -31,9 +47,13 @@ struct Cmd {
 
 #[derive(Debug, Clone, Subcommand)]
 enum ModeCmd {
-    /// Manage the control plane's logging level.
+    /// Manage the log level of the control plane process, covering its Go
+    /// logger and the hosted C libraries but not the dataplane.
     #[clap(subcommand)]
     Logging(LoggingCmd),
+    /// Manage the shared memory the agents run on.
+    #[clap(subcommand)]
+    Memory(MemoryCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -48,6 +68,29 @@ enum LoggingCmd {
 struct SetLogLevelCmd {
     /// Minimum log level.
     level: LogLevel,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+enum MemoryCmd {
+    /// List the memory every agent generation holds.
+    List,
+    /// Grow the memory of a live agent.
+    Extend(ExtendCmd),
+}
+
+#[derive(Debug, Clone, Parser)]
+struct ExtendCmd {
+    /// Name of the agent to grow.
+    #[arg(add = ArgValueCandidates::new(agent_candidates))]
+    agent: String,
+    /// How much memory to add, for example 64MiB.
+    #[arg(long, value_parser = parse_size)]
+    size: ByteSize,
+}
+
+fn parse_size(raw: &str) -> Result<ByteSize, String> {
+    raw.parse()
+        .map_err(|_| format!("expected a size such as 64MiB, got {raw:?}"))
 }
 
 /// Log level for the logging service.
@@ -74,26 +117,42 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
-impl ModeCmd {
+impl LoggingCmd {
     pub fn action(&self) -> &'static str {
         match self {
-            ModeCmd::Logging(LoggingCmd::SetLevel(..)) => "set-level",
-            ModeCmd::Logging(LoggingCmd::Show) => "show",
+            LoggingCmd::SetLevel(..) => "set-level",
+            LoggingCmd::Show => "show",
+        }
+    }
+}
+
+impl MemoryCmd {
+    pub fn action(&self) -> &'static str {
+        match self {
+            MemoryCmd::List => "list",
+            MemoryCmd::Extend(..) => "extend",
         }
     }
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let action = cmd.mode.action();
-    let mut service = Service::connect_for(&cmd.connection, action, LOGGING_SERVICE, |channel| {
+    match cmd.mode {
+        ModeCmd::Logging(mode) => run_logging(&cmd.connection, mode).await,
+        ModeCmd::Memory(mode) => run_memory(&cmd.connection, mode).await,
+    }
+}
+
+async fn run_logging(connection: &ConnectionArgs, mode: LoggingCmd) -> Result<(), Error> {
+    let action = mode.action();
+    let mut service = Service::connect_for(connection, action, LOGGING_SERVICE, |channel| {
         LoggingClient::new(channel)
             .send_compressed(CompressionEncoding::Gzip)
             .accept_compressed(CompressionEncoding::Gzip)
     })
     .await?;
 
-    match cmd.mode {
-        ModeCmd::Logging(LoggingCmd::SetLevel(cmd)) => {
+    match mode {
+        LoggingCmd::SetLevel(cmd) => {
             let request = UpdateLevelRequest {
                 level: ynpb::pb::LogLevel::from(cmd.level.clone()).into(),
             };
@@ -109,7 +168,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                 format_args!("Set the control plane log level to '{}'.", level_name.get_name()),
             );
         }
-        ModeCmd::Logging(LoggingCmd::Show) => {
+        LoggingCmd::Show => {
             let response = service
                 .unary(action, GetLevelRequest {}, async |client, request| {
                     client.get_level(request).await
@@ -124,4 +183,119 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+async fn run_memory(connection: &ConnectionArgs, mode: MemoryCmd) -> Result<(), Error> {
+    let action = mode.action();
+    let mut service = Service::connect_for(connection, action, MEMORY_SERVICE, memory_client).await?;
+
+    match mode {
+        MemoryCmd::List => {
+            let response = service
+                .unary(action, ListArenasRequest {}, async |client, request| {
+                    client.list_arenas(request).await
+                })
+                .await?;
+
+            output::data(
+                || &response.arenas,
+                || {
+                    if response.arenas.is_empty() {
+                        output::empty(format_args!("No agents found."));
+                        return;
+                    }
+
+                    print_table_from_entries(arena_rows(&response.arenas));
+                },
+            );
+        }
+        MemoryCmd::Extend(cmd) => {
+            let request = ExtendAgentRequest {
+                agent: cmd.agent.clone(),
+                size: cmd.size.as_u64(),
+            };
+            let response = service
+                .unary_with(
+                    action,
+                    request,
+                    service.not_found(action, &format!("agent '{}'", cmd.agent)),
+                    async |client, request| client.extend_agent(request).await,
+                )
+                .await?;
+
+            output::success(
+                action,
+                format_args!(
+                    "Agent '{}' now holds {}.",
+                    cmd.agent,
+                    ByteSize::b(response.memory_limit)
+                ),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Orders each agent's generations newest first; a tie keeps the order the
+/// service sent, so the live arena stays ahead of the ones it replaced.
+fn arena_rows(arenas: &[ArenaInfo]) -> Vec<ArenaRow> {
+    let mut rows: Vec<ArenaRow> = arenas.iter().map(ArenaRow::from).collect();
+    rows.sort_by(|left, right| {
+        left.agent
+            .cmp(&right.agent)
+            .then(right.generation.cmp(&left.generation))
+    });
+    rows
+}
+
+#[derive(Debug, Tabled)]
+struct ArenaRow {
+    #[tabled(rename = "Agent")]
+    agent: String,
+    #[tabled(rename = "Generation")]
+    generation: u64,
+    #[tabled(rename = "PID")]
+    pid: u32,
+    #[tabled(rename = "Limit")]
+    limit: String,
+    #[tabled(rename = "Free")]
+    free: String,
+    #[tabled(rename = "Retired")]
+    retired: String,
+}
+
+impl From<&ArenaInfo> for ArenaRow {
+    fn from(arena: &ArenaInfo) -> Self {
+        Self {
+            agent: arena.agent.clone(),
+            generation: arena.generation,
+            pid: arena.pid,
+            limit: ByteSize::b(arena.memory_limit).to_string(),
+            free: ByteSize::b(arena.free_bytes).to_string(),
+            retired: if arena.retired { "yes" } else { "no" }.to_owned(),
+        }
+    }
+}
+
+/// Completion candidates for the agent argument: the agents that can be
+/// grown, leaving out the retired generations.
+///
+/// Strictly best-effort — an unreachable service offers no candidates.
+fn agent_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(Cmd::command, memory_client, async move |mut client| {
+        let mut names: Vec<String> = client
+            .list_arenas(ListArenasRequest {})
+            .await?
+            .into_inner()
+            .arenas
+            .into_iter()
+            .filter(|arena| !arena.retired)
+            .map(|arena| arena.agent)
+            .collect();
+        names.sort();
+        names.dedup();
+
+        Ok(names)
+    })
 }

--- a/common/rust/ynpb/build.rs
+++ b/common/rust/ynpb/build.rs
@@ -24,6 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 "controlplane/ynpb/v1/function.proto",
                 "controlplane/ynpb/v1/pipeline.proto",
                 "controlplane/ynpb/v1/inspect.proto",
+                "controlplane/ynpb/v1/memory.proto",
                 "controlplane/ynpb/v1/counters.proto",
                 "controlplane/ynpb/v1/gateway.proto",
                 "controlplane/ynpb/v1/auth.proto",


### PR DESCRIPTION
Stacked on #2431, which adds the `ExtendAgent` RPC this needs; the base is that branch and should be retargeted to `main` once it merges. The two commands ship together because they are one command group and one crate.

- Adds `yanet-cli common memory arenas`, which tables every agent generation's arena — agent, generation, pid, limit, free and whether it is retired — with sizes humanised in the table and left exact in the JSON, and an empty result reported through the shared empty-result primitive.
- Adds `yanet-cli common memory extend <AGENT> --size <SIZE>`, which grows a live agent and reports the size its arena reached.
- Proves the size before a connection is opened, so a malformed amount and an amount that would add nothing both fail as usage errors rather than as a refusal from the service. A missing agent, a dataplane that is not ready and a pool that cannot back the request stay distinguishable by exit code alone: 3, 4 and 1.
- Offers completion for the agent argument from the agents that can actually be grown, leaving out the retired generations.
- Compiles the memory protos into the shared `ynpb` crate, and splits the command dispatch so a memory command no longer builds a logging client on the way.
- Orders each agent's generations newest first; generations can tie, because the number counts configuration updates rather than attachments, and a tie keeps the order the service sent so the live arena stays ahead of the ones it replaced.
- Lands in the existing `common` binary rather than a new one, as #2357 settled, so nothing is added to the workspace members, the Makefile or the Debian install list.

Closes #2357.
Closes #2432.
