### PR TITLE
fix(controlplane): validate value ranges in services

### DIFF
--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -79,6 +79,21 @@ func (m ShmDeviceConfig) AsRawPtr() unsafe.Pointer {
 	return unsafe.Pointer(m.ptr)
 }
 
+// MaxDeviceNameLen is the size of the C-side device name buffer, including
+// the terminating NUL.
+//
+// The largest usable name is one byte shorter than this bound.
+const MaxDeviceNameLen = C.CP_DEVICE_NAME_LEN
+
+// ValidateDeviceName rejects a name the C-side fixed-size device name
+// buffer cannot round-trip without silent truncation.
+func ValidateDeviceName(name string) error {
+	if len(name) > MaxDeviceNameLen-1 {
+		return fmt.Errorf("name is %d bytes, exceeds the %d-byte limit", len(name), MaxDeviceNameLen-1)
+	}
+	return nil
+}
+
 type Agent struct {
 	name string
 	ptr  *C.struct_agent

--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -21,6 +21,7 @@ import "C"
 
 import (
 	"fmt"
+	"strings"
 	"unsafe"
 
 	"github.com/c2h5oh/datasize"
@@ -86,8 +87,11 @@ func (m ShmDeviceConfig) AsRawPtr() unsafe.Pointer {
 const MaxDeviceNameLen = C.CP_DEVICE_NAME_LEN
 
 // ValidateDeviceName rejects a name the C-side fixed-size device name
-// buffer cannot round-trip without silent truncation.
+// buffer cannot round-trip: one with a NUL byte, or one that does not fit.
 func ValidateDeviceName(name string) error {
+	if strings.ContainsRune(name, 0) {
+		return fmt.Errorf("name contains a NUL byte")
+	}
 	if len(name) > MaxDeviceNameLen-1 {
 		return fmt.Errorf("name is %d bytes, exceeds the %d-byte limit", len(name), MaxDeviceNameLen-1)
 	}

--- a/controlplane/ffi/agent_test.go
+++ b/controlplane/ffi/agent_test.go
@@ -1,0 +1,17 @@
+package ffi_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+// TestValidateDeviceName pins the two rejection classes: a name the C-side
+// buffer cannot hold and a name with an embedded NUL byte.
+func TestValidateDeviceName(t *testing.T) {
+	require.NoError(t, ffi.ValidateDeviceName(strings.Repeat("a", ffi.MaxDeviceNameLen-1)))
+	require.Error(t, ffi.ValidateDeviceName(strings.Repeat("a", ffi.MaxDeviceNameLen)))
+	require.Error(t, ffi.ValidateDeviceName("edge\x00backup"))
+}

--- a/devices/plain/controlplane/plainpb/v1/plain.proto
+++ b/devices/plain/controlplane/plainpb/v1/plain.proto
@@ -9,6 +9,7 @@ option go_package = "github.com/yanet-platform/yanet2/devices/plain/controlplane
 service DevicePlainService { rpc UpdateDevice(UpdateDevicePlainRequest) returns (UpdateDevicePlainResponse); }
 
 message UpdateDevicePlainRequest {
+  // Accepted range: at most 79 bytes.
   string name = 1;
   common.commonpb.v1.Device device = 2;
 }

--- a/devices/plain/controlplane/service.go
+++ b/devices/plain/controlplane/service.go
@@ -45,6 +45,9 @@ func (m *DevicePlainService) UpdateDevice(
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
+	if err := ffi.ValidateDeviceName(name); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	deviceConfig, err := NewDeviceConfig(m.agent, name, request.GetDevice())
 	if err != nil {

--- a/devices/plain/controlplane/service_test.go
+++ b/devices/plain/controlplane/service_test.go
@@ -1,10 +1,13 @@
 package plain
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
@@ -116,6 +119,45 @@ func TestUpdateDevice_ReclaimsAcrossMultipleNames(t *testing.T) {
 		}
 		previousFreeBytes = freeBytes
 	}
+}
+
+// Test_DevicePlainService_UpdateDevice_RejectsOverlongName verifies that a name
+// the C-side fixed-size buffer cannot hold is rejected before the agent.
+func Test_DevicePlainService_UpdateDevice_RejectsOverlongName(t *testing.T) {
+	service := NewDevicePlainService(nil)
+
+	resp, err := service.UpdateDevice(t.Context(), &plainpb.UpdateDevicePlainRequest{
+		Name:   strings.Repeat("a", ffi.MaxDeviceNameLen),
+		Device: &commonpb.Device{},
+	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Test_DevicePlainService_UpdateDevice_AcceptsNameAtLimit verifies that a name
+// exactly at the C-side buffer's usable length is published end to end.
+func Test_DevicePlainService_UpdateDevice_AcceptsNameAtLimit(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	agent, err := shm.AgentAttach("plain", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	service := NewDevicePlainService(agent)
+
+	_, err = service.UpdateDevice(t.Context(), &plainpb.UpdateDevicePlainRequest{
+		Name:   strings.Repeat("a", ffi.MaxDeviceNameLen-1),
+		Device: &commonpb.Device{},
+	})
+	require.NoError(t, err)
 }
 
 // freeBytesForAgent returns the free byte count reported for the named

--- a/devices/trafgen/controlplane/service.go
+++ b/devices/trafgen/controlplane/service.go
@@ -87,6 +87,9 @@ func (m *TrafgenService) UpdateDevice(
 	if name == "" {
 		return nil, errConfigNameRequired
 	}
+	if err := ffi.ValidateDeviceName(name); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	input := pipelinesFromProto(req.GetDevice().GetInput())
 	output := pipelinesFromProto(req.GetDevice().GetOutput())
@@ -186,6 +189,9 @@ func (m *TrafgenService) UploadPcap(
 	if name == "" {
 		return nil, errConfigNameRequired
 	}
+	if err := ffi.ValidateDeviceName(name); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	packets, err := parsePcap(req.GetPcap())
 	if err != nil {
@@ -225,6 +231,9 @@ func (m *TrafgenService) SetRate(
 	name := req.GetName()
 	if name == "" {
 		return nil, errConfigNameRequired
+	}
+	if err := ffi.ValidateDeviceName(name); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	m.mu.Lock()

--- a/devices/trafgen/controlplane/service_test.go
+++ b/devices/trafgen/controlplane/service_test.go
@@ -2,6 +2,7 @@ package trafgen
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/devices/trafgen/bindings/go/ctrafgen"
 	trafgenpb "github.com/yanet-platform/yanet2/devices/trafgen/controlplane/trafgenpb/v1"
 )
@@ -274,6 +276,61 @@ func Test_TrafgenService_EmptyConfigName(t *testing.T) {
 		require.Nil(t, resp)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
+}
+
+// Test_TrafgenService_UpdateDevice_RejectsOverlongName verifies that a name
+// the C-side fixed-size buffer cannot hold is rejected before the backend.
+func Test_TrafgenService_UpdateDevice_RejectsOverlongName(t *testing.T) {
+	svc, backend := newTestService()
+
+	resp, err := svc.UpdateDevice(t.Context(), &trafgenpb.UpdateDeviceRequest{
+		Name:   strings.Repeat("a", ffi.MaxDeviceNameLen),
+		Device: &commonpb.Device{},
+	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Zero(t, backend.calls)
+}
+
+// Test_TrafgenService_UpdateDevice_AcceptsNameAtLimit verifies that a name
+// exactly at the C-side buffer's usable length reaches the backend.
+func Test_TrafgenService_UpdateDevice_AcceptsNameAtLimit(t *testing.T) {
+	svc, backend := newTestService()
+
+	_, err := svc.UpdateDevice(t.Context(), &trafgenpb.UpdateDeviceRequest{
+		Name:   strings.Repeat("a", ffi.MaxDeviceNameLen-1),
+		Device: &commonpb.Device{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, backend.calls)
+}
+
+// Test_TrafgenService_UploadPcap_RejectsOverlongName verifies that an overlong
+// name is rejected before the backend even when no config exists yet.
+func Test_TrafgenService_UploadPcap_RejectsOverlongName(t *testing.T) {
+	svc, backend := newTestService()
+
+	resp, err := svc.UploadPcap(t.Context(), &trafgenpb.UploadPcapRequest{
+		Name: strings.Repeat("a", ffi.MaxDeviceNameLen),
+		Pcap: buildPcap(t, [][]byte{bytes.Repeat([]byte{0x01}, 64)}),
+	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Zero(t, backend.calls)
+}
+
+// Test_TrafgenService_SetRate_RejectsOverlongName verifies that an overlong
+// name is rejected before the backend even when no config exists yet.
+func Test_TrafgenService_SetRate_RejectsOverlongName(t *testing.T) {
+	svc, backend := newTestService()
+
+	resp, err := svc.SetRate(t.Context(), &trafgenpb.SetRateRequest{
+		Name:    strings.Repeat("a", ffi.MaxDeviceNameLen),
+		RatePps: 1,
+	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Zero(t, backend.calls)
 }
 
 func Test_TrafgenService_InvalidPcap(t *testing.T) {

--- a/devices/trafgen/controlplane/trafgenpb/v1/trafgen.proto
+++ b/devices/trafgen/controlplane/trafgenpb/v1/trafgen.proto
@@ -42,6 +42,7 @@ service TrafgenService {
 
 // UpdateDeviceRequest binds the input/output pipelines of a generator.
 message UpdateDeviceRequest {
+  // Accepted range: at most 79 bytes.
   string name = 1;
   common.commonpb.v1.Device device = 2;
 }

--- a/devices/vlan/controlplane/service.go
+++ b/devices/vlan/controlplane/service.go
@@ -13,6 +13,13 @@ import (
 	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )
 
+// maxVlanID is the highest VLAN id the dataplane accepts.
+//
+// 802.1Q reserves VID 4095. The dataplane also writes the id straight
+// into the tag's 16-bit TCI unmasked, so anything above 4095 would spill
+// into the adjacent PCP/DEI bits too.
+const maxVlanID = 4094
+
 // DeviceVlanService implements the DeviceVlan gRPC service.
 type DeviceVlanService struct {
 	vlanpb.UnimplementedDeviceVlanServiceServer
@@ -45,8 +52,16 @@ func (m *DeviceVlanService) UpdateDevice(
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
+	if err := ffi.ValidateDeviceName(name); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
-	deviceConfig, err := NewDeviceConfig(m.agent, name, request.GetDevice(), uint16(request.GetVlan()))
+	vlan := request.GetVlan()
+	if vlan > maxVlanID {
+		return nil, status.Errorf(codes.InvalidArgument, "vlan %d exceeds maximum allowed value %d", vlan, maxVlanID)
+	}
+
+	deviceConfig, err := NewDeviceConfig(m.agent, name, request.GetDevice(), uint16(vlan))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create device config: %w", err)
 	}

--- a/devices/vlan/controlplane/service_test.go
+++ b/devices/vlan/controlplane/service_test.go
@@ -1,10 +1,13 @@
 package vlan
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
@@ -64,6 +67,77 @@ func TestUpdateDevice_DrainsUnusedDevices(t *testing.T) {
 		}
 		previousFreeBytes = freeBytes
 	}
+}
+
+// Test_DeviceVlanService_UpdateDevice_RejectsVlanOutOfRange verifies that a
+// vlan id at or above the reserved VID 4095 is rejected before the agent.
+//
+// The service is built with a nil agent: skipping the rejection would
+// surface a different error than InvalidArgument, so this also pins the
+// validation order.
+func Test_DeviceVlanService_UpdateDevice_RejectsVlanOutOfRange(t *testing.T) {
+	cases := []struct {
+		name string
+		vlan uint32
+	}{
+		{name: "just above maximum", vlan: 4095},
+		{name: "PCP/DEI-colliding value", vlan: 5000},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			service := NewDeviceVlanService(nil)
+
+			resp, err := service.UpdateDevice(t.Context(), &vlanpb.UpdateDeviceVlanRequest{
+				Name:   "d0",
+				Device: &commonpb.Device{},
+				Vlan:   testCase.vlan,
+			})
+			require.Nil(t, resp)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// Test_DeviceVlanService_UpdateDevice_RejectsOverlongName verifies that a name
+// the C-side fixed-size buffer cannot hold is rejected before the agent.
+func Test_DeviceVlanService_UpdateDevice_RejectsOverlongName(t *testing.T) {
+	service := NewDeviceVlanService(nil)
+
+	resp, err := service.UpdateDevice(t.Context(), &vlanpb.UpdateDeviceVlanRequest{
+		Name:   strings.Repeat("a", ffi.MaxDeviceNameLen),
+		Device: &commonpb.Device{},
+		Vlan:   100,
+	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Test_DeviceVlanService_UpdateDevice_AcceptsNameAtLimit verifies that a name
+// exactly at the C-side buffer's usable length is published end to end.
+func Test_DeviceVlanService_UpdateDevice_AcceptsNameAtLimit(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		DevicesToLoad: []string{"vlan"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	agent, err := shm.AgentAttach("vlan", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	service := NewDeviceVlanService(agent)
+
+	_, err = service.UpdateDevice(t.Context(), &vlanpb.UpdateDeviceVlanRequest{
+		Name:   strings.Repeat("a", ffi.MaxDeviceNameLen-1),
+		Device: &commonpb.Device{},
+		Vlan:   100,
+	})
+	require.NoError(t, err)
 }
 
 // freeBytesForAgent returns the free byte count reported for the named

--- a/devices/vlan/controlplane/vlanpb/v1/vlan.proto
+++ b/devices/vlan/controlplane/vlanpb/v1/vlan.proto
@@ -9,8 +9,10 @@ option go_package = "github.com/yanet-platform/yanet2/devices/vlan/controlplane/
 service DeviceVlanService { rpc UpdateDevice(UpdateDeviceVlanRequest) returns (UpdateDeviceVlanResponse); }
 
 message UpdateDeviceVlanRequest {
+  // Accepted range: at most 79 bytes.
   string name = 1;
   common.commonpb.v1.Device device = 2;
+  // Accepted range: 0..4094.
   uint32 vlan = 3;
 }
 

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -131,9 +131,9 @@ message ListConfigsResponse { repeated string configs = 1; }
 message SyncConfig {
   common.commonpb.v1.MACAddress dst_ether = 1;         // Destination MAC address;
   common.commonpb.v1.IPAddress dst_addr_multicast = 2; // Multicast IPv6 address;
-  uint32 port_multicast = 3;                           // Multicast port;
+  uint32 port_multicast = 3;                           // Multicast port. Required. Accepted range: 1..65535.
   common.commonpb.v1.IPAddress dst_addr_unicast = 4;   // Unicast IPv6 address;
-  uint32 port_unicast = 5;                             // Unicast port;
+  uint32 port_unicast = 5;                             // Unicast port. Accepted range: 0..65535.
 }
 
 // Request for per-rule counters. An empty name returns the rule counters

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
@@ -69,7 +69,7 @@ message SyncConfig {
   // module's SyncConfig; fwstate ignores this field.
   common.commonpb.v1.MACAddress dst_ether = 2 [ deprecated = true ];
   common.commonpb.v1.IPAddress dst_addr_multicast = 3; // Multicast IPv6 address matched on incoming sync packets;
-  uint32 port_multicast = 4;                           // Multicast port. Required. Accepted range: 1..65535.
+  uint32 port_multicast = 4;                           // Multicast port. The applied config requires 1..65535. Zero keeps the current port on update.
   // Deprecated: the emission-side unicast destination moved to the ACL
   // module's SyncConfig; fwstate ignores this field.
   common.commonpb.v1.IPAddress dst_addr_unicast = 5 [ deprecated = true ];

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
@@ -69,12 +69,12 @@ message SyncConfig {
   // module's SyncConfig; fwstate ignores this field.
   common.commonpb.v1.MACAddress dst_ether = 2 [ deprecated = true ];
   common.commonpb.v1.IPAddress dst_addr_multicast = 3; // Multicast IPv6 address matched on incoming sync packets;
-  uint32 port_multicast = 4;                           // Multicast port;
+  uint32 port_multicast = 4;                           // Multicast port. Required. Accepted range: 1..65535.
   // Deprecated: the emission-side unicast destination moved to the ACL
   // module's SyncConfig; fwstate ignores this field.
   common.commonpb.v1.IPAddress dst_addr_unicast = 5 [ deprecated = true ];
   // Deprecated: see dst_addr_unicast.
-  uint32 port_unicast = 6 [ deprecated = true ]; // Unused;
+  uint32 port_unicast = 6 [ deprecated = true ]; // Unused. Ignored by fwstate.
 
   // Connection timeouts
   uint64 tcp_syn_ack = 7; // TCP SYN-ACK timeout in nanoseconds;

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -405,9 +405,9 @@ func decodeNAT64Prefix(prefix *commonpb.IPv6Prefix) ([]byte, error) {
 	}
 	if network.Bits() != nat64PrefixBits {
 		return nil, fmt.Errorf(
-			"invalid prefix length: got %d, want %d",
-			network.Bits(),
+			"prefix must be a /%d, got /%d",
 			nat64PrefixBits,
+			network.Bits(),
 		)
 	}
 

--- a/modules/pdump/controlplane/pdumppb/v1/pdump.proto
+++ b/modules/pdump/controlplane/pdumppb/v1/pdump.proto
@@ -68,7 +68,8 @@ message Config {
   // Mode specifies a bitmap of queues that should be dumped.
   // For now available queues are INPUT, OUTPUT, DROP.
   uint32 mode = 2;
-  // Snaplen specifies maximum packet length to capture.
+  // Snaplen specifies maximum packet length to capture. Must be greater
+  // than zero.
   uint32 snaplen = 3;
   // Ring_size specifies per worker ring buffer size.
   uint32 ring_size = 4;

--- a/modules/pdump/controlplane/service.go
+++ b/modules/pdump/controlplane/service.go
@@ -468,8 +468,7 @@ func (m *PdumpService) prepareConfig(name string, request *pdumppb.SetConfigRequ
 			case "snaplen":
 				snaplen := request.Config.GetSnaplen()
 				if snaplen == 0 {
-					m.log.Info("snaplen is zero, resetting to default value", zap.Uint32("default_snaplen", defaultSnaplen))
-					snaplen = defaultSnaplen
+					return nil, status.Error(codes.InvalidArgument, "snaplen must be greater than zero")
 				}
 				newConfig.Snaplen = snaplen
 			case "ring_size":

--- a/modules/pdump/controlplane/service_test.go
+++ b/modules/pdump/controlplane/service_test.go
@@ -19,3 +19,16 @@ func TestShowConfigUnknownConfig(t *testing.T) {
 	_, err := service.ShowConfig(t.Context(), &pdumppb.ShowConfigRequest{Name: "missing"})
 	require.Equal(t, codes.NotFound, status.Code(err))
 }
+
+// Test_PdumpService_SetConfig_RejectsExplicitZeroSnaplen verifies that an
+// explicit snaplen=0 in the update mask is rejected, not defaulted.
+func Test_PdumpService_SetConfig_RejectsExplicitZeroSnaplen(t *testing.T) {
+	service := pdump.NewPdumpService(nil)
+
+	_, err := service.SetConfig(t.Context(), &pdumppb.SetConfigRequest{
+		Name:       "pdump0",
+		Config:     &pdumppb.Config{Snaplen: 0},
+		UpdateMask: &pdumppb.FieldMask{Paths: []string{"snaplen"}},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}

--- a/modules/route-mpls/controlplane/routemplspb/v1/routempls.proto
+++ b/modules/route-mpls/controlplane/routemplspb/v1/routempls.proto
@@ -58,6 +58,7 @@ message Rule {
 
 message NextHop {
   ActionKind kind = 1;
+  // Accepted range: 0..1048575 (20 bits).
   uint32 label = 2;
   common.commonpb.v1.IPAddress source_ip = 3;      // host address
   common.commonpb.v1.IPAddress destination_ip = 4; // host address

--- a/modules/route-mpls/controlplane/service.go
+++ b/modules/route-mpls/controlplane/service.go
@@ -446,6 +446,19 @@ func (m *RouteMPLSService) UpdateConfig(
 	return &routemplspb.UpdateConfigResponse{}, nil
 }
 
+// maxMPLSLabel is the highest value the dataplane's 20-bit MPLS label field
+// can hold.
+const maxMPLSLabel = 1048575
+
+// validateMPLSLabel rejects a label that would not fit the dataplane's
+// 20-bit MPLS label field.
+func validateMPLSLabel(label uint32) error {
+	if label > maxMPLSLabel {
+		return fmt.Errorf("nexthop label %d exceeds maximum allowed value %d", label, maxMPLSLabel)
+	}
+	return nil
+}
+
 func makeNextHop(nexthop *routemplspb.NextHop) (NextHop, error) {
 	src, err := nexthop.GetSourceIp().ToAddr()
 	if err != nil {
@@ -454,6 +467,9 @@ func makeNextHop(nexthop *routemplspb.NextHop) (NextHop, error) {
 	dst, err := nexthop.GetDestinationIp().ToAddr()
 	if err != nil {
 		return NextHop{}, fmt.Errorf("invalid destination_ip (bytes=%x): %w", nexthop.GetDestinationIp().GetAddr(), err)
+	}
+	if err := validateMPLSLabel(nexthop.GetLabel()); err != nil {
+		return NextHop{}, err
 	}
 
 	return NextHop{
@@ -471,6 +487,9 @@ func makeWithdrawNextHop(nexthop *routemplspb.NextHop) (NextHop, error) {
 	destination, err := nexthop.GetDestinationIp().ToAddr()
 	if err != nil {
 		return NextHop{}, fmt.Errorf("invalid destination_ip (bytes=%x): %w", nexthop.GetDestinationIp().GetAddr(), err)
+	}
+	if err := validateMPLSLabel(nexthop.GetLabel()); err != nil {
+		return NextHop{}, err
 	}
 
 	return NextHop{

--- a/modules/route-mpls/controlplane/service_test.go
+++ b/modules/route-mpls/controlplane/service_test.go
@@ -294,6 +294,60 @@ func Test_RouteMPLSService_UpdateConfig_WithdrawInvalidDestination(t *testing.T)
 	}
 }
 
+// Test_RouteMPLSService_CreateConfig_LabelBoundary verifies that a label at
+// the 20-bit limit is accepted and one past it is rejected.
+func Test_RouteMPLSService_CreateConfig_LabelBoundary(t *testing.T) {
+	cases := []struct {
+		name    string
+		label   uint32
+		wantErr bool
+	}{
+		{name: "maximum 20-bit label", label: 1048575, wantErr: false},
+		{name: "label above 20 bits", label: 1048576, wantErr: true},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			svc := newTestService(t)
+
+			response, err := svc.CreateConfig(t.Context(), &routemplspb.CreateConfigRequest{
+				Name:  "mpls0",
+				Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", testCase.label)},
+			})
+			if !testCase.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Nil(t, response)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// Test_RouteMPLSService_UpdateConfig_WithdrawLabelBoundary verifies that a
+// withdraw carrying a label above the 20-bit limit is rejected.
+func Test_RouteMPLSService_UpdateConfig_WithdrawLabelBoundary(t *testing.T) {
+	service := newTestService(t)
+	ctx := t.Context()
+
+	_, err := service.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
+		Name:  "mpls0",
+		Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
+	})
+	require.NoError(t, err)
+
+	response, err := service.UpdateConfig(ctx, &routemplspb.UpdateConfigRequest{
+		Name: "mpls0",
+		Updates: []*routemplspb.UpdateEvent{
+			{Event: &routemplspb.UpdateEvent_Withdraw{
+				Withdraw: makeRule(t, "10.0.0.0/24", "203.0.113.1", 1048576),
+			}},
+		},
+	})
+	require.Nil(t, response)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
 func Test_RouteMPLSService_ShowConfig_NotFound(t *testing.T) {
 	svc := newTestService(t)
 


### PR DESCRIPTION
- Reject a VLAN id above 4094 in the vlan device service before it is cast into the TCI.
- Reject device names longer than 79 bytes in the plain, vlan and trafgen services, including the trafgen pcap-upload and rate paths, with the limit sourced from the C define through a shared ffi helper.
- Reject MPLS labels above the 20-bit maximum on the route-mpls insert and withdraw paths.
- Reject an explicit zero snaplen in pdump config updates instead of silently substituting the default.
- Name the expected /96 length in the nat64 prefix rejection message.
- Document the accepted ranges in the proto field comments, including the already-validated acl and fwstate sync ports.
- Add boundary tests for each validated field.
- Part of #2388.