### PR TITLE
feat(cli): report build identity

### DIFF
--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -23,3 +23,10 @@ pub fn init<F: Format>(verbosity: u8, format: F) {
     self::signal::init();
     self::output::init(verbosity, format);
 }
+
+pub fn version() -> &'static str {
+    match option_env!("YANET_VERSION") {
+        Some("") | None => concat!(env!("CARGO_PKG_VERSION"), "-unknown"),
+        Some(version) => version,
+    }
+}

--- a/cli/core/src/main.rs
+++ b/cli/core/src/main.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, sync::LazyLock};
 
-use clap::{crate_name, crate_version, ArgMatches, Command};
+use clap::{crate_name, ArgMatches, Command};
 use colored::{ColoredString, Colorize};
 use yanet_cli::dispatcher::{self, Dispatch, Namespace};
 
@@ -26,7 +26,7 @@ struct Dispatcher;
 impl Dispatch for Dispatcher {
     fn cmd(&self, modules: &HashSet<String>) -> Command {
         let cmd = Command::new(crate_name!())
-            .version(crate_version!())
+            .version(yanet_cli::version())
             .allow_external_subcommands(true);
         dispatcher::add_subcommands(cmd, modules)
     }

--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -14,7 +14,7 @@ const LOGGING_SERVICE: &str = "controlplane.ynpb.v1.Logging";
 
 /// Common functionality.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 struct Cmd {
     #[command(subcommand)]

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -19,7 +19,7 @@ const COUNTERS_SERVICE: &str = "controlplane.ynpb.v1.CountersService";
 
 /// Counters module - displays counters information.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/cli/modules/device/src/main.rs
+++ b/cli/modules/device/src/main.rs
@@ -20,7 +20,7 @@ const DEVICE_SERVICE: &str = "controlplane.ynpb.v1.DeviceService";
 /// Device list module - displays all configured devices with their registry
 /// indices.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[command(flatten)]

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -23,7 +23,7 @@ const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(FUNCTION_SERVICE, "request
 
 /// Function module.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -18,7 +18,7 @@ const GATEWAY_SERVICE: &str = "controlplane.ynpb.v1.Gateway";
 
 /// Gateway - inspects the gateway service registry.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -19,7 +19,7 @@ const INSPECT_SERVICE: &str = "controlplane.ynpb.v1.InspectService";
 
 /// Inspect module - displays system introspection information.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[command(flatten)]

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -33,7 +33,7 @@ const NO_SERVICES: &str = "no metrics services are registered with the gateway";
 /// large payload, so naming none is a usage error whose hint lists the
 /// available services rather than dumping them all.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     /// Metrics service to probe: either a fully-qualified gRPC service name

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -23,7 +23,7 @@ const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(PIPELINE_SERVICE, "request
 
 /// Pipeline module.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -41,7 +41,7 @@ const READINESS_SERVICE: &str = "ReadinessService";
 /// discovered from the gateway registry, so neither the user nor the CLI has
 /// to keep a list of them.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     /// Readiness service to probe: either a fully-qualified gRPC service name

--- a/debian/rules
+++ b/debian/rules
@@ -10,6 +10,8 @@ export DEB_LDFLAGS_MAINT_APPEND = -fno-lto
 
 # Enable all hardening options
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+YANET_VERSION ?= $(DEB_VERSION)
+export YANET_VERSION
 
 # Pin the DWARF source path so it does not carry the package version.
 #

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -18,7 +18,7 @@ pub mod code {
 
 /// DevicePlain module.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -27,7 +27,7 @@ pub mod trafgenpb {
 
 /// Traffic generator device CLI.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -18,7 +18,7 @@ pub mod code {
 
 /// DeviceVlan module.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -231,7 +231,7 @@ struct ShowConfig {
 
 /// ACL module CLI.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,

--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -28,7 +28,7 @@ use crate::service::Balancer2Service;
 
 /// Balancer2 module CLI.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -24,7 +24,7 @@ pub mod blackholepb {
 
 /// Blackhole module.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -27,7 +27,7 @@ pub mod decappb {
 
 /// Decap module.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -29,7 +29,7 @@ pub mod dscppb {
 
 /// DSCP module for packet marking.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -27,7 +27,7 @@ pub mod forwardpb {
 
 /// Forward module.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -30,7 +30,7 @@ const SERVICE_NAME: &str = "modules.fwstate.controlplane.fwstatepb.v1.FWStateSer
 
 /// FWState module CLI.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -32,7 +32,7 @@ pub mod mirrorpb {
 
 /// Mirror module.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -34,7 +34,7 @@ const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested c
 
 /// NAT64 module CLI.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -35,7 +35,7 @@ pub mod pdumppb {
 
 /// Pdump - packet dump module
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -29,7 +29,7 @@ use ync::{
 
 /// Route module.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -111,7 +111,7 @@ impl FibConfig {
 
 /// Route module CLI.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -33,7 +33,7 @@ pub mod unrduppb {
 
 /// Unrdup module.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -32,7 +32,7 @@ const SERVICE_NAME: &str = "objects.fwstate.controlplane.fwstatemappb.v1.FWState
 /// FWState-map CLI: manages the standalone fwstate-map objects module
 /// configs (fwstate sync, ACL) link by name.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/operators/pipeline/cli/src/main.rs
+++ b/operators/pipeline/cli/src/main.rs
@@ -11,7 +11,7 @@ use ync::{client::ConnectionArgs, output::CommonFormat};
 
 /// Pipeline operator CLI.
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true, subcommand_required = true, arg_required_else_help = true)]
 pub struct Cmd {
     #[command(flatten)]

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -47,7 +47,7 @@ const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested t
 
 /// Neighbour operator CLI (neighbour table management).
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -42,7 +42,7 @@ const SERVICE_NAME: &str = "operators.route.operatorpb.v1.RouteService";
 
 /// Route operator CLI (RIB management).
 #[derive(Debug, Clone, Parser)]
-#[command(version, about)]
+#[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]


### PR DESCRIPTION
- Report a shared build identity from every CLI binary.
- Use `YANET_VERSION` when CI injects it and fall back to the CLI Cargo version with an `-unknown` suffix.
- Seed Debian builds from `DEB_VERSION` while preserving explicit overrides.

Closes #2351.