### PR TITLE
feat(dataplane)!: deliver config contexts to workers via instance threads

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -363,6 +363,33 @@ func (m *Harness) OutstandingMbufs() uint64 {
 	return uint64(C.dataplane_ut_mempool_outstanding(m.ptr))
 }
 
+// holdRoundLock takes the harness round lock.
+//
+// Test support mirroring a round in flight: a concurrent install must
+// wait for the same lock before it may retire the old contexts. Every
+// hold must pair with exactly one release.
+func (m *Harness) holdRoundLock() {
+	C.dataplane_ut_round_lock_acquire(m.ptr)
+}
+
+// releaseRoundLock drops the harness round lock taken by holdRoundLock.
+func (m *Harness) releaseRoundLock() {
+	C.dataplane_ut_round_lock_release(m.ptr)
+}
+
+// validateWorkerIdx bounds a worker index against the registered
+// topology, so a caller cannot silently inspect the wrong worker.
+func (m *Harness) validateWorkerIdx(worker int) error {
+	if worker < 0 || worker >= m.workerCount {
+		return fmt.Errorf(
+			"worker %d exceeds topology worker count %d",
+			worker,
+			m.workerCount,
+		)
+	}
+	return nil
+}
+
 // SetWorkerCounter overwrites the value of a named size-1 counter in the
 // given worker's shared worker-counter storage.
 //
@@ -374,12 +401,8 @@ func (m *Harness) OutstandingMbufs() uint64 {
 func (m *Harness) SetWorkerCounter(worker int, name string, value uint64) error {
 	// The setter indexes the worker's counter storage directly, so an
 	// index outside the registered workers would corrupt C memory.
-	if worker < 0 || worker >= m.workerCount {
-		return fmt.Errorf(
-			"worker %d exceeds topology worker count %d",
-			worker,
-			m.workerCount,
-		)
+	if err := m.validateWorkerIdx(worker); err != nil {
+		return err
 	}
 
 	cName := C.CString(name)
@@ -400,6 +423,61 @@ func (m *Harness) SetWorkerCounter(worker int, name string, value uint64) error 
 func (m *Harness) SharedMemory() *ffi.SharedMemory {
 	shm := C.dataplane_ut_shm(m.ptr)
 	return ffi.NewSharedMemoryFromRaw(unsafe.Pointer(shm))
+}
+
+// InstallEmptyPipeline installs one named empty pipeline, forcing a
+// generation switch that completes synchronously: on return every worker
+// holds the newly published generation's execution context.
+func (m *Harness) InstallEmptyPipeline(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	rc := C.dataplane_ut_install_empty_pipeline(m.ptr, cName)
+	if rc != 0 {
+		return fmt.Errorf("failed to install empty pipeline %q: rc=%d", name, int(rc))
+	}
+	return nil
+}
+
+// WorkerExecutionContext returns the execution context currently assigned
+// to the given worker, zero when none is assigned.
+//
+// An error is returned when the worker index is outside the topology,
+// distinguishing a missing context from an invalid worker.
+func (m *Harness) WorkerExecutionContext(workerIdx int) (uintptr, error) {
+	if err := m.validateWorkerIdx(workerIdx); err != nil {
+		return 0, err
+	}
+	return uintptr(C.dataplane_ut_worker_ectx(m.ptr, C.size_t(workerIdx))), nil
+}
+
+// PublishedExecutionContext returns the per-worker execution context of
+// the currently published generation, zero when none is published.
+//
+// An error is returned when the worker index is outside the topology,
+// distinguishing a missing context from an invalid worker.
+func (m *Harness) PublishedExecutionContext(workerIdx int) (uintptr, error) {
+	if err := m.validateWorkerIdx(workerIdx); err != nil {
+		return 0, err
+	}
+	return uintptr(C.dataplane_ut_published_ectx(m.ptr, C.size_t(workerIdx))), nil
+}
+
+// WorkerGeneration returns the generation the given worker last
+// acknowledged.
+//
+// An error is returned when the worker index is outside the topology.
+func (m *Harness) WorkerGeneration(workerIdx int) (uint64, error) {
+	if err := m.validateWorkerIdx(workerIdx); err != nil {
+		return 0, err
+	}
+	return uint64(C.dataplane_ut_worker_gen(m.ptr, C.size_t(workerIdx))), nil
+}
+
+// PublishedGeneration returns the generation number of the currently
+// published generation, zero when no generation was published.
+func (m *Harness) PublishedGeneration() uint64 {
+	return uint64(C.dataplane_ut_published_gen(m.ptr))
 }
 
 // SetCurrentTime installs a deterministic wall-clock value used by the next

--- a/bindings/go/dataplane_ut/dataplane_ut_test.go
+++ b/bindings/go/dataplane_ut/dataplane_ut_test.go
@@ -21,6 +21,252 @@ import (
 
 // TestHarnessLifecycle exercises construction, shared-memory access, and
 // teardown of the Harness without running any packets.
+// executionContextWorkers is the worker population every test below
+// uses: two workers are the minimum that separates the worker that ran
+// a round from a worker that never ran.
+const executionContextWorkers = 2
+
+// newExecutionContextHarness builds a two-worker harness with an
+// otherwise empty topology. The generation-assignment protocol under
+// test needs only generation switches, not packet-routing modules or
+// device wiring.
+func newExecutionContextHarness(t *testing.T) *Harness {
+	t.Helper()
+
+	harness, err := NewHarness(Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB * 4),
+		WorkerCount: executionContextWorkers,
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	return harness
+}
+
+// Test_WorkerExecutionContext_Bootstrap_FieldIsNullAndNothingAcked
+// verifies that a fresh harness with no installs reports a zero
+// published generation, no per-worker context in any worker's field,
+// and no acknowledged generation on any worker.
+func Test_WorkerExecutionContext_Bootstrap_FieldIsNullAndNothingAcked(t *testing.T) {
+	harness := newExecutionContextHarness(t)
+
+	require.Zero(t, harness.PublishedGeneration(), "no install ran, so no generation is published")
+	for workerIdx := range executionContextWorkers {
+		published, err := harness.PublishedExecutionContext(workerIdx)
+		require.NoError(t, err)
+		require.Zero(
+			t,
+			published,
+			"worker %d must have no published context before any install",
+			workerIdx,
+		)
+		assigned, err := harness.WorkerExecutionContext(workerIdx)
+		require.NoError(t, err)
+		require.Zero(
+			t,
+			assigned,
+			"worker %d must hold no context before any install",
+			workerIdx,
+		)
+		generation, err := harness.WorkerGeneration(workerIdx)
+		require.NoError(t, err)
+		require.Zero(
+			t,
+			generation,
+			"worker %d must acknowledge nothing before any install",
+			workerIdx,
+		)
+	}
+}
+
+// Test_WorkerExecutionContext_Install_AssignsPublishedContextToEveryWorker
+// verifies that one empty-pipeline install assigns every worker,
+// synchronously on return, the per-worker execution context of the
+// newly published generation.
+//
+// Every acknowledgement must stay zero: an install switches contexts
+// but only a round acknowledges, and no round has run.
+func Test_WorkerExecutionContext_Install_AssignsPublishedContextToEveryWorker(t *testing.T) {
+	harness := newExecutionContextHarness(t)
+
+	require.NoError(t, harness.InstallEmptyPipeline("assigned"))
+
+	require.NotZero(t, harness.PublishedGeneration(), "an install must publish a new generation")
+	for workerIdx := range executionContextWorkers {
+		published, err := harness.PublishedExecutionContext(workerIdx)
+		require.NoError(t, err)
+		require.NotZero(
+			t,
+			published,
+			"worker %d must have a published context after an install",
+			workerIdx,
+		)
+		assigned, err := harness.WorkerExecutionContext(workerIdx)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			published,
+			assigned,
+			"worker %d's field must already hold the published context on return from the install",
+			workerIdx,
+		)
+		generation, err := harness.WorkerGeneration(workerIdx)
+		require.NoError(t, err)
+		require.Zero(
+			t,
+			generation,
+			"worker %d must not acknowledge a generation without a round",
+			workerIdx,
+		)
+	}
+}
+
+// Test_WorkerExecutionContext_Reinstall_ReassignsNewContextToEveryWorker
+// verifies that a second install publishes a fresh per-worker context
+// and every worker's field follows it, pinning re-assignment on every
+// generation switch rather than a one-time bootstrap stamp.
+func Test_WorkerExecutionContext_Reinstall_ReassignsNewContextToEveryWorker(t *testing.T) {
+	harness := newExecutionContextHarness(t)
+
+	require.NoError(t, harness.InstallEmptyPipeline("first"))
+	firstGeneration := harness.PublishedGeneration()
+	firstContexts := [executionContextWorkers]uintptr{}
+	for workerIdx := range executionContextWorkers {
+		published, err := harness.PublishedExecutionContext(workerIdx)
+		require.NoError(t, err)
+		firstContexts[workerIdx] = published
+	}
+
+	require.NoError(t, harness.InstallEmptyPipeline("second"))
+	require.Greater(
+		t,
+		harness.PublishedGeneration(),
+		firstGeneration,
+		"a reinstall must advance the published generation",
+	)
+
+	for workerIdx := range executionContextWorkers {
+		second, err := harness.PublishedExecutionContext(workerIdx)
+		require.NoError(t, err)
+		require.NotZero(
+			t,
+			second,
+			"worker %d must have a published context after the second install",
+			workerIdx,
+		)
+		require.NotEqual(
+			t,
+			firstContexts[workerIdx],
+			second,
+			"worker %d's second generation must publish a fresh context",
+			workerIdx,
+		)
+		assigned, err := harness.WorkerExecutionContext(workerIdx)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			second,
+			assigned,
+			"worker %d's field must follow the second generation",
+			workerIdx,
+		)
+	}
+}
+
+// Test_WorkerExecutionContext_Round_AcksAssignedGenerationOnThatWorkerOnly
+// verifies that one round run on a single worker acknowledges exactly
+// the published generation on that worker, while a worker that never
+// ran keeps acknowledging zero.
+func Test_WorkerExecutionContext_Round_AcksAssignedGenerationOnThatWorkerOnly(t *testing.T) {
+	harness := newExecutionContextHarness(t)
+
+	require.NoError(t, harness.InstallEmptyPipeline("round"))
+
+	ethernet := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ipv4 := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolICMPv4,
+		SrcIP:    net.ParseIP("1.2.3.4"),
+		DstIP:    net.ParseIP("10.0.0.5"),
+	}
+	icmp := layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
+	}
+	packet := xpacket.LayersToPacket(t, &ethernet, &ipv4, &icmp)
+
+	// The topology wires no device, so the round drops the packet; the
+	// dropped packet proves the round processed input on worker 0.
+	result, err := harness.HandlePacketsOnWorker(0, packet)
+	require.NoError(t, err)
+	require.Empty(t, result.Output)
+	require.Len(t, result.Drop, 1)
+
+	acknowledged, err := harness.WorkerGeneration(0)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		harness.PublishedGeneration(),
+		acknowledged,
+		"worker 0 must acknowledge the published generation after its round",
+	)
+	idleAcknowledged, err := harness.WorkerGeneration(1)
+	require.NoError(t, err)
+	require.Zero(
+		t,
+		idleAcknowledged,
+		"worker 1 never ran a round and must keep acknowledging zero",
+	)
+}
+
+// Test_WorkerExecutionContext_ConcurrentPublish_WaitsForInFlightRound
+// verifies that a publish running while a round holds the round lock
+// blocks until the round releases it, so no round can still touch the
+// retired context when the old generation is freed.
+func Test_WorkerExecutionContext_ConcurrentPublish_WaitsForInFlightRound(t *testing.T) {
+	harness := newExecutionContextHarness(t)
+
+	require.NoError(t, harness.InstallEmptyPipeline("before"))
+
+	// Hold the round lock across the publish, exactly as a round holds
+	// it across every context dereference: the install may retire the
+	// old contexts only after this release.
+	harness.holdRoundLock()
+
+	publishDone := make(chan error, 1)
+	go func() {
+		publishDone <- harness.InstallEmptyPipeline("during")
+	}()
+
+	select {
+	case err := <-publishDone:
+		t.Fatalf("install completed while the round lock is held: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	harness.releaseRoundLock()
+	require.NoError(t, <-publishDone)
+
+	for workerIdx := range executionContextWorkers {
+		published, err := harness.PublishedExecutionContext(workerIdx)
+		require.NoError(t, err)
+		assigned, err := harness.WorkerExecutionContext(workerIdx)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			published,
+			assigned,
+			"worker %d's field must hold the context published after the round lock was released",
+			workerIdx,
+		)
+	}
+}
+
 func TestHarnessLifecycle(t *testing.T) {
 	cfg := Config{
 		CPMemory:    uint64(datasize.MB * 32),

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -529,6 +529,7 @@ dataplane_init(
 
 		instance->dp_config->instance_idx = instance_idx;
 		instance->dp_config->instance_count = dataplane->instance_count;
+		instance->config_assigner_started = false;
 
 		static const char *default_modules[] = {
 			"forward",
@@ -965,6 +966,19 @@ dataplane_start(struct dataplane *dataplane) {
 		}
 	}
 
+	for (uint32_t instance_idx = 0;
+	     instance_idx < dataplane->instance_count;
+	     ++instance_idx) {
+		if (dataplane_instance_config_assigner_start(
+			    dataplane->instances + instance_idx
+		    )) {
+			LOG(ERROR,
+			    "failed to start config assigner for instance %u",
+			    instance_idx);
+			return -1;
+		}
+	}
+
 	pthread_t thread_id;
 	int rc = pthread_create(&thread_id, NULL, stat_thread, dataplane);
 	if (rc != 0) {
@@ -980,6 +994,20 @@ int
 dataplane_stop(struct dataplane *dataplane) {
 	for (size_t dev_idx = 0; dev_idx < dataplane->device_count; ++dev_idx) {
 		dataplane_device_stop(dataplane->devices + dev_idx);
+	}
+
+	// The workers are joined above while the assigners still run:
+	// this call parks the process (the worker loops never return on
+	// their own), and a join only ends once the worker's loop has
+	// ended, so the assigners must keep publishing generations for
+	// as long as workers acknowledge them. The assigners are stopped
+	// only after every worker loop has ended.
+	for (uint32_t instance_idx = 0;
+	     instance_idx < dataplane->instance_count;
+	     ++instance_idx) {
+		dataplane_instance_config_assigner_stop(
+			dataplane->instances + instance_idx
+		);
 	}
 
 	return 0;

--- a/dataplane/dataplane.h
+++ b/dataplane/dataplane.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <pthread.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -12,7 +14,19 @@ struct dataplane_instance {
 	struct dp_config *dp_config;
 	struct cp_config *cp_config;
 	uint32_t **device_xstat_map;
+
+	// Assigner of published generations to this instance's workers.
+	pthread_t config_assigner_thread;
+	// Gates the join: false unless a thread was created and not yet
+	// reaped.
+	bool config_assigner_started;
 };
+
+int
+dataplane_instance_config_assigner_start(struct dataplane_instance *instance);
+
+void
+dataplane_instance_config_assigner_stop(struct dataplane_instance *instance);
 
 #define DATAPLANE_MAX_INSTANCES 8
 

--- a/dataplane/instance.c
+++ b/dataplane/instance.c
@@ -1,0 +1,107 @@
+#include "dataplane.h"
+
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+#include "common/memory_address.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/logging/log.h"
+
+// Busy phase length of one poll cycle.
+//
+// A few microseconds of yielding keep the thread hot through the
+// window right after a poll without turning the phase into a spin.
+#define CONFIG_ASSIGNER_YIELD_ITERS 16
+
+// Sleep that closes each poll cycle.
+//
+// A hundred-microsecond request sleeps roughly half again as long on
+// a default-slack kernel, so a published generation reaches the
+// workers well inside a millisecond while the idle thread burns only
+// a few percent of one unpinned core.
+#define CONFIG_ASSIGNER_SLEEP_NS UINT64_C(100000)
+
+// Process-wide stop request for the assigner threads.
+//
+// The dataplane starts and stops exactly once, and every instance's
+// assigner is stopped together, so one flag serves them all. Stored with
+// release ordering before the joins; loaded with acquire ordering in the
+// poll loops.
+static bool config_assigner_stop;
+
+static void *
+config_assigner_thread(void *arg) {
+	struct dataplane_instance *instance = (struct dataplane_instance *)arg;
+	struct dp_config *dp_config = instance->dp_config;
+	struct cp_config *cp_config = instance->cp_config;
+
+	static const struct timespec sleep_ts = {
+		.tv_sec = (time_t)(CONFIG_ASSIGNER_SLEEP_NS / 1000000000ULL),
+		.tv_nsec = (long)(CONFIG_ASSIGNER_SLEEP_NS % 1000000000ULL),
+	};
+
+	// Nothing is assigned yet, so the first pass also delivers the
+	// generation published before the thread started, bootstrap state
+	// included.
+	struct cp_config_gen *last_assigned = NULL;
+
+	for (;;) {
+		struct cp_config_gen *published =
+			ATOMIC_ADDR_OF(&cp_config->cp_config_gen);
+		if (published != last_assigned) {
+			dp_config_assign_worker_ectxs(dp_config, published);
+			last_assigned = published;
+		}
+
+		if (__atomic_load_n(&config_assigner_stop, __ATOMIC_ACQUIRE)) {
+			break;
+		}
+
+		for (unsigned iters = 0; iters < CONFIG_ASSIGNER_YIELD_ITERS;
+		     ++iters) {
+			if (__atomic_load_n(
+				    &config_assigner_stop, __ATOMIC_ACQUIRE
+			    )) {
+				break;
+			}
+			sched_yield();
+		}
+		nanosleep(&sleep_ts, NULL);
+	}
+
+	return NULL;
+}
+
+int
+dataplane_instance_config_assigner_start(struct dataplane_instance *instance) {
+	int rc = pthread_create(
+		&instance->config_assigner_thread,
+		NULL,
+		config_assigner_thread,
+		instance
+	);
+	if (rc != 0) {
+		LOG(ERROR,
+		    "failed to create config assigner thread: %s",
+		    strerror(rc));
+		return -1;
+	}
+	instance->config_assigner_started = true;
+	return 0;
+}
+
+void
+dataplane_instance_config_assigner_stop(struct dataplane_instance *instance) {
+	if (!instance->config_assigner_started) {
+		return;
+	}
+
+	__atomic_store_n(&config_assigner_stop, true, __ATOMIC_RELEASE);
+	pthread_join(instance->config_assigner_thread, NULL);
+	instance->config_assigner_started = false;
+}

--- a/dataplane/meson.build
+++ b/dataplane/meson.build
@@ -17,6 +17,7 @@ lib_sources = files(
   'config.c',
   'dataplane.c',
   'device.c',
+  'instance.c',
   'worker.c',
   'numa.c',
 )

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -287,15 +287,13 @@ worker_write(
 
 static void
 worker_loop_round(struct dataplane_worker *worker) {
-	struct cp_config *cp_config = worker->instance->cp_config;
 	uint64_t current_time_ns =
 		tsc_clock_get_time_ns(&worker->dp_worker->clock);
 	worker_rx_pool_sampler_sample(
 		&worker->rx_pool_sampler, worker->rx_mempool, current_time_ns
 	);
-	struct worker_round round = worker_round_prepare(
-		worker->dp_worker, cp_config, current_time_ns
-	);
+	struct worker_round round =
+		worker_round_prepare(worker->dp_worker, current_time_ns);
 	struct cp_config_gen *cp_config_gen = round.cp_config_gen;
 	struct config_gen_ectx *config_gen_ectx = round.config_gen_ectx;
 

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -286,7 +286,7 @@ cp_config_gen_install(
 	// Release-publish the new generation so workers never observe this
 	// pointer before its contents are fully written.
 	ATOMIC_SET_OFFSET_OF(&cp_config->cp_config_gen, new_config_gen);
-	dp_config_wait_for_gen(dp_config, new_config_gen->gen);
+	dp_config_wait_for_gen(dp_config, new_config_gen);
 
 	// The new generation already carries the pin it was created with, so
 	// publishing it as current spends that pin rather than adding one.

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -24,7 +24,7 @@ _Static_assert(
 	"struct module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct dp_config) == 1184,
+	sizeof(struct dp_config) == 1240,
 	"struct dp_config size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
@@ -52,7 +52,7 @@ _Static_assert(
 	"struct config_gen_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct dp_worker) == 160,
+	sizeof(struct dp_worker) == 168,
 	"struct dp_worker size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/config/zone.c
+++ b/lib/dataplane/config/zone.c
@@ -4,6 +4,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "lib/controlplane/config/zone.h"
+
 struct dp_config *
 dp_config_nextk(struct dp_config *current, uint32_t k) {
 	for (uint32_t i = 0; i < k; ++i) {
@@ -19,15 +21,32 @@ dp_config_nextk(struct dp_config *current, uint32_t k) {
 // Fixed nanosleep interval used once the yield phase is exhausted.
 #define DP_CONFIG_GEN_ACK_SLEEP_NS UINT64_C(1000000)
 
-// Waits for a single worker to acknowledge gen.
+// Observes both the worker's context assignment and its acknowledged
+// generation.
+//
+// The waiter needs the pair, not either alone: the assignment proves the
+// worker switched away from the superseded context, the acknowledgement
+// orders the round that last used it before this observation.
+static bool
+dp_worker_ectx_and_gen_observed(
+	struct dp_worker *worker, struct config_gen_ectx *expected, uint64_t gen
+) {
+	return ATOMIC_ADDR_OF(&worker->config_gen_ectx) == expected &&
+	       __atomic_load_n(&worker->gen, __ATOMIC_ACQUIRE) >= gen;
+}
+
+// Waits for a single worker to take the expected context and acknowledge
+// gen.
 //
 // Backs off from sched_yield to a fixed-interval nanosleep, without ever
 // giving up.
 static void
-dp_config_wait_for_worker_gen(struct dp_worker *worker, uint64_t gen) {
+dp_config_wait_for_worker_ectx(
+	struct dp_worker *worker, struct config_gen_ectx *expected, uint64_t gen
+) {
 	for (unsigned iters = 0; iters < DP_CONFIG_GEN_ACK_YIELD_ITERS;
 	     ++iters) {
-		if (__atomic_load_n(&worker->gen, __ATOMIC_ACQUIRE) >= gen) {
+		if (dp_worker_ectx_and_gen_observed(worker, expected, gen)) {
 			return;
 		}
 		sched_yield();
@@ -38,7 +57,7 @@ dp_config_wait_for_worker_gen(struct dp_worker *worker, uint64_t gen) {
 		.tv_nsec = (long)(DP_CONFIG_GEN_ACK_SLEEP_NS % 1000000000ULL),
 	};
 	for (;;) {
-		if (__atomic_load_n(&worker->gen, __ATOMIC_ACQUIRE) >= gen) {
+		if (dp_worker_ectx_and_gen_observed(worker, expected, gen)) {
 			return;
 		}
 		nanosleep(&sleep_ts, NULL);
@@ -46,14 +65,61 @@ dp_config_wait_for_worker_gen(struct dp_worker *worker, uint64_t gen) {
 }
 
 void
-dp_config_wait_for_gen(struct dp_config *dp_config, uint64_t gen) {
+dp_config_assign_worker_ectxs(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+) {
 	// The loop bound and the array it indexes come from one observation.
 	struct dp_worker *const *workers = ADDR_OF(&dp_config->workers);
 	const uint64_t worker_count = dp_config->worker_count;
 
 	for (uint64_t idx = 0; idx < worker_count; ++idx) {
 		struct dp_worker *worker = ADDR_OF(workers + idx);
-		dp_config_wait_for_worker_gen(worker, gen);
+		struct config_gen_ectx *expected =
+			cp_config_gen_worker_ectx(config_gen, idx);
+		// Skip workers already holding the expected context: the
+		// release store exists for the switch, and re-issuing it on
+		// every assignment pass would make the field flap for
+		// readers that are content.
+		if (ADDR_OF(&worker->config_gen_ectx) != expected) {
+			ATOMIC_SET_OFFSET_OF(
+				&worker->config_gen_ectx, expected
+			);
+		}
+	}
+}
+
+void
+dp_config_wait_for_gen(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+) {
+	// The harness round driver holds external_round_lock across every
+	// dereference of a worker context, and rounds are the only users
+	// of the contexts in this mode.
+	//
+	// Waiting for the lock therefore spans any in-flight round: once
+	// it is held, no round can still be dereferencing the retired
+	// contexts, so delivering the new ones in place completes the
+	// switch with no further acknowledgement to wait for.
+	if (dp_config->external_worker_rounds) {
+		pthread_mutex_t *round_lock =
+			dp_config_external_round_lock(dp_config);
+		pthread_mutex_lock(round_lock);
+		dp_config_assign_worker_ectxs(dp_config, config_gen);
+		pthread_mutex_unlock(round_lock);
+		return;
+	}
+
+	// The loop bound and the array it indexes come from one observation.
+	struct dp_worker *const *workers = ADDR_OF(&dp_config->workers);
+	const uint64_t worker_count = dp_config->worker_count;
+
+	for (uint64_t idx = 0; idx < worker_count; ++idx) {
+		struct dp_worker *worker = ADDR_OF(workers + idx);
+		struct config_gen_ectx *expected =
+			cp_config_gen_worker_ectx(config_gen, idx);
+		dp_config_wait_for_worker_ectx(
+			worker, expected, config_gen->gen
+		);
 	}
 }
 

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
@@ -15,6 +16,7 @@
 #include "lib/counters/counters.h"
 
 struct cp_config;
+struct cp_config_gen;
 struct rte_mempool;
 
 struct dp_module {
@@ -101,6 +103,16 @@ struct dp_worker {
 	uint32_t device_id;
 	uint32_t queue_id;
 	uint32_t rx_burst_size;
+
+	// Offset pointer to the execution context this worker runs,
+	// taken from the generation most recently assigned to it.
+	//
+	// Written by the instance's config assigner with release ordering
+	// whenever a new generation is published; read by the worker at
+	// the start of every round with acquire ordering. NULL until the
+	// first generation carrying execution contexts is assigned, which
+	// keeps the worker on the pre-configuration drop path.
+	struct config_gen_ectx *config_gen_ectx;
 };
 
 // Value written to dp_config.ready_magic by dp_config_mark_ready once the
@@ -159,6 +171,23 @@ struct dp_config {
 	uint64_t port_count;
 	struct dp_port_counters *port_counters;
 
+	// Selects the synchronous generation hand-off used by in-process
+	// harnesses; production leaves it clear.
+	//
+	// Set once before the instance is marked ready, when no worker
+	// threads exist and rounds run on caller threads: the generation
+	// waiter then delivers contexts to the workers itself,
+	// synchronously, under the round lock below.
+	bool external_worker_rounds;
+
+	// Storage of the harness round lock.
+	//
+	// pthread_mutex_t sizing differs between architectures, so the
+	// lock lives in fixed-size storage to keep the shared-memory
+	// layout architecture-independent. Only a harness that set
+	// external_worker_rounds initializes and locks it.
+	uint64_t external_round_lock_storage[6];
+
 	// Written by dp_config_mark_ready with release ordering after the
 	// dataplane releases cp_config and finishes initialising the instance.
 	//
@@ -167,6 +196,18 @@ struct dp_config {
 	// cp_config is not held, so an attacher will not block on the lock.
 	uint64_t ready_magic;
 };
+
+// The harness round lock, reached through its fixed-size storage.
+static inline pthread_mutex_t *
+dp_config_external_round_lock(struct dp_config *dp_config) {
+	return (pthread_mutex_t *)dp_config->external_round_lock_storage;
+}
+
+_Static_assert(
+	sizeof(((struct dp_config *)NULL)->external_round_lock_storage) >=
+		sizeof(pthread_mutex_t),
+	"external_round_lock_storage no longer fits pthread_mutex_t"
+);
 
 /*
  * Returns dp_config of k-th instance from current.
@@ -206,11 +247,24 @@ dp_config_lookup_object(
 uint64_t
 dp_config_device_worker_count(struct dp_config *dp_config, uint32_t device_id);
 
-// Waits for every worker of dp_config to acknowledge generation gen.
+// Deliver each worker of dp_config the execution context built for it in
+// config_gen.
 //
-// This is the grace period cp_config_gen_install needs before it may
-// reclaim the generation gen superseded. Blocks with no timeout, by
-// design: an early return would let an owner reclaim memory an
-// unacknowledged worker may still dereference.
+// A context of NULL is valid and returns the worker to the pre-configuration
+// drop path; it is what generations without per-worker contexts assign.
 void
-dp_config_wait_for_gen(struct dp_config *dp_config, uint64_t gen);
+dp_config_assign_worker_ectxs(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+);
+
+// Waits for every worker of dp_config to hold the execution context of
+// config_gen and to have acknowledged that generation.
+//
+// This is the grace period the publisher needs before it may reclaim the
+// generation config_gen superseded. Blocks with no timeout, by design: an
+// early return would let an owner reclaim memory an unacknowledged worker
+// may still dereference.
+void
+dp_config_wait_for_gen(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+);

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 21
+#define YANET_MODULE_ABI_VERSION 22
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/worker/round.h
+++ b/lib/dataplane/worker/round.h
@@ -14,26 +14,33 @@ struct worker_round {
 // Prepare the worker state that precedes packet processing.
 //
 // The caller evaluates current_time_ns before entering this helper. The
-// release publication and iteration increment retain production ordering.
+// release acknowledgement and iteration increment retain production
+// ordering.
 static inline struct worker_round
-worker_round_prepare(
-	struct dp_worker *dp_worker,
-	struct cp_config *cp_config,
-	uint64_t current_time_ns
-) {
+worker_round_prepare(struct dp_worker *dp_worker, uint64_t current_time_ns) {
 	__atomic_store_n(
 		&dp_worker->current_time, current_time_ns, __ATOMIC_RELAXED
 	);
 
+	// The round acknowledges the generation of the context it actually
+	// snapshotted.
+	//
+	// The release store orders the previous round's uses of a retired
+	// context before the acknowledgement that permits its reclamation;
+	// a NULL context acknowledges zero, the pre-configuration state.
+	struct config_gen_ectx *config_gen_ectx =
+		ATOMIC_ADDR_OF(&dp_worker->config_gen_ectx);
+	struct cp_config_gen *cp_config_gen = NULL;
+	uint64_t acknowledged_gen = 0;
+	if (config_gen_ectx != NULL) {
+		cp_config_gen = ADDR_OF(&config_gen_ectx->cp_config_gen);
+		acknowledged_gen = cp_config_gen->gen;
+	}
 	struct worker_round round = {
-		.cp_config_gen = ATOMIC_ADDR_OF(&cp_config->cp_config_gen),
+		.cp_config_gen = cp_config_gen,
+		.config_gen_ectx = config_gen_ectx,
 	};
-	round.config_gen_ectx =
-		cp_config_gen_worker_ectx(round.cp_config_gen, dp_worker->idx);
-
-	__atomic_store_n(
-		&dp_worker->gen, round.cp_config_gen->gen, __ATOMIC_RELEASE
-	);
+	__atomic_store_n(&dp_worker->gen, acknowledged_gen, __ATOMIC_RELEASE);
 	*dp_worker->iterations += 1;
 
 	// Flip or first-build the worklists before any packet of this tick

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -1,10 +1,5 @@
 #include "dataplane_ut.h"
 
-// dp_worker->gen is initialized to a value far above any plausible
-// production cp_config_gen->gen so that harness workers never
-// observe a "wait for newer generation" state.
-#define DATAPLANE_UT_HIGH_GEN 1000000000000000ULL
-
 #include <dlfcn.h>
 #include <errno.h>
 #include <stdint.h>
@@ -120,6 +115,12 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 	ut->dp_config->packet_recirc_limit =
 		cfg->packet_recirc_limit == 0 ? PACKET_RECIRC_LIMIT_DEFAULT
 					      : cfg->packet_recirc_limit;
+
+	// The harness runs no worker threads of its own: rounds and
+	// installs run on arbitrary caller threads, and the lock
+	// serializes the synchronous deliveries against in-flight rounds.
+	ut->dp_config->external_worker_rounds = true;
+	pthread_mutex_init(dp_config_external_round_lock(ut->dp_config), NULL);
 
 	// Open the current binary so dlsym can resolve module/device symbols.
 	void *bin_hndl = dlopen(NULL, RTLD_NOW | RTLD_GLOBAL);
@@ -331,9 +332,6 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		}
 		memset(dp_worker, 0, sizeof(struct dp_worker));
 		dp_worker->idx = idx;
-		// A high generation value ensures the pipeline never waits for
-		// a newer config snapshot — same trick used by mock.
-		dp_worker->gen = DATAPLANE_UT_HIGH_GEN;
 		dp_worker->rx_mempool = ut->mempool;
 		dp_worker->core_id = (uint32_t)idx;
 		if (cfg->workers != NULL) {
@@ -605,9 +603,13 @@ dataplane_ut_run(
 	struct dp_worker **workers = ADDR_OF(&ut->dp_config->workers);
 	struct dp_worker *dp_worker = ADDR_OF(&workers[worker_idx]);
 
-	struct worker_round round = worker_round_prepare(
-		dp_worker, ut->cp_config, ut->mock_time_ns
-	);
+	// Held across the whole round: the synchronous delivery inside a
+	// generation install waits on this lock, so a context the round
+	// snapshotted cannot be retired underneath it.
+	pthread_mutex_lock(dp_config_external_round_lock(ut->dp_config));
+
+	struct worker_round round =
+		worker_round_prepare(dp_worker, ut->mock_time_ns);
 	struct cp_config_gen *cp_config_gen = round.cp_config_gen;
 	struct config_gen_ectx *config_gen_ectx = round.config_gen_ectx;
 
@@ -623,6 +625,8 @@ dataplane_ut_run(
 		while ((packet = packet_list_pop(input)) != NULL) {
 			packet_list_add(&result->drop, packet);
 		}
+		pthread_mutex_unlock(dp_config_external_round_lock(ut->dp_config
+		));
 		return;
 	}
 
@@ -650,6 +654,8 @@ dataplane_ut_run(
 
 	packet_list_concat(&result->output, &packet_front.output);
 	packet_list_concat(&result->drop, &packet_front.drop);
+
+	pthread_mutex_unlock(dp_config_external_round_lock(ut->dp_config));
 }
 
 // Saved per-packet state used by dataplane_ut_run_rounds.
@@ -837,7 +843,91 @@ cleanup:
 	return result;
 }
 
+void
+dataplane_ut_round_lock_acquire(struct dataplane_ut *ut) {
+	pthread_mutex_lock(dp_config_external_round_lock(ut->dp_config));
+}
+
+void
+dataplane_ut_round_lock_release(struct dataplane_ut *ut) {
+	pthread_mutex_unlock(dp_config_external_round_lock(ut->dp_config));
+}
+
 int
 dataplane_ut_build_optimized(void) {
 	return build_is_optimized();
+}
+
+int
+dataplane_ut_install_empty_pipeline(struct dataplane_ut *ut, const char *name) {
+	struct cp_pipeline_config *config = cp_pipeline_config_create(name, 0);
+	if (config == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_install_empty_pipeline: failed to allocate "
+		    "pipeline config");
+		return -1;
+	}
+
+	yanet_error *err = NULL;
+	struct cp_pipeline_config *configs[] = {config};
+	int rc = cp_config_update_pipelines(
+		ut->dp_config, ut->cp_config, 1, configs, &err
+	);
+	if (rc != 0) {
+		LOG(ERROR,
+		    "dataplane_ut_install_empty_pipeline: update failed: %s",
+		    yanet_error_message(err) ? yanet_error_message(err) : "?");
+	}
+	yanet_error_free(err);
+	cp_pipeline_config_free(config);
+	return rc;
+}
+
+static struct dp_worker *
+dataplane_ut_worker(struct dataplane_ut *ut, size_t worker_idx) {
+	if (worker_idx >= ut->dp_config->worker_count) {
+		return NULL;
+	}
+	// An observation read: a caller inspecting while rounds or
+	// installs run on other threads must order the read itself.
+	struct dp_worker **workers = ADDR_OF(&ut->dp_config->workers);
+	return ADDR_OF(workers + worker_idx);
+}
+
+uintptr_t
+dataplane_ut_worker_ectx(struct dataplane_ut *ut, size_t worker_idx) {
+	struct dp_worker *worker = dataplane_ut_worker(ut, worker_idx);
+	if (worker == NULL) {
+		return 0;
+	}
+	return (uintptr_t)ADDR_OF(&worker->config_gen_ectx);
+}
+
+uintptr_t
+dataplane_ut_published_ectx(struct dataplane_ut *ut, size_t worker_idx) {
+	struct cp_config_gen *config_gen =
+		ADDR_OF(&ut->cp_config->cp_config_gen);
+	if (config_gen == NULL) {
+		return 0;
+	}
+	return (uintptr_t)cp_config_gen_worker_ectx(config_gen, worker_idx);
+}
+
+uint64_t
+dataplane_ut_worker_gen(struct dataplane_ut *ut, size_t worker_idx) {
+	struct dp_worker *worker = dataplane_ut_worker(ut, worker_idx);
+	if (worker == NULL) {
+		return 0;
+	}
+	return worker->gen;
+}
+
+uint64_t
+dataplane_ut_published_gen(struct dataplane_ut *ut) {
+	struct cp_config_gen *config_gen =
+		ADDR_OF(&ut->cp_config->cp_config_gen);
+	if (config_gen == NULL) {
+		return 0;
+	}
+	return config_gen->gen;
 }

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -125,8 +125,10 @@ dataplane_ut_set_worker_counter(
 // input is drained to empty on return; result->output and result->drop
 // hold the post-pipeline packets, whose mbuf ownership transfers to the caller.
 //
-// The harness is single-threaded: concurrent calls on the same handle
-// race on dp_worker state and the shared mempool.
+// The harness is single-threaded with one pairing: an install
+// running concurrently with a round serializes with it on the harness
+// round lock. Every other concurrent pairing on the same handle races
+// on dp_worker state and the shared mempool.
 void
 dataplane_ut_run(
 	struct dataplane_ut *ut,
@@ -176,3 +178,45 @@ dataplane_ut_run_rounds(
 	uint64_t rounds,
 	int reset_payload
 );
+
+// Install one named empty pipeline, forcing a generation switch.
+//
+// Returns 0 on success. The switch runs synchronously under the harness
+// round lock, so on return every worker's context field holds the newly
+// published generation's context; acknowledgements advance only as
+// rounds run.
+int
+dataplane_ut_install_empty_pipeline(struct dataplane_ut *ut, const char *name);
+
+// Hold the harness round lock.
+//
+// The lock a round holds across every context dereference; a caller
+// holding it proves that a concurrent install waits for the in-flight
+// round instead of retiring its contexts. Every acquire must pair
+// with exactly one release.
+void
+dataplane_ut_round_lock_acquire(struct dataplane_ut *ut);
+
+// Release the harness round lock taken by the acquire above.
+void
+dataplane_ut_round_lock_release(struct dataplane_ut *ut);
+
+// Resolved value of the worker's assigned context field, 0 when the
+// worker index is out of range or no context is assigned.
+uintptr_t
+dataplane_ut_worker_ectx(struct dataplane_ut *ut, size_t worker_idx);
+
+// Resolved per-worker context of the currently published generation,
+// with the same conventions as the worker field reader above.
+uintptr_t
+dataplane_ut_published_ectx(struct dataplane_ut *ut, size_t worker_idx);
+
+// The generation number the worker last acknowledged, 0 when the worker
+// index is out of range.
+uint64_t
+dataplane_ut_worker_gen(struct dataplane_ut *ut, size_t worker_idx);
+
+// Generation number of the currently published generation, 0 when no
+// generation is published.
+uint64_t
+dataplane_ut_published_gen(struct dataplane_ut *ut);


### PR DESCRIPTION
- Each worker now holds its execution context in a dedicated field, assigned by a new intermediate thread per dataplane instance whenever a generation is published.
- The generation switch waits until every worker holds the new context and acknowledges its generation, so the superseded generation is reclaimed only after its last use.
- In-process harnesses deliver contexts synchronously under a round lock that serializes installs against in-flight rounds; new behavioral tests pin the assignment, acknowledgement, and concurrent-publish protocol.
- Bumps YANET_MODULE_ABI_VERSION to 22, covering both shared-memory layout changes of this change.