### PR TITLE
feat(forward,cli)!: move the rule file to the wire request form

### DIFF
--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -63,15 +63,16 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   writing it.
 - Wire values are built with `From` when the request is made
   (`IpAddress::from(addr)`), never parsed from text there.
-- Positional arguments carry the key of an element only (`insert <prefix>
-  --via …`, `remove <next-hop>…`, `table create <name>`); everything else is a
-  flag.
-- Flags: `--name/-n` is the config name and nothing else; `--file/-f` an input
-  document; `--category` a metric category (`--rules`/`--name` migrate under
-  #2373); `-4/-6` family filters, mutually exclusive (nat64's address pair
-  excepted); `--endpoint` and `--auth` exist only through `ConnectionArgs`. A
-  short flag has one meaning across all binaries and never shadows the global
-  `-v`, so no auto `short` on a subcommand flag.
+- Positional arguments carry the key of an element (`insert <prefix>
+  --via …`, `remove <next-hop>…`, `table create <name>`) or the input
+  document of an `update` (`update -n <name> <path>`); everything else is
+  a flag.
+- Flags: `--name/-n` is the config name and nothing else; `--category` a
+  metric category (`--rules` retires into the positional update document
+  under #2373); `-4/-6` family filters, mutually exclusive (nat64's
+  address pair excepted); `--endpoint` and `--auth` exist only through
+  `ConnectionArgs`. A short flag has one meaning across all binaries and
+  never shadows the global `-v`, so no auto `short` on a subcommand flag.
 - Verbs: configs `list / show / update` (upsert) `/ delete`; elements inside a
   config `insert` (upsert by key), `add` (strict or idempotent add to a set),
   `remove`; scalars `set-<x>`; the whole object `flush`. A rename keeps the old

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,11 +3306,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "colored",
- "netip",
  "prost",
- "prost-types",
- "ptree",
  "serde",
  "serde_yaml",
  "tokio",

--- a/common/rust/filterpb/build.rs
+++ b/common/rust/filterpb/build.rs
@@ -1,9 +1,10 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    // Decoding mirrors the Go xproto contract: an omitted field takes its
-    // zero value and an unknown key is refused.
+    // Decoding mirrors the Go xproto contract: an omitted or null field
+    // takes its zero value and an unknown key is refused.
     let serialize_deserialize = "#[derive(serde::Serialize, serde::Deserialize)]#[serde(default, deny_unknown_fields)]";
+    let null_as_default = "#[serde(deserialize_with = \"crate::null_as_default\")]";
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
@@ -13,6 +14,11 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         .message_attribute(".common.filterpb.v1.ProtoRange", serialize_deserialize)
         .message_attribute(".common.filterpb.v1.VlanRange", serialize_deserialize)
         .message_attribute(".common.filterpb.v1.Fragment", serialize_deserialize)
+        .field_attribute(".common.filterpb.v1.Device", null_as_default)
+        .field_attribute(".common.filterpb.v1.PortRange", null_as_default)
+        .field_attribute(".common.filterpb.v1.ProtoRange", null_as_default)
+        .field_attribute(".common.filterpb.v1.VlanRange", null_as_default)
+        .field_attribute(".common.filterpb.v1.Fragment", null_as_default)
         .compile_protos(&["common/filterpb/v1/filter.proto"], &["../../.."])?;
 
     Ok(())

--- a/common/rust/filterpb/build.rs
+++ b/common/rust/filterpb/build.rs
@@ -1,7 +1,9 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    let serialize_deserialize = "#[derive(serde::Serialize, serde::Deserialize)]";
+    // Decoding mirrors the Go xproto contract: an omitted field takes its
+    // zero value and an unknown key is refused.
+    let serialize_deserialize = "#[derive(serde::Serialize, serde::Deserialize)]#[serde(default, deny_unknown_fields)]";
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)

--- a/common/rust/filterpb/src/lib.rs
+++ b/common/rust/filterpb/src/lib.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 #[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod pb {
@@ -12,7 +12,7 @@ pub mod network;
 pub fn null_as_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     T: Default + Deserialize<'de>,
-    D: serde::Deserializer<'de>,
+    D: Deserializer<'de>,
 {
     Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
 }

--- a/common/rust/filterpb/src/lib.rs
+++ b/common/rust/filterpb/src/lib.rs
@@ -1,6 +1,18 @@
+use serde::Deserialize;
+
 #[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod pb {
     tonic::include_proto!("common.filterpb.v1");
 }
 
 pub mod network;
+
+/// Deserializes a null as the field's zero value, as the operator's YAML
+/// decoder reads it.
+pub fn null_as_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+}

--- a/forward.yaml
+++ b/forward.yaml
@@ -1,42 +1,47 @@
 rules:
-  - target: "virtio_user_kni0"
-    counter: "to_virtio_user_kni0"
-    mode: "Out"
+  - action:
+      target: "virtio_user_kni0"
+      mode: OUT
+      counter: "to_virtio_user_kni0"
     devices:
-      - "01:00.0"
+      - name: "01:00.0"
     vlan_ranges:
       - from: 0
         to: 4095
-    srcs:
+    sources4:
       - "0.0.0.0/0"
+    sources6:
       - "::/0"
-    dsts:
+    destinations4:
       - "203.0.113.14/32"
-      - "fe80::5054:ff:fe6b:ffa5/64"
+    destinations6:
+      - "fe80::/64"
       - "ff02::/16"
 
-  - target: "01:00.0"
-    counter: "to_pass"
-    mode: "None"
+  - action:
+      target: "01:00.0"
+      mode: NONE
+      counter: "to_pass"
     devices:
-      - "01:00.0"
+      - name: "01:00.0"
     vlan_ranges:
       - from: 0
         to: 4095
-    srcs:
+    sources4:
       - "0.0.0.0/0"
+    sources6:
       - "::/0"
-    dsts:
+    destinations4:
       - "0.0.0.0/0"
+    destinations6:
       - "::/0"
 
-  - target: "01:00.0"
-    counter: "to_01:00.0"
-    mode: "Out"
+  - action:
+      target: "01:00.0"
+      mode: OUT
+      counter: "to_01:00.0"
     devices:
-      - "virtio_user_kni0"
+      - name: "virtio_user_kni0"
     vlan_ranges:
       - from: 0
         to: 4095
-    srcs: []
-    dsts: []

--- a/modules/forward/cli/Cargo.toml
+++ b/modules/forward/cli/Cargo.toml
@@ -13,13 +13,9 @@ workspace = true
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
-netip = "0.3"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-colored = "3"
 prost = "0.13"
-prost-types = "0.13"
-ptree = "0.5"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/modules/forward/cli/build.rs
+++ b/modules/forward/cli/build.rs
@@ -8,7 +8,12 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")
         .extern_path(".common.filterpb.v1", "::filterpb::pb")
-        .message_attribute(".", "#[derive(Serialize)]")
+        .message_attribute(".", "#[derive(Serialize, Deserialize)]")
+        .message_attribute(".", "#[serde(default, deny_unknown_fields)]")
+        .field_attribute(
+            ".modules.forward.controlplane.forwardpb.v1.Action.mode",
+            "#[serde(serialize_with = \"crate::serialize_forward_mode\", deserialize_with = \"crate::deserialize_forward_mode\")]",
+        )
         .compile_protos(&["forwardpb/v1/forward.proto"], &["../../..", "../controlplane"])?;
 
     Ok(())

--- a/modules/forward/cli/build.rs
+++ b/modules/forward/cli/build.rs
@@ -14,6 +14,22 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             ".modules.forward.controlplane.forwardpb.v1.Action.mode",
             "#[serde(serialize_with = \"crate::serialize_forward_mode\", deserialize_with = \"crate::deserialize_forward_mode\")]",
         )
+        .field_attribute(
+            ".modules.forward.controlplane.forwardpb.v1.Action.target",
+            "#[serde(deserialize_with = \"crate::null_as_default\")]",
+        )
+        .field_attribute(
+            ".modules.forward.controlplane.forwardpb.v1.Action.counter",
+            "#[serde(deserialize_with = \"crate::null_as_default\")]",
+        )
+        .field_attribute(
+            ".modules.forward.controlplane.forwardpb.v1.Rule",
+            "#[serde(deserialize_with = \"crate::null_as_default\")]",
+        )
+        .field_attribute(
+            ".modules.forward.controlplane.forwardpb.v1.UpdateConfigRequest",
+            "#[serde(deserialize_with = \"crate::null_as_default\")]",
+        )
         .compile_protos(&["forwardpb/v1/forward.proto"], &["../../..", "../controlplane"])?;
 
     Ok(())

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -74,8 +74,9 @@ pub struct UpdateCmd {
     /// The file spells the wire request, exactly what the generic operator
     /// pushes and what `show` prints: rules with an `action`, `devices` as
     /// named objects, family-typed `sources4/6` and `destinations4/6`
-    /// networks, a mode by its declared name or a raw number. The `name`
-    /// may be omitted, it is then taken from `--name`, and a file naming
+    /// networks, a mode by its declared name or number. An undeclared mode
+    /// number, which `show` still prints raw, is refused. The `name` may
+    /// be omitted, it is then taken from `--name`, and a file naming
     /// another config is refused.
     #[arg(long = "file", short = 'f', alias = "rules", value_name = "PATH")]
     pub file: PathBuf,
@@ -115,23 +116,51 @@ fn deserialize_forward_mode<'de, D: Deserializer<'de>>(deserializer: D) -> Resul
 
 /// Loads the update request from its YAML file.
 ///
-/// Merge keys are expanded first, so a document shared with the generic
-/// operator may reuse a rule through an anchor and `<<`, and an empty
-/// document is the zero request, as the operator reads it.
+/// The reading matches the generic operator's: merge keys expand, a null
+/// field takes its zero value, an empty document is the zero request and
+/// a bare document separator is tolerated.
 fn load_request<P>(path: P) -> Result<UpdateConfigRequest, Box<dyn core::error::Error>>
 where
     P: AsRef<Path>,
 {
     let content = std::fs::read_to_string(path)?;
-    if content.trim().is_empty() {
-        return Ok(UpdateConfigRequest::default());
+    let mut documents = Vec::new();
+    for document in serde_yaml::Deserializer::from_str(&content) {
+        let value = serde_yaml::Value::deserialize(document)?;
+        if !value.is_null() {
+            documents.push(value);
+        }
     }
-    let mut value: serde_yaml::Value = serde_yaml::from_str(&content)?;
-    if value.is_null() {
-        return Ok(UpdateConfigRequest::default());
-    }
+
+    let mut value = match documents.pop() {
+        None => return Ok(UpdateConfigRequest::default()),
+        Some(_) if !documents.is_empty() => {
+            return Err("the file holds more than one document".into());
+        }
+        Some(value) => value,
+    };
     value.apply_merge()?;
+    strip_null_fields(&mut value);
     Ok(serde_yaml::from_value(value)?)
+}
+
+/// Removes null-valued mapping entries, so a spelled null reads as the
+/// field's zero value, as the operator reads it.
+fn strip_null_fields(value: &mut serde_yaml::Value) {
+    match value {
+        serde_yaml::Value::Mapping(mapping) => {
+            mapping.retain(|_, entry| !entry.is_null());
+            for (_, entry) in mapping.iter_mut() {
+                strip_null_fields(entry);
+            }
+        }
+        serde_yaml::Value::Sequence(sequence) => {
+            for entry in sequence.iter_mut() {
+                strip_null_fields(entry);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Binds the config name into a loaded request, refusing a file that names
@@ -478,6 +507,38 @@ rules:
                 .to_string()
                 .contains("mtu")
         );
+    }
+
+    #[test]
+    fn test_null_fields_read_as_zero_values() {
+        let yaml = "name: forward0\nrules:\n  - action:\n      target: t\n      mode: OUT\n      counter: c\n    devices: null\n    sources4: null\n";
+        let path = std::env::temp_dir().join(format!("fwd-null-{}.yaml", std::process::id()));
+        std::fs::write(&path, yaml).expect("the fixture must be written");
+
+        let request = load_request(&path).expect("null fields must load");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!("forward0", request.name);
+        assert!(request.rules[0].devices.is_empty());
+    }
+
+    #[test]
+    fn test_trailing_separator_is_tolerated_but_a_second_document_is_not() {
+        let trailing = "name: forward0\n---\n";
+        let second = "name: forward0\n---\nname: forward1\n";
+        let dir = std::env::temp_dir();
+        let trailing_path = dir.join(format!("fwd-sep-{}.yaml", std::process::id()));
+        let second_path = dir.join(format!("fwd-two-{}.yaml", std::process::id()));
+        std::fs::write(&trailing_path, trailing).expect("the fixture must be written");
+        std::fs::write(&second_path, second).expect("the fixture must be written");
+
+        let tolerated = load_request(&trailing_path).expect("a bare separator must be tolerated");
+        let refused = load_request(&second_path).expect_err("a second document must be refused");
+        std::fs::remove_file(&trailing_path).ok();
+        std::fs::remove_file(&second_path).ok();
+
+        assert_eq!("forward0", tolerated.name);
+        assert!(refused.to_string().contains("more than one document"));
     }
 
     #[test]

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -204,7 +204,8 @@ impl ForwardService {
             || &response,
             || {
                 // The document is printed even without rules, so a
-                // redirected show always yields a file update accepts.
+                // redirected show yields a file update accepts, an
+                // undeclared mode number excepted.
                 print!(
                     "{}",
                     serde_yaml::to_string(&response).expect("forward config YAML serialization must not fail")

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -78,7 +78,7 @@ pub struct UpdateCmd {
     /// number, which `show` still prints raw, is refused. The `name` may
     /// be omitted, it is then taken from `--name`, and a file naming
     /// another config is refused.
-    #[arg(long = "file", short = 'f', alias = "rules", value_name = "PATH")]
+    #[arg(value_name = "PATH")]
     pub file: PathBuf,
 }
 

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -1,4 +1,3 @@
-use core::fmt::{self, Display, Formatter};
 use std::{
     fs::File,
     path::{Path, PathBuf},
@@ -9,13 +8,11 @@ use clap_complete::{
     CompleteEnv,
     engine::{ArgValueCandidates, CompletionCandidate},
 };
-use commonpb::pb::{IPv4Network, IPv6Network};
 use forwardpb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     forward_service_client::ForwardServiceClient,
 };
-use netip::IpNetwork;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
@@ -26,7 +23,7 @@ use ync::{
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod forwardpb {
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
     tonic::include_proto!("modules.forward.controlplane.forwardpb.v1");
 }
@@ -75,214 +72,71 @@ pub struct UpdateCmd {
     /// The name of the module config to operate on.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config: String,
-    /// Ruleset file path.
-    #[arg(required = true, long = "rules", value_name = "PATH")]
-    pub rules: PathBuf,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct VlanRange {
-    from: u32,
-    to: u32,
-}
-
-impl From<VlanRange> for filterpb::pb::VlanRange {
-    fn from(r: VlanRange) -> Self {
-        Self { from: r.from, to: r.to }
-    }
-}
-
-impl From<filterpb::pb::VlanRange> for VlanRange {
-    fn from(r: filterpb::pb::VlanRange) -> Self {
-        Self { from: r.from, to: r.to }
-    }
-}
-
-/// Forwarding direction for a rule's action.
-///
-/// The uppercase spelling is canonical, matching `ForwardMode`'s proto enum
-/// names. The PascalCase spellings are accepted because the schema used them
-/// previously.
-#[derive(Debug, Deserialize)]
-enum ModeKind {
-    #[serde(rename = "NONE", alias = "None")]
-    None,
-    #[serde(rename = "IN", alias = "In")]
-    In,
-    #[serde(rename = "OUT", alias = "Out")]
-    Out,
-    /// An unrecognised proto enum value.
+    /// Path to the module config file: the update request in YAML.
     ///
-    /// `show` renders the raw number so one rule from a newer module cannot
-    /// hide the rest of a configuration. `update` rejects it.
-    #[serde(skip)]
-    Unknown(i32),
+    /// The file spells the wire request, exactly what the generic operator
+    /// pushes and what `show` prints: rules with an `action`, `devices` as
+    /// named objects, family-typed `sources4/6` and `destinations4/6`
+    /// networks, a mode by its declared name or a raw number. The `name`
+    /// may be omitted, it is then taken from `--name`, and a file naming
+    /// another config is refused.
+    #[arg(long = "file", short = 'f', alias = "rules", value_name = "PATH")]
+    pub file: PathBuf,
 }
 
-impl Display for ModeKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            Self::None => write!(f, "NONE"),
-            Self::In => write!(f, "IN"),
-            Self::Out => write!(f, "OUT"),
-            Self::Unknown(mode) => write!(f, "{mode}"),
-        }
+/// Serializes a forward mode as its declared name, an undeclared number as
+/// the number itself, so one rule from a newer module cannot hide the rest
+/// of a configuration.
+fn serialize_forward_mode<S: Serializer>(mode: &i32, serializer: S) -> Result<S::Ok, S::Error> {
+    match forwardpb::ForwardMode::try_from(*mode) {
+        Ok(mode) => serializer.serialize_str(mode.as_str_name()),
+        Err(_) => serializer.serialize_i32(*mode),
     }
 }
 
-impl Serialize for ModeKind {
-    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        s.collect_str(self)
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct ForwardRule {
-    target: String,
-    mode: ModeKind,
-    counter: String,
-    devices: Vec<String>,
-    vlan_ranges: Vec<VlanRange>,
-    srcs: Vec<String>,
-    dsts: Vec<String>,
-}
-
-impl TryFrom<ForwardRule> for forwardpb::Rule {
-    type Error = Box<dyn core::error::Error>;
-
-    fn try_from(forward_rule: ForwardRule) -> Result<Self, Self::Error> {
-        let mode: i32 = match forward_rule.mode {
-            ModeKind::None => forwardpb::ForwardMode::None.into(),
-            ModeKind::In => forwardpb::ForwardMode::In.into(),
-            ModeKind::Out => forwardpb::ForwardMode::Out.into(),
-            ModeKind::Unknown(mode) => return Err(format!("unknown forward mode {mode}").into()),
-        };
-
-        let (sources4, sources6) = partition_nets(forward_rule.srcs)?;
-        let (destinations4, destinations6) = partition_nets(forward_rule.dsts)?;
-
-        Ok(Self {
-            action: Some(forwardpb::Action {
-                target: forward_rule.target,
-                mode,
-                counter: forward_rule.counter,
-            }),
-            devices: forward_rule.devices.into_iter().map(|m| m.into()).collect(),
-            vlan_ranges: forward_rule.vlan_ranges.into_iter().map(Into::into).collect(),
-            sources4,
-            sources6,
-            destinations4,
-            destinations6,
-        })
-    }
-}
-
-/// Partitions a mixed-family network list into the family-typed wire
-/// messages, preserving the within-family order.
-fn partition_nets(nets: Vec<String>) -> Result<(Vec<IPv4Network>, Vec<IPv6Network>), Box<dyn core::error::Error>> {
-    let mut v4 = Vec::new();
-    let mut v6 = Vec::new();
-    for net in nets {
-        match IpNetwork::parse(&net)? {
-            IpNetwork::V4(net) => v4.push(net.into()),
-            IpNetwork::V6(net) => v6.push(net.into()),
-        }
-    }
-
-    Ok((v4, v6))
-}
-
-/// Renders the family-typed wire lists back into one mixed list, IPv4
-/// entries first.
-fn render_nets(v4: Vec<IPv4Network>, v6: Vec<IPv6Network>) -> Vec<String> {
-    v4.into_iter()
-        .map(|net| net.to_string())
-        .chain(v6.into_iter().map(|net| net.to_string()))
-        .collect()
-}
-
-impl TryFrom<forwardpb::Rule> for ForwardRule {
-    type Error = Box<dyn core::error::Error>;
-
-    fn try_from(rule: forwardpb::Rule) -> Result<Self, Self::Error> {
-        let action = rule.action.ok_or("forward rule is missing its action")?;
-        let mode = match forwardpb::ForwardMode::try_from(action.mode) {
-            Ok(forwardpb::ForwardMode::None) => ModeKind::None,
-            Ok(forwardpb::ForwardMode::In) => ModeKind::In,
-            Ok(forwardpb::ForwardMode::Out) => ModeKind::Out,
-            Err(_) => ModeKind::Unknown(action.mode),
-        };
-
-        Ok(Self {
-            target: action.target,
-            mode,
-            counter: action.counter,
-            devices: rule.devices.into_iter().map(|d| d.name).collect(),
-            vlan_ranges: rule.vlan_ranges.into_iter().map(VlanRange::from).collect(),
-            srcs: render_nets(rule.sources4, rule.sources6),
-            dsts: render_nets(rule.destinations4, rule.destinations6),
-        })
-    }
-}
-
-/// A forward module configuration as read from or written to a rule file.
+/// Deserializes a forward mode from its declared name or a raw number.
 ///
-/// Every rule field is always emitted, including an empty sequence as `[]`
-/// and an empty counter as an empty string, and none of them is optional on
-/// `update` either.
-///
-/// The `srcs` and `dsts` lists are mixed-family in the file but travel
-/// family-split on the wire, so `show` renders IPv4 entries before IPv6
-/// entries and only within-family order survives a round trip. A network
-/// parses in CIDR or address/mask form, normalising an address that
-/// carries host bits outside its mask. Any parseable mask is sent as-is,
-/// and the server enforces the filter compiler's mask classes: contiguous
-/// for IPv4, bi-contiguous for IPv6. A stored IPv6 mask with its hole
-/// exactly at the `/64` boundary renders in expanded-mask form and
-/// round-trips through `update`.
-///
-/// A `counter` left empty on `update` is not stored empty: the server
-/// materialises it to `to_<target>` before storing, bounded to whatever
-/// length the shared-memory counter registry accepts by cutting it back
-/// to the last whole character that still fits, so `show` renders that
-/// name instead of an empty string once the rule has gone through
-/// `update`, and a non-empty `counter` is used verbatim.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ForwardConfig {
-    rules: Vec<ForwardRule>,
-}
+/// An undeclared number passes through for the service to judge, an
+/// undeclared name is refused.
+fn deserialize_forward_mode<'de, D: Deserializer<'de>>(deserializer: D) -> Result<i32, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum NameOrNumber {
+        Number(i32),
+        Name(String),
+    }
 
-impl TryFrom<ForwardConfig> for Vec<forwardpb::Rule> {
-    type Error = Box<dyn core::error::Error>;
-
-    fn try_from(config: ForwardConfig) -> Result<Self, Self::Error> {
-        config.rules.into_iter().map(forwardpb::Rule::try_from).collect()
+    match NameOrNumber::deserialize(deserializer)? {
+        NameOrNumber::Number(mode) => Ok(mode),
+        NameOrNumber::Name(name) => forwardpb::ForwardMode::from_str_name(&name)
+            .map(|mode| mode as i32)
+            .ok_or_else(|| serde::de::Error::custom(format!("unknown forward mode {name:?}"))),
     }
 }
 
-impl TryFrom<Vec<forwardpb::Rule>> for ForwardConfig {
-    type Error = Box<dyn core::error::Error>;
-
-    fn try_from(rules: Vec<forwardpb::Rule>) -> Result<Self, Self::Error> {
-        Ok(Self {
-            rules: rules
-                .into_iter()
-                .map(ForwardRule::try_from)
-                .collect::<Result<Vec<_>, _>>()?,
-        })
-    }
+/// Loads the update request from its YAML file.
+fn load_request<P>(path: P) -> Result<UpdateConfigRequest, Box<dyn core::error::Error>>
+where
+    P: AsRef<Path>,
+{
+    let file = File::open(path)?;
+    Ok(serde_yaml::from_reader(file)?)
 }
 
-impl ForwardConfig {
-    pub fn load<P>(path: P) -> Result<Self, Box<dyn core::error::Error>>
-    where
-        P: AsRef<Path>,
-    {
-        let file = File::open(path)?;
-        let config = serde_yaml::from_reader(file)?;
-
-        Ok(config)
+/// Binds the config name into a loaded request, refusing a file that names
+/// another config.
+fn bind_request_name(request: &mut UpdateConfigRequest, name: &str) -> Result<(), String> {
+    if request.name.is_empty() {
+        request.name = name.to_string();
+        return Ok(());
     }
+    if request.name != name {
+        return Err(format!(
+            "the file names config {:?}, but --name is {:?}",
+            request.name, name
+        ));
+    }
+    Ok(())
 }
 
 /// The fully-qualified gRPC service name used in error messages.
@@ -314,23 +168,21 @@ impl ForwardService {
             .map_err(self.service.status("show"))?
             .into_inner();
 
-        let config = ForwardConfig::try_from(response.rules)
-            .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("show", e.to_string()))?;
-
         output::data(
-            || &config,
+            || &response,
             || {
-                print!(
-                    "{}",
-                    serde_yaml::to_string(&config).expect("forward config YAML serialization must not fail")
-                );
-
-                if config.rules.is_empty() {
+                if response.rules.is_empty() {
                     output::empty_with_hint(
                         format_args!("No forward rules found for '{}'.", cmd.config_name),
-                        format_args!("create one with 'yanet-cli-forward update --name <name> --rules <path>'"),
+                        format_args!("create one with 'yanet-cli-forward update --name <name> --file <path>'"),
                     );
+                    return;
                 }
+
+                print!(
+                    "{}",
+                    serde_yaml::to_string(&response).expect("forward config YAML serialization must not fail")
+                );
             },
         );
 
@@ -353,7 +205,7 @@ impl ForwardService {
                 if response.configs.is_empty() {
                     output::empty_with_hint(
                         format_args!("No forward configurations found."),
-                        format_args!("create one with 'yanet-cli-forward update --name <name> --rules <path>'"),
+                        format_args!("create one with 'yanet-cli-forward update --name <name> --file <path>'"),
                     );
                     return;
                 }
@@ -381,11 +233,8 @@ impl ForwardService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let config = ForwardConfig::load(&cmd.rules).map_err(|e| self.service.invalid("update", e.to_string()))?;
-        let rules: Vec<forwardpb::Rule> = config
-            .try_into()
-            .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("update", e.to_string()))?;
-        let request = UpdateConfigRequest { name: cmd.config.clone(), rules };
+        let mut request = load_request(&cmd.file).map_err(|e| self.service.invalid("update", e.to_string()))?;
+        bind_request_name(&mut request, &cmd.config).map_err(|e| self.service.invalid("update", e))?;
         self.service
             .client()
             .update_config(request)
@@ -443,6 +292,8 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 
 #[cfg(test)]
 mod test {
+    use commonpb::pb::{IPv4Network, IPv6Network};
+
     use super::*;
 
     fn v4_net(net: &str) -> IPv4Network {
@@ -470,14 +321,16 @@ mod test {
                     filterpb::pb::VlanRange { from: 200, to: 300 },
                 ],
                 sources4: vec![v4_net("192.0.2.0/24")],
-                sources6: vec![v6_net("2001:db8::/32")],
+                // The second mask hole sits exactly at the /64 boundary,
+                // which the filter compiler accepts.
+                sources6: vec![v6_net("2001:db8::/32"), v6_net("2001:db8::/ffff:ffff:ffff:0:ffff::")],
                 destinations4: vec![v4_net("203.0.113.0/24")],
                 destinations6: vec![v6_net("2001:db8:1::/48")],
             },
             forwardpb::Rule {
                 action: Some(forwardpb::Action {
-                    target: "target-in".to_string(),
-                    mode: forwardpb::ForwardMode::In as i32,
+                    target: "target-out".to_string(),
+                    mode: forwardpb::ForwardMode::Out as i32,
                     counter: String::new(),
                 }),
                 devices: vec![],
@@ -487,162 +340,117 @@ mod test {
                 destinations4: vec![],
                 destinations6: vec![],
             },
-            forwardpb::Rule {
-                action: Some(forwardpb::Action {
-                    target: "target-out".to_string(),
-                    mode: forwardpb::ForwardMode::Out as i32,
-                    counter: "counter-out".to_string(),
-                }),
-                devices: vec![filterpb::pb::Device { name: "eth2".to_string() }],
-                vlan_ranges: vec![filterpb::pb::VlanRange { from: 10, to: 20 }],
-                sources4: vec![v4_net("10.0.0.0/8")],
-                sources6: vec![],
-                destinations4: vec![v4_net("10.1.0.0/16")],
-                destinations6: vec![],
-            },
         ]
     }
 
     #[test]
-    fn a_shown_config_round_trips_through_yaml_back_into_the_original_rules() {
-        let rules = sample_rules();
+    fn test_shown_config_round_trips_into_the_update_request() {
+        let shown = forwardpb::ShowConfigResponse {
+            name: "forward0".to_string(),
+            rules: sample_rules(),
+        };
 
-        let config = ForwardConfig::try_from(rules.clone()).expect("pb rules must convert into a forward config");
-        let yaml = serde_yaml::to_string(&config).expect("forward config must serialize");
-        let parsed: ForwardConfig = serde_yaml::from_str(&yaml).expect("forward config must deserialize");
-        let reconstructed: Vec<forwardpb::Rule> = parsed.try_into().expect("forward config must convert back");
+        let yaml = serde_yaml::to_string(&shown).expect("shown config must serialize");
+        let parsed: UpdateConfigRequest = serde_yaml::from_str(&yaml).expect("shown config must parse back");
 
-        assert_eq!(rules, reconstructed);
+        assert_eq!(shown.name, parsed.name);
+        assert_eq!(shown.rules, parsed.rules);
     }
 
     #[test]
-    fn a_rule_file_accepts_the_full_mode_vocabulary() {
-        let uppercase = r#"
-rules:
-  - target: "t1"
-    mode: "NONE"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    srcs: []
-    dsts: []
-  - target: "t2"
-    mode: "IN"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    srcs: []
-    dsts: []
-  - target: "t3"
-    mode: "OUT"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    srcs: []
-    dsts: []
-"#;
-        let legacy = r#"
-rules:
-  - target: "t1"
-    mode: "None"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    srcs: []
-    dsts: []
-  - target: "t2"
-    mode: "In"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    srcs: []
-    dsts: []
-  - target: "t3"
-    mode: "Out"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    srcs: []
-    dsts: []
-"#;
-
-        for yaml in [uppercase, legacy] {
-            let config: ForwardConfig = serde_yaml::from_str(yaml).expect("mode spellings must parse");
-            assert!(matches!(config.rules[0].mode, ModeKind::None));
-            assert!(matches!(config.rules[1].mode, ModeKind::In));
-            assert!(matches!(config.rules[2].mode, ModeKind::Out));
-        }
-    }
-
-    #[test]
-    fn mixed_family_networks_partition_by_family_preserving_order() {
+    fn test_file_fields_default_when_omitted() {
         let yaml = r#"
 rules:
-  - target: "t"
-    mode: "NONE"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    srcs:
-      - 2001:db8::/32
-      - 192.0.2.0/24
-      - 10.0.0.0/8
-    dsts: []
+  - action:
+      target: "01:00.0"
+      mode: OUT
+      counter: recirc
+    devices:
+      - name: "01:00.0"
+    sources4:
+      - "0.0.0.0/0"
 "#;
 
-        let config: ForwardConfig = serde_yaml::from_str(yaml).expect("mixed families must parse");
-        let rules: Vec<forwardpb::Rule> = config.try_into().expect("mixed families must convert");
+        let parsed: UpdateConfigRequest = serde_yaml::from_str(yaml).expect("a sparse file must parse");
 
-        assert_eq!(vec![v4_net("192.0.2.0/24"), v4_net("10.0.0.0/8")], rules[0].sources4);
-        assert_eq!(vec![v6_net("2001:db8::/32")], rules[0].sources6);
+        assert_eq!("", parsed.name);
+        assert_eq!(
+            forwardpb::ForwardMode::Out as i32,
+            parsed.rules[0].action.as_ref().expect("action").mode
+        );
+        assert!(parsed.rules[0].vlan_ranges.is_empty());
+        assert!(parsed.rules[0].sources6.is_empty());
     }
 
     #[test]
-    fn a_bi_contiguous_v6_mask_round_trips_through_the_rule_file() {
-        let rule = forwardpb::Rule {
-            action: Some(forwardpb::Action {
-                target: "t".to_string(),
-                mode: forwardpb::ForwardMode::None as i32,
-                counter: "c".to_string(),
-            }),
-            devices: vec![],
-            vlan_ranges: vec![],
-            sources4: vec![],
-            // The mask hole sits exactly at the /64 boundary, which the
-            // filter compiler accepts.
-            sources6: vec![v6_net("2001:db8::/ffff:ffff:ffff:0:ffff::")],
-            destinations4: vec![],
-            destinations6: vec![],
-        };
+    fn test_file_rejects_an_unknown_key() {
+        let yaml = "rules:\n  - action:\n      target: t\n    srcs: []\n";
 
-        let config = ForwardConfig::try_from(vec![rule.clone()]).expect("a bi-contiguous v6 network must render");
-        let yaml = serde_yaml::to_string(&config).expect("forward config must serialize");
-        let parsed: ForwardConfig = serde_yaml::from_str(&yaml).expect("forward config must deserialize");
-        let rebuilt: Vec<forwardpb::Rule> = parsed.try_into().expect("forward config must convert back");
+        let parsed: Result<UpdateConfigRequest, _> = serde_yaml::from_str(yaml);
 
-        assert_eq!(vec![rule], rebuilt);
+        assert!(
+            parsed
+                .expect_err("the legacy srcs key must be refused")
+                .to_string()
+                .contains("srcs")
+        );
     }
 
     #[test]
-    fn an_unrecognised_mode_number_is_shown_but_rejected_by_update() {
-        let rule = forwardpb::Rule {
-            action: Some(forwardpb::Action {
-                target: "t".to_string(),
-                mode: 99,
-                counter: String::new(),
-            }),
-            devices: vec![],
-            vlan_ranges: vec![],
-            sources4: vec![],
-            sources6: vec![],
-            destinations4: vec![],
-            destinations6: vec![],
+    fn test_mode_serializes_by_name_and_an_undeclared_number_as_is() {
+        let declared = forwardpb::Action {
+            target: "t".to_string(),
+            mode: forwardpb::ForwardMode::Out as i32,
+            counter: String::new(),
         };
+        let undeclared = forwardpb::Action { mode: 99, ..declared.clone() };
 
-        let config = ForwardConfig::try_from(vec![rule]).expect("an unrecognised mode must not blank the show");
-        assert!(serde_yaml::to_string(&config).is_ok());
+        assert!(
+            serde_yaml::to_string(&declared)
+                .expect("must serialize")
+                .contains("mode: OUT")
+        );
+        assert!(
+            serde_yaml::to_string(&undeclared)
+                .expect("must serialize")
+                .contains("mode: 99")
+        );
+    }
 
-        let rebuilt: Result<Vec<forwardpb::Rule>, _> = config.try_into();
-        assert!(rebuilt.is_err());
+    #[test]
+    fn test_mode_parses_a_name_or_a_number_and_refuses_an_unknown_name() {
+        let by_name: forwardpb::Action = serde_yaml::from_str("mode: IN\n").expect("a declared name must parse");
+        let by_number: forwardpb::Action = serde_yaml::from_str("mode: 99\n").expect("a raw number must parse");
+        let unknown: Result<forwardpb::Action, _> = serde_yaml::from_str("mode: BOGUS\n");
+
+        assert_eq!(forwardpb::ForwardMode::In as i32, by_name.mode);
+        assert_eq!(99, by_number.mode);
+        assert!(
+            unknown
+                .expect_err("an undeclared name must be refused")
+                .to_string()
+                .contains("BOGUS")
+        );
+    }
+
+    #[test]
+    fn test_bind_request_name_fills_checks_and_refuses() {
+        let mut nameless = UpdateConfigRequest::default();
+        bind_request_name(&mut nameless, "forward0").expect("an empty name must bind");
+        assert_eq!("forward0", nameless.name);
+
+        let mut matching = UpdateConfigRequest {
+            name: "forward0".to_string(),
+            ..Default::default()
+        };
+        bind_request_name(&mut matching, "forward0").expect("a matching name must pass");
+
+        let mut mismatched = UpdateConfigRequest {
+            name: "other".to_string(),
+            ..Default::default()
+        };
+        let err = bind_request_name(&mut mismatched, "forward0").expect_err("a mismatch must be refused");
+        assert!(err.contains("other"));
+        assert!(err.contains("forward0"));
     }
 }

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -94,10 +94,10 @@ fn serialize_forward_mode<S: Serializer>(mode: &i32, serializer: S) -> Result<S:
     }
 }
 
-/// Deserializes a forward mode from its declared name or a raw number.
+/// Deserializes a forward mode from its declared name or number.
 ///
-/// An undeclared number passes through for the service to judge, an
-/// undeclared name is refused.
+/// An undeclared value is refused here, because the service would
+/// silently coerce it to NONE rather than reject it.
 fn deserialize_forward_mode<'de, D: Deserializer<'de>>(deserializer: D) -> Result<i32, D::Error> {
     #[derive(Deserialize)]
     #[serde(untagged)]
@@ -107,7 +107,9 @@ fn deserialize_forward_mode<'de, D: Deserializer<'de>>(deserializer: D) -> Resul
     }
 
     match NameOrNumber::deserialize(deserializer)? {
-        NameOrNumber::Number(mode) => Ok(mode),
+        NameOrNumber::Number(mode) => forwardpb::ForwardMode::try_from(mode)
+            .map(|mode| mode as i32)
+            .map_err(|_| serde::de::Error::custom(format!("unknown forward mode {mode}"))),
         NameOrNumber::Name(name) => forwardpb::ForwardMode::from_str_name(&name)
             .map(|mode| mode as i32)
             .ok_or_else(|| serde::de::Error::custom(format!("unknown forward mode {name:?}"))),
@@ -115,12 +117,17 @@ fn deserialize_forward_mode<'de, D: Deserializer<'de>>(deserializer: D) -> Resul
 }
 
 /// Loads the update request from its YAML file.
+///
+/// Merge keys are expanded first, so a document shared with the generic
+/// operator may reuse a rule through an anchor and `<<`.
 fn load_request<P>(path: P) -> Result<UpdateConfigRequest, Box<dyn core::error::Error>>
 where
     P: AsRef<Path>,
 {
     let file = File::open(path)?;
-    Ok(serde_yaml::from_reader(file)?)
+    let mut value: serde_yaml::Value = serde_yaml::from_reader(file)?;
+    value.apply_merge()?;
+    Ok(serde_yaml::from_value(value)?)
 }
 
 /// Binds the config name into a loaded request, refusing a file that names
@@ -171,18 +178,19 @@ impl ForwardService {
         output::data(
             || &response,
             || {
+                // The document is printed even without rules, so a
+                // redirected show always yields a file update accepts.
+                print!(
+                    "{}",
+                    serde_yaml::to_string(&response).expect("forward config YAML serialization must not fail")
+                );
+
                 if response.rules.is_empty() {
                     output::empty_with_hint(
                         format_args!("No forward rules found for '{}'.", cmd.config_name),
                         format_args!("create one with 'yanet-cli-forward update --name <name> --file <path>'"),
                     );
-                    return;
                 }
-
-                print!(
-                    "{}",
-                    serde_yaml::to_string(&response).expect("forward config YAML serialization must not fail")
-                );
             },
         );
 
@@ -418,19 +426,57 @@ rules:
     }
 
     #[test]
-    fn test_mode_parses_a_name_or_a_number_and_refuses_an_unknown_name() {
+    fn test_mode_parses_a_declared_name_or_number_and_refuses_the_rest() {
         let by_name: forwardpb::Action = serde_yaml::from_str("mode: IN\n").expect("a declared name must parse");
-        let by_number: forwardpb::Action = serde_yaml::from_str("mode: 99\n").expect("a raw number must parse");
-        let unknown: Result<forwardpb::Action, _> = serde_yaml::from_str("mode: BOGUS\n");
+        let by_number: forwardpb::Action = serde_yaml::from_str("mode: 2\n").expect("a declared number must parse");
+        let unknown_name: Result<forwardpb::Action, _> = serde_yaml::from_str("mode: BOGUS\n");
+        let unknown_number: Result<forwardpb::Action, _> = serde_yaml::from_str("mode: 99\n");
 
         assert_eq!(forwardpb::ForwardMode::In as i32, by_name.mode);
-        assert_eq!(99, by_number.mode);
+        assert_eq!(forwardpb::ForwardMode::Out as i32, by_number.mode);
         assert!(
-            unknown
+            unknown_name
                 .expect_err("an undeclared name must be refused")
                 .to_string()
                 .contains("BOGUS")
         );
+        assert!(
+            unknown_number
+                .expect_err("an undeclared number must be refused")
+                .to_string()
+                .contains("99")
+        );
+    }
+
+    #[test]
+    fn test_file_expands_merge_keys() {
+        let yaml = r#"
+rules:
+  - &base
+    action:
+      target: base
+      mode: OUT
+      counter: base
+    vlan_ranges:
+      - from: 0
+        to: 100
+  - <<: *base
+    devices:
+      - name: eth0
+"#;
+        let path = std::env::temp_dir().join(format!("fwd-merge-{}.yaml", std::process::id()));
+        std::fs::write(&path, yaml).expect("the fixture must be written");
+
+        let request = load_request(&path).expect("a merged document must load");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(2, request.rules.len());
+        assert_eq!("base", request.rules[1].action.as_ref().expect("merged action").target);
+        assert_eq!(
+            vec![filterpb::pb::Device { name: "eth0".to_string() }],
+            request.rules[1].devices
+        );
+        assert_eq!(request.rules[0].vlan_ranges, request.rules[1].vlan_ranges);
     }
 
     #[test]

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -92,7 +92,8 @@ fn serialize_forward_mode<S: Serializer>(mode: &i32, serializer: S) -> Result<S:
     }
 }
 
-/// Deserializes a forward mode from its declared name or number.
+/// Deserializes a forward mode from its declared name or number, a null
+/// as NONE.
 ///
 /// An undeclared value is refused here, because the service would
 /// silently coerce it to NONE rather than reject it.
@@ -104,14 +105,25 @@ fn deserialize_forward_mode<'de, D: Deserializer<'de>>(deserializer: D) -> Resul
         Name(String),
     }
 
-    match NameOrNumber::deserialize(deserializer)? {
-        NameOrNumber::Number(mode) => forwardpb::ForwardMode::try_from(mode)
+    match Option::<NameOrNumber>::deserialize(deserializer)? {
+        None => Ok(forwardpb::ForwardMode::None as i32),
+        Some(NameOrNumber::Number(mode)) => forwardpb::ForwardMode::try_from(mode)
             .map(|mode| mode as i32)
             .map_err(|_| serde::de::Error::custom(format!("unknown forward mode {mode}"))),
-        NameOrNumber::Name(name) => forwardpb::ForwardMode::from_str_name(&name)
+        Some(NameOrNumber::Name(name)) => forwardpb::ForwardMode::from_str_name(&name)
             .map(|mode| mode as i32)
             .ok_or_else(|| serde::de::Error::custom(format!("unknown forward mode {name:?}"))),
     }
+}
+
+/// Deserializes a null as the field's zero value, as the operator's YAML
+/// decoder reads it.
+fn null_as_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 /// Loads the update request from its YAML file.
@@ -140,27 +152,7 @@ where
         Some(value) => value,
     };
     value.apply_merge()?;
-    strip_null_fields(&mut value);
     Ok(serde_yaml::from_value(value)?)
-}
-
-/// Removes null-valued mapping entries, so a spelled null reads as the
-/// field's zero value, as the operator reads it.
-fn strip_null_fields(value: &mut serde_yaml::Value) {
-    match value {
-        serde_yaml::Value::Mapping(mapping) => {
-            mapping.retain(|_, entry| !entry.is_null());
-            for (_, entry) in mapping.iter_mut() {
-                strip_null_fields(entry);
-            }
-        }
-        serde_yaml::Value::Sequence(sequence) => {
-            for entry in sequence.iter_mut() {
-                strip_null_fields(entry);
-            }
-        }
-        _ => {}
-    }
 }
 
 /// Binds the config name into a loaded request, refusing a file that names
@@ -273,9 +265,7 @@ impl ForwardService {
         Ok(())
     }
 
-    pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let mut request = load_request(&cmd.file).map_err(|e| self.service.invalid("update", e.to_string()))?;
-        bind_request_name(&mut request, &cmd.config).map_err(|e| self.service.invalid("update", e))?;
+    pub async fn update_config(&mut self, cmd: UpdateCmd, request: UpdateConfigRequest) -> Result<(), Error> {
         self.service
             .client()
             .update_config(request)
@@ -289,11 +279,29 @@ impl ForwardService {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
+    // The update file is read and bound before the connection, so bad
+    // local input fails deterministically with or without a reachable
+    // gateway.
+    let update = match &cmd.mode {
+        ModeCmd::Update(update) => {
+            let endpoint = cmd.connection.endpoint.as_str();
+            let mut request =
+                load_request(&update.file).map_err(|e| Error::invalid_argument("update", endpoint, e.to_string()))?;
+            bind_request_name(&mut request, &update.config)
+                .map_err(|e| Error::invalid_argument("update", endpoint, e))?;
+            Some(request)
+        }
+        _ => None,
+    };
+
     let mut service = ForwardService::new(&cmd.connection).await?;
 
     match cmd.mode {
         ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
-        ModeCmd::Update(cmd) => service.update_config(cmd).await,
+        ModeCmd::Update(cmd) => {
+            let request = update.expect("prepared for the update mode");
+            service.update_config(cmd, request).await
+        }
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
         ModeCmd::List => service.list_configs().await,
     }
@@ -507,6 +515,18 @@ rules:
                 .to_string()
                 .contains("mtu")
         );
+    }
+
+    #[test]
+    fn test_unknown_null_valued_keys_are_still_refused() {
+        let yaml = "rulez: null\n";
+        let path = std::env::temp_dir().join(format!("fwd-nullkey-{}.yaml", std::process::id()));
+        std::fs::write(&path, yaml).expect("the fixture must be written");
+
+        let refused = load_request(&path).expect_err("a misspelled null-valued key must be refused");
+        std::fs::remove_file(&path).ok();
+
+        assert!(refused.to_string().contains("rulez"));
     }
 
     #[test]

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs::File,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::{
@@ -119,13 +116,20 @@ fn deserialize_forward_mode<'de, D: Deserializer<'de>>(deserializer: D) -> Resul
 /// Loads the update request from its YAML file.
 ///
 /// Merge keys are expanded first, so a document shared with the generic
-/// operator may reuse a rule through an anchor and `<<`.
+/// operator may reuse a rule through an anchor and `<<`, and an empty
+/// document is the zero request, as the operator reads it.
 fn load_request<P>(path: P) -> Result<UpdateConfigRequest, Box<dyn core::error::Error>>
 where
     P: AsRef<Path>,
 {
-    let file = File::open(path)?;
-    let mut value: serde_yaml::Value = serde_yaml::from_reader(file)?;
+    let content = std::fs::read_to_string(path)?;
+    if content.trim().is_empty() {
+        return Ok(UpdateConfigRequest::default());
+    }
+    let mut value: serde_yaml::Value = serde_yaml::from_str(&content)?;
+    if value.is_null() {
+        return Ok(UpdateConfigRequest::default());
+    }
     value.apply_merge()?;
     Ok(serde_yaml::from_value(value)?)
 }
@@ -445,6 +449,48 @@ rules:
                 .expect_err("an undeclared number must be refused")
                 .to_string()
                 .contains("99")
+        );
+    }
+
+    #[test]
+    fn test_empty_and_comment_only_files_are_the_zero_request() {
+        for content in ["", "# nothing yet\n"] {
+            let path = std::env::temp_dir().join(format!("fwd-empty-{}-{}.yaml", std::process::id(), content.len()));
+            std::fs::write(&path, content).expect("the fixture must be written");
+
+            let request = load_request(&path).expect("an empty document must load");
+            std::fs::remove_file(&path).ok();
+
+            assert_eq!(UpdateConfigRequest::default(), request);
+        }
+    }
+
+    #[test]
+    fn test_extern_messages_default_and_refuse_unknown_keys() {
+        let sparse: forwardpb::Rule =
+            serde_yaml::from_str("vlan_ranges:\n  - {}\n").expect("an empty vlan range must default");
+        let unknown: Result<forwardpb::Rule, _> = serde_yaml::from_str("devices:\n  - name: eth0\n    mtu: 9000\n");
+
+        assert_eq!(vec![filterpb::pb::VlanRange { from: 0, to: 0 }], sparse.vlan_ranges);
+        assert!(
+            unknown
+                .expect_err("an unknown device key must be refused")
+                .to_string()
+                .contains("mtu")
+        );
+    }
+
+    #[test]
+    fn test_file_rejects_duplicate_keys() {
+        let yaml = "rules:\n  - action:\n      target: t\n      mode: OUT\n      mode: NONE\n";
+
+        let parsed: Result<serde_yaml::Value, _> = serde_yaml::from_str(yaml);
+
+        assert!(
+            parsed
+                .expect_err("a duplicate mapping key must be refused")
+                .to_string()
+                .contains("duplicate")
         );
     }
 

--- a/scripts/setup-example.sh
+++ b/scripts/setup-example.sh
@@ -11,7 +11,7 @@ cd -P -- "$script_dir"
 script_dir=$PWD
 repo_root=${script_dir%/scripts}
 
-yanet-cli-forward update --name=forward0 --rules "$repo_root/forward.yaml"
+yanet-cli-forward update --name=forward0 --file "$repo_root/forward.yaml"
 
 yanet-cli-pipeline update --name=dummy --functions
 

--- a/scripts/setup-example.sh
+++ b/scripts/setup-example.sh
@@ -11,7 +11,7 @@ cd -P -- "$script_dir"
 script_dir=$PWD
 repo_root=${script_dir%/scripts}
 
-yanet-cli-forward update --name=forward0 --file "$repo_root/forward.yaml"
+yanet-cli-forward update --name=forward0 "$repo_root/forward.yaml"
 
 yanet-cli-pipeline update --name=dummy --functions
 

--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -156,7 +156,7 @@ func (f *TestFramework) CommonConfigCommands() []string {
 		"ip addr replace " + VMIPv4Host + "/24 dev kni0",
 
 		// Configure L2 and L3 forwarding
-		p.CLI("yanet-cli-forward") + " update --name=forward0 --file " + p.ForwardYAML,
+		p.CLI("yanet-cli-forward") + " update --name=forward0 " + p.ForwardYAML,
 
 		// Bootstrap the default IPv4/IPv6 FIB for the "route0" config.
 		p.CLI("yanet-cli-route") + " fib update --name=route0 --rules " + p.ConfigDir + "/route0.yaml",

--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -156,7 +156,7 @@ func (f *TestFramework) CommonConfigCommands() []string {
 		"ip addr replace " + VMIPv4Host + "/24 dev kni0",
 
 		// Configure L2 and L3 forwarding
-		p.CLI("yanet-cli-forward") + " update --name=forward0 --rules " + p.ForwardYAML,
+		p.CLI("yanet-cli-forward") + " update --name=forward0 --file " + p.ForwardYAML,
 
 		// Bootstrap the default IPv4/IPv6 FIB for the "route0" config.
 		p.CLI("yanet-cli-route") + " fib update --name=route0 --rules " + p.ConfigDir + "/route0.yaml",

--- a/tests/functional/framework/harness.go
+++ b/tests/functional/framework/harness.go
@@ -168,55 +168,59 @@ devices:
 func DefaultForwardConfig() string {
 	return `
 rules:
-  - target: virtio_user_kni0
-    counter: to_virtio_user_kni0
+  - action:
+      target: virtio_user_kni0
+      mode: OUT
+      counter: to_virtio_user_kni0
+    devices:
+      - name: 01:00.0
     vlan_ranges:
       - from: 0
         to: 4095
-    srcs:
+    sources4:
       - "0.0.0.0/0"
+    sources6:
       - "::/0"
-    dsts:
+    destinations4:
       - ` + VMIPv4Host + `/32
+    destinations6:
       - ` + VMIPv6Host + `/64
       - "ff02::0/16"
-    mode: Out
+  - action:
+      target: 01:00.0
+      mode: NONE
+      counter: to_pass
     devices:
-      - 01:00.0
-  - target: 01:00.0
-    counter: to_pass
+      - name: 01:00.0
     vlan_ranges:
       - from: 0
         to: 4095
-    srcs:
+    sources4:
       - "0.0.0.0/0"
+    sources6:
       - "::/0"
-    dsts:
+    destinations4:
       - "0.0.0.0/0"
+    destinations6:
       - "::/0"
-    mode: None
+  - action:
+      target: virtio_user_kni0
+      mode: OUT
+      counter: to_virtio_user_kni0
     devices:
-      - 01:00.0
-  - target: virtio_user_kni0
-    counter: to_virtio_user_kni0
+      - name: 01:00.0
     vlan_ranges:
       - from: 0
         to: 4095
-    srcs:
-    dsts:
-    mode: Out
+  - action:
+      target: 01:00.0
+      mode: OUT
+      counter: to_01:00.0
     devices:
-      - 01:00.0
-  - target: 01:00.0
-    counter: to_01:00.0
+      - name: virtio_user_kni0
     vlan_ranges:
       - from: 0
         to: 4095
-    srcs:
-    dsts:
-    mode: Out
-    devices:
-      - virtio_user_kni0
 `
 }
 

--- a/tests/functional/main/forward_test.go
+++ b/tests/functional/main/forward_test.go
@@ -307,24 +307,25 @@ func Test_PacketRecircLimit_FromDataplaneConfig(t *testing.T) {
 		const device = "01:00.0"
 		require.NoError(t, testFramework.CreateConfigFile("recirc-forward.yaml", `
 rules:
-  - target: "01:00.0"
-    mode: OUT
-    counter: recirc
+  - action:
+      target: "01:00.0"
+      mode: OUT
+      counter: recirc
     devices:
-      - "01:00.0"
+      - name: "01:00.0"
     vlan_ranges:
       - from: 0
         to: 4095
-    srcs:
+    sources4:
       - "0.0.0.0/0"
-    dsts:
+    destinations4:
       - "0.0.0.0/0"
 `))
 
 		paths := testFramework.Paths
 		_, err := testFramework.ExecuteCommands(
 			paths.CLI("yanet-cli-forward")+
-				" update --name=recirc --rules "+
+				" update --name=recirc --file "+
 				"/mnt/config/recirc-forward.yaml",
 			paths.CLI("yanet-cli-function")+
 				" update --name=recirc --chains recirc:1=forward:recirc",

--- a/tests/functional/main/forward_test.go
+++ b/tests/functional/main/forward_test.go
@@ -325,7 +325,7 @@ rules:
 		paths := testFramework.Paths
 		_, err := testFramework.ExecuteCommands(
 			paths.CLI("yanet-cli-forward")+
-				" update --name=recirc --file "+
+				" update --name=recirc "+
 				"/mnt/config/recirc-forward.yaml",
 			paths.CLI("yanet-cli-function")+
 				" update --name=recirc --chains recirc:1=forward:recirc",

--- a/tests/packaging/packaging_test.go
+++ b/tests/packaging/packaging_test.go
@@ -252,7 +252,7 @@ func Test_SetupExampleUsesSourceTreeForwardFlow(t *testing.T) {
 	recorded, err := os.ReadFile(logPath)
 	require.NoError(t, err)
 	expected := strings.Join([]string{
-		"yanet-cli-forward\tupdate\t--name=forward0\t--file\t" + resolvedForwardPath,
+		"yanet-cli-forward\tupdate\t--name=forward0\t" + resolvedForwardPath,
 		"yanet-cli-pipeline\tupdate\t--name=dummy\t--functions",
 		"yanet-cli-function\tupdate\t--name=virt\t--chains\tchain0:10=forward:forward0",
 		"yanet-cli-pipeline\tupdate\t--name=virt\t--functions\tvirt",

--- a/tests/packaging/packaging_test.go
+++ b/tests/packaging/packaging_test.go
@@ -252,7 +252,7 @@ func Test_SetupExampleUsesSourceTreeForwardFlow(t *testing.T) {
 	recorded, err := os.ReadFile(logPath)
 	require.NoError(t, err)
 	expected := strings.Join([]string{
-		"yanet-cli-forward\tupdate\t--name=forward0\t--rules\t" + resolvedForwardPath,
+		"yanet-cli-forward\tupdate\t--name=forward0\t--file\t" + resolvedForwardPath,
 		"yanet-cli-pipeline\tupdate\t--name=dummy\t--functions",
 		"yanet-cli-function\tupdate\t--name=virt\t--chains\tchain0:10=forward:forward0",
 		"yanet-cli-pipeline\tupdate\t--name=virt\t--functions\tvirt",


### PR DESCRIPTION
- Read the update file as the wire `UpdateConfigRequest` in YAML — the same document the generic operator pushes and `show` now prints — and delete the mirror rule schema.
- Take the update document as the command's positional argument (`update -n <name> <path>`), retiring `--rules` without an alias and amending the CLI dictionary's positional rule.
- Validate the file before connecting, bind `--name` into a file that omits its own name and refuse one naming another config.
- Match the operator's reading edge for edge: declared mode names or numbers, nulls as zero values, merge-key expansion, empty documents as the zero request, tolerated bare separators, defaults and unknown-key refusal on the shared filterpb messages.
- Convert the example `forward.yaml`, the functional baseline and fixture, and drop the CLI's unused dependencies.