### PR TITLE
fix(ci): publish the generic operator image

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -87,6 +87,9 @@ jobs:
           - component: bird-adapter
             image: ghcr.io/yanet-platform/yanet2/bird-adapter
             dockerfile: deploy/bird-adapter.Dockerfile
+          - component: generic-operator
+            image: ghcr.io/yanet-platform/yanet2/generic-operator
+            dockerfile: deploy/yanet-generic-operator.Dockerfile
           - component: pipeline-operator
             image: ghcr.io/yanet-platform/yanet2/pipeline-operator
             dockerfile: deploy/yanet-pipeline-operator.Dockerfile


### PR DESCRIPTION
- Add the generic operator to the container publishing matrix.
- Publish it from the existing Debian-backed Dockerfile under ghcr.io/yanet-platform/yanet2/generic-operator.