### PR TITLE
perf(dataplane): resolve pipeline stage hops at publish time

### DIFF
--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -466,14 +466,17 @@ chain_ectx_free(
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
-	for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
-		struct module_ectx *module_ectx =
-			ADDR_OF(&chain_ectx->modules[idx].module_ectx);
-		if (module_ectx == NULL) {
-			continue;
-		}
+	struct module_ectx **module_ptrs = ADDR_OF(&chain_ectx->module_ptrs);
+	if (module_ptrs != NULL) {
+		for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
+			struct module_ectx *module_ectx =
+				ADDR_OF(module_ptrs + idx);
+			if (module_ectx == NULL) {
+				continue;
+			}
 
-		module_ectx_free(cp_config_gen, module_ectx);
+			module_ectx_free(cp_config_gen, module_ectx);
+		}
 	}
 	struct counter_storage *counter_storage =
 		ADDR_OF(&chain_ectx->counter_storage);
@@ -481,11 +484,19 @@ chain_ectx_free(
 		counter_storage_free(counter_storage);
 	}
 
+	if (module_ptrs != NULL) {
+		memory_bfree(
+			memory_context,
+			module_ptrs,
+			sizeof(struct module_ectx *) * chain_ectx->length
+		);
+	}
+
 	memory_bfree(
 		memory_context,
 		chain_ectx,
 		sizeof(struct chain_ectx) +
-			sizeof(struct chain_module_ectx) * chain_ectx->length
+			sizeof(struct module_ectx *) * chain_ectx->length
 	);
 }
 
@@ -504,9 +515,8 @@ chain_ectx_create(
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
-	uint64_t ectx_size =
-		sizeof(struct chain_ectx) +
-		sizeof(struct chain_module_ectx) * cp_chain->length;
+	uint64_t ectx_size = sizeof(struct chain_ectx) +
+			     sizeof(struct module_ectx *) * cp_chain->length;
 	struct chain_ectx *chain_ectx =
 		(struct chain_ectx *)memory_balloc(memory_context, ectx_size);
 	if (chain_ectx == NULL) {
@@ -520,6 +530,21 @@ chain_ectx_create(
 	memset(chain_ectx, 0, ectx_size);
 	SET_OFFSET_OF(&chain_ectx->cp_chain, cp_chain);
 	chain_ectx->length = cp_chain->length;
+
+	struct module_ectx **module_ptrs = (struct module_ectx **)memory_balloc(
+		memory_context, sizeof(struct module_ectx *) * cp_chain->length
+	);
+	if (module_ptrs == NULL && cp_chain->length > 0) {
+		yanet_error_add(
+			err,
+			"failed to allocate memory for the module "
+			"addresses of chain '%s'",
+			cp_chain->name
+		);
+		goto error;
+	}
+	memset(module_ptrs, 0, sizeof(struct module_ectx *) * cp_chain->length);
+	SET_OFFSET_OF(&chain_ectx->module_ptrs, module_ptrs);
 
 	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
 	struct cp_pipeline *cp_pipeline = ADDR_OF(&pipeline_ectx->cp_pipeline);
@@ -617,9 +642,7 @@ chain_ectx_create(
 			goto error;
 		}
 
-		SET_OFFSET_OF(
-			&chain_ectx->modules[idx].module_ectx, module_ectx
-		);
+		SET_OFFSET_OF(module_ptrs + idx, module_ectx);
 	}
 
 	return chain_ectx;
@@ -814,20 +837,32 @@ pipeline_ectx_free(
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
-	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
-		struct function_ectx *function_ectx =
-			ADDR_OF(pipeline_ectx->functions + idx);
-		if (function_ectx == NULL) {
-			continue;
-		}
+	struct function_ectx **function_ptrs =
+		ADDR_OF(&pipeline_ectx->function_ptrs);
+	if (function_ptrs != NULL) {
+		for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
+			struct function_ectx *function_ectx =
+				ADDR_OF(function_ptrs + idx);
+			if (function_ectx == NULL) {
+				continue;
+			}
 
-		function_ectx_free(cp_config_gen, function_ectx);
+			function_ectx_free(cp_config_gen, function_ectx);
+		}
 	}
 
 	struct counter_storage *counter_storage =
 		ADDR_OF(&pipeline_ectx->counter_storage);
 	if (counter_storage != NULL) {
 		counter_storage_free(counter_storage);
+	}
+
+	if (function_ptrs != NULL) {
+		memory_bfree(
+			memory_context,
+			function_ptrs,
+			sizeof(struct function_ectx *) * pipeline_ectx->length
+		);
 	}
 
 	size_t ectx_size =
@@ -865,6 +900,25 @@ pipeline_ectx_create(
 	memset(pipeline_ectx, 0, ectx_size);
 	SET_OFFSET_OF(&pipeline_ectx->cp_pipeline, cp_pipeline);
 	pipeline_ectx->length = cp_pipeline->length;
+
+	struct function_ectx **function_ptrs =
+		(struct function_ectx **)memory_balloc(
+			memory_context,
+			sizeof(struct function_ectx *) * cp_pipeline->length
+		);
+	if (function_ptrs == NULL && cp_pipeline->length > 0) {
+		yanet_error_add(
+			err,
+			"failed to allocate memory for the function "
+			"addresses of pipeline '%s'",
+			cp_pipeline->name
+		);
+		goto error;
+	}
+	memset(function_ptrs,
+	       0,
+	       sizeof(struct function_ectx *) * cp_pipeline->length);
+	SET_OFFSET_OF(&pipeline_ectx->function_ptrs, function_ptrs);
 
 	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
 
@@ -939,7 +993,7 @@ pipeline_ectx_create(
 			goto error;
 		}
 
-		SET_OFFSET_OF(pipeline_ectx->functions + idx, function_ectx);
+		SET_OFFSET_OF(function_ptrs + idx, function_ectx);
 	}
 
 	return pipeline_ectx;
@@ -1082,7 +1136,10 @@ device_entry_ectx_create(
 		for (uint64_t weight_idx = 0;
 		     weight_idx < cp_device_entry->pipelines[idx].weight;
 		     ++weight_idx) {
-			device_entry_ectx->pipeline_map[pos] = idx;
+			SET_OFFSET_OF(
+				device_entry_ectx->pipeline_map + pos,
+				pipeline_ectx
+			);
 			++pos;
 		}
 	}
@@ -1495,9 +1552,9 @@ link_chain_ectx(
 	struct chain_ectx *chain_ectx,
 	yanet_error **err
 ) {
+	struct module_ectx **module_ptrs = ADDR_OF(&chain_ectx->module_ptrs);
 	for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
-		struct module_ectx *module_ectx =
-			ADDR_OF(&chain_ectx->modules[idx].module_ectx);
+		struct module_ectx *module_ectx = ADDR_OF(module_ptrs + idx);
 		if (module_ectx == NULL) {
 			continue;
 		}
@@ -1569,9 +1626,11 @@ link_pipeline_ectx(
 	struct pipeline_ectx *pipeline_ectx,
 	yanet_error **err
 ) {
+	struct function_ectx **function_ptrs =
+		ADDR_OF(&pipeline_ectx->function_ptrs);
 	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
 		struct function_ectx *function_ectx =
-			ADDR_OF(pipeline_ectx->functions + idx);
+			ADDR_OF(function_ptrs + idx);
 		if (function_ectx == NULL) {
 			continue;
 		}

--- a/lib/dataplane/config/zone.c
+++ b/lib/dataplane/config/zone.c
@@ -77,11 +77,11 @@ dp_config_assign_worker_ectxs(
 		struct dp_worker *worker = ADDR_OF(workers + idx);
 		struct config_gen_ectx *expected =
 			cp_config_gen_worker_ectx(config_gen, idx);
-		// Derive the absolute counter pointers before the release
+		// Derive the absolute stage addresses before the release
 		// store.
 		//
 		// The store pairs with the acquire load at the worker's
-		// round start, so the derived pointers are complete before
+		// round start, so the derived addresses are complete before
 		// any stage runs. The derivation is idempotent, so a worker
 		// already holding this context is unaffected.
 		if (expected != NULL) {

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -102,10 +102,6 @@ module_ectx_decode_device(struct module_ectx *module_ectx, uint64_t index) {
 	return cm_index[index];
 }
 
-struct chain_module_ectx {
-	struct module_ectx *module_ectx;
-};
-
 struct chain_ectx {
 	struct cp_chain *cp_chain;
 	struct counter_storage *counter_storage;
@@ -117,9 +113,21 @@ struct chain_ectx {
 	// context is released to workers; they are zero until then.
 	struct counter_value_handle *abs_counter_packet_pending_input;
 	struct counter_value_handle *abs_counter_packet_pending_output;
+	// Offset pointer to an array of per-slot offset pointers to the
+	// chain's module contexts, mirroring the tail below.
+	//
+	// Owned by the control plane: creation fills it and the free path
+	// walks it, so the relative addresses stay available after the
+	// tail is turned into absolute ones.
+	struct module_ectx **module_ptrs;
 	uint64_t length;
 	struct packet_front schedule;
-	struct chain_module_ectx modules[];
+	// Absolute addresses of the chain's module contexts.
+	//
+	// The publishing process copies them from the module_ptrs array
+	// before the context is released to workers; they are zero until
+	// then, and the packet hot path loads them directly.
+	struct module_ectx *modules[];
 };
 
 struct function_ectx {
@@ -140,6 +148,12 @@ struct function_ectx {
 	uint64_t chain_count;
 	struct chain_ectx **chains;
 	uint64_t chain_map_size;
+	// The function's chains, indexed by packet hash for the demux.
+	//
+	// Creation writes relative addresses; the publishing process
+	// recodes them to absolute ones in place, re-deriving the
+	// weighted expansion from the chains array and the controlplane
+	// weights so repeated passes stay correct.
 	struct chain_ectx *chain_map[];
 };
 
@@ -158,8 +172,20 @@ struct pipeline_ectx {
 	struct counter_value_handle *abs_counter_packet_pending_input;
 	struct counter_value_handle *abs_counter_packet_pending_output;
 	struct counter_storage *counter_storage;
+	// Offset pointer to an array of per-slot offset pointers to the
+	// pipeline's functions, mirroring the tail below.
+	//
+	// Owned by the control plane: creation fills it and the free and
+	// link paths walk it, so the relative addresses stay available
+	// after the tail is turned into absolute ones.
+	struct function_ectx **function_ptrs;
 	uint64_t length;
 	struct packet_front schedule;
+	// Absolute addresses of the pipeline's functions.
+	//
+	// The publishing process copies them from the function_ptrs
+	// array before the context is released to workers; they are zero
+	// until then, and the packet hot path loads them directly.
 	struct function_ectx *functions[];
 };
 
@@ -206,7 +232,13 @@ struct device_entry_ectx {
 	// routed back here during processing remain queued for the next
 	// traversal.
 	struct packet_front schedule;
-	uint64_t pipeline_map[];
+	// The entry's pipelines, indexed by packet hash for the demux.
+	//
+	// Creation writes relative addresses; the publishing process
+	// recodes them to absolute ones in place, re-deriving the
+	// weighted expansion from the pipelines array and the
+	// controlplane weights so repeated passes stay correct.
+	struct pipeline_ectx *pipeline_map[];
 };
 
 struct device_ectx {

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -114,6 +114,11 @@ chain_ectx_resolve_absolutes(struct chain_ectx *chain_ectx) {
 		counter_get_value_handle(
 			cp_chain->counter_packet_pending_output, counter_storage
 		);
+
+	struct module_ectx **module_ptrs = ADDR_OF(&chain_ectx->module_ptrs);
+	for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
+		chain_ectx->modules[idx] = ADDR_OF(module_ptrs + idx);
+	}
 }
 
 static void
@@ -146,6 +151,21 @@ function_ectx_resolve_absolutes(struct function_ectx *function_ectx) {
 	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
 		chain_ectx_resolve_absolutes(ADDR_OF(chains + idx));
 	}
+
+	// Recode the chain map to absolute addresses in place.
+	//
+	// The recode re-derives the weighted expansion from the chains
+	// array and the controlplane weights, in the order creation used,
+	// so a repeated pass never transforms an already-absolute entry.
+	uint64_t pos = 0;
+	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
+		for (uint64_t weight_idx = 0;
+		     weight_idx < cp_function->chains[idx].weight;
+		     ++weight_idx) {
+			function_ectx->chain_map[pos] = ADDR_OF(chains + idx);
+			++pos;
+		}
+	}
 }
 
 static void
@@ -174,10 +194,11 @@ pipeline_ectx_resolve_absolutes(struct pipeline_ectx *pipeline_ectx) {
 			counter_storage
 		);
 
+	struct function_ectx **function_ptrs =
+		ADDR_OF(&pipeline_ectx->function_ptrs);
 	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
-		function_ectx_resolve_absolutes(
-			ADDR_OF(pipeline_ectx->functions + idx)
-		);
+		pipeline_ectx->functions[idx] = ADDR_OF(function_ptrs + idx);
+		function_ectx_resolve_absolutes(pipeline_ectx->functions[idx]);
 	}
 }
 
@@ -213,11 +234,28 @@ device_entry_ectx_resolve_absolutes(
 	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
 		pipeline_ectx_resolve_absolutes(ADDR_OF(pipelines + idx));
 	}
+
+	// Recode the pipeline map to absolute addresses in place.
+	//
+	// The recode re-derives the weighted expansion from the pipelines
+	// array and the controlplane weights, in the order creation used,
+	// so a repeated pass never transforms an already-absolute entry.
+	uint64_t pos = 0;
+	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
+		for (uint64_t weight_idx = 0;
+		     weight_idx < cp_device_entry->pipelines[idx].weight;
+		     ++weight_idx) {
+			entry_ectx->pipeline_map[pos] =
+				ADDR_OF(pipelines + idx);
+			++pos;
+		}
+	}
 }
 
-// Derive the absolute counter pointers of every pipeline stage of the
-// execution context, resolved from the counter registry ids and the
-// stage counter storages.
+// Derive the absolute addresses the packet hot path runs on: the
+// counter pointers of every stage, resolved from the counter registry
+// ids and the stage counter storages, and the stage hop addresses,
+// copied or recoded from the controlplane-owned relative arrays.
 //
 // Runs in the dataplane process before the context is released to the
 // worker, and recomputes everything from controlplane-owned data, so a
@@ -275,10 +313,9 @@ chain_ectx_process(
 			packet_front_switch(packet_front);
 		}
 
-		struct module_ectx *module_ectx =
-			ADDR_OF(&chain_ectx->modules[idx].module_ectx);
-
-		module_ectx_process(dp_worker, module_ectx, packet_front);
+		module_ectx_process(
+			dp_worker, chain_ectx->modules[idx], packet_front
+		);
 	}
 
 	counter_add_packets_bytes(
@@ -332,7 +369,7 @@ function_ectx_run_chains(
 		uint64_t map_idx = packet->hash % function_ectx->chain_map_size;
 
 		struct chain_ectx *chain_ectx =
-			ADDR_OF(function_ectx->chain_map + map_idx);
+			function_ectx->chain_map[map_idx];
 		packet_front_input(&chain_ectx->schedule, packet);
 
 		packet = packet_list_pop(&packet_front->output);
@@ -447,10 +484,9 @@ pipeline_ectx_process(
 	);
 
 	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
-		struct function_ectx *function_ectx =
-			ADDR_OF(pipeline_ectx->functions + idx);
-
-		function_ectx_process(dp_worker, function_ectx, packet_front);
+		function_ectx_process(
+			dp_worker, pipeline_ectx->functions[idx], packet_front
+		);
 	}
 
 	counter_add_packets_bytes(
@@ -513,12 +549,9 @@ device_entry_ectx_dispatch_many(
 
 	struct packet *packet = packet_list_pop(&packet_front->output);
 	while (packet != NULL) {
-		uint64_t pipeline_idx =
+		struct pipeline_ectx *pipeline_ectx =
 			entry_ectx->pipeline_map
 				[packet->hash % entry_ectx->pipeline_map_size];
-
-		struct pipeline_ectx *pipeline_ectx =
-			ADDR_OF(pipelines + pipeline_idx);
 		packet_front_output(&pipeline_ectx->schedule, packet);
 
 		packet = packet_list_pop(&packet_front->output);


### PR DESCRIPTION
Stacked on #2449 — merge that first (and #2441 beneath it).

- Chains, functions and the weighted chain and pipeline maps expose absolute addresses to the packet hot path: creation writes relative ones and the publishing process turns them absolute when a generation is assigned to workers.
- Chain and pipeline tails keep a controlplane-owned relative array for the free and link paths, while the weighted maps are recoded in place from the relative arrays and the controlplane weights.
- Recomputation on every assignment re-derives everything from controlplane-owned data, staying correct across dataplane restarts and re-publications.