### PR TITLE
fix(mirror): reject empty rule configurations

### DIFF
--- a/modules/mirror/api/controlplane.c
+++ b/modules/mirror/api/controlplane.c
@@ -288,6 +288,13 @@ mirror_module_config_update(
 	uint32_t rule_count,
 	yanet_error **err
 ) {
+	if (rule_count == 0) {
+		yanet_error_add(
+			err, "mirror config must contain at least one rule"
+		);
+		return -1;
+	}
+
 	struct mirror_module_config *config =
 		container_of(cp_module, struct mirror_module_config, cp_module);
 

--- a/modules/mirror/controlplane/service.go
+++ b/modules/mirror/controlplane/service.go
@@ -118,7 +118,13 @@ func (m *MirrorService) UpdateConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	reqRules := req.Rules
+	reqRules := req.GetRules()
+	if len(reqRules) == 0 {
+		return nil, status.Error(
+			codes.InvalidArgument,
+			"mirror config must contain at least one rule",
+		)
+	}
 
 	rules := make([]cmirror.MirrorRule, 0, len(reqRules))
 	for _, reqRule := range reqRules {

--- a/modules/mirror/controlplane/service_test.go
+++ b/modules/mirror/controlplane/service_test.go
@@ -97,28 +97,50 @@ func TestDeleteConfigUnknownConfig(t *testing.T) {
 	require.Equal(t, codes.NotFound, status.Code(err))
 }
 
-// TestShowConfigEmptyRules verifies that ShowConfig succeeds with an empty
-// rule list for a config that was applied without rules.
-func TestShowConfigEmptyRules(t *testing.T) {
-	svc := mirror.NewMirrorService(&mockBackend{})
+// Test_MirrorService_UpdateConfigEmptyRules verifies that empty rule lists are
+// reported as invalid client input with an actionable error.
+func Test_MirrorService_UpdateConfigEmptyRules(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules []*mirrorpb.Rule
+	}{
+		{name: "nil rules"},
+		{name: "empty rules", rules: []*mirrorpb.Rule{}},
+	}
 
-	_, err := svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{Name: "empty"})
-	require.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := mirror.NewMirrorService(&mockBackend{})
 
-	response, err := svc.ShowConfig(t.Context(), &mirrorpb.ShowConfigRequest{Name: "empty"})
-	require.NoError(t, err)
-	require.Empty(t, response.GetRules())
+			_, err := service.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{
+				Name:  "config",
+				Rules: test.rules,
+			})
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+			require.Equal(
+				t,
+				"mirror config must contain at least one rule",
+				status.Convert(err).Message(),
+			)
+		})
+	}
 }
 
 // TestUpdateConfigReplacesConfigWithoutHandle verifies that replacing a
 // config that holds no module handle releases it without panicking.
 func TestUpdateConfigReplacesConfigWithoutHandle(t *testing.T) {
 	svc := mirror.NewMirrorService(&nilHandleBackend{})
+	request := &mirrorpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*mirrorpb.Rule{
+			{Action: &mirrorpb.Action{Target: "device0"}},
+		},
+	}
 
-	_, err := svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{Name: "config"})
+	_, err := svc.UpdateConfig(t.Context(), request)
 	require.NoError(t, err)
 
-	_, err = svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{Name: "config"})
+	_, err = svc.UpdateConfig(t.Context(), request)
 	require.NoError(t, err)
 }
 

--- a/modules/mirror/tests/functional/mirror_test.go
+++ b/modules/mirror/tests/functional/mirror_test.go
@@ -282,6 +282,20 @@ func TestMirror_NoMatch(t *testing.T) {
 	require.Empty(t, result.Drop, "unmatched packet must not be dropped")
 }
 
+// Test_MirrorBackend_UpdateModuleEmptyRules verifies that an empty ruleset is
+// rejected with an actionable error.
+func Test_MirrorBackend_UpdateModuleEmptyRules(t *testing.T) {
+	_, _, backend := setupMirrorHarness(t, []string{"port0"})
+
+	_, err := backend.UpdateModule("test", nil)
+	require.EqualError(
+		t,
+		err,
+		"failed to update module config: failed to update mirror config: "+
+			"mirror config must contain at least one rule",
+	)
+}
+
 // TestMirror_ModeNone_IPv4 verifies that an IPv4 packet matched by an ip4
 // rule with ModeNone passes through to the next module without device redirect,
 // and that the per-rule counter is incremented.


### PR DESCRIPTION
- Reject empty mirror rule configurations with an actionable control-plane error.
- Cover the complete backend error chain for an empty ruleset.
- Supersedes #2487.