### PR TITLE
perf(filter): store line attributes in a single memory chunk

### DIFF
--- a/common/value.h
+++ b/common/value.h
@@ -165,3 +165,101 @@ value_table_compact(
 		}
 	}
 }
+
+/*
+ * Single-dimensional value line: a value_table of one row, with the
+ * values kept in one contiguous memory chunk instead of the chunked
+ * pointer array.
+ */
+struct vline {
+	struct memory_context *memory_context;
+	uint32_t size;
+	uint32_t *values;
+};
+
+// Releases a value line, including its own memory-tree node.
+//
+// Safe on a zero-initialised line, mirroring value_table_free.
+static inline void
+vline_free(struct vline *vline) {
+	struct memory_context *memory_context = ADDR_OF(&vline->memory_context);
+	if (memory_context == NULL) {
+		return;
+	}
+
+	uint32_t *values = ADDR_OF(&vline->values);
+	if (values != NULL) {
+		memory_bfree(
+			memory_context, values, vline->size * sizeof(uint32_t)
+		);
+		SET_OFFSET_OF(&vline->values, NULL);
+	}
+
+	// The memory_context was balloc'd out of its parent in vline_init,
+	// so it is released the same way.
+	struct memory_context *parent = ADDR_OF(&memory_context->parent);
+	memory_context_fini(memory_context);
+	memory_bfree(parent, memory_context, sizeof(*memory_context));
+	SET_OFFSET_OF(&vline->memory_context, NULL);
+}
+
+static inline int
+vline_init(
+	struct vline *vline,
+	struct memory_context *parent_context,
+	const char *name,
+	uint32_t size
+) {
+	// Balloc'd rather than embedded for the same reason as in
+	// value_table_init: a line lives inside shared-memory configs the
+	// dataplane reads, so an inline context would multiply across
+	// every line.
+	struct memory_context *memory_context = (struct memory_context *)
+		memory_balloc(parent_context, sizeof(*memory_context));
+	if (memory_context == NULL) {
+		SET_OFFSET_OF(&vline->memory_context, NULL);
+		SET_OFFSET_OF(&vline->values, NULL);
+		return -1;
+	}
+
+	memory_context_init_from(memory_context, parent_context, name);
+	SET_OFFSET_OF(&vline->memory_context, memory_context);
+
+	vline->size = size;
+	SET_OFFSET_OF(&vline->values, NULL);
+
+	uint32_t *values = (uint32_t *)memory_balloc(
+		memory_context, size * sizeof(uint32_t)
+	);
+	if (values == NULL) {
+		vline_free(vline);
+		return -1;
+	}
+
+	memset(values, 0, size * sizeof(uint32_t));
+	SET_OFFSET_OF(&vline->values, values);
+
+	return 0;
+}
+
+static inline uint32_t *
+vline_get_ptr(struct vline *vline, uint32_t idx) {
+	// The values chunk is set at init and cleared only by vline_free,
+	// which never races a lookup, so on the query path it is never
+	// NULL.
+	uint32_t *values = ADDR_OF_NONNULL(&vline->values);
+	return values + idx;
+}
+
+static inline uint32_t
+vline_get(struct vline *vline, uint32_t idx) {
+	return *vline_get_ptr(vline, idx);
+}
+
+static inline void
+vline_compact(struct vline *vline, struct remap_table *remap_table) {
+	for (uint32_t idx = 0; idx < vline->size; ++idx) {
+		uint32_t *value = vline_get_ptr(vline, idx);
+		*value = remap_table_compacted(remap_table, *value);
+	}
+}

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -543,7 +543,11 @@ chain_ectx_create(
 		);
 		goto error;
 	}
-	memset(module_ptrs, 0, sizeof(struct module_ectx *) * cp_chain->length);
+	if (cp_chain->length > 0) {
+		memset(module_ptrs,
+		       0,
+		       sizeof(struct module_ectx *) * cp_chain->length);
+	}
 	SET_OFFSET_OF(&chain_ectx->module_ptrs, module_ptrs);
 
 	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
@@ -915,9 +919,11 @@ pipeline_ectx_create(
 		);
 		goto error;
 	}
-	memset(function_ptrs,
-	       0,
-	       sizeof(struct function_ectx *) * cp_pipeline->length);
+	if (cp_pipeline->length > 0) {
+		memset(function_ptrs,
+		       0,
+		       sizeof(struct function_ectx *) * cp_pipeline->length);
+	}
 	SET_OFFSET_OF(&pipeline_ectx->function_ptrs, function_ptrs);
 
 	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);

--- a/lib/filter/classifiers/proto_range.h
+++ b/lib/filter/classifiers/proto_range.h
@@ -3,5 +3,5 @@
 #include "common/value.h"
 
 struct proto_range_classifier {
-	struct value_table table;
+	struct vline line;
 };

--- a/lib/filter/compiler/device.c
+++ b/lib/filter/compiler/device.c
@@ -31,18 +31,15 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 		}
 	}
 
-	struct value_table *t =
-		memory_balloc(memory_context, sizeof(struct value_table));
-	if (t == NULL) {
+	struct vline *l = memory_balloc(memory_context, sizeof(struct vline));
+	if (l == NULL) {
 		return -1;
 	}
-	int res = value_table_init(
-		t, memory_context, "device", 1, max_device_id + 1
-	);
+	int res = vline_init(l, memory_context, "device", max_device_id + 1);
 	if (res < 0) {
 		goto error_init;
 	}
-	SET_OFFSET_OF(data, t);
+	SET_OFFSET_OF(data, l);
 
 	struct remap_table remap_table;
 	if (remap_table_init(&remap_table, memory_context, max_device_id + 1)) {
@@ -62,8 +59,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 		}
 		remap_table_new_gen(&remap_table);
 		for (uint16_t idx = 0; idx < r->device_count; ++idx) {
-			uint32_t *value =
-				value_table_get_ptr(t, 0, r->devices[idx].id);
+			uint32_t *value = vline_get_ptr(l, r->devices[idx].id);
 			if (remap_table_touch(&remap_table, *value, value) <
 			    0) {
 				goto error_touch;
@@ -72,7 +68,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 	}
 
 	remap_table_compact(&remap_table);
-	value_table_compact(t, &remap_table);
+	vline_compact(l, &remap_table);
 	remap_table_free(&remap_table);
 
 	for (const struct filter_rule **r_ptr = rules;
@@ -90,7 +86,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 		if (r->device_count == 0) {
 			for (uint64_t id = 0; id < max_device_id + 1; ++id) {
 				if (value_registry_collect(
-					    registry, value_table_get(t, 0, id)
+					    registry, vline_get(l, id)
 				    )) {
 					goto error_collect;
 				}
@@ -99,9 +95,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 			for (uint16_t idx = 0; idx < r->device_count; ++idx) {
 				if (value_registry_collect(
 					    registry,
-					    value_table_get(
-						    t, 0, r->devices[idx].id
-					    )
+					    vline_get(l, r->devices[idx].id)
 				    )) {
 					goto error_collect;
 				}
@@ -115,11 +109,11 @@ error_touch:
 
 error_collect:
 error_remap_table:
-	value_table_free(t);
+	vline_free(l);
 	SET_OFFSET_OF(data, NULL);
 
 error_init:
-	memory_bfree(memory_context, t, sizeof(struct value_table));
+	memory_bfree(memory_context, l, sizeof(struct vline));
 
 	return -1;
 }
@@ -128,10 +122,10 @@ void
 FILTER_ATTR_COMPILER_FREE_FUNC(device)(
 	void *data, struct memory_context *memory_context
 ) {
-	struct value_table *t = (struct value_table *)data;
-	if (t == NULL) {
+	struct vline *l = (struct vline *)data;
+	if (l == NULL) {
 		return;
 	}
-	value_table_free(t);
-	memory_bfree(memory_context, t, sizeof(struct value_table));
+	vline_free(l);
+	memory_bfree(memory_context, l, sizeof(struct vline));
 }

--- a/lib/filter/compiler/port.c
+++ b/lib/filter/compiler/port.c
@@ -18,10 +18,10 @@ collect_port_values(
 	const struct filter_rule **actions,
 	uint32_t count,
 	action_get_port_range_func get_port_range,
-	struct value_table *table,
+	struct vline *line,
 	struct value_registry *registry
 ) {
-	if (value_table_init(table, memory_context, "port", 1, 65536)) {
+	if (vline_init(line, memory_context, "port", 65536)) {
 		return -1;
 	}
 
@@ -52,8 +52,7 @@ collect_port_values(
 			}
 			for (uint32_t port = ports->from; port <= ports->to;
 			     ++port) {
-				uint32_t *value =
-					value_table_get_ptr(table, 0, port);
+				uint32_t *value = vline_get_ptr(line, port);
 				if (remap_table_touch(
 					    &remap_table, *value, value
 				    ) < 0) {
@@ -64,7 +63,7 @@ collect_port_values(
 	}
 
 	remap_table_compact(&remap_table);
-	value_table_compact(table, &remap_table);
+	vline_compact(line, &remap_table);
 	remap_table_free(&remap_table);
 
 	for (const struct filter_rule **action_ptr = actions;
@@ -88,8 +87,7 @@ collect_port_values(
 			for (uint32_t port = ports->from; port <= ports->to;
 			     ++port) {
 				if (value_registry_collect(
-					    registry,
-					    value_table_get(table, 0, port)
+					    registry, vline_get(line, port)
 				    )) {
 					goto error_collect;
 				}
@@ -100,8 +98,7 @@ collect_port_values(
 		if (!port_range_count) {
 			for (uint32_t port = 0; port <= 65535; ++port) {
 				if (value_registry_collect(
-					    registry,
-					    value_table_get(table, 0, port)
+					    registry, vline_get(line, port)
 				    )) {
 					goto error_collect;
 				}
@@ -116,7 +113,7 @@ error_touch:
 
 error_collect:
 error_remap_table:
-	value_table_free(table);
+	vline_free(line);
 	return -1;
 }
 
@@ -148,22 +145,22 @@ FILTER_ATTR_COMPILER_INIT_FUNC(port_dst)(
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {
-	struct value_table *table =
-		memory_balloc(memory_context, sizeof(struct value_table));
-	if (table == NULL) {
+	struct vline *line =
+		memory_balloc(memory_context, sizeof(struct vline));
+	if (line == NULL) {
 		return -1;
 	}
-	SET_OFFSET_OF(data, table);
+	SET_OFFSET_OF(data, line);
 	if (collect_port_values(
 		    memory_context,
 		    actions,
 		    actions_count,
 		    get_port_range_dst,
-		    table,
+		    line,
 		    registry
 	    )) {
 		SET_OFFSET_OF(data, NULL);
-		memory_bfree(memory_context, table, sizeof(struct value_table));
+		memory_bfree(memory_context, line, sizeof(struct vline));
 		return -1;
 	}
 	return 0;
@@ -177,22 +174,22 @@ FILTER_ATTR_COMPILER_INIT_FUNC(port_src)(
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {
-	struct value_table *table =
-		memory_balloc(memory_context, sizeof(struct value_table));
-	if (table == NULL) {
+	struct vline *line =
+		memory_balloc(memory_context, sizeof(struct vline));
+	if (line == NULL) {
 		return -1;
 	}
-	SET_OFFSET_OF(data, table);
+	SET_OFFSET_OF(data, line);
 	if (collect_port_values(
 		    memory_context,
 		    actions,
 		    actions_count,
 		    get_port_range_src,
-		    table,
+		    line,
 		    registry
 	    )) {
 		SET_OFFSET_OF(data, NULL);
-		memory_bfree(memory_context, table, sizeof(struct value_table));
+		memory_bfree(memory_context, line, sizeof(struct vline));
 		return -1;
 	}
 
@@ -203,24 +200,24 @@ void
 FILTER_ATTR_COMPILER_FREE_FUNC(port_src)(
 	void *data, struct memory_context *memory_context
 ) {
-	struct value_table *table = (struct value_table *)data;
-	if (table == NULL) {
+	struct vline *line = (struct vline *)data;
+	if (line == NULL) {
 		return;
 	}
 
-	value_table_free(table);
-	memory_bfree(memory_context, table, sizeof(struct value_table));
+	vline_free(line);
+	memory_bfree(memory_context, line, sizeof(struct vline));
 }
 
 void
 FILTER_ATTR_COMPILER_FREE_FUNC(port_dst)(
 	void *data, struct memory_context *memory_context
 ) {
-	struct value_table *table = (struct value_table *)data;
-	if (table == NULL) {
+	struct vline *line = (struct vline *)data;
+	if (line == NULL) {
 		return;
 	}
 
-	value_table_free(table);
-	memory_bfree(memory_context, table, sizeof(struct value_table));
+	vline_free(line);
+	memory_bfree(memory_context, line, sizeof(struct vline));
 }

--- a/lib/filter/compiler/proto_range.c
+++ b/lib/filter/compiler/proto_range.c
@@ -14,14 +14,13 @@ collect_proto_values(
 	struct memory_context *memory_context,
 	const struct filter_rule **rules,
 	uint32_t count,
-	struct value_table *table,
+	struct vline *line,
 	struct value_registry *registry
 ) {
-	if (value_table_init(
-		    table,
+	if (vline_init(
+		    line,
 		    memory_context,
 		    "proto-range",
-		    1,
 		    PROTO_RANGE_CLASSIFIER_MAX_VALUE
 	    )) {
 		return -1;
@@ -56,8 +55,7 @@ collect_proto_values(
 			for (uint32_t proto = proto_range->from;
 			     proto <= proto_range->to;
 			     ++proto) {
-				uint32_t *value =
-					value_table_get_ptr(table, 0, proto);
+				uint32_t *value = vline_get_ptr(line, proto);
 				if (remap_table_touch(
 					    &remap_table, *value, value
 				    ) < 0) {
@@ -68,7 +66,7 @@ collect_proto_values(
 	}
 
 	remap_table_compact(&remap_table);
-	value_table_compact(table, &remap_table);
+	vline_compact(line, &remap_table);
 	remap_table_free(&remap_table);
 
 	for (const struct filter_rule **rule_ptr = rules;
@@ -95,8 +93,7 @@ collect_proto_values(
 			     proto <= proto_range->to;
 			     ++proto) {
 				if (value_registry_collect(
-					    registry,
-					    value_table_get(table, 0, proto)
+					    registry, vline_get(line, proto)
 				    )) {
 					goto error_collect;
 				}
@@ -112,7 +109,7 @@ error_touch:
 error_collect:
 error_remap_table:
 
-	value_table_free(table);
+	vline_free(line);
 	return -1;
 }
 
@@ -131,7 +128,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(proto_range)(
 	}
 	SET_OFFSET_OF(data, classifier);
 	if (collect_proto_values(
-		    mctx, rules, rule_count, &classifier->table, registry
+		    mctx, rules, rule_count, &classifier->line, registry
 	    )) {
 		SET_OFFSET_OF(data, NULL);
 		memory_bfree(mctx, classifier, sizeof(*classifier));
@@ -150,7 +147,7 @@ FILTER_ATTR_COMPILER_FREE_FUNC(proto_range)(
 	}
 	struct proto_range_classifier *c =
 		(struct proto_range_classifier *)data;
-	value_table_free(&c->table);
+	vline_free(&c->line);
 	memory_bfree(memory_context, c, sizeof(*c));
 }
 

--- a/lib/filter/compiler/vlan.c
+++ b/lib/filter/compiler/vlan.c
@@ -14,16 +14,15 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 	size_t rule_count,
 	struct memory_context *memory_context
 ) {
-	struct value_table *t =
-		memory_balloc(memory_context, sizeof(struct value_table));
-	if (t == NULL) {
+	struct vline *l = memory_balloc(memory_context, sizeof(struct vline));
+	if (l == NULL) {
 		return -1;
 	}
 
-	if (value_table_init(t, memory_context, "vlan", 1, 4096)) {
+	if (vline_init(l, memory_context, "vlan", 4096)) {
 		goto error_init;
 	}
-	SET_OFFSET_OF(data, t);
+	SET_OFFSET_OF(data, l);
 
 	struct remap_table remap_table;
 	if (remap_table_init(&remap_table, memory_context, 4096)) {
@@ -46,8 +45,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 			for (uint16_t vlan = r->vlan_ranges[idx].from;
 			     vlan <= r->vlan_ranges[idx].to;
 			     ++vlan) {
-				uint32_t *value =
-					value_table_get_ptr(t, 0, vlan);
+				uint32_t *value = vline_get_ptr(l, vlan);
 				if (remap_table_touch(
 					    &remap_table, *value, value
 				    ) < 0) {
@@ -58,7 +56,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 	}
 
 	remap_table_compact(&remap_table);
-	value_table_compact(t, &remap_table);
+	vline_compact(l, &remap_table);
 	remap_table_free(&remap_table);
 
 	for (const struct filter_rule **r_ptr = rules;
@@ -76,8 +74,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 		if (r->vlan_range_count == 0) {
 			for (uint16_t vlan = 0; vlan <= 4095; ++vlan) {
 				if (value_registry_collect(
-					    registry,
-					    value_table_get(t, 0, vlan)
+					    registry, vline_get(l, vlan)
 				    )) {
 					goto error_collect;
 				}
@@ -88,8 +85,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 			     vlan <= r->vlan_ranges[idx].to;
 			     ++vlan) {
 				if (value_registry_collect(
-					    registry,
-					    value_table_get(t, 0, vlan)
+					    registry, vline_get(l, vlan)
 				    )) {
 					goto error_collect;
 				}
@@ -103,11 +99,11 @@ error_touch:
 
 error_collect:
 error_remap_table:
-	value_table_free(t);
+	vline_free(l);
 	SET_OFFSET_OF(data, NULL);
 
 error_init:
-	memory_bfree(memory_context, t, sizeof(struct value_table));
+	memory_bfree(memory_context, l, sizeof(struct vline));
 
 	return -1;
 }
@@ -116,10 +112,10 @@ void
 FILTER_ATTR_COMPILER_FREE_FUNC(vlan)(
 	void *data, struct memory_context *memory_context
 ) {
-	struct value_table *t = (struct value_table *)data;
-	if (t == NULL) {
+	struct vline *l = (struct vline *)data;
+	if (l == NULL) {
 		return;
 	}
-	value_table_free(t);
-	memory_bfree(memory_context, t, sizeof(struct value_table));
+	vline_free(l);
+	memory_bfree(memory_context, l, sizeof(struct vline));
 }

--- a/lib/filter/query/device.h
+++ b/lib/filter/query/device.h
@@ -10,12 +10,12 @@ static inline void
 FILTER_ATTR_QUERY_FUNC(device)(
 	void *data, struct packet **packets, uint32_t *result, uint32_t count
 ) {
-	struct value_table *t = (struct value_table *)data;
+	struct vline *l = (struct vline *)data;
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		uint64_t device_id = packets[idx]->module_device_id;
-		if (device_id >= t->h_dim) {
+		if (device_id >= l->size) {
 			device_id = 0;
 		}
-		result[idx] = value_table_get(t, 0, device_id);
+		result[idx] = vline_get(l, device_id);
 	}
 }

--- a/lib/filter/query/port.h
+++ b/lib/filter/query/port.h
@@ -62,12 +62,10 @@ static inline void
 FILTER_ATTR_QUERY_FUNC(port_src)(
 	void *data, struct packet **packets, uint32_t *result, uint32_t count
 ) {
-	struct value_table *table = (struct value_table *)data;
+	struct vline *line = (struct vline *)data;
 
 	for (uint32_t idx = 0; idx < count; ++idx) {
-		result[idx] = value_table_get(
-			table, 0, packet_src_port(packets[idx])
-		);
+		result[idx] = vline_get(line, packet_src_port(packets[idx]));
 	}
 }
 
@@ -75,11 +73,9 @@ static inline void
 FILTER_ATTR_QUERY_FUNC(port_dst)(
 	void *data, struct packet **packets, uint32_t *result, uint32_t count
 ) {
-	struct value_table *table = (struct value_table *)data;
+	struct vline *line = (struct vline *)data;
 
 	for (uint32_t idx = 0; idx < count; ++idx) {
-		result[idx] = value_table_get(
-			table, 0, packet_dst_port(packets[idx])
-		);
+		result[idx] = vline_get(line, packet_dst_port(packets[idx]));
 	}
 }

--- a/lib/filter/query/proto_range.h
+++ b/lib/filter/query/proto_range.h
@@ -50,6 +50,6 @@ FILTER_ATTR_QUERY_FUNC(proto_range)(
 			proto += icmp_header->icmp_type;
 		}
 
-		result[idx] = value_table_get(&c->table, 0, proto);
+		result[idx] = vline_get(&c->line, proto);
 	}
 }

--- a/lib/filter/query/vlan.h
+++ b/lib/filter/query/vlan.h
@@ -10,10 +10,10 @@ static inline void
 FILTER_ATTR_QUERY_FUNC(vlan)(
 	void *data, struct packet **packets, uint32_t *result, uint32_t count
 ) {
-	struct value_table *t = (struct value_table *)data;
+	struct vline *l = (struct vline *)data;
 
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		uint16_t vlan = packets[idx]->vlan;
-		result[idx] = value_table_get(t, 0, vlan);
+		result[idx] = vline_get(l, vlan);
 	}
 }


### PR DESCRIPTION
Stacked on #2484 — merge that first (and #2449, #2441 beneath it).

- Vlan, device, port and proto-range attributes build and query a vline, a single-dimensional value table whose values live in one contiguous memory chunk instead of the chunked pointer array.
- The per-packet lookup dereferences the chunk directly, and the device bound check reads the line size.
- Multi-dimensional attributes keep the value table.