### PR TITLE
perf(dataplane): resolve pipeline stage counters at publish time

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -370,6 +370,43 @@ func (m *Harness) SharedMemory() *ffi.SharedMemory {
 	return ffi.NewSharedMemoryFromRaw(unsafe.Pointer(shm))
 }
 
+// InstallEmptyPipeline installs one named empty pipeline, forcing a
+// generation switch that completes synchronously: on return every worker
+// holds the newly published generation's execution context.
+func (m *Harness) InstallEmptyPipeline(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	rc := C.dataplane_ut_install_empty_pipeline(m.ptr, cName)
+	if rc != 0 {
+		return fmt.Errorf("failed to install empty pipeline %q: rc=%d", name, int(rc))
+	}
+	return nil
+}
+
+// WorkerEctx returns the execution context currently assigned to the given
+// worker, zero when none is assigned.
+func (m *Harness) WorkerEctx(workerIdx int) uintptr {
+	return uintptr(C.dataplane_ut_worker_ectx(m.ptr, C.size_t(workerIdx)))
+}
+
+// PublishedEctx returns the per-worker execution context of the currently
+// published generation, zero when none is published.
+func (m *Harness) PublishedEctx(workerIdx int) uintptr {
+	return uintptr(C.dataplane_ut_published_ectx(m.ptr, C.size_t(workerIdx)))
+}
+
+// WorkerGen returns the generation the given worker last acknowledged.
+func (m *Harness) WorkerGen(workerIdx int) uint64 {
+	return uint64(C.dataplane_ut_worker_gen(m.ptr, C.size_t(workerIdx)))
+}
+
+// PublishedGen returns the generation number of the currently published
+// generation, zero when no generation was published.
+func (m *Harness) PublishedGen() uint64 {
+	return uint64(C.dataplane_ut_published_gen(m.ptr))
+}
+
 // SetCurrentTime installs a deterministic wall-clock value used by the next
 // HandlePackets call.
 func (m *Harness) SetCurrentTime(t time.Time) {

--- a/bindings/go/dataplane_ut/worker_ectx_test.go
+++ b/bindings/go/dataplane_ut/worker_ectx_test.go
@@ -1,0 +1,232 @@
+package dataplaneut_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/common/go/xerror"
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+)
+
+// workerEctxWorkerCount is the worker population every test below uses:
+// two workers are the minimum that separates the worker that ran a round
+// from a worker that never ran.
+const workerEctxWorkerCount = 2
+
+// newWorkerEctxHarness builds a two-worker harness with an otherwise empty
+// topology. The generation-assignment protocol under test needs only
+// generation switches, not packet-routing modules or device wiring.
+func newWorkerEctxHarness(t *testing.T) *dataplaneut.Harness {
+	t.Helper()
+
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB * 4),
+		WorkerCount: workerEctxWorkerCount,
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	return harness
+}
+
+// Test_WorkerEctx_Bootstrap_FieldIsNullAndNothingAcked verifies that a
+// fresh harness with no installs reports a zero published generation, no
+// per-worker context in any worker's field, and no acknowledged generation
+// on any worker.
+func Test_WorkerEctx_Bootstrap_FieldIsNullAndNothingAcked(t *testing.T) {
+	harness := newWorkerEctxHarness(t)
+
+	require.Zero(t, harness.PublishedGen(), "no install ran, so no generation is published")
+	for workerIdx := range workerEctxWorkerCount {
+		require.Zero(
+			t,
+			harness.PublishedEctx(workerIdx),
+			"worker %d must have no published context before any install",
+			workerIdx,
+		)
+		require.Zero(
+			t,
+			harness.WorkerEctx(workerIdx),
+			"worker %d must hold no context before any install",
+			workerIdx,
+		)
+		require.Zero(
+			t,
+			harness.WorkerGen(workerIdx),
+			"worker %d must acknowledge nothing before any install",
+			workerIdx,
+		)
+	}
+}
+
+// Test_WorkerEctx_Install_AssignsPublishedEctxToEveryWorker verifies that
+// one empty-pipeline install assigns every worker, synchronously on return,
+// the per-worker execution context of the newly published generation.
+//
+// Every acknowledgement must stay zero: an install switches contexts but
+// only a round acknowledges, and no round has run.
+func Test_WorkerEctx_Install_AssignsPublishedEctxToEveryWorker(t *testing.T) {
+	harness := newWorkerEctxHarness(t)
+
+	require.NoError(t, harness.InstallEmptyPipeline("assigned"))
+
+	require.NotZero(t, harness.PublishedGen(), "an install must publish a new generation")
+	for workerIdx := range workerEctxWorkerCount {
+		published := harness.PublishedEctx(workerIdx)
+		require.NotZero(
+			t,
+			published,
+			"worker %d must have a published context after an install",
+			workerIdx,
+		)
+		require.Equal(
+			t,
+			published,
+			harness.WorkerEctx(workerIdx),
+			"worker %d's field must already hold the published context on return from the install",
+			workerIdx,
+		)
+		require.Zero(
+			t,
+			harness.WorkerGen(workerIdx),
+			"worker %d must not acknowledge a generation without a round",
+			workerIdx,
+		)
+	}
+}
+
+// Test_WorkerEctx_Reinstall_ReassignsNewEctxToEveryWorker verifies that a
+// second install publishes a fresh per-worker context and every worker's
+// field follows it, pinning re-assignment on every generation switch
+// rather than a one-time bootstrap stamp.
+func Test_WorkerEctx_Reinstall_ReassignsNewEctxToEveryWorker(t *testing.T) {
+	harness := newWorkerEctxHarness(t)
+
+	require.NoError(t, harness.InstallEmptyPipeline("first"))
+	firstGen := harness.PublishedGen()
+	firstEctx := [workerEctxWorkerCount]uintptr{}
+	for workerIdx := range workerEctxWorkerCount {
+		firstEctx[workerIdx] = harness.PublishedEctx(workerIdx)
+	}
+
+	require.NoError(t, harness.InstallEmptyPipeline("second"))
+	require.Greater(
+		t,
+		harness.PublishedGen(),
+		firstGen,
+		"a reinstall must advance the published generation",
+	)
+
+	for workerIdx := range workerEctxWorkerCount {
+		second := harness.PublishedEctx(workerIdx)
+		require.NotZero(
+			t,
+			second,
+			"worker %d must have a published context after the second install",
+			workerIdx,
+		)
+		require.NotEqual(
+			t,
+			firstEctx[workerIdx],
+			second,
+			"worker %d's second generation must publish a fresh context",
+			workerIdx,
+		)
+		require.Equal(
+			t,
+			second,
+			harness.WorkerEctx(workerIdx),
+			"worker %d's field must follow the second generation",
+			workerIdx,
+		)
+	}
+}
+
+// Test_WorkerEctx_Round_AcksAssignedGenOnThatWorkerOnly verifies that one
+// round run on a single worker acknowledges exactly the published
+// generation on that worker, while a worker that never ran keeps
+// acknowledging zero.
+func Test_WorkerEctx_Round_AcksAssignedGenOnThatWorkerOnly(t *testing.T) {
+	harness := newWorkerEctxHarness(t)
+
+	require.NoError(t, harness.InstallEmptyPipeline("round"))
+
+	ethernet := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ipv4 := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolICMPv4,
+		SrcIP:    net.ParseIP("1.2.3.4"),
+		DstIP:    net.ParseIP("10.0.0.5"),
+	}
+	icmp := layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
+	}
+	packet := xpacket.LayersToPacket(t, &ethernet, &ipv4, &icmp)
+
+	// The topology wires no device, so the round drops the packet; the
+	// dropped packet proves the round processed input on worker 0.
+	result, err := harness.HandlePacketsOnWorker(0, packet)
+	require.NoError(t, err)
+	require.Empty(t, result.Output)
+	require.Len(t, result.Drop, 1)
+
+	require.Equal(
+		t,
+		harness.PublishedGen(),
+		harness.WorkerGen(0),
+		"worker 0 must acknowledge the published generation after its round",
+	)
+	require.Zero(
+		t,
+		harness.WorkerGen(1),
+		"worker 1 never ran a round and must keep acknowledging zero",
+	)
+}
+
+// Test_WorkerEctx_ConcurrentPublish_WaitsForInFlightRound verifies that a
+// publish running concurrently with rounds on another thread completes
+// only across them, so every worker ends up holding the newly published
+// context and no round can still touch the retired one.
+func Test_WorkerEctx_ConcurrentPublish_WaitsForInFlightRound(t *testing.T) {
+	harness := newWorkerEctxHarness(t)
+
+	require.NoError(t, harness.InstallEmptyPipeline("before"))
+
+	publishDone := make(chan error, 1)
+	go func() {
+		publishDone <- harness.InstallEmptyPipeline("during")
+	}()
+
+	publishing := true
+	for publishing {
+		select {
+		case err := <-publishDone:
+			require.NoError(t, err)
+			publishing = false
+		default:
+			_, err := harness.HandlePacketsOnWorker(0)
+			require.NoError(t, err)
+		}
+	}
+
+	for workerIdx := range workerEctxWorkerCount {
+		require.Equal(
+			t,
+			harness.PublishedEctx(workerIdx),
+			harness.WorkerEctx(workerIdx),
+			"worker %d's field must hold the concurrently published context",
+			workerIdx,
+		)
+	}
+}

--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -5,6 +5,7 @@ package ffi
 //#cgo LDFLAGS: -L../../build/lib/controlplane/config -lconfig_cp
 //#cgo LDFLAGS: -L../../build/lib/counters/ -lcounters
 //#cgo LDFLAGS: -L../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../build/lib/dataplane/pipeline -lpipeline
 //#cgo LDFLAGS: -L../../build/devices/plain/api -ldev_plain_api
 //#cgo LDFLAGS: -L../../build/devices/vlan/api -ldev_vlan_api
 //#cgo LDFLAGS: -L../../build/lib/logging/ -llogging

--- a/controlplane/ffi/counter.go
+++ b/controlplane/ffi/counter.go
@@ -5,6 +5,7 @@ package ffi
 //#cgo LDFLAGS: -L../../build/lib/controlplane/config -lconfig_cp
 //#cgo LDFLAGS: -L../../build/lib/counters -lcounters
 //#cgo LDFLAGS: -L../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../build/lib/dataplane/pipeline -lpipeline
 //#cgo LDFLAGS: -L../../build/lib/errors -lerrors
 //#include "api/agent.h"
 //#include "api/counter.h"

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -6,6 +6,7 @@ package ffi
 //#cgo LDFLAGS: -L../../build/lib/controlplane/config -lconfig_cp
 //#cgo LDFLAGS: -L../../build/lib/counters -lcounters
 //#cgo LDFLAGS: -L../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../build/lib/dataplane/pipeline -lpipeline
 //#cgo LDFLAGS: -L../../build/lib/errors -lerrors
 //#cgo LDFLAGS: -L../../build/lib/counters -lcounter_pattern
 //#cgo LDFLAGS: -L../../build/subprojects/regex -lrure

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -529,6 +529,7 @@ dataplane_init(
 
 		instance->dp_config->instance_idx = instance_idx;
 		instance->dp_config->instance_count = dataplane->instance_count;
+		instance->config_assigner_started = false;
 
 		static const char *default_modules[] = {
 			"forward",
@@ -910,6 +911,19 @@ dataplane_start(struct dataplane *dataplane) {
 		}
 	}
 
+	for (uint32_t instance_idx = 0;
+	     instance_idx < dataplane->instance_count;
+	     ++instance_idx) {
+		if (dataplane_instance_config_assigner_start(
+			    dataplane->instances + instance_idx
+		    )) {
+			LOG(ERROR,
+			    "failed to start config assigner for instance %u",
+			    instance_idx);
+			return -1;
+		}
+	}
+
 	pthread_t thread_id;
 	int rc = pthread_create(&thread_id, NULL, stat_thread, dataplane);
 	if (rc != 0) {
@@ -925,6 +939,20 @@ int
 dataplane_stop(struct dataplane *dataplane) {
 	for (size_t dev_idx = 0; dev_idx < dataplane->device_count; ++dev_idx) {
 		dataplane_device_stop(dataplane->devices + dev_idx);
+	}
+
+	// The workers are joined above while the assigners still run:
+	// this call parks the process (the worker loops never return on
+	// their own), and a join only ends once the worker's loop has
+	// ended, so the assigners must keep publishing generations for
+	// as long as workers acknowledge them. The assigners are stopped
+	// only after every worker loop has ended.
+	for (uint32_t instance_idx = 0;
+	     instance_idx < dataplane->instance_count;
+	     ++instance_idx) {
+		dataplane_instance_config_assigner_stop(
+			dataplane->instances + instance_idx
+		);
 	}
 
 	return 0;

--- a/dataplane/dataplane.h
+++ b/dataplane/dataplane.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <pthread.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -12,7 +14,19 @@ struct dataplane_instance {
 	struct dp_config *dp_config;
 	struct cp_config *cp_config;
 	uint32_t **device_xstat_map;
+
+	// Assigner of published generations to this instance's workers.
+	pthread_t config_assigner_thread;
+	// Gates the join: false unless a thread was created and not yet
+	// reaped.
+	bool config_assigner_started;
 };
+
+int
+dataplane_instance_config_assigner_start(struct dataplane_instance *instance);
+
+void
+dataplane_instance_config_assigner_stop(struct dataplane_instance *instance);
 
 #define DATAPLANE_MAX_INSTANCES 8
 

--- a/dataplane/instance.c
+++ b/dataplane/instance.c
@@ -1,0 +1,106 @@
+#include "dataplane.h"
+
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+#include "common/memory_address.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/logging/log.h"
+
+// sched_yield iterations per poll cycle, before the fixed sleep. Sixteen
+// yields cost a few microseconds of busy time on an idle core, which keeps
+// the thread hot through the window right after a poll without turning
+// the phase into a spin.
+#define CONFIG_ASSIGNER_YIELD_ITERS 16
+
+// Fixed nanosleep interval that closes each poll cycle. A request of 100
+// microseconds sleeps roughly 150 on a default-slack kernel, so the full
+// cycle lands near 160 microseconds: a published generation reaches the
+// workers well inside a millisecond while the idle thread burns only a
+// few percent of one unpinned core.
+#define CONFIG_ASSIGNER_SLEEP_NS UINT64_C(100000)
+
+// Process-wide stop request for the assigner threads.
+//
+// The dataplane starts and stops exactly once, and every instance's
+// assigner is stopped together, so one flag serves them all. Stored with
+// release ordering before the joins; loaded with acquire ordering in the
+// poll loops.
+static bool config_assigner_stop;
+
+static void *
+config_assigner_thread(void *arg) {
+	struct dataplane_instance *instance = (struct dataplane_instance *)arg;
+	struct dp_config *dp_config = instance->dp_config;
+	struct cp_config *cp_config = instance->cp_config;
+
+	static const struct timespec sleep_ts = {
+		.tv_sec = (time_t)(CONFIG_ASSIGNER_SLEEP_NS / 1000000000ULL),
+		.tv_nsec = (long)(CONFIG_ASSIGNER_SLEEP_NS % 1000000000ULL),
+	};
+
+	// Nothing is assigned yet, so the first pass also delivers the
+	// generation published before the thread started, bootstrap state
+	// included.
+	struct cp_config_gen *last_assigned = NULL;
+
+	for (;;) {
+		struct cp_config_gen *published =
+			ATOMIC_ADDR_OF(&cp_config->cp_config_gen);
+		if (published != last_assigned) {
+			dp_config_assign_worker_ectxs(dp_config, published);
+			last_assigned = published;
+		}
+
+		if (__atomic_load_n(&config_assigner_stop, __ATOMIC_ACQUIRE)) {
+			break;
+		}
+
+		for (unsigned iters = 0; iters < CONFIG_ASSIGNER_YIELD_ITERS;
+		     ++iters) {
+			if (__atomic_load_n(
+				    &config_assigner_stop, __ATOMIC_ACQUIRE
+			    )) {
+				break;
+			}
+			sched_yield();
+		}
+		nanosleep(&sleep_ts, NULL);
+	}
+
+	return NULL;
+}
+
+int
+dataplane_instance_config_assigner_start(struct dataplane_instance *instance) {
+	int rc = pthread_create(
+		&instance->config_assigner_thread,
+		NULL,
+		config_assigner_thread,
+		instance
+	);
+	if (rc != 0) {
+		LOG(ERROR,
+		    "failed to create config assigner thread: %s",
+		    strerror(rc));
+		return -1;
+	}
+	instance->config_assigner_started = true;
+	return 0;
+}
+
+void
+dataplane_instance_config_assigner_stop(struct dataplane_instance *instance) {
+	if (!instance->config_assigner_started) {
+		return;
+	}
+
+	__atomic_store_n(&config_assigner_stop, true, __ATOMIC_RELEASE);
+	pthread_join(instance->config_assigner_thread, NULL);
+	instance->config_assigner_started = false;
+}

--- a/dataplane/meson.build
+++ b/dataplane/meson.build
@@ -17,6 +17,7 @@ lib_sources = files(
   'config.c',
   'dataplane.c',
   'device.c',
+  'instance.c',
   'worker.c',
   'numa.c',
 )

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -257,10 +257,8 @@ worker_write(
 
 static void
 worker_loop_round(struct dataplane_worker *worker) {
-	struct cp_config *cp_config = worker->instance->cp_config;
 	struct worker_round round = worker_round_prepare(
 		worker->dp_worker,
-		cp_config,
 		tsc_clock_get_time_ns(&worker->dp_worker->clock)
 	);
 	struct cp_config_gen *cp_config_gen = round.cp_config_gen;

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -475,7 +475,6 @@ chain_ectx_free(
 
 		module_ectx_free(cp_config_gen, module_ectx);
 	}
-
 	struct counter_storage *counter_storage =
 		ADDR_OF(&chain_ectx->counter_storage);
 	if (counter_storage != NULL) {
@@ -572,19 +571,6 @@ chain_ectx_create(
 		);
 		goto error;
 	}
-
-	SET_OFFSET_OF(
-		&chain_ectx->counter_packet_pending_input,
-		counter_get_value_handle(
-			cp_chain->counter_packet_pending_input, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&chain_ectx->counter_packet_pending_output,
-		counter_get_value_handle(
-			cp_chain->counter_packet_pending_output, counter_storage
-		)
-	);
 
 	for (uint64_t idx = 0; idx < cp_chain->length; ++idx) {
 		struct cp_module *cp_module = cp_config_gen_lookup_module(
@@ -783,39 +769,6 @@ function_ectx_create(
 		goto error;
 	}
 
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_in,
-		counter_get_value_handle(
-			cp_function->counter_packet_in, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_out,
-		counter_get_value_handle(
-			cp_function->counter_packet_out, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_drop,
-		counter_get_value_handle(
-			cp_function->counter_packet_drop, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_pending_input,
-		counter_get_value_handle(
-			cp_function->counter_packet_pending_input,
-			counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_pending_output,
-		counter_get_value_handle(
-			cp_function->counter_packet_pending_output,
-			counter_storage
-		)
-	);
-
 	uint64_t pos = 0;
 	for (uint64_t idx = 0; idx < cp_function->chain_count; ++idx) {
 		struct cp_chain *cp_chain =
@@ -958,39 +911,6 @@ pipeline_ectx_create(
 		goto error;
 	}
 
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_in,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_in, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_out,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_out, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_drop,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_drop, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_pending_input,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_pending_input,
-			counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_pending_output,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_pending_output,
-			counter_storage
-		)
-	);
-
 	for (uint64_t idx = 0; idx < cp_pipeline->length; ++idx) {
 		struct cp_function *cp_function = cp_config_gen_lookup_function(
 			cp_config_gen, cp_pipeline->functions[idx].name
@@ -1103,54 +1023,6 @@ device_entry_ectx_create(
 
 	memset(device_entry_ectx, 0, ectx_size);
 	device_entry_ectx->handler = handler;
-
-	struct counter_storage *counter_storage =
-		ADDR_OF(&device_ectx->counter_storage);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_rx,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_rx, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_entry,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_entry, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_tx,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_tx, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_drop,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_drop, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_recirc_drop,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_recirc_drop,
-			counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_pending_input,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_pending_input,
-			counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_pending_output,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_pending_output,
-			counter_storage
-		)
-	);
 
 	struct pipeline_ectx **pipelines =
 		(struct pipeline_ectx **)memory_balloc(

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -38,9 +38,9 @@ static inline void
 device_entry_ectx_count_recirc_drop(
 	struct device_entry_ectx *entry_ectx, const struct packet *packet
 ) {
-	uint64_t *counter = counter_handle_get_value(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_recirc_drop)
-	);
+	uint64_t *counter =
+		counter_handle_get_value(entry_ectx->counter_packet_recirc_drop
+		);
 	counter[0] += 1;
 	counter[1] += rte_pktmbuf_pkt_len(packet_to_mbuf(packet));
 }

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -286,7 +286,7 @@ cp_config_gen_install(
 	// Release-publish the new generation so workers never observe this
 	// pointer before its contents are fully written.
 	ATOMIC_SET_OFFSET_OF(&cp_config->cp_config_gen, new_config_gen);
-	dp_config_wait_for_gen(dp_config, new_config_gen->gen);
+	dp_config_wait_for_gen(dp_config, new_config_gen);
 
 	// The new generation already carries the pin it was created with, so
 	// publishing it as current spends that pin rather than adding one.

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -24,7 +24,7 @@ _Static_assert(
 	"struct module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct dp_config) == 1184,
+	sizeof(struct dp_config) == 1240,
 	"struct dp_config size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
@@ -52,7 +52,7 @@ _Static_assert(
 	"struct config_gen_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct dp_worker) == 160,
+	sizeof(struct dp_worker) == 168,
 	"struct dp_worker size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/config/zone.c
+++ b/lib/dataplane/config/zone.c
@@ -4,6 +4,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "lib/controlplane/config/zone.h"
+
 struct dp_config *
 dp_config_nextk(struct dp_config *current, uint32_t k) {
 	for (uint32_t i = 0; i < k; ++i) {
@@ -19,15 +21,32 @@ dp_config_nextk(struct dp_config *current, uint32_t k) {
 // Fixed nanosleep interval used once the yield phase is exhausted.
 #define DP_CONFIG_GEN_ACK_SLEEP_NS UINT64_C(1000000)
 
-// Waits for a single worker to acknowledge gen.
+// Observes both the worker's context assignment and its acknowledged
+// generation.
+//
+// The waiter needs the pair, not either alone: the assignment proves the
+// worker switched away from the superseded context, the acknowledgement
+// orders the round that last used it before this observation.
+static bool
+dp_worker_ectx_and_gen_observed(
+	struct dp_worker *worker, struct config_gen_ectx *expected, uint64_t gen
+) {
+	return ATOMIC_ADDR_OF(&worker->config_gen_ectx) == expected &&
+	       __atomic_load_n(&worker->gen, __ATOMIC_ACQUIRE) >= gen;
+}
+
+// Waits for a single worker to take the expected context and acknowledge
+// gen.
 //
 // Backs off from sched_yield to a fixed-interval nanosleep, without ever
 // giving up.
 static void
-dp_config_wait_for_worker_gen(struct dp_worker *worker, uint64_t gen) {
+dp_config_wait_for_worker_ectx(
+	struct dp_worker *worker, struct config_gen_ectx *expected, uint64_t gen
+) {
 	for (unsigned iters = 0; iters < DP_CONFIG_GEN_ACK_YIELD_ITERS;
 	     ++iters) {
-		if (__atomic_load_n(&worker->gen, __ATOMIC_ACQUIRE) >= gen) {
+		if (dp_worker_ectx_and_gen_observed(worker, expected, gen)) {
 			return;
 		}
 		sched_yield();
@@ -38,7 +57,7 @@ dp_config_wait_for_worker_gen(struct dp_worker *worker, uint64_t gen) {
 		.tv_nsec = (long)(DP_CONFIG_GEN_ACK_SLEEP_NS % 1000000000ULL),
 	};
 	for (;;) {
-		if (__atomic_load_n(&worker->gen, __ATOMIC_ACQUIRE) >= gen) {
+		if (dp_worker_ectx_and_gen_observed(worker, expected, gen)) {
 			return;
 		}
 		nanosleep(&sleep_ts, NULL);
@@ -46,14 +65,61 @@ dp_config_wait_for_worker_gen(struct dp_worker *worker, uint64_t gen) {
 }
 
 void
-dp_config_wait_for_gen(struct dp_config *dp_config, uint64_t gen) {
+dp_config_assign_worker_ectxs(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+) {
 	// The loop bound and the array it indexes come from one observation.
 	struct dp_worker *const *workers = ADDR_OF(&dp_config->workers);
 	const uint64_t worker_count = dp_config->worker_count;
 
 	for (uint64_t idx = 0; idx < worker_count; ++idx) {
 		struct dp_worker *worker = ADDR_OF(workers + idx);
-		dp_config_wait_for_worker_gen(worker, gen);
+		struct config_gen_ectx *expected =
+			cp_config_gen_worker_ectx(config_gen, idx);
+		// Skip workers already holding the expected context: the
+		// release store exists for the switch, and re-issuing it on
+		// every assignment pass would make the field flap for
+		// readers that are content.
+		if (ADDR_OF(&worker->config_gen_ectx) != expected) {
+			ATOMIC_SET_OFFSET_OF(
+				&worker->config_gen_ectx, expected
+			);
+		}
+	}
+}
+
+void
+dp_config_wait_for_gen(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+) {
+	// The harness round driver holds external_round_lock across every
+	// dereference of a worker context, and rounds are the only users
+	// of the contexts in this mode.
+	//
+	// Waiting for the lock therefore spans any in-flight round: once
+	// it is held, no round can still be dereferencing the retired
+	// contexts, so delivering the new ones in place completes the
+	// switch with no further acknowledgement to wait for.
+	if (dp_config->external_worker_rounds) {
+		pthread_mutex_t *round_lock =
+			dp_config_external_round_lock(dp_config);
+		pthread_mutex_lock(round_lock);
+		dp_config_assign_worker_ectxs(dp_config, config_gen);
+		pthread_mutex_unlock(round_lock);
+		return;
+	}
+
+	// The loop bound and the array it indexes come from one observation.
+	struct dp_worker *const *workers = ADDR_OF(&dp_config->workers);
+	const uint64_t worker_count = dp_config->worker_count;
+
+	for (uint64_t idx = 0; idx < worker_count; ++idx) {
+		struct dp_worker *worker = ADDR_OF(workers + idx);
+		struct config_gen_ectx *expected =
+			cp_config_gen_worker_ectx(config_gen, idx);
+		dp_config_wait_for_worker_ectx(
+			worker, expected, config_gen->gen
+		);
 	}
 }
 

--- a/lib/dataplane/config/zone.c
+++ b/lib/dataplane/config/zone.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include "lib/controlplane/config/zone.h"
+#include "lib/dataplane/pipeline/pipeline.h"
 
 struct dp_config *
 dp_config_nextk(struct dp_config *current, uint32_t k) {
@@ -76,6 +77,16 @@ dp_config_assign_worker_ectxs(
 		struct dp_worker *worker = ADDR_OF(workers + idx);
 		struct config_gen_ectx *expected =
 			cp_config_gen_worker_ectx(config_gen, idx);
+		// Derive the absolute counter pointers before the release
+		// store.
+		//
+		// The store pairs with the acquire load at the worker's
+		// round start, so the derived pointers are complete before
+		// any stage runs. The derivation is idempotent, so a worker
+		// already holding this context is unaffected.
+		if (expected != NULL) {
+			config_gen_ectx_resolve_counters(expected);
+		}
 		// Skip workers already holding the expected context: the
 		// release store exists for the switch, and re-issuing it on
 		// every assignment pass would make the field flap for

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
@@ -15,6 +16,7 @@
 #include "lib/counters/counters.h"
 
 struct cp_config;
+struct cp_config_gen;
 struct rte_mempool;
 
 struct dp_module {
@@ -99,6 +101,16 @@ struct dp_worker {
 	uint32_t device_id;
 	uint32_t queue_id;
 	uint32_t rx_burst_size;
+
+	// Offset pointer to the execution context this worker runs,
+	// taken from the generation most recently assigned to it.
+	//
+	// Written by the instance's config assigner with release ordering
+	// whenever a new generation is published; read by the worker at
+	// the start of every round with acquire ordering. NULL until the
+	// first generation carrying execution contexts is assigned, which
+	// keeps the worker on the pre-configuration drop path.
+	struct config_gen_ectx *config_gen_ectx;
 };
 
 // Value written to dp_config.ready_magic by dp_config_mark_ready once the
@@ -157,6 +169,23 @@ struct dp_config {
 	uint64_t port_count;
 	struct dp_port_counters *port_counters;
 
+	// Selects the synchronous generation hand-off used by in-process
+	// harnesses; production leaves it clear.
+	//
+	// Set once before the instance is marked ready, when no worker
+	// threads exist and rounds run on caller threads: the generation
+	// waiter then delivers contexts to the workers itself,
+	// synchronously, under the round lock below.
+	bool external_worker_rounds;
+
+	// Storage of the harness round lock.
+	//
+	// pthread_mutex_t sizing differs between architectures, so the
+	// lock lives in fixed-size storage to keep the shared-memory
+	// layout architecture-independent. Only a harness that set
+	// external_worker_rounds initializes and locks it.
+	uint64_t external_round_lock_storage[6];
+
 	// Written by dp_config_mark_ready with release ordering after the
 	// dataplane releases cp_config and finishes initialising the instance.
 	//
@@ -165,6 +194,18 @@ struct dp_config {
 	// cp_config is not held, so an attacher will not block on the lock.
 	uint64_t ready_magic;
 };
+
+// The harness round lock, reached through its fixed-size storage.
+static inline pthread_mutex_t *
+dp_config_external_round_lock(struct dp_config *dp_config) {
+	return (pthread_mutex_t *)dp_config->external_round_lock_storage;
+}
+
+_Static_assert(
+	sizeof(((struct dp_config *)NULL)->external_round_lock_storage) >=
+		sizeof(pthread_mutex_t),
+	"external_round_lock_storage no longer fits pthread_mutex_t"
+);
 
 /*
  * Returns dp_config of k-th instance from current.
@@ -204,11 +245,24 @@ dp_config_lookup_object(
 uint64_t
 dp_config_device_worker_count(struct dp_config *dp_config, uint32_t device_id);
 
-// Waits for every worker of dp_config to acknowledge generation gen.
+// Deliver each worker of dp_config the execution context built for it in
+// config_gen.
 //
-// This is the grace period cp_config_gen_install needs before it may
-// reclaim the generation gen superseded. Blocks with no timeout, by
-// design: an early return would let an owner reclaim memory an
-// unacknowledged worker may still dereference.
+// A context of NULL is valid and returns the worker to the pre-configuration
+// drop path; it is what generations without per-worker contexts assign.
 void
-dp_config_wait_for_gen(struct dp_config *dp_config, uint64_t gen);
+dp_config_assign_worker_ectxs(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+);
+
+// Waits for every worker of dp_config to hold the execution context of
+// config_gen and to have acknowledged that generation.
+//
+// This is the grace period the publisher needs before it may reclaim the
+// generation config_gen superseded. Blocks with no timeout, by design: an
+// early return would let an owner reclaim memory an unacknowledged worker
+// may still dereference.
+void
+dp_config_wait_for_gen(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+);

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 21
+#define YANET_MODULE_ABI_VERSION 22
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -109,8 +109,14 @@ struct chain_module_ectx {
 struct chain_ectx {
 	struct cp_chain *cp_chain;
 	struct counter_storage *counter_storage;
-	struct counter_value_handle *counter_packet_pending_input;
-	struct counter_value_handle *counter_packet_pending_output;
+	// Absolute counterparts of the chain's counters, for the packet
+	// hot path.
+	//
+	// The publishing process derives them from the counter registry
+	// ids of the cp_chain and the chain's counter storage before the
+	// context is released to workers; they are zero until then.
+	struct counter_value_handle *abs_counter_packet_pending_input;
+	struct counter_value_handle *abs_counter_packet_pending_output;
 	uint64_t length;
 	struct packet_front schedule;
 	struct chain_module_ectx modules[];
@@ -118,11 +124,18 @@ struct chain_ectx {
 
 struct function_ectx {
 	struct cp_function *cp_function;
-	struct counter_value_handle *counter_packet_in;
-	struct counter_value_handle *counter_packet_out;
-	struct counter_value_handle *counter_packet_drop;
-	struct counter_value_handle *counter_packet_pending_input;
-	struct counter_value_handle *counter_packet_pending_output;
+	// Absolute counterparts of the function's counters, for the packet
+	// hot path.
+	//
+	// The publishing process derives them from the counter registry
+	// ids of the cp_function and the function's counter storage
+	// before the context is released to workers; they are zero until
+	// then.
+	struct counter_value_handle *abs_counter_packet_in;
+	struct counter_value_handle *abs_counter_packet_out;
+	struct counter_value_handle *abs_counter_packet_drop;
+	struct counter_value_handle *abs_counter_packet_pending_input;
+	struct counter_value_handle *abs_counter_packet_pending_output;
 	struct counter_storage *counter_storage;
 	uint64_t chain_count;
 	struct chain_ectx **chains;
@@ -132,11 +145,18 @@ struct function_ectx {
 
 struct pipeline_ectx {
 	struct cp_pipeline *cp_pipeline;
-	struct counter_value_handle *counter_packet_in;
-	struct counter_value_handle *counter_packet_out;
-	struct counter_value_handle *counter_packet_drop;
-	struct counter_value_handle *counter_packet_pending_input;
-	struct counter_value_handle *counter_packet_pending_output;
+	// Absolute counterparts of the pipeline's counters, for the packet
+	// hot path.
+	//
+	// The publishing process derives them from the counter registry
+	// ids of the cp_pipeline and the pipeline's counter storage
+	// before the context is released to workers; they are zero until
+	// then.
+	struct counter_value_handle *abs_counter_packet_in;
+	struct counter_value_handle *abs_counter_packet_out;
+	struct counter_value_handle *abs_counter_packet_drop;
+	struct counter_value_handle *abs_counter_packet_pending_input;
+	struct counter_value_handle *abs_counter_packet_pending_output;
 	struct counter_storage *counter_storage;
 	uint64_t length;
 	struct packet_front schedule;
@@ -163,6 +183,13 @@ struct device_entry_ectx {
 	uint8_t direction;
 	struct device_ectx *device_ectx;
 
+	// The entry's counters, as absolute addresses for the packet hot
+	// path.
+	//
+	// The publishing process derives them from the counter registry
+	// ids of the entry's controlplane counterpart and the device's
+	// counter storage before the context is released to workers; they
+	// are zero until then.
 	struct counter_value_handle *counter_packet_rx;
 	struct counter_value_handle *counter_packet_entry;
 	struct counter_value_handle *counter_packet_tx;

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -101,6 +101,162 @@ module_ectx_dp_config(struct module_ectx *module_ectx) {
 	return ADDR_OF(&cp_config_gen->dp_config);
 }
 
+static void
+chain_ectx_resolve_absolutes(struct chain_ectx *chain_ectx) {
+	struct cp_chain *cp_chain = ADDR_OF(&chain_ectx->cp_chain);
+	struct counter_storage *counter_storage =
+		ADDR_OF(&chain_ectx->counter_storage);
+
+	chain_ectx->abs_counter_packet_pending_input = counter_get_value_handle(
+		cp_chain->counter_packet_pending_input, counter_storage
+	);
+	chain_ectx->abs_counter_packet_pending_output =
+		counter_get_value_handle(
+			cp_chain->counter_packet_pending_output, counter_storage
+		);
+}
+
+static void
+function_ectx_resolve_absolutes(struct function_ectx *function_ectx) {
+	struct cp_function *cp_function = ADDR_OF(&function_ectx->cp_function);
+	struct counter_storage *counter_storage =
+		ADDR_OF(&function_ectx->counter_storage);
+
+	function_ectx->abs_counter_packet_in = counter_get_value_handle(
+		cp_function->counter_packet_in, counter_storage
+	);
+	function_ectx->abs_counter_packet_out = counter_get_value_handle(
+		cp_function->counter_packet_out, counter_storage
+	);
+	function_ectx->abs_counter_packet_drop = counter_get_value_handle(
+		cp_function->counter_packet_drop, counter_storage
+	);
+	function_ectx->abs_counter_packet_pending_input =
+		counter_get_value_handle(
+			cp_function->counter_packet_pending_input,
+			counter_storage
+		);
+	function_ectx->abs_counter_packet_pending_output =
+		counter_get_value_handle(
+			cp_function->counter_packet_pending_output,
+			counter_storage
+		);
+
+	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
+	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
+		chain_ectx_resolve_absolutes(ADDR_OF(chains + idx));
+	}
+}
+
+static void
+pipeline_ectx_resolve_absolutes(struct pipeline_ectx *pipeline_ectx) {
+	struct cp_pipeline *cp_pipeline = ADDR_OF(&pipeline_ectx->cp_pipeline);
+	struct counter_storage *counter_storage =
+		ADDR_OF(&pipeline_ectx->counter_storage);
+
+	pipeline_ectx->abs_counter_packet_in = counter_get_value_handle(
+		cp_pipeline->counter_packet_in, counter_storage
+	);
+	pipeline_ectx->abs_counter_packet_out = counter_get_value_handle(
+		cp_pipeline->counter_packet_out, counter_storage
+	);
+	pipeline_ectx->abs_counter_packet_drop = counter_get_value_handle(
+		cp_pipeline->counter_packet_drop, counter_storage
+	);
+	pipeline_ectx->abs_counter_packet_pending_input =
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_pending_input,
+			counter_storage
+		);
+	pipeline_ectx->abs_counter_packet_pending_output =
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_pending_output,
+			counter_storage
+		);
+
+	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
+		function_ectx_resolve_absolutes(
+			ADDR_OF(pipeline_ectx->functions + idx)
+		);
+	}
+}
+
+static void
+device_entry_ectx_resolve_absolutes(
+	struct device_entry_ectx *entry_ectx,
+	struct cp_device_entry *cp_device_entry,
+	struct counter_storage *counter_storage
+) {
+	entry_ectx->counter_packet_rx = counter_get_value_handle(
+		cp_device_entry->counter_packet_rx, counter_storage
+	);
+	entry_ectx->counter_packet_entry = counter_get_value_handle(
+		cp_device_entry->counter_packet_entry, counter_storage
+	);
+	entry_ectx->counter_packet_tx = counter_get_value_handle(
+		cp_device_entry->counter_packet_tx, counter_storage
+	);
+	entry_ectx->counter_packet_drop = counter_get_value_handle(
+		cp_device_entry->counter_packet_drop, counter_storage
+	);
+	entry_ectx->counter_packet_recirc_drop = counter_get_value_handle(
+		cp_device_entry->counter_packet_recirc_drop, counter_storage
+	);
+	entry_ectx->counter_packet_pending_input = counter_get_value_handle(
+		cp_device_entry->counter_packet_pending_input, counter_storage
+	);
+	entry_ectx->counter_packet_pending_output = counter_get_value_handle(
+		cp_device_entry->counter_packet_pending_output, counter_storage
+	);
+
+	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
+	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
+		pipeline_ectx_resolve_absolutes(ADDR_OF(pipelines + idx));
+	}
+}
+
+// Derive the absolute counter pointers of every pipeline stage of the
+// execution context, resolved from the counter registry ids and the
+// stage counter storages.
+//
+// Runs in the dataplane process before the context is released to the
+// worker, and recomputes everything from controlplane-owned data, so a
+// re-run never corrupts a previous derivation.
+void
+config_gen_ectx_resolve_counters(struct config_gen_ectx *config_gen_ectx) {
+	for (uint64_t idx = 0; idx < config_gen_ectx->device_count; ++idx) {
+		struct device_ectx *device_ectx =
+			ADDR_OF(&config_gen_ectx->devices[idx]);
+		if (device_ectx == NULL) {
+			continue;
+		}
+
+		struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
+		struct counter_storage *counter_storage =
+			ADDR_OF(&device_ectx->counter_storage);
+
+		struct device_entry_ectx *input =
+			ADDR_OF(&device_ectx->input_pipelines);
+		if (input != NULL) {
+			device_entry_ectx_resolve_absolutes(
+				input,
+				ADDR_OF(&cp_device->input_pipelines),
+				counter_storage
+			);
+		}
+
+		struct device_entry_ectx *output =
+			ADDR_OF(&device_ectx->output_pipelines);
+		if (output != NULL) {
+			device_entry_ectx_resolve_absolutes(
+				output,
+				ADDR_OF(&cp_device->output_pipelines),
+				counter_storage
+			);
+		}
+	}
+}
+
 static inline void
 chain_ectx_process(
 	struct dp_worker *dp_worker,
@@ -126,12 +282,12 @@ chain_ectx_process(
 	}
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&chain_ectx->counter_packet_pending_input),
+		chain_ectx->abs_counter_packet_pending_input,
 		packet_front_pending_input_count(packet_front),
 		packet_front_pending_input_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&chain_ectx->counter_packet_pending_output),
+		chain_ectx->abs_counter_packet_pending_output,
 		packet_front_pending_output_count(packet_front),
 		packet_front_pending_output_bytes(packet_front)
 	);
@@ -234,7 +390,7 @@ function_ectx_process(
 		packet_front_pending_output_bytes(packet_front);
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_in),
+		function_ectx->abs_counter_packet_in,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -252,24 +408,24 @@ function_ectx_process(
 	}
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_out),
+		function_ectx->abs_counter_packet_out,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_drop),
+		function_ectx->abs_counter_packet_drop,
 		packet_front_drop_count(packet_front) - drop_count,
 		packet_front_drop_bytes(packet_front) - drop_bytes
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_pending_input),
+		function_ectx->abs_counter_packet_pending_input,
 		packet_front_pending_input_count(packet_front) -
 			pending_input_count,
 		packet_front_pending_input_bytes(packet_front) -
 			pending_input_bytes
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_pending_output),
+		function_ectx->abs_counter_packet_pending_output,
 		packet_front_pending_output_count(packet_front) -
 			pending_output_count,
 		packet_front_pending_output_bytes(packet_front) -
@@ -285,7 +441,7 @@ pipeline_ectx_process(
 ) {
 	// Packets arrive in output list, count them before processing
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_in),
+		pipeline_ectx->abs_counter_packet_in,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -298,22 +454,22 @@ pipeline_ectx_process(
 	}
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_out),
+		pipeline_ectx->abs_counter_packet_out,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_drop),
+		pipeline_ectx->abs_counter_packet_drop,
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_pending_input),
+		pipeline_ectx->abs_counter_packet_pending_input,
 		packet_front_pending_input_count(packet_front),
 		packet_front_pending_input_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_pending_output),
+		pipeline_ectx->abs_counter_packet_pending_output,
 		packet_front_pending_output_count(packet_front),
 		packet_front_pending_output_bytes(packet_front)
 	);
@@ -433,7 +589,7 @@ device_ectx_process_entry(
 	struct packet_front *packet_front
 ) {
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_rx),
+		entry_ectx->counter_packet_rx,
 		packet_front_input_count(packet_front),
 		packet_front_input_bytes(packet_front)
 	);
@@ -441,7 +597,7 @@ device_ectx_process_entry(
 	entry_ectx->handler(dp_worker, device_ectx, packet_front);
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_entry),
+		entry_ectx->counter_packet_entry,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -449,22 +605,22 @@ device_ectx_process_entry(
 	device_entry_ectx_dispatch(dp_worker, entry_ectx, packet_front);
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_tx),
+		entry_ectx->counter_packet_tx,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_drop),
+		entry_ectx->counter_packet_drop,
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_pending_input),
+		entry_ectx->counter_packet_pending_input,
 		packet_front_pending_input_count(packet_front),
 		packet_front_pending_input_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_pending_output),
+		entry_ectx->counter_packet_pending_output,
 		packet_front_pending_output_count(packet_front),
 		packet_front_pending_output_bytes(packet_front)
 	);

--- a/lib/dataplane/pipeline/pipeline.h
+++ b/lib/dataplane/pipeline/pipeline.h
@@ -6,7 +6,11 @@ struct dp_config;
 struct dp_worker;
 struct packet_front;
 
+struct config_gen_ectx;
 struct device_ectx;
+
+void
+config_gen_ectx_resolve_counters(struct config_gen_ectx *config_gen_ectx);
 
 void
 device_ectx_process_input(

--- a/lib/dataplane/worker/round.h
+++ b/lib/dataplane/worker/round.h
@@ -14,24 +14,31 @@ struct worker_round {
 // Prepare the worker state that precedes packet processing.
 //
 // The caller evaluates current_time_ns before entering this helper. The
-// release publication and iteration increment retain production ordering.
+// release acknowledgement and iteration increment retain production
+// ordering.
 static inline struct worker_round
-worker_round_prepare(
-	struct dp_worker *dp_worker,
-	struct cp_config *cp_config,
-	uint64_t current_time_ns
-) {
+worker_round_prepare(struct dp_worker *dp_worker, uint64_t current_time_ns) {
 	dp_worker->current_time = current_time_ns;
 
+	// The round acknowledges the generation of the context it actually
+	// snapshotted.
+	//
+	// The release store orders the previous round's uses of a retired
+	// context before the acknowledgement that permits its reclamation;
+	// a NULL context acknowledges zero, the pre-configuration state.
+	struct config_gen_ectx *config_gen_ectx =
+		ATOMIC_ADDR_OF(&dp_worker->config_gen_ectx);
+	struct cp_config_gen *cp_config_gen = NULL;
+	uint64_t acknowledged_gen = 0;
+	if (config_gen_ectx != NULL) {
+		cp_config_gen = ADDR_OF(&config_gen_ectx->cp_config_gen);
+		acknowledged_gen = cp_config_gen->gen;
+	}
 	struct worker_round round = {
-		.cp_config_gen = ATOMIC_ADDR_OF(&cp_config->cp_config_gen),
+		.cp_config_gen = cp_config_gen,
+		.config_gen_ectx = config_gen_ectx,
 	};
-	round.config_gen_ectx =
-		cp_config_gen_worker_ectx(round.cp_config_gen, dp_worker->idx);
-
-	__atomic_store_n(
-		&dp_worker->gen, round.cp_config_gen->gen, __ATOMIC_RELEASE
-	);
+	__atomic_store_n(&dp_worker->gen, acknowledged_gen, __ATOMIC_RELEASE);
 	*dp_worker->iterations += 1;
 
 	// Flip or first-build the worklists before any packet of this tick

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -1,10 +1,5 @@
 #include "dataplane_ut.h"
 
-// dp_worker->gen is initialized to a value far above any plausible
-// production cp_config_gen->gen so that harness workers never
-// observe a "wait for newer generation" state.
-#define DATAPLANE_UT_HIGH_GEN 1000000000000000ULL
-
 #include <dlfcn.h>
 #include <errno.h>
 #include <stdint.h>
@@ -119,6 +114,12 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 	ut->dp_config->packet_recirc_limit =
 		cfg->packet_recirc_limit == 0 ? PACKET_RECIRC_LIMIT_DEFAULT
 					      : cfg->packet_recirc_limit;
+
+	// The harness runs no worker threads of its own: rounds and
+	// installs run on arbitrary caller threads, and the lock
+	// serializes the synchronous deliveries against in-flight rounds.
+	ut->dp_config->external_worker_rounds = true;
+	pthread_mutex_init(dp_config_external_round_lock(ut->dp_config), NULL);
 
 	// Open the current binary so dlsym can resolve module/device symbols.
 	void *bin_hndl = dlopen(NULL, RTLD_NOW | RTLD_GLOBAL);
@@ -332,9 +333,6 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		}
 		memset(dp_worker, 0, sizeof(struct dp_worker));
 		dp_worker->idx = idx;
-		// A high generation value ensures the pipeline never waits for
-		// a newer config snapshot — same trick used by mock.
-		dp_worker->gen = DATAPLANE_UT_HIGH_GEN;
 		dp_worker->rx_mempool = ut->mempool;
 		dp_worker->core_id = (uint32_t)idx;
 		if (cfg->workers != NULL) {
@@ -498,9 +496,13 @@ dataplane_ut_run(
 	struct dp_worker **workers = ADDR_OF(&ut->dp_config->workers);
 	struct dp_worker *dp_worker = ADDR_OF(&workers[worker_idx]);
 
-	struct worker_round round = worker_round_prepare(
-		dp_worker, ut->cp_config, ut->mock_time_ns
-	);
+	// Held across the whole round: the synchronous delivery inside a
+	// generation install waits on this lock, so a context the round
+	// snapshotted cannot be retired underneath it.
+	pthread_mutex_lock(dp_config_external_round_lock(ut->dp_config));
+
+	struct worker_round round =
+		worker_round_prepare(dp_worker, ut->mock_time_ns);
 	struct cp_config_gen *cp_config_gen = round.cp_config_gen;
 	struct config_gen_ectx *config_gen_ectx = round.config_gen_ectx;
 
@@ -516,6 +518,8 @@ dataplane_ut_run(
 		while ((packet = packet_list_pop(input)) != NULL) {
 			packet_list_add(&result->drop, packet);
 		}
+		pthread_mutex_unlock(dp_config_external_round_lock(ut->dp_config
+		));
 		return;
 	}
 
@@ -543,6 +547,8 @@ dataplane_ut_run(
 
 	packet_list_concat(&result->output, &packet_front.output);
 	packet_list_concat(&result->drop, &packet_front.drop);
+
+	pthread_mutex_unlock(dp_config_external_round_lock(ut->dp_config));
 }
 
 // Saved per-packet state used by dataplane_ut_run_rounds.
@@ -733,4 +739,78 @@ cleanup:
 int
 dataplane_ut_build_optimized(void) {
 	return build_is_optimized();
+}
+
+int
+dataplane_ut_install_empty_pipeline(struct dataplane_ut *ut, const char *name) {
+	struct cp_pipeline_config *config = cp_pipeline_config_create(name, 0);
+	if (config == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_install_empty_pipeline: failed to allocate "
+		    "pipeline config");
+		return -1;
+	}
+
+	yanet_error *err = NULL;
+	struct cp_pipeline_config *configs[] = {config};
+	int rc = cp_config_update_pipelines(
+		ut->dp_config, ut->cp_config, 1, configs, &err
+	);
+	if (rc != 0) {
+		LOG(ERROR,
+		    "dataplane_ut_install_empty_pipeline: update failed: %s",
+		    yanet_error_message(err) ? yanet_error_message(err) : "?");
+	}
+	yanet_error_free(err);
+	cp_pipeline_config_free(config);
+	return rc;
+}
+
+static struct dp_worker *
+dataplane_ut_worker(struct dataplane_ut *ut, size_t worker_idx) {
+	if (worker_idx >= ut->dp_config->worker_count) {
+		return NULL;
+	}
+	// An observation read: a caller inspecting while rounds or
+	// installs run on other threads must order the read itself.
+	struct dp_worker **workers = ADDR_OF(&ut->dp_config->workers);
+	return ADDR_OF(workers + worker_idx);
+}
+
+uintptr_t
+dataplane_ut_worker_ectx(struct dataplane_ut *ut, size_t worker_idx) {
+	struct dp_worker *worker = dataplane_ut_worker(ut, worker_idx);
+	if (worker == NULL) {
+		return 0;
+	}
+	return (uintptr_t)ADDR_OF(&worker->config_gen_ectx);
+}
+
+uintptr_t
+dataplane_ut_published_ectx(struct dataplane_ut *ut, size_t worker_idx) {
+	struct cp_config_gen *config_gen =
+		ADDR_OF(&ut->cp_config->cp_config_gen);
+	if (config_gen == NULL) {
+		return 0;
+	}
+	return (uintptr_t)cp_config_gen_worker_ectx(config_gen, worker_idx);
+}
+
+uint64_t
+dataplane_ut_worker_gen(struct dataplane_ut *ut, size_t worker_idx) {
+	struct dp_worker *worker = dataplane_ut_worker(ut, worker_idx);
+	if (worker == NULL) {
+		return 0;
+	}
+	return worker->gen;
+}
+
+uint64_t
+dataplane_ut_published_gen(struct dataplane_ut *ut) {
+	struct cp_config_gen *config_gen =
+		ADDR_OF(&ut->cp_config->cp_config_gen);
+	if (config_gen == NULL) {
+		return 0;
+	}
+	return config_gen->gen;
 }

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -159,3 +159,31 @@ dataplane_ut_run_rounds(
 	uint64_t rounds,
 	int reset_payload
 );
+
+// Install one named empty pipeline, forcing a generation switch.
+//
+// Returns 0 on success. This is the same update the in-process install
+// helpers drive, so the switch completes synchronously and the workers'
+// contexts and acknowledgements are already settled on return.
+int
+dataplane_ut_install_empty_pipeline(struct dataplane_ut *ut, const char *name);
+
+// Resolved value of the worker's assigned context field, 0 when the
+// worker index is out of range or no context is assigned.
+uintptr_t
+dataplane_ut_worker_ectx(struct dataplane_ut *ut, size_t worker_idx);
+
+// Resolved per-worker context of the currently published generation,
+// with the same conventions as the worker field reader above.
+uintptr_t
+dataplane_ut_published_ectx(struct dataplane_ut *ut, size_t worker_idx);
+
+// The generation number the worker last acknowledged, 0 when the worker
+// index is out of range.
+uint64_t
+dataplane_ut_worker_gen(struct dataplane_ut *ut, size_t worker_idx);
+
+// Generation number of the currently published generation, 0 when no
+// generation is published.
+uint64_t
+dataplane_ut_published_gen(struct dataplane_ut *ut);

--- a/lib/tests/dataplane/worker_clone_test.c
+++ b/lib/tests/dataplane/worker_clone_test.c
@@ -262,10 +262,8 @@ test_recirc_drop_counts_full_packet(struct rte_mempool *pool) {
 	};
 	struct device_entry_ectx entry = {0};
 	uint64_t counters[2] = {0, 0};
-	SET_OFFSET_OF(
-		&entry.counter_packet_recirc_drop,
-		(struct counter_value_handle *)counters
-	);
+	entry.counter_packet_recirc_drop =
+		(struct counter_value_handle *)counters;
 
 	device_entry_ectx_count_recirc_drop(&entry, &packet);
 

--- a/modules/fwstate/bindings/go/cfwstate/cgo.go
+++ b/modules/fwstate/bindings/go/cfwstate/cgo.go
@@ -5,6 +5,7 @@ package cfwstate
 //#cgo LDFLAGS: -L../../../../../build/objects/fwstate/api -lfwstate_objects
 //#cgo LDFLAGS: -L../../../../../build/lib/controlplane/config -lconfig_cp
 //#cgo LDFLAGS: -L../../../../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../../../../build/lib/dataplane/pipeline -lpipeline
 //#cgo LDFLAGS: -L../../../../../build/lib/counters -lcounters
 //
 //#include "api/agent.h"

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -6,6 +6,7 @@ package fwstate
 //#cgo LDFLAGS: -L../../../../build/objects/fwstate/api -lfwstate_objects
 //#cgo LDFLAGS: -L../../../../build/lib/controlplane/config -lconfig_cp
 //#cgo LDFLAGS: -L../../../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../../../build/lib/dataplane/pipeline -lpipeline
 //#cgo LDFLAGS: -L../../../../build/lib/counters -lcounters
 //#cgo LDFLAGS: -L../../../../build/lib/dataplane/packet -lpacket
 //#cgo LDFLAGS: -L../../../../build/lib/fwstate -lfwstate


### PR DESCRIPTION
Stacked on #2441 — merge that first.

- Pipeline, function, chain and device-entry stages carry only absolute counter pointers, resolved by the publishing process from the counter registry ids and the stage counter storages when a generation is assigned to workers; the relative counter fields are gone.
- Derivation recomputes from controlplane-owned data on every assignment, staying correct across dataplane restarts and re-publications.
- Links the pipeline library into the five cgo consumers of the dataplane config library.