### PR TITLE
chore(controlplane,devices,web)!: drop response fields no server sets

### DIFF
--- a/devices/plain/controlplane/plainpb/v1/plain.proto
+++ b/devices/plain/controlplane/plainpb/v1/plain.proto
@@ -14,4 +14,4 @@ message UpdateDevicePlainRequest {
   common.commonpb.v1.Device device = 2;
 }
 
-message UpdateDevicePlainResponse { string error = 1; }
+message UpdateDevicePlainResponse {}

--- a/devices/plain/web/device.ts
+++ b/devices/plain/web/device.ts
@@ -3,13 +3,10 @@ import type { BaseDevice, DeviceTypeManifest } from '@yanet/core/registry';
 import { IconPlain } from './icon';
 
 const save = async (device: BaseDevice): Promise<Record<string, unknown>> => {
-    const response = await devices.updatePlain({
+    await devices.updatePlain({
         name: device.id.name,
         device: toDevicePayload(device.inputPipelines, device.outputPipelines),
     });
-    if (response.error) {
-        throw new Error(response.error);
-    }
     return {};
 };
 

--- a/devices/vlan/controlplane/vlanpb/v1/vlan.proto
+++ b/devices/vlan/controlplane/vlanpb/v1/vlan.proto
@@ -16,4 +16,4 @@ message UpdateDeviceVlanRequest {
   uint32 vlan = 3;
 }
 
-message UpdateDeviceVlanResponse { string error = 1; }
+message UpdateDeviceVlanResponse {}

--- a/devices/vlan/web/device.ts
+++ b/devices/vlan/web/device.ts
@@ -11,14 +11,11 @@ const vlanExt = (device: BaseDevice): VlanExt =>
 
 const save = async (device: BaseDevice): Promise<Record<string, unknown>> => {
     const { vlanId } = vlanExt(device);
-    const response = await devices.updateVlan({
+    await devices.updateVlan({
         name: device.id.name,
         device: toDevicePayload(device.inputPipelines, device.outputPipelines),
         vlan: vlanId ?? 0,
     });
-    if (response.error) {
-        throw new Error(response.error);
-    }
     return { vlanId: vlanId ?? 0 };
 };
 

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -118,7 +118,7 @@ message DeleteConfigRequest {
   string name = 1;
 }
 
-message DeleteConfigResponse { bool deleted = 1; }
+message DeleteConfigResponse {}
 
 message ListConfigsRequest {}
 

--- a/modules/blackhole/controlplane/blackholepb/v1/blackhole.proto
+++ b/modules/blackhole/controlplane/blackholepb/v1/blackhole.proto
@@ -48,4 +48,4 @@ message UpdateConfigResponse {}
 message DeleteConfigRequest { string name = 1; }
 
 // DeleteConfigResponse is the response to a DeleteConfig call.
-message DeleteConfigResponse { bool deleted = 1; }
+message DeleteConfigResponse {}

--- a/modules/blackhole/controlplane/service.go
+++ b/modules/blackhole/controlplane/service.go
@@ -181,7 +181,7 @@ func (m *BlackholeService) DeleteConfig(
 
 	delete(m.configs, name)
 
-	return &blackholepb.DeleteConfigResponse{Deleted: true}, nil
+	return &blackholepb.DeleteConfigResponse{}, nil
 }
 
 // parkOrFree frees the handle when it is dangling and parks it for

--- a/modules/blackhole/controlplane/service_test.go
+++ b/modules/blackhole/controlplane/service_test.go
@@ -98,9 +98,8 @@ func Test_BlackholeService_DeleteConfig(t *testing.T) {
 	_, err := svc.UpdateConfig(ctx, &blackholepb.UpdateConfigRequest{Name: "blackhole0"})
 	require.NoError(t, err)
 
-	resp, err := svc.DeleteConfig(ctx, &blackholepb.DeleteConfigRequest{Name: "blackhole0"})
+	_, err = svc.DeleteConfig(ctx, &blackholepb.DeleteConfigRequest{Name: "blackhole0"})
 	require.NoError(t, err)
-	require.True(t, resp.Deleted)
 
 	_, err = svc.ShowConfig(ctx, &blackholepb.ShowConfigRequest{Name: "blackhole0"})
 	require.Equal(t, codes.NotFound, status.Code(err))

--- a/modules/forward/controlplane/forwardpb/v1/forward.proto
+++ b/modules/forward/controlplane/forwardpb/v1/forward.proto
@@ -85,7 +85,7 @@ message UpdateConfigRequest {
   repeated Rule rules = 2;
 }
 
-message UpdateConfigResponse { string error = 1; }
+message UpdateConfigResponse {}
 
 // Delete config with specified name.
 message DeleteConfigRequest {
@@ -94,4 +94,4 @@ message DeleteConfigRequest {
   string name = 1;
 }
 
-message DeleteConfigResponse { bool deleted = 1; }
+message DeleteConfigResponse {}

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -250,7 +250,7 @@ func (m *ForwardService) DeleteConfig(ctx context.Context, req *forwardpb.Delete
 
 	delete(m.configs, name)
 
-	return &forwardpb.DeleteConfigResponse{Deleted: true}, nil
+	return &forwardpb.DeleteConfigResponse{}, nil
 }
 
 // parkOrFree frees the handle when it is dangling and parks it for

--- a/modules/mirror/controlplane/mirrorpb/v1/mirror.proto
+++ b/modules/mirror/controlplane/mirrorpb/v1/mirror.proto
@@ -66,9 +66,9 @@ message UpdateConfigRequest {
   repeated Rule rules = 2;
 }
 
-message UpdateConfigResponse { string error = 1; }
+message UpdateConfigResponse {}
 
 // Delete config with specified name.
 message DeleteConfigRequest { string name = 1; }
 
-message DeleteConfigResponse { bool deleted = 1; }
+message DeleteConfigResponse {}

--- a/modules/mirror/controlplane/service.go
+++ b/modules/mirror/controlplane/service.go
@@ -222,7 +222,7 @@ func (m *MirrorService) DeleteConfig(
 
 	delete(m.configs, name)
 
-	return &mirrorpb.DeleteConfigResponse{Deleted: true}, nil
+	return &mirrorpb.DeleteConfigResponse{}, nil
 }
 
 // parkOrFree frees the handle when it is dangling and parks it for

--- a/modules/route-mpls/controlplane/routemplspb/v1/routempls.proto
+++ b/modules/route-mpls/controlplane/routemplspb/v1/routempls.proto
@@ -78,7 +78,7 @@ message DeleteConfigRequest {
   string name = 1;
 }
 
-message DeleteConfigResponse { bool deleted = 1; }
+message DeleteConfigResponse {}
 
 message ListConfigsRequest {}
 

--- a/web/src/core/api/acl.ts
+++ b/web/src/core/api/acl.ts
@@ -95,9 +95,7 @@ export interface DeleteConfigRequest {
     name?: string;
 }
 
-export interface DeleteConfigResponse {
-    deleted?: boolean;
-}
+export interface DeleteConfigResponse {}
 
 const aclService = createService('modules.acl.controlplane.aclpb.v1.ACLService');
 

--- a/web/src/core/api/devices.ts
+++ b/web/src/core/api/devices.ts
@@ -30,9 +30,7 @@ export interface UpdateDevicePlainRequest {
     device?: Device;
 }
 
-export interface UpdateDevicePlainResponse {
-    error?: string;
-}
+export interface UpdateDevicePlainResponse {}
 
 // VLAN device update request/response
 export interface UpdateDeviceVlanRequest {
@@ -41,9 +39,7 @@ export interface UpdateDeviceVlanRequest {
     vlan?: number;
 }
 
-export interface UpdateDeviceVlanResponse {
-    error?: string;
-}
+export interface UpdateDeviceVlanResponse {}
 
 /** Device type discriminator; the concrete set is owned by the device registry. */
 export type DeviceType = string;

--- a/web/src/core/api/forward.ts
+++ b/web/src/core/api/forward.ts
@@ -89,17 +89,13 @@ export interface UpdateConfigRequest {
     rules?: Rule[];
 }
 
-export interface UpdateConfigResponse {
-    error?: string;
-}
+export interface UpdateConfigResponse {}
 
 export interface DeleteConfigRequest {
     name?: string;
 }
 
-export interface DeleteConfigResponse {
-    deleted?: boolean;
-}
+export interface DeleteConfigResponse {}
 
 const forwardService = createService('modules.forward.controlplane.forwardpb.v1.ForwardService');
 


### PR DESCRIPTION
- Remove `DeleteConfigResponse.deleted` from acl, blackhole, forward, mirror and route-mpls, `UpdateConfigResponse.error` from forward and mirror, and `UpdateDevice{Plain,Vlan}Response.error` from the plain and vlan devices.
- Stop blackhole, forward and mirror from setting the constant `Deleted: true`, and drop the blackhole assertion on it; the surviving `ShowConfig` NotFound check is what pins the deletion.
- Mirror the removal in the web API types and delete the unreachable `if (response.error) throw` branches in the plain and vlan device save paths.
- Leave `truncated` on the trafgen `ShowPacketsResponse` in place: the server sets it to a truthful `false`, the web renders it, and a cap is still to come.
- Accept nine field deletions from frozen `.v1` packages against the rule in `docs/proto-compatibility.md`. The `Buf breaking` job reports eight of them, since `modules/acl` sits in the `buf.yaml` ignore list for an unrelated cutover. No client anywhere reads any of the fields: the Rust CLIs discard the responses, the pipeline operator discards both `UpdateDevice` replies, and the private tree consumes them only through its pinned submodule copy. Merged deliberately over the red gate, as in #2253.

Closes #2391.
