### PR TITLE
feat(cli): summarize metrics histograms with percentiles

### DIFF
--- a/cli/core/src/display.rs
+++ b/cli/core/src/display.rs
@@ -192,7 +192,7 @@ impl Glyphs {
             ellipsis: "…",
             bar_full: '█',
             bar_partial: &['▏', '▎', '▍', '▌', '▋', '▊', '▉'],
-            spark: Some(&['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█']),
+            spark: Some(&['▁', '▂', '▃', '▄', '▅', '▆', '▇']),
         }
     }
 
@@ -252,7 +252,9 @@ pub fn bar(count: u64, max: u64, width: usize, glyphs: &Glyphs) -> String {
 ///
 /// An empty bucket takes the lowest glyph and any populated bucket at
 /// least the next one, so a bucket with one observation beside a bucket
-/// with a billion still shows. Returns `None` when the glyph set has no
+/// with a billion still shows. The tallest glyph stops an eighth short of
+/// the cell top, so the sparklines of stacked rows never touch and read
+/// as one column each. Returns `None` when the glyph set has no
 /// sparkline.
 pub fn sparkline(counts: &[u64], glyphs: &Glyphs) -> Option<String> {
     let levels = glyphs.spark?;
@@ -357,13 +359,13 @@ mod test {
 
     #[test]
     fn test_sparkline_scales_to_the_largest_count() {
-        assert_eq!(Some("▁▂▅█".to_owned()), sparkline(&[0, 1, 50, 100], &Glyphs::unicode()));
+        assert_eq!(Some("▁▂▅▇".to_owned()), sparkline(&[0, 1, 50, 100], &Glyphs::unicode()));
     }
 
     #[test]
     fn test_sparkline_nonzero_count_is_never_the_zero_glyph() {
         assert_eq!(
-            Some("█▂".to_owned()),
+            Some("▇▂".to_owned()),
             sparkline(&[1_000_000_000, 1], &Glyphs::unicode())
         );
     }

--- a/cli/core/src/display.rs
+++ b/cli/core/src/display.rs
@@ -145,9 +145,121 @@ pub fn bar_len(count: u64, max_count: u64) -> usize {
     n
 }
 
+/// Glyphs a histogram is drawn with, chosen once from
+/// [`crate::output::is_colored`].
+///
+/// The whole set degrades together, so a non-UTF-8 locale or a piped run
+/// never mixes block characters with ASCII. The sparkline has no ASCII
+/// form at all: a row of punctuation reads worse than no shape, and the
+/// bucket listing still carries it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Glyphs {
+    /// Header of a bucket-bound column, read "at most".
+    pub at_most: &'static str,
+    /// Range separator inside a collapsed run of buckets.
+    pub ellipsis: &'static str,
+    bar_full: char,
+    bar_partial: &'static [char],
+    spark: Option<&'static [char]>,
+}
+
+impl Glyphs {
+    /// Picks the Unicode or ASCII set from the shared colour decision.
+    pub fn detect() -> Self {
+        if crate::output::is_colored() {
+            Self::unicode()
+        } else {
+            Self::ascii()
+        }
+    }
+
+    /// Block characters, eighth-block bar remainders and a sparkline.
+    pub const fn unicode() -> Self {
+        Self {
+            at_most: "≤",
+            ellipsis: "…",
+            bar_full: '█',
+            bar_partial: &['▏', '▎', '▍', '▌', '▋', '▊', '▉'],
+            spark: Some(&['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█']),
+        }
+    }
+
+    /// Hash bars, whole cells only, no sparkline.
+    pub const fn ascii() -> Self {
+        Self {
+            at_most: "<=",
+            ellipsis: "...",
+            bar_full: '#',
+            bar_partial: &[],
+            spark: None,
+        }
+    }
+
+    /// Whether [`sparkline`] draws anything with this set.
+    pub const fn has_sparkline(&self) -> bool {
+        self.spark.is_some()
+    }
+}
+
+/// Draws a bar of at most `width` cells proportional to `count / max`.
+///
+/// A non-zero count always shows at least a partial cell, so a populated
+/// bucket next to a dominant one is never drawn as empty. Zero counts and
+/// a zero maximum draw nothing.
+pub fn bar(count: u64, max: u64, width: usize, glyphs: &Glyphs) -> String {
+    if count == 0 || max == 0 || width == 0 {
+        return String::new();
+    }
+
+    let cells = count as f64 / max as f64 * width as f64;
+    let mut full = cells.floor() as usize;
+    let eighths = ((cells - full as f64) * 8.0).round() as usize;
+
+    if eighths == 8 {
+        full += 1;
+    }
+
+    let mut bar: String = core::iter::repeat_n(glyphs.bar_full, full).collect();
+
+    match glyphs.bar_partial.get(eighths.wrapping_sub(1)) {
+        Some(partial) if eighths < 8 => bar.push(*partial),
+        _ if bar.is_empty() => bar.push(*glyphs.bar_partial.first().unwrap_or(&glyphs.bar_full)),
+        _ => {}
+    }
+
+    bar
+}
+
+/// Draws one character per bucket scaled to the largest count.
+///
+/// An empty bucket takes the lowest glyph and any populated bucket at
+/// least the next one, so a bucket with one observation beside a bucket
+/// with a billion still shows. Returns `None` when the glyph set has no
+/// sparkline.
+pub fn sparkline(counts: &[u64], glyphs: &Glyphs) -> Option<String> {
+    let levels = glyphs.spark?;
+    let max = counts.iter().copied().max().unwrap_or(0);
+    let top = levels.len() - 1;
+
+    let line = counts
+        .iter()
+        .map(|&count| {
+            if count == 0 || max == 0 {
+                return levels[0];
+            }
+
+            let level = 1 + (count as f64 / max as f64 * (top - 1) as f64).round() as usize;
+
+            levels[level.clamp(1, top)]
+        })
+        .collect();
+
+    Some(line)
+}
+
 #[cfg(test)]
 mod test {
-    use super::{bar_len, wrap_words};
+    use super::{bar, bar_len, sparkline, wrap_words, Glyphs};
 
     #[test]
     fn bar_len_scaling() {
@@ -191,5 +303,60 @@ mod test {
     #[test]
     fn wrap_words_empty_text_returns_one_empty_line() {
         assert_eq!(vec![String::new()], wrap_words("", 10));
+    }
+
+    #[test]
+    fn test_bar_full_width_at_the_maximum() {
+        assert_eq!("████", bar(10, 10, 4, &Glyphs::unicode()));
+        assert_eq!("####", bar(10, 10, 4, &Glyphs::ascii()));
+    }
+
+    #[test]
+    fn test_bar_remainder_uses_eighth_blocks() {
+        // 3 of 8 over 4 cells is 1.5 cells: one full block and a half.
+        assert_eq!("█▌", bar(3, 8, 4, &Glyphs::unicode()));
+        assert_eq!("#", bar(3, 8, 4, &Glyphs::ascii()));
+    }
+
+    #[test]
+    fn test_bar_remainder_that_rounds_to_a_whole_cell_becomes_one() {
+        // 15 of 16 over one cell is 0.9375 cells, which rounds to eight
+        // eighths and so to one full block, never to a phantom partial.
+        assert_eq!("█", bar(15, 16, 1, &Glyphs::unicode()));
+    }
+
+    #[test]
+    fn test_bar_nonzero_count_is_never_empty() {
+        assert_eq!("▏", bar(1, 1_000_000, 32, &Glyphs::unicode()));
+        assert_eq!("#", bar(1, 1_000_000, 32, &Glyphs::ascii()));
+    }
+
+    #[test]
+    fn test_bar_zero_count_draws_nothing() {
+        assert_eq!("", bar(0, 10, 4, &Glyphs::unicode()));
+        assert_eq!("", bar(5, 0, 4, &Glyphs::unicode()));
+    }
+
+    #[test]
+    fn test_sparkline_scales_to_the_largest_count() {
+        assert_eq!(Some("▁▂▅█".to_owned()), sparkline(&[0, 1, 50, 100], &Glyphs::unicode()));
+    }
+
+    #[test]
+    fn test_sparkline_nonzero_count_is_never_the_zero_glyph() {
+        assert_eq!(
+            Some("█▂".to_owned()),
+            sparkline(&[1_000_000_000, 1], &Glyphs::unicode())
+        );
+    }
+
+    #[test]
+    fn test_sparkline_all_empty_is_flat() {
+        assert_eq!(Some("▁▁▁".to_owned()), sparkline(&[0, 0, 0], &Glyphs::unicode()));
+    }
+
+    #[test]
+    fn test_sparkline_has_no_ascii_form() {
+        assert_eq!(None, sparkline(&[1, 2, 3], &Glyphs::ascii()));
     }
 }

--- a/cli/core/src/display.rs
+++ b/cli/core/src/display.rs
@@ -40,6 +40,18 @@ pub fn fit_terminal_width(table: &mut Table) {
     }
 }
 
+/// Width in columns [`print_table`] would give `table` on an unbounded
+/// terminal: the shared style applied, nothing wrapped.
+///
+/// Lets a renderer decide what to leave out before the table is fitted,
+/// with the width semantics the renderer itself uses for wide characters
+/// and colour escapes.
+pub fn styled_width(table: &Table) -> usize {
+    let mut table = table.clone();
+    apply_style(&mut table);
+    table.total_width()
+}
+
 /// Returns the current terminal width in columns, detected from stdout.
 ///
 /// Returns `None` when stdout is not a TTY (piped or redirected), matching
@@ -198,6 +210,12 @@ impl Glyphs {
     /// Whether [`sparkline`] draws anything with this set.
     pub const fn has_sparkline(&self) -> bool {
         self.spark.is_some()
+    }
+
+    /// The glyph [`sparkline`] draws for an empty bucket, so a renderer can
+    /// tone the baseline down and let the populated buckets stand out.
+    pub fn spark_zero(&self) -> Option<char> {
+        self.spark.and_then(|levels| levels.first().copied())
     }
 }
 

--- a/cli/core/src/histogram.rs
+++ b/cli/core/src/histogram.rs
@@ -85,11 +85,12 @@ impl Quantile {
 /// Locates the bucket holding the `percent`-th observation.
 ///
 /// The estimate is the bucket's upper bound rather than an interpolated
-/// point: it is exact for integer-valued histograms and a conservative
-/// bound for continuous ones, and it never invents precision the buckets
-/// do not have. The target rank rounds up, so p99 of ten observations is
-/// the tenth. The rank is taken over the bucket counts themselves, so a
-/// stale total on the wire cannot push it past the last bucket.
+/// point: exact when every bucket holds a single integer value, as the
+/// burst histograms do, a conservative bound otherwise, and never a
+/// precision the buckets do not have. The target rank rounds up, so p99 of ten
+/// observations is the tenth. The rank is taken over the bucket counts
+/// themselves, so a stale total on the wire cannot push it past the last
+/// bucket.
 pub fn quantile(buckets: &[Bucket], percent: f64) -> Quantile {
     let total: u64 = buckets.iter().map(|bucket| bucket.count).sum();
 
@@ -215,7 +216,7 @@ pub fn format_share(count: u64, total: u64) -> String {
 }
 
 /// Formats `seconds` on the s/ms/us/ns ladder, picking the coarsest step
-/// on which the rounded value is at least one.
+/// on which the rounded magnitude is at least one.
 fn format_seconds(seconds: f64) -> String {
     const LADDER: [(f64, &str); 4] = [(1.0, "s"), (1e-3, "ms"), (1e-6, "us"), (1e-9, "ns")];
 
@@ -223,11 +224,13 @@ fn format_seconds(seconds: f64) -> String {
         return "0s".to_owned();
     }
 
+    let (sign, magnitude) = sign_and_magnitude(seconds);
+
     for (position, (scale, suffix)) in LADDER.iter().enumerate() {
-        let scaled = round_readable(seconds / scale);
+        let scaled = round_readable(magnitude / scale);
 
         if scaled >= 1.0 || position + 1 == LADDER.len() {
-            return format!("{}{suffix}", render_readable(scaled));
+            return format!("{sign}{}{suffix}", render_readable(scaled));
         }
     }
 
@@ -235,22 +238,32 @@ fn format_seconds(seconds: f64) -> String {
 }
 
 /// Formats `bytes` on the IEC ladder, moving up a step whenever the
-/// rounded value would reach the next one.
+/// rounded magnitude would reach the next one.
 fn format_bytes(bytes: f64) -> String {
     const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
 
-    let mut value = bytes;
+    let (sign, mut value) = sign_and_magnitude(bytes);
     let mut unit = 0;
 
     loop {
         let rounded = round_readable(value);
 
         if rounded < 1024.0 || unit + 1 == UNITS.len() {
-            return format!("{}{}", render_readable(rounded), UNITS[unit]);
+            return format!("{sign}{}{}", render_readable(rounded), UNITS[unit]);
         }
 
         value /= 1024.0;
         unit += 1;
+    }
+}
+
+/// Splits `value` into the sign to print and its magnitude, so a ladder
+/// walks the magnitude and a negative bound keeps its unit.
+fn sign_and_magnitude(value: f64) -> (&'static str, f64) {
+    if value < 0.0 {
+        ("-", -value)
+    } else {
+        ("", value)
     }
 }
 
@@ -344,6 +357,12 @@ mod test {
     }
 
     #[test]
+    fn test_unit_format_seconds_negative_keeps_its_unit() {
+        assert_eq!("-1s", Unit::Seconds.format(-1.0));
+        assert_eq!("-2.5ms", Unit::Seconds.format(-0.0025));
+    }
+
+    #[test]
     fn test_unit_format_bytes_ladder() {
         assert_eq!("512B", Unit::Bytes.format(512.0));
         assert_eq!("1KiB", Unit::Bytes.format(1024.0));
@@ -355,6 +374,11 @@ mod test {
     fn test_unit_format_bytes_rounding_moves_up_a_step() {
         assert_eq!("1KiB", Unit::Bytes.format(1023.9));
         assert_eq!("1023B", Unit::Bytes.format(1023.0));
+    }
+
+    #[test]
+    fn test_unit_format_bytes_negative_keeps_its_unit() {
+        assert_eq!("-2KiB", Unit::Bytes.format(-2048.0));
     }
 
     #[test]

--- a/cli/core/src/histogram.rs
+++ b/cli/core/src/histogram.rs
@@ -46,8 +46,10 @@ impl Unit {
             Self::Seconds => format_seconds(value),
             Self::Bytes => format_bytes(value),
             Self::Plain => {
-                if value >= 0.0 && value.fract() == 0.0 && value < u64::MAX as f64 {
-                    format_number(value as u64)
+                let (sign, magnitude) = sign_and_magnitude(value);
+
+                if magnitude.fract() == 0.0 && magnitude < u64::MAX as f64 {
+                    format!("{sign}{}", format_number(magnitude as u64))
                 } else {
                     render_readable(round_readable(value))
                 }
@@ -399,8 +401,9 @@ mod test {
     }
 
     #[test]
-    fn test_unit_format_plain_negative_is_not_clamped_to_zero() {
+    fn test_unit_format_plain_negative_keeps_separators_and_fractions() {
         assert_eq!("-3", Unit::Plain.format(-3.0));
+        assert_eq!("-1,234,567", Unit::Plain.format(-1_234_567.0));
         assert_eq!("-0.25", Unit::Plain.format(-0.25));
     }
 

--- a/cli/core/src/histogram.rs
+++ b/cli/core/src/histogram.rs
@@ -1,0 +1,505 @@
+//! Histogram arithmetic and unit formatting shared by the metrics CLIs.
+//!
+//! Everything here works on the wire `commonpb` histogram directly and is
+//! pure, so a CLI decides layout and glyphs while every number it prints
+//! comes from one place. Bucket counts on the wire are per bucket, not
+//! cumulative, and the last bucket is the `+Inf` overflow.
+
+use commonpb::pb::Bucket;
+
+use crate::metrics::format_number;
+
+/// Unit of a metric's values, inferred from its name suffix.
+///
+/// Prometheus names carry the base unit as their last segment, so
+/// `_seconds` and `_bytes` are scaled to a readable magnitude and every
+/// other name is printed as a plain number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Unit {
+    Seconds,
+    Bytes,
+    Plain,
+}
+
+impl Unit {
+    /// Infers the unit from a metric name.
+    pub fn of(name: &str) -> Self {
+        if name.ends_with("_seconds") {
+            Self::Seconds
+        } else if name.ends_with("_bytes") {
+            Self::Bytes
+        } else {
+            Self::Plain
+        }
+    }
+
+    /// Formats `value` in this unit, with three significant digits below a
+    /// hundred and the whole part in full from there on.
+    ///
+    /// Seconds walk the s/ms/us/ns ladder and bytes the IEC ladder, both
+    /// choosing the step after rounding so a value just under a step reads
+    /// `1s` or `1KiB` rather than `1000ms` or `1024B`. A plain whole number
+    /// gets thousands separators. Bucket bounds are the main input, so
+    /// `0.001` seconds must read `1ms`, not `0.001`.
+    pub fn format(self, value: f64) -> String {
+        match self {
+            Self::Seconds => format_seconds(value),
+            Self::Bytes => format_bytes(value),
+            Self::Plain => {
+                if value >= 0.0 && value.fract() == 0.0 && value < u64::MAX as f64 {
+                    format_number(value as u64)
+                } else {
+                    render_readable(round_readable(value))
+                }
+            }
+        }
+    }
+}
+
+/// Where a histogram's percentile falls.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Quantile {
+    /// The histogram holds no observations.
+    Empty,
+    /// Inside the bucket with this upper bound.
+    Within(f64),
+    /// Inside the overflow bucket, above this last finite bound.
+    Above(f64),
+    /// Inside an overflow bucket that no finite bound precedes.
+    Unbounded,
+}
+
+impl Quantile {
+    /// Renders the estimate in `unit`: the bucket bound, `>` and the last
+    /// finite bound for an overflow, `-` for no observations.
+    pub fn render(self, unit: Unit) -> String {
+        match self {
+            Self::Empty => "-".to_owned(),
+            Self::Within(bound) => unit.format(bound),
+            Self::Above(bound) => format!(">{}", unit.format(bound)),
+            Self::Unbounded => "+Inf".to_owned(),
+        }
+    }
+}
+
+/// Locates the bucket holding the `percent`-th observation.
+///
+/// The estimate is the bucket's upper bound rather than an interpolated
+/// point: it is exact for integer-valued histograms and a conservative
+/// bound for continuous ones, and it never invents precision the buckets
+/// do not have. The target rank rounds up, so p99 of ten observations is
+/// the tenth. The rank is taken over the bucket counts themselves, so a
+/// stale total on the wire cannot push it past the last bucket.
+pub fn quantile(buckets: &[Bucket], percent: f64) -> Quantile {
+    let total: u64 = buckets.iter().map(|bucket| bucket.count).sum();
+
+    if total == 0 {
+        return Quantile::Empty;
+    }
+
+    let target = ((total as f64 * percent / 100.0).ceil() as u64).clamp(1, total);
+    let mut cumulative = 0;
+    let mut last_finite = None;
+
+    for bucket in buckets {
+        cumulative += bucket.count;
+
+        if cumulative >= target {
+            return if bucket.upper_bound.is_finite() {
+                Quantile::Within(bucket.upper_bound)
+            } else {
+                last_finite.map_or(Quantile::Unbounded, Quantile::Above)
+            };
+        }
+
+        if bucket.upper_bound.is_finite() {
+            last_finite = Some(bucket.upper_bound);
+        }
+    }
+
+    Quantile::Empty
+}
+
+/// One row of an expanded bucket listing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BucketRow {
+    /// A single bucket, by index.
+    Bucket(usize),
+    /// A run of consecutive empty buckets, by first and last index.
+    EmptyRun { first: usize, last: usize },
+}
+
+/// Chooses the rows worth printing for a bucket listing.
+///
+/// Leading and trailing empty buckets are dropped and an interior run of
+/// two or more empty buckets collapses into one row, so a 34-bucket
+/// histogram with five populated buckets prints in a handful of lines
+/// while still showing where its gaps are. A lone empty bucket stays as
+/// is: collapsing it would cost a line, not save one.
+pub fn bucket_rows(buckets: &[Bucket]) -> Vec<BucketRow> {
+    let populated = || buckets.iter().enumerate().filter(|(_, bucket)| bucket.count > 0);
+    let Some((first, _)) = populated().next() else {
+        return Vec::new();
+    };
+    let (last, _) = populated().next_back().expect("a populated bucket exists");
+
+    let mut rows = Vec::new();
+    let mut index = first;
+
+    while index <= last {
+        if buckets[index].count == 0 {
+            let mut end = index;
+
+            while end < last && buckets[end + 1].count == 0 {
+                end += 1;
+            }
+
+            if end > index {
+                rows.push(BucketRow::EmptyRun { first: index, last: end });
+                index = end + 1;
+                continue;
+            }
+        }
+
+        rows.push(BucketRow::Bucket(index));
+        index += 1;
+    }
+
+    rows
+}
+
+/// Labels the bucket at `index` by its upper bound.
+///
+/// The overflow bucket is labelled `>` and the last finite bound before
+/// it, or `+Inf` when no finite bucket precedes it.
+pub fn bucket_label(buckets: &[Bucket], index: usize, unit: Unit) -> String {
+    let bound = buckets[index].upper_bound;
+
+    if bound.is_finite() {
+        return unit.format(bound);
+    }
+
+    let last_finite = buckets[..index]
+        .iter()
+        .rev()
+        .map(|bucket| bucket.upper_bound)
+        .find(|bound| bound.is_finite());
+
+    match last_finite {
+        Some(bound) => format!(">{}", unit.format(bound)),
+        None => "+Inf".to_owned(),
+    }
+}
+
+/// Formats `count` as a percentage of `total` with one decimal.
+///
+/// A non-zero share that rounds to nothing reads `<0.1%` so a populated
+/// bucket is never mistaken for an empty one, and a total of zero reads
+/// `-` since no share exists.
+pub fn format_share(count: u64, total: u64) -> String {
+    if total == 0 {
+        return "-".to_owned();
+    }
+
+    let percent = count as f64 * 100.0 / total as f64;
+
+    if count > 0 && percent < 0.1 {
+        return "<0.1%".to_owned();
+    }
+
+    if count == total {
+        return "100%".to_owned();
+    }
+
+    format!("{percent:.1}%")
+}
+
+/// Formats `seconds` on the s/ms/us/ns ladder, picking the coarsest step
+/// on which the rounded value is at least one.
+fn format_seconds(seconds: f64) -> String {
+    const LADDER: [(f64, &str); 4] = [(1.0, "s"), (1e-3, "ms"), (1e-6, "us"), (1e-9, "ns")];
+
+    if seconds == 0.0 {
+        return "0s".to_owned();
+    }
+
+    for (position, (scale, suffix)) in LADDER.iter().enumerate() {
+        let scaled = round_readable(seconds / scale);
+
+        if scaled >= 1.0 || position + 1 == LADDER.len() {
+            return format!("{}{suffix}", render_readable(scaled));
+        }
+    }
+
+    unreachable!("the last ladder step always matches")
+}
+
+/// Formats `bytes` on the IEC ladder, moving up a step whenever the
+/// rounded value would reach the next one.
+fn format_bytes(bytes: f64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+
+    let mut value = bytes;
+    let mut unit = 0;
+
+    loop {
+        let rounded = round_readable(value);
+
+        if rounded < 1024.0 || unit + 1 == UNITS.len() {
+            return format!("{}{}", render_readable(rounded), UNITS[unit]);
+        }
+
+        value /= 1024.0;
+        unit += 1;
+    }
+}
+
+/// Number of decimals that show three significant digits below a hundred
+/// and none from there on, so the whole part is never cut short.
+fn readable_decimals(value: f64) -> usize {
+    if value == 0.0 {
+        return 0;
+    }
+
+    let magnitude = value.abs().log10().floor() as i32;
+
+    (2 - magnitude).max(0) as usize
+}
+
+/// Rounds `value` to its readable decimals.
+fn round_readable(value: f64) -> f64 {
+    let factor = 10f64.powi(readable_decimals(value) as i32);
+
+    (value * factor).round() / factor
+}
+
+/// Prints an already rounded `value` without trailing zeros, so `2.5`,
+/// `75` and `100` all come out at their natural length.
+fn render_readable(value: f64) -> String {
+    let decimals = readable_decimals(value);
+    let rendered = format!("{value:.decimals$}");
+
+    if rendered.contains('.') {
+        rendered.trim_end_matches('0').trim_end_matches('.').to_owned()
+    } else {
+        rendered
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Builds a wire histogram from `(upper_bound, count)` pairs and appends
+    /// the overflow bucket with `overflow` observations.
+    fn histogram(buckets: &[(f64, u64)], overflow: u64) -> Vec<Bucket> {
+        buckets
+            .iter()
+            .map(|&(upper_bound, count)| Bucket { count, upper_bound })
+            .chain(core::iter::once(Bucket {
+                count: overflow,
+                upper_bound: f64::INFINITY,
+            }))
+            .collect()
+    }
+
+    #[test]
+    fn test_unit_of_seconds_suffix() {
+        assert_eq!(Unit::Seconds, Unit::of("grpc_server_handling_seconds"));
+    }
+
+    #[test]
+    fn test_unit_of_bytes_suffix() {
+        assert_eq!(Unit::Bytes, Unit::of("memory_arena_free_bytes"));
+    }
+
+    #[test]
+    fn test_unit_of_other_suffix_is_plain() {
+        assert_eq!(Unit::Plain, Unit::of("worker_rx_bursts"));
+    }
+
+    #[test]
+    fn test_unit_format_seconds_ladder() {
+        assert_eq!("1ms", Unit::Seconds.format(0.001));
+        assert_eq!("2.5ms", Unit::Seconds.format(0.0025));
+        assert_eq!("75ms", Unit::Seconds.format(0.075));
+        assert_eq!("1s", Unit::Seconds.format(1.0));
+        assert_eq!("1.5s", Unit::Seconds.format(1.5));
+        assert_eq!("10s", Unit::Seconds.format(10.0));
+        assert_eq!("100us", Unit::Seconds.format(0.0001));
+        assert_eq!("250ns", Unit::Seconds.format(0.00000025));
+        assert_eq!("0s", Unit::Seconds.format(0.0));
+    }
+
+    #[test]
+    fn test_unit_format_seconds_rounding_moves_up_a_step() {
+        assert_eq!("1s", Unit::Seconds.format(0.99951));
+        assert_eq!("1ms", Unit::Seconds.format(0.00099951));
+    }
+
+    #[test]
+    fn test_unit_format_seconds_keeps_the_whole_part_above_a_hundred() {
+        assert_eq!("1234s", Unit::Seconds.format(1234.4));
+        assert_eq!("999ms", Unit::Seconds.format(0.9994));
+    }
+
+    #[test]
+    fn test_unit_format_bytes_ladder() {
+        assert_eq!("512B", Unit::Bytes.format(512.0));
+        assert_eq!("1KiB", Unit::Bytes.format(1024.0));
+        assert_eq!("1.5KiB", Unit::Bytes.format(1536.0));
+        assert_eq!("8GiB", Unit::Bytes.format(8_589_934_592.0));
+    }
+
+    #[test]
+    fn test_unit_format_bytes_rounding_moves_up_a_step() {
+        assert_eq!("1KiB", Unit::Bytes.format(1023.9));
+        assert_eq!("1023B", Unit::Bytes.format(1023.0));
+    }
+
+    #[test]
+    fn test_unit_format_bytes_stops_at_the_top_step() {
+        assert_eq!("2048TiB", Unit::Bytes.format(2048.0 * 1024f64.powi(4)));
+    }
+
+    #[test]
+    fn test_unit_format_plain_whole_number_has_separators() {
+        assert_eq!("1,234,567", Unit::Plain.format(1_234_567.0));
+        assert_eq!("0", Unit::Plain.format(0.0));
+    }
+
+    #[test]
+    fn test_unit_format_plain_fraction_keeps_three_significant_digits() {
+        assert_eq!("0.5", Unit::Plain.format(0.5));
+        assert_eq!("12.3", Unit::Plain.format(12.345));
+    }
+
+    #[test]
+    fn test_unit_format_plain_negative_is_not_clamped_to_zero() {
+        assert_eq!("-3", Unit::Plain.format(-3.0));
+        assert_eq!("-0.25", Unit::Plain.format(-0.25));
+    }
+
+    #[test]
+    fn test_quantile_empty_histogram() {
+        let buckets = histogram(&[(1.0, 0), (2.0, 0)], 0);
+
+        assert_eq!(Quantile::Empty, quantile(&buckets, 50.0));
+    }
+
+    #[test]
+    fn test_quantile_first_bucket_holds_low_percentiles() {
+        let buckets = histogram(&[(0.001, 63), (0.002, 6)], 0);
+
+        assert_eq!(Quantile::Within(0.001), quantile(&buckets, 50.0));
+        assert_eq!(Quantile::Within(0.001), quantile(&buckets, 90.0));
+        assert_eq!(Quantile::Within(0.002), quantile(&buckets, 99.0));
+    }
+
+    #[test]
+    fn test_quantile_target_rank_rounds_up() {
+        // Ten observations, nine in the first bucket: p90 is the ninth
+        // observation and still inside it, p91 is the tenth and beyond.
+        let buckets = histogram(&[(1.0, 9), (2.0, 1)], 0);
+
+        assert_eq!(Quantile::Within(1.0), quantile(&buckets, 90.0));
+        assert_eq!(Quantile::Within(2.0), quantile(&buckets, 91.0));
+    }
+
+    #[test]
+    fn test_quantile_overflow_reports_last_finite_bound() {
+        let buckets = histogram(&[(1.0, 1), (5.0, 0)], 9);
+
+        assert_eq!(Quantile::Above(5.0), quantile(&buckets, 99.0));
+    }
+
+    #[test]
+    fn test_quantile_overflow_without_finite_bound_is_unbounded() {
+        let buckets = histogram(&[], 3);
+
+        assert_eq!(Quantile::Unbounded, quantile(&buckets, 50.0));
+    }
+
+    #[test]
+    fn test_quantile_render_per_unit() {
+        assert_eq!("5ms", Quantile::Within(0.005).render(Unit::Seconds));
+        assert_eq!(">10s", Quantile::Above(10.0).render(Unit::Seconds));
+        assert_eq!("-", Quantile::Empty.render(Unit::Plain));
+        assert_eq!("+Inf", Quantile::Unbounded.render(Unit::Plain));
+    }
+
+    #[test]
+    fn test_bucket_rows_trims_edges_and_collapses_runs() {
+        let buckets = histogram(
+            &[(0.0, 0), (1.0, 5), (2.0, 0), (3.0, 0), (4.0, 0), (5.0, 1), (6.0, 0)],
+            0,
+        );
+
+        assert_eq!(
+            vec![
+                BucketRow::Bucket(1),
+                BucketRow::EmptyRun { first: 2, last: 4 },
+                BucketRow::Bucket(5),
+            ],
+            bucket_rows(&buckets)
+        );
+    }
+
+    #[test]
+    fn test_bucket_rows_keeps_single_interior_empty_bucket() {
+        let buckets = histogram(&[(1.0, 5), (2.0, 0), (3.0, 1)], 0);
+
+        assert_eq!(
+            vec![BucketRow::Bucket(0), BucketRow::Bucket(1), BucketRow::Bucket(2)],
+            bucket_rows(&buckets)
+        );
+    }
+
+    #[test]
+    fn test_bucket_rows_populated_overflow_is_kept() {
+        let buckets = histogram(&[(1.0, 5), (2.0, 0)], 2);
+
+        assert_eq!(
+            vec![BucketRow::Bucket(0), BucketRow::Bucket(1), BucketRow::Bucket(2)],
+            bucket_rows(&buckets)
+        );
+    }
+
+    #[test]
+    fn test_bucket_rows_single_populated_bucket() {
+        let buckets = histogram(&[(1.0, 0), (2.0, 7), (3.0, 0)], 0);
+
+        assert_eq!(vec![BucketRow::Bucket(1)], bucket_rows(&buckets));
+    }
+
+    #[test]
+    fn test_bucket_rows_empty_histogram_has_no_rows() {
+        let buckets = histogram(&[(1.0, 0), (2.0, 0)], 0);
+
+        assert!(bucket_rows(&buckets).is_empty());
+    }
+
+    #[test]
+    fn test_bucket_label_finite_and_overflow() {
+        let buckets = histogram(&[(0.005, 1), (0.01, 1)], 1);
+
+        assert_eq!("5ms", bucket_label(&buckets, 0, Unit::Seconds));
+        assert_eq!(">10ms", bucket_label(&buckets, 2, Unit::Seconds));
+    }
+
+    #[test]
+    fn test_bucket_label_overflow_without_finite_bound() {
+        let buckets = histogram(&[], 1);
+
+        assert_eq!("+Inf", bucket_label(&buckets, 0, Unit::Plain));
+    }
+
+    #[test]
+    fn test_format_share_cases() {
+        assert_eq!("91.3%", format_share(63, 69));
+        assert_eq!("100%", format_share(24, 24));
+        assert_eq!("<0.1%", format_share(1, 10_000));
+        assert_eq!("0.0%", format_share(0, 10));
+        assert_eq!("-", format_share(0, 0));
+    }
+}

--- a/cli/core/src/histogram.rs
+++ b/cli/core/src/histogram.rs
@@ -40,8 +40,17 @@ impl Unit {
     /// choosing the step after rounding so a value just under a step reads
     /// `1s` or `1KiB` rather than `1000ms` or `1024B`. A plain whole number
     /// gets thousands separators. Bucket bounds are the main input, so
-    /// `0.001` seconds must read `1ms`, not `0.001`.
+    /// `0.001` seconds must read `1ms`, not `0.001`, and an infinite bound
+    /// keeps its sign as `+Inf` or `-Inf` in every unit.
     pub fn format(self, value: f64) -> String {
+        if value.is_infinite() {
+            return if value > 0.0 { "+Inf" } else { "-Inf" }.to_owned();
+        }
+
+        if value.is_nan() {
+            return "NaN".to_owned();
+        }
+
         match self {
             Self::Seconds => format_seconds(value),
             Self::Bytes => format_bytes(value),
@@ -89,38 +98,49 @@ impl Quantile {
 /// The estimate is the bucket's upper bound rather than an interpolated
 /// point: exact when every bucket holds a single integer value, as the
 /// burst histograms do, a conservative bound otherwise, and never a
-/// precision the buckets do not have. The target rank rounds up, so p99 of ten
-/// observations is the tenth. The rank is taken over the bucket counts
-/// themselves, so a stale total on the wire cannot push it past the last
-/// bucket.
-pub fn quantile(buckets: &[Bucket], percent: f64) -> Quantile {
+/// precision the buckets do not have. The target rank rounds up, so p99 of
+/// ten observations is the tenth, and it is computed in integers so a
+/// count beyond the float mantissa still lands in the right bucket. The
+/// rank is taken over the bucket counts themselves, so a stale total on
+/// the wire cannot push it past the last bucket. Only a `+Inf` bound is
+/// the overflow: a `-Inf` bound is an ordinary bucket that holds exactly
+/// the `-Inf` observations.
+pub fn quantile(buckets: &[Bucket], percent: u8) -> Quantile {
     let total: u64 = buckets.iter().map(|bucket| bucket.count).sum();
 
     if total == 0 {
         return Quantile::Empty;
     }
 
-    let target = ((total as f64 * percent / 100.0).ceil() as u64).clamp(1, total);
-    let mut cumulative = 0;
-    let mut last_finite = None;
+    let target = (u128::from(total) * u128::from(percent))
+        .div_ceil(100)
+        .clamp(1, u128::from(total));
+    let mut cumulative: u128 = 0;
+    let mut last_bound = None;
 
     for bucket in buckets {
-        cumulative += bucket.count;
+        cumulative += u128::from(bucket.count);
 
         if cumulative >= target {
-            return if bucket.upper_bound.is_finite() {
-                Quantile::Within(bucket.upper_bound)
+            return if is_overflow(bucket.upper_bound) {
+                last_bound.map_or(Quantile::Unbounded, Quantile::Above)
             } else {
-                last_finite.map_or(Quantile::Unbounded, Quantile::Above)
+                Quantile::Within(bucket.upper_bound)
             };
         }
 
-        if bucket.upper_bound.is_finite() {
-            last_finite = Some(bucket.upper_bound);
+        if !is_overflow(bucket.upper_bound) {
+            last_bound = Some(bucket.upper_bound);
         }
     }
 
     Quantile::Empty
+}
+
+/// Whether `bound` closes the overflow bucket that catches every
+/// observation above the last real bound.
+fn is_overflow(bound: f64) -> bool {
+    bound == f64::INFINITY
 }
 
 /// One row of an expanded bucket listing.
@@ -173,22 +193,22 @@ pub fn bucket_rows(buckets: &[Bucket]) -> Vec<BucketRow> {
 
 /// Labels the bucket at `index` by its upper bound.
 ///
-/// The overflow bucket is labelled `>` and the last finite bound before
-/// it, or `+Inf` when no finite bucket precedes it.
+/// The overflow bucket is labelled `>` and the last real bound before it,
+/// or `+Inf` when no other bucket precedes it.
 pub fn bucket_label(buckets: &[Bucket], index: usize, unit: Unit) -> String {
     let bound = buckets[index].upper_bound;
 
-    if bound.is_finite() {
+    if !is_overflow(bound) {
         return unit.format(bound);
     }
 
-    let last_finite = buckets[..index]
+    let last_bound = buckets[..index]
         .iter()
         .rev()
         .map(|bucket| bucket.upper_bound)
-        .find(|bound| bound.is_finite());
+        .find(|bound| !is_overflow(*bound));
 
-    match last_finite {
+    match last_bound {
         Some(bound) => format!(">{}", unit.format(bound)),
         None => "+Inf".to_owned(),
     }
@@ -347,6 +367,13 @@ mod test {
     }
 
     #[test]
+    fn test_unit_format_infinite_keeps_its_sign_in_every_unit() {
+        assert_eq!("+Inf", Unit::Seconds.format(f64::INFINITY));
+        assert_eq!("-Inf", Unit::Bytes.format(f64::NEG_INFINITY));
+        assert_eq!("-Inf", Unit::Plain.format(f64::NEG_INFINITY));
+    }
+
+    #[test]
     fn test_unit_format_seconds_rounding_moves_up_a_step() {
         assert_eq!("1s", Unit::Seconds.format(0.99951));
         assert_eq!("1ms", Unit::Seconds.format(0.00099951));
@@ -390,7 +417,7 @@ mod test {
 
     #[test]
     fn test_unit_format_plain_whole_number_has_separators() {
-        assert_eq!("1,234,567", Unit::Plain.format(1_234_567.0));
+        assert_eq!("1'234'567", Unit::Plain.format(1_234_567.0));
         assert_eq!("0", Unit::Plain.format(0.0));
     }
 
@@ -403,7 +430,7 @@ mod test {
     #[test]
     fn test_unit_format_plain_negative_keeps_separators_and_fractions() {
         assert_eq!("-3", Unit::Plain.format(-3.0));
-        assert_eq!("-1,234,567", Unit::Plain.format(-1_234_567.0));
+        assert_eq!("-1'234'567", Unit::Plain.format(-1_234_567.0));
         assert_eq!("-0.25", Unit::Plain.format(-0.25));
     }
 
@@ -411,16 +438,16 @@ mod test {
     fn test_quantile_empty_histogram() {
         let buckets = histogram(&[(1.0, 0), (2.0, 0)], 0);
 
-        assert_eq!(Quantile::Empty, quantile(&buckets, 50.0));
+        assert_eq!(Quantile::Empty, quantile(&buckets, 50));
     }
 
     #[test]
     fn test_quantile_first_bucket_holds_low_percentiles() {
         let buckets = histogram(&[(0.001, 63), (0.002, 6)], 0);
 
-        assert_eq!(Quantile::Within(0.001), quantile(&buckets, 50.0));
-        assert_eq!(Quantile::Within(0.001), quantile(&buckets, 90.0));
-        assert_eq!(Quantile::Within(0.002), quantile(&buckets, 99.0));
+        assert_eq!(Quantile::Within(0.001), quantile(&buckets, 50));
+        assert_eq!(Quantile::Within(0.001), quantile(&buckets, 90));
+        assert_eq!(Quantile::Within(0.002), quantile(&buckets, 99));
     }
 
     #[test]
@@ -429,22 +456,41 @@ mod test {
         // observation and still inside it, p91 is the tenth and beyond.
         let buckets = histogram(&[(1.0, 9), (2.0, 1)], 0);
 
-        assert_eq!(Quantile::Within(1.0), quantile(&buckets, 90.0));
-        assert_eq!(Quantile::Within(2.0), quantile(&buckets, 91.0));
+        assert_eq!(Quantile::Within(1.0), quantile(&buckets, 90));
+        assert_eq!(Quantile::Within(2.0), quantile(&buckets, 91));
+    }
+
+    #[test]
+    fn test_quantile_rank_is_exact_beyond_the_float_mantissa() {
+        // 2^53 observations: the exact p99 rank is 8'917'127'262'193'583,
+        // one more than a float computation gives, and that one lands in
+        // the second bucket.
+        let first = 8_917_127_262_193_582;
+        let buckets = histogram(&[(1.0, first), (2.0, (1u64 << 53) - first)], 0);
+
+        assert_eq!(Quantile::Within(2.0), quantile(&buckets, 99));
+    }
+
+    #[test]
+    fn test_quantile_negative_infinity_is_an_ordinary_bucket() {
+        let buckets = histogram(&[(f64::NEG_INFINITY, 3), (1.0, 1)], 0);
+
+        assert_eq!(Quantile::Within(f64::NEG_INFINITY), quantile(&buckets, 50));
+        assert_eq!("-Inf", quantile(&buckets, 50).render(Unit::Seconds));
     }
 
     #[test]
     fn test_quantile_overflow_reports_last_finite_bound() {
         let buckets = histogram(&[(1.0, 1), (5.0, 0)], 9);
 
-        assert_eq!(Quantile::Above(5.0), quantile(&buckets, 99.0));
+        assert_eq!(Quantile::Above(5.0), quantile(&buckets, 99));
     }
 
     #[test]
     fn test_quantile_overflow_without_finite_bound_is_unbounded() {
         let buckets = histogram(&[], 3);
 
-        assert_eq!(Quantile::Unbounded, quantile(&buckets, 50.0));
+        assert_eq!(Quantile::Unbounded, quantile(&buckets, 50));
     }
 
     #[test]
@@ -512,6 +558,14 @@ mod test {
 
         assert_eq!("5ms", bucket_label(&buckets, 0, Unit::Seconds));
         assert_eq!(">10ms", bucket_label(&buckets, 2, Unit::Seconds));
+    }
+
+    #[test]
+    fn test_bucket_label_negative_infinity_keeps_its_sign() {
+        let buckets = histogram(&[(f64::NEG_INFINITY, 1), (0.5, 1)], 1);
+
+        assert_eq!("-Inf", bucket_label(&buckets, 0, Unit::Plain));
+        assert_eq!(">0.5", bucket_label(&buckets, 2, Unit::Plain));
     }
 
     #[test]

--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod discovery;
 pub mod dispatcher;
 pub mod display;
 pub mod errors;
+pub mod histogram;
 pub mod humanfmt;
 pub mod logging;
 pub mod metrics;

--- a/cli/core/src/metrics.rs
+++ b/cli/core/src/metrics.rs
@@ -110,13 +110,16 @@ pub fn proto_kind(m: &commonpb::pb::Metric) -> Kind {
     }
 }
 
-/// Formats `n` with thousands separators, e.g. `1234567` -> `1,234,567`.
+/// Formats `n` with thousands separators, e.g. `1234567` -> `1'234'567`.
+///
+/// The apostrophe keeps the groups readable at ten digits and cannot be
+/// mistaken for a decimal comma.
 pub fn format_number(n: u64) -> String {
     let s = n.to_string();
     let mut result = String::new();
     for (i, c) in s.chars().rev().enumerate() {
         if i > 0 && i % 3 == 0 {
-            result.push(',');
+            result.push('\'');
         }
         result.push(c);
     }

--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -431,6 +431,31 @@ pub fn paint_dim(text: &str) -> String {
     text.truecolor(127, 127, 127).to_string()
 }
 
+/// Returns `text` in the accent colour of drawn data, such as histogram
+/// bars and sparklines, or plain when colour is off.
+///
+/// Drawn shapes share one colour so a screen of bars does not compete with
+/// the state marks, which keep the standard red, green and yellow for
+/// their meaning. The soft green is a truecolour value like the grey of
+/// [`dim`], so it reads the same on any terminal theme.
+pub fn accent(text: &str) -> String {
+    if is_colored() {
+        text.truecolor(127, 202, 166).to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+/// Returns `text` in bold, the weight a table header row carries, or plain
+/// when colour is off.
+pub fn strong(text: &str) -> String {
+    if is_colored() {
+        text.bold().to_string()
+    } else {
+        text.to_string()
+    }
+}
+
 /// Returns `true` if the current locale advertises UTF-8 encoding.
 fn is_utf8_locale() -> bool {
     for var in ["LC_ALL", "LC_CTYPE", "LANG"] {

--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -431,16 +431,15 @@ pub fn paint_dim(text: &str) -> String {
     text.truecolor(127, 127, 127).to_string()
 }
 
-/// Returns `text` in the accent colour of drawn data, such as histogram
-/// bars and sparklines, or plain when colour is off.
+/// Returns `text` in the green of drawn data, such as histogram bars and
+/// sparklines, or plain when colour is off.
 ///
-/// Drawn shapes share one colour so a screen of bars does not compete with
-/// the state marks, which keep the standard red, green and yellow for
-/// their meaning. The soft green is a truecolour value like the grey of
-/// [`dim`], so it reads the same on any terminal theme.
+/// The standard palette green, the same the success mark uses, so it is
+/// green on every terminal and theme, including multiplexers without
+/// truecolour support.
 pub fn accent(text: &str) -> String {
     if is_colored() {
-        text.truecolor(127, 202, 166).to_string()
+        text.green().to_string()
     } else {
         text.to_string()
     }

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -357,17 +357,6 @@ fn format_number(n: u64) -> String {
     } else if n_f >= 100_000.0 {
         format!("{:.2}K", n_f / THOUSAND)
     } else {
-        // For smaller numbers, use thousand separators
-        let s = n.to_string();
-        let mut result = String::new();
-
-        for (count, c) in s.chars().rev().enumerate() {
-            if count > 0 && count % 3 == 0 {
-                result.push(',');
-            }
-            result.push(c);
-        }
-
-        result.chars().rev().collect()
+        ync::metrics::format_number(n)
     }
 }

--- a/cli/modules/metrics/src/histogram.rs
+++ b/cli/modules/metrics/src/histogram.rs
@@ -34,6 +34,12 @@ const BAR_WIDTH_MIN: usize = 8;
 /// Indent of a series' lines under its block header.
 const SERIES_INDENT: usize = 2;
 
+/// Cell of a series that lacks a label other series of its block carry.
+///
+/// Distinct from an empty cell: a label present with an empty value is a
+/// different series on the server side, and the two must not read alike.
+const ABSENT_LABEL: &str = "-";
+
 /// One histogram series: the wire metric and its histogram value.
 pub struct Series<'a> {
     metric: &'a Metric,
@@ -132,7 +138,8 @@ pub fn print_summary(group: &Group<'_>, glyphs: &Glyphs) {
 
 /// Builds the summary table of a group, header row first.
 ///
-/// Label columns first, then the observation count, the percentiles and,
+/// Label columns first, a series lacking one of them showing the absent
+/// marker, then the observation count, the percentiles and,
 /// when the glyph set has one, a sparkline over every bucket so the rows
 /// share one axis and compare at a glance. A sparkline that would not fit
 /// in `columns` is dropped rather than wrapped: broken across lines it
@@ -153,7 +160,7 @@ fn summary_rows(group: &Group<'_>, glyphs: &Glyphs, columns: Option<usize>) -> V
         let mut row: Vec<String> = group
             .varying
             .iter()
-            .map(|key| label_value(series.metric, key).unwrap_or("").to_owned())
+            .map(|key| label_value(series.metric, key).unwrap_or(ABSENT_LABEL).to_owned())
             .collect();
 
         row.push(format_number(series.histogram.total_count));
@@ -206,7 +213,7 @@ pub fn print_buckets(group: &Group<'_>, glyphs: &Glyphs) {
                 .filter(|label| group.varying.contains(&label.name.as_str()))
                 .collect();
             let identity = if own.is_empty() {
-                "-".to_owned()
+                ABSENT_LABEL.to_owned()
             } else {
                 format_labels(own.into_iter())
             };
@@ -527,6 +534,19 @@ mod test {
         assert_eq!(
             vec![("a_bytes", Unit::Bytes), ("b_seconds", Unit::Seconds)],
             groups.iter().map(|group| (group.name, group.unit)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_summary_rows_tell_an_absent_label_from_an_empty_value() {
+        let metrics = [metric("h", &[("config", "")]), metric("h", &[])];
+        let groups = group(&metrics);
+
+        let rows = summary_rows(&groups[0], &Glyphs::ascii(), None);
+
+        assert_eq!(
+            vec!["", "-"],
+            rows[1..].iter().map(|row| row[0].as_str()).collect::<Vec<_>>()
         );
     }
 

--- a/cli/modules/metrics/src/histogram.rs
+++ b/cli/modules/metrics/src/histogram.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 
 use commonpb::pb::{Histogram, Label, Metric, metric::Value};
 use tabled::{
+    Table,
     builder::Builder,
     settings::{Alignment, Margin, object::Columns},
 };
@@ -24,6 +25,10 @@ use crate::format_labels;
 
 /// Percentiles shown for every series, as percents.
 const PERCENTILES: [f64; 3] = [50.0, 90.0, 99.0];
+
+/// Columns of the summary table after the label columns and before the
+/// optional sparkline: the count and the percentiles.
+const SUMMARY_FIXED: usize = 1 + PERCENTILES.len();
 
 /// Widest bar of a bucket listing, in cells.
 const BAR_WIDTH: usize = 32;
@@ -124,14 +129,17 @@ pub fn group(metrics: &[Metric]) -> Vec<Group<'_>> {
 pub fn print_summary(group: &Group<'_>, glyphs: &Glyphs) {
     print_header(group, glyphs);
 
-    let mut builder = Builder::new();
+    let mut rows = summary_rows(group, glyphs);
+    fit_sparkline(&mut rows, group.varying.len(), display::terminal_width());
 
-    for row in summary_rows(group, glyphs, display::terminal_width()) {
-        builder.push_record(row);
+    if has_sparkline(&rows, group.varying.len()) {
+        for cell in rows.iter_mut().skip(1).filter_map(|row| row.last_mut()) {
+            *cell = paint_sparkline(cell, glyphs);
+        }
     }
 
-    let numeric = group.varying.len()..group.varying.len() + 1 + PERCENTILES.len();
-    let mut table = builder.build();
+    let numeric = group.varying.len()..group.varying.len() + SUMMARY_FIXED;
+    let mut table = table_of(&rows);
     table.modify(Columns::new(numeric), Alignment::right());
     display::print_table(table);
 }
@@ -139,12 +147,10 @@ pub fn print_summary(group: &Group<'_>, glyphs: &Glyphs) {
 /// Builds the summary table of a group, header row first.
 ///
 /// Label columns first, a series lacking one of them showing the absent
-/// marker, then the observation count, the percentiles and,
-/// when the glyph set has one, a sparkline over every bucket so the rows
-/// share one axis and compare at a glance. A sparkline that would not fit
-/// in `columns` is dropped rather than wrapped: broken across lines it
-/// shows nothing, and the bucket listing still carries the shape.
-fn summary_rows(group: &Group<'_>, glyphs: &Glyphs, columns: Option<usize>) -> Vec<Vec<String>> {
+/// marker, then the observation count, the percentiles and, when the glyph
+/// set has one, a sparkline over every bucket so the rows share one axis
+/// and compare at a glance.
+fn summary_rows(group: &Group<'_>, glyphs: &Glyphs) -> Vec<Vec<String>> {
     let mut headers: Vec<String> = group.varying.iter().map(|key| (*key).to_owned()).collect();
     headers.push("count".to_owned());
     headers.extend(PERCENTILES.iter().map(|percent| format!("p{percent:.0}")));
@@ -179,13 +185,74 @@ fn summary_rows(group: &Group<'_>, glyphs: &Glyphs, columns: Option<usize>) -> V
         rows.push(row);
     }
 
-    if glyphs.has_sparkline() && columns.is_some_and(|columns| table_width(&rows) > columns) {
-        for row in &mut rows {
+    rows
+}
+
+/// Drops the sparkline column when the table would not fit in `columns`.
+///
+/// Broken across lines a sparkline shows nothing, and the bucket listing
+/// still carries the shape, so the column goes rather than wraps. The
+/// width is measured the way the table is rendered: wide characters by
+/// their columns, colour escapes not at all.
+fn fit_sparkline(rows: &mut [Vec<String>], label_columns: usize, columns: Option<usize>) {
+    let Some(columns) = columns else {
+        return;
+    };
+
+    if has_sparkline(rows, label_columns) && display::styled_width(&table_of(rows)) > columns {
+        for row in rows.iter_mut() {
             row.pop();
         }
     }
+}
 
-    rows
+/// Whether summary `rows` still carry the sparkline column.
+fn has_sparkline(rows: &[Vec<String>], label_columns: usize) -> bool {
+    rows.first()
+        .is_some_and(|header| header.len() > label_columns + SUMMARY_FIXED)
+}
+
+/// Colours a sparkline so the populated buckets stand out: the empty
+/// baseline dimmed, everything above it in the accent colour.
+fn paint_sparkline(line: &str, glyphs: &Glyphs) -> String {
+    let Some(zero) = glyphs.spark_zero() else {
+        return line.to_owned();
+    };
+
+    let mut painted = String::new();
+    let mut run = String::new();
+    let mut run_is_zero = None;
+
+    for glyph in line.chars().map(Some).chain(core::iter::once(None)) {
+        let is_zero = glyph.map(|glyph| glyph == zero);
+
+        if run_is_zero.is_some() && run_is_zero != is_zero {
+            painted.push_str(&if run_is_zero == Some(true) {
+                output::dim(&run)
+            } else {
+                output::accent(&run)
+            });
+            run.clear();
+        }
+
+        if let Some(glyph) = glyph {
+            run.push(glyph);
+            run_is_zero = is_zero;
+        }
+    }
+
+    painted
+}
+
+/// Builds an unstyled table from `rows`, header row first.
+fn table_of(rows: &[Vec<String>]) -> Table {
+    let mut builder = Builder::new();
+
+    for row in rows {
+        builder.push_record(row.iter().map(String::as_str));
+    }
+
+    builder.build()
 }
 
 /// Prints every series of a group as a bucket listing.
@@ -271,17 +338,11 @@ pub fn print_buckets(group: &Group<'_>, glyphs: &Glyphs) {
 
         for (row, cell) in rows.iter().zip(cells.iter_mut().skip(1)) {
             if let BucketRow::Bucket(index) = *row {
-                cell[3] = display::bar(buckets[index].count, max, width, glyphs);
+                cell[3] = output::accent(&display::bar(buckets[index].count, max, width, glyphs));
             }
         }
 
-        let mut builder = Builder::new();
-
-        for cell in cells {
-            builder.push_record(cell);
-        }
-
-        let mut table = builder.build();
+        let mut table = table_of(&cells);
         table.modify(Columns::new(..3), Alignment::right());
         table.with(Margin::new(SERIES_INDENT * 2, 0, 0, 0));
         display::print_table(table);
@@ -296,7 +357,7 @@ pub fn print_buckets(group: &Group<'_>, glyphs: &Glyphs) {
 /// bucket layout in every producer today, so the header speaks for all of
 /// them.
 fn print_header(group: &Group<'_>, glyphs: &Glyphs) {
-    let mut line = group.name.to_owned();
+    let mut line = output::strong(group.name);
 
     if !group.constant.is_empty() {
         line.push_str("  ");
@@ -326,34 +387,17 @@ fn print_header(group: &Group<'_>, glyphs: &Glyphs) {
 
 /// Picks the bar width that keeps a bucket listing inside the terminal.
 ///
-/// `cells` are the listing's rows with an empty bar column, so their table
-/// width is exactly the part the bar cannot have. Off a terminal the bar
-/// takes its full width.
+/// `cells` are the listing's rows with an empty bar column, so their
+/// rendered width is exactly the part the bar cannot have. Off a terminal
+/// the bar takes its full width.
 fn bar_width(cells: &[Vec<String>]) -> usize {
     let Some(columns) = display::terminal_width() else {
         return BAR_WIDTH;
     };
 
     columns
-        .saturating_sub(SERIES_INDENT * 2 + table_width(cells))
+        .saturating_sub(SERIES_INDENT * 2 + display::styled_width(&table_of(cells)))
         .clamp(BAR_WIDTH_MIN, BAR_WIDTH)
-}
-
-/// Width in columns the shared table style needs for `rows`, header
-/// included: every cell padded by one space on each side and one border
-/// between neighbouring columns.
-fn table_width(rows: &[Vec<String>]) -> usize {
-    let columns = rows.first().map_or(0, Vec::len);
-    let text: usize = (0..columns)
-        .map(|column| {
-            rows.iter()
-                .map(|row| row.get(column).map_or(0, |cell| cell.chars().count()))
-                .max()
-                .unwrap_or(0)
-        })
-        .sum();
-
-    text + 3 * columns - 1
 }
 
 /// Returns the value of the label named `key` on `metric`, if present.
@@ -378,15 +422,31 @@ fn natural_cmp(a: &str, b: &str) -> Ordering {
             (None, None) => return Ordering::Equal,
             (None, Some(_)) => return Ordering::Less,
             (Some(_), None) => return Ordering::Greater,
-            (Some(x), Some(y)) => match (x.parse::<u64>(), y.parse::<u64>()) {
-                (Ok(x), Ok(y)) => x.cmp(&y),
-                _ => x.cmp(y),
-            },
+            (Some(x), Some(y)) => compare_runs(x, y),
         };
 
         if ordering.is_ne() {
             return ordering;
         }
+    }
+}
+
+/// Orders two runs: digit runs by numeric value at any length, anything
+/// else as text.
+///
+/// Digits are compared by length after leading zeros and then digit by
+/// digit, so the order never changes mode on a value too large to parse
+/// and stays a total order, which sorting requires.
+fn compare_runs(x: &str, y: &str) -> Ordering {
+    let is_digits = |run: &str| run.bytes().all(|byte| byte.is_ascii_digit());
+
+    if is_digits(x) && is_digits(y) {
+        let x = x.trim_start_matches('0');
+        let y = y.trim_start_matches('0');
+
+        x.len().cmp(&y.len()).then_with(|| x.cmp(y))
+    } else {
+        x.cmp(y)
     }
 }
 
@@ -542,7 +602,7 @@ mod test {
         let metrics = [metric("h", &[("config", "")]), metric("h", &[])];
         let groups = group(&metrics);
 
-        let rows = summary_rows(&groups[0], &Glyphs::ascii(), None);
+        let rows = summary_rows(&groups[0], &Glyphs::ascii());
 
         assert_eq!(
             vec!["", "-"],
@@ -555,7 +615,8 @@ mod test {
         let metrics = [bursts("0")];
         let groups = group(&metrics);
 
-        let rows = summary_rows(&groups[0], &Glyphs::unicode(), Some(120));
+        let mut rows = summary_rows(&groups[0], &Glyphs::unicode());
+        fit_sparkline(&mut rows, 0, Some(120));
 
         assert_eq!("distribution", rows[0].last().map(String::as_str).unwrap());
         assert_eq!(34, rows[1].last().map(|cell| cell.chars().count()).unwrap());
@@ -566,7 +627,8 @@ mod test {
         let metrics = [bursts("0")];
         let groups = group(&metrics);
 
-        let rows = summary_rows(&groups[0], &Glyphs::unicode(), Some(60));
+        let mut rows = summary_rows(&groups[0], &Glyphs::unicode());
+        fit_sparkline(&mut rows, 0, Some(60));
 
         assert_eq!("p99", rows[0].last().map(String::as_str).unwrap());
         assert!(rows.iter().all(|row| row.len() == rows[0].len()));
@@ -577,7 +639,8 @@ mod test {
         let metrics = [bursts("0")];
         let groups = group(&metrics);
 
-        let rows = summary_rows(&groups[0], &Glyphs::unicode(), None);
+        let mut rows = summary_rows(&groups[0], &Glyphs::unicode());
+        fit_sparkline(&mut rows, 0, None);
 
         assert_eq!("distribution", rows[0].last().map(String::as_str).unwrap());
     }
@@ -587,20 +650,9 @@ mod test {
         let metrics = [bursts("0")];
         let groups = group(&metrics);
 
-        let rows = summary_rows(&groups[0], &Glyphs::ascii(), None);
+        let rows = summary_rows(&groups[0], &Glyphs::ascii());
 
         assert_eq!(vec!["count", "p50", "p90", "p99"], rows[0]);
-    }
-
-    #[test]
-    fn test_table_width_counts_padding_and_borders() {
-        // " ab │ c " is eight columns wide.
-        let rows = vec![
-            vec!["ab".to_owned(), "c".to_owned()],
-            vec!["a".to_owned(), "".to_owned()],
-        ];
-
-        assert_eq!(8, table_width(&rows));
     }
 
     #[test]
@@ -608,6 +660,13 @@ mod test {
         assert_eq!(Ordering::Less, natural_cmp("2", "10"));
         assert_eq!(Ordering::Less, natural_cmp("eth2", "eth10"));
         assert_eq!(Ordering::Equal, natural_cmp("eth10", "eth10"));
+    }
+
+    #[test]
+    fn test_natural_cmp_orders_digit_runs_beyond_u64_and_leading_zeros() {
+        assert_eq!(Ordering::Less, natural_cmp("9", "500000000000000000000"));
+        assert_eq!(Ordering::Greater, natural_cmp("500000000000000000000", "10"));
+        assert_eq!(Ordering::Equal, natural_cmp("007", "7"));
     }
 
     #[test]

--- a/cli/modules/metrics/src/histogram.rs
+++ b/cli/modules/metrics/src/histogram.rs
@@ -24,7 +24,7 @@ use ync::{
 use crate::format_labels;
 
 /// Percentiles shown for every series, as percents.
-const PERCENTILES: [f64; 3] = [50.0, 90.0, 99.0];
+const PERCENTILES: [u8; 3] = [50, 90, 99];
 
 /// Columns of the summary table after the label columns and before the
 /// optional sparkline: the count and the percentiles.
@@ -153,7 +153,7 @@ pub fn print_summary(group: &Group<'_>, glyphs: &Glyphs) {
 fn summary_rows(group: &Group<'_>, glyphs: &Glyphs) -> Vec<Vec<String>> {
     let mut headers: Vec<String> = group.varying.iter().map(|key| (*key).to_owned()).collect();
     headers.push("count".to_owned());
-    headers.extend(PERCENTILES.iter().map(|percent| format!("p{percent:.0}")));
+    headers.extend(PERCENTILES.iter().map(|percent| format!("p{percent}")));
 
     if glyphs.has_sparkline() {
         headers.push("distribution".to_owned());
@@ -290,7 +290,7 @@ pub fn print_buckets(group: &Group<'_>, glyphs: &Glyphs) {
 
         let stats: Vec<String> = PERCENTILES
             .iter()
-            .map(|&percent| format!("p{percent:.0} {}", quantile(buckets, percent).render(group.unit)))
+            .map(|&percent| format!("p{percent} {}", quantile(buckets, percent).render(group.unit)))
             .collect();
 
         println!(

--- a/cli/modules/metrics/src/histogram.rs
+++ b/cli/modules/metrics/src/histogram.rs
@@ -1,0 +1,598 @@
+//! Histogram section of the report: series grouped by metric name.
+//!
+//! Every metric name becomes one block. Labels shared by all of its series
+//! move into the block header and the rest become table columns, so a
+//! block of gRPC handling latencies reads as a table of methods rather
+//! than as eleven copies of the same three-label brace.
+
+use core::cmp::Ordering;
+use std::collections::BTreeMap;
+
+use commonpb::pb::{Histogram, Label, Metric, metric::Value};
+use tabled::{
+    builder::Builder,
+    settings::{Alignment, Margin, object::Columns},
+};
+use ync::{
+    display::{self, Glyphs},
+    histogram::{BucketRow, Unit, bucket_label, bucket_rows, format_share, quantile},
+    metrics::format_number,
+    output,
+};
+
+use crate::format_labels;
+
+/// Percentiles shown for every series, as percents.
+const PERCENTILES: [f64; 3] = [50.0, 90.0, 99.0];
+
+/// Widest bar of a bucket listing, in cells.
+const BAR_WIDTH: usize = 32;
+
+/// Narrowest bar of a bucket listing on a cramped terminal, in cells.
+const BAR_WIDTH_MIN: usize = 8;
+
+/// Indent of a series' lines under its block header.
+const SERIES_INDENT: usize = 2;
+
+/// One histogram series: the wire metric and its histogram value.
+pub struct Series<'a> {
+    metric: &'a Metric,
+    histogram: &'a Histogram,
+}
+
+/// Every series of one metric name, with its labels split into the ones
+/// that vary across the series and the ones they all share.
+pub struct Group<'a> {
+    pub name: &'a str,
+    pub unit: Unit,
+    pub constant: Vec<&'a Label>,
+    pub varying: Vec<&'a str>,
+    pub series: Vec<Series<'a>>,
+}
+
+/// Groups the histogram metrics of a response by name.
+///
+/// Groups come out sorted by name and the series inside a group by their
+/// varying label values, comparing digit runs as numbers so worker 2
+/// precedes worker 10. Label columns keep the order the first series
+/// listed them in.
+pub fn group(metrics: &[Metric]) -> Vec<Group<'_>> {
+    let mut by_name: BTreeMap<&str, Vec<Series<'_>>> = BTreeMap::new();
+
+    for metric in metrics {
+        if let Some(Value::Histogram(histogram)) = &metric.value {
+            by_name
+                .entry(metric.name.as_str())
+                .or_default()
+                .push(Series { metric, histogram });
+        }
+    }
+
+    by_name
+        .into_iter()
+        .map(|(name, mut series)| {
+            let mut keys: Vec<&str> = Vec::new();
+
+            for label in series.iter().flat_map(|series| &series.metric.labels) {
+                if !keys.contains(&label.name.as_str()) {
+                    keys.push(&label.name);
+                }
+            }
+
+            let (varying, constant): (Vec<&str>, Vec<&str>) = keys.iter().partition(|key| {
+                let first = label_value(series[0].metric, key);
+
+                series.iter().any(|series| label_value(series.metric, key) != first)
+            });
+
+            let constant = constant
+                .iter()
+                .filter_map(|key| series[0].metric.labels.iter().find(|label| label.name == *key))
+                .collect();
+
+            series.sort_by(|a, b| {
+                varying
+                    .iter()
+                    .map(|key| {
+                        natural_cmp(
+                            label_value(a.metric, key).unwrap_or(""),
+                            label_value(b.metric, key).unwrap_or(""),
+                        )
+                    })
+                    .find(|ordering| ordering.is_ne())
+                    .unwrap_or(Ordering::Equal)
+            });
+
+            Group {
+                name,
+                unit: Unit::of(name),
+                constant,
+                varying,
+                series,
+            }
+        })
+        .collect()
+}
+
+/// Prints the one-line-per-series table of a group.
+pub fn print_summary(group: &Group<'_>, glyphs: &Glyphs) {
+    print_header(group, glyphs);
+
+    let mut builder = Builder::new();
+
+    for row in summary_rows(group, glyphs, display::terminal_width()) {
+        builder.push_record(row);
+    }
+
+    let numeric = group.varying.len()..group.varying.len() + 1 + PERCENTILES.len();
+    let mut table = builder.build();
+    table.modify(Columns::new(numeric), Alignment::right());
+    display::print_table(table);
+}
+
+/// Builds the summary table of a group, header row first.
+///
+/// Label columns first, then the observation count, the percentiles and,
+/// when the glyph set has one, a sparkline over every bucket so the rows
+/// share one axis and compare at a glance. A sparkline that would not fit
+/// in `columns` is dropped rather than wrapped: broken across lines it
+/// shows nothing, and the bucket listing still carries the shape.
+fn summary_rows(group: &Group<'_>, glyphs: &Glyphs, columns: Option<usize>) -> Vec<Vec<String>> {
+    let mut headers: Vec<String> = group.varying.iter().map(|key| (*key).to_owned()).collect();
+    headers.push("count".to_owned());
+    headers.extend(PERCENTILES.iter().map(|percent| format!("p{percent:.0}")));
+
+    if glyphs.has_sparkline() {
+        headers.push("distribution".to_owned());
+    }
+
+    let mut rows: Vec<Vec<String>> = vec![headers];
+
+    for series in &group.series {
+        let buckets = &series.histogram.buckets;
+        let mut row: Vec<String> = group
+            .varying
+            .iter()
+            .map(|key| label_value(series.metric, key).unwrap_or("").to_owned())
+            .collect();
+
+        row.push(format_number(series.histogram.total_count));
+        row.extend(
+            PERCENTILES
+                .iter()
+                .map(|&percent| quantile(buckets, percent).render(group.unit)),
+        );
+
+        let counts: Vec<u64> = buckets.iter().map(|bucket| bucket.count).collect();
+
+        if let Some(line) = display::sparkline(&counts, glyphs) {
+            row.push(line);
+        }
+
+        rows.push(row);
+    }
+
+    if glyphs.has_sparkline() && columns.is_some_and(|columns| table_width(&rows) > columns) {
+        for row in &mut rows {
+            row.pop();
+        }
+    }
+
+    rows
+}
+
+/// Prints every series of a group as a bucket listing.
+///
+/// Each series gets its distinguishing labels, a stats line and a table
+/// of the buckets worth showing, with the share of observations next to
+/// a bar so a bucket dwarfed by a dominant neighbour still has a number.
+pub fn print_buckets(group: &Group<'_>, glyphs: &Glyphs) {
+    print_header(group, glyphs);
+
+    let indent = " ".repeat(SERIES_INDENT);
+
+    for (position, series) in group.series.iter().enumerate() {
+        if position > 0 {
+            println!();
+        }
+
+        let buckets = &series.histogram.buckets;
+
+        if !group.varying.is_empty() {
+            let own: Vec<&Label> = series
+                .metric
+                .labels
+                .iter()
+                .filter(|label| group.varying.contains(&label.name.as_str()))
+                .collect();
+            let identity = if own.is_empty() {
+                "-".to_owned()
+            } else {
+                format_labels(own.into_iter())
+            };
+
+            println!("{indent}{identity}");
+        }
+
+        let stats: Vec<String> = PERCENTILES
+            .iter()
+            .map(|&percent| format!("p{percent:.0} {}", quantile(buckets, percent).render(group.unit)))
+            .collect();
+
+        println!(
+            "{indent}count {}   {}",
+            format_number(series.histogram.total_count),
+            stats.join("   ")
+        );
+
+        let rows = bucket_rows(buckets);
+
+        if rows.is_empty() {
+            println!("{indent}{indent}{}", output::dim("no observations"));
+            continue;
+        }
+
+        let total: u64 = buckets.iter().map(|bucket| bucket.count).sum();
+        let max = buckets.iter().map(|bucket| bucket.count).max().unwrap_or(0);
+        let label = |index| bucket_label(buckets, index, group.unit);
+
+        // The bar column starts empty so the text columns alone decide how
+        // much of the terminal is left for it.
+        let mut cells: Vec<Vec<String>> = vec![vec![
+            glyphs.at_most.to_owned(),
+            "count".to_owned(),
+            "share".to_owned(),
+            String::new(),
+        ]];
+
+        cells.extend(rows.iter().map(|row| match *row {
+            BucketRow::Bucket(index) => vec![
+                label(index),
+                format_number(buckets[index].count),
+                format_share(buckets[index].count, total),
+                String::new(),
+            ],
+            BucketRow::EmptyRun { first, last } => vec![
+                format!("{} {} {}", label(first), glyphs.ellipsis, label(last)),
+                "0".to_owned(),
+                format_share(0, total),
+                String::new(),
+            ],
+        }));
+
+        let width = bar_width(&cells);
+
+        for (row, cell) in rows.iter().zip(cells.iter_mut().skip(1)) {
+            if let BucketRow::Bucket(index) = *row {
+                cell[3] = display::bar(buckets[index].count, max, width, glyphs);
+            }
+        }
+
+        let mut builder = Builder::new();
+
+        for cell in cells {
+            builder.push_record(cell);
+        }
+
+        let mut table = builder.build();
+        table.modify(Columns::new(..3), Alignment::right());
+        table.with(Margin::new(SERIES_INDENT * 2, 0, 0, 0));
+        display::print_table(table);
+    }
+}
+
+/// Prints the block header: the name, the labels every series shares and,
+/// dimmed, the bucket count with the finite bound range so a sparkline
+/// can be read against its axis.
+///
+/// The range describes the first series. Series of one name share their
+/// bucket layout in every producer today, so the header speaks for all of
+/// them.
+fn print_header(group: &Group<'_>, glyphs: &Glyphs) {
+    let mut line = group.name.to_owned();
+
+    if !group.constant.is_empty() {
+        line.push_str("  ");
+        line.push_str(&format_labels(group.constant.iter().copied()));
+    }
+
+    let buckets = &group.series[0].histogram.buckets;
+    let mut finite = buckets
+        .iter()
+        .map(|bucket| bucket.upper_bound)
+        .filter(|bound| bound.is_finite());
+    let noun = if buckets.len() == 1 { "bucket" } else { "buckets" };
+    let mut meta = format!("{} {noun}", buckets.len());
+
+    if let Some(first) = finite.next() {
+        let last = finite.next_back().unwrap_or(first);
+        meta = format!(
+            "{meta} {} {} {}",
+            group.unit.format(first),
+            glyphs.ellipsis,
+            group.unit.format(last)
+        );
+    }
+
+    println!("{line}   {}", output::dim(&meta));
+}
+
+/// Picks the bar width that keeps a bucket listing inside the terminal.
+///
+/// `cells` are the listing's rows with an empty bar column, so their table
+/// width is exactly the part the bar cannot have. Off a terminal the bar
+/// takes its full width.
+fn bar_width(cells: &[Vec<String>]) -> usize {
+    let Some(columns) = display::terminal_width() else {
+        return BAR_WIDTH;
+    };
+
+    columns
+        .saturating_sub(SERIES_INDENT * 2 + table_width(cells))
+        .clamp(BAR_WIDTH_MIN, BAR_WIDTH)
+}
+
+/// Width in columns the shared table style needs for `rows`, header
+/// included: every cell padded by one space on each side and one border
+/// between neighbouring columns.
+fn table_width(rows: &[Vec<String>]) -> usize {
+    let columns = rows.first().map_or(0, Vec::len);
+    let text: usize = (0..columns)
+        .map(|column| {
+            rows.iter()
+                .map(|row| row.get(column).map_or(0, |cell| cell.chars().count()))
+                .max()
+                .unwrap_or(0)
+        })
+        .sum();
+
+    text + 3 * columns - 1
+}
+
+/// Returns the value of the label named `key` on `metric`, if present.
+fn label_value<'a>(metric: &'a Metric, key: &str) -> Option<&'a str> {
+    metric
+        .labels
+        .iter()
+        .find(|label| label.name == key)
+        .map(|label| label.value.as_str())
+}
+
+/// Orders two label values so that digit runs compare as numbers.
+///
+/// A plain string order puts `10` before `2`, which scrambles worker,
+/// queue and port indices that are the most common label values.
+fn natural_cmp(a: &str, b: &str) -> Ordering {
+    let mut a = chunks(a).into_iter();
+    let mut b = chunks(b).into_iter();
+
+    loop {
+        let ordering = match (a.next(), b.next()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(x), Some(y)) => match (x.parse::<u64>(), y.parse::<u64>()) {
+                (Ok(x), Ok(y)) => x.cmp(&y),
+                _ => x.cmp(y),
+            },
+        };
+
+        if ordering.is_ne() {
+            return ordering;
+        }
+    }
+}
+
+/// Splits `text` into alternating runs of digits and non-digits.
+fn chunks(text: &str) -> Vec<&str> {
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    let mut digits = None;
+
+    for (offset, ch) in text.char_indices() {
+        let is_digit = ch.is_ascii_digit();
+
+        if digits.is_some_and(|current| current != is_digit) {
+            chunks.push(&text[start..offset]);
+            start = offset;
+        }
+
+        digits = Some(is_digit);
+    }
+
+    if start < text.len() {
+        chunks.push(&text[start..]);
+    }
+
+    chunks
+}
+
+#[cfg(test)]
+mod test {
+    use commonpb::pb::Bucket;
+
+    use super::*;
+
+    /// Builds a histogram metric with the given labels and no buckets.
+    fn metric(name: &str, labels: &[(&str, &str)]) -> Metric {
+        Metric {
+            name: name.to_owned(),
+            labels: labels
+                .iter()
+                .map(|&(name, value)| Label {
+                    name: name.to_owned(),
+                    value: value.to_owned(),
+                })
+                .collect(),
+            value: Some(Value::Histogram(Histogram { buckets: Vec::new(), total_count: 0 })),
+        }
+    }
+
+    /// Builds a `worker_rx_bursts`-shaped metric: 34 buckets with every
+    /// observation in the first one, so its sparkline is 34 columns wide.
+    fn bursts(worker: &str) -> Metric {
+        let buckets = (0..=32)
+            .map(|bound| Bucket {
+                count: if bound == 0 { 1_000 } else { 0 },
+                upper_bound: f64::from(bound),
+            })
+            .chain(core::iter::once(Bucket { count: 0, upper_bound: f64::INFINITY }))
+            .collect();
+
+        Metric {
+            name: "worker_rx_bursts".to_owned(),
+            labels: vec![Label {
+                name: "worker_idx".to_owned(),
+                value: worker.to_owned(),
+            }],
+            value: Some(Value::Histogram(Histogram { buckets, total_count: 1_000 })),
+        }
+    }
+
+    /// Returns the values of the label named `key` across a group's series,
+    /// in series order.
+    fn column<'a>(group: &'a Group<'_>, key: &str) -> Vec<&'a str> {
+        group
+            .series
+            .iter()
+            .map(|series| label_value(series.metric, key).unwrap_or(""))
+            .collect()
+    }
+
+    #[test]
+    fn test_group_lifts_shared_labels_into_the_header() {
+        let metrics = [
+            metric("h", &[("method", "Get"), ("service", "svc"), ("kind", "unary")]),
+            metric("h", &[("method", "Put"), ("service", "svc"), ("kind", "unary")]),
+        ];
+
+        let groups = group(&metrics);
+
+        assert_eq!(1, groups.len());
+        assert_eq!(vec!["method"], groups[0].varying);
+        assert_eq!(
+            vec!["service", "kind"],
+            groups[0]
+                .constant
+                .iter()
+                .map(|label| label.name.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_group_single_series_has_only_constant_labels() {
+        let metrics = [metric("h", &[("gateway", "numa0")])];
+
+        let groups = group(&metrics);
+
+        assert!(groups[0].varying.is_empty());
+        assert_eq!("numa0", groups[0].constant[0].value);
+    }
+
+    #[test]
+    fn test_group_label_missing_on_one_series_is_varying() {
+        let metrics = [metric("h", &[("config", "acl0")]), metric("h", &[])];
+
+        let groups = group(&metrics);
+
+        assert_eq!(vec!["config"], groups[0].varying);
+        assert!(groups[0].constant.is_empty());
+    }
+
+    #[test]
+    fn test_group_sorts_series_numerically_by_label_value() {
+        let metrics = [
+            metric("h", &[("worker_idx", "10")]),
+            metric("h", &[("worker_idx", "2")]),
+            metric("h", &[("worker_idx", "1")]),
+        ];
+
+        let groups = group(&metrics);
+
+        assert_eq!(vec!["1", "2", "10"], column(&groups[0], "worker_idx"));
+    }
+
+    #[test]
+    fn test_group_orders_groups_by_metric_name_and_skips_scalars() {
+        let mut metrics = vec![metric("b_seconds", &[]), metric("a_bytes", &[])];
+        metrics.push(Metric {
+            name: "a_total".to_owned(),
+            labels: Vec::new(),
+            value: Some(Value::Counter(1)),
+        });
+
+        let groups = group(&metrics);
+
+        assert_eq!(
+            vec![("a_bytes", Unit::Bytes), ("b_seconds", Unit::Seconds)],
+            groups.iter().map(|group| (group.name, group.unit)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_summary_rows_keep_the_sparkline_when_it_fits() {
+        let metrics = [bursts("0")];
+        let groups = group(&metrics);
+
+        let rows = summary_rows(&groups[0], &Glyphs::unicode(), Some(120));
+
+        assert_eq!("distribution", rows[0].last().map(String::as_str).unwrap());
+        assert_eq!(34, rows[1].last().map(|cell| cell.chars().count()).unwrap());
+    }
+
+    #[test]
+    fn test_summary_rows_drop_the_sparkline_on_a_narrow_terminal() {
+        let metrics = [bursts("0")];
+        let groups = group(&metrics);
+
+        let rows = summary_rows(&groups[0], &Glyphs::unicode(), Some(60));
+
+        assert_eq!("p99", rows[0].last().map(String::as_str).unwrap());
+        assert!(rows.iter().all(|row| row.len() == rows[0].len()));
+    }
+
+    #[test]
+    fn test_summary_rows_keep_the_sparkline_off_a_terminal() {
+        let metrics = [bursts("0")];
+        let groups = group(&metrics);
+
+        let rows = summary_rows(&groups[0], &Glyphs::unicode(), None);
+
+        assert_eq!("distribution", rows[0].last().map(String::as_str).unwrap());
+    }
+
+    #[test]
+    fn test_summary_rows_have_no_sparkline_column_in_ascii() {
+        let metrics = [bursts("0")];
+        let groups = group(&metrics);
+
+        let rows = summary_rows(&groups[0], &Glyphs::ascii(), None);
+
+        assert_eq!(vec!["count", "p50", "p90", "p99"], rows[0]);
+    }
+
+    #[test]
+    fn test_table_width_counts_padding_and_borders() {
+        // " ab │ c " is eight columns wide.
+        let rows = vec![
+            vec!["ab".to_owned(), "c".to_owned()],
+            vec!["a".to_owned(), "".to_owned()],
+        ];
+
+        assert_eq!(8, table_width(&rows));
+    }
+
+    #[test]
+    fn test_natural_cmp_orders_digit_runs_as_numbers() {
+        assert_eq!(Ordering::Less, natural_cmp("2", "10"));
+        assert_eq!(Ordering::Less, natural_cmp("eth2", "eth10"));
+        assert_eq!(Ordering::Equal, natural_cmp("eth10", "eth10"));
+    }
+
+    #[test]
+    fn test_natural_cmp_falls_back_to_text_order() {
+        assert_eq!(Ordering::Less, natural_cmp("Get", "Update"));
+        assert_eq!(Ordering::Less, natural_cmp("eth", "eth1"));
+    }
+}

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -1,13 +1,16 @@
 //! Generic metrics probe CLI.
 
+mod histogram;
+
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
-use commonpb::pb::{GetMetricsRequest, GetMetricsResponse, Histogram, Label, Metric, MetricTag, metric::Value};
+use commonpb::pb::{GetMetricsRequest, GetMetricsResponse, Label, Metric, MetricTag, metric::Value};
 use tabled::Tabled;
 use ync::{
     client::{self, Connection, ConnectionArgs},
     completion,
     discovery::{self, Resolution},
+    display::Glyphs,
     errors::{Error, ErrorKind},
     output::{self, CommonFormat},
 };
@@ -51,6 +54,13 @@ pub struct Cmd {
     /// `--tag 'config=*'`.
     #[arg(long = "tag", short = 't', value_name = "NAME=VALUE", global = true)]
     pub tags: Vec<String>,
+    /// Show every bucket of each histogram instead of one line per series.
+    ///
+    /// Empty buckets at either end are left out and a run of empty buckets
+    /// in the middle collapses into one row. In both views a percentile is
+    /// the upper bound of the bucket holding that observation.
+    #[arg(long)]
+    pub buckets: bool,
     /// Output format.
     #[arg(long, value_enum, default_value = "human", global = true)]
     pub format: CommonFormat,
@@ -99,7 +109,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         resolve_alias(&connection, &name).await?
     };
 
-    run_probe(&connection, &name, tags).await
+    run_probe(&connection, &name, tags, cmd.buckets).await
 }
 
 /// Parses a `NAME=VALUE` tag entry into a [`MetricTag`].
@@ -152,7 +162,7 @@ async fn require_service(cmd: &Cmd) -> Error {
 /// Probes one metrics service's `GetMetrics` over the shared connection, and
 /// suggests the services that do exist when the probe finds none under that
 /// name.
-async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>) -> Result<(), Error> {
+async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>, buckets: bool) -> Result<(), Error> {
     let result = connection
         .invoke_unary::<_, GetMetricsResponse>("metrics", name, "GetMetrics", GetMetricsRequest { tags })
         .await;
@@ -179,28 +189,31 @@ async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>) ->
                 .collect();
             scalars.sort_by(|a, b| a.name.cmp(&b.name));
 
-            let mut histograms: Vec<&Metric> = response
-                .metrics
-                .iter()
-                .filter(|m| matches!(&m.value, Some(Value::Histogram(_))))
-                .collect();
-            histograms.sort_by(|a, b| a.name.cmp(&b.name));
-
             if !scalars.is_empty() {
                 let rows: Vec<MetricRow> = scalars.iter().map(|m| MetricRow::from(*m)).collect();
                 ync::display::print_table_from_entries(rows);
             }
 
-            if !histograms.is_empty() {
-                println!();
-                println!("Histograms");
-                println!();
+            let groups = histogram::group(&response.metrics);
+            let glyphs = Glyphs::detect();
+            let mut printed = !scalars.is_empty();
 
-                for metric in &histograms {
-                    if let Some(Value::Histogram(h)) = &metric.value {
-                        print_histogram(&metric.name, &metric.labels, h);
-                    }
+            for group in &groups {
+                if printed {
+                    println!();
                 }
+
+                if buckets {
+                    histogram::print_buckets(group, &glyphs);
+                } else {
+                    histogram::print_summary(group, &glyphs);
+                }
+
+                printed = true;
+            }
+
+            if !groups.is_empty() {
+                println!();
             }
 
             println!("summary: {total} metrics");
@@ -295,15 +308,14 @@ pub struct MetricRow {
 impl From<&Metric> for MetricRow {
     fn from(m: &Metric) -> Self {
         let labels = {
-            let s = format_labels(&m.labels);
+            let s = format_labels(m.labels.iter());
             if s.is_empty() { "-".to_string() } else { s }
         };
 
         let (kind, value) = match &m.value {
             Some(Value::Counter(c)) => ("counter".to_string(), c.to_string()),
             Some(Value::Gauge(g)) => ("gauge".to_string(), g.to_string()),
-            Some(Value::Histogram(h)) => ("histogram".to_string(), format!("count={}", h.total_count)),
-            None => ("unknown".to_string(), "-".to_string()),
+            Some(Value::Histogram(_)) | None => ("unknown".to_string(), "-".to_string()),
         };
 
         Self {
@@ -317,74 +329,11 @@ impl From<&Metric> for MetricRow {
 
 /// Returns the `k=v, k=v` join of `labels`, or an empty string when `labels`
 /// is empty.
-fn format_labels(labels: &[Label]) -> String {
+fn format_labels<'a>(labels: impl Iterator<Item = &'a Label>) -> String {
     labels
-        .iter()
         .map(|l| format!("{}={}", l.name, l.value))
         .collect::<Vec<_>>()
         .join(", ")
-}
-
-/// Formats `value` as a human-readable bound string.
-///
-/// `+Inf`/`-Inf` become `"inf"`/`"-inf"`, whole numbers become their integer
-/// form, and all other values use the default `f64` display.
-fn format_bound(value: f64) -> String {
-    if value.is_infinite() {
-        if value.is_sign_negative() {
-            return "-inf".to_string();
-        }
-
-        return "inf".to_string();
-    }
-
-    if value.fract() == 0.0 {
-        return format!("{}", value as i64);
-    }
-
-    format!("{value}")
-}
-
-/// Prints a single histogram block to stdout.
-fn print_histogram(name: &str, labels: &[Label], histogram: &Histogram) {
-    let label_str = format_labels(labels);
-    if label_str.is_empty() {
-        println!("{name}");
-    } else {
-        println!("{name} {{{label_str}}}");
-    }
-
-    let buckets = &histogram.buckets;
-
-    if buckets.is_empty() {
-        println!("  count = {}", histogram.total_count);
-        println!();
-        return;
-    }
-
-    let max_count = buckets.iter().map(|b| b.count).max().unwrap_or(0);
-
-    let bounds: Vec<(String, String)> = buckets
-        .iter()
-        .enumerate()
-        .map(|(idx, bucket)| {
-            let lower = if idx == 0 { 0.0 } else { buckets[idx - 1].upper_bound };
-            (format_bound(lower), format_bound(bucket.upper_bound))
-        })
-        .collect();
-
-    let wl = bounds.iter().map(|(l, _)| l.len()).max().unwrap_or(0);
-    let wu = bounds.iter().map(|(_, u)| u.len()).max().unwrap_or(0);
-    let wc = buckets.iter().map(|b| b.count.to_string().len()).max().unwrap_or(0);
-
-    for (bucket, (lower, upper)) in buckets.iter().zip(bounds.iter()) {
-        let bars = "∎".repeat(ync::display::bar_len(bucket.count, max_count));
-        let count = bucket.count;
-        println!("  {lower:>wl$} .. {upper:>wu$} [ {count:>wc$} ] {bars}");
-    }
-
-    println!("  count = {}", histogram.total_count);
-    println!();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Groups histograms by metric name: labels shared by every series move into the block header, the rest become table columns, so the controlplane histogram section shrinks from 401 lines to two blocks.
- Shows one row per series with the observation count, p50/p90/p99 and a sparkline over all buckets. A percentile is the upper bound of the bucket holding that observation, never an interpolated value.
- Adds `--buckets` for the expanded listing: leading and trailing empty buckets are omitted, interior runs of empty buckets collapse into one row, each row carries its share of observations next to the bar.
- Scales bucket bounds by the metric name suffix: `_seconds` reads as `1ms … 5s`, `_bytes` as IEC sizes, everything else as a plain number with thousands separators.
- Degrades glyphs together with the existing colour decision: ASCII bars, `<=` and `...` when colour is off, and no sparkline column there or when the table would not fit the terminal.
- Adds the histogram arithmetic as a new shared module next to the existing metrics types, which private CLIs still consume, and the glyph set, bar and sparkline helpers to the shared display module.
- JSON output is unchanged.
- Draws bars and populated sparkline buckets in green with the empty baseline dimmed, and separates thousands with an apostrophe in the shared number formatter, which the acl and counters human output pick up as well.
- Part of #2366, the watch mode of #2365 follows in a separate change.
