### PR TITLE
refactor(cli): centralize command lifecycle

### DIFF
--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -27,20 +27,20 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   (`CommonFormat`, `default_value = "human"`, `global = true`, doc
   `Output format.`) and `-v` (`ArgAction::Count`, `global = true`, doc
   `Be verbose: shows debug log lines and raw gRPC error details.`).
-- `fn main()` is synchronous: `CompleteEnv::with_factory(Cmd::command).complete();
-  start();`. `#[tokio::main(flavor = "current_thread")] async fn start()` parses,
-  calls `ync::init(cmd.verbose, cmd.format)` and ends with
-  `if let Err(err) = run(cmd).await { output::failure(&err);
-  std::process::exit(err.exit_code()); }`. Completion never runs inside the
-  runtime.
-- `run(cmd)` builds the service object once and matches `cmd.mode`; every
-  handler returns `Result<(), Error>`.
+- `fn main() -> std::process::ExitCode` delegates the lifecycle to
+  `ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)`. The scaffold
+  owns completion before Tokio, parsing, output initialisation, the
+  current-thread runtime, error rendering and the process status.
+- `run(cmd)` determines the action, builds the service object once and matches
+  `cmd.mode`; every handler returns `Result<(), Error>`.
 - `const SERVICE_NAME: &str = "<proto package>.<Service>";` with the doc
   `/// The fully-qualified gRPC service name used in error messages.`. One
-  service: `Service::connect(&cmd.connection, SERVICE_NAME, |channel|
-  Client::new(channel).send_compressed(Gzip).accept_compressed(Gzip)).await?`.
-  Several: `Connection::connect(&cmd.connection).await?` once, then
-  `Service::new(&connection, NAME, build)` per client.
+  service: `Service::connect_for(&cmd.connection, action, SERVICE_NAME,
+  |channel| Client::new(channel).send_compressed(Gzip)
+  .accept_compressed(Gzip)).await?`. Several:
+  `Connection::connect_for(&cmd.connection, action).await?` once, then
+  `Service::new(&connection, NAME, build)` per client. The action is the same
+  user-facing verb passed to the command's RPC error mapping.
 - Every RPC: `self.service.client().<rpc>(request).await
   .map_err(self.service.status("<verb>"))?.into_inner()`.
 - Generated code: `#[allow(clippy::all, clippy::std_instead_of_core,

--- a/.agents/skills/code-cli/references/new-crate.md
+++ b/.agents/skills/code-cli/references/new-crate.md
@@ -43,7 +43,6 @@ netip = "0.3"
 prost = "0.13"
 serde = { version = "1", features = ["derive"] }
 tabled = { version = "0.18", features = ["ansi"] }
-tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }
 
 [build-dependencies]
@@ -91,7 +90,6 @@ use std::borrow::Cow;
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::{
-    CompleteEnv,
     engine::{ArgValueCandidates, CompletionCandidate},
 };
 use tabled::Tabled;
@@ -149,6 +147,17 @@ pub enum ModeCmd {
     Delete(DeleteCmd),
 }
 
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Show(..) => "show",
+            Self::Update(..) => "update",
+            Self::Delete(..) => "delete",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Name of the <x> config to operate on.
@@ -173,24 +182,13 @@ pub struct DeleteCmd {
     pub config_name: String,
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = <X>Service::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = <X>Service::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -205,8 +203,8 @@ pub struct <X>Service {
 }
 
 impl <X>Service {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             <X>ServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
@@ -340,9 +338,10 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 }
 ```
 
-Several services behind one binary: `Connection::connect(connection).await?`
-once, then `Service::new(&connection, NAME, build)` for each client, all
-kept in the service struct.
+Several services behind one binary:
+`Connection::connect_for(connection, action).await?` once, then
+`Service::new(&connection, NAME, build)` for each client, all kept in the
+service struct.
 
 ## Registration
 
@@ -368,5 +367,5 @@ cargo test -p yanet-cli-<suffix>
 
 Then run the binary against a closed port (`--endpoint grpc://127.0.0.1:1`):
 a malformed argument must exit 2 with clap's message, a valid one must reach
-`connect failed` and exit 4; `--help` must describe every flag; `--format json`
+`<action> failed` and exit 4; `--help` must describe every flag; `--format json`
 must print the wire message.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,7 +3193,6 @@ dependencies = [
  "bytesize",
  "clap",
  "clap_complete",
- "colored",
  "serde_yaml",
  "tabled",
  "tokio",
@@ -3376,7 +3375,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "colored",
  "prost-types",
  "tabled",
  "tokio",

--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -120,7 +120,7 @@ pub async fn connect(args: &ConnectionArgs) -> Result<LayeredChannel, Connection
 ///
 /// Connect once, then build one [`Service`] per gRPC service over it with
 /// [`Service::new`]. Single-service CLIs skip this and use
-/// [`Service::connect`], which establishes the connection for them.
+/// [`Service::connect_for`], which establishes the connection for them.
 pub struct Connection {
     channel: LayeredChannel,
     endpoint: String,
@@ -305,6 +305,26 @@ impl<C> Service<C> {
         Ok(Self::new(&Connection::connect(connection).await?, name, build))
     }
 
+    /// Connect to one service with operation-aware failures.
+    ///
+    /// Transport and service failures carry the same user-facing operation
+    /// as the command's RPC failures.
+    pub async fn connect_for<F>(
+        connection: &ConnectionArgs,
+        action: &str,
+        name: &'static str,
+        build: F,
+    ) -> Result<Self, Error>
+    where
+        F: FnOnce(LayeredChannel) -> C,
+    {
+        Ok(Self::new(
+            &Connection::connect_for(connection, action).await?,
+            name,
+            build,
+        ))
+    }
+
     /// Mutable access to the inner client for issuing RPCs.
     pub fn client(&mut self) -> &mut C {
         &mut self.client
@@ -404,7 +424,7 @@ mod test {
     use socket2::{Domain, Socket, Type};
     use tonic::Status;
 
-    use super::{parse_timeout, Connection, ConnectionArgs, Service};
+    use super::{parse_timeout, ConnectionArgs, Service};
     use crate::{
         auth::{AuthArgs, AuthMethod},
         errors::ErrorKind,
@@ -424,9 +444,9 @@ mod test {
     }
 
     /// Verifies that a connect wedged before the TCP handshake completes
-    /// fails within the budget as a connection error naming it.
+    /// fails within the budget and retains the requested operation.
     #[tokio::test]
-    async fn test_connect_tcp_handshake_never_completing_times_out() {
+    async fn test_service_connect_for_tcp_handshake_never_completing_times_out() {
         // A backlog of 0 holds exactly one pending connection on Linux.
         // With that slot taken, further SYNs are silently dropped.
         let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
@@ -444,10 +464,14 @@ mod test {
             timeout: Some(Duration::from_millis(200)),
         };
 
-        let err = Connection::connect(&args).await.err().unwrap();
+        let err = Service::<()>::connect_for(&args, "show", "test.Service", |_| ())
+            .await
+            .err()
+            .unwrap();
 
         assert_eq!(ErrorKind::Connection, err.kind());
         assert_eq!(4, err.exit_code());
+        assert_eq!("show", err.action);
         assert_eq!("connect timed out after 0.2s", err.message());
     }
 

--- a/cli/core/src/completion.rs
+++ b/cli/core/src/completion.rs
@@ -90,38 +90,14 @@ pub fn connection_args(command: impl FnOnce() -> Command) -> ConnectionArgs {
 
 /// Best-effort completion candidates for a config-name argument.
 ///
-/// `command` is the caller's own `Cmd::command`, exactly the factory passed
-/// to `CompleteEnv::with_factory` in `main` — it recovers the connection
-/// flags (`--endpoint`, `--auth`, …) the user has actually typed so far, so
-/// completion talks to the gateway the user is targeting rather than
-/// silently falling back to the default one. `build` receives the layered
-/// channel and returns the caller's tonic-generated client, exactly like
-/// the `build` parameter of [`Service::new`](crate::client::Service::new) —
-/// compression is configured there, since it is an inherent client method.
-/// `lookup` issues the RPC on that client and returns the config names.
-///
-/// Strictly best-effort: a gateway that is down, slow, or refusing auth
-/// yields an empty list, never an error or a hang. Connect and lookup share
-/// one [`DISCOVERY_TIMEOUT`] budget, and the whole call runs on its own
-/// single-threaded runtime built and torn down here — nothing may reach
-/// stdout, since `clap_complete` owns it.
-///
-/// The caller must invoke `CompleteEnv::complete` from a sync `main`, before
-/// any runtime is entered, because the runtime built here is blocked on
-/// directly, which panics if it is reached from inside another runtime's
-/// context.
-///
-/// `lookup` must be a genuine async closure, `async move |client| …`, not a
-/// plain closure returning an `async move` block — the latter cannot infer
-/// `client`'s type and fails to compile.
-///
-/// Do not attach these candidates to an argument that uses clap's
-/// `value_delimiter`, such as a comma-separated list like pipeline's
-/// `--functions acl,route`. `ArgValueCandidates` completes the whole raw
-/// token before delimiter splitting, so a candidate would try to replace the
-/// entire typed token rather than just its trailing element, producing a
-/// wrong insertion — completing a delimited list needs delimiter-aware
-/// candidates, which this helper does not provide.
+/// The parser factory recovers connection flags from the partially typed
+/// command line, including its target endpoint. A slow or unavailable gateway
+/// yields an empty list within one fixed budget and writes nothing to stdout.
+/// Lookup runs on a temporary single-threaded runtime, so completion must
+/// execute before any command runtime. [`crate::entrypoint`] guarantees that
+/// ordering; direct lifecycle callers must preserve it. The lookup callback
+/// must be a direct async closure for type inference. Delimited arguments are
+/// unsupported because completion replaces the entire raw token.
 pub fn candidates<C, B, F>(command: impl FnOnce() -> Command, build: B, lookup: F) -> Vec<CompletionCandidate>
 where
     B: FnOnce(LayeredChannel) -> C,

--- a/cli/core/src/discovery.rs
+++ b/cli/core/src/discovery.rs
@@ -226,10 +226,11 @@ pub fn candidates(args: &ConnectionArgs, suffix: &str, budget: Duration) -> Vec<
     let args = args.clone();
     let suffix = suffix.to_owned();
 
-    // The completer is called from within the binary's `#[tokio::main]`
-    // runtime, which forbids a nested `block_on`, so the lookup gets a thread
-    // and a runtime of its own. A panic in it joins as an error and, like
-    // every other failure here, yields no candidates.
+    // Isolate discovery from any runtime the caller may already own.
+    //
+    // Direct lifecycle callers may request completion from Tokio. Blocking
+    // another runtime there would panic; a worker thread also turns such a
+    // panic into an empty candidate list like every other failure.
     std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -1,4 +1,10 @@
-use crate::output::Format;
+use core::future::Future;
+use std::process::{ExitCode, Termination};
+
+use clap::Parser;
+use clap_complete::CompleteEnv;
+
+use crate::{errors::Error, output::Format};
 
 pub mod auth;
 pub mod client;
@@ -15,18 +21,126 @@ pub mod timeout;
 
 mod signal;
 
-/// Initialise the logger and output backend from a `Format` choice.
+/// Initialise the logger and selected output backend.
 ///
-/// Must be called exactly once from `main` before any `output::*` helper.
-/// Panics if called twice or if the logger fails to install.
+/// Call exactly once before any output helper. Panics if called twice or if
+/// the logger fails to install.
 pub fn init<F: Format>(verbosity: u8, format: F) {
     self::signal::init();
     self::output::init(verbosity, format);
+}
+
+/// Runs a typed command through the shared CLI lifecycle.
+///
+/// Completion and parsing happen before the asynchronous runtime is entered.
+/// Output initialisation precedes command execution, and every structured
+/// error is rendered before its process status is returned.
+pub fn entrypoint<C, O, Options, Run, Fut, Success>(options: Options, run: Run) -> ExitCode
+where
+    C: Parser,
+    O: output::Format,
+    Options: FnOnce(&C) -> (u8, O),
+    Run: FnOnce(C) -> Fut,
+    Fut: Future<Output = Result<Success, Error>>,
+    Success: Termination,
+{
+    entrypoint_with(
+        || CompleteEnv::with_factory(C::command).complete(),
+        C::parse,
+        options,
+        crate::init,
+        run,
+    )
+}
+
+fn entrypoint_with<C, O, Complete, Parse, Options, Initialise, Run, Fut, Success>(
+    complete: Complete,
+    parse: Parse,
+    options: Options,
+    initialise: Initialise,
+    run: Run,
+) -> ExitCode
+where
+    Complete: FnOnce(),
+    Parse: FnOnce() -> C,
+    Options: FnOnce(&C) -> (u8, O),
+    Initialise: FnOnce(u8, O),
+    Run: FnOnce(C) -> Fut,
+    Fut: Future<Output = Result<Success, Error>>,
+    Success: Termination,
+{
+    complete();
+
+    let cmd = parse();
+    let (verbosity, format) = options(&cmd);
+    initialise(verbosity, format);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build the CLI runtime");
+
+    match runtime.block_on(async move { run(cmd).await }) {
+        Ok(success) => success.report(),
+        Err(err) => {
+            output::failure(&err);
+
+            let code = u8::try_from(err.exit_code()).expect("CLI exit codes must fit into a byte");
+            ExitCode::from(code)
+        }
+    }
 }
 
 pub fn version() -> &'static str {
     match option_env!("YANET_VERSION") {
         Some("") | None => concat!(env!("CARGO_PKG_VERSION"), "-unknown"),
         Some(version) => version,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::cell::RefCell;
+    use std::rc::Rc;
+
+    use super::*;
+
+    /// Verifies that setup finishes outside Tokio and execution starts inside
+    /// it.
+    #[test]
+    fn test_entrypoint_orders_setup_around_runtime() {
+        let steps = Rc::new(RefCell::new(Vec::new()));
+
+        let complete_steps = Rc::clone(&steps);
+        let parse_steps = Rc::clone(&steps);
+        let options_steps = Rc::clone(&steps);
+        let initialise_steps = Rc::clone(&steps);
+        let run_steps = Rc::clone(&steps);
+
+        let _ = entrypoint_with(
+            move || {
+                assert!(tokio::runtime::Handle::try_current().is_err());
+                complete_steps.borrow_mut().push("complete");
+            },
+            move || {
+                assert!(tokio::runtime::Handle::try_current().is_err());
+                parse_steps.borrow_mut().push("parse");
+            },
+            move |_: &()| {
+                options_steps.borrow_mut().push("options");
+                (0, ())
+            },
+            move |_, _| initialise_steps.borrow_mut().push("initialise"),
+            move |_| async move {
+                assert!(tokio::runtime::Handle::try_current().is_ok());
+                run_steps.borrow_mut().push("run");
+                Ok::<(), Error>(())
+            },
+        );
+
+        assert_eq!(
+            ["complete", "parse", "options", "initialise", "run"],
+            steps.borrow().as_slice()
+        );
     }
 }

--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -1,14 +1,9 @@
-//! Process-global output context and free-function API.
+//! Process-global output context and reporting facade.
 //!
-//! Call [`init`] once from `main` after parsing CLI flags. Every helper
-//! (`success`, `failure`, `data`) reads the global state set by that
-//! call — callers never need to thread an `Output` reference through
-//! their signatures.
-//!
-//! The extension point is the [`Format`] trait: each CLI declares its own
-//! enum of supported formats and implements [`Format`] once. [`init`] accepts
-//! any `F: Format`. [`CommonFormat`] is a ready-made `{ Human, Json }` enum
-//! for CLIs that do not need additional formats.
+//! The shared lifecycle installs one backend after parsing CLI flags. Reports
+//! read that state, so callers never thread an output reference through their
+//! signatures. Each CLI implements [`Format`] for its supported choices;
+//! [`CommonFormat`] provides the usual human and JSON pair.
 
 use core::fmt::Arguments;
 use std::{io::IsTerminal, sync::OnceLock};
@@ -218,13 +213,14 @@ impl Format for CommonFormat {
 
 static OUTPUT: OnceLock<Box<dyn Output>> = OnceLock::new();
 
-/// Initialise the logger and output backend from a `Format` choice.
+/// Initialise the logger and selected output backend.
 ///
-/// Must be called exactly once from `main` before any `output::*` helper.
-/// Panics if called twice or if the logger fails to install.
+/// Call exactly once before any output helper. Panics if called twice or if
+/// the logger fails to install.
 pub fn init<F: Format>(verbosity: u8, format: F) {
     logging::init(verbosity as usize).expect("logger init failed");
     OUTPUT.set(format.build()).ok().expect("output already initialised");
+    colored::control::set_override(is_colored());
 }
 
 fn current() -> &'static dyn Output {

--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -1,10 +1,9 @@
 //! CLI for YANET "logging" core module.
 
-use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
-use clap_complete::CompleteEnv;
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::ConnectionArgs,
+    client::{ConnectionArgs, Service},
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -68,17 +67,8 @@ impl From<LogLevel> for ynpb::pb::LogLevel {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+pub fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 impl ModeCmd {
@@ -91,25 +81,23 @@ impl ModeCmd {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let endpoint = cmd.connection.endpoint.clone();
-
-    let channel = ync::client::connect(&cmd.connection)
-        .await
-        .map_err(|err| Error::from_connection(err, action, endpoint.clone()))?;
-
-    let mut client = LoggingClient::new(channel)
-        .send_compressed(CompressionEncoding::Gzip)
-        .accept_compressed(CompressionEncoding::Gzip);
+    let mut service = Service::connect_for(&cmd.connection, action, LOGGING_SERVICE, |channel| {
+        LoggingClient::new(channel)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip)
+    })
+    .await?;
 
     match cmd.mode {
         ModeCmd::Logging(LoggingCmd::SetLevel(cmd)) => {
             let request = UpdateLevelRequest {
                 level: ynpb::pb::LogLevel::from(cmd.level.clone()).into(),
             };
-            client
+            service
+                .client()
                 .update_level(request)
                 .await
-                .map_err(|status| Error::from_status(status, action, endpoint.clone(), LOGGING_SERVICE))?;
+                .map_err(service.status(action))?;
 
             output::success(action, format_args!("Set log level to {:?}.", cmd.level));
         }

--- a/cli/modules/counters/Cargo.toml
+++ b/cli/modules/counters/Cargo.toml
@@ -18,5 +18,4 @@ tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }
 bytesize = "2.0.1"
 tabled = { version = "0.18", features = ["ansi"] }
-colored = "3"
 serde_yaml = "0.9"

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -1,8 +1,7 @@
 //! CLI for YANET "counters" module.
 
 use bytesize::ByteSize;
-use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap::{ArgAction, Parser};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
@@ -118,18 +117,8 @@ impl ModeCmd {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-    colored::control::set_override(output::is_colored());
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+pub fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
@@ -190,7 +179,7 @@ pub struct CountersService {
 
 impl CountersService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect(connection, COUNTERS_SERVICE, |channel| {
+        let service = Service::connect_for(connection, action, COUNTERS_SERVICE, |channel| {
             CountersServiceClient::new(channel)
                 .max_decoding_message_size(256 * 1024 * 1024)
                 .max_encoding_message_size(256 * 1024 * 1024)

--- a/cli/modules/device/src/main.rs
+++ b/cli/modules/device/src/main.rs
@@ -4,12 +4,11 @@
 //! consumers to resolve numeric device_id values (e.g. from pdump
 //! RecordMeta.rx_device_id) to human-readable names.
 
-use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap::{ArgAction, Parser};
 use colored::Colorize;
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, LayeredChannel},
+    client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -33,17 +32,8 @@ pub struct Cmd {
     pub verbose: u8,
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+pub fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
@@ -56,31 +46,28 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 pub struct DeviceService {
-    client: DeviceServiceClient<LayeredChannel>,
-    endpoint: String,
+    service: Service<DeviceServiceClient<LayeredChannel>>,
 }
 
 impl DeviceService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let channel = ync::client::connect(connection)
-            .await
-            .map_err(|err| Error::from_connection(err, "device-list", connection.endpoint.clone()))?;
-        let client = DeviceServiceClient::new(channel)
-            .send_compressed(CompressionEncoding::Gzip)
-            .accept_compressed(CompressionEncoding::Gzip);
-
-        Ok(Self {
-            client,
-            endpoint: connection.endpoint.clone(),
+        let service = Service::connect_for(connection, "device-list", DEVICE_SERVICE, |channel| {
+            DeviceServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
         })
+        .await?;
+
+        Ok(Self { service })
     }
 
     pub async fn list(&mut self) -> Result<ListDevicesResponse, Error> {
         let response = self
-            .client
+            .service
+            .client()
             .list(ListDevicesRequest {})
             .await
-            .map_err(|status| Error::from_status(status, "device-list", self.endpoint.clone(), DEVICE_SERVICE))?
+            .map_err(self.service.status("device-list"))?
             .into_inner();
 
         Ok(response)

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -1,10 +1,7 @@
 //! CLI for YANET "function" module.
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    engine::{ArgValueCandidates, CompletionCandidate},
-    CompleteEnv,
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::FunctionId;
 use tonic::{codec::CompressionEncoding, Status};
 use ync::{
@@ -50,6 +47,17 @@ pub enum ModeCmd {
     Delete(DeleteCmd),
 }
 
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list functions",
+            Self::Show(..) => "show function",
+            Self::Update(..) => "update function",
+            Self::Delete(..) => "delete function",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Function name.
@@ -78,24 +86,13 @@ pub struct DeleteCmd {
     pub name: String,
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = FunctionService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = FunctionService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => {
@@ -154,8 +151,8 @@ pub struct FunctionService {
 }
 
 impl FunctionService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, FUNCTION_SERVICE, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, FUNCTION_SERVICE, |channel| {
             FunctionServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)

--- a/cli/modules/gateway/Cargo.toml
+++ b/cli/modules/gateway/Cargo.toml
@@ -21,5 +21,4 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost-types = "0.13"
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }
-colored = "3"
 tabled = { version = "0.18", features = ["ansi"] }

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -2,8 +2,7 @@
 
 use std::time::SystemTime;
 
-use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap::{ArgAction, Parser};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
@@ -39,18 +38,8 @@ pub enum ModeCmd {
     List,
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-    colored::control::set_override(output::is_colored());
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+pub fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
@@ -67,7 +56,7 @@ pub struct GatewayService {
 
 impl GatewayService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, GATEWAY_SERVICE, |channel| {
+        let service = Service::connect_for(connection, "gateway", GATEWAY_SERVICE, |channel| {
             GatewayClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -4,8 +4,7 @@ use core::cmp::Reverse;
 use std::collections::BTreeMap;
 
 use bytesize::ByteSize;
-use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap::{ArgAction, Parser};
 use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
@@ -32,17 +31,8 @@ pub struct Cmd {
     pub verbose: u8,
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+pub fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
@@ -60,7 +50,7 @@ pub struct InspectService {
 
 impl InspectService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, INSPECT_SERVICE, |channel| {
+        let service = Service::connect_for(connection, "inspect", INSPECT_SERVICE, |channel| {
             InspectServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -1,10 +1,7 @@
 //! Generic metrics probe CLI.
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{GetMetricsRequest, GetMetricsResponse, Histogram, Label, Metric, MetricTag, metric::Value};
 use tabled::Tabled;
 use ync::{
@@ -62,20 +59,8 @@ pub struct Cmd {
     pub verbose: u8,
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    match run(cmd).await {
-        Ok(()) => {}
-        Err(err) => {
-            output::failure(&err);
-            std::process::exit(err.exit_code());
-        }
-    }
+pub fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Run the metrics probe against the named service.

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -1,10 +1,7 @@
 //! CLI for YANET "pipeline" module.
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    engine::{ArgValueCandidates, CompletionCandidate},
-    CompleteEnv,
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{FunctionId, PipelineId};
 use tonic::codec::CompressionEncoding;
 use ync::{
@@ -89,20 +86,8 @@ pub struct DeleteCmd {
     pub name: String,
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
@@ -170,7 +155,7 @@ pub struct PipelineService {
 
 impl PipelineService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect(connection, PIPELINE_SERVICE, |channel| {
+        let service = Service::connect_for(connection, action, PIPELINE_SERVICE, |channel| {
             PipelineServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -1,12 +1,9 @@
 //! Generic readiness probe CLI.
 
-use std::{collections::BTreeMap, time::SystemTime};
+use std::{collections::BTreeMap, process::ExitCode, time::SystemTime};
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use colored::Colorize;
 use readinesspb::pb::{ReadyRequest, ReadyResponse, Scope, State};
 use serde::Serialize;
@@ -22,7 +19,7 @@ mod render;
 mod watch;
 
 /// Exit code used when the RPC succeeds but not all scopes are `STATE_READY`.
-const EXIT_NOT_READY: i32 = 2;
+const EXIT_NOT_READY: u8 = 2;
 
 /// Caption of the hint that lists every discovered readiness service.
 const AVAILABLE_SERVICES: &str = "available readiness services:";
@@ -114,22 +111,8 @@ struct ServiceReport {
     error: Option<String>,
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-    colored::control::set_override(output::is_colored());
-
-    match run(cmd).await {
-        Ok(true) => {}
-        Ok(false) => std::process::exit(EXIT_NOT_READY),
-        Err(err) => {
-            output::failure(&err);
-            std::process::exit(err.exit_code());
-        }
-    }
+pub fn main() -> ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Run the readiness probe, dispatching to aggregate or single-service mode.
@@ -138,30 +121,36 @@ pub async fn main() {
 /// needs over it: resolving the alias, probing the service and enriching the
 /// error hint. A failure to establish it is reported as a failure of the verb
 /// the user asked for, `ready`, exactly like a failing probe.
-async fn run(cmd: Cmd) -> Result<bool, Error> {
-    if cmd.is_aggregate() {
-        return run_aggregate(cmd).await;
-    }
-
-    let name = cmd.name.clone().expect("a non-aggregate command names a service");
-
-    if is_blank(&name) {
-        return Err(Error::invalid_argument(
-            "ready",
-            &cmd.connection.endpoint,
-            "service name must not be empty",
-        ));
-    }
-
-    let connection = Connection::connect_for(&cmd.connection, "ready").await?;
-
-    let name = if name.contains('.') {
-        name
+async fn run(cmd: Cmd) -> Result<ExitCode, Error> {
+    let ready = if cmd.is_aggregate() {
+        run_aggregate(cmd).await?
     } else {
-        resolve_alias(&cmd, &connection, &name).await?
+        let name = cmd.name.clone().expect("a non-aggregate command names a service");
+
+        if is_blank(&name) {
+            return Err(Error::invalid_argument(
+                "ready",
+                &cmd.connection.endpoint,
+                "service name must not be empty",
+            ));
+        }
+
+        let connection = Connection::connect_for(&cmd.connection, "ready").await?;
+
+        let name = if name.contains('.') {
+            name
+        } else {
+            resolve_alias(&cmd, &connection, &name).await?
+        };
+
+        run_service(&cmd, &connection, &name).await?
     };
 
-    run_service(&cmd, &connection, &name).await
+    Ok(if ready {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(EXIT_NOT_READY)
+    })
 }
 
 /// Whether a service name is empty or whitespace only.

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -1,5 +1,4 @@
-use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap::{ArgAction, Parser};
 use code::{UpdateDevicePlainRequest, device_plain_service_client::DevicePlainServiceClient};
 use commonpb::pb::Device;
 use tonic::codec::CompressionEncoding;
@@ -60,7 +59,7 @@ pub struct DevicePlainService {
 
 impl DevicePlainService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+        let service = Service::connect_for(connection, "update", SERVICE_NAME, |channel| {
             DevicePlainServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
@@ -109,14 +108,6 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+pub fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -1,10 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::Device;
 use tonic::codec::CompressionEncoding;
 use trafgenpb::{
@@ -56,6 +53,18 @@ pub enum ModeCmd {
     Rate(SetRateCmd),
 }
 
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::Update(..) => "update",
+            Self::List => "list",
+            Self::Show(..) => "show",
+            Self::Upload(..) => "upload",
+            Self::Rate(..) => "rate",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// Generator device name to operate on.
@@ -104,8 +113,8 @@ pub struct TrafgenService {
 }
 
 impl TrafgenService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             TrafgenServiceClient::new(channel)
                 .max_decoding_message_size(256 * 1024 * 1024)
                 .max_encoding_message_size(256 * 1024 * 1024)
@@ -239,7 +248,8 @@ impl TrafgenService {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = TrafgenService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = TrafgenService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Update(cmd) => service.update_device(cmd).await,
@@ -250,20 +260,8 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Completion candidates for a `--name` argument: the generator device

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -1,5 +1,4 @@
-use clap::{ArgAction, CommandFactory, Parser, value_parser};
-use clap_complete::CompleteEnv;
+use clap::{ArgAction, Parser, value_parser};
 use code::{UpdateDeviceVlanRequest, device_vlan_service_client::DeviceVlanServiceClient};
 use commonpb::pb::Device;
 use tonic::codec::CompressionEncoding;
@@ -63,7 +62,7 @@ pub struct DeviceVlanService {
 
 impl DeviceVlanService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+        let service = Service::connect_for(connection, "update", SERVICE_NAME, |channel| {
             DeviceVlanServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
@@ -113,21 +112,13 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+pub fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 #[cfg(test)]
 mod test {
-    use clap::error::ErrorKind;
+    use clap::{CommandFactory, error::ErrorKind};
 
     use super::*;
 

--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -22,6 +22,19 @@ pub enum ModeCmd {
     RuleCounters(RuleCountersCmd),
 }
 
+impl ModeCmd {
+    pub(crate) fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Delete(..) => "delete",
+            Self::Update(..) => "update",
+            Self::Show(..) => "show",
+            Self::MetricsRules(..) => "metrics-rules",
+            Self::RuleCounters(..) => "rule-counters",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// ACL config name

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -7,7 +7,7 @@ use aclpb::{
 };
 use args::{DeleteCmd, MetricsRulesCmd, ModeCmd, RuleCountersCmd, ShowCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{CompleteEnv, engine::CompletionCandidate};
+use clap_complete::engine::CompletionCandidate;
 use serde::{Deserialize, Serialize};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
@@ -254,8 +254,8 @@ pub struct ACLService {
 }
 
 impl ACLService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let conn = Connection::connect(connection).await?;
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let conn = Connection::connect_for(connection, action).await?;
         let service = Service::new(&conn, SERVICE_NAME, |channel| {
             AclServiceClient::new(channel)
                 .max_decoding_message_size(256 * 1024 * 1024)
@@ -554,7 +554,8 @@ impl ACLService {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = ACLService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = ACLService::new(&cmd.connection, action).await?;
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
         ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
@@ -565,20 +566,8 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Completion candidates for a `--name` argument: the ACL configs the

--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -11,18 +11,10 @@ use core::{
 };
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use yanet_cli_balancer2::balancerpb;
-use ync::{
-    client::ConnectionArgs,
-    completion,
-    errors::Error,
-    output::{self, CommonFormat},
-};
+use ync::{client::ConnectionArgs, completion, errors::Error, output::CommonFormat};
 
 use crate::service::Balancer2Service;
 
@@ -59,6 +51,27 @@ pub enum ModeCmd {
     Metrics(MetricsCmd),
     /// Manage real servers.
     Reals(reals::RealsCmd),
+}
+
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::Update(..) => "update",
+            Self::List => "list",
+            Self::Config(..) => "config",
+            Self::Show(..) => "show",
+            Self::Sessions(cmd) => match &cmd.mode {
+                sessions::SessionsMode::List => "sessions list",
+                sessions::SessionsMode::Show(..) => "sessions show",
+                sessions::SessionsMode::Update(..) => "sessions update",
+            },
+            Self::Metrics(..) => "metrics",
+            Self::Reals(cmd) => match &cmd.mode {
+                reals::RealsMode::Enable(..) => "enable",
+                reals::RealsMode::Disable(..) => "disable",
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -304,24 +317,13 @@ impl FilterFlags {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = Balancer2Service::connect(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = Balancer2Service::connect(&cmd.connection, action).await?;
     service.handle(cmd.mode, cmd.format).await
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Completion candidates for a `--name` argument: the balancer configs the

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -31,8 +31,8 @@ pub struct Balancer2Service {
 }
 
 impl Balancer2Service {
-    pub async fn connect(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn connect(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             BalancerClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -3,13 +3,10 @@ use blackholepb::{
     blackhole_service_client::BlackholeServiceClient,
 };
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, LayeredChannel},
+    client::{ConnectionArgs, LayeredChannel, Service},
     completion,
     errors::Error,
     output::{self, CommonFormat},
@@ -46,6 +43,17 @@ pub enum ModeCmd {
     Delete(DeleteConfigCmd),
 }
 
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Show(..) => "show",
+            Self::Update(..) => "update",
+            Self::Delete(..) => "delete",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
     /// Blackhole module name to operate on.
@@ -70,24 +78,13 @@ pub struct DeleteConfigCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.blackhole.controlplane.blackholepb.v1.BlackholeService";
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = BlackholeService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = BlackholeService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -98,37 +95,30 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 pub struct BlackholeService {
-    client: BlackholeServiceClient<LayeredChannel>,
-    endpoint: String,
+    service: Service<BlackholeServiceClient<LayeredChannel>>,
 }
 
 impl BlackholeService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let channel = ync::client::connect(connection)
-            .await
-            .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
-        let client = BlackholeServiceClient::new(channel)
-            .send_compressed(CompressionEncoding::Gzip)
-            .accept_compressed(CompressionEncoding::Gzip);
-        Ok(Self {
-            client,
-            endpoint: connection.endpoint.clone(),
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
+            BlackholeServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
         })
-    }
+        .await?;
 
-    fn map_err<'a>(&'a self, action: &'a str) -> impl FnOnce(tonic::Status) -> Error + 'a {
-        let endpoint = self.endpoint.clone();
-        move |status| Error::from_status(status, action, endpoint, SERVICE_NAME)
+        Ok(Self { service })
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
         let request = ListConfigsRequest {};
         log::trace!("list configs request: {request:?}");
         let response = self
-            .client
+            .service
+            .client()
             .list_configs(request)
             .await
-            .map_err(self.map_err("list"))?
+            .map_err(self.service.status("list"))?
             .into_inner();
         log::debug!("list configs response: {response:?}");
 
@@ -156,10 +146,11 @@ impl BlackholeService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         log::trace!("show config request: {request:?}");
         let response = self
-            .client
+            .service
+            .client()
             .show_config(request)
             .await
-            .map_err(self.map_err("show"))?
+            .map_err(self.service.status("show"))?
             .into_inner();
         log::debug!("show config response: {response:?}");
 
@@ -177,10 +168,11 @@ impl BlackholeService {
         let request = UpdateConfigRequest { name: cmd.config_name.clone() };
         log::trace!("update config request: {request:?}");
         let response = self
-            .client
+            .service
+            .client()
             .update_config(request)
             .await
-            .map_err(self.map_err("update"))?
+            .map_err(self.service.status("update"))?
             .into_inner();
         log::debug!("update config response: {response:?}");
 
@@ -193,10 +185,11 @@ impl BlackholeService {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
         log::trace!("delete config request: {request:?}");
         let response = self
-            .client
+            .service
+            .client()
             .delete_config(request)
             .await
-            .map_err(self.map_err("delete"))?
+            .map_err(self.service.status("delete"))?
             .into_inner();
         log::debug!("delete config response: {response:?}");
 

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -1,8 +1,5 @@
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::partition_prefixes;
 use decappb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, ShowConfigResponse, UpdateConfigRequest,
@@ -51,6 +48,17 @@ pub enum ModeCmd {
     Delete(DeleteConfigCmd),
 }
 
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Show(..) => "show",
+            Self::Update(..) => "update",
+            Self::Delete(..) => "delete",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
     /// Decap module name to operate on.
@@ -81,24 +89,13 @@ const SERVICE_NAME: &str = "modules.decap.controlplane.decappb.v1.DecapService";
 /// Maps a genuine "config not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = DecapService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = DecapService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -113,8 +110,8 @@ pub struct DecapService {
 }
 
 impl DecapService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             DecapServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -1,8 +1,5 @@
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::partition_prefixes;
 use dscppb::{
     AddPrefixesRequest, DeleteConfigRequest, DscpConfig, RemovePrefixesRequest, SetDscpMarkingRequest,
@@ -53,6 +50,19 @@ pub enum ModeCmd {
     SetMarking(SetDscpMarkingCmd),
     /// Delete a dscp module config.
     Delete(DeleteConfigCmd),
+}
+
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Show(..) => "show",
+            Self::PrefixAdd(..) => "prefix-add",
+            Self::PrefixRemove(..) => "prefix-remove",
+            Self::SetMarking(..) => "set-marking",
+            Self::Delete(..) => "delete",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -109,24 +119,13 @@ const SERVICE_NAME: &str = "modules.dscp.controlplane.dscppb.v1.DscpService";
 /// Maps a genuine "config not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = DscpService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = DscpService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -143,8 +142,8 @@ pub struct DscpService {
 }
 
 impl DscpService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             DscpServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -1,10 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use forwardpb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     forward_service_client::ForwardServiceClient,
@@ -48,6 +45,17 @@ pub enum ModeCmd {
     Update(UpdateCmd),
     Show(ShowCmd),
     List,
+}
+
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::Delete(..) => "delete",
+            Self::Update(..) => "update",
+            Self::Show(..) => "show",
+            Self::List => "list",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -179,8 +187,8 @@ pub struct ForwardService {
 }
 
 impl ForwardService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             ForwardServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
@@ -280,6 +288,8 @@ impl ForwardService {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
+    let action = cmd.mode.action();
+
     // The update file is read and bound before the connection, so bad
     // local input fails deterministically with or without a reachable
     // gateway.
@@ -295,7 +305,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         _ => None,
     };
 
-    let mut service = ForwardService::new(&cmd.connection).await?;
+    let mut service = ForwardService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
@@ -308,20 +318,8 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Completion candidates for a `--name` argument: the forward configs the

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -21,6 +21,17 @@ pub enum ModeCmd {
     Show(ShowCmd),
 }
 
+impl ModeCmd {
+    pub(crate) fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Delete(..) => "delete",
+            Self::Update(..) => "update",
+            Self::Show(..) => "show",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// The name of the fwstate config to delete

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -2,7 +2,7 @@ use core::net::IpAddr;
 
 use args::{DeleteCmd, ModeCmd, ShowCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{CompleteEnv, engine::CompletionCandidate};
+use clap_complete::engine::CompletionCandidate;
 use commonpb::pb::IpAddress;
 use fwstatepb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, ShowConfigResponse, UpdateConfigRequest,
@@ -71,8 +71,8 @@ pub struct FWStateService {
 }
 
 impl FWStateService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let conn = Connection::connect(connection).await?;
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let conn = Connection::connect_for(connection, action).await?;
         let service = Service::new(&conn, SERVICE_NAME, |channel| {
             FwStateServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
@@ -236,7 +236,8 @@ impl FWStateService {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = FWStateService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = FWStateService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -246,20 +247,8 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Completion candidates for a `--name` argument: the fwstate configs the

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -5,10 +5,7 @@ use std::{
 };
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{IPv4Network, IPv6Network};
 use mirrorpb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
@@ -53,6 +50,17 @@ pub enum ModeCmd {
     Update(UpdateCmd),
     Show(ShowCmd),
     List,
+}
+
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::Delete(..) => "delete",
+            Self::Update(..) => "update",
+            Self::Show(..) => "show",
+            Self::List => "list",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -247,8 +255,8 @@ pub struct MirrorService {
 }
 
 impl MirrorService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             MirrorServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
@@ -353,7 +361,8 @@ impl MirrorService {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = MirrorService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = MirrorService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
@@ -363,20 +372,8 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Completion candidates for a `--name` argument: the mirror configs the

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -1,10 +1,7 @@
 use core::net::{Ipv4Addr, Ipv6Addr};
 
 use clap::{ArgAction, CommandFactory, Parser, Subcommand};
-use clap_complete::{
-    engine::{ArgValueCandidates, CompletionCandidate},
-    CompleteEnv,
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use nat64pb::{
     nat64_service_client::Nat64ServiceClient, AddMappingRequest, AddPrefixRequest, DeleteConfigRequest,
     ListConfigsRequest, RemoveMappingRequest, RemovePrefixRequest, SetDropUnknownRequest, SetMtuRequest,
@@ -71,6 +68,22 @@ pub enum ModeCmd {
     Mtu(MtuCmd),
     /// Set drop_unknown flags
     Drop(DropCmd),
+}
+
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Show(..) => "show",
+            Self::Delete(..) => "delete",
+            Self::Prefix { cmd: PrefixCmd::Add(..) } => "add prefix",
+            Self::Prefix { cmd: PrefixCmd::Remove(..) } => "remove prefix",
+            Self::Mapping { cmd: MappingCmd::Add(..) } => "add mapping",
+            Self::Mapping { cmd: MappingCmd::Remove(..) } => "remove mapping",
+            Self::Mtu(..) => "set mtu",
+            Self::Drop(..) => "set drop",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -176,24 +189,13 @@ pub struct DropCmd {
     pub drop_unknown_mapping: bool,
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = NAT64Service::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = NAT64Service::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -217,8 +219,8 @@ pub struct NAT64Service {
 }
 
 impl NAT64Service {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             Nat64ServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)

--- a/modules/pdump/cli/src/args.rs
+++ b/modules/pdump/cli/src/args.rs
@@ -13,6 +13,18 @@ pub enum ModeCmd {
     Read(ReadCmd),
 }
 
+impl ModeCmd {
+    pub(crate) fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Show(..) => "show",
+            Self::Set(..) => "set",
+            Self::Delete(..) => "delete",
+            Self::Read(..) => "read",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// Pdump config name to delete.

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -1,6 +1,6 @@
 use args::{DeleteCmd, ModeCmd, ReadCmd, SetConfigCmd, ShowConfigCmd};
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{CompleteEnv, engine::CompletionCandidate};
+use clap_complete::engine::CompletionCandidate;
 use pdumppb::{
     DeleteConfigRequest, ListConfigsRequest, ReadDumpRequest, ShowConfigRequest, ShowConfigResponse,
     pdump_service_client::PdumpServiceClient,
@@ -51,7 +51,8 @@ pub struct Cmd {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = PdumpService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = PdumpService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -70,8 +71,8 @@ pub struct PdumpService {
 }
 
 impl PdumpService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             PdumpServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
@@ -81,7 +82,7 @@ impl PdumpService {
         Ok(Self { service })
     }
 
-    async fn get_config(&mut self, name: &str) -> Result<ShowConfigResponse, Error> {
+    async fn get_config(&mut self, name: &str, action: &'static str) -> Result<ShowConfigResponse, Error> {
         let request = ShowConfigRequest { name: name.to_owned() };
         log::trace!("show config request: {request:?}");
         let response = self
@@ -89,7 +90,7 @@ impl PdumpService {
             .client()
             .show_config(request)
             .await
-            .map_err(self.service.status("show"))?
+            .map_err(self.service.status(action))?
             .into_inner();
         log::debug!("show config response: {response:?}");
         Ok(response)
@@ -130,7 +131,7 @@ impl PdumpService {
     }
 
     pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
-        let response = self.get_config(&cmd.config_name).await?;
+        let response = self.get_config(&cmd.config_name, "show").await?;
 
         output::data(
             || &response,
@@ -214,7 +215,7 @@ impl PdumpService {
         let (tx, rx) = tokio::sync::mpsc::channel::<pdumppb::Record>(16);
 
         log::debug!("request current pdump configuration");
-        let config = self.get_config(&cmd.config_name).await?;
+        let config = self.get_config(&cmd.config_name, "read").await?;
         let Some(config) = config.config else {
             return Err(Error::from_status(
                 Status::not_found(format!("config '{}' not found", cmd.config_name)),
@@ -320,20 +321,8 @@ fn print_tree(resp: &ShowConfigResponse) {
     let _ = ptree::print_tree(&tree.build());
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Completion candidates for a `--name` argument: the pdump configs the

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -10,10 +10,7 @@ pub mod routemplspb {
 }
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    engine::{ArgValueCandidates, CompletionCandidate},
-    CompleteEnv,
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use netip::{Contiguous, IpNetwork};
 use routemplspb::{
     route_mpls_service_client::RouteMplsServiceClient, update_event::Event, CreateConfigRequest, DeleteConfigRequest,
@@ -58,6 +55,19 @@ pub enum ModeCmd {
     Update(RouteUpdateCmd),
     /// Withdraw route
     Withdraw(RouteWithdrawCmd),
+}
+
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Show(..) => "show",
+            Self::Create(..) => "create",
+            Self::Delete(..) => "delete",
+            Self::Update(..) => "update",
+            Self::Withdraw(..) => "withdraw",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -125,20 +135,8 @@ pub struct RouteWithdrawCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.route_mpls.controlplane.routemplspb.v1.RouteMPLSService";
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Completion candidates for a `--name` argument: the route-mpls configs
@@ -158,7 +156,8 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = RouteMplsService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = RouteMplsService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -175,8 +174,8 @@ pub struct RouteMplsService {
 }
 
 impl RouteMplsService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             RouteMplsServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -4,14 +4,10 @@ use core::error::Error as StdError;
 use std::{
     fs::File,
     path::{Path, PathBuf},
-    process,
 };
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    engine::{ArgValueCandidates, CompletionCandidate},
-    CompleteEnv,
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use yanet_cli_route::{
     fib::render::print_fib,
@@ -131,6 +127,19 @@ pub enum ModeCmd {
     Fib(FibCmd),
 }
 
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::Fib(cmd) => match &cmd.action {
+                FibAction::List => "list",
+                FibAction::Show(..) => "show",
+                FibAction::Update(..) => "update",
+                FibAction::Delete(..) => "delete",
+            },
+        }
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 pub struct FibCmd {
     #[clap(subcommand)]
@@ -185,20 +194,8 @@ const SERVICE_NAME: &str = "modules.route.controlplane.routepb.v1.RouteService";
 /// Rewrites a genuine missing-config `NotFound` into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Completion candidates for a `--name` argument: the route configs the
@@ -218,7 +215,8 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = RouteService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = RouteService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Fib(cmd) => match cmd.action {
@@ -235,8 +233,8 @@ pub struct RouteService {
 }
 
 impl RouteService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             RouteServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
@@ -734,7 +732,7 @@ entries:
 
     #[test]
     fn test_fib_config_load_missing_file_names_the_path() {
-        let path = env::temp_dir().join(format!("yanet-cli-route-missing-fib-{}.yaml", process::id()));
+        let path = env::temp_dir().join(format!("yanet-cli-route-missing-fib-{}.yaml", std::process::id()));
 
         let err = FibConfig::load(&path).unwrap_err();
 
@@ -743,7 +741,7 @@ entries:
 
     #[test]
     fn test_fib_config_load_invalid_entry_names_the_path() {
-        let path = env::temp_dir().join(format!("yanet-cli-route-invalid-fib-{}.yaml", process::id()));
+        let path = env::temp_dir().join(format!("yanet-cli-route-invalid-fib-{}.yaml", std::process::id()));
         fs::write(&path, "entries:\n  - nexthops: []\n").unwrap();
 
         let err = FibConfig::load(&path).unwrap_err();
@@ -765,7 +763,7 @@ entries:
             timeout: None,
         };
 
-        let err = RouteService::new(&connection).await.err().unwrap();
+        let err = RouteService::new(&connection, "list").await.err().unwrap();
 
         assert_eq!(ErrorKind::Connection, err.kind());
         assert_eq!(4, err.exit_code());

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -5,10 +5,7 @@ use std::{
 };
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::IpAddress;
 use filterpb::pb::IpNet;
 use serde::{Deserialize, Serialize};
@@ -18,7 +15,7 @@ use unrduppb::{
     UpdateConfigRequest, unrdup_service_client::UnrdupServiceClient,
 };
 use ync::{
-    client::{ConnectionArgs, LayeredChannel},
+    client::{ConnectionArgs, LayeredChannel, Service as GrpcService},
     completion,
     errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
@@ -54,6 +51,17 @@ pub enum ModeCmd {
     Update(UpdateConfigCmd),
     /// Delete an unrdup module config.
     Delete(DeleteConfigCmd),
+}
+
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Show(..) => "show",
+            Self::Update(..) => "update",
+            Self::Delete(..) => "delete",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -230,24 +238,13 @@ const SERVICE_NAME: &str = "modules.unrdup.controlplane.unrduppb.v1.UnrdupServic
 /// Maps a genuine "config not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = UnrdupService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = UnrdupService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -258,42 +255,30 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 pub struct UnrdupService {
-    client: UnrdupServiceClient<LayeredChannel>,
-    endpoint: String,
+    service: GrpcService<UnrdupServiceClient<LayeredChannel>>,
 }
 
 impl UnrdupService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let channel = ync::client::connect(connection)
-            .await
-            .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
-        let client = UnrdupServiceClient::new(channel)
-            .send_compressed(CompressionEncoding::Gzip)
-            .accept_compressed(CompressionEncoding::Gzip);
-
-        Ok(Self {
-            client,
-            endpoint: connection.endpoint.clone(),
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = GrpcService::connect_for(connection, action, SERVICE_NAME, |channel| {
+            UnrdupServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
         })
-    }
+        .await?;
 
-    fn invalid(&self, action: &str, message: impl Into<String>) -> Error {
-        Error::invalid_argument(action, self.endpoint.clone(), message)
-    }
-
-    fn map_err<'a>(&'a self, action: &'a str) -> impl FnOnce(tonic::Status) -> Error + 'a {
-        let endpoint = self.endpoint.clone();
-        move |status| Error::from_status(status, action, endpoint, SERVICE_NAME)
+        Ok(Self { service })
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
         let request = ListConfigsRequest {};
         log::trace!("list configs request: {request:?}");
         let response = self
-            .client
+            .service
+            .client()
             .list_configs(request)
             .await
-            .map_err(self.map_err("list"))?
+            .map_err(self.service.status("list"))?
             .into_inner();
         log::debug!("list configs response: {response:?}");
 
@@ -321,18 +306,20 @@ impl UnrdupService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         log::trace!("show config request: {request:?}");
         let response = self
-            .client
+            .service
+            .client()
             .show_config(request)
             .await
-            .map_err(self.map_err("show"))?
+            .map_err(self.service.status("show"))?
             .into_inner();
         log::debug!("show config response: {response:?}");
 
         let config = response
             .config
-            .ok_or_else(|| self.invalid("show", "response carries no config"))?;
+            .ok_or_else(|| self.service.invalid("show", "response carries no config"))?;
 
-        let rendered = UnrdupConfig::try_from(config.clone()).map_err(|err| self.invalid("show", err.to_string()))?;
+        let rendered =
+            UnrdupConfig::try_from(config.clone()).map_err(|err| self.service.invalid("show", err.to_string()))?;
 
         output::data(
             || &config,
@@ -348,8 +335,8 @@ impl UnrdupService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Error> {
-        let config = UnrdupConfig::load(&cmd.config_path)
-            .map_err(|err| Error::invalid_argument("update", self.endpoint.clone(), err.to_string()))?;
+        let config =
+            UnrdupConfig::load(&cmd.config_path).map_err(|err| self.service.invalid("update", err.to_string()))?;
 
         let request = UpdateConfigRequest {
             name: cmd.config_name.clone(),
@@ -357,10 +344,11 @@ impl UnrdupService {
         };
         log::trace!("update config request: {request:?}");
         let response = self
-            .client
+            .service
+            .client()
             .update_config(request)
             .await
-            .map_err(self.map_err("update"))?
+            .map_err(self.service.status("update"))?
             .into_inner();
         log::debug!("update config response: {response:?}");
 
@@ -373,14 +361,15 @@ impl UnrdupService {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
         log::trace!("delete config request: {request:?}");
         let response = self
-            .client
+            .service
+            .client()
             .delete_config(request)
             .await
             .map_err(|status| {
                 NOT_FOUND.map(
                     status,
                     "delete",
-                    self.endpoint.clone(),
+                    self.service.endpoint(),
                     Some(&format!("config '{}'", cmd.config_name)),
                 )
             })?

--- a/objects/fwstate/cli/src/args.rs
+++ b/objects/fwstate/cli/src/args.rs
@@ -17,6 +17,19 @@ pub enum ModeCmd {
     InsertLayer(InsertLayerCmd),
 }
 
+impl ModeCmd {
+    pub(crate) fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Create(..) => "create",
+            Self::Delete(..) => "delete",
+            Self::Stats(..) => "stats",
+            Self::Entries(..) => "entries",
+            Self::InsertLayer(..) => "insert-layer",
+        }
+    }
+}
+
 /// Address family of a fwstate-map object.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum MapKind {

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -2,7 +2,7 @@ use core::{fmt, net::IpAddr};
 
 use args::{CreateCmd, DeleteCmd, DirectionArg, EntriesCmd, InsertLayerCmd, ListCmd, ModeCmd, StatsCmd};
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{CompleteEnv, engine::CompletionCandidate};
+use clap_complete::engine::CompletionCandidate;
 use commonpb::pb::IpAddress;
 use fwstatemappb::{
     CreateMapRequest, DeleteMapRequest, Direction, GetMapStatsRequest, InsertLayerRequest, Kind, ListEntriesRequest,
@@ -90,8 +90,8 @@ impl DumpState {
 }
 
 impl FWStateMapService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let conn = Connection::connect(connection).await?;
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let conn = Connection::connect_for(connection, action).await?;
         let service = Service::new(&conn, SERVICE_NAME, |channel| {
             FwStateMapServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
@@ -433,7 +433,8 @@ fn print_entry(entry: &fwstatemappb::FwStateEntry) {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = FWStateMapService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = FWStateMapService::new(&cmd.connection, action).await?;
     let format = cmd.format;
 
     match cmd.mode {
@@ -446,20 +447,8 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Completion candidates for a `--name` argument: the fwstate-map objects

--- a/operators/pipeline/cli/src/main.rs
+++ b/operators/pipeline/cli/src/main.rs
@@ -5,9 +5,8 @@
 //! invocation ends in help or a usage error. Operator metrics are read
 //! with `yanet-cli metrics`.
 
-use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
-use ync::{client::ConnectionArgs, output::CommonFormat};
+use clap::{ArgAction, Parser};
+use ync::{client::ConnectionArgs, errors::Error, output::CommonFormat};
 
 /// Pipeline operator CLI.
 #[derive(Debug, Clone, Parser)]
@@ -24,8 +23,10 @@ pub struct Cmd {
     pub verbose: u8,
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+}
 
-    Cmd::parse();
+async fn run(_: Cmd) -> Result<(), Error> {
+    Ok(())
 }

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -11,10 +11,7 @@ use std::{
 };
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{IpAddress, MacAddress};
 use netip::MacAddr;
 use tabled::Tabled;
@@ -72,6 +69,22 @@ pub enum ModeCmd {
     Remove(RemoveCmd),
     /// Neighbour table operations.
     Table(TableCmd),
+}
+
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::Show(..) => "show",
+            Self::Add(..) => "add",
+            Self::Remove(..) => "remove",
+            Self::Table(cmd) => match &cmd.action {
+                TableAction::Show => "list tables",
+                TableAction::Create(..) => "create table",
+                TableAction::Update(..) => "update table",
+                TableAction::Remove(..) => "remove table",
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -159,24 +172,13 @@ pub struct RemoveTableCmd {
     pub name: String,
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-    ync::init(cmd.verbose, cmd.format);
-
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = NeighbourService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = NeighbourService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Show(args) => service.show_neighbours(args).await,
@@ -196,8 +198,8 @@ pub struct NeighbourService {
 }
 
 impl NeighbourService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             NeighbourServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -11,10 +11,7 @@ use core::{
 use std::collections::HashMap;
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::{
-    CompleteEnv,
-    engine::{ArgValueCandidates, CompletionCandidate},
-};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use colored::Colorize;
 use commonpb::pb::IpPrefix;
 use netip::{Contiguous, IpNetwork};
@@ -70,6 +67,19 @@ pub enum ModeCmd {
     Remove(RouteRemoveCmd),
     /// Flush RIB to FIB for a configuration.
     Flush(RouteFlushCmd),
+}
+
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Show(..) => "show",
+            Self::Lookup(..) => "lookup",
+            Self::Insert(..) => "insert",
+            Self::Remove(..) => "remove",
+            Self::Flush(..) => "flush",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -155,24 +165,8 @@ impl RouteSource {
     }
 }
 
-fn main() {
-    CompleteEnv::with_factory(Cmd::command).complete();
-    start();
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn start() {
-    let cmd = Cmd::parse();
-
-    ync::init(cmd.verbose, cmd.format);
-
-    match run(cmd).await {
-        Ok(()) => {}
-        Err(err) => {
-            output::failure(&err);
-            std::process::exit(err.exit_code());
-        }
-    }
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
 
 /// Completion candidates for a `--name` argument: the route operator
@@ -196,7 +190,8 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 /// Returns `Ok(())` when the RPC succeeded, `Err(_)` on transport or RPC
 /// failure.
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = RouteService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = RouteService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -213,8 +208,8 @@ pub struct RouteService {
 }
 
 impl RouteService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let conn = Connection::connect(connection).await?;
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let conn = Connection::connect_for(connection, action).await?;
         let service = Service::new(&conn, SERVICE_NAME, |channel| {
             RouteServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)


### PR DESCRIPTION
- Centralize completion, initialization, current-thread runtime setup, structured error reporting, and exit status handling in `ync`.
- Propagate command actions through connection setup and migrate bespoke CLI clients to the shared service wrapper.
- Align the CLI authoring guidance with the shared lifecycle.
- Closes #2356.