### PR TITLE
feat(cli): configuration file and certificate tag selection

### DIFF
--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -41,6 +41,11 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   `Connection::connect_for(&cmd.connection, action).await?` once, then
   `Service::new(&connection, NAME, build)` per client. The action is the same
   user-facing verb passed to the command's RPC error mapping.
+- Connection settings resolve inside `ync`, from flags, environment and the
+  configuration file (`ync::config`). A CLI never reads
+  `cmd.connection.endpoint` itself. A pre-connect error label comes from
+  `client::resolve_label`, a post-connect one from `Service::endpoint()` /
+  `Connection::endpoint()`.
 - Every RPC: `self.service.client().<rpc>(request).await
   .map_err(self.service.status("<verb>"))?.into_inner()`.
 - Generated code: `#[allow(clippy::all, clippy::std_instead_of_core,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3298,6 +3298,7 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
+ "serde_yaml",
  "simple_logger",
  "socket2 0.5.10",
  "ssh-key",

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -31,6 +31,7 @@ base64 = "0.22"
 erased-serde = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9.34"
 uuid = { version = "1", features = ["v4"] }
 thiserror = "1"
 humantime = "2"

--- a/cli/core/src/auth/mod.rs
+++ b/cli/core/src/auth/mod.rs
@@ -14,16 +14,13 @@ pub mod interceptor;
 pub mod token;
 
 use clap::ValueEnum;
+use serde::Deserialize;
 
 pub use self::interceptor::AuthLayer;
 
-/// Default certificate tag to match in the SSH agent.
-///
-/// TODO: from config.
-const DEFAULT_CERT_TAG: &str = ":insecure:";
-
 /// Supported authentication methods.
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum AuthMethod {
     None,
     /// SSH certificate authentication via ssh-agent.
@@ -36,8 +33,17 @@ pub enum AuthMethod {
 #[derive(Debug, Clone, clap::Args)]
 pub struct AuthArgs {
     /// Authentication method.
-    #[arg(long, default_value = "none", global = true)]
-    pub auth: AuthMethod,
+    ///
+    /// Falls back to the `auth` key of the configuration file, then to
+    /// `none`.
+    #[arg(long, global = true, env = "YANET_AUTH")]
+    pub auth: Option<AuthMethod>,
+    /// Substring matched against a certificate's key id to select it from
+    /// the SSH agent, required when `--auth sshcert` is in effect.
+    ///
+    /// Falls back to the `cert_tag` key of the configuration file.
+    #[arg(long, global = true, env = "YANET_CERT_TAG")]
+    pub cert_tag: Option<String>,
 }
 
 /// Error type for layer creation.
@@ -47,13 +53,21 @@ pub enum AuthError {
     Agent(#[from] agent::AgentError),
 }
 
-/// Create a tower layer based on the CLI auth arguments.
-pub async fn create_layer(args: &AuthArgs) -> Result<AuthLayer, AuthError> {
-    match args.auth {
-        AuthMethod::None => Ok(AuthLayer::nop()),
-        AuthMethod::Sshcert => {
-            let layer = AuthLayer::from_agent(DEFAULT_CERT_TAG).await?;
-            Ok(layer)
-        }
+/// A method together with the identity it authenticates as.
+///
+/// Unlike [`AuthMethod`] alone, an `Sshcert` value here always carries its
+/// tag. [`crate::config::Settings::resolved_auth`] checks for a missing one
+/// at connect time, so [`create_layer`] never sees an `Sshcert` without one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedAuth {
+    None,
+    Sshcert { tag: String },
+}
+
+/// Create a tower layer for a resolved authentication method.
+pub async fn create_layer(auth: ResolvedAuth) -> Result<AuthLayer, AuthError> {
+    match auth {
+        ResolvedAuth::None => Ok(AuthLayer::nop()),
+        ResolvedAuth::Sshcert { tag } => Ok(AuthLayer::from_agent(&tag).await?),
     }
 }

--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -39,6 +39,7 @@ use tower::Layer;
 
 use crate::{
     auth::{self, interceptor::AuthService, AuthArgs},
+    config::{self, Settings},
     errors::{root_cause, Error},
     timeout::{TimeoutLayer, TimeoutService},
 };
@@ -58,28 +59,18 @@ pub struct TlsArgs {
     #[arg(long, global = true, env = "YANET_CA", value_name = "PATH")]
     pub ca: Option<PathBuf>,
     /// PEM client certificate chain for mutual TLS.
-    #[arg(
-        long,
-        global = true,
-        env = "YANET_CLIENT_CERT",
-        value_name = "PATH",
-        requires = "client_key"
-    )]
+    ///
+    /// The configuration file may supply the matching key.
+    #[arg(long, global = true, env = "YANET_CLIENT_CERT", value_name = "PATH")]
     pub client_cert: Option<PathBuf>,
     /// PEM client private key for mutual TLS.
-    #[arg(
-        long,
-        global = true,
-        env = "YANET_CLIENT_KEY",
-        value_name = "PATH",
-        requires = "client_cert"
-    )]
+    #[arg(long, global = true, env = "YANET_CLIENT_KEY", value_name = "PATH")]
     pub client_key: Option<PathBuf>,
 }
 
-impl TlsArgs {
-    fn is_configured(&self) -> bool {
-        self.ca.is_some() || self.client_cert.is_some() || self.client_key.is_some()
+impl Settings {
+    fn tls_configured(&self) -> bool {
+        self.ca.value.is_some() || self.client_cert.value.is_some() || self.client_key.value.is_some()
     }
 }
 
@@ -88,9 +79,16 @@ impl TlsArgs {
 /// Embed this in your module's `Cmd` struct with `#[command(flatten)]`.
 #[derive(Debug, Clone, clap::Args)]
 pub struct ConnectionArgs {
-    /// Gateway endpoint using grpc://, grpcs://, or unix://.
-    #[arg(long, default_value = "grpc://[::1]:8080", global = true, env = "YANET_ENDPOINT")]
-    pub endpoint: String,
+    /// Gateway endpoint (grpc://, grpcs://, or unix://) or an alias from the
+    /// configuration file.
+    ///
+    /// Falls back to the `endpoint` key of the configuration file,
+    /// /etc/yanet2/cli.yaml merged with $XDG_CONFIG_HOME/yanet2/cli.yaml
+    /// (~/.config by default) or the single file named by YANET_CONFIG,
+    /// then to grpc://[::1]:8080. A value without :// is an alias from
+    /// the file's `endpoints:` map.
+    #[arg(long, global = true, env = "YANET_ENDPOINT")]
+    pub endpoint: Option<String>,
     /// Authentication options.
     #[command(flatten)]
     pub auth: AuthArgs,
@@ -98,7 +96,8 @@ pub struct ConnectionArgs {
     pub tls: TlsArgs,
     /// Time budget in seconds for connecting and for each request.
     ///
-    /// Long-lived streams are bounded only while being established.
+    /// Long-lived streams are bounded only while being established. Falls
+    /// back to the `timeout` key of the configuration file.
     #[arg(long, global = true, env = "YANET_TIMEOUT", value_name = "SECONDS", value_parser = parse_timeout)]
     pub timeout: Option<Duration>,
 }
@@ -109,6 +108,13 @@ fn parse_timeout(value: &str) -> Result<Duration, String> {
         .parse()
         .map_err(|_| "expected a positive number of seconds".to_owned())?;
 
+    timeout_from_seconds(seconds)
+}
+
+/// Converts a positive, possibly fractional, number of seconds into a
+/// [`Duration`], the shared rule behind [`parse_timeout`] and the file's
+/// `timeout` key.
+pub(crate) fn timeout_from_seconds(seconds: f64) -> Result<Duration, String> {
     if !seconds.is_finite() || seconds <= 0.0 {
         return Err("expected a positive number of seconds".to_owned());
     }
@@ -142,28 +148,32 @@ pub enum ConnectionError {
     Auth(#[from] auth::AuthError),
     #[error("connect timed out after {}s", .0.as_secs_f64())]
     Timeout(Duration),
+    #[error("{0}")]
+    Config(#[from] config::Error),
 }
 
 /// Rejects TLS material before any plaintext transport can use it.
-fn build_endpoint(args: &ConnectionArgs) -> Result<Endpoint, ConnectionError> {
-    match args.endpoint.split_once("://") {
-        Some(("grpcs", address)) => {
-            let endpoint = Channel::from_shared(format!("https://{address}"))?;
-            let tls = build_tls_config(&args.tls)?;
+fn build_endpoint(settings: &Settings) -> Result<Endpoint, ConnectionError> {
+    let endpoint = &settings.endpoint.value;
 
-            endpoint.tls_config(tls).map_err(ConnectionError::TlsConfig)
+    match endpoint.split_once("://") {
+        Some(("grpcs", address)) => {
+            let channel = Channel::from_shared(format!("https://{address}"))?;
+            let tls = build_tls_config(settings)?;
+
+            channel.tls_config(tls).map_err(ConnectionError::TlsConfig)
         }
-        Some(("grpc" | "unix", ..)) if args.tls.is_configured() => Err(ConnectionError::TlsOptionsWithoutTls),
-        Some(("grpc", ..)) => Channel::from_shared(args.endpoint.clone()).map_err(ConnectionError::InvalidUri),
-        Some(("unix", ..)) => Endpoint::from_shared(args.endpoint.clone()).map_err(ConnectionError::Transport),
+        Some(("grpc" | "unix", ..)) if settings.tls_configured() => Err(ConnectionError::TlsOptionsWithoutTls),
+        Some(("grpc", ..)) => Channel::from_shared(endpoint.clone()).map_err(ConnectionError::InvalidUri),
+        Some(("unix", ..)) => Endpoint::from_shared(endpoint.clone()).map_err(ConnectionError::Transport),
         Some((scheme, ..)) => Err(ConnectionError::InvalidEndpointScheme(scheme.to_owned())),
         None => Err(ConnectionError::InvalidEndpointScheme("<missing>".to_owned())),
     }
 }
 
 /// Uses native roots unless an explicit CA bundle replaces them.
-fn build_tls_config(args: &TlsArgs) -> Result<ClientTlsConfig, ConnectionError> {
-    let identity = match (&args.client_cert, &args.client_key) {
+fn build_tls_config(settings: &Settings) -> Result<ClientTlsConfig, ConnectionError> {
+    let identity = match (&settings.client_cert.value, &settings.client_key.value) {
         (Some(cert), Some(key)) => Some(Identity::from_pem(
             read_tls_file(cert, "client certificate")?,
             read_tls_file(key, "client key")?,
@@ -172,7 +182,7 @@ fn build_tls_config(args: &TlsArgs) -> Result<ClientTlsConfig, ConnectionError> 
         (..) => return Err(ConnectionError::IncompleteClientIdentity),
     };
 
-    let mut tls = match &args.ca {
+    let mut tls = match &settings.ca.value {
         Some(path) => {
             ClientTlsConfig::new().ca_certificate(Certificate::from_pem(read_tls_file(path, "CA certificate bundle")?))
         }
@@ -191,27 +201,60 @@ fn read_tls_file(path: &Path, kind: &'static str) -> Result<Vec<u8>, ConnectionE
     fs::read(path).map_err(|source| ConnectionError::TlsFile { kind, path: path.to_owned(), source })
 }
 
-/// Connect to the endpoint with all interceptors pre-applied.
+/// Connects with all interceptors pre-applied, given an already-resolved
+/// [`Settings`].
 ///
-/// When `args.timeout` is set, it bounds channel establishment and auth
-/// setup together, then rides along as the per-request budget of the
-/// returned channel.
-pub async fn connect(args: &ConnectionArgs) -> Result<LayeredChannel, ConnectionError> {
-    let establish = async {
-        let channel = build_endpoint(args)?.connect().await?;
-        let auth = auth::create_layer(&args.auth).await?;
+/// When the resolved timeout is set, it bounds channel establishment and
+/// auth setup together, then rides along as the per-request budget of the
+/// returned channel. Resolution stays the caller's job so that a transport
+/// failure can still be blamed on the alias and URI that were actually
+/// resolved, rather than losing that context to a fresh, potentially
+/// different resolution.
+async fn establish(settings: &Settings) -> Result<LayeredChannel, ConnectionError> {
+    // Checked before any I/O, like the TLS/identity checks in
+    // `build_endpoint`: a missing cert tag must not cost a round trip or
+    // get masked by an unrelated transport failure.
+    let resolved_auth = settings.resolved_auth()?;
+
+    let attempt = async {
+        let channel = build_endpoint(settings)?.connect().await?;
+        let auth = auth::create_layer(resolved_auth).await?;
 
         Ok::<_, ConnectionError>(auth.layer(channel))
     };
 
-    let auth_service = match args.timeout {
-        Some(budget) => tokio::time::timeout(budget, establish)
+    let auth_service = match settings.timeout.value {
+        Some(budget) => tokio::time::timeout(budget, attempt)
             .await
             .map_err(|_| ConnectionError::Timeout(budget))??,
-        None => establish.await?,
+        None => attempt.await?,
     };
 
-    Ok(TimeoutLayer::new(args.timeout).layer(auth_service))
+    Ok(TimeoutLayer::new(settings.timeout.value).layer(auth_service))
+}
+
+/// Resolves the label for an error raised before any RPC is attempted.
+///
+/// Runs the same resolution [`connect`] runs, without opening a connection:
+/// a bad file or an unknown alias becomes the same [`Error`] here as it
+/// would from [`Connection::connect_for`], so a configuration mistake exits
+/// the same way regardless of where the command first needs an endpoint to
+/// reject something.
+// The siblings returning the same `Error` are all `async fn`, whose
+// desugared `Future` output hides the `Result` from this lint.
+#[allow(clippy::result_large_err)]
+pub fn resolve_label(args: &ConnectionArgs, action: &str) -> Result<String, Error> {
+    config::resolve(args, &config::Sources::from_process_env())
+        .map(|settings| settings.label())
+        .map_err(|err| Error::from_config(err, action, args.endpoint.clone()))
+}
+
+/// Resolves the configuration, then connects with all interceptors
+/// pre-applied.
+pub async fn connect(args: &ConnectionArgs) -> Result<LayeredChannel, ConnectionError> {
+    let settings = config::resolve(args, &config::Sources::from_process_env())?;
+
+    establish(&settings).await
 }
 
 /// An established, authenticated channel to one endpoint.
@@ -225,7 +268,7 @@ pub struct Connection {
 }
 
 impl Connection {
-    /// Establish the authenticated channel to `args.endpoint`.
+    /// Resolve the target and establish an authenticated channel to it.
     pub async fn connect(args: &ConnectionArgs) -> Result<Self, Error> {
         Self::connect_for(args, "connect").await
     }
@@ -239,14 +282,31 @@ impl Connection {
     /// that one connection: a connect failure must read the same as an RPC
     /// failure of the same command.
     pub async fn connect_for(args: &ConnectionArgs, action: &str) -> Result<Self, Error> {
-        let channel = connect(args)
-            .await
-            .map_err(|err| Error::from_connection(err, action, &args.endpoint))?;
+        let settings = config::resolve(args, &config::Sources::from_process_env())
+            .map_err(|err| Error::from_config(err, action, args.endpoint.clone()))?;
 
-        Ok(Self {
-            channel,
-            endpoint: args.endpoint.clone(),
-        })
+        Self::connect_settings(&settings, action).await
+    }
+
+    /// Establish the channel from an already-resolved [`Settings`], blaming
+    /// a failure on `action`.
+    ///
+    /// For a caller that has its own reason to resolve first (to reuse the
+    /// resolved label, say) rather than resolving twice via
+    /// [`Connection::connect_for`].
+    pub async fn connect_settings(settings: &Settings, action: &str) -> Result<Self, Error> {
+        let endpoint = settings.label();
+
+        establish(settings)
+            .await
+            .map(|channel| Self { channel, endpoint: endpoint.clone() })
+            .map_err(|err| Error::from_connection(err, action, endpoint))
+    }
+
+    /// The resolved endpoint this connection reached: `<alias> (<uri>)`
+    /// when an alias was used, the bare URI otherwise.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
     }
 
     /// Invoke a unary RPC on an arbitrary gRPC service over this connection.
@@ -531,9 +591,10 @@ mod test {
     };
     use tonic_health::pb::{health_client::HealthClient, HealthCheckRequest};
 
-    use super::{connect, parse_timeout, ConnectionArgs, ConnectionError, Service, TlsArgs};
+    use super::{connect, establish, parse_timeout, ConnectionArgs, ConnectionError, Service, TlsArgs};
     use crate::{
         auth::{AuthArgs, AuthMethod},
+        config,
         errors::{Error, ErrorKind},
     };
 
@@ -592,8 +653,11 @@ mod test {
     /// Test connections omit application auth and share a two-second deadline.
     fn tls_connection_args(endpoint: String, tls: TlsArgs) -> ConnectionArgs {
         ConnectionArgs {
-            endpoint,
-            auth: AuthArgs { auth: AuthMethod::None },
+            endpoint: Some(endpoint),
+            auth: AuthArgs {
+                auth: Some(AuthMethod::None),
+                cert_tag: None,
+            },
             tls,
             timeout: Some(Duration::from_secs(2)),
         }
@@ -601,15 +665,16 @@ mod test {
 
     /// A successful probe proves the transport reached an authenticated RPC.
     async fn check_tls_health(args: &ConnectionArgs) -> Result<(), Error> {
+        let endpoint = args.endpoint.clone().unwrap_or_default();
         let channel = connect(args)
             .await
-            .map_err(|err| Error::from_connection(err, "check", &args.endpoint))?;
+            .map_err(|err| Error::from_connection(err, "check", &endpoint))?;
         let mut client = HealthClient::new(channel);
 
         client
             .check(HealthCheckRequest::default())
             .await
-            .map_err(|status| Error::from_status(status, "check", &args.endpoint, "grpc.health.v1.Health"))?;
+            .map_err(|status| Error::from_status(status, "check", &endpoint, "grpc.health.v1.Health"))?;
 
         Ok(())
     }
@@ -643,8 +708,11 @@ mod test {
         let _plugged = TcpStream::connect(("127.0.0.1", port)).unwrap();
 
         let args = ConnectionArgs {
-            endpoint: format!("grpc://127.0.0.1:{port}"),
-            auth: AuthArgs { auth: AuthMethod::None },
+            endpoint: Some(format!("grpc://127.0.0.1:{port}")),
+            auth: AuthArgs {
+                auth: Some(AuthMethod::None),
+                cert_tag: None,
+            },
             tls: TlsArgs::default(),
             timeout: Some(Duration::from_millis(200)),
         };
@@ -663,8 +731,11 @@ mod test {
     #[tokio::test]
     async fn test_connect_rejects_unknown_endpoint_scheme_before_io() {
         let args = ConnectionArgs {
-            endpoint: "https://127.0.0.1:9".to_owned(),
-            auth: AuthArgs { auth: AuthMethod::None },
+            endpoint: Some("https://127.0.0.1:9".to_owned()),
+            auth: AuthArgs {
+                auth: Some(AuthMethod::None),
+                cert_tag: None,
+            },
             tls: TlsArgs {
                 ca: Some("missing.pem".into()),
                 ..TlsArgs::default()
@@ -680,8 +751,11 @@ mod test {
     #[tokio::test]
     async fn test_connect_rejects_tls_options_for_plaintext_endpoint_before_io() {
         let args = ConnectionArgs {
-            endpoint: "grpc://127.0.0.1:9".to_owned(),
-            auth: AuthArgs { auth: AuthMethod::None },
+            endpoint: Some("grpc://127.0.0.1:9".to_owned()),
+            auth: AuthArgs {
+                auth: Some(AuthMethod::None),
+                cert_tag: None,
+            },
             tls: TlsArgs {
                 ca: Some("missing.pem".into()),
                 ..TlsArgs::default()
@@ -697,8 +771,11 @@ mod test {
     #[tokio::test]
     async fn test_connect_rejects_incomplete_client_identity_before_io() {
         let args = ConnectionArgs {
-            endpoint: "grpcs://127.0.0.1:9".to_owned(),
-            auth: AuthArgs { auth: AuthMethod::None },
+            endpoint: Some("grpcs://127.0.0.1:9".to_owned()),
+            auth: AuthArgs {
+                auth: Some(AuthMethod::None),
+                cert_tag: None,
+            },
             tls: TlsArgs {
                 client_cert: Some("missing.pem".into()),
                 ..TlsArgs::default()
@@ -709,6 +786,33 @@ mod test {
         let err = connect(&args).await.err().unwrap();
 
         assert!(matches!(err, ConnectionError::IncompleteClientIdentity));
+    }
+
+    #[tokio::test]
+    async fn test_connect_rejects_sshcert_without_tag_before_io() {
+        let args = ConnectionArgs {
+            endpoint: Some("grpc://127.0.0.1:9".to_owned()),
+            auth: AuthArgs {
+                auth: Some(AuthMethod::Sshcert),
+                cert_tag: None,
+            },
+            tls: TlsArgs::default(),
+            timeout: None,
+        };
+        // A real `~/.config/yanet2/cli.yaml` or `/etc/yanet2/cli.yaml`
+        // could supply `cert_tag` and mask this on a developer machine, so
+        // resolve against locations guaranteed not to exist instead of the
+        // real ones `connect` would consult.
+        let sources = config::Sources {
+            system_path: PathBuf::from("/nonexistent/yanet-cli-test/system.yaml"),
+            user_path: None,
+            config_override: None,
+        };
+        let settings = config::resolve(&args, &sources).unwrap();
+
+        let err = establish(&settings).await.err().unwrap();
+
+        assert!(matches!(err, ConnectionError::Config(config::Error::MissingCertTag)));
     }
 
     #[tokio::test]

--- a/cli/core/src/completion.rs
+++ b/cli/core/src/completion.rs
@@ -187,7 +187,7 @@ mod test {
         name: String,
     }
 
-    fn recovered_endpoint(argv: &[&str]) -> String {
+    fn recovered_endpoint(argv: &[&str]) -> Option<String> {
         recover_connection_args(TestCmd::command, words(argv)).endpoint
     }
 
@@ -204,7 +204,7 @@ mod test {
             "",
         ]);
 
-        assert_eq!("grpc://example:1", endpoint);
+        assert_eq!(Some("grpc://example:1".to_owned()), endpoint);
     }
 
     #[test]
@@ -220,13 +220,19 @@ mod test {
             "",
         ]);
 
-        assert_eq!("grpc://example:1", endpoint);
+        assert_eq!(Some("grpc://example:1".to_owned()), endpoint);
     }
 
     #[test]
     fn falls_back_to_defaults_without_a_separator() {
-        let fallback = default_connection_args().endpoint;
+        // No `--` escape means there is no real argv to recover flags
+        // from, so a typed `--endpoint` here is simply never seen — unlike
+        // the same words placed after a separator, covered above. The
+        // fallback is `default_connection_args()`, not `None`, since it
+        // honours `YANET_ENDPOINT` when the process happens to export one.
+        let recovered = recovered_endpoint(&["completer", "--endpoint", "grpc://typed:1", "show", "--name", ""]);
 
-        assert_eq!(fallback, recovered_endpoint(&["completer", "show", "--name", ""]));
+        assert_eq!(default_connection_args().endpoint, recovered);
+        assert_ne!(Some("grpc://typed:1".to_owned()), recovered);
     }
 }

--- a/cli/core/src/config.rs
+++ b/cli/core/src/config.rs
@@ -1,0 +1,1104 @@
+//! CLI configuration file: fleet defaults, personal aliases and per-key
+//! precedence.
+//!
+//! The model is `ssh_config`, not kubeconfig: a flat set of top-level
+//! defaults plus an optional `endpoints:` map of named sections that
+//! override any of those keys. [`resolve`] applies the fixed precedence
+//! (flag, environment variable, alias section, top-level key, built-in
+//! default) and returns a [`Settings`] that also carries where each value
+//! came from.
+
+use core::time::Duration;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env,
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::Deserialize;
+
+use crate::{
+    auth::{self, AuthMethod},
+    client::{timeout_from_seconds, ConnectionArgs},
+};
+
+/// Built-in target used when no flag, environment variable or file supplies
+/// one.
+const DEFAULT_ENDPOINT: &str = "grpc://[::1]:8080";
+
+/// System-wide configuration file, deployed alongside `controlplane.d/*`.
+const SYSTEM_PATH: &str = "/etc/yanet2/cli.yaml";
+
+/// Environment variable that replaces both default file locations with one
+/// path. A missing file at that path is an error rather than falling back.
+const CONFIG_ENV: &str = "YANET_CONFIG";
+
+/// Where the configuration file lives, injectable so tests never touch the
+/// real filesystem locations or `$HOME`.
+#[derive(Debug, Clone)]
+pub struct Sources {
+    /// Fleet-wide file, merged under the user file.
+    pub system_path: PathBuf,
+    /// Personal file, merged over the system file. `None` when neither
+    /// `XDG_CONFIG_HOME` nor `HOME` is set: there is then no location to
+    /// derive a personal file from, so none is consulted, rather than
+    /// guessing one relative to the current directory.
+    pub user_path: Option<PathBuf>,
+    /// `YANET_CONFIG` value, if set: the only file consulted when present,
+    /// and a missing file at this path is an error.
+    pub config_override: Option<PathBuf>,
+}
+
+impl Sources {
+    /// The real locations: `/etc/yanet2/cli.yaml`, and the personal file
+    /// under an absolute `XDG_CONFIG_HOME`, otherwise `$HOME/.config`,
+    /// otherwise no personal file at all. `$YANET_CONFIG` replaces both.
+    pub fn from_process_env() -> Self {
+        let config_dir = user_config_dir(env::var_os("XDG_CONFIG_HOME"), env::var_os("HOME"));
+
+        Self {
+            system_path: PathBuf::from(SYSTEM_PATH),
+            user_path: config_dir.map(|dir| dir.join("yanet2/cli.yaml")),
+            config_override: env::var_os(CONFIG_ENV).map(PathBuf::from),
+        }
+    }
+}
+
+/// Chooses the base directory for the personal file from `XDG_CONFIG_HOME`
+/// and `HOME`, treating an empty value as unset for either one, per the
+/// XDG base directory spec. A relative `XDG_CONFIG_HOME` is ignored the
+/// same way, since the spec requires an absolute path.
+///
+/// Pure so it is testable without mutating the process environment.
+fn user_config_dir(xdg_config_home: Option<OsString>, home: Option<OsString>) -> Option<PathBuf> {
+    non_empty(xdg_config_home)
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .or_else(|| non_empty(home).map(|home| PathBuf::from(home).join(".config")))
+}
+
+fn non_empty(value: Option<OsString>) -> Option<OsString> {
+    value.filter(|value| !value.is_empty())
+}
+
+/// One file consulted while resolving the configuration, and whether it was
+/// actually read.
+///
+/// Data only — kept for the `config show` seam that reports the files a
+/// command consulted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsultedFile {
+    pub path: PathBuf,
+    pub read: bool,
+}
+
+/// Where a resolved value came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Origin {
+    /// A `clap` flag or its environment variable.
+    Argument,
+    /// The named alias's own section of the given file.
+    Section { path: PathBuf, alias: String },
+    /// The top-level key of the given file.
+    File(PathBuf),
+    /// A file value existed but was dropped because the resolved endpoint
+    /// is plaintext, e.g. a fleet-wide TLS key that a lab alias never uses.
+    Ignored { path: PathBuf, alias: Option<String> },
+    /// No flag, environment variable or file supplied a value.
+    BuiltIn,
+}
+
+/// One resolved value paired with where it came from.
+#[derive(Debug, Clone)]
+pub struct Resolved<T> {
+    pub value: T,
+    pub origin: Origin,
+}
+
+/// The fully resolved connection configuration for one invocation.
+#[derive(Debug, Clone)]
+pub struct Settings {
+    pub endpoint: Resolved<String>,
+    /// The alias name the endpoint was selected through, if any, paired
+    /// with where that *name* came from (a flag/environment value or the
+    /// file's top-level `endpoint` key) — distinct from `endpoint.origin`,
+    /// which names where the alias's URI itself came from.
+    pub alias: Option<Resolved<String>>,
+    pub auth: Resolved<AuthMethod>,
+    pub cert_tag: Resolved<Option<String>>,
+    pub ca: Resolved<Option<PathBuf>>,
+    pub client_cert: Resolved<Option<PathBuf>>,
+    pub client_key: Resolved<Option<PathBuf>>,
+    pub timeout: Resolved<Option<Duration>>,
+    /// Every file consulted while resolving, in system-then-user order.
+    pub files: Vec<ConsultedFile>,
+}
+
+impl Settings {
+    /// The endpoint label used in error and status messages: `<alias>
+    /// (<uri>)` when an alias was used, the bare URI otherwise.
+    pub fn label(&self) -> String {
+        match &self.alias {
+            Some(alias) => format!("{} ({})", alias.value, self.endpoint.value),
+            None => self.endpoint.value.clone(),
+        }
+    }
+
+    /// Pairs the resolved auth method with its own identity, checked here
+    /// rather than during [`resolve`].
+    ///
+    /// `config show` calls [`resolve`] alone and still needs to report an
+    /// `sshcert` method with no tag rather than fail outright, so the
+    /// missing-tag rejection lives on this connect-time boundary instead.
+    pub fn resolved_auth(&self) -> Result<auth::ResolvedAuth, Error> {
+        match self.auth.value {
+            AuthMethod::None => Ok(auth::ResolvedAuth::None),
+            AuthMethod::Sshcert => match self.cert_tag.value.as_deref().map(str::trim) {
+                Some(tag) if !tag.is_empty() => Ok(auth::ResolvedAuth::Sshcert { tag: tag.to_owned() }),
+                // An empty tag matches every identity in the agent through
+                // `contains("")`, so it is treated the same as no tag at all.
+                _ => Err(Error::MissingCertTag),
+            },
+        }
+    }
+}
+
+/// Errors resolving the configuration file and applying it.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to read configuration file {}: {source}", path.display())]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse configuration file {}: {source}", path.display())]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: serde_yaml::Error,
+    },
+    #[error("unknown endpoint alias \"{alias}\": {}", alias_hint(known))]
+    UnknownAlias { alias: String, known: Vec<String> },
+    #[error("endpoint alias \"{alias}\" has no \"endpoint\" key in {}", path.display())]
+    SectionMissingEndpoint { alias: String, path: PathBuf },
+    #[error("endpoint alias \"{alias}\" resolves to another alias: alias chains are not supported")]
+    AliasChain { alias: String },
+    #[error(
+        "auth sshcert requires a certificate tag: pass --cert-tag, set YANET_CERT_TAG, \
+         or set cert_tag in the configuration file"
+    )]
+    MissingCertTag,
+    #[error("invalid \"timeout\" value in {}: {message}", path.display())]
+    InvalidTimeout { path: PathBuf, message: String },
+}
+
+impl Error {
+    fn unknown_alias(alias: &str, merged: &MergedFile) -> Self {
+        let mut known: Vec<String> = merged.endpoints.keys().cloned().collect();
+        known.sort();
+
+        Self::UnknownAlias { alias: alias.to_owned(), known }
+    }
+}
+
+/// Renders the known-aliases clause of [`Error::UnknownAlias`].
+fn alias_hint(known: &[String]) -> String {
+    if known.is_empty() {
+        "no aliases are defined in the configuration file".to_owned()
+    } else {
+        format!("known aliases: {}", known.join(", "))
+    }
+}
+
+/// One file's raw contents, exactly as written. Unknown keys are rejected
+/// here rather than silently ignored.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawFile {
+    endpoint: Option<String>,
+    auth: Option<AuthMethod>,
+    cert_tag: Option<String>,
+    ca: Option<PathBuf>,
+    client_cert: Option<PathBuf>,
+    client_key: Option<PathBuf>,
+    timeout: Option<f64>,
+    endpoints: Option<BTreeMap<String, RawSection>>,
+}
+
+/// One `endpoints.<alias>` section. `endpoint` is required once the section
+/// itself is used, checked in [`resolve`] rather than here so a section
+/// present only to be merged into by the other file need not carry it.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawSection {
+    endpoint: Option<String>,
+    auth: Option<AuthMethod>,
+    cert_tag: Option<String>,
+    ca: Option<PathBuf>,
+    client_cert: Option<PathBuf>,
+    client_key: Option<PathBuf>,
+    timeout: Option<f64>,
+}
+
+/// One value merged from (at most) two files, with the file it came from.
+#[derive(Debug, Clone)]
+struct MergedField<T> {
+    value: T,
+    path: PathBuf,
+}
+
+/// Picks `user` over `system`, tagging the result with the file it came
+/// from.
+fn merge_field<T>(system: Option<T>, system_path: &Path, user: Option<T>, user_path: &Path) -> Option<MergedField<T>> {
+    match user {
+        Some(value) => Some(MergedField { value, path: user_path.to_owned() }),
+        None => system.map(|value| MergedField { value, path: system_path.to_owned() }),
+    }
+}
+
+/// One `endpoints.<alias>` section merged key-wise from both files.
+#[derive(Debug, Clone)]
+struct MergedSection {
+    endpoint: Option<MergedField<String>>,
+    auth: Option<MergedField<AuthMethod>>,
+    cert_tag: Option<MergedField<String>>,
+    ca: Option<MergedField<PathBuf>>,
+    client_cert: Option<MergedField<PathBuf>>,
+    client_key: Option<MergedField<PathBuf>>,
+    timeout: Option<MergedField<f64>>,
+    /// The file that defines this alias, preferring the user file: the
+    /// location named in [`Error::SectionMissingEndpoint`].
+    defined_in: PathBuf,
+}
+
+fn merge_section(
+    system: Option<&RawSection>,
+    system_path: &Path,
+    user: Option<&RawSection>,
+    user_path: &Path,
+) -> MergedSection {
+    let defined_in = if user.is_some() {
+        user_path.to_owned()
+    } else {
+        system_path.to_owned()
+    };
+
+    MergedSection {
+        endpoint: merge_field(
+            system.and_then(|s| s.endpoint.clone()),
+            system_path,
+            user.and_then(|s| s.endpoint.clone()),
+            user_path,
+        ),
+        auth: merge_field(
+            system.and_then(|s| s.auth),
+            system_path,
+            user.and_then(|s| s.auth),
+            user_path,
+        ),
+        cert_tag: merge_field(
+            system.and_then(|s| s.cert_tag.clone()),
+            system_path,
+            user.and_then(|s| s.cert_tag.clone()),
+            user_path,
+        ),
+        ca: merge_field(
+            system.and_then(|s| s.ca.clone()),
+            system_path,
+            user.and_then(|s| s.ca.clone()),
+            user_path,
+        ),
+        client_cert: merge_field(
+            system.and_then(|s| s.client_cert.clone()),
+            system_path,
+            user.and_then(|s| s.client_cert.clone()),
+            user_path,
+        ),
+        client_key: merge_field(
+            system.and_then(|s| s.client_key.clone()),
+            system_path,
+            user.and_then(|s| s.client_key.clone()),
+            user_path,
+        ),
+        timeout: merge_field(
+            system.and_then(|s| s.timeout),
+            system_path,
+            user.and_then(|s| s.timeout),
+            user_path,
+        ),
+        defined_in,
+    }
+}
+
+fn merge_endpoints(
+    system: &BTreeMap<String, RawSection>,
+    system_path: &Path,
+    user: &BTreeMap<String, RawSection>,
+    user_path: &Path,
+) -> BTreeMap<String, MergedSection> {
+    let names: BTreeSet<&String> = system.keys().chain(user.keys()).collect();
+
+    names
+        .into_iter()
+        .map(|name| {
+            (
+                name.clone(),
+                merge_section(system.get(name), system_path, user.get(name), user_path),
+            )
+        })
+        .collect()
+}
+
+/// Both files merged key-wise, the user file winning per key and per alias.
+#[derive(Debug, Clone)]
+struct MergedFile {
+    endpoint: Option<MergedField<String>>,
+    auth: Option<MergedField<AuthMethod>>,
+    cert_tag: Option<MergedField<String>>,
+    ca: Option<MergedField<PathBuf>>,
+    client_cert: Option<MergedField<PathBuf>>,
+    client_key: Option<MergedField<PathBuf>>,
+    timeout: Option<MergedField<f64>>,
+    endpoints: BTreeMap<String, MergedSection>,
+    files: Vec<ConsultedFile>,
+}
+
+/// Reads one file, returning `None` when it is absent and `required` is
+/// `false`. A missing required file and a present-but-unreadable file are
+/// both [`Error::Read`].
+// `core::io::ErrorKind` is behind the unstable `core_io` feature, so this
+// function keeps `std::io::ErrorKind`. The allow sits here rather than on a
+// `use` because clippy's `useless_attribute` rejects it directly on a `use`
+// item.
+#[allow(clippy::std_instead_of_core)]
+fn read_file(path: &Path, required: bool) -> Result<(Option<RawFile>, ConsultedFile), Error> {
+    use std::io::ErrorKind;
+
+    match fs::read_to_string(path) {
+        Ok(text) => {
+            let raw: RawFile =
+                serde_yaml::from_str(&text).map_err(|source| Error::Parse { path: path.to_owned(), source })?;
+
+            Ok((Some(raw), ConsultedFile { path: path.to_owned(), read: true }))
+        }
+        Err(source) if source.kind() == ErrorKind::NotFound && !required => {
+            Ok((None, ConsultedFile { path: path.to_owned(), read: false }))
+        }
+        Err(source) => Err(Error::Read { path: path.to_owned(), source }),
+    }
+}
+
+/// Reads and merges the configuration file(s) named by `sources`.
+fn load(sources: &Sources) -> Result<MergedFile, Error> {
+    if let Some(path) = &sources.config_override {
+        let (raw, file) = read_file(path, true)?;
+
+        return Ok(merge_files(
+            RawFile::default(),
+            path,
+            raw.unwrap_or_default(),
+            path,
+            vec![file],
+        ));
+    }
+
+    let (system, system_file) = read_file(&sources.system_path, false)?;
+    let system_path = sources.system_path.as_path();
+
+    let Some(user_path) = &sources.user_path else {
+        // No personal file to merge over the system one at all.
+        return Ok(merge_files(
+            system.unwrap_or_default(),
+            system_path,
+            RawFile::default(),
+            system_path,
+            vec![system_file],
+        ));
+    };
+
+    let (user, user_file) = read_file(user_path, false)?;
+
+    Ok(merge_files(
+        system.unwrap_or_default(),
+        system_path,
+        user.unwrap_or_default(),
+        user_path,
+        vec![system_file, user_file],
+    ))
+}
+
+/// Merges an already-read system/user pair of raw files, key-wise and per
+/// alias, into one [`MergedFile`].
+///
+/// `user_path` is only ever read back out of `user`'s own fields, so it is
+/// never dereferenced when `user` carries no values of its own — the shape
+/// [`load`] relies on when there is no personal file to merge.
+fn merge_files(
+    system: RawFile,
+    system_path: &Path,
+    user: RawFile,
+    user_path: &Path,
+    files: Vec<ConsultedFile>,
+) -> MergedFile {
+    MergedFile {
+        endpoint: merge_field(system.endpoint.clone(), system_path, user.endpoint.clone(), user_path),
+        auth: merge_field(system.auth, system_path, user.auth, user_path),
+        cert_tag: merge_field(system.cert_tag.clone(), system_path, user.cert_tag.clone(), user_path),
+        ca: merge_field(system.ca.clone(), system_path, user.ca.clone(), user_path),
+        client_cert: merge_field(
+            system.client_cert.clone(),
+            system_path,
+            user.client_cert.clone(),
+            user_path,
+        ),
+        client_key: merge_field(
+            system.client_key.clone(),
+            system_path,
+            user.client_key.clone(),
+            user_path,
+        ),
+        timeout: merge_field(system.timeout, system_path, user.timeout, user_path),
+        endpoints: merge_endpoints(
+            &system.endpoints.unwrap_or_default(),
+            system_path,
+            &user.endpoints.unwrap_or_default(),
+            user_path,
+        ),
+        files,
+    }
+}
+
+/// Resolves one key by the fixed precedence: the `clap` value, the alias
+/// section, the top-level file key, then `default`.
+fn resolve_key<T: Clone>(
+    argument: Option<T>,
+    section: Option<&MergedField<T>>,
+    top_level: Option<&MergedField<T>>,
+    alias: Option<&str>,
+    default: Option<T>,
+) -> (Option<T>, Origin) {
+    if let Some(value) = argument {
+        return (Some(value), Origin::Argument);
+    }
+
+    if let Some(field) = section {
+        let alias = alias.expect("a section value implies its alias").to_owned();
+
+        return (
+            Some(field.value.clone()),
+            Origin::Section { path: field.path.clone(), alias },
+        );
+    }
+
+    if let Some(field) = top_level {
+        return (Some(field.value.clone()), Origin::File(field.path.clone()));
+    }
+
+    (default, Origin::BuiltIn)
+}
+
+/// Drops a TLS value that came from a file when the resolved endpoint is
+/// plaintext, so a fleet-wide `ca` cannot break a plaintext lab alias.
+///
+/// A value given on the command line or through its environment variable
+/// is kept, and still rejected downstream by the existing TLS/plaintext
+/// check. The dropped value's origin becomes [`Origin::Ignored`] rather
+/// than vanishing into [`Origin::BuiltIn`], so a caller can still say
+/// where the ignored value came from.
+fn drop_file_tls_if_plaintext<T>(
+    value: Option<T>,
+    origin: Origin,
+    is_plaintext: bool,
+    key: &str,
+) -> (Option<T>, Origin) {
+    if !is_plaintext || value.is_none() {
+        return (value, origin);
+    }
+
+    match origin {
+        Origin::Section { path, alias } => {
+            log::debug!("dropping file-provided {key} for a plaintext endpoint");
+
+            (None, Origin::Ignored { path, alias: Some(alias) })
+        }
+        Origin::File(path) => {
+            log::debug!("dropping file-provided {key} for a plaintext endpoint");
+
+            (None, Origin::Ignored { path, alias: None })
+        }
+        other => (value, other),
+    }
+}
+
+/// Resolves every connection setting for one invocation.
+///
+/// Applies the target resolution (a scheme-less endpoint is an alias
+/// looked up in `endpoints`), then the flag > alias section > top-level
+/// key > built-in precedence for every other key, then the plaintext TLS
+/// drop. The `sshcert` certificate-tag requirement is not checked here —
+/// see [`Settings::resolved_auth`].
+pub fn resolve(args: &ConnectionArgs, sources: &Sources) -> Result<Settings, Error> {
+    let merged = load(sources)?;
+
+    let (mut endpoint, target_origin) = match &args.endpoint {
+        Some(value) => (value.clone(), Origin::Argument),
+        None => match &merged.endpoint {
+            Some(field) => (field.value.clone(), Origin::File(field.path.clone())),
+            None => (DEFAULT_ENDPOINT.to_owned(), Origin::BuiltIn),
+        },
+    };
+
+    let mut endpoint_origin = target_origin.clone();
+    // The alias *name*'s own origin (how `--endpoint`/`YANET_ENDPOINT`/the
+    // file selected it), kept apart from `endpoint_origin` above, which
+    // becomes the alias section's own origin once the name resolves.
+    let mut alias: Option<Resolved<String>> = None;
+    let mut section: Option<&MergedSection> = None;
+
+    if !endpoint.contains("://") {
+        let name = endpoint.clone();
+        let found = merged
+            .endpoints
+            .get(&name)
+            .ok_or_else(|| Error::unknown_alias(&name, &merged))?;
+
+        let target = found.endpoint.as_ref().ok_or_else(|| Error::SectionMissingEndpoint {
+            alias: name.clone(),
+            path: found.defined_in.clone(),
+        })?;
+
+        if !target.value.contains("://") {
+            return Err(Error::AliasChain { alias: name });
+        }
+
+        endpoint = target.value.clone();
+        endpoint_origin = Origin::Section {
+            path: target.path.clone(),
+            alias: name.clone(),
+        };
+        alias = Some(Resolved {
+            value: name.clone(),
+            origin: target_origin,
+        });
+        section = Some(found);
+    }
+
+    let alias_ref = alias.as_ref().map(|a| a.value.as_str());
+
+    let (auth, auth_origin) = resolve_key(
+        args.auth.auth,
+        section.and_then(|s| s.auth.as_ref()),
+        merged.auth.as_ref(),
+        alias_ref,
+        Some(AuthMethod::None),
+    );
+    let auth = auth.expect("a built-in default was supplied");
+
+    let (cert_tag, cert_tag_origin) = resolve_key(
+        args.auth.cert_tag.clone(),
+        section.and_then(|s| s.cert_tag.as_ref()),
+        merged.cert_tag.as_ref(),
+        alias_ref,
+        None,
+    );
+
+    let (ca, ca_origin) = resolve_key(
+        args.tls.ca.clone(),
+        section.and_then(|s| s.ca.as_ref()),
+        merged.ca.as_ref(),
+        alias_ref,
+        None,
+    );
+    let (client_cert, client_cert_origin) = resolve_key(
+        args.tls.client_cert.clone(),
+        section.and_then(|s| s.client_cert.as_ref()),
+        merged.client_cert.as_ref(),
+        alias_ref,
+        None,
+    );
+    let (client_key, client_key_origin) = resolve_key(
+        args.tls.client_key.clone(),
+        section.and_then(|s| s.client_key.as_ref()),
+        merged.client_key.as_ref(),
+        alias_ref,
+        None,
+    );
+
+    let (timeout_seconds, timeout_seconds_origin) = resolve_key(
+        None,
+        section.and_then(|s| s.timeout.as_ref()),
+        merged.timeout.as_ref(),
+        alias_ref,
+        None,
+    );
+    let (timeout, timeout_origin) = match args.timeout {
+        Some(value) => (Some(value), Origin::Argument),
+        None => match timeout_seconds {
+            Some(seconds) => {
+                let path = match &timeout_seconds_origin {
+                    Origin::Section { path, .. } | Origin::File(path) => path.clone(),
+                    Origin::Argument | Origin::Ignored { .. } | Origin::BuiltIn => {
+                        unreachable!("resolve_key never returns these without a value")
+                    }
+                };
+                let value = timeout_from_seconds(seconds).map_err(|message| Error::InvalidTimeout { path, message })?;
+
+                (Some(value), timeout_seconds_origin)
+            }
+            None => (None, Origin::BuiltIn),
+        },
+    };
+
+    let is_plaintext = matches!(endpoint.split_once("://"), Some(("grpc" | "unix", ..)));
+    let (ca, ca_origin) = drop_file_tls_if_plaintext(ca, ca_origin, is_plaintext, "ca");
+    let (client_cert, client_cert_origin) =
+        drop_file_tls_if_plaintext(client_cert, client_cert_origin, is_plaintext, "client_cert");
+    let (client_key, client_key_origin) =
+        drop_file_tls_if_plaintext(client_key, client_key_origin, is_plaintext, "client_key");
+
+    Ok(Settings {
+        endpoint: Resolved {
+            value: endpoint,
+            origin: endpoint_origin,
+        },
+        alias,
+        auth: Resolved { value: auth, origin: auth_origin },
+        cert_tag: Resolved {
+            value: cert_tag,
+            origin: cert_tag_origin,
+        },
+        ca: Resolved { value: ca, origin: ca_origin },
+        client_cert: Resolved {
+            value: client_cert,
+            origin: client_cert_origin,
+        },
+        client_key: Resolved {
+            value: client_key,
+            origin: client_key_origin,
+        },
+        timeout: Resolved {
+            value: timeout,
+            origin: timeout_origin,
+        },
+        files: merged.files,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs;
+
+    use super::*;
+    use crate::{auth::AuthArgs, client::TlsArgs};
+
+    /// A scratch directory unique to the calling test, so parallel tests
+    /// never share a file.
+    fn scratch_dir(name: &str) -> PathBuf {
+        let dir = env::temp_dir().join(format!("yanet-cli-config-test-{name}-{}", std::process::id()));
+        // A PID can be recycled across runs. Start from a clean directory
+        // rather than risking a leftover file from an earlier one.
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        dir
+    }
+
+    #[test]
+    fn test_user_config_dir_prefers_xdg_config_home() {
+        let dir = user_config_dir(Some("/xdg".into()), Some("/home/x".into()));
+
+        assert_eq!(Some(PathBuf::from("/xdg")), dir);
+    }
+
+    #[test]
+    fn test_user_config_dir_falls_back_to_home_dot_config() {
+        let dir = user_config_dir(None, Some("/home/x".into()));
+
+        assert_eq!(Some(PathBuf::from("/home/x/.config")), dir);
+    }
+
+    #[test]
+    fn test_user_config_dir_treats_empty_xdg_config_home_as_unset() {
+        let dir = user_config_dir(Some("".into()), Some("/home/x".into()));
+
+        assert_eq!(Some(PathBuf::from("/home/x/.config")), dir);
+    }
+
+    #[test]
+    fn test_user_config_dir_ignores_a_relative_xdg_config_home() {
+        let dir = user_config_dir(Some("relative/xdg".into()), Some("/home/x".into()));
+
+        assert_eq!(Some(PathBuf::from("/home/x/.config")), dir);
+    }
+
+    #[test]
+    fn test_user_config_dir_treats_empty_home_as_unset() {
+        let dir = user_config_dir(Some("".into()), Some("".into()));
+
+        assert_eq!(None, dir);
+    }
+
+    #[test]
+    fn test_user_config_dir_none_when_neither_is_set() {
+        assert_eq!(None, user_config_dir(None, None));
+    }
+
+    fn write(dir: &Path, name: &str, contents: &str) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, contents).unwrap();
+
+        path
+    }
+
+    /// A `Sources` pointing at two files under `dir` that need not exist.
+    fn sources(dir: &Path) -> Sources {
+        Sources {
+            system_path: dir.join("system.yaml"),
+            user_path: Some(dir.join("user.yaml")),
+            config_override: None,
+        }
+    }
+
+    fn bare_args() -> ConnectionArgs {
+        ConnectionArgs {
+            endpoint: None,
+            auth: AuthArgs { auth: None, cert_tag: None },
+            tls: TlsArgs::default(),
+            timeout: None,
+        }
+    }
+
+    #[test]
+    fn test_resolve_endpoint_falls_back_through_all_five_levels() {
+        let dir = scratch_dir("precedence");
+        let sources = sources(&dir);
+
+        let builtin = resolve(&bare_args(), &sources).unwrap();
+        assert_eq!(DEFAULT_ENDPOINT, builtin.endpoint.value);
+        assert_eq!(Origin::BuiltIn, builtin.endpoint.origin);
+
+        write(&dir, "system.yaml", "endpoint: grpc://system:1\n");
+        let file = resolve(&bare_args(), &sources).unwrap();
+        assert_eq!("grpc://system:1", file.endpoint.value);
+        assert!(matches!(file.endpoint.origin, Origin::File(..)));
+
+        write(&dir, "user.yaml", "endpoint: grpc://user:1\n");
+        let user_over_system = resolve(&bare_args(), &sources).unwrap();
+        assert_eq!("grpc://user:1", user_over_system.endpoint.value);
+
+        let mut args = bare_args();
+        args.endpoint = Some("grpc://argument:1".to_owned());
+        let argument = resolve(&args, &sources).unwrap();
+        assert_eq!("grpc://argument:1", argument.endpoint.value);
+        assert_eq!(Origin::Argument, argument.endpoint.origin);
+    }
+
+    #[test]
+    fn test_resolve_endpoint_alias_from_argument() {
+        // A flag value and its environment variable both land in
+        // `ConnectionArgs.endpoint` before `resolve` ever runs, so this
+        // layer sees one `Origin::Argument` for both. Telling them apart
+        // is `main.rs`'s `describe_origin`, from `ArgMatches::value_source`.
+        let dir = scratch_dir("alias-arg");
+        let sources = sources(&dir);
+        write(
+            &dir,
+            "user.yaml",
+            "endpoints:\n  lab: { endpoint: grpc://lab.example.net:8080 }\n",
+        );
+
+        let mut args = bare_args();
+        args.endpoint = Some("lab".to_owned());
+        let settings = resolve(&args, &sources).unwrap();
+
+        assert_eq!("grpc://lab.example.net:8080", settings.endpoint.value);
+        let alias = settings.alias.as_ref().unwrap();
+        assert_eq!("lab", alias.value);
+        assert_eq!(Origin::Argument, alias.origin);
+        assert_eq!("lab (grpc://lab.example.net:8080)", settings.label());
+    }
+
+    #[test]
+    fn test_resolve_top_level_endpoint_may_itself_be_an_alias() {
+        let dir = scratch_dir("alias-top-level");
+        let sources = sources(&dir);
+        let user_path = write(
+            &dir,
+            "user.yaml",
+            "endpoint: lab\nendpoints:\n  lab: { endpoint: grpc://lab.example.net:8080 }\n",
+        );
+
+        let settings = resolve(&bare_args(), &sources).unwrap();
+
+        assert_eq!("grpc://lab.example.net:8080", settings.endpoint.value);
+        let alias = settings.alias.as_ref().unwrap();
+        assert_eq!("lab", alias.value);
+        assert_eq!(Origin::File(user_path), alias.origin);
+    }
+
+    #[test]
+    fn test_resolve_unknown_alias_lists_the_known_ones() {
+        let dir = scratch_dir("unknown-alias");
+        let sources = sources(&dir);
+        write(
+            &dir,
+            "user.yaml",
+            "endpoints:\n  lab: { endpoint: grpc://lab:1 }\n  m9: { endpoint: grpc://m9:1 }\n",
+        );
+
+        let mut args = bare_args();
+        args.endpoint = Some("nope".to_owned());
+        let err = resolve(&args, &sources).unwrap_err();
+
+        assert_eq!(
+            "unknown endpoint alias \"nope\": known aliases: lab, m9",
+            err.to_string()
+        );
+    }
+
+    #[test]
+    fn test_resolve_unknown_alias_without_any_defined_says_so() {
+        let dir = scratch_dir("no-aliases");
+        let sources = sources(&dir);
+
+        let mut args = bare_args();
+        args.endpoint = Some("nope".to_owned());
+        let err = resolve(&args, &sources).unwrap_err();
+
+        assert_eq!(
+            "unknown endpoint alias \"nope\": no aliases are defined in the configuration file",
+            err.to_string()
+        );
+    }
+
+    #[test]
+    fn test_resolve_section_without_endpoint_names_the_alias_and_path() {
+        let dir = scratch_dir("section-no-endpoint");
+        let sources = sources(&dir);
+        let user_path = write(&dir, "user.yaml", "endpoints:\n  lab: { auth: none }\n");
+
+        let mut args = bare_args();
+        args.endpoint = Some("lab".to_owned());
+        let err = resolve(&args, &sources).unwrap_err();
+
+        assert!(
+            matches!(err, Error::SectionMissingEndpoint { ref alias, ref path } if alias == "lab" && *path == user_path)
+        );
+    }
+
+    #[test]
+    fn test_resolve_rejects_alias_chains() {
+        let dir = scratch_dir("alias-chain");
+        let sources = sources(&dir);
+        write(
+            &dir,
+            "user.yaml",
+            "endpoints:\n  a: { endpoint: b }\n  b: { endpoint: grpc://b:1 }\n",
+        );
+
+        let mut args = bare_args();
+        args.endpoint = Some("a".to_owned());
+        let err = resolve(&args, &sources).unwrap_err();
+
+        assert!(matches!(err, Error::AliasChain { ref alias } if alias == "a"));
+    }
+
+    #[test]
+    fn test_resolve_merges_two_files_per_alias_per_key() {
+        let dir = scratch_dir("merge-per-key");
+        let sources = sources(&dir);
+        write(
+            &dir,
+            "system.yaml",
+            "auth: sshcert\ncert_tag: fleet\nendpoints:\n  lab: { endpoint: grpc://lab:1, auth: sshcert }\n",
+        );
+        write(&dir, "user.yaml", "endpoints:\n  lab: { auth: none }\n");
+
+        let mut args = bare_args();
+        args.endpoint = Some("lab".to_owned());
+        let settings = resolve(&args, &sources).unwrap();
+
+        // The alias overrides `auth` in the user file, but its `endpoint`
+        // still comes from the system file, and the top-level `cert_tag`
+        // is left in effect even though the alias overrides `auth`.
+        assert_eq!("grpc://lab:1", settings.endpoint.value);
+        assert_eq!(AuthMethod::None, settings.auth.value);
+        assert_eq!(Some("fleet".to_owned()), settings.cert_tag.value);
+    }
+
+    #[test]
+    fn test_resolve_malformed_file_names_path_and_offending_key() {
+        let dir = scratch_dir("malformed");
+        let sources = sources(&dir);
+        let path = write(&dir, "user.yaml", "bogus_key: 1\n");
+
+        let err = resolve(&bare_args(), &sources).unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains(&path.display().to_string()), "{message}");
+        assert!(message.contains("bogus_key"), "{message}");
+    }
+
+    #[test]
+    fn test_resolve_missing_default_files_are_not_an_error() {
+        let dir = scratch_dir("missing-default");
+        let sources = sources(&dir);
+
+        assert!(resolve(&bare_args(), &sources).is_ok());
+    }
+
+    #[test]
+    fn test_resolve_without_a_user_path_only_consults_the_system_file() {
+        let dir = scratch_dir("no-user-path");
+        write(&dir, "system.yaml", "endpoint: grpc://system:1\n");
+        let sources = Sources {
+            system_path: dir.join("system.yaml"),
+            user_path: None,
+            config_override: None,
+        };
+
+        let settings = resolve(&bare_args(), &sources).unwrap();
+
+        assert_eq!("grpc://system:1", settings.endpoint.value);
+        assert_eq!(1, settings.files.len());
+    }
+
+    #[test]
+    fn test_resolve_missing_config_override_is_an_error() {
+        let dir = scratch_dir("missing-override");
+        let sources = Sources {
+            system_path: dir.join("system.yaml"),
+            user_path: Some(dir.join("user.yaml")),
+            config_override: Some(dir.join("missing.yaml")),
+        };
+
+        let err = resolve(&bare_args(), &sources).unwrap_err();
+
+        assert!(matches!(err, Error::Read { .. }));
+    }
+
+    #[test]
+    fn test_resolve_sshcert_without_tag_still_resolves() {
+        // `resolve` alone must not fail here: `config show` calls only
+        // `resolve` and still needs to report `auth sshcert` with no tag
+        // rather than exit outright. `Settings::resolved_auth` is where
+        // that combination is finally rejected, at connect time.
+        let dir = scratch_dir("sshcert-no-tag");
+        let sources = sources(&dir);
+
+        let mut args = bare_args();
+        args.auth.auth = Some(AuthMethod::Sshcert);
+        let settings = resolve(&args, &sources).unwrap();
+
+        assert_eq!(AuthMethod::Sshcert, settings.auth.value);
+        assert_eq!(None, settings.cert_tag.value);
+    }
+
+    #[test]
+    fn test_settings_resolved_auth_rejects_sshcert_without_tag() {
+        let dir = scratch_dir("resolved-auth-no-tag");
+        let sources = sources(&dir);
+
+        let mut args = bare_args();
+        args.auth.auth = Some(AuthMethod::Sshcert);
+        let settings = resolve(&args, &sources).unwrap();
+
+        assert!(matches!(settings.resolved_auth(), Err(Error::MissingCertTag)));
+    }
+
+    #[test]
+    fn test_settings_resolved_auth_pairs_sshcert_with_its_tag() {
+        let dir = scratch_dir("resolved-auth-with-tag");
+        let sources = sources(&dir);
+
+        let mut args = bare_args();
+        args.auth.auth = Some(AuthMethod::Sshcert);
+        args.auth.cert_tag = Some("prod".to_owned());
+        let settings = resolve(&args, &sources).unwrap();
+
+        assert_eq!(
+            auth::ResolvedAuth::Sshcert { tag: "prod".to_owned() },
+            settings.resolved_auth().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_settings_resolved_auth_none_needs_no_tag() {
+        let dir = scratch_dir("resolved-auth-none");
+        let sources = sources(&dir);
+
+        let settings = resolve(&bare_args(), &sources).unwrap();
+
+        assert_eq!(auth::ResolvedAuth::None, settings.resolved_auth().unwrap());
+    }
+
+    #[test]
+    fn test_settings_resolved_auth_rejects_a_blank_tag() {
+        let dir = scratch_dir("resolved-auth-blank-tag");
+        let sources = sources(&dir);
+
+        let mut args = bare_args();
+        args.auth.auth = Some(AuthMethod::Sshcert);
+        args.auth.cert_tag = Some("   ".to_owned());
+        let settings = resolve(&args, &sources).unwrap();
+
+        assert!(matches!(settings.resolved_auth(), Err(Error::MissingCertTag)));
+    }
+
+    #[test]
+    fn test_resolve_drops_file_tls_for_plaintext_alias() {
+        let dir = scratch_dir("drop-file-tls");
+        let sources = sources(&dir);
+        let system_path = write(
+            &dir,
+            "system.yaml",
+            "ca: /etc/yanet2/tls/ca.pem\nendpoints:\n  lab: { endpoint: grpc://lab:1 }\n",
+        );
+
+        let mut args = bare_args();
+        args.endpoint = Some("lab".to_owned());
+        let settings = resolve(&args, &sources).unwrap();
+
+        assert_eq!(None, settings.ca.value);
+        assert_eq!(Origin::Ignored { path: system_path, alias: None }, settings.ca.origin);
+    }
+
+    #[test]
+    fn test_resolve_keeps_argument_tls_for_plaintext_endpoint() {
+        let dir = scratch_dir("keep-argument-tls");
+        let sources = sources(&dir);
+
+        let mut args = bare_args();
+        args.endpoint = Some("grpc://lab:1".to_owned());
+        args.tls.ca = Some(PathBuf::from("/tmp/ca.pem"));
+        let settings = resolve(&args, &sources).unwrap();
+
+        assert_eq!(Some(PathBuf::from("/tmp/ca.pem")), settings.ca.value);
+        assert_eq!(Origin::Argument, settings.ca.origin);
+    }
+
+    #[test]
+    fn test_resolve_timeout_shares_the_flag_parsing_rule() {
+        let dir = scratch_dir("timeout-rule");
+        let sources = sources(&dir);
+        write(&dir, "user.yaml", "timeout: 0\n");
+
+        let err = resolve(&bare_args(), &sources).unwrap_err();
+
+        assert!(matches!(err, Error::InvalidTimeout { .. }));
+    }
+
+    #[test]
+    fn test_resolve_timeout_from_file_parses_fractional_seconds() {
+        let dir = scratch_dir("timeout-fractional");
+        let sources = sources(&dir);
+        write(&dir, "user.yaml", "timeout: 2.5\n");
+
+        let settings = resolve(&bare_args(), &sources).unwrap();
+
+        assert_eq!(Some(Duration::from_millis(2500)), settings.timeout.value);
+    }
+}

--- a/cli/core/src/discovery.rs
+++ b/cli/core/src/discovery.rs
@@ -16,6 +16,7 @@ use ynpb::pb::{gateway_client::GatewayClient, ListServicesRequest};
 
 use crate::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
+    config,
     errors::{Error, ErrorKind},
 };
 
@@ -178,8 +179,16 @@ pub fn alias_map(services: &[String]) -> BTreeMap<String, String> {
 /// Discovery the user asked for runs over the [`Connection`] the probe
 /// already established and is deliberately unbounded.
 pub async fn discover_within(args: &ConnectionArgs, suffix: &str, budget: Duration) -> Result<Vec<String>, Error> {
+    // Resolved once, up front, and reused by both the connect attempt and
+    // the timeout arm: a bad file or an unknown alias is a config error
+    // reported as such, and the label must not shift, or the file be read
+    // twice, between the attempt and a timeout.
+    let settings = config::resolve(args, &config::Sources::from_process_env())
+        .map_err(|err| Error::from_config(err, "discover", args.endpoint.clone()))?;
+    let endpoint = settings.label();
+
     let lookup = async {
-        let connection = Connection::connect(args).await?;
+        let connection = Connection::connect_settings(&settings, "discover").await?;
 
         list_services(&connection, suffix).await
     };
@@ -190,7 +199,7 @@ pub async fn discover_within(args: &ConnectionArgs, suffix: &str, budget: Durati
             let formatted_budget = humantime::format_duration(budget);
             let message = format!("gateway did not answer within {formatted_budget}");
 
-            Err(Error::new(ErrorKind::Unavailable, "discover", &args.endpoint, message))
+            Err(Error::new(ErrorKind::Unavailable, "discover", endpoint, message))
         }
     }
 }

--- a/cli/core/src/dispatcher.rs
+++ b/cli/core/src/dispatcher.rs
@@ -47,6 +47,14 @@ pub trait Dispatch {
     fn on_empty_namespace(&self, _namespace: &str, modules: &HashSet<String>) -> i32 {
         self.on_empty_subcommand(modules)
     }
+    /// Names `cmd` registers as its own built-in subcommands.
+    ///
+    /// Removed from the discovered module set everywhere it is used, so a
+    /// stray binary of that name on `PATH` cannot collide with, or receive
+    /// completion requests meant for, the built-in subcommand.
+    fn reserved(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 fn search_paths() -> Vec<PathBuf> {
@@ -186,6 +194,16 @@ fn filter_namespaced(modules: &HashSet<String>, namespaces: &[Namespace]) -> Has
         .collect()
 }
 
+/// Removes names reserved by the dispatcher's own built-in subcommands
+/// (see [`Dispatch::reserved`]) from the discovered set.
+fn filter_reserved(modules: &HashSet<String>, reserved: &[&str]) -> HashSet<String> {
+    modules
+        .iter()
+        .filter(|name| !reserved.contains(&name.as_str()))
+        .cloned()
+        .collect()
+}
+
 pub fn try_complete(name: &str, prefix: &str, behavior: &impl Dispatch) {
     if env::var_os("COMPLETE").is_none() {
         return;
@@ -193,7 +211,7 @@ pub fn try_complete(name: &str, prefix: &str, behavior: &impl Dispatch) {
 
     let raw = locate_modules(prefix).unwrap_or_default();
     let namespaces = behavior.namespaces();
-    let submodules = filter_namespaced(&raw, namespaces);
+    let submodules = filter_reserved(&filter_namespaced(&raw, namespaces), behavior.reserved());
     let args = env::args().collect::<Vec<_>>();
 
     // If args are ["<self>", "--", "<self>", "<module>", ..], forward the
@@ -278,7 +296,7 @@ pub fn dispatch(name: &str, prefix: &str, behavior: &impl Dispatch) -> ! {
 
     let namespaces = behavior.namespaces();
     let raw = locate_modules(prefix).unwrap_or_default();
-    let modules = filter_namespaced(&raw, namespaces);
+    let modules = filter_reserved(&filter_namespaced(&raw, namespaces), behavior.reserved());
 
     let matches = build_command(behavior, &modules, namespaces, prefix).get_matches();
 
@@ -360,4 +378,21 @@ fn collect_args(matches: &ArgMatches) -> Vec<std::ffi::OsString> {
         .get_raw("")
         .map(|v| v.map(|s| s.to_os_string()).collect::<Vec<_>>())
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_filter_reserved_removes_a_reserved_name() {
+        let modules: HashSet<String> = ["config", "route", "ready"].into_iter().map(String::from).collect();
+
+        let filtered = filter_reserved(&modules, &["config"]);
+
+        assert_eq!(
+            ["route", "ready"].into_iter().map(String::from).collect::<HashSet<_>>(),
+            filtered
+        );
+    }
 }

--- a/cli/core/src/errors.rs
+++ b/cli/core/src/errors.rs
@@ -11,7 +11,7 @@ use core::fmt::{self, Display, Formatter};
 
 use tonic::{Code, Status};
 
-use crate::client::ConnectionError;
+use crate::{client::ConnectionError, config};
 
 /// Category of a CLI-level error, derived from the underlying `tonic::Code`
 /// or transport failure.
@@ -151,6 +151,7 @@ impl Error {
                 ErrorKind::Connection,
                 Some("verify the endpoint is reachable and the gateway is up".to_owned()),
             ),
+            ConnectionError::Config(ref config_err) => (ErrorKind::InvalidArgument, config_error_hint(config_err)),
         };
 
         Self {
@@ -158,6 +159,29 @@ impl Error {
             kind,
             message,
             endpoint: Some(endpoint),
+            service: None,
+            hint,
+            raw_code: None,
+            raw_message: None,
+        }
+    }
+
+    /// Build an [`Error`] straight from a [`config::Error`], without the
+    /// endpoint a call site has no real value for.
+    ///
+    /// Pass `None` when nothing was ever typed for the endpoint, such as an
+    /// unreadable or malformed file. Pass `args.endpoint.clone()` otherwise,
+    /// since even an alias that turned out unknown is worth showing.
+    pub fn from_config(err: config::Error, action: impl Into<String>, endpoint: Option<String>) -> Self {
+        let action = action.into();
+        let message = err.to_string();
+        let hint = config_error_hint(&err);
+
+        Self {
+            action,
+            kind: ErrorKind::InvalidArgument,
+            message,
+            endpoint,
             service: None,
             hint,
             raw_code: None,
@@ -294,6 +318,25 @@ pub fn root_cause<'a>(err: &'a (dyn core::error::Error + 'static)) -> &'a (dyn c
     }
 
     err
+}
+
+/// Builds the hint for a [`ConnectionError::Config`] failure.
+///
+/// The message of [`config::Error::UnknownAlias`] already lists the known
+/// aliases, so no separate hint is needed there. A file-reading or -parsing
+/// failure adds one naming the offending path.
+fn config_error_hint(err: &config::Error) -> Option<String> {
+    match err {
+        config::Error::Read { path, .. }
+        | config::Error::Parse { path, .. }
+        | config::Error::InvalidTimeout { path, .. } => {
+            Some(format!("check the configuration file at {}", path.display()))
+        }
+        config::Error::SectionMissingEndpoint { path, .. } => {
+            Some(format!("add an \"endpoint\" key to that alias in {}", path.display()))
+        }
+        config::Error::UnknownAlias { .. } | config::Error::AliasChain { .. } | config::Error::MissingCertTag => None,
+    }
 }
 
 /// Build a default hint for the given error kind.

--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -9,6 +9,7 @@ use crate::{errors::Error, output::Format};
 pub mod auth;
 pub mod client;
 pub mod completion;
+pub mod config;
 pub mod discovery;
 pub mod dispatcher;
 pub mod display;

--- a/cli/core/src/main.rs
+++ b/cli/core/src/main.rs
@@ -1,8 +1,17 @@
-use std::{collections::HashSet, sync::LazyLock};
+use std::{collections::HashSet, path::PathBuf, sync::LazyLock};
 
-use clap::{crate_name, ArgMatches, Command};
+use clap::{crate_name, parser::ValueSource, Arg, ArgAction, ArgMatches, Args as _, Command, FromArgMatches};
 use colored::{ColoredString, Colorize};
-use yanet_cli::dispatcher::{self, Dispatch, Namespace};
+use serde::Serialize;
+use yanet_cli::{
+    auth::AuthMethod,
+    client::ConnectionArgs,
+    config::{self, Origin, Settings},
+    dispatcher::{self, Dispatch, Namespace},
+    errors::Error,
+    init,
+    output::{self, CommonFormat},
+};
 
 static ERROR: LazyLock<ColoredString> = LazyLock::new(|| "error".bold().bright_red());
 
@@ -17,6 +26,59 @@ const NAMESPACES: &[Namespace] = &[
     },
 ];
 
+/// A resolved connection key: its `clap` argument id, long flag and
+/// environment variable, used to both build the `config show` command and
+/// to describe where a value came from.
+struct KeyInfo {
+    id: &'static str,
+    flag: &'static str,
+    variable: &'static str,
+}
+
+const KEYS: &[KeyInfo] = &[
+    KeyInfo {
+        id: "endpoint",
+        flag: "--endpoint",
+        variable: "YANET_ENDPOINT",
+    },
+    KeyInfo {
+        id: "auth",
+        flag: "--auth",
+        variable: "YANET_AUTH",
+    },
+    KeyInfo {
+        id: "cert_tag",
+        flag: "--cert-tag",
+        variable: "YANET_CERT_TAG",
+    },
+    KeyInfo {
+        id: "ca",
+        flag: "--ca",
+        variable: "YANET_CA",
+    },
+    KeyInfo {
+        id: "client_cert",
+        flag: "--client-cert",
+        variable: "YANET_CLIENT_CERT",
+    },
+    KeyInfo {
+        id: "client_key",
+        flag: "--client-key",
+        variable: "YANET_CLIENT_KEY",
+    },
+    KeyInfo {
+        id: "timeout",
+        flag: "--timeout",
+        variable: "YANET_TIMEOUT",
+    },
+];
+
+fn key_info(id: &str) -> &'static KeyInfo {
+    KEYS.iter()
+        .find(|key| key.id == id)
+        .unwrap_or_else(|| panic!("no KeyInfo registered for connection key \"{id}\""))
+}
+
 fn main() {
     dispatcher::dispatch(crate_name!(), "yanet-cli-", &Dispatcher);
 }
@@ -27,12 +89,16 @@ impl Dispatch for Dispatcher {
     fn cmd(&self, modules: &HashSet<String>) -> Command {
         let cmd = Command::new(crate_name!())
             .version(yanet_cli::version())
-            .allow_external_subcommands(true);
+            .allow_external_subcommands(true)
+            .subcommand(config_command());
+
         dispatcher::add_subcommands(cmd, modules)
     }
 
-    fn try_match(&self, _matches: &ArgMatches) -> Option<i32> {
-        None
+    fn try_match(&self, matches: &ArgMatches) -> Option<i32> {
+        let show_matches = matches.subcommand_matches("config")?.subcommand_matches("show")?;
+
+        Some(run_config_show(show_matches))
     }
 
     fn on_empty_subcommand(&self, modules: &HashSet<String>) -> i32 {
@@ -55,6 +121,364 @@ impl Dispatch for Dispatcher {
 
     fn namespaces(&self) -> &[Namespace] {
         NAMESPACES
+    }
+
+    fn reserved(&self) -> &[&'static str] {
+        &["config"]
+    }
+}
+
+/// Builds the `config show` subcommand tree.
+///
+/// `show` embeds [`ConnectionArgs`] directly (rather than a dedicated
+/// `Cmd`) so its flags, environment variables and completion candidates stay
+/// identical to every other command's.
+fn config_command() -> Command {
+    const SHOW_ABOUT: &str = "Prints the effective connection settings and where each came from.";
+    const SHOW_LONG_ABOUT: &str = "Prints the effective connection settings and where each came \
+        from. Reads /etc/yanet2/cli.yaml merged with $XDG_CONFIG_HOME/yanet2/cli.yaml \
+        (~/.config by default), or the single file named by YANET_CONFIG.";
+
+    let show = ConnectionArgs::augment_args(Command::new("show"))
+        .about(SHOW_ABOUT)
+        .long_about(SHOW_LONG_ABOUT)
+        .arg(
+            Arg::new("format")
+                .long("format")
+                .value_parser(clap::value_parser!(CommonFormat))
+                .default_value("human")
+                .global(true)
+                .help("Output format."),
+        )
+        .arg(
+            Arg::new("verbose")
+                .short('v')
+                .long("verbose")
+                .action(ArgAction::Count)
+                .global(true)
+                .help("Be verbose: shows debug log lines and raw gRPC error details."),
+        );
+
+    Command::new("config")
+        .about("Configuration file inspection.")
+        .subcommand_required(true)
+        .subcommand(show)
+}
+
+/// Runs `config show`: resolves the connection settings and reports them
+/// through the shared output backend, exactly like any other command.
+fn run_config_show(matches: &ArgMatches) -> i32 {
+    let connection =
+        ConnectionArgs::from_arg_matches(matches).expect("show's own augmented matches must parse into ConnectionArgs");
+    let format = matches
+        .get_one::<CommonFormat>("format")
+        .copied()
+        .unwrap_or(CommonFormat::Human);
+    let verbose = matches.get_count("verbose");
+
+    init(verbose, format);
+
+    match config::resolve(&connection, &config::Sources::from_process_env()) {
+        Ok(settings) => {
+            output::data(
+                || show_payload(&settings, matches),
+                || print_settings(&settings, matches),
+            );
+            0
+        }
+        Err(err) => {
+            let error = Error::from_config(err, "show", connection.endpoint.clone());
+
+            output::failure(&error);
+            error.exit_code()
+        }
+    }
+}
+
+/// Where a resolved value came from, refined for display: [`Origin::Argument`]
+/// is split into `flag` and `environment` using the `show` command's own
+/// `ArgMatches::value_source`, since [`Origin`] itself does not distinguish
+/// them.
+struct OriginView {
+    kind: &'static str,
+    path: Option<String>,
+    alias: Option<String>,
+    variable: Option<&'static str>,
+    label: String,
+}
+
+/// Pure: never reads the process environment itself. The caller reads
+/// clap's own value source for the key and hands it in as `value_source`.
+fn describe_origin(origin: &Origin, value_source: Option<ValueSource>, key: &'static KeyInfo) -> OriginView {
+    match origin {
+        Origin::Argument => match value_source {
+            Some(ValueSource::EnvVariable) => OriginView {
+                kind: "environment",
+                path: None,
+                alias: None,
+                variable: Some(key.variable),
+                label: format!("environment {}", key.variable),
+            },
+            _ => OriginView {
+                kind: "flag",
+                path: None,
+                alias: None,
+                variable: None,
+                label: format!("flag {}", key.flag),
+            },
+        },
+        Origin::Section { path, alias } => {
+            let path = path.display().to_string();
+
+            OriginView {
+                kind: "alias",
+                label: format!("alias {alias} in {path}"),
+                path: Some(path),
+                alias: Some(alias.clone()),
+                variable: None,
+            }
+        }
+        Origin::File(path) => {
+            let path = path.display().to_string();
+
+            OriginView {
+                kind: "file",
+                label: path.clone(),
+                path: Some(path),
+                alias: None,
+                variable: None,
+            }
+        }
+        Origin::Ignored { path, alias } => {
+            let path = path.display().to_string();
+            let label = match alias {
+                Some(alias) => format!("ignored for a plaintext endpoint, set in alias {alias} in {path}"),
+                None => format!("ignored for a plaintext endpoint, set in {path}"),
+            };
+
+            OriginView {
+                kind: "ignored",
+                label,
+                path: Some(path),
+                alias: alias.clone(),
+                variable: None,
+            }
+        }
+        Origin::BuiltIn => OriginView {
+            kind: "built-in",
+            path: None,
+            alias: None,
+            variable: None,
+            label: "built-in".to_owned(),
+        },
+    }
+}
+
+/// Widest connection key label (`client_cert`) plus two separating spaces.
+const LABEL_WIDTH: usize = 13;
+
+fn print_settings(settings: &Settings, matches: &ArgMatches) {
+    print_endpoint_line(settings, matches);
+    print_optional_line(
+        "auth",
+        Some(auth_str(settings.auth.value).to_owned()),
+        &settings.auth.origin,
+        matches,
+    );
+    print_optional_line(
+        "cert_tag",
+        settings.cert_tag.value.clone(),
+        &settings.cert_tag.origin,
+        matches,
+    );
+    print_optional_line("ca", path_str(&settings.ca.value), &settings.ca.origin, matches);
+    print_optional_line(
+        "client_cert",
+        path_str(&settings.client_cert.value),
+        &settings.client_cert.origin,
+        matches,
+    );
+    print_optional_line(
+        "client_key",
+        path_str(&settings.client_key.value),
+        &settings.client_key.origin,
+        matches,
+    );
+    print_optional_line(
+        "timeout",
+        settings.timeout.value.map(|d| format!("{}s", d.as_secs_f64())),
+        &settings.timeout.origin,
+        matches,
+    );
+
+    println!();
+    println!("files:");
+    for file in &settings.files {
+        let state = if file.read { "read  " } else { "absent" };
+
+        println!("  {state}  {}", file.path.display());
+    }
+}
+
+/// Prints the `endpoint` line, the one key whose selection (the alias name)
+/// can carry its own origin distinct from the URI's.
+fn print_endpoint_line(settings: &Settings, matches: &ArgMatches) {
+    let key = key_info("endpoint");
+    let source = matches.value_source(key.id);
+    let view = describe_origin(&settings.endpoint.origin, source, key);
+
+    let annotation = match &settings.alias {
+        Some(alias) => {
+            let selected_by = describe_origin(&alias.origin, source, key);
+
+            format!("({}, selected by {})", view.label, selected_by.label)
+        }
+        None => format!("({})", view.label),
+    };
+
+    println!(
+        "{:<LABEL_WIDTH$}{}  {}",
+        key.id,
+        settings.endpoint.value,
+        output::dim(&annotation)
+    );
+}
+
+fn print_line(id: &'static str, value: &str, origin: &Origin, matches: &ArgMatches) {
+    let key = key_info(id);
+    let view = describe_origin(origin, matches.value_source(key.id), key);
+    let annotation = output::dim(&format!("({})", view.label));
+
+    println!("{id:<LABEL_WIDTH$}{value}  {annotation}");
+}
+
+fn print_optional_line(id: &'static str, value: Option<String>, origin: &Origin, matches: &ArgMatches) {
+    print_line(id, value.as_deref().unwrap_or("-"), origin, matches);
+}
+
+fn auth_str(auth: AuthMethod) -> &'static str {
+    match auth {
+        AuthMethod::None => "none",
+        AuthMethod::Sshcert => "sshcert",
+    }
+}
+
+fn path_str(path: &Option<PathBuf>) -> Option<String> {
+    path.as_ref().map(|p| p.display().to_string())
+}
+
+#[derive(Serialize)]
+struct OriginJson {
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alias: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    variable: Option<&'static str>,
+}
+
+impl From<OriginView> for OriginJson {
+    fn from(view: OriginView) -> Self {
+        Self {
+            kind: view.kind,
+            path: view.path,
+            alias: view.alias,
+            variable: view.variable,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct EntryJson<T: Serialize> {
+    value: Option<T>,
+    origin: OriginJson,
+}
+
+#[derive(Serialize)]
+struct EndpointEntryJson {
+    value: String,
+    alias: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    selected_by: Option<OriginJson>,
+    origin: OriginJson,
+}
+
+#[derive(Serialize)]
+struct FileJson {
+    path: String,
+    read: bool,
+}
+
+#[derive(Serialize)]
+struct ShowJson {
+    endpoint: EndpointEntryJson,
+    auth: EntryJson<String>,
+    cert_tag: EntryJson<String>,
+    ca: EntryJson<String>,
+    client_cert: EntryJson<String>,
+    client_key: EntryJson<String>,
+    timeout: EntryJson<f64>,
+    files: Vec<FileJson>,
+}
+
+fn show_payload(settings: &Settings, matches: &ArgMatches) -> ShowJson {
+    let entry = |id: &'static str, value: Option<String>, origin: &Origin| {
+        let key = key_info(id);
+
+        EntryJson {
+            value,
+            origin: describe_origin(origin, matches.value_source(key.id), key).into(),
+        }
+    };
+
+    let endpoint_key = key_info("endpoint");
+    let endpoint_source = matches.value_source(endpoint_key.id);
+
+    ShowJson {
+        endpoint: EndpointEntryJson {
+            value: settings.endpoint.value.clone(),
+            alias: settings.alias.as_ref().map(|alias| alias.value.clone()),
+            selected_by: settings
+                .alias
+                .as_ref()
+                .map(|alias| describe_origin(&alias.origin, endpoint_source, endpoint_key).into()),
+            origin: describe_origin(&settings.endpoint.origin, endpoint_source, endpoint_key).into(),
+        },
+        auth: entry(
+            "auth",
+            Some(auth_str(settings.auth.value).to_owned()),
+            &settings.auth.origin,
+        ),
+        cert_tag: entry("cert_tag", settings.cert_tag.value.clone(), &settings.cert_tag.origin),
+        ca: entry("ca", path_str(&settings.ca.value), &settings.ca.origin),
+        client_cert: entry(
+            "client_cert",
+            path_str(&settings.client_cert.value),
+            &settings.client_cert.origin,
+        ),
+        client_key: entry(
+            "client_key",
+            path_str(&settings.client_key.value),
+            &settings.client_key.origin,
+        ),
+        timeout: EntryJson {
+            value: settings.timeout.value.map(|d| d.as_secs_f64()),
+            origin: describe_origin(
+                &settings.timeout.origin,
+                matches.value_source("timeout"),
+                key_info("timeout"),
+            )
+            .into(),
+        },
+        files: settings
+            .files
+            .iter()
+            .map(|file| FileJson {
+                path: file.path.display().to_string(),
+                read: file.read,
+            })
+            .collect(),
     }
 }
 
@@ -105,4 +529,96 @@ fn print_module_not_found_message(subcommand: &str, modules: &HashSet<String>) {
     );
 
     print_available_modules_message(None, modules);
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_describe_origin_argument_from_command_line_is_flag() {
+        let view = describe_origin(&Origin::Argument, Some(ValueSource::CommandLine), key_info("endpoint"));
+
+        assert_eq!("flag", view.kind);
+        assert_eq!(None, view.variable);
+    }
+
+    #[test]
+    fn test_describe_origin_argument_from_environment_is_environment() {
+        let view = describe_origin(&Origin::Argument, Some(ValueSource::EnvVariable), key_info("endpoint"));
+
+        assert_eq!("environment", view.kind);
+        assert_eq!(Some("YANET_ENDPOINT"), view.variable);
+    }
+
+    #[test]
+    fn test_describe_origin_section_names_alias_and_path() {
+        let origin = Origin::Section {
+            path: "/home/x/.config/yanet2/cli.yaml".into(),
+            alias: "m9-r1".to_owned(),
+        };
+        let view = describe_origin(&origin, None, key_info("endpoint"));
+
+        assert_eq!("alias", view.kind);
+        assert_eq!(Some("m9-r1".to_owned()), view.alias);
+        assert_eq!(Some("/home/x/.config/yanet2/cli.yaml".to_owned()), view.path);
+    }
+
+    #[test]
+    fn test_describe_origin_file_is_the_bare_path() {
+        let origin = Origin::File("/etc/yanet2/cli.yaml".into());
+        let view = describe_origin(&origin, None, key_info("endpoint"));
+
+        assert_eq!("file", view.kind);
+        assert_eq!(Some("/etc/yanet2/cli.yaml".to_owned()), view.path);
+        assert_eq!(None, view.alias);
+    }
+
+    #[test]
+    fn test_describe_origin_ignored_names_the_plaintext_reason_and_path() {
+        let origin = Origin::Ignored {
+            path: "/etc/yanet2/cli.yaml".into(),
+            alias: Some("lab".to_owned()),
+        };
+        let view = describe_origin(&origin, None, key_info("ca"));
+
+        assert_eq!("ignored", view.kind);
+        assert_eq!(Some("/etc/yanet2/cli.yaml".to_owned()), view.path);
+        assert_eq!(Some("lab".to_owned()), view.alias);
+    }
+
+    #[test]
+    fn test_describe_origin_built_in_has_no_path_or_alias() {
+        let view = describe_origin(&Origin::BuiltIn, None, key_info("endpoint"));
+
+        assert_eq!("built-in", view.kind);
+        assert_eq!(None, view.path);
+        assert_eq!(None, view.alias);
+    }
+
+    #[test]
+    fn test_auth_str_matches_the_wire_value_names() {
+        assert_eq!("none", auth_str(AuthMethod::None));
+        assert_eq!("sshcert", auth_str(AuthMethod::Sshcert));
+    }
+
+    /// A `KEYS` entry naming an argument `show` no longer has (e.g. after a
+    /// rename) must fail the suite here rather than panic in `key_info` at
+    /// runtime.
+    #[test]
+    fn test_every_key_id_is_a_show_argument() {
+        let show = config_command()
+            .find_subcommand("show")
+            .expect("config_command always registers show")
+            .clone();
+        let ids: HashSet<&str> = show.get_arguments().map(|arg| arg.get_id().as_str()).collect();
+
+        for key in KEYS {
+            assert!(
+                ids.contains(key.id),
+                "KEYS entry \"{}\" is not a `show` argument",
+                key.id
+            );
+        }
+    }
 }

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -5,7 +5,7 @@ use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{GetMetricsRequest, GetMetricsResponse, Histogram, Label, Metric, MetricTag, metric::Value};
 use tabled::Tabled;
 use ync::{
-    client::{Connection, ConnectionArgs},
+    client::{self, Connection, ConnectionArgs},
     completion,
     discovery::{self, Resolution},
     errors::{Error, ErrorKind},
@@ -26,7 +26,7 @@ const NO_SERVICES: &str = "no metrics services are registered with the gateway";
 /// Connects to the gateway and invokes `/<FQN>/GetMetrics` using tonic's
 /// low-level dynamic dispatcher with the shared `commonpb` message types. No
 /// per-service generated client is needed. The service to probe is resolved
-/// against the gateway registry; a single service's metrics can already be a
+/// against the gateway registry. A single service's metrics can already be a
 /// large payload, so naming none is a usage error whose hint lists the
 /// available services rather than dumping them all.
 #[derive(Debug, Clone, Parser)]
@@ -74,10 +74,12 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         return Err(require_service(&cmd).await);
     };
 
+    let endpoint = client::resolve_label(&cmd.connection, "metrics")?;
+
     if is_blank(&name) {
         return Err(Error::invalid_argument(
             "metrics",
-            &cmd.connection.endpoint,
+            endpoint.clone(),
             "service name must not be empty",
         ));
     }
@@ -87,14 +89,14 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         .iter()
         .map(|entry| parse_tag(entry))
         .collect::<Result<Vec<_>, String>>()
-        .map_err(|message| Error::invalid_argument("metrics", &cmd.connection.endpoint, message))?;
+        .map_err(|message| Error::invalid_argument("metrics", endpoint, message))?;
 
     let connection = Connection::connect_for(&cmd.connection, "metrics").await?;
 
     let name = if name.contains('.') {
         name
     } else {
-        resolve_alias(&cmd, &connection, &name).await?
+        resolve_alias(&connection, &name).await?
     };
 
     run_probe(&connection, &name, tags).await
@@ -135,7 +137,11 @@ fn is_blank(name: &str) -> bool {
 /// or slower than the budget simply leaves the error hintless, since the
 /// usage mistake stands on its own.
 async fn require_service(cmd: &Cmd) -> Error {
-    let err = Error::invalid_argument("metrics", &cmd.connection.endpoint, "no metrics service specified");
+    let endpoint = match client::resolve_label(&cmd.connection, "metrics") {
+        Ok(endpoint) => endpoint,
+        Err(err) => return err,
+    };
+    let err = Error::invalid_argument("metrics", endpoint, "no metrics service specified");
 
     match discovery::discover_within(&cmd.connection, METRICS_SERVICE, discovery::DISCOVERY_TIMEOUT).await {
         Ok(services) => err.with_hint(discovery::services_hint(AVAILABLE_SERVICES, NO_SERVICES, &services)),
@@ -213,9 +219,9 @@ async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>) ->
 /// gateway's own answer would map to, so that a monitoring script gets one
 /// exit code for both spellings of the condition. An ambiguous alias, in
 /// contrast, really is bad input.
-async fn resolve_alias(cmd: &Cmd, connection: &Connection, alias: &str) -> Result<String, Error> {
+async fn resolve_alias(connection: &Connection, alias: &str) -> Result<String, Error> {
     let services = discovery::list_services(connection, METRICS_SERVICE).await?;
-    let endpoint = &cmd.connection.endpoint;
+    let endpoint = connection.endpoint();
 
     match discovery::resolve_alias(alias, &services) {
         Resolution::Resolved(name) => Ok(name),

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -130,7 +130,7 @@ async fn run(cmd: Cmd) -> Result<ExitCode, Error> {
         if is_blank(&name) {
             return Err(Error::invalid_argument(
                 "ready",
-                &cmd.connection.endpoint,
+                client::resolve_label(&cmd.connection, "ready")?,
                 "service name must not be empty",
             ));
         }
@@ -140,7 +140,7 @@ async fn run(cmd: Cmd) -> Result<ExitCode, Error> {
         let name = if name.contains('.') {
             name
         } else {
-            resolve_alias(&cmd, &connection, &name).await?
+            resolve_alias(&connection, &name).await?
         };
 
         run_service(&cmd, &connection, &name).await?
@@ -169,7 +169,7 @@ fn is_blank(name: &str) -> bool {
 /// do exist when the probe finds none under that name.
 async fn run_service(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool, Error> {
     let result = if cmd.watch {
-        run_watch(cmd, name).await.map(|()| true)
+        run_watch(cmd, connection, name).await.map(|()| true)
     } else {
         run_once(cmd, connection, name).await
     };
@@ -229,66 +229,66 @@ async fn run_once(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool
 /// the status block; each subsequent message carries only the scopes that
 /// changed and renders one append-only log line per scope. Returns `Ok(())`
 /// on clean stream close.
-async fn run_watch(cmd: &Cmd, name: &str) -> Result<(), Error> {
+async fn run_watch(cmd: &Cmd, connection: &Connection, name: &str) -> Result<(), Error> {
     let mut snapshot: BTreeMap<(String, String), Scope> = BTreeMap::new();
     let mut name_width: Option<usize> = None;
 
-    client::invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
-        &cmd.connection,
-        "ready",
-        name,
-        "Watch",
-        ReadyRequest { scopes: cmd.scopes.clone() },
-        |resp| {
-            output::data(
-                || &resp.scopes,
-                || {
-                    if resp.scopes.is_empty() {
-                        output::empty(format_args!("No scopes found for {name}."));
-                        return;
-                    }
-
-                    let mut scopes = resp.scopes.clone();
-                    scopes.sort_by(|a, b| a.name.cmp(&b.name));
-
-                    match name_width {
-                        None => {
-                            let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
-                            name_width = Some(width);
-
-                            for scope in &scopes {
-                                snapshot.insert((name.to_owned(), scope.name.clone()), scope.clone());
-                            }
-
-                            render::print_status_block(
-                                name,
-                                &scopes,
-                                width,
-                                cmd.stale_multiple,
-                                SystemTime::now(),
-                                true,
-                            );
+    connection
+        .invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
+            "ready",
+            name,
+            "Watch",
+            ReadyRequest { scopes: cmd.scopes.clone() },
+            |resp| {
+                output::data(
+                    || &resp.scopes,
+                    || {
+                        if resp.scopes.is_empty() {
+                            output::empty(format_args!("No scopes found for {name}."));
+                            return;
                         }
-                        Some(width) => {
-                            for scope in &scopes {
-                                let transition = render::record_transition(&mut snapshot, name, scope);
 
-                                if transition != render::Transition::Unchanged {
-                                    render::print_transition_line(
-                                        render::ServiceColumn::None,
-                                        scope,
-                                        width,
-                                        transition,
-                                    );
+                        let mut scopes = resp.scopes.clone();
+                        scopes.sort_by(|a, b| a.name.cmp(&b.name));
+
+                        match name_width {
+                            None => {
+                                let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
+                                name_width = Some(width);
+
+                                for scope in &scopes {
+                                    snapshot.insert((name.to_owned(), scope.name.clone()), scope.clone());
+                                }
+
+                                render::print_status_block(
+                                    name,
+                                    &scopes,
+                                    width,
+                                    cmd.stale_multiple,
+                                    SystemTime::now(),
+                                    true,
+                                );
+                            }
+                            Some(width) => {
+                                for scope in &scopes {
+                                    let transition = render::record_transition(&mut snapshot, name, scope);
+
+                                    if transition != render::Transition::Unchanged {
+                                        render::print_transition_line(
+                                            render::ServiceColumn::None,
+                                            scope,
+                                            width,
+                                            transition,
+                                        );
+                                    }
                                 }
                             }
                         }
-                    }
-                },
-            );
-        },
-    )
-    .await
+                    },
+                );
+            },
+        )
+        .await
 }
 
 /// Probes every discovered readiness service over one shared connection.
@@ -423,9 +423,9 @@ fn print_missing(missing: &[&str]) {
 /// gateway's own answer would map to, so that a monitoring script gets one exit
 /// code for both spellings of the condition. An ambiguous alias, in contrast,
 /// really is bad input.
-async fn resolve_alias(cmd: &Cmd, connection: &Connection, alias: &str) -> Result<String, Error> {
+async fn resolve_alias(connection: &Connection, alias: &str) -> Result<String, Error> {
     let services = discovery::list_services(connection, READINESS_SERVICE).await?;
-    let endpoint = &cmd.connection.endpoint;
+    let endpoint = connection.endpoint();
 
     match discovery::resolve_alias(alias, &services) {
         Resolution::Resolved(name) => Ok(name),

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -9,7 +9,7 @@ use forwardpb::{
 use serde::{Deserialize, Deserializer, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{self, ConnectionArgs, LayeredChannel, Service},
     completion,
     errors::Error,
     output::{self, CommonFormat},
@@ -295,9 +295,9 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     // gateway.
     let update = match &cmd.mode {
         ModeCmd::Update(update) => {
-            let endpoint = cmd.connection.endpoint.as_str();
-            let mut request =
-                load_request(&update.file).map_err(|e| Error::invalid_argument("update", endpoint, e.to_string()))?;
+            let endpoint = client::resolve_label(&cmd.connection, action)?;
+            let mut request = load_request(&update.file)
+                .map_err(|e| Error::invalid_argument("update", endpoint.clone(), e.to_string()))?;
             bind_request_name(&mut request, &update.config)
                 .map_err(|e| Error::invalid_argument("update", endpoint, e))?;
             Some(request)

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -759,8 +759,11 @@ entries:
         let port = listener.local_addr().unwrap().port();
         drop(listener);
         let connection = ConnectionArgs {
-            endpoint: format!("grpc://127.0.0.1:{port}"),
-            auth: AuthArgs { auth: AuthMethod::None },
+            endpoint: Some(format!("grpc://127.0.0.1:{port}")),
+            auth: AuthArgs {
+                auth: Some(AuthMethod::None),
+                cert_tag: None,
+            },
             tls: TlsArgs::default(),
             timeout: None,
         };


### PR DESCRIPTION
- Adds a YAML configuration file for every `yanet-cli*` binary, read from `/etc/yanet2/cli.yaml` and `${XDG_CONFIG_HOME:-$HOME/.config}/yanet2/cli.yaml`, the personal file merged key-wise over the fleet-wide one, or from the single file named by `YANET_CONFIG`.
- The file follows the `ssh_config` model: flat top-level defaults (`endpoint`, `auth`, `cert_tag`, `ca`, `client_cert`, `client_key`, `timeout`) plus an optional `endpoints:` map of named sections overriding any of them.
- A scheme-less `--endpoint` / `YANET_ENDPOINT` value, or a scheme-less top-level `endpoint` key, selects a section by alias, so `yanet-cli --endpoint m9-r1 …` needs no new flag and no mutable "current context".
- Every key resolves independently with a strict order: flag, environment variable, alias section, top-level file key, built-in default. Resolution lives in `ync`, so the module binaries and the completion path are untouched.
- Adds `--cert-tag` / `YANET_CERT_TAG` and `YANET_AUTH`, removes the compiled-in `:insecure:` tag: `sshcert` without a tag is rejected before any I/O with a message naming the flag, the variable and the file key.
- Adds `yanet-cli config show`, built into the root dispatcher, printing every resolved key with its origin (flag, environment variable, alias section, file, built-in) and the files consulted, in human and JSON form.
- Records the resolution rule in the `code-cli` skill.

Assumptions taken while implementing:

- TLS keys supplied by a file are dropped for `grpc://` and `unix://` targets, so a fleet-wide `ca` does not break a plaintext lab alias. TLS values given on the command line or in the environment still error against a plaintext endpoint as before. `config show` reports such a dropped value as ignored.
- No global `--config` flag: `--config` and `-c` are taken by the acl, balancer2 and unrdup binaries until #2373, so another file is selected with `YANET_CONFIG` only. A file named by `YANET_CONFIG` that does not exist is an error, a missing default-location file is not.
- The environment variable beats an alias section for every key, without exceptions. `YANET_CERT_TAG` exported in a shell profile therefore applies to an alias that sets `auth: none` too, where it is simply unused.
- No `config set`: the host-specific default is a one-line system file deployed alongside `controlplane.d/<name>.yaml`, and rewriting a hand-edited YAML file would lose its comments.
- `serde_yaml 0.9.34` is used because the workspace already depends on it. #2380 replaces it everywhere at once.

Closes #2352.
