### PR TITLE
feat(forward,web)!: move the yaml import and export to the wire request form

### DIFF
--- a/modules/forward/web/SaveDiffModal.tsx
+++ b/modules/forward/web/SaveDiffModal.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
-import type { ForwardMode, Rule } from '@yanet/core/api/forward';
-import { declaredForwardMode } from '@yanet/core/api/forward';
+import type { Rule } from '@yanet/core/api/forward';
+import { ForwardMode, declaredForwardMode } from '@yanet/core/api/forward';
 import { dumpYamlDoc } from '@yanet/core/utils';
 import { SaveDiffModal as SharedSaveDiffModal } from '@yanet/core/components';
 import { effectiveCounterName } from './hooks';
@@ -8,9 +8,12 @@ import { effectiveCounterName } from './hooks';
 /**
  * Formats a mode as its declared name, an undeclared number as is, so one
  * rule from a newer module cannot hide the rest of a configuration.
+ *
+ * An absent mode is the zero value NONE, which the gateway omits from its
+ * JSON.
  */
 const formatForwardMode = (mode: ForwardMode | number | undefined): ForwardMode | number => {
-    return declaredForwardMode(mode) ?? (typeof mode === 'number' ? mode : 0);
+    return declaredForwardMode(mode) ?? (typeof mode === 'number' ? mode : ForwardMode.NONE);
 };
 
 /**

--- a/modules/forward/web/SaveDiffModal.tsx
+++ b/modules/forward/web/SaveDiffModal.tsx
@@ -1,12 +1,21 @@
 import React, { useMemo } from 'react';
-import type { Rule } from '@yanet/core/api/forward';
-import { FORWARD_MODE_LABELS, parseForwardMode } from '@yanet/core/api/forward';
+import type { ForwardMode, Rule } from '@yanet/core/api/forward';
+import { declaredForwardMode } from '@yanet/core/api/forward';
 import { dumpYamlDoc } from '@yanet/core/utils';
 import { SaveDiffModal as SharedSaveDiffModal } from '@yanet/core/components';
 import { effectiveCounterName } from './hooks';
 
 /**
- * Serialize a rules array into the canonical YAML schema.
+ * Formats a mode as its declared name, an undeclared number as is, so one
+ * rule from a newer module cannot hide the rest of a configuration.
+ */
+const formatForwardMode = (mode: ForwardMode | number | undefined): ForwardMode | number => {
+    return declaredForwardMode(mode) ?? (typeof mode === 'number' ? mode : 0);
+};
+
+/**
+ * Serialize a rules array into the wire request YAML: the document the
+ * generic operator pushes and `yanet-cli-forward update` accepts.
  *
  * The `counter` key mirrors the raw stored value by default. Pass
  * `showEffectiveCounter` to emit the name the server would use instead
@@ -14,36 +23,40 @@ import { effectiveCounterName } from './hooks';
  */
 export const rulesToDiffYaml = (rules: Rule[], showEffectiveCounter = false): string => {
     const yamlRules = rules.map((r) => {
-        const devices = (r.devices ?? []).map(d => d.name ?? '').filter(Boolean);
-        const srcs = [...(r.sources4 ?? []), ...(r.sources6 ?? [])];
-        const dsts = [...(r.destinations4 ?? []), ...(r.destinations6 ?? [])];
+        const target = r.action?.target ?? '';
+        const action: Record<string, unknown> = {
+            target,
+            mode: formatForwardMode(r.action?.mode),
+        };
+        if (showEffectiveCounter) {
+            action['counter'] = effectiveCounterName(r.action?.counter ?? '', target);
+        } else if (r.action?.counter) {
+            action['counter'] = r.action.counter;
+        }
+
+        const entry: Record<string, unknown> = { action };
+        const devices = (r.devices ?? []).map(d => ({ name: d.name ?? '' }));
+        if (devices.length > 0) {
+            entry['devices'] = devices;
+        }
         const vlan_ranges = (r.vlan_ranges ?? []).map(vr => ({
             from: vr.from ?? 0,
             to: vr.to ?? 0,
         }));
-
-        const target = r.action?.target ?? '';
-        const entry: Record<string, unknown> = {
-            target,
-        };
-        if (showEffectiveCounter) {
-            entry['counter'] = effectiveCounterName(r.action?.counter ?? '', target);
-        } else if (r.action?.counter) {
-            entry['counter'] = r.action.counter;
-        }
         if (vlan_ranges.length > 0) {
             entry['vlan_ranges'] = vlan_ranges;
         }
-        if (srcs.length > 0) {
-            entry['srcs'] = srcs;
+        const networkLists = [
+            ['sources4', r.sources4],
+            ['sources6', r.sources6],
+            ['destinations4', r.destinations4],
+            ['destinations6', r.destinations6],
+        ] as const;
+        for (const [key, list] of networkLists) {
+            if (list && list.length > 0) {
+                entry[key] = list;
+            }
         }
-        if (dsts.length > 0) {
-            entry['dsts'] = dsts;
-        }
-        if (devices.length > 0) {
-            entry['devices'] = devices;
-        }
-        entry['mode'] = FORWARD_MODE_LABELS[parseForwardMode(r.action?.mode)];
 
         return entry;
     });

--- a/modules/forward/web/YamlIO.test.ts
+++ b/modules/forward/web/YamlIO.test.ts
@@ -24,8 +24,8 @@ const sampleRules = (): Rule[] => [
     },
 ];
 
-describe('parseYamlToRules', () => {
-    it('parses the wire document the operator and the CLI speak', () => {
+describe('importing a wire rules document', () => {
+    it('parses the document the operator and the CLI speak', () => {
         const text = [
             'name: forward0',
             'rules:',
@@ -71,8 +71,11 @@ describe('parseYamlToRules', () => {
         expect(() => parseYamlToRules(text)).toThrow(/retired flat schema/);
     });
 
-    it('refuses an unknown key and an undeclared mode', () => {
+    it('refuses an unknown top-level key', () => {
         expect(() => parseYamlToRules('rulez: []\n')).toThrow(/Unknown key "rulez"/);
+    });
+
+    it('refuses an undeclared mode name, number and inherited object key', () => {
         expect(() => parseYamlToRules('rules:\n  - action:\n      mode: BOGUS\n')).toThrow(/unknown forward mode/);
         expect(() => parseYamlToRules('rules:\n  - action:\n      mode: 99\n')).toThrow(/unknown forward mode/);
         expect(() => parseYamlToRules('rules:\n  - action:\n      mode: toString\n')).toThrow(/unknown forward mode/);
@@ -96,46 +99,60 @@ describe('parseYamlToRules', () => {
         expect(parsed.rules).toEqual(rules);
     });
 
-    it('refuses a non-string config name and a rule without an action', () => {
+    it('accepts bare host networks as the wire decoders do', () => {
+        const text = 'rules:\n  - action:\n      target: t\n    sources4:\n      - 192.0.2.1\n    sources6:\n      - 2001:db8::1\n';
+
+        const parsed = parseYamlToRules(text);
+
+        expect(parsed.rules[0].sources4).toEqual(['192.0.2.1']);
+        expect(parsed.rules[0].sources6).toEqual(['2001:db8::1']);
+    });
+
+    it('refuses a network of the wrong family', () => {
+        const text = 'rules:\n  - action:\n      target: t\n    sources4:\n      - fe80::/10\n';
+
+        expect(() => parseYamlToRules(text)).toThrow(/sources4 entry "fe80::\/10"/);
+    });
+
+    it('refuses a padded prefix length the wire parser rejects', () => {
+        const text = 'rules:\n  - action:\n      target: t\n    sources4:\n      - 10.0.0.0/024\n';
+
+        expect(() => parseYamlToRules(text)).toThrow(/sources4 entry "10.0.0.0\/024"/);
+    });
+
+    it('refuses a non-string config name', () => {
         expect(() => parseYamlToRules('name: 123\nrules: []\n')).toThrow(/"name" to be a string/);
+    });
+
+    it('refuses a rule without an action', () => {
         expect(() => parseYamlToRules('rules:\n  - devices: []\n')).toThrow(/"action" is required/);
         expect(() => parseYamlToRules('rules:\n  - action: null\n')).toThrow(/"action" is required/);
     });
 
-    it('refuses a scalar document, a sequence action and a mistyped vlan bound', () => {
-        expect(() => parseYamlToRules('2026-08-31\n')).toThrow(/Expected a YAML object/);
+    it('refuses a sequence where the action mapping is required', () => {
         expect(() => parseYamlToRules('rules:\n  - action: []\n')).toThrow(/"action" is required/);
+    });
+
+    it('refuses a scalar document, such as a bare timestamp', () => {
+        expect(() => parseYamlToRules('2026-08-31\n')).toThrow(/Expected a YAML object/);
+    });
+
+    it('refuses a non-string action target', () => {
+        expect(() => parseYamlToRules('rules:\n  - action:\n      target: 123\n')).toThrow(/"target" to be a string/);
+    });
+
+    it('refuses a vlan bound that is not an unsigned integer', () => {
         expect(() =>
             parseYamlToRules("rules:\n  - action:\n      target: t\n    vlan_ranges:\n      - from: '100'\n"),
         ).toThrow(/unsigned integer/);
     });
 
-    it('accepts bare host networks and null vlan bounds as zero', () => {
-        const text = [
-            'rules:',
-            '  - action:',
-            '      target: t',
-            '    vlan_ranges:',
-            '      - from: null',
-            '        to: 100',
-            '    sources4:',
-            '      - 192.0.2.1',
-            '    sources6:',
-            '      - 2001:db8::1',
-        ].join('\n');
+    it('reads null vlan bounds as zero', () => {
+        const text = 'rules:\n  - action:\n      target: t\n    vlan_ranges:\n      - from: null\n        to: 100\n';
 
         const parsed = parseYamlToRules(text);
 
         expect(parsed.rules[0].vlan_ranges).toEqual([{ from: 0, to: 100 }]);
-        expect(parsed.rules[0].sources4).toEqual(['192.0.2.1']);
-        expect(parsed.rules[0].sources6).toEqual(['2001:db8::1']);
-    });
-
-    it('tolerates a bare trailing separator but not a second document', () => {
-        const parsed = parseYamlToRules('name: forward0\nrules: []\n---\n');
-        expect(parsed.name).toBe('forward0');
-
-        expect(() => parseYamlToRules('rules: []\n---\nrules: []\n')).toThrow(/more than one document/);
     });
 
     it('accepts a declared numeric mode and null fields as zero values', () => {
@@ -148,30 +165,37 @@ describe('parseYamlToRules', () => {
         expect(parsed.rules[0].sources4).toEqual([]);
     });
 
-    it('refuses a network of the wrong family', () => {
-        const text = 'rules:\n  - action:\n      target: eth0\n      mode: OUT\n    sources4:\n      - fe80::/10\n';
-
-        expect(() => parseYamlToRules(text)).toThrow(/sources4 entry "fe80::\/10"/);
-    });
-
     it('reads an empty document as no rules', () => {
         expect(parseYamlToRules('')).toEqual({ rules: [] });
         expect(parseYamlToRules('# nothing yet\n')).toEqual({ rules: [] });
     });
+
+    it('tolerates a bare trailing separator', () => {
+        const parsed = parseYamlToRules('name: forward0\nrules: []\n---\n');
+
+        expect(parsed.name).toBe('forward0');
+    });
+
+    it('refuses a second non-empty document', () => {
+        expect(() => parseYamlToRules('rules: []\n---\nrules: []\n')).toThrow(/more than one document/);
+    });
 });
 
-describe('rulesToDiffYaml', () => {
+describe('exporting rules to the wire document', () => {
     it('emits the action form with declared mode names', () => {
         const text = rulesToDiffYaml(sampleRules());
 
         expect(text).toContain('action:');
         expect(text).toContain('mode: OUT');
-        expect(text).toContain('- name: \'01:00.0\'');
+        expect(text).toContain("- name: '01:00.0'");
         expect(text).not.toContain('srcs');
     });
 
-    it('emits an undeclared mode number as is and an absent mode as NONE', () => {
+    it('emits an undeclared mode number as is', () => {
         expect(rulesToDiffYaml([{ action: { target: 't', mode: 99 } }])).toContain('mode: 99');
+    });
+
+    it('emits an absent mode as its zero value NONE', () => {
         expect(rulesToDiffYaml([{ action: { target: 't' } }])).toContain('mode: NONE');
     });
 });

--- a/modules/forward/web/YamlIO.test.ts
+++ b/modules/forward/web/YamlIO.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { parseYamlToRules } from './YamlIO';
+import { rulesToDiffYaml } from './SaveDiffModal';
+import { ForwardMode, type Rule } from '@yanet/core/api/forward';
+
+const sampleRules = (): Rule[] => [
+    {
+        action: { target: 'virtio_user_kni0', mode: ForwardMode.OUT, counter: 'to_kni0' },
+        devices: [{ name: '01:00.0' }],
+        vlan_ranges: [{ from: 0, to: 4095 }],
+        sources4: ['10.0.0.0/8'],
+        sources6: ['fe80::/10'],
+        destinations4: ['203.0.113.0/24'],
+        destinations6: ['ff02::/16'],
+    },
+    {
+        action: { target: '01:00.0', mode: ForwardMode.NONE, counter: undefined },
+        devices: [],
+        vlan_ranges: [],
+        sources4: [],
+        sources6: [],
+        destinations4: [],
+        destinations6: [],
+    },
+];
+
+describe('parseYamlToRules', () => {
+    it('parses the wire document the operator and the CLI speak', () => {
+        const text = [
+            'name: forward0',
+            'rules:',
+            '  - action:',
+            '      target: virtio_user_kni0',
+            '      mode: OUT',
+            '      counter: to_kni0',
+            '    devices:',
+            '      - name: "01:00.0"',
+            '    vlan_ranges:',
+            '      - from: 0',
+            '        to: 4095',
+            '    sources4:',
+            '      - 10.0.0.0/8',
+            '    destinations6:',
+            '      - ff02::/16',
+        ].join('\n');
+
+        const parsed = parseYamlToRules(text);
+
+        expect(parsed.name).toBe('forward0');
+        expect(parsed.rules).toHaveLength(1);
+        const rule = parsed.rules[0];
+        expect(rule.action).toEqual({ target: 'virtio_user_kni0', mode: ForwardMode.OUT, counter: 'to_kni0' });
+        expect(rule.devices).toEqual([{ name: '01:00.0' }]);
+        expect(rule.vlan_ranges).toEqual([{ from: 0, to: 4095 }]);
+        expect(rule.sources4).toEqual(['10.0.0.0/8']);
+        expect(rule.sources6).toEqual([]);
+        expect(rule.destinations6).toEqual(['ff02::/16']);
+    });
+
+    it('round-trips the export back into the same rules', () => {
+        const rules = sampleRules();
+
+        const parsed = parseYamlToRules(rulesToDiffYaml(rules));
+
+        expect(parsed.rules).toEqual(rules);
+    });
+
+    it('refuses the retired flat schema with a pointer to the wire form', () => {
+        const text = 'rules:\n  - target: eth0\n    mode: OUT\n    srcs:\n      - 10.0.0.0/8\n';
+
+        expect(() => parseYamlToRules(text)).toThrow(/retired flat schema/);
+    });
+
+    it('refuses an unknown key and an undeclared mode', () => {
+        expect(() => parseYamlToRules('rulez: []\n')).toThrow(/Unknown key "rulez"/);
+        expect(() => parseYamlToRules('rules:\n  - action:\n      mode: BOGUS\n')).toThrow(/unknown forward mode/);
+        expect(() => parseYamlToRules('rules:\n  - action:\n      mode: 99\n')).toThrow(/unknown forward mode/);
+    });
+
+    it('accepts a declared numeric mode and null fields as zero values', () => {
+        const text = 'rules:\n  - action:\n      target: eth0\n      mode: 2\n    devices: null\n    sources4: null\n';
+
+        const parsed = parseYamlToRules(text);
+
+        expect(parsed.rules[0].action?.mode).toBe(ForwardMode.OUT);
+        expect(parsed.rules[0].devices).toEqual([]);
+        expect(parsed.rules[0].sources4).toEqual([]);
+    });
+
+    it('refuses a network of the wrong family', () => {
+        const text = 'rules:\n  - action:\n      target: eth0\n      mode: OUT\n    sources4:\n      - fe80::/10\n';
+
+        expect(() => parseYamlToRules(text)).toThrow(/sources4 entry "fe80::\/10"/);
+    });
+
+    it('reads an empty document as no rules', () => {
+        expect(parseYamlToRules('')).toEqual({ rules: [] });
+        expect(parseYamlToRules('# nothing yet\n')).toEqual({ rules: [] });
+    });
+});
+
+describe('rulesToDiffYaml', () => {
+    it('emits the action form with declared mode names', () => {
+        const text = rulesToDiffYaml(sampleRules());
+
+        expect(text).toContain('action:');
+        expect(text).toContain('mode: OUT');
+        expect(text).toContain('- name: \'01:00.0\'');
+        expect(text).not.toContain('srcs');
+    });
+
+    it('emits an undeclared mode number as is', () => {
+        const text = rulesToDiffYaml([{ action: { target: 't', mode: 99 } }]);
+
+        expect(text).toContain('mode: 99');
+    });
+});

--- a/modules/forward/web/YamlIO.test.ts
+++ b/modules/forward/web/YamlIO.test.ts
@@ -75,6 +75,38 @@ describe('parseYamlToRules', () => {
         expect(() => parseYamlToRules('rulez: []\n')).toThrow(/Unknown key "rulez"/);
         expect(() => parseYamlToRules('rules:\n  - action:\n      mode: BOGUS\n')).toThrow(/unknown forward mode/);
         expect(() => parseYamlToRules('rules:\n  - action:\n      mode: 99\n')).toThrow(/unknown forward mode/);
+        expect(() => parseYamlToRules('rules:\n  - action:\n      mode: toString\n')).toThrow(/unknown forward mode/);
+    });
+
+    it('accepts the bi-contiguous IPv6 mask form the filter compiler supports', () => {
+        const rules: Rule[] = [
+            {
+                action: { target: 't', mode: ForwardMode.OUT, counter: 'c' },
+                devices: [],
+                vlan_ranges: [],
+                sources4: [],
+                sources6: ['2001:db8::/ffff:ffff:ffff:0:ffff::'],
+                destinations4: [],
+                destinations6: [],
+            },
+        ];
+
+        const parsed = parseYamlToRules(rulesToDiffYaml(rules));
+
+        expect(parsed.rules).toEqual(rules);
+    });
+
+    it('refuses a non-string config name and a rule without an action', () => {
+        expect(() => parseYamlToRules('name: 123\nrules: []\n')).toThrow(/"name" to be a string/);
+        expect(() => parseYamlToRules('rules:\n  - devices: []\n')).toThrow(/"action" is required/);
+        expect(() => parseYamlToRules('rules:\n  - action: null\n')).toThrow(/"action" is required/);
+    });
+
+    it('tolerates a bare trailing separator but not a second document', () => {
+        const parsed = parseYamlToRules('name: forward0\nrules: []\n---\n');
+        expect(parsed.name).toBe('forward0');
+
+        expect(() => parseYamlToRules('rules: []\n---\nrules: []\n')).toThrow(/more than one document/);
     });
 
     it('accepts a declared numeric mode and null fields as zero values', () => {
@@ -109,9 +141,8 @@ describe('rulesToDiffYaml', () => {
         expect(text).not.toContain('srcs');
     });
 
-    it('emits an undeclared mode number as is', () => {
-        const text = rulesToDiffYaml([{ action: { target: 't', mode: 99 } }]);
-
-        expect(text).toContain('mode: 99');
+    it('emits an undeclared mode number as is and an absent mode as NONE', () => {
+        expect(rulesToDiffYaml([{ action: { target: 't', mode: 99 } }])).toContain('mode: 99');
+        expect(rulesToDiffYaml([{ action: { target: 't' } }])).toContain('mode: NONE');
     });
 });

--- a/modules/forward/web/YamlIO.test.ts
+++ b/modules/forward/web/YamlIO.test.ts
@@ -102,6 +102,35 @@ describe('parseYamlToRules', () => {
         expect(() => parseYamlToRules('rules:\n  - action: null\n')).toThrow(/"action" is required/);
     });
 
+    it('refuses a scalar document, a sequence action and a mistyped vlan bound', () => {
+        expect(() => parseYamlToRules('2026-08-31\n')).toThrow(/Expected a YAML object/);
+        expect(() => parseYamlToRules('rules:\n  - action: []\n')).toThrow(/"action" is required/);
+        expect(() =>
+            parseYamlToRules("rules:\n  - action:\n      target: t\n    vlan_ranges:\n      - from: '100'\n"),
+        ).toThrow(/unsigned integer/);
+    });
+
+    it('accepts bare host networks and null vlan bounds as zero', () => {
+        const text = [
+            'rules:',
+            '  - action:',
+            '      target: t',
+            '    vlan_ranges:',
+            '      - from: null',
+            '        to: 100',
+            '    sources4:',
+            '      - 192.0.2.1',
+            '    sources6:',
+            '      - 2001:db8::1',
+        ].join('\n');
+
+        const parsed = parseYamlToRules(text);
+
+        expect(parsed.rules[0].vlan_ranges).toEqual([{ from: 0, to: 100 }]);
+        expect(parsed.rules[0].sources4).toEqual(['192.0.2.1']);
+        expect(parsed.rules[0].sources6).toEqual(['2001:db8::1']);
+    });
+
     it('tolerates a bare trailing separator but not a second document', () => {
         const parsed = parseYamlToRules('name: forward0\nrules: []\n---\n');
         expect(parsed.name).toBe('forward0');

--- a/modules/forward/web/YamlIO.tsx
+++ b/modules/forward/web/YamlIO.tsx
@@ -46,6 +46,17 @@ const isPlainMapping = (value: unknown): value is Record<string, unknown> => {
     return proto === Object.prototype || proto === null;
 };
 
+/** Reads a string field, a null as the empty string, other types refused. */
+const stringField = (value: unknown, where: string): string => {
+    if (value == null) {
+        return '';
+    }
+    if (typeof value !== 'string') {
+        throw new Error(`Expected ${where} to be a string.`);
+    }
+    return value;
+};
+
 /** Reads an integer field, a null as zero, any other spelling refused. */
 const uint32Field = (value: unknown, where: string): number => {
     if (value == null) {
@@ -83,9 +94,11 @@ const isValidNetwork = (net: string, isAddress: (addr: string) => boolean, maxLe
     if (!isAddress(address)) {
         return false;
     }
-    if (/^\d+$/.test(suffix)) {
+    // The strict form refuses a padded length such as /024, which the
+    // wire parser rejects too.
+    if (/^(0|[1-9][0-9]*)$/.test(suffix)) {
         const length = Number(suffix);
-        return length >= 0 && length <= maxLength;
+        return length <= maxLength;
     }
     return isAddress(suffix);
 };
@@ -178,7 +191,7 @@ export const parseYamlToRules = (text: string): ParsedRulesDoc => {
                 throw new Error(`Rule ${idx}: device ${deviceIdx} is not a mapping with a "name".`);
             }
             checkKnownKeys(d, `rule ${idx} device ${deviceIdx}`, ['name']);
-            return { name: typeof d['name'] === 'string' ? d['name'] : '' };
+            return { name: stringField(d['name'], `rule ${idx} device ${deviceIdx} "name"`) };
         });
 
         const vlanRaw = rule['vlan_ranges'] == null ? [] : rule['vlan_ranges'];
@@ -196,13 +209,12 @@ export const parseYamlToRules = (text: string): ParsedRulesDoc => {
             };
         });
 
+        const counter = stringField(action['counter'], `rule ${idx} action "counter"`);
         return {
             action: {
-                target: typeof action['target'] === 'string' ? action['target'] : '',
+                target: stringField(action['target'], `rule ${idx} action "target"`),
                 mode,
-                counter: typeof action['counter'] === 'string' && action['counter'] !== ''
-                    ? action['counter']
-                    : undefined,
+                counter: counter !== '' ? counter : undefined,
             },
             devices,
             vlan_ranges,

--- a/modules/forward/web/YamlIO.tsx
+++ b/modules/forward/web/YamlIO.tsx
@@ -1,34 +1,70 @@
 import React, { useState } from 'react';
 import yaml from 'js-yaml';
 import type { Rule } from '@yanet/core/api/forward';
-import { ForwardMode } from '@yanet/core/api/forward';
+import { declaredForwardMode } from '@yanet/core/api/forward';
 import { toaster } from '@yanet/core/utils';
-import { partitionCidrsToTyped } from '@yanet/core/utils';
+import { isValidIPv4Prefix, isValidIPv6Prefix } from '@yanet/core/utils/netip';
 import { rulesToDiffYaml } from './SaveDiffModal';
 import YamlIOModal from '@yanet/core/components/YamlIOModal';
 
-/** Raw shape of a rule entry in the new YAML schema. */
-interface YamlVlanRange {
-    from: number;
-    to: number;
+/** A parsed wire update document: the optional config name and the rules. */
+export interface ParsedRulesDoc {
+    name?: string;
+    rules: Rule[];
 }
 
-interface YamlRule {
-    target: string;
-    counter?: string;
-    vlan_ranges?: YamlVlanRange[];
-    srcs?: string[] | null;
-    dsts?: string[] | null;
-    devices?: string[] | null;
-    mode?: string;
-}
-
-/** Parse a YAML string into rules using the canonical schema.
- *
- * Top-level key is `rules`. Config name comes from outside the YAML (the import UI).
- * Returns the parsed rules array on success, throws with a descriptive message on failure.
+/**
+ * Refuses a mapping key outside the known set, naming the legacy schema
+ * when the key belongs to it, so an old flat-format file fails loudly
+ * instead of importing empty rules.
  */
-export const parseYamlToRules = (text: string): Rule[] => {
+const checkKnownKeys = (value: Record<string, unknown>, where: string, known: string[]): void => {
+    const legacy = ['target', 'mode', 'counter', 'srcs', 'dsts'];
+    for (const key of Object.keys(value)) {
+        if (known.includes(key)) {
+            continue;
+        }
+        if (legacy.includes(key)) {
+            throw new Error(
+                `Unknown key "${key}" in ${where}: this is the retired flat schema. ` +
+                'Export the wire form with "yanet-cli-forward show" or the page Export.',
+            );
+        }
+        throw new Error(`Unknown key "${key}" in ${where}, expected ${known.map(k => `"${k}"`).join(', ')}.`);
+    }
+};
+
+/** Reads a string list field, a null as the empty list. */
+const stringList = (value: unknown, where: string): string[] => {
+    if (value == null) {
+        return [];
+    }
+    if (!Array.isArray(value) || value.some(entry => typeof entry !== 'string')) {
+        throw new Error(`Expected ${where} to be a list of strings.`);
+    }
+    return value as string[];
+};
+
+/** Reads a family-typed network list, refusing an entry of the wrong family. */
+const networkList = (value: unknown, where: string, isValid: (net: string) => boolean): string[] => {
+    const nets = stringList(value, where);
+    for (const net of nets) {
+        if (!isValid(net)) {
+            throw new Error(`${where} entry "${net}" is not a valid network for that family.`);
+        }
+    }
+    return nets;
+};
+
+/**
+ * Parse a YAML string as the wire update request: the document the
+ * generic operator pushes and `yanet-cli-forward` prints and accepts.
+ *
+ * A null field reads as its zero value and an unknown key is refused,
+ * as the other readers of the format do. Throws with a descriptive
+ * message on failure.
+ */
+export const parseYamlToRules = (text: string): ParsedRulesDoc => {
     let parsed: unknown;
     try {
         parsed = yaml.load(text);
@@ -36,73 +72,93 @@ export const parseYamlToRules = (text: string): Rule[] => {
         throw new Error(`YAML parse error: ${(e as Error).message}`);
     }
 
-    if (!parsed || typeof parsed !== 'object') {
+    if (parsed == null) {
+        return { rules: [] };
+    }
+    if (typeof parsed !== 'object' || Array.isArray(parsed)) {
         throw new Error('Expected a YAML object with a "rules" list.');
     }
 
     const doc = parsed as Record<string, unknown>;
+    checkKnownKeys(doc, 'the document', ['name', 'rules']);
 
-    if (!Array.isArray(doc['rules'])) {
+    const name = typeof doc['name'] === 'string' && doc['name'] !== '' ? doc['name'] : undefined;
+    if (doc['rules'] != null && !Array.isArray(doc['rules'])) {
         throw new Error('Expected a top-level "rules" list.');
     }
+    const rows = (doc['rules'] ?? []) as unknown[];
 
-    const modeMap: Record<string, ForwardMode> = {
-        IN: ForwardMode.IN,
-        OUT: ForwardMode.OUT,
-        NONE: ForwardMode.NONE,
-        In: ForwardMode.IN,
-        Out: ForwardMode.OUT,
-        None: ForwardMode.NONE,
-    };
-
-    const rules: Rule[] = (doc['rules'] as unknown[]).map((r: unknown): Rule => {
-        if (!r || typeof r !== 'object') {
-            return { action: { target: '', mode: ForwardMode.NONE } };
+    const rules: Rule[] = rows.map((row: unknown, idx: number): Rule => {
+        if (row == null || typeof row !== 'object') {
+            throw new Error(`Rule ${idx} is not a mapping.`);
         }
-        const row = r as YamlRule;
+        const rule = row as Record<string, unknown>;
+        checkKnownKeys(rule, `rule ${idx}`, [
+            'action', 'devices', 'vlan_ranges', 'sources4', 'sources6', 'destinations4', 'destinations6',
+        ]);
 
-        const target = typeof row.target === 'string' ? row.target : '';
-        const counter = typeof row.counter === 'string' ? row.counter : undefined;
-        const modeRaw = typeof row.mode === 'string' ? row.mode : 'None';
-        const mode = modeMap[modeRaw] ?? ForwardMode.NONE;
+        const actionRaw = rule['action'];
+        if (actionRaw != null && typeof actionRaw !== 'object') {
+            throw new Error(`Rule ${idx}: "action" is not a mapping.`);
+        }
+        const action = (actionRaw ?? {}) as Record<string, unknown>;
+        checkKnownKeys(action, `rule ${idx} action`, ['target', 'mode', 'counter']);
 
-        const devicesRaw = Array.isArray(row.devices) ? row.devices : [];
-        const devices = (devicesRaw as unknown[])
-            .filter((d): d is string => typeof d === 'string')
-            .map(name => ({ name }));
+        const modeRaw = action['mode'];
+        const mode = modeRaw == null
+            ? declaredForwardMode(0)
+            : declaredForwardMode(modeRaw as string | number);
+        if (mode === undefined) {
+            throw new Error(`Rule ${idx}: unknown forward mode ${JSON.stringify(modeRaw)}.`);
+        }
 
-        const vlanRangesRaw = Array.isArray(row.vlan_ranges) ? row.vlan_ranges : [];
-        const vlan_ranges = (vlanRangesRaw as unknown[]).map((vr: unknown) => {
-            if (!vr || typeof vr !== 'object') return { from: 0, to: 0 };
-            const v = vr as Record<string, unknown>;
+        const devicesRaw = rule['devices'] == null ? [] : rule['devices'];
+        if (!Array.isArray(devicesRaw)) {
+            throw new Error(`Rule ${idx}: "devices" is not a list.`);
+        }
+        const devices = devicesRaw.map((d: unknown, deviceIdx: number) => {
+            if (d == null || typeof d !== 'object') {
+                throw new Error(`Rule ${idx}: device ${deviceIdx} is not a mapping with a "name".`);
+            }
+            const device = d as Record<string, unknown>;
+            checkKnownKeys(device, `rule ${idx} device ${deviceIdx}`, ['name']);
+            return { name: typeof device['name'] === 'string' ? device['name'] : '' };
+        });
+
+        const vlanRaw = rule['vlan_ranges'] == null ? [] : rule['vlan_ranges'];
+        if (!Array.isArray(vlanRaw)) {
+            throw new Error(`Rule ${idx}: "vlan_ranges" is not a list.`);
+        }
+        const vlan_ranges = vlanRaw.map((vr: unknown, rangeIdx: number) => {
+            if (vr == null || typeof vr !== 'object') {
+                throw new Error(`Rule ${idx}: vlan range ${rangeIdx} is not a mapping.`);
+            }
+            const range = vr as Record<string, unknown>;
+            checkKnownKeys(range, `rule ${idx} vlan range ${rangeIdx}`, ['from', 'to']);
             return {
-                from: typeof v['from'] === 'number' ? v['from'] : 0,
-                to: typeof v['to'] === 'number' ? v['to'] : 0,
+                from: typeof range['from'] === 'number' ? range['from'] : 0,
+                to: typeof range['to'] === 'number' ? range['to'] : 0,
             };
         });
 
-        const srcsRaw = Array.isArray(row.srcs) ? row.srcs : [];
-        const sources = partitionCidrsToTyped(
-            (srcsRaw as unknown[]).filter((s): s is string => typeof s === 'string'),
-        );
-
-        const dstsRaw = Array.isArray(row.dsts) ? row.dsts : [];
-        const destinations = partitionCidrsToTyped(
-            (dstsRaw as unknown[]).filter((s): s is string => typeof s === 'string'),
-        );
-
         return {
-            action: { target, mode, counter },
+            action: {
+                target: typeof action['target'] === 'string' ? action['target'] : '',
+                mode,
+                counter: typeof action['counter'] === 'string' && action['counter'] !== ''
+                    ? action['counter']
+                    : undefined,
+            },
             devices,
             vlan_ranges,
-            sources4: sources.v4,
-            sources6: sources.v6,
-            destinations4: destinations.v4,
-            destinations6: destinations.v6,
+            sources4: networkList(rule['sources4'], `rule ${idx} sources4`, isValidIPv4Prefix),
+            sources6: networkList(rule['sources6'], `rule ${idx} sources6`, isValidIPv6Prefix),
+            destinations4: networkList(rule['destinations4'], `rule ${idx} destinations4`, isValidIPv4Prefix),
+            destinations6: networkList(rule['destinations6'], `rule ${idx} destinations6`, isValidIPv6Prefix),
         };
     });
 
-    return rules;
+    return { name, rules };
 };
 
 interface YamlIOProps {
@@ -121,9 +177,12 @@ const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport, disabled }
 
     const handleImport = (text: string): void => {
         const parsed = parseYamlToRules(text);
-        const targetConfig = importConfigName.trim() || configName;
-        onImport(targetConfig, parsed);
-        toaster.success('yn-yaml-import', `Imported ${parsed.length} rules into "${targetConfig}".`);
+        const targetConfig = importConfigName.trim() || parsed.name || configName;
+        if (parsed.name && parsed.name !== targetConfig) {
+            throw new Error(`The file names config "${parsed.name}", but "${targetConfig}" is chosen.`);
+        }
+        onImport(targetConfig, parsed.rules);
+        toaster.success('yn-yaml-import', `Imported ${parsed.rules.length} rules into "${targetConfig}".`);
     };
 
     const importExtraControls = (
@@ -153,7 +212,7 @@ const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport, disabled }
             exportYaml={() => rulesToDiffYaml(rules)}
             onImport={handleImport}
             toastPrefix="yn-yaml"
-            importPlaceholder={'rules:\n  - target: eth0\n    mode: OUT\n    srcs:\n      - 10.0.0.0/8'}
+            importPlaceholder={'rules:\n  - action:\n      target: eth0\n      mode: OUT\n    sources4:\n      - 10.0.0.0/8'}
             exportFooterHint="Exports current draft rules (unsaved changes included)."
             importFooterHint="Importing replaces all rules in the target config locally. Use Save to push to the server."
             importButtonLabel="Import"

--- a/modules/forward/web/YamlIO.tsx
+++ b/modules/forward/web/YamlIO.tsx
@@ -34,6 +34,29 @@ const checkKnownKeys = (value: Record<string, unknown>, where: string, known: st
     }
 };
 
+/**
+ * Tells a plain YAML mapping from every other loaded value, including the
+ * Date a bare timestamp scalar becomes and the array a sequence becomes.
+ */
+const isPlainMapping = (value: unknown): value is Record<string, unknown> => {
+    if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+        return false;
+    }
+    const proto: unknown = Object.getPrototypeOf(value);
+    return proto === Object.prototype || proto === null;
+};
+
+/** Reads an integer field, a null as zero, any other spelling refused. */
+const uint32Field = (value: unknown, where: string): number => {
+    if (value == null) {
+        return 0;
+    }
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 4294967295) {
+        throw new Error(`Expected ${where} to be an unsigned integer.`);
+    }
+    return value;
+};
+
 /** Reads a string list field, a null as the empty list. */
 const stringList = (value: unknown, where: string): string[] => {
     if (value == null) {
@@ -46,14 +69,14 @@ const stringList = (value: unknown, where: string): string[] => {
 };
 
 /**
- * Accepts a network in CIDR or address/mask form of one family, the two
- * spellings the wire types parse — a mask covers the bi-contiguous IPv6
- * networks the filter compiler supports.
+ * Accepts a network in the forms the wire types parse: CIDR, explicit
+ * address/mask — covering the bi-contiguous IPv6 networks the filter
+ * compiler supports — or a bare host address.
  */
 const isValidNetwork = (net: string, isAddress: (addr: string) => boolean, maxLength: number): boolean => {
     const slash = net.indexOf('/');
     if (slash < 0) {
-        return false;
+        return isAddress(net);
     }
     const address = net.slice(0, slash);
     const suffix = net.slice(slash + 1);
@@ -106,11 +129,11 @@ export const parseYamlToRules = (text: string): ParsedRulesDoc => {
         throw new Error('The file holds more than one document.');
     }
     const parsed = documents[0];
-    if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    if (!isPlainMapping(parsed)) {
         throw new Error('Expected a YAML object with a "rules" list.');
     }
 
-    const doc = parsed as Record<string, unknown>;
+    const doc = parsed;
     checkKnownKeys(doc, 'the document', ['name', 'rules']);
 
     if (doc['name'] != null && typeof doc['name'] !== 'string') {
@@ -123,19 +146,19 @@ export const parseYamlToRules = (text: string): ParsedRulesDoc => {
     const rows = (doc['rules'] ?? []) as unknown[];
 
     const rules: Rule[] = rows.map((row: unknown, idx: number): Rule => {
-        if (row == null || typeof row !== 'object') {
+        if (!isPlainMapping(row)) {
             throw new Error(`Rule ${idx} is not a mapping.`);
         }
-        const rule = row as Record<string, unknown>;
+        const rule = row;
         checkKnownKeys(rule, `rule ${idx}`, [
             'action', 'devices', 'vlan_ranges', 'sources4', 'sources6', 'destinations4', 'destinations6',
         ]);
 
         const actionRaw = rule['action'];
-        if (actionRaw == null || typeof actionRaw !== 'object') {
+        if (!isPlainMapping(actionRaw)) {
             throw new Error(`Rule ${idx}: "action" is required and must be a mapping.`);
         }
-        const action = actionRaw as Record<string, unknown>;
+        const action = actionRaw;
         checkKnownKeys(action, `rule ${idx} action`, ['target', 'mode', 'counter']);
 
         const modeRaw = action['mode'];
@@ -151,12 +174,11 @@ export const parseYamlToRules = (text: string): ParsedRulesDoc => {
             throw new Error(`Rule ${idx}: "devices" is not a list.`);
         }
         const devices = devicesRaw.map((d: unknown, deviceIdx: number) => {
-            if (d == null || typeof d !== 'object') {
+            if (!isPlainMapping(d)) {
                 throw new Error(`Rule ${idx}: device ${deviceIdx} is not a mapping with a "name".`);
             }
-            const device = d as Record<string, unknown>;
-            checkKnownKeys(device, `rule ${idx} device ${deviceIdx}`, ['name']);
-            return { name: typeof device['name'] === 'string' ? device['name'] : '' };
+            checkKnownKeys(d, `rule ${idx} device ${deviceIdx}`, ['name']);
+            return { name: typeof d['name'] === 'string' ? d['name'] : '' };
         });
 
         const vlanRaw = rule['vlan_ranges'] == null ? [] : rule['vlan_ranges'];
@@ -164,14 +186,13 @@ export const parseYamlToRules = (text: string): ParsedRulesDoc => {
             throw new Error(`Rule ${idx}: "vlan_ranges" is not a list.`);
         }
         const vlan_ranges = vlanRaw.map((vr: unknown, rangeIdx: number) => {
-            if (vr == null || typeof vr !== 'object') {
+            if (!isPlainMapping(vr)) {
                 throw new Error(`Rule ${idx}: vlan range ${rangeIdx} is not a mapping.`);
             }
-            const range = vr as Record<string, unknown>;
-            checkKnownKeys(range, `rule ${idx} vlan range ${rangeIdx}`, ['from', 'to']);
+            checkKnownKeys(vr, `rule ${idx} vlan range ${rangeIdx}`, ['from', 'to']);
             return {
-                from: typeof range['from'] === 'number' ? range['from'] : 0,
-                to: typeof range['to'] === 'number' ? range['to'] : 0,
+                from: uint32Field(vr['from'], `rule ${idx} vlan range ${rangeIdx} "from"`),
+                to: uint32Field(vr['to'], `rule ${idx} vlan range ${rangeIdx} "to"`),
             };
         });
 

--- a/modules/forward/web/YamlIO.tsx
+++ b/modules/forward/web/YamlIO.tsx
@@ -3,7 +3,7 @@ import yaml from 'js-yaml';
 import type { Rule } from '@yanet/core/api/forward';
 import { declaredForwardMode } from '@yanet/core/api/forward';
 import { toaster } from '@yanet/core/utils';
-import { isValidIPv4Prefix, isValidIPv6Prefix } from '@yanet/core/utils/netip';
+import { isValidIPv4Address, isValidIPv6Address } from '@yanet/core/utils/netip';
 import { rulesToDiffYaml } from './SaveDiffModal';
 import YamlIOModal from '@yanet/core/components/YamlIOModal';
 
@@ -45,6 +45,31 @@ const stringList = (value: unknown, where: string): string[] => {
     return value as string[];
 };
 
+/**
+ * Accepts a network in CIDR or address/mask form of one family, the two
+ * spellings the wire types parse — a mask covers the bi-contiguous IPv6
+ * networks the filter compiler supports.
+ */
+const isValidNetwork = (net: string, isAddress: (addr: string) => boolean, maxLength: number): boolean => {
+    const slash = net.indexOf('/');
+    if (slash < 0) {
+        return false;
+    }
+    const address = net.slice(0, slash);
+    const suffix = net.slice(slash + 1);
+    if (!isAddress(address)) {
+        return false;
+    }
+    if (/^\d+$/.test(suffix)) {
+        const length = Number(suffix);
+        return length >= 0 && length <= maxLength;
+    }
+    return isAddress(suffix);
+};
+
+const isValidIPv4Network = (net: string): boolean => isValidNetwork(net, isValidIPv4Address, 32);
+const isValidIPv6Network = (net: string): boolean => isValidNetwork(net, isValidIPv6Address, 128);
+
 /** Reads a family-typed network list, refusing an entry of the wrong family. */
 const networkList = (value: unknown, where: string, isValid: (net: string) => boolean): string[] => {
     const nets = stringList(value, where);
@@ -65,16 +90,22 @@ const networkList = (value: unknown, where: string, isValid: (net: string) => bo
  * message on failure.
  */
 export const parseYamlToRules = (text: string): ParsedRulesDoc => {
-    let parsed: unknown;
+    let documents: unknown[];
     try {
-        parsed = yaml.load(text);
+        // The stream is read whole, so a bare trailing separator is
+        // tolerated the way the operator and the CLI read it.
+        documents = (yaml.loadAll(text) as unknown[]).filter(doc => doc != null);
     } catch (e) {
         throw new Error(`YAML parse error: ${(e as Error).message}`);
     }
 
-    if (parsed == null) {
+    if (documents.length === 0) {
         return { rules: [] };
     }
+    if (documents.length > 1) {
+        throw new Error('The file holds more than one document.');
+    }
+    const parsed = documents[0];
     if (typeof parsed !== 'object' || Array.isArray(parsed)) {
         throw new Error('Expected a YAML object with a "rules" list.');
     }
@@ -82,6 +113,9 @@ export const parseYamlToRules = (text: string): ParsedRulesDoc => {
     const doc = parsed as Record<string, unknown>;
     checkKnownKeys(doc, 'the document', ['name', 'rules']);
 
+    if (doc['name'] != null && typeof doc['name'] !== 'string') {
+        throw new Error('Expected "name" to be a string.');
+    }
     const name = typeof doc['name'] === 'string' && doc['name'] !== '' ? doc['name'] : undefined;
     if (doc['rules'] != null && !Array.isArray(doc['rules'])) {
         throw new Error('Expected a top-level "rules" list.');
@@ -98,10 +132,10 @@ export const parseYamlToRules = (text: string): ParsedRulesDoc => {
         ]);
 
         const actionRaw = rule['action'];
-        if (actionRaw != null && typeof actionRaw !== 'object') {
-            throw new Error(`Rule ${idx}: "action" is not a mapping.`);
+        if (actionRaw == null || typeof actionRaw !== 'object') {
+            throw new Error(`Rule ${idx}: "action" is required and must be a mapping.`);
         }
-        const action = (actionRaw ?? {}) as Record<string, unknown>;
+        const action = actionRaw as Record<string, unknown>;
         checkKnownKeys(action, `rule ${idx} action`, ['target', 'mode', 'counter']);
 
         const modeRaw = action['mode'];
@@ -151,10 +185,10 @@ export const parseYamlToRules = (text: string): ParsedRulesDoc => {
             },
             devices,
             vlan_ranges,
-            sources4: networkList(rule['sources4'], `rule ${idx} sources4`, isValidIPv4Prefix),
-            sources6: networkList(rule['sources6'], `rule ${idx} sources6`, isValidIPv6Prefix),
-            destinations4: networkList(rule['destinations4'], `rule ${idx} destinations4`, isValidIPv4Prefix),
-            destinations6: networkList(rule['destinations6'], `rule ${idx} destinations6`, isValidIPv6Prefix),
+            sources4: networkList(rule['sources4'], `rule ${idx} sources4`, isValidIPv4Network),
+            sources6: networkList(rule['sources6'], `rule ${idx} sources6`, isValidIPv6Network),
+            destinations4: networkList(rule['destinations4'], `rule ${idx} destinations4`, isValidIPv4Network),
+            destinations6: networkList(rule['destinations6'], `rule ${idx} destinations6`, isValidIPv6Network),
         };
     });
 

--- a/web/src/core/api/forward.ts
+++ b/web/src/core/api/forward.ts
@@ -33,7 +33,12 @@ export const declaredForwardMode = (value: ForwardMode | number | string | undef
     if (typeof value === 'number') {
         return FORWARD_MODE_BY_NUMBER[value];
     }
-    return typeof value === 'string' && value in FORWARD_MODE_LABELS ? (value as ForwardMode) : undefined;
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    // An own-value check, so an inherited object key such as "toString"
+    // does not pass as a declared mode.
+    return (Object.values(ForwardMode) as string[]).includes(value) ? (value as ForwardMode) : undefined;
 };
 
 /**

--- a/web/src/core/api/forward.ts
+++ b/web/src/core/api/forward.ts
@@ -26,6 +26,17 @@ const FORWARD_MODE_BY_NUMBER: Record<number, ForwardMode> = {
 };
 
 /**
+ * Maps a declared mode name or number to the mode, undefined for anything
+ * this build does not declare.
+ */
+export const declaredForwardMode = (value: ForwardMode | number | string | undefined): ForwardMode | undefined => {
+    if (typeof value === 'number') {
+        return FORWARD_MODE_BY_NUMBER[value];
+    }
+    return typeof value === 'string' && value in FORWARD_MODE_LABELS ? (value as ForwardMode) : undefined;
+};
+
+/**
  * Reads a mode off the wire in either spelling.
  *
  * A name or a declared number maps to the mode. Anything else, including a
@@ -33,10 +44,7 @@ const FORWARD_MODE_BY_NUMBER: Record<number, ForwardMode> = {
  * used before names existed.
  */
 export const parseForwardMode = (value: ForwardMode | number | undefined): ForwardMode => {
-    if (typeof value === 'number') {
-        return FORWARD_MODE_BY_NUMBER[value] ?? ForwardMode.NONE;
-    }
-    return value !== undefined && value in FORWARD_MODE_LABELS ? value : ForwardMode.NONE;
+    return declaredForwardMode(value) ?? ForwardMode.NONE;
 };
 
 export interface Action {


### PR DESCRIPTION
- Export and import the wire `UpdateConfigRequest` document — the one the generic operator pushes and `yanet-cli-forward` prints and accepts — and delete the flat legacy schema.
- Refuse a legacy-schema file loudly with a pointer to the wire form, instead of silently importing empty rules.
- Spell a declared mode by its name, pass an undeclared number through export as is and refuse it on import, matching the CLI.
- Read null fields as zero values, validate the family-typed network lists and bind the document's `name` against the chosen config.
- Closes the file-format migration started by #2425 and #2437.