### PR TITLE
feat(controlplane): expose the dataplane current time to attached processes

### DIFF
--- a/api/agent.h
+++ b/api/agent.h
@@ -142,6 +142,15 @@ dataplane_instance_numa_idx(struct dp_config *dp_config);
 uint32_t
 dataplane_instance_worker_count(struct dp_config *dp_config);
 
+// Returns the current time of the dataplane instance, in nanoseconds.
+//
+// @param dp_config Handle to the dataplane instance.
+// @param time_ns Set to the current time in nanoseconds on success.
+//
+// @return 0 on success, -1 when the instance has published no time yet.
+int
+dataplane_instance_current_time(struct dp_config *dp_config, uint64_t *time_ns);
+
 // Detaches a module agent from shared memory, releasing associated resources.
 //
 // @param agent Handle to the module agent to detach

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -131,6 +131,15 @@ func (m *DPConfig) WorkerCount() uint32 {
 	return uint32(C.dataplane_instance_worker_count(m.ptr))
 }
 
+func (m *DPConfig) CurrentTime() (uint64, bool) {
+	var timeNS C.uint64_t
+	if C.dataplane_instance_current_time(m.ptr, &timeNS) != 0 {
+		return 0, false
+	}
+
+	return uint64(timeNS), true
+}
+
 // Modules returns a list of dataplane modules available.
 func (m *DPConfig) Modules() []DPModule {
 	ptr := C.yanet_get_dp_module_list_info(m.ptr)

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -109,6 +109,43 @@ dataplane_instance_worker_count(struct dp_config *dp_config) {
 	return (uint32_t)dp_config->worker_count;
 }
 
+int
+dataplane_instance_current_time(
+	struct dp_config *dp_config, uint64_t *time_ns
+) {
+	if (dp_config == NULL || time_ns == NULL) {
+		return -1;
+	}
+
+	uint64_t worker_count = dp_config->worker_count;
+	struct dp_worker **workers = ADDR_OF(&dp_config->workers);
+	if (workers == NULL) {
+		return -1;
+	}
+
+	uint64_t latest = 0;
+	for (uint64_t idx = 0; idx < worker_count; ++idx) {
+		struct dp_worker *worker = ADDR_OF(&workers[idx]);
+		if (worker == NULL) {
+			continue;
+		}
+
+		uint64_t published = __atomic_load_n(
+			&worker->current_time, __ATOMIC_RELAXED
+		);
+		if (published > latest) {
+			latest = published;
+		}
+	}
+
+	if (latest == 0) {
+		return -1;
+	}
+
+	*time_ns = latest;
+	return 0;
+}
+
 // Body of agent_free_unused_agents for a caller that already holds
 // cp_config_lock. See the definition further down for details.
 static void

--- a/lib/controlplane/agent/agent_test.c
+++ b/lib/controlplane/agent/agent_test.c
@@ -23,6 +23,195 @@
 #define TEST_CP_MEMORY (1 << 20)
 #define TEST_STORAGE_SIZE (TEST_DP_MEMORY + TEST_CP_MEMORY)
 
+// Publish a worker array on the instance, mirroring the registration the
+// dataplane performs at startup.
+//
+// The array and the workers are allocated from the instance's own memory so
+// the relative pointers a reader follows resolve the same way they do in a
+// live segment.
+static int
+publish_workers(
+	struct dp_config *dp_config, const uint64_t *times, uint64_t count
+) {
+	struct dp_worker **workers = (struct dp_worker **)memory_balloc(
+		&dp_config->memory_context, sizeof(struct dp_worker *) * count
+	);
+	if (workers == NULL) {
+		return -1;
+	}
+
+	for (uint64_t idx = 0; idx < count; ++idx) {
+		struct dp_worker *worker = (struct dp_worker *)memory_balloc(
+			&dp_config->memory_context, sizeof(struct dp_worker)
+		);
+		if (worker == NULL) {
+			return -1;
+		}
+
+		memset(worker, 0, sizeof(struct dp_worker));
+		worker->idx = idx;
+		worker->current_time = times[idx];
+		SET_OFFSET_OF(workers + idx, worker);
+	}
+
+	SET_OFFSET_OF(&dp_config->workers, workers);
+	dp_config->worker_count = count;
+	return 0;
+}
+
+// Initialise a storage segment and hand back its instance configuration.
+static int
+init_instance(void *storage, struct dp_config **dp_config) {
+	struct cp_config *cp_config = NULL;
+	int rc = dp_storage_init(
+		0,
+		0,
+		storage,
+		TEST_DP_MEMORY,
+		TEST_CP_MEMORY,
+		dp_config,
+		&cp_config
+	);
+	if (rc != 0) {
+		return -1;
+	}
+
+	(void)cp_config;
+	return 0;
+}
+
+// Verify that an instance whose workers have not run yet reports no time
+// rather than a value a caller could mistake for one.
+//
+// A caller that cannot tell "no time" from a time has no way to avoid
+// falling back to the host clock, which is the comparison this accessor
+// exists to remove.
+static int
+test_current_time_without_workers_reports_none() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct dp_config *dp_config = NULL;
+	TEST_ASSERT(
+		init_instance(storage, &dp_config) == 0,
+		"dp_storage_init failed"
+	);
+
+	uint64_t time_ns = 0;
+	int rc = dataplane_instance_current_time(dp_config, &time_ns);
+	TEST_ASSERT(rc == -1, "an instance with no workers must report none");
+
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verify that an instance whose workers are registered but have published
+// nothing reports no time.
+static int
+test_current_time_before_first_round_reports_none() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct dp_config *dp_config = NULL;
+	TEST_ASSERT(
+		init_instance(storage, &dp_config) == 0,
+		"dp_storage_init failed"
+	);
+
+	const uint64_t times[] = {0, 0};
+	TEST_ASSERT(
+		publish_workers(dp_config, times, 2) == 0,
+		"failed to publish workers"
+	);
+
+	uint64_t time_ns = 0;
+	int rc = dataplane_instance_current_time(dp_config, &time_ns);
+	TEST_ASSERT(rc == -1, "workers that have not run must report none");
+
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verify that the instance time is the latest one its workers published, and
+// that a worker left behind does not hold it back.
+//
+// A worker stopped inside a driver call keeps publishing its last time
+// forever; taking anything but the latest would freeze the instance's clock
+// on that worker for as long as the process lives.
+static int
+test_current_time_reports_latest_worker() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct dp_config *dp_config = NULL;
+	TEST_ASSERT(
+		init_instance(storage, &dp_config) == 0,
+		"dp_storage_init failed"
+	);
+
+	const uint64_t times[] = {700, 900, 100};
+	TEST_ASSERT(
+		publish_workers(dp_config, times, 3) == 0,
+		"failed to publish workers"
+	);
+
+	uint64_t time_ns = 0;
+	int rc = dataplane_instance_current_time(dp_config, &time_ns);
+	TEST_ASSERT_SUCCESS(rc, "an instance with a running worker has a time");
+	TEST_ASSERT_EQUAL(
+		time_ns,
+		900,
+		"the instance time must be the latest a worker published"
+	);
+
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verify that the instance time does not move backwards when the worker that
+// last advanced it stops.
+static int
+test_current_time_does_not_regress_when_a_worker_stops() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct dp_config *dp_config = NULL;
+	TEST_ASSERT(
+		init_instance(storage, &dp_config) == 0,
+		"dp_storage_init failed"
+	);
+
+	const uint64_t times[] = {900, 100};
+	TEST_ASSERT(
+		publish_workers(dp_config, times, 2) == 0,
+		"failed to publish workers"
+	);
+
+	uint64_t before = 0;
+	TEST_ASSERT_SUCCESS(
+		dataplane_instance_current_time(dp_config, &before),
+		"the instance must report a time"
+	);
+
+	// The lagging worker keeps running while the leader stays put.
+	struct dp_worker **workers = ADDR_OF(&dp_config->workers);
+	struct dp_worker *lagging = ADDR_OF(workers + 1);
+	lagging->current_time = 800;
+
+	uint64_t after = 0;
+	TEST_ASSERT_SUCCESS(
+		dataplane_instance_current_time(dp_config, &after),
+		"the instance must still report a time"
+	);
+	TEST_ASSERT(
+		after >= before, "the instance time must not move backwards"
+	);
+	TEST_ASSERT_EQUAL(after, 900, "the stopped worker still bounds it");
+
+	free(storage);
+	return TEST_SUCCESS;
+}
+
 // Verify that agent_attach returns NULL with a non-NULL error when the
 // shared memory segment is zeroed (simulating the pre-init startup race).
 static int
@@ -719,6 +908,36 @@ main() {
 	if (test_extend_rolls_back_on_exhausted_pool() != TEST_SUCCESS) {
 		++tests_failed;
 		LOG(ERROR, "test_extend_rolls_back_on_exhausted_pool failed");
+	}
+
+	++tests_count;
+	if (test_current_time_without_workers_reports_none() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_current_time_without_workers_reports_none failed");
+	}
+
+	++tests_count;
+	if (test_current_time_before_first_round_reports_none() !=
+	    TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_current_time_before_first_round_reports_none failed");
+	}
+
+	++tests_count;
+	if (test_current_time_reports_latest_worker() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR, "test_current_time_reports_latest_worker failed");
+	}
+
+	++tests_count;
+	if (test_current_time_does_not_regress_when_a_worker_stops() !=
+	    TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_current_time_does_not_regress_when_a_worker_stops "
+		    "failed");
 	}
 
 	if (tests_failed != 0) {

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -71,6 +71,8 @@ struct dp_worker {
 	// Current worker time in nanoseconds,
 	// initialized on the start of the current
 	// loop round.
+	//
+	// Also read by processes attached to this zone.
 	uint64_t current_time;
 
 	uint64_t *iterations;

--- a/lib/dataplane/worker/round.h
+++ b/lib/dataplane/worker/round.h
@@ -21,7 +21,9 @@ worker_round_prepare(
 	struct cp_config *cp_config,
 	uint64_t current_time_ns
 ) {
-	dp_worker->current_time = current_time_ns;
+	__atomic_store_n(
+		&dp_worker->current_time, current_time_ns, __ATOMIC_RELAXED
+	);
 
 	struct worker_round round = {
 		.cp_config_gen = ATOMIC_ADDR_OF(&cp_config->cp_config_gen),

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "common/buildinfo.h"
 #include "common/memory.h"
@@ -349,6 +350,21 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		SET_OFFSET_OF(dp_workers + idx, dp_worker);
 	}
 
+	// The harness instance starts with its clock already running.
+	//
+	// A test that never drives a packet still exercises control-plane
+	// code that has to judge the deadlines in this instance, and an
+	// instance whose workers have never published cannot be judged at
+	// all. Real time is the same reading a started worker would take.
+	struct timespec startup_ts;
+	if (clock_gettime(CLOCK_REALTIME, &startup_ts) == 0) {
+		dataplane_ut_set_time_ns(
+			ut,
+			(uint64_t)startup_ts.tv_sec * 1000000000ULL +
+				(uint64_t)startup_ts.tv_nsec
+		);
+	}
+
 	worker_counters_bind(ut->dp_config, &counter_ids);
 
 	// Skipped when device_count == 0: the implicit device 0 (see above)
@@ -426,9 +442,34 @@ dataplane_ut_shm(struct dataplane_ut *ut) {
 	return &ut->shm;
 }
 
+// Publish a time on every worker of the harness instance.
+//
+// In a live instance each worker publishes the time at the head of its
+// round, which is what tells an attached process what time the instance
+// thinks it is. A harness runs a round only when a test drives packets
+// through it, so without this an instance with idle workers would answer
+// that it has no time at all.
+static void
+dataplane_ut_publish_time(struct dataplane_ut *ut, uint64_t ns) {
+	struct dp_worker **workers = ADDR_OF(&ut->dp_config->workers);
+	if (workers == NULL) {
+		return;
+	}
+
+	for (uint64_t idx = 0; idx < ut->dp_config->worker_count; ++idx) {
+		struct dp_worker *worker = ADDR_OF(workers + idx);
+		if (worker == NULL) {
+			continue;
+		}
+
+		__atomic_store_n(&worker->current_time, ns, __ATOMIC_RELAXED);
+	}
+}
+
 void
 dataplane_ut_set_time_ns(struct dataplane_ut *ut, uint64_t ns) {
 	ut->mock_time_ns = ns;
+	dataplane_ut_publish_time(ut, ns);
 }
 
 uint64_t

--- a/objects/fwstate/controlplane/map_service.go
+++ b/objects/fwstate/controlplane/map_service.go
@@ -14,7 +14,6 @@ import (
 	"math"
 	"strings"
 	"sync"
-	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -238,7 +237,7 @@ func (m *FWStateMapService) collectMapStats() []*commonpb.Metric {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	now := time.Now()
+	now, haveNow := m.dataplaneTime()
 
 	result := make([]*commonpb.Metric, 0, len(m.maps)*7)
 	for name, fwMap := range m.maps {
@@ -247,7 +246,10 @@ func (m *FWStateMapService) collectMapStats() []*commonpb.Metric {
 			af = "ipv6"
 		}
 		result = append(
-			result, mapStatsGauges(name, af, now, fwMap.Config().GetStats())...,
+			result,
+			mapStatsGauges(
+				name, af, now, haveNow, fwMap.Config().GetStats(),
+			)...,
 		)
 	}
 
@@ -259,29 +261,34 @@ func (m *FWStateMapService) collectMapStats() []*commonpb.Metric {
 // The names match the series the fwstate service exported per config
 // before the maps became standalone objects, so existing dashboards keep
 // working with the map and af labels in place of the config label.
-func mapStatsGauges(mapName, af string, now time.Time, stats mapStats) []*commonpb.Metric {
+func mapStatsGauges(
+	mapName, af string, now uint64, haveNow bool, stats mapStats,
+) []*commonpb.Metric {
 	labels := []*commonpb.Label{
 		{Name: "map", Value: mapName},
 		{Name: "af", Value: af},
 	}
 
-	// MaxDeadline is an absolute timestamp on the dataplane's monotonic
-	// clock. Export the remaining time-to-live (clamped at zero once the
-	// deadline has passed).
-	deadlineTTL := uint64(0)
-	if nowNS := uint64(now.UnixNano()); stats.MaxDeadline > nowNS {
-		deadlineTTL = stats.MaxDeadline - nowNS
-	}
-
-	return []*commonpb.Metric{
+	gauges := []*commonpb.Metric{
 		commonpb.NewMetricGauge("fwstate_index_size", float64(stats.IndexSize), labels...),
 		commonpb.NewMetricGauge("fwstate_extra_bucket_count", float64(stats.ExtraBucketCount), labels...),
 		commonpb.NewMetricGauge("fwstate_max_chain_length", float64(stats.MaxChainLength), labels...),
 		commonpb.NewMetricGauge("fwstate_layer_count", float64(stats.LayerCount), labels...),
 		commonpb.NewMetricGauge("fwstate_total_elements", float64(stats.TotalElements), labels...),
-		commonpb.NewMetricGauge("fwstate_max_deadline_ns", float64(deadlineTTL), labels...),
 		commonpb.NewMetricGauge("fwstate_memory_bytes", float64(stats.MemoryUsed), labels...),
 	}
+
+	if haveNow {
+		deadlineTTL := uint64(0)
+		if stats.MaxDeadline > now {
+			deadlineTTL = stats.MaxDeadline - now
+		}
+		gauges = append(gauges, commonpb.NewMetricGauge(
+			"fwstate_max_deadline_ns", float64(deadlineTTL), labels...,
+		))
+	}
+
+	return gauges
 }
 
 func (m *FWStateMapService) mapRetention() func(metrics.MetricID) bool {
@@ -528,7 +535,13 @@ func (m *FWStateMapService) InsertLayer(
 	}
 
 	mapCP := *fwMap.Config()
-	m.ReclaimStaleLayers(fwMap.Config(), mapCP, uint64(time.Now().UnixNano()))
+	if now, ok := m.dataplaneTime(); ok {
+		m.ReclaimStaleLayers(fwMap.Config(), mapCP, now)
+	} else {
+		m.log.Warn("skipped stale-layer reclamation without a dataplane time",
+			zap.String("map", name),
+		)
+	}
 
 	m.log.Info("successfully inserted fwstate-map layer", zap.String("map", name))
 	return &fwstatemappb.InsertLayerResponse{}, nil
@@ -562,7 +575,15 @@ func (m *FWStateMapService) ListEntries(
 		return nil, err
 	}
 
-	now := uint64(time.Now().UnixNano())
+	// Every entry the walk returns carries whether it has expired, so the
+	// read needs the clock those deadlines are on.
+	now, haveNow := m.dataplaneTime()
+	if !haveNow {
+		return nil, status.Error(
+			codes.Unavailable,
+			"dataplane instance has published no time yet",
+		)
+	}
 
 	m.mu.Lock()
 	fwMap, ok := m.maps[mapName]
@@ -698,6 +719,16 @@ func ValidateWorkerCount(workerCount uint32) error {
 		return status.Errorf(codes.InvalidArgument, "worker_count %d exceeds maximum %d", workerCount, maxWorkerCount)
 	}
 	return nil
+}
+
+// dataplaneTime reports the instance's current time, and whether the
+// instance has one to report.
+func (m *FWStateMapService) dataplaneTime() (uint64, bool) {
+	if m.agent == nil {
+		return 0, false
+	}
+
+	return m.agent.DPConfig().CurrentTime()
 }
 
 func (m *FWStateMapService) dpWorkerCountOf() func() uint32 {

--- a/objects/fwstate/controlplane/map_service_test.go
+++ b/objects/fwstate/controlplane/map_service_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
@@ -616,6 +617,96 @@ func Test_FWStateMapService_MetricsExposesGRPCSeries(t *testing.T) {
 		}
 	}
 	require.Equal(t, fwstatemap.ServiceName, serviceLabel)
+}
+
+// Test_FWStateMapService_ListEntriesWithoutInstanceTime verifies that a
+// listing is refused while the instance has published no time.
+//
+// Every entry a listing returns is labelled with whether it has expired,
+// and that label is derived from the instance's clock. Answering without
+// one would report every entry as live, expired ones included.
+func Test_FWStateMapService_ListEntriesWithoutInstanceTime(t *testing.T) {
+	h, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(64 * datasize.MB),
+		DPMemory:      uint64(4 * datasize.MB),
+		WorkerCount:   1,
+		ObjectsToLoad: []string{"fwstate_map_v4", "fwstate_map_v6"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	// Wind the instance back to where a worker that has never run leaves
+	// it, which is how it reports having no time at all.
+	h.SetCurrentTime(time.Unix(0, 0))
+
+	shm := h.SharedMemory()
+	agent, err := shm.AgentAttach("fwstatemap-test", 0, 16*datasize.MB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	svc := fwstatemap.NewFWStateMapService(agent)
+	_, err = svc.CreateMap(t.Context(), &fwstatemappb.CreateMapRequest{
+		Name:             "no-time-list-v4",
+		Kind:             fwstatemappb.Kind_V4,
+		IndexSize:        1024,
+		ExtraBucketCount: 64,
+	})
+	require.NoError(t, err)
+
+	_, err = svc.ListEntries(t.Context(), &fwstatemappb.ListEntriesRequest{
+		MapName:   "no-time-list-v4",
+		Direction: fwstatemappb.Direction_FORWARD,
+		BatchSize: 10,
+	})
+	require.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+// Test_FWStateMapService_MetricsOmitLifetimeWithoutInstanceTime verifies
+// that the remaining-lifetime gauge is left out while the instance has
+// published no time, and that the rest of the set is still exported.
+//
+// The furthest deadline in a map is on the instance's clock. With no time
+// from that clock there is nothing to measure it against, and a zero would
+// read on a dashboard as an expiry that has already happened.
+func Test_FWStateMapService_MetricsOmitLifetimeWithoutInstanceTime(t *testing.T) {
+	h, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(64 * datasize.MB),
+		DPMemory:      uint64(4 * datasize.MB),
+		WorkerCount:   1,
+		ObjectsToLoad: []string{"fwstate_map_v4", "fwstate_map_v6"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	// Wind the instance back to where a worker that has never run leaves
+	// it, which is how it reports having no time at all.
+	h.SetCurrentTime(time.Unix(0, 0))
+
+	shm := h.SharedMemory()
+	agent, err := shm.AgentAttach("fwstatemap-test", 0, 16*datasize.MB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	svc := fwstatemap.NewFWStateMapService(agent)
+	_, err = svc.CreateMap(t.Context(), &fwstatemappb.CreateMapRequest{
+		Name:             "no-time-v4",
+		Kind:             fwstatemappb.Kind_V4,
+		IndexSize:        1024,
+		ExtraBucketCount: 64,
+	})
+	require.NoError(t, err)
+
+	collected, err := svc.Metrics()
+	require.NoError(t, err)
+
+	gauges := map[string]*commonpb.Metric{}
+	for _, metric := range collected {
+		gauges[metric.Name] = metric
+	}
+	require.NotContains(t, gauges, "fwstate_max_deadline_ns",
+		"a lifetime must not be reported without a clock to measure it")
+	require.Contains(t, gauges, "fwstate_total_elements",
+		"the rest of the gauge set must still be exported")
 }
 
 // Test_FWStateMapService_MetricsEmitPerMapGauges verifies that the map


### PR DESCRIPTION
Timestamps and deadlines in an instance's shared memory are on the dataplane's clock, which is anchored to real time once at startup and advanced from the cycle counter afterwards. Nothing outside that process could read a value in the same domain, so every consumer substituted the host clock and diverged from the dataplane whenever the host clock was corrected.

- Report an instance's current time as the latest its workers have published: that trails processing by at most one round, cannot be held back by a worker stopped inside a driver call, and never moves backwards.
- Report the absence of a time distinguishably, so a caller with nothing to compare against says so instead of reaching for the host clock.
- Publish the per-round worker time atomically, now that it is read from outside the process that writes it.

Closes #2450