### PR TITLE
fix(fwstate): reclaim stale map layers on a timer

### DIFF
--- a/lib/fwstate/fwtable.h
+++ b/lib/fwstate/fwtable.h
@@ -68,6 +68,63 @@ fwtable_free_stale(fwtable_t *table, struct memory_context *ctx) {
 	SET_OFFSET_OF(&table->stale, NULL);
 }
 
+// The oldest layer past the head, or NULL when the chain has none.
+//
+// The head is never a reclamation candidate: it is the layer writes go
+// to, so only what sits behind it can drain and be released.
+static inline fwmap_t *
+fwtable_tail_layer(const fwtable_t *table, fwmap_t **prev_out) {
+	fwmap_t *head = ADDR_OF(&table->head);
+	if (!head || !head->next) {
+		return NULL;
+	}
+
+	fwmap_t *prev = head;
+	fwmap_t *tail = (fwmap_t *)ADDR_OF(&head->next);
+	while (tail->next) {
+		prev = tail;
+		tail = (fwmap_t *)ADDR_OF(&tail->next);
+	}
+
+	if (prev_out) {
+		*prev_out = prev;
+	}
+	return tail;
+}
+
+// How many layers are parked awaiting a release.
+//
+// Parked layers hold their whole key and value stores, so a chain that
+// stops draining is the difference between a bounded table and one that
+// grows without limit.
+static inline uint32_t
+fwtable_stale_count(const fwtable_t *table) {
+	uint32_t count = 0;
+	for (const fwmap_t *layer = ADDR_OF(&table->stale); layer != NULL;
+	     layer = (const fwmap_t *)ADDR_OF(&layer->next)) {
+		count += 1;
+	}
+	return count;
+}
+
+// Whether a reclamation round would do anything.
+//
+// Mirrors the conditions the unlink and the release steps act on, so a
+// caller can decline to pay the generation barriers those need when
+// neither has work. Reading it without a barrier is safe in
+// both directions: deadlines only move forward, so a round skipped on a
+// stale read is picked up by the next one, and a round started on one
+// simply finds nothing to unlink.
+static inline bool
+fwtable_has_reclaimable(const fwtable_t *table, uint64_t now) {
+	if (ADDR_OF(&table->stale) != NULL) {
+		return true;
+	}
+
+	const fwmap_t *tail = fwtable_tail_layer(table, NULL);
+	return tail != NULL && fwmap_max_deadline(tail) <= now;
+}
+
 // Unlink an expired tail layer from the active chain.
 //
 // If the oldest layer past the head is expired, atomically unlinks it
@@ -79,19 +136,9 @@ fwtable_free_stale(fwtable_t *table, struct memory_context *ctx) {
 // simply leaves them parked for a later round.  Returns 0.
 static inline int
 fwtable_unlink_stale_cp(fwtable_t *table, uint64_t now) {
-	fwmap_t *head = ADDR_OF(&table->head);
-	if (!head || !head->next) {
-		return 0;
-	}
-
-	fwmap_t *prev = head;
-	fwmap_t *tail = (fwmap_t *)ADDR_OF(&head->next);
-	while (tail->next) {
-		prev = tail;
-		tail = (fwmap_t *)ADDR_OF(&tail->next);
-	}
-
-	if (fwmap_max_deadline(tail) > now) {
+	fwmap_t *prev = NULL;
+	fwmap_t *tail = fwtable_tail_layer(table, &prev);
+	if (!tail || fwmap_max_deadline(tail) > now) {
 		return 0;
 	}
 

--- a/modules/fwstate/controlplane/cfg.go
+++ b/modules/fwstate/controlplane/cfg.go
@@ -1,8 +1,12 @@
 package fwstate
 
 import (
+	"time"
+
 	"github.com/c2h5oh/datasize"
+
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	fwstatemap "github.com/yanet-platform/yanet2/objects/fwstate/controlplane"
 )
 
 // Config represents FWState module configuration
@@ -20,6 +24,9 @@ type Config struct {
 
 	// Endpoint is the gRPC endpoint address
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+
+	// StaleLayerSweepInterval is the period between stale-layer sweeps.
+	StaleLayerSweepInterval time.Duration `yaml:"stale_layer_sweep_interval"`
 }
 
 // DefaultConfig returns default configuration
@@ -32,8 +39,9 @@ func DefaultConfig() *Config {
 		// CreateMap picks a 1,048,576-entry index, and one such layer
 		// across both families needs well over 100 MB before module
 		// configs and allocator overhead.
-		MemoryRequirements: xcfg.MustNonZero(1024 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		MemoryRequirements:      xcfg.MustNonZero(1024 * datasize.MB),
+		Endpoint:                xcfg.MustNonEmptyString("[::1]:0"),
+		StaleLayerSweepInterval: fwstatemap.DefaultStaleLayerSweepInterval,
 	}
 }
 

--- a/modules/fwstate/controlplane/mod.go
+++ b/modules/fwstate/controlplane/mod.go
@@ -1,6 +1,7 @@
 package fwstate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -118,6 +119,17 @@ func (m *FWStateModule) UnaryServerInterceptors() []grpc.UnaryServerInterceptor 
 		interceptors = append(interceptors, si)
 	}
 	return interceptors
+}
+
+// Run reclaims stale map layers until the context is cancelled.
+//
+// The sweep publishes config generations through the module's agent, so it
+// belongs to the phase that ends before anything is closed rather than to
+// the module's own construction: a module whose ownership never transfers
+// leaves nothing running behind it.
+func (m *FWStateModule) Run(ctx context.Context) error {
+	m.mapService.RunStaleLayerSweeper(ctx, m.cfg.StaleLayerSweepInterval)
+	return nil
 }
 
 // Close closes the module.

--- a/modules/fwstate/web/FWStatePage.tsx
+++ b/modules/fwstate/web/FWStatePage.tsx
@@ -1583,6 +1583,7 @@ const FWStatePage: React.FC = () => {
             row('Overflow buckets', (s) => s?.extra_bucket_count ?? '-'),
             row('Max chain', (s) => s?.max_chain_length ?? '-'),
             row('Layers', (s) => s?.layer_count ?? '-'),
+            row('Parked layers', (s) => s?.stale_layer_count ?? '-'),
             row('State entries', (s) => s?.total_elements ?? '-'),
             row('Max deadline', (s) => formatNsUtc(s?.max_deadline)),
             row('Memory used', (s) => formatMemoryBytes(s?.memory_used)),

--- a/objects/fwstate/api/fwstate_map_object.c
+++ b/objects/fwstate/api/fwstate_map_object.c
@@ -274,6 +274,19 @@ fwstate_map_v4_object_free_stale_layers(struct fwstate_map_v4_object *self) {
 	fwtable_free_stale(&self->table, &self->cp_object.memory_context);
 }
 
+uint32_t
+fwstate_map_v4_object_stale_layer_count(const struct fwstate_map_v4_object *self
+) {
+	return fwtable_stale_count(&self->table);
+}
+
+bool
+fwstate_map_v4_object_has_reclaimable(
+	const struct fwstate_map_v4_object *self, uint64_t now
+) {
+	return fwtable_has_reclaimable(&self->table, now);
+}
+
 // --- IPv6 object -------------------------------------------------------------
 
 // Typed destructor: tears the object down and returns its storage to the
@@ -427,6 +440,19 @@ fwstate_map_v6_object_unlink_stale_layers(
 void
 fwstate_map_v6_object_free_stale_layers(struct fwstate_map_v6_object *self) {
 	fwtable_free_stale(&self->table, &self->cp_object.memory_context);
+}
+
+uint32_t
+fwstate_map_v6_object_stale_layer_count(const struct fwstate_map_v6_object *self
+) {
+	return fwtable_stale_count(&self->table);
+}
+
+bool
+fwstate_map_v6_object_has_reclaimable(
+	const struct fwstate_map_v6_object *self, uint64_t now
+) {
+	return fwtable_has_reclaimable(&self->table, now);
 }
 
 // --- object factories --------------------------------------------------------

--- a/objects/fwstate/api/fwstate_map_v4_object.h
+++ b/objects/fwstate/api/fwstate_map_v4_object.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -110,3 +111,17 @@ fwstate_map_v4_object_unlink_stale_layers(
 // walking the parked chain.
 void
 fwstate_map_v4_object_free_stale_layers(struct fwstate_map_v4_object *self);
+
+// How many layers are parked awaiting a release.
+uint32_t
+fwstate_map_v4_object_stale_layer_count(const struct fwstate_map_v4_object *self
+);
+
+// Whether a reclamation round would do anything.
+//
+// Lets a caller skip the generation barriers reclamation needs when
+// there is nothing to unlink and nothing parked.
+bool
+fwstate_map_v4_object_has_reclaimable(
+	const struct fwstate_map_v4_object *self, uint64_t now
+);

--- a/objects/fwstate/api/fwstate_map_v6_object.h
+++ b/objects/fwstate/api/fwstate_map_v6_object.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -110,3 +111,17 @@ fwstate_map_v6_object_unlink_stale_layers(
 // walking the parked chain.
 void
 fwstate_map_v6_object_free_stale_layers(struct fwstate_map_v6_object *self);
+
+// How many layers are parked awaiting a release.
+uint32_t
+fwstate_map_v6_object_stale_layer_count(const struct fwstate_map_v6_object *self
+);
+
+// Whether a reclamation round would do anything.
+//
+// Lets a caller skip the generation barriers reclamation needs when
+// there is nothing to unlink and nothing parked.
+bool
+fwstate_map_v6_object_has_reclaimable(
+	const struct fwstate_map_v6_object *self, uint64_t now
+);

--- a/objects/fwstate/bindings/go/cfwstate/map.go
+++ b/objects/fwstate/bindings/go/cfwstate/map.go
@@ -256,7 +256,9 @@ func (m *MapObjectConfig) resolveMap(layerIndex uint32) *C.fwmap_t {
 
 // GetStats retrieves statistics for this map's fwtable.
 func (m *MapObjectConfig) GetStats() MapStats {
-	return mapStatsFromC(fwmapStatsOrZero(m.resolveMap(0)))
+	stats := mapStatsFromC(fwmapStatsOrZero(m.resolveMap(0)))
+	stats.StaleLayerCount = m.StaleLayerCount()
+	return stats
 }
 
 // ResolveMap resolves a specific layer's fwmap pointer.
@@ -292,6 +294,33 @@ func (m *MapObjectConfig) UnlinkStaleLayers(now uint64) error {
 		return fmt.Errorf("failed to unlink stale layers: error code=%d", rc)
 	}
 	return nil
+}
+
+// StaleLayerCount reports how many layers are parked awaiting a release.
+func (m *MapObjectConfig) StaleLayerCount() uint32 {
+	if m.kind == KindV6 {
+		return uint32(C.fwstate_map_v6_object_stale_layer_count(
+			C.fwstate_map_v6_from_cp_object(m.asRawPtr()),
+		))
+	}
+	return uint32(C.fwstate_map_v4_object_stale_layer_count(
+		C.fwstate_map_v4_from_cp_object(m.asRawPtr()),
+	))
+}
+
+// HasReclaimable reports whether a reclamation round would do anything,
+// so a caller can skip the generation barriers it otherwise costs.
+func (m *MapObjectConfig) HasReclaimable(now uint64) bool {
+	if m.kind == KindV6 {
+		return bool(C.fwstate_map_v6_object_has_reclaimable(
+			C.fwstate_map_v6_from_cp_object(m.asRawPtr()),
+			C.uint64_t(now),
+		))
+	}
+	return bool(C.fwstate_map_v4_object_has_reclaimable(
+		C.fwstate_map_v4_from_cp_object(m.asRawPtr()),
+		C.uint64_t(now),
+	))
 }
 
 // FreeStaleLayers releases the layers parked by UnlinkStaleLayers.

--- a/objects/fwstate/bindings/go/cfwstate/stats.go
+++ b/objects/fwstate/bindings/go/cfwstate/stats.go
@@ -13,6 +13,7 @@ type MapStats struct {
 	TotalElements    uint64
 	MaxDeadline      uint64
 	MemoryUsed       uint64
+	StaleLayerCount  uint32
 }
 
 // MapsStats stores IPv4 and IPv6 fwmap statistics.

--- a/objects/fwstate/controlplane/fwstatemappb/v1/fwstatemap.proto
+++ b/objects/fwstate/controlplane/fwstatemappb/v1/fwstatemap.proto
@@ -53,6 +53,7 @@ message MapStats {
   uint64 max_deadline = 6;
   uint64 memory_used = 7;
   string note = 8;
+  uint32 stale_layer_count = 9;
 }
 
 message FwStateKey {

--- a/objects/fwstate/controlplane/map_service.go
+++ b/objects/fwstate/controlplane/map_service.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"strings"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -239,7 +240,7 @@ func (m *FWStateMapService) collectMapStats() []*commonpb.Metric {
 
 	now, haveNow := m.dataplaneTime()
 
-	result := make([]*commonpb.Metric, 0, len(m.maps)*7)
+	result := make([]*commonpb.Metric, 0, len(m.maps)*8)
 	for name, fwMap := range m.maps {
 		af := "ipv4"
 		if fwMap.Config().Kind() == cfwstate.KindV6 {
@@ -274,6 +275,7 @@ func mapStatsGauges(
 		commonpb.NewMetricGauge("fwstate_extra_bucket_count", float64(stats.ExtraBucketCount), labels...),
 		commonpb.NewMetricGauge("fwstate_max_chain_length", float64(stats.MaxChainLength), labels...),
 		commonpb.NewMetricGauge("fwstate_layer_count", float64(stats.LayerCount), labels...),
+		commonpb.NewMetricGauge("fwstate_stale_layer_count", float64(stats.StaleLayerCount), labels...),
 		commonpb.NewMetricGauge("fwstate_total_elements", float64(stats.TotalElements), labels...),
 		commonpb.NewMetricGauge("fwstate_memory_bytes", float64(stats.MemoryUsed), labels...),
 	}
@@ -710,6 +712,127 @@ func (m *FWStateMapService) ReclaimStaleLayers(
 	}
 }
 
+// DefaultStaleLayerSweepInterval is the default period between stale-layer
+// sweeps.
+const DefaultStaleLayerSweepInterval = 30 * time.Second
+
+// SweepStaleLayers reclaims every map that has something to reclaim.
+//
+// A map with nothing parked and no drained layer behind its head is
+// skipped without publishing a generation, so a settled table costs a
+// pointer test rather than two barriers. The whole round is skipped while
+// the instance has published no time, since deciding a layer has drained
+// means deciding every deadline in it has passed.
+func (m *FWStateMapService) SweepStaleLayers(ctx context.Context) {
+	now, haveNow := m.dataplaneTime()
+	if !haveNow {
+		m.log.Debug("skipped stale-layer sweep without a dataplane time")
+		return
+	}
+
+	for _, name := range m.mapNames() {
+		if ctx.Err() != nil {
+			return
+		}
+
+		m.sweepNamedMap(name, now)
+	}
+}
+
+// mapNames snapshots the registry so a sweep can release the lock between
+// maps.
+func (m *FWStateMapService) mapNames() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	names := make([]string, 0, len(m.maps))
+	for name := range m.maps {
+		names = append(names, name)
+	}
+	return names
+}
+
+// sweepNamedMap reclaims one map, re-resolving it under the lock.
+//
+// A map named by the snapshot can be deleted before its turn, in which
+// case there is nothing left to reclaim and the handle must not be
+// touched.
+func (m *FWStateMapService) sweepNamedMap(name string, now uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fwMap, ok := m.maps[name]
+	if !ok {
+		return
+	}
+
+	m.SweepMap(name, fwMap.Config(), *fwMap.Config(), now)
+}
+
+// StaleLayerSource is one map a sweep can consider: what it holds, and
+// whether reclaiming it is worth the barriers.
+type StaleLayerSource interface {
+	MapLayerReclaimer
+
+	HasReclaimable(now uint64) bool
+	StaleLayerCount() uint32
+}
+
+// Compile-time assertion that [cfwstate.MapObjectConfig] satisfies
+// [StaleLayerSource].
+var _ StaleLayerSource = (*cfwstate.MapObjectConfig)(nil)
+
+// SweepMap reclaims one map, or declines to.
+//
+// The precheck is what keeps a periodic sweep affordable: a settled table
+// answers it from its own pointers, where reclaiming would publish two
+// config generations and wait for every worker to pick them up.
+func (m *FWStateMapService) SweepMap(
+	name string,
+	source StaleLayerSource,
+	mapCP cfwstate.MapObjectConfig,
+	now uint64,
+) {
+	if !source.HasReclaimable(now) {
+		return
+	}
+
+	before := source.StaleLayerCount()
+	m.ReclaimStaleLayers(source, mapCP, now)
+
+	m.log.Debug("swept stale fwstate-map layers",
+		zap.String("map", name),
+		zap.Uint32("parked_before", before),
+		zap.Uint32("parked_after", source.StaleLayerCount()),
+	)
+}
+
+// RunStaleLayerSweeper reclaims stale layers until the context is
+// cancelled.
+func (m *FWStateMapService) RunStaleLayerSweeper(
+	ctx context.Context, interval time.Duration,
+) {
+	if interval <= 0 {
+		m.log.Warn("non-positive stale-layer sweep interval, falling back to default",
+			zap.Duration("configured", interval),
+			zap.Duration("default", DefaultStaleLayerSweepInterval),
+		)
+		interval = DefaultStaleLayerSweepInterval
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.SweepStaleLayers(ctx)
+		}
+	}
+}
+
 // ValidateWorkerCount rejects zero and out-of-range worker_count values.
 func ValidateWorkerCount(workerCount uint32) error {
 	if workerCount == 0 {
@@ -791,9 +914,11 @@ func ResolveReadIndex(backward bool, index int64) (int64, error) {
 
 // MapStatsToProto converts bindings-level map stats into the proto form.
 //
-// The stats describe the active head layer only (fwmap_get_stats walks
-// one layer; only layer_count spans the chain), so the note says so —
-// the values must not be presented as map totals after a rotation.
+// The values here describe the active head layer only (one layer is
+// walked for them; only the layer count spans the chain), so the note
+// says so — they must not be presented as map totals after a rotation.
+// The count of layers parked awaiting a release belongs to neither, and
+// is carried through unchanged.
 func MapStatsToProto(stats mapStats) *fwstatemappb.MapStats {
 	return &fwstatemappb.MapStats{
 		IndexSize:        stats.IndexSize,
@@ -803,6 +928,7 @@ func MapStatsToProto(stats mapStats) *fwstatemappb.MapStats {
 		TotalElements:    stats.TotalElements,
 		MaxDeadline:      stats.MaxDeadline,
 		MemoryUsed:       stats.MemoryUsed,
+		StaleLayerCount:  stats.StaleLayerCount,
 		Note:             "Statistics are currently shown for the first layer only",
 	}
 }

--- a/objects/fwstate/controlplane/sweep_test.go
+++ b/objects/fwstate/controlplane/sweep_test.go
@@ -1,0 +1,162 @@
+package fwstatemap_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	cfwstate "github.com/yanet-platform/yanet2/objects/fwstate/bindings/go/cfwstate"
+	fwstatemap "github.com/yanet-platform/yanet2/objects/fwstate/controlplane"
+)
+
+// sweepSource stands in for one map a sweep can consider: it answers the
+// precheck from a script and records what reclamation asked of it.
+type sweepSource struct {
+	mu          sync.Mutex
+	reclaimable []bool
+	parked      uint32
+	unlinkErr   error
+	unlinkCalls int
+	freeCalls   int
+	prechecks   int
+}
+
+func (m *sweepSource) HasReclaimable(uint64) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	answer := true
+	if m.prechecks < len(m.reclaimable) {
+		answer = m.reclaimable[m.prechecks]
+	}
+	m.prechecks++
+	return answer
+}
+
+func (m *sweepSource) StaleLayerCount() uint32 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.parked
+}
+
+func (m *sweepSource) UnlinkStaleLayers(uint64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.unlinkCalls++
+	return m.unlinkErr
+}
+
+func (m *sweepSource) FreeStaleLayers() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.freeCalls++
+	return nil
+}
+
+func (m *sweepSource) counts() (int, int, int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.prechecks, m.unlinkCalls, m.freeCalls
+}
+
+// newSweepService builds a service whose barrier only counts, so a test
+// can tell a declined sweep from one that published a generation.
+func newSweepService(barriers *int) *fwstatemap.FWStateMapService {
+	var mu sync.Mutex
+	return fwstatemap.NewFWStateMapServiceForTest(func(cfwstate.MapObjectConfig) error {
+		mu.Lock()
+		defer mu.Unlock()
+		*barriers++
+		return nil
+	})
+}
+
+// Test_SweepMap_DeclinesWhenNothingToReclaim verifies that a settled map
+// costs no generation barrier.
+//
+// This is what makes a periodic sweep affordable: an idle router would
+// otherwise publish two generations per map per tick forever.
+func Test_SweepMap_DeclinesWhenNothingToReclaim(t *testing.T) {
+	barriers := 0
+	svc := newSweepService(&barriers)
+	source := &sweepSource{reclaimable: []bool{false}}
+
+	svc.SweepMap("m", source, cfwstate.MapObjectConfig{}, 100)
+
+	prechecks, unlinks, frees := source.counts()
+	require.Equal(t, 1, prechecks, "the precheck must run")
+	require.Equal(t, 0, unlinks, "a settled map must not be unlinked")
+	require.Equal(t, 0, frees)
+	require.Equal(t, 0, barriers, "a declined sweep must publish no generation")
+}
+
+// Test_SweepMap_ReclaimsWhenWorkIsWaiting verifies that a map the
+// precheck admits goes through the full barrier-unlink-barrier-free
+// sequence.
+func Test_SweepMap_ReclaimsWhenWorkIsWaiting(t *testing.T) {
+	barriers := 0
+	svc := newSweepService(&barriers)
+	source := &sweepSource{reclaimable: []bool{true}, parked: 1}
+
+	svc.SweepMap("m", source, cfwstate.MapObjectConfig{}, 100)
+
+	_, unlinks, frees := source.counts()
+	require.Equal(t, 1, unlinks)
+	require.Equal(t, 1, frees)
+	require.Equal(t, 2, barriers, "one barrier before the unlink and one after")
+}
+
+// Test_SweepMap_RetriesAfterAFailedReclamation verifies that a sweep
+// whose reclamation failed is attempted again by the next one.
+//
+// A failed reclamation is not reported to whoever triggered it, so the
+// only thing that releases those layers is a later attempt.
+func Test_SweepMap_RetriesAfterAFailedReclamation(t *testing.T) {
+	barriers := 0
+	svc := newSweepService(&barriers)
+	source := &sweepSource{
+		reclaimable: []bool{true, true},
+		parked:      1,
+		unlinkErr:   errors.New("unlink failed"),
+	}
+
+	svc.SweepMap("m", source, cfwstate.MapObjectConfig{}, 100)
+	_, unlinks, frees := source.counts()
+	require.Equal(t, 1, unlinks)
+	require.Equal(t, 0, frees, "a failed unlink frees nothing")
+
+	source.mu.Lock()
+	source.unlinkErr = nil
+	source.mu.Unlock()
+
+	svc.SweepMap("m", source, cfwstate.MapObjectConfig{}, 200)
+	_, unlinks, frees = source.counts()
+	require.Equal(t, 2, unlinks, "the next sweep must try again")
+	require.Equal(t, 1, frees, "the retry releases what the failure left parked")
+}
+
+// Test_RunStaleLayerSweeper_StopsWithItsContext verifies that cancelling
+// the context ends the loop, which is what lets the module join it
+// before the agent the sweep publishes through goes away.
+func Test_RunStaleLayerSweeper_StopsWithItsContext(t *testing.T) {
+	barriers := 0
+	svc := newSweepService(&barriers)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		svc.RunStaleLayerSweeper(ctx, time.Hour)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the sweeper did not stop with its context")
+	}
+}

--- a/tests/fwstate/fwtable_test.c
+++ b/tests/fwstate/fwtable_test.c
@@ -1,5 +1,6 @@
 // Regression tests for the fwtable layer chain: lock discipline across
-// the head-miss paths of fwtable_lookup_internal.
+// the head-miss paths of fwtable_lookup_internal, and the predicate a
+// caller uses to decide whether a reclamation round has anything to do.
 //
 // A lookup that misses the head layer and probes deeper layers must
 // release the head bucket's read lock before the deeper probes store
@@ -125,6 +126,86 @@ test_lookup_head_miss_then_insert(void *arena) {
 	fprintf(stderr, "OK\n");
 }
 
+// A chain that has never rotated offers nothing to reclaim, and neither
+// does one whose oldest layer is still live. Only once that layer has
+// drained, or once a previous round parked something, does the
+// predicate report work — the caller pays generation barriers on its
+// word, so a false positive costs a wasted round and a false negative
+// strands a layer.
+static void
+test_reclaimable_predicate(void *arena) {
+	fprintf(stderr, "Testing reclaimable predicate...\n");
+
+	struct memory_context *ctx =
+		init_context_from_arena(arena, ARENA_SIZE, "fwtable_reclaim");
+
+	fwmap_config_t config = table_test_config();
+	fwtable_t table = {0};
+
+	assert(!fwtable_has_reclaimable(&table, now_time));
+
+	assert(fwtable_insert_layer_cp(&table, &config, ctx) == 0);
+	assert(!fwtable_has_reclaimable(&table, now_time));
+	assert(fwtable_stale_count(&table) == 0);
+
+	// Rotation leaves the first layer behind the head carrying no
+	// entries, so its deadline is already behind us.
+	assert(fwtable_insert_layer_cp(&table, &config, ctx) == 0);
+	assert(fwtable_has_reclaimable(&table, now_time));
+
+	assert(fwtable_unlink_stale_cp(&table, now_time) == 0);
+	assert(fwtable_stale_count(&table) == 1);
+	assert(fwtable_has_reclaimable(&table, now_time));
+
+	fwtable_free_stale(&table, ctx);
+	assert(fwtable_stale_count(&table) == 0);
+	assert(!fwtable_has_reclaimable(&table, now_time));
+
+	fprintf(stderr, "OK\n");
+}
+
+// A tail layer that still holds a live entry is not reclaimable.
+//
+// Rotation alone does not release the layer behind the head: it keeps
+// answering lookups until every deadline in it has passed, so the
+// predicate has to weigh the entries and not just the shape of the chain.
+static void
+test_reclaimable_predicate_live_tail(void *arena) {
+	fprintf(stderr, "Testing reclaimable predicate with a live tail...\n");
+
+	struct memory_context *ctx =
+		init_context_from_arena(arena, ARENA_SIZE, "fwtable_live_tail");
+
+	fwmap_config_t config = table_test_config();
+	fwtable_t table = {0};
+
+	assert(fwtable_insert_layer_cp(&table, &config, ctx) == 0);
+
+	int key = 7, value = 77;
+	assert(fwtable_insert(&table, 0, now_time, 60, &key, &value, NULL) >= 0
+	);
+
+	// Rotation moves the live entry one layer down, where reclamation
+	// looks for drained layers.
+	assert(fwtable_insert_layer_cp(&table, &config, ctx) == 0);
+
+	assert(!fwtable_has_reclaimable(&table, now_time));
+	assert(!fwtable_has_reclaimable(&table, now_time + 59));
+
+	// The decision and the predicate must agree: neither releases a
+	// layer whose last entry outlives the time asked about.
+	assert(fwtable_unlink_stale_cp(&table, now_time + 59) == 0);
+	assert(fwtable_stale_count(&table) == 0);
+
+	assert(fwtable_has_reclaimable(&table, now_time + 60));
+	assert(fwtable_unlink_stale_cp(&table, now_time + 60) == 0);
+	assert(fwtable_stale_count(&table) == 1);
+
+	fwtable_free_stale(&table, ctx);
+
+	fprintf(stderr, "OK\n");
+}
+
 int
 main(void) {
 	printf("%s%s=== FWTable Lock Tests ===%s\n\n", C_BOLD, C_WHITE, C_RESET
@@ -139,6 +220,8 @@ main(void) {
 	}
 
 	test_lookup_head_miss_then_insert(arena);
+	test_reclaimable_predicate(arena);
+	test_reclaimable_predicate_live_tail(arena);
 
 	free_arena(arena, ARENA_SIZE);
 

--- a/web/src/core/api/fwstatemap.ts
+++ b/web/src/core/api/fwstatemap.ts
@@ -9,6 +9,7 @@ export interface MapStats {
     max_deadline?: number;
     memory_used?: number;
     note?: string;
+    stale_layer_count?: number;
 }
 
 export enum Direction {


### PR DESCRIPTION
- Sweep every map periodically so a drained layer is released without a client inserting another one. Reclamation was reached only from that request, so a router whose maps stopped being resized held a layer, and the key and value stores it preallocated, for the lifetime of the process.
- Decline a sweep that has nothing to reclaim, so a settled table answers from its own pointers instead of publishing two config generations and waiting for every worker to pick them up.
- Count the layers unlinked from the active chain and awaiting a release, and export it alongside the existing layer gauge. Only the active chain was visible, so a layer parked by a reclamation that failed its barrier showed up nowhere.
- Share the walk to the oldest layer between the reclamation decision and the question of whether one is due, so the two cannot disagree about whether there is work.
- Stop and join the sweep before the agent it publishes through goes away.