### PR TITLE
fix(controlplane): refuse an agent name that does not fit

### DIFF
--- a/api/agent.h
+++ b/api/agent.h
@@ -82,6 +82,7 @@ agent_dp_config_ready(struct yanet_shm *shm, uint32_t instance_idx);
 //
 // Creates a new agent for a specific module in the given dataplane instance.
 // The agent provides module-specific operations and memory management.
+// A name longer than 79 characters is rejected.
 //
 // @param shm Handle to shared memory segment
 // @param instance_idx Index of the dataplane instance where the agent should

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -179,6 +179,15 @@ agent_attach(
 	size_t memory_limit,
 	yanet_error **err
 ) {
+	if (strnlen(agent_name, AGENT_NAME_LEN) == AGENT_NAME_LEN) {
+		yanet_error_add(
+			err,
+			"agent name is longer than %d characters",
+			AGENT_NAME_LEN - 1
+		);
+		return NULL;
+	}
+
 	struct dp_config *dp_config = yanet_shm_dp_config(shm, instance_idx);
 
 	// Guard against attaching before the dataplane finishes initialising
@@ -278,7 +287,7 @@ agent_attach(
 	     ++agent_idx) {
 		struct agent *old_agent =
 			ADDR_OF(&old_registry->agents[agent_idx]);
-		if (!strncmp(old_agent->name, agent_name, 80)) {
+		if (!strncmp(old_agent->name, agent_name, AGENT_NAME_LEN)) {
 			found = true;
 			SET_OFFSET_OF(
 				&old_registry->agents[agent_idx], new_agent

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -17,6 +17,9 @@ struct cp_object;
 
 struct agent;
 
+// Longest agent name the registry can hold, terminator included.
+#define AGENT_NAME_LEN 80
+
 // Process-local handle to a mapped shared-memory segment.
 //
 // Carries the mapping length next to its base address so that releasing
@@ -72,7 +75,7 @@ struct agent {
 	// individually first.
 	uint64_t loaded_object_count;
 	struct agent *prev;
-	char name[80];
+	char name[AGENT_NAME_LEN];
 
 	uint64_t arena_count;
 	struct agent_arena *arenas;

--- a/lib/controlplane/agent/agent_test.c
+++ b/lib/controlplane/agent/agent_test.c
@@ -614,6 +614,31 @@ test_extend_rolls_back_on_exhausted_pool() {
 	return TEST_SUCCESS;
 }
 
+static int
+test_attach_name_too_long_is_refused() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct cp_config *cp_config = NULL;
+	int rc = extend_env_init(storage, TEST_CP_MEMORY, &cp_config);
+	TEST_ASSERT(rc == 0, "storage setup failed");
+
+	char name[AGENT_NAME_LEN + 1];
+	memset(name, 'a', AGENT_NAME_LEN);
+	name[AGENT_NAME_LEN] = '\0';
+
+	struct yanet_shm shm = {.base = storage, .size = TEST_STORAGE_SIZE};
+	yanet_error *err = NULL;
+	struct agent *agent = agent_attach(&shm, 0, name, 4096, &err);
+
+	TEST_ASSERT_NULL(agent, "a name that does not fit must be refused");
+	TEST_ASSERT_NOT_NULL(err, "a refused attach must set an error");
+
+	yanet_error_free(err);
+	free(storage);
+	return TEST_SUCCESS;
+}
+
 int
 main() {
 	log_enable_name("error");
@@ -657,6 +682,12 @@ main() {
 	if (test_attach_initialised_segment_succeeds() != TEST_SUCCESS) {
 		++tests_failed;
 		LOG(ERROR, "test_attach_initialised_segment_succeeds failed");
+	}
+
+	++tests_count;
+	if (test_attach_name_too_long_is_refused() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR, "test_attach_name_too_long_is_refused failed");
 	}
 
 	++tests_count;


### PR DESCRIPTION
- An agent name too long for the registry field was stored cut, while attach compared the full name against it, so attaching the same long name twice registered a second agent instead of replacing the first.
- Two agents then lived under one name: a lookup could return either, and the superseded one was never reclaimed.
- Attaching now refuses a name that cannot be stored whole and reports it through the error output, so the registry cannot hold two agents with the same name.
- The name capacity is a named constant, used by the stored field and by the registry comparison that previously hardcoded its length.
- Closes #2433.
