### PR TITLE
fix(fwstate,cli): abort update on a failed pre-flight config read

### DIFF
--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -156,24 +156,23 @@ impl FWStateService {
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
         // First, fetch the current config to merge with new values
+        //
+        // A failed read aborts the update: only an empty reply proves the
+        // config is missing and may take the create path.
         let current_request = ShowConfigRequest {
             name: cmd.config_name.clone(),
             ok_if_not_found: true,
         };
-        let current_response = self.service.client().show_config(current_request).await;
-        let (map_name_v4, map_name_v6, mut sync_config) = match current_response {
-            Ok(resp) => {
-                let msg = resp.into_inner();
-                let (map_name_v4, map_name_v6) =
-                    merged_map_names(&msg, &cmd).map_err(|err| self.service.invalid("update", err))?;
-                (map_name_v4, map_name_v6, msg.sync_config.unwrap_or_default())
-            }
-            _ => (
-                cmd.map_name_v4.clone().unwrap_or_default(),
-                cmd.map_name_v6.clone().unwrap_or_default(),
-                Default::default(),
-            ),
-        };
+        let current = self
+            .service
+            .client()
+            .show_config(current_request)
+            .await
+            .map_err(self.service.status("update"))?
+            .into_inner();
+        let (map_name_v4, map_name_v6) =
+            merged_map_names(&current, &cmd).map_err(|err| self.service.invalid("update", err))?;
+        let mut sync_config = current.sync_config.unwrap_or_default();
 
         // Update only the fields that were provided
         if let Some(src_addr) = cmd.src_addr {


### PR DESCRIPTION
- The `update` command treated any failed pre-flight `ShowConfig` read — a transient `Unavailable`, an auth failure, a timeout — as a missing config, built the request from the flags alone and either failed with a misleading `InvalidArgument` or reported success without ever having verified what it was updating.
- A failed read now aborts the command with that error and the matching exit code, and the create path is taken only on the empty reply a genuinely missing name gets under `ok_if_not_found`.
- The catch-all arm also duplicated the map-name fallback without the create check that `merged_map_names` enforces, and is gone with it.
- The issue's unit-test acceptance item is deliberately not delivered: after the fix the error path is bare error propagation with no crate-own logic left to pin.
- Closes #2338.