### PR TITLE
feat(counters): expose worker rx mempool utilization

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -364,6 +364,39 @@ func (m *Harness) OutstandingMbufs() uint64 {
 	return uint64(C.dataplane_ut_mempool_outstanding(m.ptr))
 }
 
+// SetWorkerCounter overwrites the value of a named size-1 counter in the
+// given worker's shared worker-counter storage.
+//
+// A fault-injection hook for control-plane tests: it publishes snapshots
+// no healthy dataplane would produce, such as an availability above the
+// pool capacity. A counter carrying more than one value is refused.
+// Returns an error when the worker index or the counter name is unknown
+// or the counter is not size-1.
+func (m *Harness) SetWorkerCounter(worker int, name string, value uint64) error {
+	// The setter indexes the worker's counter storage directly, so an
+	// index outside the registered workers would corrupt C memory.
+	if worker < 0 || worker >= m.workerCount {
+		return fmt.Errorf(
+			"worker %d exceeds topology worker count %d",
+			worker,
+			m.workerCount,
+		)
+	}
+
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	if rc := C.dataplane_ut_set_worker_counter(
+		m.ptr,
+		C.size_t(worker),
+		cName,
+		C.uint64_t(value),
+	); rc != 0 {
+		return fmt.Errorf("failed to set worker %d counter %q", worker, name)
+	}
+	return nil
+}
+
 // SharedMemory returns the shared-memory handle backing this harness.
 func (m *Harness) SharedMemory() *ffi.SharedMemory {
 	shm := C.dataplane_ut_shm(m.ptr)

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -11,7 +11,8 @@ use ync::{
 };
 use ynpb::pb::{
     CounterTag, CountersByTagsRequest, CountersByTagsResponse, PortCountersRequest, PortCountersResponse,
-    WorkerCounter, WorkerCountersRequest, WorkerCountersResponse, counters_service_client::CountersServiceClient,
+    WorkerCounter, WorkerCountersRequest, WorkerCountersResponse, WorkerRxMempool,
+    counters_service_client::CountersServiceClient,
 };
 
 const COUNTERS_SERVICE: &str = "controlplane.ynpb.v1.CountersService";
@@ -253,6 +254,8 @@ struct WorkerRow {
     remote_tx_drops: String,
     #[tabled(rename = "Disposed")]
     disposed: String,
+    #[tabled(rename = "RX pool free")]
+    rx_pool_free: String,
 }
 
 impl From<&WorkerCounter> for WorkerRow {
@@ -296,7 +299,19 @@ impl From<&WorkerCounter> for WorkerRow {
             local_tx_drops: format_number(w.local_tx_drops),
             remote_tx_drops: format_number(w.remote_tx_drops),
             disposed: format_number(w.disposed),
+            rx_pool_free: format_rx_pool_free(w.rx_mempool.as_ref()),
         }
+    }
+}
+
+/// Renders one worker's RX pool free objects as `available/capacity`.
+///
+/// An absent pool stays `n/a`: the serving side predates pool gauges,
+/// which presence on the wire distinguishes from any real occupancy.
+fn format_rx_pool_free(pool: Option<&WorkerRxMempool>) -> String {
+    match pool {
+        None => "n/a".to_string(),
+        Some(pool) => format!("{}/{}", pool.available, pool.capacity),
     }
 }
 
@@ -369,5 +384,36 @@ fn format_number(n: u64) -> String {
         }
 
         result.chars().rev().collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ynpb::pb::WorkerRxMempool;
+
+    use super::format_rx_pool_free;
+
+    fn pool(available: u32, capacity: u32) -> Option<WorkerRxMempool> {
+        Some(WorkerRxMempool { capacity, available })
+    }
+
+    #[test]
+    fn test_format_rx_pool_free_absent_pool_is_na() {
+        assert_eq!(format_rx_pool_free(None), "n/a");
+    }
+
+    #[test]
+    fn test_format_rx_pool_free_full_pool() {
+        assert_eq!(format_rx_pool_free(pool(16384, 16384).as_ref()), "16384/16384");
+    }
+
+    #[test]
+    fn test_format_rx_pool_free_partially_used_pool() {
+        assert_eq!(format_rx_pool_free(pool(9728, 16384).as_ref()), "9728/16384");
+    }
+
+    #[test]
+    fn test_format_rx_pool_free_exhausted_pool() {
+        assert_eq!(format_rx_pool_free(pool(0, 16384).as_ref()), "0/16384");
     }
 }

--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -155,7 +155,8 @@ func (m *Counters) ByTags(
 	return response, nil
 }
 
-// Workers returns raw cumulative worker counters.
+// Workers returns a per-worker snapshot: cumulative polling and traffic
+// counters plus the RX pool occupancy gauges.
 func (m *Counters) Workers(
 	ctx context.Context,
 	request *ynpb.WorkerCountersRequest,
@@ -170,6 +171,14 @@ func (m *Counters) Workers(
 		Workers: make([]*ynpb.WorkerCounter, 0, len(workers)),
 	}
 	for _, worker := range workers {
+		var pool *ynpb.WorkerRxMempool
+		if worker.RxMempool != nil {
+			pool = &ynpb.WorkerRxMempool{
+				Capacity:  worker.RxMempool.Capacity,
+				Available: worker.RxMempool.Available,
+			}
+		}
+
 		response.Workers = append(response.Workers, &ynpb.WorkerCounter{
 			WorkerIdx:       worker.WorkerIdx,
 			CoreId:          worker.CoreID,
@@ -187,6 +196,7 @@ func (m *Counters) Workers(
 			LocalTxDrops:    worker.LocalTxDrops,
 			RemoteTxDrops:   worker.RemoteTxDrops,
 			Disposed:        worker.Disposed,
+			RxMempool:       pool,
 		})
 	}
 
@@ -240,7 +250,7 @@ func (m *Counters) Collect() []*commonpb.Metric {
 	}
 
 	if workers, err := dpConfig.WorkerCounters(); err == nil {
-		metrics = append(metrics, workerMetrics(workers)...)
+		metrics = append(metrics, workerMetrics(workers, m.instanceID)...)
 	} else {
 		m.log.Warn("failed to collect worker counters", zap.Error(err))
 	}
@@ -265,8 +275,9 @@ func portMetrics(ports []ffi.PortGroup) []*commonpb.Metric {
 	return metrics
 }
 
-func workerMetrics(workers []ffi.WorkerCounter) []*commonpb.Metric {
+func workerMetrics(workers []ffi.WorkerCounter, instanceID uint32) []*commonpb.Metric {
 	metrics := make([]*commonpb.Metric, 0)
+	instance := strconv.FormatUint(uint64(instanceID), 10)
 	for _, worker := range workers {
 		labels := []*commonpb.Label{
 			{Name: "worker_idx", Value: strconv.FormatUint(uint64(worker.WorkerIdx), 10)},
@@ -287,6 +298,29 @@ func workerMetrics(workers []ffi.WorkerCounter) []*commonpb.Metric {
 			commonpb.NewMetricCounter("worker_remote_tx_drops", worker.RemoteTxDrops, labels...),
 			commonpb.NewMetricCounter("worker_disposed", worker.Disposed, labels...),
 		)
+
+		// The pool gauges are the only worker series keyed by
+		// instance: a pool identity only exists inside its instance,
+		// while the counters above keep their long-standing label
+		// set so existing time series are not recreated.
+		if worker.RxMempool != nil {
+			poolLabels := append(
+				[]*commonpb.Label{{Name: "instance_id", Value: instance}},
+				labels...,
+			)
+			metrics = append(metrics,
+				commonpb.NewMetricGauge(
+					"worker_rx_mempool_capacity",
+					float64(worker.RxMempool.Capacity),
+					poolLabels...,
+				),
+				commonpb.NewMetricGauge(
+					"worker_rx_mempool_available",
+					float64(worker.RxMempool.Available),
+					poolLabels...,
+				),
+			)
+		}
 
 		if len(worker.RxBursts) > 0 {
 			metrics = append(metrics, makeHistogram(

--- a/controlplane/builtin/counters_test.go
+++ b/controlplane/builtin/counters_test.go
@@ -2,15 +2,39 @@ package builtin_test
 
 import (
 	"fmt"
+	"maps"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/builtin"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
+
+// newCountersHarness builds a one-instance in-process dataplane harness
+// with the given worker count and registers its teardown. Worker pool
+// gauges are seeded at creation from the shared mock pool.
+func newCountersHarness(t *testing.T, workers uint64) *dataplaneut.Harness {
+	t.Helper()
+
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:    1 << 25,
+		DPMemory:    1 << 20,
+		WorkerCount: workers,
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	return harness
+}
 
 // An oversized query is refused before any shared memory is touched.
 func TestCountersByTagsRejectsOversizedQuery(t *testing.T) {
@@ -27,4 +51,157 @@ func TestCountersByTagsRejectsOversizedQuery(t *testing.T) {
 
 	require.Nil(t, response)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// metricByExactLabels finds the metric carrying exactly the given name
+// and label set — same names, same values, nothing extra — so a series
+// with renamed or dropped labels cannot slip through a subset match.
+func metricByExactLabels(
+	t *testing.T,
+	metrics []*commonpb.Metric,
+	name string,
+	want map[string]string,
+) *commonpb.Metric {
+	t.Helper()
+
+	for _, metric := range metrics {
+		if metric.GetName() != name {
+			continue
+		}
+
+		got := make(map[string]string, len(metric.GetLabels()))
+		for _, label := range metric.GetLabels() {
+			got[label.GetName()] = label.GetValue()
+		}
+		if maps.Equal(got, want) {
+			return metric
+		}
+	}
+
+	return nil
+}
+
+// TestCountersWorkersReportsPoolGauges verifies that the worker snapshot
+// carries each worker's pool occupancy as a presence-bearing field with
+// the values the dataplane published.
+func TestCountersWorkersReportsPoolGauges(t *testing.T) {
+	harness := newCountersHarness(t, 2)
+
+	svc := builtin.NewCounters(0, harness.SharedMemory())
+
+	response, err := svc.Workers(t.Context(), &ynpb.WorkerCountersRequest{})
+
+	require.NoError(t, err)
+	require.Len(t, response.GetWorkers(), 2)
+	for _, worker := range response.GetWorkers() {
+		require.NotNil(
+			t,
+			worker.GetRxMempool(),
+			"worker %d pool must be present",
+			worker.GetWorkerIdx(),
+		)
+		require.Equal(t, uint32(1024), worker.GetRxMempool().GetCapacity())
+		require.Equal(t, uint32(1024), worker.GetRxMempool().GetAvailable())
+	}
+}
+
+// TestCountersCollectEmitsPoolGauges verifies that the metrics snapshot
+// publishes one capacity and one availability gauge per worker with the
+// exact instance-and-worker identity in the labels — both workers, so a
+// hardcoded identity fails — while the long-standing worker counters
+// keep their original label set.
+func TestCountersCollectEmitsPoolGauges(t *testing.T) {
+	harness := newCountersHarness(t, 2)
+
+	svc := builtin.NewCounters(0, harness.SharedMemory())
+
+	metrics := svc.Collect()
+
+	// Worker identity (core and queue equal the worker index in the
+	// harness), so the two expected label sets differ per worker.
+	identity := []map[string]string{
+		{
+			"instance_id": "0",
+			"worker_idx":  "0",
+			"core_id":     "0",
+			"device_id":   "0",
+			"queue_id":    "0",
+		},
+		{
+			"instance_id": "0",
+			"worker_idx":  "1",
+			"core_id":     "1",
+			"device_id":   "0",
+			"queue_id":    "1",
+		},
+	}
+	for _, labels := range identity {
+		capacity := metricByExactLabels(t, metrics, "worker_rx_mempool_capacity", labels)
+		require.NotNil(
+			t,
+			capacity,
+			"capacity gauge with exactly the labels %v is missing",
+			labels,
+		)
+		require.Equal(t, float64(1024), capacity.GetGauge())
+
+		available := metricByExactLabels(t, metrics, "worker_rx_mempool_available", labels)
+		require.NotNil(
+			t,
+			available,
+			"availability gauge with exactly the labels %v is missing",
+			labels,
+		)
+		require.Equal(t, float64(1024), available.GetGauge())
+	}
+
+	disposed := metricByExactLabels(t, metrics, "worker_disposed", map[string]string{
+		"worker_idx": "1",
+		"core_id":    "1",
+		"device_id":  "0",
+		"queue_id":   "1",
+	})
+	require.NotNil(t, disposed, "existing counters must keep their label set")
+}
+
+// TestCountersWorkersRejectsInvalidPoolSnapshot verifies that a pool
+// snapshot no healthy dataplane would publish fails the read naming the
+// worker instead of rendering a plausible value.
+func TestCountersWorkersRejectsInvalidPoolSnapshot(t *testing.T) {
+	harness := newCountersHarness(t, 1)
+	require.NoError(t, harness.SetWorkerCounter(0, "rx_mempool_available", 5000))
+
+	svc := builtin.NewCounters(0, harness.SharedMemory())
+
+	response, err := svc.Workers(t.Context(), &ynpb.WorkerCountersRequest{})
+
+	require.Nil(t, response)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "worker 0")
+}
+
+// TestCountersCollectOmitsWorkerFamilyOnInvalidPoolSnapshot verifies
+// that an unpublishable pool snapshot removes the whole worker family
+// from the metrics snapshot and logs a warning, rather than emitting
+// zero-valued gauges or a partial family.
+func TestCountersCollectOmitsWorkerFamilyOnInvalidPoolSnapshot(t *testing.T) {
+	harness := newCountersHarness(t, 1)
+	require.NoError(t, harness.SetWorkerCounter(0, "rx_mempool_capacity", 0))
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	svc := builtin.NewCounters(0, harness.SharedMemory(), builtin.WithCountersLog(zap.New(core)))
+
+	metrics := svc.Collect()
+
+	for _, metric := range metrics {
+		require.False(
+			t,
+			strings.HasPrefix(metric.GetName(), "worker_"),
+			"%s must be absent from the snapshot",
+			metric.GetName(),
+		)
+	}
+
+	warnings := logs.FilterMessage("failed to collect worker counters")
+	require.Equal(t, 1, warnings.Len(), "the family failure must be logged once")
 }

--- a/controlplane/ffi/worker.go
+++ b/controlplane/ffi/worker.go
@@ -6,11 +6,23 @@ import "C"
 
 import "fmt"
 
+// maxUint32 bounds the pool gauges: both live in the dataplane as
+// mempool object counts, whose native width is 32 bits.
+const maxUint32 = uint64(1<<32 - 1)
+
 const (
 	singleValueIdx = 0
 	packetsIdx     = 0
 	bytesIdx       = 1
 )
+
+// WorkerRxMempool is the occupancy of one worker's RX packet pool, in
+// mempool objects. In-use objects are the difference Capacity minus
+// Available, which counts mbufs held by NIC descriptors and in flight.
+type WorkerRxMempool struct {
+	Capacity  uint32
+	Available uint32
+}
 
 type WorkerCounter struct {
 	WorkerIdx       uint32
@@ -29,6 +41,7 @@ type WorkerCounter struct {
 	LocalTxDrops    uint64
 	RemoteTxDrops   uint64
 	Disposed        uint64
+	RxMempool       *WorkerRxMempool
 }
 
 func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
@@ -51,6 +64,8 @@ func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
 	localTxDrops := counterSet.Lookup("local_tx_drops", 1).Require()
 	remoteTxDrops := counterSet.Lookup("remote_tx_drops", 1).Require()
 	drops := counterSet.Lookup("drops", 1).Require()
+	rxMempoolCapacity := counterSet.Lookup("rx_mempool_capacity", 1).Require()
+	rxMempoolAvailable := counterSet.Lookup("rx_mempool_available", 1).Require()
 
 	if err := counterSet.Err(); err != nil {
 		return nil, fmt.Errorf("failed to resolve worker counters: %w", err)
@@ -65,6 +80,14 @@ func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
 				"failed to get metadata for worker at index %d",
 				idx,
 			)
+		}
+
+		pool, err := workerRxMempool(
+			rxMempoolCapacity.Value(idx, singleValueIdx),
+			rxMempoolAvailable.Value(idx, singleValueIdx),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("worker %d: %w", idx, err)
 		}
 
 		result[idx] = WorkerCounter{
@@ -84,8 +107,33 @@ func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
 			LocalTxDrops:    localTxDrops.Value(idx, singleValueIdx),
 			RemoteTxDrops:   remoteTxDrops.Value(idx, singleValueIdx),
 			Disposed:        drops.Value(idx, singleValueIdx),
+			RxMempool:       pool,
 		}
 	}
 
 	return result, nil
+}
+
+// workerRxMempool validates one worker's pool gauge pair. A snapshot no
+// healthy dataplane would publish is an error rather than a clamped or
+// zero-valued pool, so monitoring sees the failure instead of a
+// plausible value.
+func workerRxMempool(capacity, available uint64) (*WorkerRxMempool, error) {
+	if capacity == 0 || capacity > maxUint32 {
+		return nil, fmt.Errorf(
+			"invalid rx mempool capacity %d", capacity,
+		)
+	}
+	if available > capacity {
+		return nil, fmt.Errorf(
+			"rx mempool availability %d exceeds capacity %d",
+			available,
+			capacity,
+		)
+	}
+
+	return &WorkerRxMempool{
+		Capacity:  uint32(capacity),
+		Available: uint32(available),
+	}, nil
 }

--- a/controlplane/ffi/worker_test.go
+++ b/controlplane/ffi/worker_test.go
@@ -1,0 +1,94 @@
+package ffi_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+)
+
+// newWorkerCountersHarness builds a one-instance in-process dataplane
+// harness with the given worker count and registers its teardown. Every
+// worker shares the harness mock pool, whose gauges are seeded at
+// creation.
+func newWorkerCountersHarness(t *testing.T, workers uint64) *dataplaneut.Harness {
+	t.Helper()
+
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:    1 << 25,
+		DPMemory:    1 << 20,
+		WorkerCount: workers,
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	return harness
+}
+
+// TestWorkerCountersReportsPoolGauges verifies that every worker's
+// snapshot carries the pool occupancy published by the dataplane: the
+// mock pool's full capacity and its current availability.
+func TestWorkerCountersReportsPoolGauges(t *testing.T) {
+	harness := newWorkerCountersHarness(t, 2)
+
+	dpConfig := harness.SharedMemory().DPConfig(0)
+	workers, err := dpConfig.WorkerCounters()
+	require.NoError(t, err)
+	require.Len(t, workers, 2)
+
+	for idx, worker := range workers {
+		require.Equal(t, idx, int(worker.WorkerIdx))
+		require.NotNil(t, worker.RxMempool, "worker %d pool must be present", idx)
+		require.Equal(t, uint32(1024), worker.RxMempool.Capacity)
+		require.Equal(t, uint32(1024), worker.RxMempool.Available)
+	}
+}
+
+// TestWorkerCountersRejectsZeroCapacity verifies that a pool reported
+// with no capacity fails the read naming the worker rather than
+// surfacing a zero-valued pool.
+func TestWorkerCountersRejectsZeroCapacity(t *testing.T) {
+	harness := newWorkerCountersHarness(t, 1)
+	require.NoError(t, harness.SetWorkerCounter(0, "rx_mempool_capacity", 0))
+
+	dpConfig := harness.SharedMemory().DPConfig(0)
+	workers, err := dpConfig.WorkerCounters()
+
+	require.Nil(t, workers)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "worker 0")
+	require.Contains(t, err.Error(), "capacity")
+}
+
+// TestWorkerCountersRejectsAvailabilityAboveCapacity verifies that an
+// availability exceeding the capacity is refused instead of being
+// clamped into a plausible value.
+func TestWorkerCountersRejectsAvailabilityAboveCapacity(t *testing.T) {
+	harness := newWorkerCountersHarness(t, 1)
+	require.NoError(t, harness.SetWorkerCounter(0, "rx_mempool_available", 5000))
+
+	dpConfig := harness.SharedMemory().DPConfig(0)
+	workers, err := dpConfig.WorkerCounters()
+
+	require.Nil(t, workers)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "worker 0")
+	require.Contains(t, err.Error(), "exceeds capacity")
+}
+
+// TestWorkerCountersRejectsOversizedCapacity verifies that a capacity
+// beyond the mempool object width is refused rather than truncated into
+// a wrong pool size.
+func TestWorkerCountersRejectsOversizedCapacity(t *testing.T) {
+	harness := newWorkerCountersHarness(t, 1)
+	require.NoError(t, harness.SetWorkerCounter(0, "rx_mempool_capacity", 1<<32))
+
+	dpConfig := harness.SharedMemory().DPConfig(0)
+	workers, err := dpConfig.WorkerCounters()
+
+	require.Nil(t, workers)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "worker 0")
+	require.Contains(t, err.Error(), "capacity")
+}

--- a/controlplane/ynpb/v1/counters.proto
+++ b/controlplane/ynpb/v1/counters.proto
@@ -35,11 +35,28 @@ message CounterInfo {
   repeated CounterInstanceInfo instances = 2;
 }
 
-// Requests a snapshot of raw cumulative worker polling and traffic counters.
+// Requests a snapshot of raw worker polling and traffic counters together
+// with worker pool gauges.
 message WorkerCountersRequest {}
 
-// Returns one cumulative counter record per dataplane worker thread.
+// Returns one record per dataplane worker thread: cumulative counters and
+// point-in-time gauges, scoped to the instance this service serves.
 message WorkerCountersResponse { repeated WorkerCounter workers = 1; }
+
+// Occupancy of one worker's RX packet pool.
+//
+// Both values count mempool objects (mbufs). `available` is a gauge
+// resampled by the owning worker at most once every 10 ms — slow
+// worker rounds stretch the spacing further — so it reflects the most
+// recent dataplane sample rather than the moment of the read.
+// Objects in use by the NIC descriptors or in flight are the difference
+// `capacity - available`.
+message WorkerRxMempool {
+  // Total object capacity for the lifetime of this worker pool.
+  uint32 capacity = 1;
+  // Objects currently available in the most recent dataplane sample.
+  uint32 available = 2;
+}
 
 message WorkerCounter {
   // Stable worker index in the dataplane worker table.
@@ -78,6 +95,11 @@ message WorkerCounter {
   // drops such as an ACL deny, so nonzero alone is not a fault. Already
   // includes every local_tx_drops and remote_tx_drops packet.
   uint64 disposed = 16;
+  // Occupancy of this worker's RX packet pool. Absent only when the
+  // serving control plane predates this field; a dataplane without the
+  // pool gauges fails the whole read instead, so an empty value here is
+  // never a stand-in for a real pool.
+  WorkerRxMempool rx_mempool = 17;
 }
 
 // Requests a snapshot of raw cumulative per-port extended stats counters.

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -831,6 +831,52 @@ dataplane_init(
 
 		worker_counters_bind(dp_config, &counter_ids);
 
+		// Publish each worker pool's occupancy before the instance
+		// becomes visible: until the worker threads run their first
+		// rounds, a scrape would otherwise read the zero-filled
+		// storage, fail pool validation, and drop the whole worker
+		// family despite a healthy startup.
+		for (uint32_t device_idx = 0;
+		     device_idx < dataplane->device_count;
+		     ++device_idx) {
+			struct dataplane_device *device =
+				dataplane->devices + device_idx;
+			for (uint32_t wrk_idx = 0;
+			     wrk_idx < device->worker_count;
+			     ++wrk_idx) {
+				struct dataplane_worker *worker =
+					device->workers + wrk_idx;
+				if (worker->instance != instance) {
+					continue;
+				}
+
+				uint64_t worker_idx = worker->dp_worker->idx;
+				if (worker_rx_pool_sampler_init(
+					    &worker->rx_pool_sampler,
+					    worker->rx_mempool,
+					    worker_counter_slot(
+						    dp_config,
+						    worker_idx,
+						    counter_ids
+							    .rx_mempool_capacity
+					    ),
+					    worker_counter_slot(
+						    dp_config,
+						    worker_idx,
+						    counter_ids
+							    .rx_mempool_available
+					    )
+				    )) {
+					LOG(ERROR,
+					    "failed to bind rx pool counters "
+					    "for worker %lu of instance %u",
+					    worker_idx,
+					    instance_idx);
+					return -1;
+				}
+			}
+		}
+
 		for (uint64_t device_idx = 0;
 		     device_idx < dataplane->device_count;
 		     ++device_idx) {

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -285,10 +285,13 @@ worker_write(
 static void
 worker_loop_round(struct dataplane_worker *worker) {
 	struct cp_config *cp_config = worker->instance->cp_config;
+	uint64_t current_time_ns =
+		tsc_clock_get_time_ns(&worker->dp_worker->clock);
+	worker_rx_pool_sampler_sample(
+		&worker->rx_pool_sampler, worker->rx_mempool, current_time_ns
+	);
 	struct worker_round round = worker_round_prepare(
-		worker->dp_worker,
-		cp_config,
-		tsc_clock_get_time_ns(&worker->dp_worker->clock)
+		worker->dp_worker, cp_config, current_time_ns
 	);
 	struct cp_config_gen *cp_config_gen = round.cp_config_gen;
 	struct config_gen_ectx *config_gen_ectx = round.config_gen_ectx;

--- a/dataplane/worker.h
+++ b/dataplane/worker.h
@@ -9,6 +9,7 @@
 
 #include "common/data_pipe.h"
 #include "lib/dataplane/packet/packet.h"
+#include "lib/dataplane/worker/rx_pool_sampler.h"
 #include "lib/dataplane/worker/tx_stage.h"
 
 struct dataplane;
@@ -49,6 +50,11 @@ struct dataplane_worker {
 	uint32_t device_id;
 
 	struct rte_mempool *rx_mempool;
+
+	// Publishes the rx pool occupancy gauge into shared counter
+	// storage. Bound before the instance becomes visible; state is
+	// dataplane-local on purpose (see the sampler header).
+	struct worker_rx_pool_sampler rx_pool_sampler;
 
 	struct worker_read_ctx read_ctx;
 	struct worker_write_ctx write_ctx;

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -47,6 +47,9 @@ sequenceDiagram
     end
 ```
 
+The exported metric names, types and labels are listed in
+[metrics.md](metrics.md).
+
 ## System layer pyramid
 
 ```text

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,66 @@
+# Metrics reference
+
+Operator-facing metrics exported by the built-in counters service and
+collected through the gateway metrics endpoint. All worker and port
+families come from the dataplane shared-memory counter storage; a family
+whose collection fails is omitted from the snapshot with a logged
+warning — values are never synthesized as zeros.
+
+## Worker metrics
+
+One series per dataplane worker thread. Cumulative counters carry the
+labels `worker_idx`, `core_id`, `device_id`, `queue_id` and count
+monotonically since the counters were reset:
+
+- `worker_iterations` (counter) — worker loop polls.
+- `worker_rx_packets`, `worker_rx_bytes` — received from the NIC.
+- `worker_tx_packets`, `worker_tx_bytes` — sent to the NIC.
+- `worker_remote_rx_packets`, `worker_remote_tx_packets` — inter-worker
+  traffic.
+- `worker_local_tx_drops`, `worker_remote_tx_drops`, `worker_disposed` —
+  drops by cause; `worker_disposed` already includes both drop counters.
+- `worker_rx_bursts` (histogram) — RX poll size distribution.
+
+### RX packet pool gauges
+
+Gauges report the occupancy of each worker's RX mempool, the pool packet
+allocation fails against when exhausted:
+
+- `worker_rx_mempool_capacity` (gauge, objects) — total pool capacity,
+  constant for the lifetime of the worker.
+- `worker_rx_mempool_available` (gauge, objects) — objects free in the
+  most recent dataplane sample.
+
+Semantics:
+
+- Labels: `instance_id`, `worker_idx`, `core_id`, `device_id`,
+  `queue_id`. A pool's canonical identity is `(instance_id,
+  worker_idx)`; device and queue describe the pool's ownership, the core
+  its placement. The `instance_id` label appears only on the pool
+  gauges: the cumulative worker counters above keep their historical
+  label set so existing time series continue.
+- Objects in use are `capacity - available`. That difference includes
+  mbufs held in NIC RX/TX descriptors and packets in flight, so it is an
+  allocator occupancy, not a packet backlog.
+- `0 <= available <= capacity` always holds on a published snapshot; a
+  violation fails collection of the whole worker family (see above)
+  instead of being clamped.
+- The owning worker resamples `available` at most once every 10 ms: a
+  resample happens when a worker round finds the deadline expired, and
+  slow rounds stretch the spacing further. A scrape between resamples
+  returns the previous value, so short spikes may be missed.
+- The same values are exposed per worker through the
+  `controlplane.ynpb.v1.CountersService/Workers` RPC as the
+  presence-bearing `rx_mempool` field. Compatibility across versions:
+  a client newer than the server sees the field absent (`n/a` in the
+  `RX pool free` column of `yanet-cli-counters workers`); a control
+  plane newer than the dataplane gets a missing-counter error instead —
+  the whole `Workers` call fails and `Collect()` omits the worker
+  family — so a version skew can never masquerade as a real occupancy.
+
+## Port metrics
+
+One series per DPDK port and xstat counter, cumulative:
+
+- `port_counter_value` (counter) — labels `port_id`, `port_name`,
+  `counter`.

--- a/lib/controlplane/tests/counter_workers_test.c
+++ b/lib/controlplane/tests/counter_workers_test.c
@@ -25,6 +25,7 @@
 #include "lib/controlplane/config/zone.h"
 #include "lib/counters/counters.h"
 #include "lib/dataplane/pipeline/econtext.h"
+#include "lib/dataplane/worker/counters.h"
 #include "lib/dataplane_ut/dataplane_ut.h"
 #include "lib/errors/errors.h"
 #include "lib/logging/log.h"
@@ -530,6 +531,115 @@ test_worker_counters_per_worker(struct dp_config *dp_config) {
 	return TEST_SUCCESS;
 }
 
+// Verifies that the rx pool gauges flow through the worker-counter read
+// like any shared-registry counter — each worker reports its own pair —
+// while the metadata the same read serves stays on the pre-gauge
+// layout, still reporting the values assigned at worker creation.
+static int
+test_worker_rx_mempool_gauges(struct dp_config *dp_config) {
+	const uint64_t capacity[CW_WORKER_COUNT] = {4096, 16384};
+	const uint64_t available[CW_WORKER_COUNT] = {4000, 0};
+	for (uint64_t w_idx = 0; w_idx < CW_WORKER_COUNT; ++w_idx) {
+		TEST_ASSERT_SUCCESS(
+			write_worker_counter(
+				dp_config,
+				w_idx,
+				"rx_mempool_capacity",
+				capacity[w_idx]
+			),
+			"failed to write worker %lu pool capacity",
+			(unsigned long)w_idx
+		);
+		TEST_ASSERT_SUCCESS(
+			write_worker_counter(
+				dp_config,
+				w_idx,
+				"rx_mempool_available",
+				available[w_idx]
+			),
+			"failed to write worker %lu pool availability",
+			(unsigned long)w_idx
+		);
+	}
+
+	for (uint64_t w_idx = 0; w_idx < CW_WORKER_COUNT; ++w_idx) {
+		struct counter_handle_list *list =
+			yanet_get_worker_counters(dp_config, w_idx);
+		TEST_ASSERT_NOT_NULL(
+			list,
+			"worker %lu counter read returned NULL",
+			(unsigned long)w_idx
+		);
+
+		for (size_t idx = 0; idx < list->count; ++idx) {
+			struct counter_handle *cur =
+				yanet_get_counter(list, idx);
+			if (cur == NULL) {
+				continue;
+			}
+
+			if (strcmp(cur->name, "rx_mempool_capacity") == 0) {
+				TEST_ASSERT_EQUAL(
+					capacity[w_idx],
+					yanet_get_counter_value(cur->values, 0),
+					"worker %lu pool capacity",
+					(unsigned long)w_idx
+				);
+			}
+			if (strcmp(cur->name, "rx_mempool_available") == 0) {
+				TEST_ASSERT_EQUAL(
+					available[w_idx],
+					yanet_get_counter_value(cur->values, 0),
+					"worker %lu pool availability",
+					(unsigned long)w_idx
+				);
+			}
+		}
+
+		yanet_counter_handle_list_free(list);
+	}
+
+	// The gauges must not widen the metadata the read serves: the
+	// same fields still report the values assigned at worker creation
+	// (core and queue equal the worker index, device zero).
+	for (uint64_t w_idx = 0; w_idx < CW_WORKER_COUNT; ++w_idx) {
+		struct worker_counter_metadata metadata;
+		TEST_ASSERT_SUCCESS(
+			yanet_get_worker_counter_metadata(
+				dp_config, w_idx, &metadata
+			),
+			"failed to read worker %lu metadata",
+			(unsigned long)w_idx
+		);
+		TEST_ASSERT_EQUAL(
+			w_idx,
+			metadata.core_id,
+			"worker %lu core id",
+			(unsigned long)w_idx
+		);
+		TEST_ASSERT_EQUAL(
+			0,
+			metadata.device_id,
+			"worker %lu device id",
+			(unsigned long)w_idx
+		);
+		TEST_ASSERT_EQUAL(
+			w_idx,
+			metadata.queue_id,
+			"worker %lu queue id",
+			(unsigned long)w_idx
+		);
+		TEST_ASSERT_EQUAL(
+			WORKER_RX_BURST_SIZE,
+			metadata.rx_burst_size,
+			"worker %lu burst size",
+			(unsigned long)w_idx
+		);
+	}
+
+	return TEST_SUCCESS;
+}
+
 int
 main(void) {
 	log_enable_name("debug");
@@ -583,6 +693,9 @@ main(void) {
 	}
 	if (res == TEST_SUCCESS) {
 		res = test_worker_counters_per_worker(dp_config);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_worker_rx_mempool_gauges(dp_config);
 	}
 
 	agent_detach(agent);

--- a/lib/dataplane/worker/counters.c
+++ b/lib/dataplane/worker/counters.c
@@ -65,6 +65,22 @@ worker_counters_register(
 	if (register_one(registry, "drops", 1, &ids->drops)) {
 		return -1;
 	}
+	if (register_one(
+		    registry,
+		    "rx_mempool_capacity",
+		    1,
+		    &ids->rx_mempool_capacity
+	    )) {
+		return -1;
+	}
+	if (register_one(
+		    registry,
+		    "rx_mempool_available",
+		    1,
+		    &ids->rx_mempool_available
+	    )) {
+		return -1;
+	}
 	return 0;
 }
 
@@ -114,4 +130,20 @@ worker_counters_bind(
 	for (uint64_t idx = 0; idx < count; ++idx) {
 		bind_one(ADDR_OF(workers + idx), ids, ADDR_OF(storages + idx));
 	}
+}
+
+uint64_t *
+worker_counter_slot(
+	struct dp_config *dp_config, uint64_t worker_idx, uint64_t counter_id
+) {
+	if (worker_idx >= dp_config->worker_counter_storage_count) {
+		return NULL;
+	}
+	if (counter_id >= dp_config->worker_counters.count) {
+		return NULL;
+	}
+
+	struct counter_storage **storages =
+		ADDR_OF(&dp_config->worker_counter_storages);
+	return counter_get_address(counter_id, ADDR_OF(storages + worker_idx));
 }

--- a/lib/dataplane/worker/counters.h
+++ b/lib/dataplane/worker/counters.h
@@ -20,6 +20,8 @@ struct worker_counter_ids {
 	uint64_t local_tx_drops;
 	uint64_t remote_tx_drops;
 	uint64_t drops;
+	uint64_t rx_mempool_capacity;
+	uint64_t rx_mempool_available;
 };
 
 // Registers the standard worker counters in an already initialised registry
@@ -39,4 +41,16 @@ worker_counters_register(
 void
 worker_counters_bind(
 	struct dp_config *dp_config, const struct worker_counter_ids *ids
+);
+
+// Returns the first slot of one counter in one worker's storage, or NULL
+// when the worker index or the counter id is out of range.
+//
+// The slot itself lives in the shared counter storage like every bound
+// one; what stays dataplane-local is the pointer a caller keeps to it,
+// so a writer such as the rx pool sampler can publish gauges without
+// growing the plugin-visible worker layout.
+uint64_t *
+worker_counter_slot(
+	struct dp_config *dp_config, uint64_t worker_idx, uint64_t counter_id
 );

--- a/lib/dataplane/worker/rx_pool_sampler.h
+++ b/lib/dataplane/worker/rx_pool_sampler.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <rte_mempool.h>
+
+// Lower bound on the resample spacing of one worker pool: two
+// consecutive resamples sit at least this far apart.
+#define WORKER_RX_POOL_SAMPLE_INTERVAL_NS UINT64_C(10000000)
+
+// Gauge state for one worker RX mempool, owned by the worker itself.
+//
+// A worker round resamples the occupancy at most once per interval, on
+// finding the deadline expired; a slow round delays a resample past the
+// interval, so the interval bounds the rate rather than fixing the
+// spacing. A scrape never touches DPDK state. The state lives outside
+// the plugin-visible worker layout: only the published gauge crosses
+// into shared memory.
+struct worker_rx_pool_sampler {
+	uint64_t *available_slot;
+	uint64_t next_sample_ns;
+};
+
+// Binds the sampler to its counter slots and records the initial values.
+//
+// Returns 0, or -1 when the pool or either slot is missing, so the
+// caller can fail startup instead of publishing a zero-valued pool. The
+// capacity slot is only needed here: it is written once and never
+// resampled, so it is not kept in the sampler state.
+static inline int
+worker_rx_pool_sampler_init(
+	struct worker_rx_pool_sampler *sampler,
+	struct rte_mempool *pool,
+	uint64_t *capacity_slot,
+	uint64_t *available_slot
+) {
+	if (pool == NULL || capacity_slot == NULL || available_slot == NULL) {
+		return -1;
+	}
+
+	*sampler = (struct worker_rx_pool_sampler){
+		.available_slot = available_slot,
+		// Zero leaves the deadline already expired: the first worker
+		// round resamples right after these initial values, and the
+		// resample schedule starts from the loop clock.
+		.next_sample_ns = 0,
+	};
+
+	*capacity_slot = (uint64_t)pool->size;
+	*available_slot = (uint64_t)rte_mempool_avail_count(pool);
+
+	return 0;
+}
+
+// Resamples the available gauge when the deadline has expired and
+// schedules the next one a full interval past the current time.
+static inline void
+worker_rx_pool_sampler_sample(
+	struct worker_rx_pool_sampler *sampler,
+	struct rte_mempool *pool,
+	uint64_t now_ns
+) {
+	if (now_ns < sampler->next_sample_ns) {
+		return;
+	}
+
+	sampler->next_sample_ns = now_ns + WORKER_RX_POOL_SAMPLE_INTERVAL_NS;
+	*sampler->available_slot = (uint64_t)rte_mempool_avail_count(pool);
+}

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -274,8 +274,6 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		return NULL;
 	}
 
-	dp_config_mark_ready(ut->dp_config);
-
 	// Create the mock mempool now so step 2 can allocate mbufs.
 	ut->mempool = test_mempool_create();
 	if (ut->mempool == NULL) {
@@ -367,6 +365,30 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 
 	worker_counters_bind(ut->dp_config, &counter_ids);
 
+	// Seed the rx pool gauges from the shared mock pool before the
+	// instance becomes visible: the harness runs no worker rounds, so
+	// without seeding a scrape would read the zero-filled storage and
+	// fail the same pool validation the real control plane applies.
+	for (size_t idx = 0; idx < cfg->worker_count; ++idx) {
+		uint64_t *capacity = worker_counter_slot(
+			ut->dp_config, idx, counter_ids.rx_mempool_capacity
+		);
+		uint64_t *available = worker_counter_slot(
+			ut->dp_config, idx, counter_ids.rx_mempool_available
+		);
+		if (capacity == NULL || available == NULL) {
+			LOG(ERROR,
+			    "dataplane_ut_new: worker %zu has no rx pool "
+			    "counter slot",
+			    idx);
+			dataplane_ut_free(ut);
+			return NULL;
+		}
+
+		*capacity = ut->mempool->size;
+		*available = rte_mempool_avail_count(ut->mempool);
+	}
+
 	// Skipped when device_count == 0: the implicit device 0 (see above)
 	// has no dp_topology slot, so per-device worker counts stay
 	// unavailable in that mode -- a known, deferred gap.
@@ -404,6 +426,10 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		}
 		free(device_worker_counts);
 	}
+
+	// Last: every field a reader can walk must be live by now, so no
+	// attach can observe a half-initialised instance.
+	dp_config_mark_ready(ut->dp_config);
 
 	return ut;
 }
@@ -504,6 +530,46 @@ dataplane_ut_round_result_free(struct dataplane_ut_round_result *result) {
 size_t
 dataplane_ut_mempool_outstanding(struct dataplane_ut *ut) {
 	return test_mempool_outstanding(ut->mempool);
+}
+
+int
+dataplane_ut_set_worker_counter(
+	struct dataplane_ut *ut,
+	size_t worker_idx,
+	const char *name,
+	uint64_t value
+) {
+	if (ut == NULL || name == NULL) {
+		return -1;
+	}
+	if (worker_idx >= ut->dp_config->worker_count) {
+		return -1;
+	}
+
+	struct counter_registry *registry = &ut->dp_config->worker_counters;
+	struct counter *counters = ADDR_OF(&registry->names);
+	for (uint64_t idx = 0; idx < registry->count; ++idx) {
+		if (strncmp(counters[idx].name, name, COUNTER_NAME_LEN) != 0) {
+			continue;
+		}
+
+		// Only a single-value counter has a well-defined "the"
+		// slot; a multi-value one is not this hook's contract.
+		if (counters[idx].size != 1) {
+			return -1;
+		}
+
+		uint64_t *slot =
+			worker_counter_slot(ut->dp_config, worker_idx, idx);
+		if (slot == NULL) {
+			return -1;
+		}
+
+		*slot = value;
+		return 0;
+	}
+
+	return -1;
 }
 
 void

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -103,6 +103,23 @@ dataplane_ut_round_result_free(struct dataplane_ut_round_result *result);
 size_t
 dataplane_ut_mempool_outstanding(struct dataplane_ut *ut);
 
+// Overwrite the value of a named size-1 counter in one worker's shared
+// worker-counter storage.
+//
+// A fault-injection hook for control-plane tests: it produces snapshots
+// no healthy dataplane would publish (an available above capacity, a
+// zero capacity) without reaching into the storage layout. A
+// multi-value counter is refused, matching the doc contract. Returns 0
+// on success, -1 when the worker index or the counter name is unknown
+// or the counter carries more than one value.
+int
+dataplane_ut_set_worker_counter(
+	struct dataplane_ut *ut,
+	size_t worker_idx,
+	const char *name,
+	uint64_t value
+);
+
 // Run one pipeline round on worker_idx with the given input.
 //
 // input is drained to empty on return; result->output and result->drop

--- a/lib/dataplane_ut/mempool.h
+++ b/lib/dataplane_ut/mempool.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <errno.h>
+
 #include <rte_mbuf.h>
 #include <rte_mempool.h>
 
@@ -81,6 +83,13 @@ test_pool_enqueue(struct rte_mempool *mp, void *const *obj_table, unsigned n) {
 
 static int
 test_pool_dequeue(struct rte_mempool *mp, void **obj_table, unsigned n) {
+	// The pool is a pure bookkeeping mock with no backing store, so
+	// exhaustion is defined by the outstanding count alone: refusing
+	// here keeps the reported occupancy consistent with the capacity.
+	if (*(size_t *)mp->pool_data + n > mp->size) {
+		return -ENOENT;
+	}
+
 	const size_t poison = ((const size_t *)mp->pool_data)[1];
 	for (unsigned idx = 0; idx < n; idx++) {
 		void *ptr = aligned_alloc(64, mp->header_size + mp->elt_size);
@@ -109,8 +118,7 @@ test_pool_dequeue(struct rte_mempool *mp, void **obj_table, unsigned n) {
 
 static unsigned
 test_pool_get_count(const struct rte_mempool *mp) {
-	(void)mp;
-	return 1024;
+	return (unsigned)(mp->size - *(const size_t *)mp->pool_data);
 }
 
 static const struct rte_mempool_ops test_pool_ops = {
@@ -122,8 +130,17 @@ static const struct rte_mempool_ops test_pool_ops = {
 	.get_count = test_pool_get_count,
 };
 
+// The default mock capacity, preserving the occupancy the pool reported
+// before sizing became configurable.
+#define TEST_MEMPOOL_DEFAULT_SIZE 1024
+
+// Fixture pools backing the tx pipe and staging tests: those tests hold
+// several deferred-free ring fills at once, so the default above is far
+// too small once the pool enforces its capacity.
+#define TEST_MEMPOOL_TX_FIXTURE_SIZE (1u << 14)
+
 static inline struct rte_mempool *
-test_mempool_create(void) {
+test_mempool_create_sized(uint32_t size) {
 	rte_mempool_ops_table.num_ops = 0;
 	rte_mempool_register_ops(&test_pool_ops);
 
@@ -142,6 +159,7 @@ test_mempool_create(void) {
 	mp->flags |= RTE_MEMPOOL_F_POOL_CREATED;
 	mp->socket_id = 0;
 	mp->cache_size = 0;
+	mp->size = size;
 	mp->elt_size = sizeof(struct rte_mbuf) + MBUF_MAX_SIZE;
 	mp->header_size = sizeof(struct rte_mempool_objhdr);
 	if (mp->header_size % 64 != 0) {
@@ -152,6 +170,11 @@ test_mempool_create(void) {
 		(char *)mp + sizeof(struct rte_mempool) + private_data_size;
 	rte_pktmbuf_pool_init(mp, NULL);
 	return mp;
+}
+
+static inline struct rte_mempool *
+test_mempool_create(void) {
+	return test_mempool_create_sized(TEST_MEMPOOL_DEFAULT_SIZE);
 }
 
 // Release resources allocated by test_mempool_create().

--- a/lib/dataplane_ut/tests/worker_counters_test.c
+++ b/lib/dataplane_ut/tests/worker_counters_test.c
@@ -1,5 +1,6 @@
 // verifies that every worker of an instance is bound to the counter slots its
-// own storage holds under the matching counter names.
+// own storage holds under the matching counter names, and that the rx pool
+// gauges are seeded and resampled independently per worker pool.
 
 #include "api/agent.h"
 #include "common/memory_address.h"
@@ -7,7 +8,11 @@
 #include "lib/counters/counters.h"
 #include "lib/dataplane/config/zone.h"
 #include "lib/dataplane/worker/counters.h"
+#include "lib/dataplane/worker/rx_pool_sampler.h"
 #include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/dataplane_ut/mempool.h"
+
+#include <rte_mbuf.h>
 
 #include <string.h>
 
@@ -74,6 +79,186 @@ check_worker(struct dp_config *dp_config, uint64_t worker_idx) {
 	return TEST_SUCCESS;
 }
 
+// Gauge slot pair of one worker, resolved through the shared registry by
+// name so the check does not assume a registration order.
+struct gauge_slots {
+	uint64_t *capacity;
+	uint64_t *available;
+};
+
+static struct gauge_slots
+worker_gauge_slots(struct dp_config *dp_config, uint64_t worker_idx) {
+	struct gauge_slots slots = {
+		.capacity = worker_counter_slot(
+			dp_config,
+			worker_idx,
+			lookup_id(
+				&dp_config->worker_counters,
+				"rx_mempool_capacity"
+			)
+		),
+		.available = worker_counter_slot(
+			dp_config,
+			worker_idx,
+			lookup_id(
+				&dp_config->worker_counters,
+				"rx_mempool_available"
+			)
+		),
+	};
+	return slots;
+}
+
+// Verifies that a freshly built harness publishes a real occupancy for
+// every worker: both gauges hold the shared mock pool's values, not the
+// zero fill of a just-spawned storage.
+static int
+check_seeded_gauges(struct dp_config *dp_config) {
+	for (uint64_t idx = 0; idx < WORKER_COUNT; ++idx) {
+		struct gauge_slots slots = worker_gauge_slots(dp_config, idx);
+		TEST_ASSERT_NOT_NULL(
+			slots.capacity, "worker %lu has no capacity slot", idx
+		);
+		TEST_ASSERT_NOT_NULL(
+			slots.available, "worker %lu has no available slot", idx
+		);
+		TEST_ASSERT_EQUAL(
+			TEST_MEMPOOL_DEFAULT_SIZE,
+			*slots.capacity,
+			"worker %lu seeded capacity",
+			idx
+		);
+		TEST_ASSERT_EQUAL(
+			TEST_MEMPOOL_DEFAULT_SIZE,
+			*slots.available,
+			"worker %lu seeded available",
+			idx
+		);
+	}
+
+	return TEST_SUCCESS;
+}
+
+// Verifies that the slot accessor refuses an out-of-range worker index
+// and counter id instead of handing back a stray pointer.
+static int
+check_slot_bounds(struct dp_config *dp_config) {
+	uint64_t capacity_id =
+		lookup_id(&dp_config->worker_counters, "rx_mempool_capacity");
+	TEST_ASSERT(
+		capacity_id != COUNTER_INVALID,
+		"rx_mempool_capacity is not registered"
+	);
+
+	TEST_ASSERT_NULL(
+		worker_counter_slot(dp_config, WORKER_COUNT, capacity_id),
+		"out-of-range worker index must yield no slot"
+	);
+	TEST_ASSERT_NULL(
+		worker_counter_slot(
+			dp_config, 0, dp_config->worker_counters.count
+		),
+		"out-of-range counter id must yield no slot"
+	);
+
+	return TEST_SUCCESS;
+}
+
+// Verifies the sampler timing contract on two pools of different
+// capacity: init publishes capacity and current occupancy at once, the
+// deadline starts expired so a first call resamples both pools, an
+// earlier call is a no-op, a call at the deadline resamples and
+// reschedules, and a pool whose sampler then stays idle keeps its
+// gauge.
+static int
+check_sampler_interval(struct dp_config *dp_config) {
+	struct rte_mempool *pool_a = test_mempool_create_sized(8);
+	struct rte_mempool *pool_b = test_mempool_create_sized(16);
+	TEST_ASSERT_NOT_NULL(pool_a, "failed to create the 8-object pool");
+	TEST_ASSERT_NOT_NULL(pool_b, "failed to create the 16-object pool");
+
+	struct gauge_slots slots_a = worker_gauge_slots(dp_config, 0);
+	struct gauge_slots slots_b = worker_gauge_slots(dp_config, 1);
+	TEST_ASSERT_NOT_NULL(slots_a.capacity, "worker 0 has no capacity slot");
+	TEST_ASSERT_NOT_NULL(
+		slots_a.available, "worker 0 has no available slot"
+	);
+	TEST_ASSERT_NOT_NULL(slots_b.capacity, "worker 1 has no capacity slot");
+	TEST_ASSERT_NOT_NULL(
+		slots_b.available, "worker 1 has no available slot"
+	);
+
+	struct worker_rx_pool_sampler sampler_a;
+	struct worker_rx_pool_sampler sampler_b;
+	TEST_ASSERT_SUCCESS(
+		worker_rx_pool_sampler_init(
+			&sampler_a, pool_a, slots_a.capacity, slots_a.available
+		),
+		"failed to init the sampler for the 8-object pool"
+	);
+	TEST_ASSERT_SUCCESS(
+		worker_rx_pool_sampler_init(
+			&sampler_b, pool_b, slots_b.capacity, slots_b.available
+		),
+		"failed to init the sampler for the 16-object pool"
+	);
+	TEST_ASSERT_EQUAL(8, *slots_a.capacity, "pool A capacity slot");
+	TEST_ASSERT_EQUAL(8, *slots_a.available, "pool A initial available");
+	TEST_ASSERT_EQUAL(16, *slots_b.capacity, "pool B capacity slot");
+	TEST_ASSERT_EQUAL(16, *slots_b.available, "pool B initial available");
+
+	struct rte_mbuf *held[5] = {0};
+	for (size_t idx = 0; idx < 2; ++idx) {
+		held[idx] = rte_pktmbuf_alloc(pool_a);
+		TEST_ASSERT_NOT_NULL(
+			held[idx], "pool A allocation %zu failed", idx
+		);
+	}
+
+	// Both deadlines start expired, so this call resamples both pools;
+	// only pool A lost objects, so only its gauge moves.
+	worker_rx_pool_sampler_sample(&sampler_a, pool_a, 0);
+	worker_rx_pool_sampler_sample(&sampler_b, pool_b, 0);
+	TEST_ASSERT_EQUAL(6, *slots_a.available, "pool A first resample");
+	TEST_ASSERT_EQUAL(16, *slots_b.available, "pool B first resample");
+
+	for (size_t idx = 2; idx < 5; ++idx) {
+		held[idx] = rte_pktmbuf_alloc(pool_a);
+		TEST_ASSERT_NOT_NULL(
+			held[idx], "pool A allocation %zu failed", idx
+		);
+	}
+
+	worker_rx_pool_sampler_sample(
+		&sampler_a, pool_a, WORKER_RX_POOL_SAMPLE_INTERVAL_NS - 1
+	);
+	TEST_ASSERT_EQUAL(
+		6,
+		*slots_a.available,
+		"a sample before the deadline must not republish"
+	);
+
+	worker_rx_pool_sampler_sample(
+		&sampler_a, pool_a, WORKER_RX_POOL_SAMPLE_INTERVAL_NS
+	);
+	TEST_ASSERT_EQUAL(
+		3, *slots_a.available, "an elapsed deadline must republish"
+	);
+	TEST_ASSERT_EQUAL(
+		16,
+		*slots_b.available,
+		"a pool not resampled again must keep its gauge"
+	);
+
+	for (size_t idx = 0; idx < 5; ++idx) {
+		rte_pktmbuf_free(held[idx]);
+	}
+	test_mempool_free(pool_a);
+	test_mempool_free(pool_b);
+
+	return TEST_SUCCESS;
+}
+
 int
 main(void) {
 	log_enable_name("debug");
@@ -95,6 +280,15 @@ main(void) {
 	for (uint64_t idx = 0; idx < WORKER_COUNT && result == TEST_SUCCESS;
 	     ++idx) {
 		result = check_worker(dp_config, idx);
+	}
+	if (result == TEST_SUCCESS) {
+		result = check_seeded_gauges(dp_config);
+	}
+	if (result == TEST_SUCCESS) {
+		result = check_slot_bounds(dp_config);
+	}
+	if (result == TEST_SUCCESS) {
+		result = check_sampler_interval(dp_config);
 	}
 
 	dataplane_ut_free(ut);

--- a/lib/dataplane_ut/tx_pipe.c
+++ b/lib/dataplane_ut/tx_pipe.c
@@ -20,7 +20,8 @@ dataplane_ut_tx_pipe_new(void) {
 		return NULL;
 	}
 
-	fixture->mempool = test_mempool_create();
+	fixture->mempool =
+		test_mempool_create_sized(TEST_MEMPOOL_TX_FIXTURE_SIZE);
 	if (fixture->mempool == NULL) {
 		free(fixture);
 		return NULL;

--- a/lib/dataplane_ut/tx_stage.c
+++ b/lib/dataplane_ut/tx_stage.c
@@ -34,7 +34,8 @@ dataplane_ut_tx_stage_new(uint32_t device_count, uint32_t pipes_per_device) {
 		return NULL;
 	}
 
-	fixture->mempool = test_mempool_create();
+	fixture->mempool =
+		test_mempool_create_sized(TEST_MEMPOOL_TX_FIXTURE_SIZE);
 	if (fixture->mempool == NULL) {
 		free(fixture);
 		return NULL;


### PR DESCRIPTION
- Publish per-worker RX mempool occupancy as gauges in the shared worker counter storage, resampled by the owning worker at most once every 10 ms and seeded before the instance becomes ready.
- Export `worker_rx_mempool_capacity` and `worker_rx_mempool_available` metric series labeled by instance and worker identity, documented alongside the existing worker and port families in `docs/metrics.md`.
- Serve the gauges through the Workers RPC as a presence-bearing `rx_mempool` field and render them in the worker counters CLI table, with `n/a` when the server predates the field.
- Reject snapshots no healthy dataplane would publish (zero capacity, availability above capacity) with worker-indexed errors instead of plausible values, and omit the whole worker family from the metrics snapshot with a logged warning.

Closes #1905.