### PR TITLE
refactor(cli)!: migrate flags to the dictionary

### DIFF
--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -69,15 +69,20 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
 - Wire values are built with `From` when the request is made
   (`IpAddress::from(addr)`), never parsed from text there.
 - Positional arguments carry the key of an element (`insert <prefix>
-  --via …`, `remove <next-hop>…`, `table create <name>`) or the input
-  document of an `update` (`update -n <name> <path>`); everything else is
-  a flag.
-- Flags: `--name/-n` is the config name and nothing else; `--category` a
-  metric category (`--rules` retires into the positional update document
-  under #2373); `-4/-6` family filters, mutually exclusive (nat64's
-  address pair excepted); `--endpoint` and `--auth` exist only through
-  `ConnectionArgs`. A short flag has one meaning across all binaries and
-  never shadows the global `-v`, so no auto `short` on a subcommand flag.
+  --via …`, `remove <next-hop>…`, `table create <name>`), the file a
+  command consumes (`update -n <name> <path>`, `upload -n <name>
+  <path>`) or a filter pattern (`counters [PATTERN]…`); everything else
+  is a flag. A file never has a flag.
+- Flags: `--name/-n` names the object the binary manages (a config, a map,
+  a sessions state) and nothing else; `-4/-6` family filters, mutually
+  exclusive (nat64's address pair excepted); `--endpoint` and `--auth`
+  exist only through `ConnectionArgs`. A short flag has one meaning across
+  all binaries: `-d` device, `-p` pipeline, or prefix in a binary without
+  pipelines, `-f` function, `-c` chain, `-t` tag, `-i`/`-o` input and
+  output, `-m` module name, `-r` rate. A subcommand flag never shadows the
+  global `-v`, so its `short` always spells the letter. A flag that loses
+  a letter keeps it as a hidden `short_alias` for a release unless the
+  letter moved to another flag of the same command.
 - Verbs: configs `list / show / update` (upsert) `/ delete`; elements inside a
   config `insert` (upsert by key), `add` (strict or idempotent add to a set),
   `remove`; scalars `set-<x>`; the whole object `flush`. A rename keeps the old

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -37,26 +37,26 @@ pub struct Cmd {
 
 #[derive(Debug, Clone, clap::Args, Default)]
 pub struct ByTagsCmd {
-    /// Counter name to show, as an exact name or a Rust regex pattern.
-    #[arg(short, long = "name", value_name = "PATTERN")]
+    /// Counter names to show, each an exact name or a Rust regex pattern.
+    #[arg(value_name = "PATTERN")]
     pub names: Vec<String>,
     /// Device name to filter by.
-    #[arg(short, long)]
+    #[arg(long, short = 'd')]
     pub device: Option<String>,
     /// Pipeline name to filter by.
-    #[arg(short, long)]
+    #[arg(long, short = 'p')]
     pub pipeline: Option<String>,
     /// Function name to filter by.
-    #[arg(short, long)]
+    #[arg(long, short = 'f')]
     pub function: Option<String>,
     /// Chain name to filter by.
-    #[arg(short, long)]
+    #[arg(long, short = 'c')]
     pub chain: Option<String>,
     /// Module type to filter by.
-    #[arg(short = 't', long)]
+    #[arg(long, short_alias = 't')]
     pub module_type: Option<String>,
     /// Module name to filter by.
-    #[arg(short = 'm', long)]
+    #[arg(long, short = 'm')]
     pub module_name: Option<String>,
     /// Owner level to filter by (device, pipeline, function, chain, module,
     /// object).

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -61,7 +61,7 @@ impl ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Function name.
-    #[arg(short, long, add = ArgValueCandidates::new(function_candidates))]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(function_candidates))]
     pub name: String,
 }
 
@@ -72,7 +72,7 @@ pub struct ShowCmd {
 )]
 pub struct UpdateCmd {
     /// Function name.
-    #[arg(short, long, add = ArgValueCandidates::new(function_candidates))]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(function_candidates))]
     pub name: String,
     /// Chains in format `name:weight=type:name,type:name`.
     #[arg(long, required = true)]
@@ -82,7 +82,7 @@ pub struct UpdateCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// Function name.
-    #[arg(short, long, add = ArgValueCandidates::new(function_candidates))]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(function_candidates))]
     pub name: String,
 }
 

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -61,7 +61,7 @@ impl ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Pipeline name.
-    #[arg(short, long, add = ArgValueCandidates::new(pipeline_candidates))]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(pipeline_candidates))]
     pub name: String,
 }
 
@@ -72,7 +72,7 @@ pub struct ShowCmd {
 )]
 pub struct UpdateCmd {
     /// Pipeline name.
-    #[arg(short, long, add = ArgValueCandidates::new(pipeline_candidates))]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(pipeline_candidates))]
     pub name: String,
     /// Pipeline functions.
     #[arg(long, required = true, num_args = 0.., value_delimiter = ',')]
@@ -82,7 +82,7 @@ pub struct UpdateCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// Pipeline name.
-    #[arg(short, long, add = ArgValueCandidates::new(pipeline_candidates))]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(pipeline_candidates))]
     pub name: String,
 }
 

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -40,13 +40,13 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// The name of the device.
-    #[arg(long, short)]
+    #[arg(long, short = 'n')]
     pub name: String,
     /// Pipeline assignments in format "pipeline_name:weight"
-    #[arg(short, long)]
+    #[arg(long, short = 'i')]
     pub input: Vec<String>,
     /// Pipeline assignments in format "pipeline_name:weight"
-    #[arg(short, long)]
+    #[arg(long, short = 'o')]
     pub output: Vec<String>,
 }
 

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -71,10 +71,10 @@ pub struct UpdateCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Input pipeline assignments in "pipeline:weight" format.
-    #[arg(short, long)]
+    #[arg(long, short = 'i')]
     pub input: Vec<String>,
     /// Output pipeline assignments in "pipeline:weight" format.
-    #[arg(short, long)]
+    #[arg(long, short = 'o')]
     pub output: Vec<String>,
 }
 
@@ -91,7 +91,7 @@ pub struct UploadPcapCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Path to the pcap file whose packets are replayed.
-    #[arg(long, short)]
+    #[arg(value_name = "PATH")]
     pub pcap: PathBuf,
 }
 

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -40,13 +40,13 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// The name of the device
-    #[arg(long, short)]
+    #[arg(long, short = 'n')]
     pub name: String,
     /// Pipeline assignments in format "pipeline_name:weight"
-    #[arg(short, long)]
+    #[arg(long, short = 'i')]
     pub input: Vec<String>,
     /// Pipeline assignments in format "pipeline_name:weight"
-    #[arg(short, long)]
+    #[arg(long, short = 'o')]
     pub output: Vec<String>,
     /// VLAN id in 0..=4094, where 0 makes the device emit untagged frames.
     #[arg(long, value_parser = value_parser!(u16).range(0..=4094))]

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -121,3 +121,33 @@ be deleted while any published module config links it — update or delete
 the linking module first. The proto field renumbering on the two rewritten
 services means an old CLI against a new control plane misdecodes requests:
 upgrade the `yanet2-cli` package together with the control plane.
+
+## CLI flags follow one dictionary
+
+The file a command consumes is its positional argument now. Six flags are
+gone without an alias:
+
+```bash
+yanet-cli-acl update --name acl0 acl0.yaml                    # was --rules
+yanet-cli-mirror update --name mirror0 mirror0.yaml           # was --rules
+yanet-cli-route fib update --name route0 route0.yaml          # was --rules
+yanet-cli-unrdup update --name unrdup0 unrdup0.yaml           # was --config
+yanet-cli-balancer2 update --name lb0 --sessions s0 lb0.yaml  # was --config
+yanet-cli-device-trafgen upload --name gen0 replay.pcap       # was --pcap
+```
+
+`yanet-cli-counters` takes its name patterns as positional arguments
+(`yanet-cli-counters 'rx_.*' --device eth0`), `--name` is gone.
+`yanet-cli-dscp set-marking --flag` takes `never`, `default` or `always`
+instead of `0`, `1`, `2`.
+
+Every short letter means one thing in every binary: `-n` name, `-d`
+device, `-p` pipeline or prefix, `-f` function, `-c` chain, `-t` tag.
+Two commands reuse a letter for another flag, so check scripts that pass
+them: `yanet-cli-acl metrics-rules -c` selects a chain now, the config is
+`--name`, and `yanet-cli-balancer2 show -d` expects a device name, the
+old switch is `--detail`. The other displaced letters (`-s` and `-a` in
+balancer2, `-c` in `sessions update`, `-t` in counters, `-f` and `-s` in
+pdump) and the spellings `--config` on `acl metrics-rules` and
+`--prefixes` on `decap update` keep working as hidden aliases for one
+release.

--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -47,9 +47,9 @@ pub struct UpdateCmd {
     /// ACL config name
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
-    /// Path to the ruleset YAML file
-    #[arg(required = true, long = "rules", value_name = "PATH")]
-    pub rules: PathBuf,
+    /// Path to the ruleset YAML file.
+    #[arg(value_name = "PATH")]
+    pub file: PathBuf,
     /// Name of the standalone fwstate-map (kind V4) whose fwtable this
     /// config uses for state lookups
     #[arg(long = "map-name-v4", value_name = "NAME")]
@@ -87,9 +87,9 @@ pub struct ShowCmd {
 
 #[derive(Debug, Clone, Parser, Default)]
 pub struct MetricsRulesCmd {
-    /// ACL config name; omit to match every config
-    #[arg(long = "config", short = 'c', add = ArgValueCandidates::new(crate::config_candidates))]
-    pub config: Option<String>,
+    /// ACL config name, omit to match every config.
+    #[arg(long = "name", short = 'n', alias = "config", add = ArgValueCandidates::new(crate::config_candidates))]
+    pub config_name: Option<String>,
     /// Dataplane device name; omit to match every device
     #[arg(long = "device", short = 'd')]
     pub device: Option<String>,
@@ -100,7 +100,7 @@ pub struct MetricsRulesCmd {
     #[arg(long = "function", short = 'f')]
     pub function: Option<String>,
     /// Pipeline chain name; omit to match every chain
-    #[arg(long = "chain")]
+    #[arg(long = "chain", short = 'c')]
     pub chain: Option<String>,
 }
 

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -289,7 +289,7 @@ impl ACLService {
                 if response.configs.is_empty() {
                     output::empty_with_hint(
                         format_args!("No ACL configurations found."),
-                        format_args!("create one with 'yanet-cli-acl update --name <name> --rules <path>'"),
+                        format_args!("create one with 'yanet-cli-acl update --name <name> <path>'"),
                     );
                     return;
                 }
@@ -338,7 +338,7 @@ impl ACLService {
                 if response.rules.is_empty() {
                     output::empty_with_hint(
                         format_args!("No ACL rules found for '{}'.", cmd.config_name),
-                        format_args!("create one with 'yanet-cli-acl update --name <name> --rules <path>'"),
+                        format_args!("create one with 'yanet-cli-acl update --name <name> <path>'"),
                     );
                 }
             },
@@ -401,10 +401,10 @@ impl ACLService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let config = ACLConfig::load(&cmd.rules).map_err(|err| {
+        let config = ACLConfig::load(&cmd.file).map_err(|err| {
             self.service.invalid(
                 "update",
-                format!("failed to load rules from {}: {err}", cmd.rules.display()),
+                format!("failed to load rules from {}: {err}", cmd.file.display()),
             )
         })?;
         let rule_count = config.rules.len();
@@ -517,7 +517,7 @@ impl ACLService {
 
     pub async fn metrics_rules(&mut self, cmd: MetricsRulesCmd) -> Result<(), Error> {
         let request = GetMetricsRulesRequest {
-            config: cmd.config.clone().unwrap_or_default(),
+            config: cmd.config_name.clone().unwrap_or_default(),
             device: cmd.device.clone().unwrap_or_default(),
             pipeline: cmd.pipeline.clone().unwrap_or_default(),
             function: cmd.function.clone().unwrap_or_default(),
@@ -538,7 +538,7 @@ impl ACLService {
             || &metrics,
             || {
                 if metrics.is_empty() {
-                    match cmd.config.as_deref() {
+                    match cmd.config_name.as_deref() {
                         Some(name) => output::empty(format_args!("No ACL rule metrics found for '{name}'.")),
                         None => output::empty(format_args!("No ACL rule metrics found.")),
                     }

--- a/modules/balancer2/cli/src/config.rs
+++ b/modules/balancer2/cli/src/config.rs
@@ -4,7 +4,7 @@ use core::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     str::FromStr,
 };
-use std::fs::File;
+use std::{fs::File, path::Path};
 
 use filterpb::pb::PortRange;
 use netip::IpNetwork;
@@ -40,7 +40,7 @@ pub struct BalancerConfig {
 }
 
 impl BalancerConfig {
-    pub fn from_yaml_file(path: &str) -> Result<Self, Box<dyn Error>> {
+    pub fn from_yaml_file(path: &Path) -> Result<Self, Box<dyn Error>> {
         Ok(serde_yaml::from_reader(File::open(path)?)?)
     }
 }

--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -9,6 +9,7 @@ use core::{
     net::{AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
 };
+use std::path::PathBuf;
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
@@ -79,12 +80,12 @@ pub struct UpdateCmd {
     /// Balancer configuration name.
     #[arg(long, short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub name: String,
-    /// Path to YAML configuration file.
-    #[arg(long, short = 'c')]
-    pub config: String,
+    /// Path to the YAML configuration file.
+    #[arg(value_name = "PATH")]
+    pub file: PathBuf,
     /// Sessions state name to bind this configuration to (required on first
     /// create; optional on subsequent updates of an existing config).
-    #[arg(long, short = 's', add = ArgValueCandidates::new(sessions_candidates))]
+    #[arg(long, short_alias = 's', add = ArgValueCandidates::new(sessions_candidates))]
     pub sessions: Option<String>,
 }
 
@@ -102,12 +103,12 @@ pub struct ShowCmd {
     pub name: String,
 
     /// Show all counters, active sessions and last packet timestamps.
-    #[arg(long, short = 's')]
+    #[arg(long, short_alias = 's')]
     pub stats: bool,
 
     /// Show allowed sources config per VS (with counters if --stats is
     /// present).
-    #[arg(long, short = 'a')]
+    #[arg(long, short_alias = 'a')]
     pub acl: bool,
 
     /// Show peers per VS.
@@ -119,14 +120,14 @@ pub struct ShowCmd {
     pub decap: bool,
 
     /// Enable all output sections (--stats --acl --peers --decap).
-    #[arg(long, short = 'd')]
+    #[arg(long)]
     pub detail: bool,
 
     #[command(flatten)]
     pub filter: FilterFlags,
 
     /// Filter by device name.
-    #[arg(long)]
+    #[arg(long, short = 'd')]
     pub device: Option<String>,
     /// Filter by pipeline name.
     #[arg(long, short = 'p')]
@@ -135,7 +136,7 @@ pub struct ShowCmd {
     #[arg(long, short = 'f')]
     pub function: Option<String>,
     /// Filter by chain name.
-    #[arg(long)]
+    #[arg(long, short = 'c')]
     pub chain: Option<String>,
 }
 

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -62,8 +62,8 @@ impl Balancer2Service {
     }
 
     async fn update(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let yaml_config = BalancerConfig::from_yaml_file(&cmd.config)
-            .map_err(|err| self.service.invalid("update", err.to_string()))?;
+        let yaml_config =
+            BalancerConfig::from_yaml_file(&cmd.file).map_err(|err| self.service.invalid("update", err.to_string()))?;
         let parts: ConfigParts = yaml_config
             .try_into()
             .map_err(|err: Box<dyn core::error::Error>| self.service.invalid("update", err.to_string()))?;
@@ -109,7 +109,7 @@ impl Balancer2Service {
                     output::empty_with_hint(
                         format_args!("No balancer configurations found."),
                         format_args!(
-                            "create one with 'yanet-cli-balancer2 update --name <name> --config <path> --sessions <sessions-name>'"
+                            "create one with 'yanet-cli-balancer2 update --name <name> --sessions <sessions-name> <path>'"
                         ),
                     );
                     return;

--- a/modules/balancer2/cli/src/sessions.rs
+++ b/modules/balancer2/cli/src/sessions.rs
@@ -35,6 +35,6 @@ pub struct SessionsUpdateCmd {
     #[arg(long, short = 'n', add = ArgValueCandidates::new(crate::sessions_candidates))]
     pub name: String,
     /// Capacity (number of session entries).
-    #[arg(long, short = 'c')]
+    #[arg(long, short_alias = 'c')]
     pub capacity: u64,
 }

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -72,7 +72,7 @@ pub struct UpdateConfigCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Prefixes in the full desired set, replacing the current one entirely.
-    #[arg(long, short, required = true, num_args = 0..)]
+    #[arg(long = "prefix", short = 'p', alias = "prefixes", required = true, num_args = 0..)]
     pub prefixes: Vec<Contiguous<IpNetwork>>,
 }
 
@@ -139,7 +139,7 @@ impl DecapService {
                 if response.configs.is_empty() {
                     output::empty_with_hint(
                         format_args!("No decap configurations found."),
-                        format_args!("create one with 'yanet-cli-decap update --name <name> --prefixes <cidr>'"),
+                        format_args!("create one with 'yanet-cli-decap update --name <name> --prefix <cidr>'"),
                     );
                     return;
                 }
@@ -173,7 +173,7 @@ impl DecapService {
                 if response.prefixes4.is_empty() && response.prefixes6.is_empty() {
                     output::empty_with_hint(
                         format_args!("No decap prefixes found for '{}'.", cmd.config_name),
-                        format_args!("create one with 'yanet-cli-decap update --name <name> --prefixes <cidr>'"),
+                        format_args!("create one with 'yanet-cli-decap update --name <name> --prefix <cidr>'"),
                     );
                     return;
                 }

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{ArgAction, CommandFactory, Parser, ValueEnum, value_parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::partition_prefixes;
 use dscppb::{
@@ -78,7 +78,7 @@ pub struct AddPrefixesCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Prefix to be added to the input filter of the DSCP module.
-    #[arg(long, short, required = true)]
+    #[arg(long, short = 'p', required = true)]
     pub prefix: Vec<Contiguous<IpNetwork>>,
 }
 
@@ -88,7 +88,7 @@ pub struct RemovePrefixesCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Prefix to be removed from the input filter of the DSCP module.
-    #[arg(long, short, required = true)]
+    #[arg(long, short = 'p', required = true)]
     pub prefix: Vec<Contiguous<IpNetwork>>,
 }
 
@@ -97,13 +97,33 @@ pub struct SetDscpMarkingCmd {
     /// DSCP module name to operate on.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
-    /// DSCP marking flag: 0 - Never, 1 - Default (only if original DSCP is 0),
-    /// 2 - Always
-    #[arg(long)]
-    pub flag: u32,
-    /// DSCP mark value (0-63)
-    #[arg(long)]
+    /// When the DSCP field is rewritten.
+    #[arg(long, value_enum)]
+    pub flag: MarkingFlag,
+    /// DSCP mark value in 0..=63.
+    #[arg(long, value_parser = value_parser!(u32).range(0..=63))]
     pub mark: u32,
+}
+
+/// The marking mode of a DSCP config, carried on the wire as its number.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum MarkingFlag {
+    /// Never rewrite the DSCP field.
+    Never,
+    /// Rewrite the DSCP field only when the original value is 0.
+    Default,
+    /// Always rewrite the DSCP field.
+    Always,
+}
+
+impl From<MarkingFlag> for u32 {
+    fn from(flag: MarkingFlag) -> Self {
+        match flag {
+            MarkingFlag::Never => 0,
+            MarkingFlag::Default => 1,
+            MarkingFlag::Always => 2,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -268,21 +288,12 @@ impl DscpService {
     }
 
     pub async fn set_dscp_marking(&mut self, cmd: SetDscpMarkingCmd) -> Result<(), Error> {
-        // Validate flag value
-        if cmd.flag > 2 {
-            return Err(self
-                .service
-                .invalid("set-marking", "Invalid flag value (must be 0, 1, or 2)"));
-        }
-
-        // Validate mark value (6-bit field)
-        if cmd.mark > 63 {
-            return Err(self.service.invalid("set-marking", "Invalid mark value (must be 0-63)"));
-        }
-
         let request = SetDscpMarkingRequest {
             name: cmd.config_name.clone(),
-            dscp_config: Some(DscpConfig { flag: cmd.flag, mark: cmd.mark }),
+            dscp_config: Some(DscpConfig {
+                flag: cmd.flag.into(),
+                mark: cmd.mark,
+            }),
         };
         log::trace!("SetDscpMarkingRequest: {request:?}");
         let response = self

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -82,9 +82,9 @@ pub struct UpdateCmd {
     /// The name of the module config to operate on.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config: String,
-    /// Ruleset file path.
-    #[arg(required = true, long = "rules", value_name = "PATH")]
-    pub rules: PathBuf,
+    /// Path to the ruleset YAML file.
+    #[arg(value_name = "PATH")]
+    pub file: PathBuf,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -290,7 +290,7 @@ impl MirrorService {
                 if config.rules.is_empty() {
                     output::empty_with_hint(
                         format_args!("No mirror rules found for '{}'.", cmd.config_name),
-                        format_args!("create one with 'yanet-cli-mirror update --name <name> --rules <path>'"),
+                        format_args!("create one with 'yanet-cli-mirror update --name <name> <path>'"),
                     );
                 }
             },
@@ -315,7 +315,7 @@ impl MirrorService {
                 if response.configs.is_empty() {
                     output::empty_with_hint(
                         format_args!("No mirror configurations found."),
-                        format_args!("create one with 'yanet-cli-mirror update --name <name> --rules <path>'"),
+                        format_args!("create one with 'yanet-cli-mirror update --name <name> <path>'"),
                     );
                     return;
                 }
@@ -343,7 +343,7 @@ impl MirrorService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let config = MirrorConfig::load(&cmd.rules).map_err(|e| self.service.invalid("update", e.to_string()))?;
+        let config = MirrorConfig::load(&cmd.file).map_err(|e| self.service.invalid("update", e.to_string()))?;
         let rules: Vec<mirrorpb::Rule> = config
             .try_into()
             .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("update", e.to_string()))?;

--- a/modules/pdump/cli/src/args.rs
+++ b/modules/pdump/cli/src/args.rs
@@ -54,7 +54,7 @@ pub struct SetConfigCmd {
     pub mode: Option<crate::dump_mode::Mode>,
 
     /// Snaplen is the maximum packet length to capture.
-    #[arg(long = "snaplen", short = 's')]
+    #[arg(long = "snaplen", short_alias = 's')]
     pub snaplen: Option<u32>,
 
     /// Per-worker ring buffer size
@@ -83,11 +83,11 @@ pub struct ReadCmd {
     /// individual packet, so every record captured in one round shares a
     /// single value. Repeated identical timestamps, including several
     /// leading zeros in the relative forms, are expected.
-    #[clap(long, short = 'f', value_enum, default_value_t = DumpOutputFormat::Text)]
+    #[arg(long, short_alias = 'f', value_enum, default_value_t = DumpOutputFormat::Text)]
     pub dump_format: DumpOutputFormat,
 
     /// Dump output destination.
-    #[clap(long, short = 'o')]
+    #[arg(long, short = 'o')]
     pub output: Option<String>,
 
     /// The number of packets to capture before exiting.

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -97,7 +97,7 @@ pub struct RouteUpdateCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Route prefix
-    #[arg(long = "prefix", short)]
+    #[arg(long = "prefix", short = 'p')]
     pub prefix: Contiguous<IpNetwork>,
     /// The IP address of the tunnel destination.
     #[arg(long = "dst")]
@@ -122,7 +122,7 @@ pub struct RouteWithdrawCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Route prefix
-    #[arg(long = "prefix", short)]
+    #[arg(long = "prefix", short = 'p')]
     pub prefix: Contiguous<IpNetwork>,
     /// The IP address of the tunnel destination.
     #[arg(long = "dst")]

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -164,8 +164,8 @@ pub struct FibUpdateCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Path to the FIB YAML file.
-    #[arg(required = true, long = "rules", value_name = "PATH")]
-    pub rules: PathBuf,
+    #[arg(value_name = "PATH")]
+    pub file: PathBuf,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -245,7 +245,7 @@ impl RouteService {
     }
 
     pub async fn update_fib(&mut self, cmd: FibUpdateCmd) -> Result<(), Error> {
-        let config = FibConfig::load(&cmd.rules).map_err(|err| self.service.invalid("update", err.to_string()))?;
+        let config = FibConfig::load(&cmd.file).map_err(|err| self.service.invalid("update", err.to_string()))?;
         let entry_count = config.entries.len();
         let request = UpdateFibRequest {
             module_name: cmd.config_name.clone(),
@@ -295,7 +295,7 @@ impl RouteService {
                 if response.configs.is_empty() {
                     output::empty_with_hint(
                         format_args!("No FIB configurations found."),
-                        format_args!("create one with 'yanet-cli-route fib update --name <name> --rules <path>'"),
+                        format_args!("create one with 'yanet-cli-route fib update --name <name> <path>'"),
                     );
                     return;
                 }

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -77,8 +77,8 @@ pub struct UpdateConfigCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Path to the YAML file describing the whole configuration.
-    #[arg(long = "config", short = 'c')]
-    pub config_path: PathBuf,
+    #[arg(value_name = "PATH")]
+    pub file: PathBuf,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -288,7 +288,7 @@ impl UnrdupService {
                 if response.configs.is_empty() {
                     output::empty_with_hint(
                         format_args!("No unrdup configurations found."),
-                        format_args!("create one with 'yanet-cli-unrdup update --name <name> --config <path>'"),
+                        format_args!("create one with 'yanet-cli-unrdup update --name <name> <path>'"),
                     );
                     return;
                 }
@@ -335,8 +335,7 @@ impl UnrdupService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Error> {
-        let config =
-            UnrdupConfig::load(&cmd.config_path).map_err(|err| self.service.invalid("update", err.to_string()))?;
+        let config = UnrdupConfig::load(&cmd.file).map_err(|err| self.service.invalid("update", err.to_string()))?;
 
         let request = UpdateConfigRequest {
             name: cmd.config_name.clone(),

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -124,7 +124,7 @@ pub struct AddCmd {
     #[arg(long)]
     pub hardware_addr: MacAddr,
     /// Network interface name.
-    #[arg(long)]
+    #[arg(long, short = 'd')]
     pub device: Option<String>,
     /// Neighbour table name. Defaults to "static".
     #[arg(long, add = ArgValueCandidates::new(table_candidates))]

--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -159,7 +159,7 @@ func (f *TestFramework) CommonConfigCommands() []string {
 		p.CLI("yanet-cli-forward") + " update --name=forward0 " + p.ForwardYAML,
 
 		// Bootstrap the default IPv4/IPv6 FIB for the "route0" config.
-		p.CLI("yanet-cli-route") + " fib update --name=route0 --rules " + p.ConfigDir + "/route0.yaml",
+		p.CLI("yanet-cli-route") + " fib update --name=route0 " + p.ConfigDir + "/route0.yaml",
 
 		p.CLI("yanet-cli-function") + " update --name=virt --chains chain0:10=forward:forward0",
 		p.CLI("yanet-cli-function") + " update --name=test --chains chain2:1=forward:forward0,route:route0",

--- a/tests/functional/main/acl_test.go
+++ b/tests/functional/main/acl_test.go
@@ -25,7 +25,7 @@ func testACL(t *testing.T, fw *framework.TestFramework) {
 	// 1. ACL Configuration Tests
 	fw.Run("Configure_ACL_module", func(fw *framework.TestFramework, t *testing.T) {
 		commands := []string{
-			framework.CLIACL + " update --name acl0 --rules /mnt/yanet2/tests/functional/testdata/acl.yaml",
+			framework.CLIACL + " update --name acl0 /mnt/yanet2/tests/functional/testdata/acl.yaml",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl0,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
 		}
@@ -517,7 +517,7 @@ func testACLMbufLeak(t *testing.T, fw *framework.TestFramework) {
 
 	fw.Run("Configure", func(fw *framework.TestFramework, t *testing.T) {
 		commands := []string{
-			framework.CLIACL + " update --name acl_mbufleak --rules /mnt/yanet2/tests/functional/testdata/acl-mbuf-leak.yaml",
+			framework.CLIACL + " update --name acl_mbufleak /mnt/yanet2/tests/functional/testdata/acl-mbuf-leak.yaml",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_mbufleak,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
 		}

--- a/tests/functional/main/forward_test.go
+++ b/tests/functional/main/forward_test.go
@@ -27,7 +27,7 @@ func deviceCounterValues(
 	command.WriteString(testFramework.Paths.CLI("yanet-cli-counters"))
 	command.WriteString(" --format json --device " + device + " --kind device")
 	for _, name := range names {
-		command.WriteString(" --name " + name)
+		command.WriteString(" " + name)
 	}
 	output, err := testFramework.ExecuteCommand(command.String())
 	require.NoError(t, err)

--- a/tests/functional/main/fwstate_test.go
+++ b/tests/functional/main/fwstate_test.go
@@ -148,7 +148,7 @@ func testFWStateMapListEntries(t *testing.T, fw *framework.TestFramework) {
 	fw.Run("Wire_acl_state_maps", func(fw *framework.TestFramework, t *testing.T) {
 		commands := []string{
 			framework.CLIACL + " update --name acl_fw" +
-				" --rules /mnt/yanet2/tests/functional/testdata/acl+fwstate.yaml" +
+				" /mnt/yanet2/tests/functional/testdata/acl+fwstate.yaml" +
 				" --map-name-v4 " + mapV4 + " --map-name-v6 " + mapV6,
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_fw,fwstate:fwstate0,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
@@ -413,7 +413,7 @@ func testFWStateCheckState(t *testing.T, fw *framework.TestFramework) {
 	fw.Run("Wire_acl_state_maps", func(fw *framework.TestFramework, t *testing.T) {
 		commands := []string{
 			framework.CLIACL + " update --name acl_fw" +
-				" --rules /mnt/yanet2/tests/functional/testdata/acl+fwstate.yaml" +
+				" /mnt/yanet2/tests/functional/testdata/acl+fwstate.yaml" +
 				" --map-name-v4 fwstate0-v4 --map-name-v6 fwstate0-v6",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_fw,fwstate:fwstate0,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
@@ -582,7 +582,7 @@ func testFWStateUDPEndianness(t *testing.T, fw *framework.TestFramework) {
 	fw.Run("Wire_acl_state_maps", func(fw *framework.TestFramework, t *testing.T) {
 		commands := []string{
 			framework.CLIACL + " update --name acl_udp" +
-				" --rules /mnt/yanet2/tests/functional/testdata/acl+fwstate.yaml" +
+				" /mnt/yanet2/tests/functional/testdata/acl+fwstate.yaml" +
 				" --map-name-v4 fwstate_udp-v4 --map-name-v6 fwstate_udp-v6",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_udp,fwstate:fwstate_udp,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
@@ -831,7 +831,7 @@ func testFWStateExternalSyncFrame(t *testing.T, fw *framework.TestFramework) {
 	fw.Run("Wire_acl_state_maps", func(fw *framework.TestFramework, t *testing.T) {
 		commands := []string{
 			framework.CLIACL + " update --name acl_ext" +
-				" --rules /mnt/yanet2/tests/functional/testdata/acl+fwstate.yaml" +
+				" /mnt/yanet2/tests/functional/testdata/acl+fwstate.yaml" +
 				" --map-name-v4 fwstate_ext-v4 --map-name-v6 fwstate_ext-v6",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_ext,fwstate:fwstate_ext,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",

--- a/tests/functional/main/route_test.go
+++ b/tests/functional/main/route_test.go
@@ -71,7 +71,7 @@ func applyFIB(t *testing.T, fw *framework.TestFramework, cfgName, suffix string,
 		"failed to create FIB config file")
 
 	cmd := framework.CLIRoute + " fib update --name=" + cfgName +
-		" --rules /mnt/config/" + name
+		" /mnt/config/" + name
 	_, err = fw.ExecuteCommand(cmd)
 	require.NoError(t, err, "failed to update FIB")
 }


### PR DESCRIPTION
- Retires the file flags of acl, mirror, route, unrdup, balancer2 and trafgen: the file is the positional argument now, without aliases, as forward did in #2437.
- Gives every short letter one meaning across the yanet-cli family (`-n` name, `-d` device, `-p` pipeline or prefix, `-f` function, `-c` chain, `-t` tag, `-i`/`-o` input and output) and keeps a lost letter as a hidden alias for a release unless it moved to another flag of the same command (`acl metrics-rules -c`, `balancer2 show -d`).
- Makes the counters name pattern positional and turns `acl metrics-rules --config` into `--name` with a hidden alias.
- Types `dscp set-marking --flag` as `never|default|always` and bounds `--mark` to 0..=63 in the parser.
- Unifies decap `--prefixes` as `--prefix` with a hidden alias and spells every short letter explicitly.
- Records the amended dictionary in the code-cli skill: `-f` is function and `-c` is chain, a file never has a flag, element-key positionals stay with the verb migration in #2372.
- Adds the manual steps to the upgrade notes and moves the functional tests to the positional file.

Closes #2373.
