### PR TITLE
fix(cli): connect through unix sockets

### DIFF
--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -28,7 +28,7 @@ use prost::Message;
 use tonic::{
     client::Grpc,
     codec::{CompressionEncoding, ProstCodec},
-    transport::Channel,
+    transport::{Channel, Endpoint},
     Request, Status,
 };
 use tower::Layer;
@@ -96,7 +96,11 @@ pub enum ConnectionError {
 /// returned channel.
 pub async fn connect(args: &ConnectionArgs) -> Result<LayeredChannel, ConnectionError> {
     let establish = async {
-        let channel = Channel::from_shared(args.endpoint.clone())?.connect().await?;
+        let channel = if args.endpoint.starts_with("unix://") {
+            Endpoint::from_shared(args.endpoint.clone())?.connect().await?
+        } else {
+            Channel::from_shared(args.endpoint.clone())?.connect().await?
+        };
         let auth = auth::create_layer(&args.auth).await?;
 
         Ok::<_, ConnectionError>(auth.layer(channel))

--- a/cli/core/src/errors.rs
+++ b/cli/core/src/errors.rs
@@ -29,7 +29,7 @@ pub enum ErrorKind {
     Unavailable,
     /// A gRPC-level error not covered by other variants.
     Rpc,
-    /// TCP / TLS connection could not be established.
+    /// A transport connection to the endpoint could not be established.
     Connection,
 }
 


### PR DESCRIPTION
- Route unix:/// endpoints through tonic’s Unix-domain transport while keeping the existing TCP path unchanged.
- Preserve transport-level connection error reporting for Unix socket failures.
- Implement the Unix-socket portion of #2353 while leaving TLS for a separate design and PR.