### PR TITLE
perf(dataplane,common): drop per-packet lookup overheads

### DIFF
--- a/common/rlist.h
+++ b/common/rlist.h
@@ -5,6 +5,11 @@
 // A member embeds a node and is reached back through the node; a head is
 // a plain node that points at itself when empty. Insertion appends at
 // the tail, so first-out order matches insertion order.
+//
+// A node embedded in shared memory keeps absolute addresses in its
+// links: only the process that builds the list ever writes or walks
+// them, and that process leaves them zeroed until the first build, so
+// no other mapping ever dereferences a foreign address.
 struct rlist {
 	struct rlist *prev;
 	struct rlist *next;

--- a/common/value.h
+++ b/common/value.h
@@ -3,6 +3,11 @@
 /*
  * Rectangular value table allowing one to touch each key pair using
  * remap table.
+ *
+ * The values are chunked by v index: the values array holds one chunk
+ * pointer per v index, and each chunk stores that row's h_dim entries,
+ * so a lookup indexes the chunk by v_idx directly and never multiplies
+ * or divides.
  */
 
 #include <stdint.h>
@@ -10,12 +15,12 @@
 #include "memory.h"
 #include "remap.h"
 
-#define VALUE_TABLE_CHUNK_SIZE 16384
-
 struct value_table {
 	struct memory_context *memory_context;
 	uint32_t v_dim;
 	uint32_t h_dim;
+	// Offset pointer to an array of v_dim chunk pointers, one chunk
+	// of h_dim entries per v index.
 	uint32_t **values;
 };
 
@@ -34,27 +39,22 @@ value_table_free(struct value_table *value_table) {
 
 	uint32_t **values = ADDR_OF(&value_table->values);
 	if (values != NULL) {
-		uint64_t value_count = value_table->v_dim;
-		value_count *= value_table->h_dim;
-		uint32_t chunk_count =
-			(value_count + VALUE_TABLE_CHUNK_SIZE - 1) /
-			VALUE_TABLE_CHUNK_SIZE;
-
-		for (uint32_t chunk_idx = 0; chunk_idx < chunk_count;
-		     ++chunk_idx) {
-			uint32_t *chunk = ADDR_OF(values + chunk_idx);
+		for (uint32_t v_idx = 0; v_idx < value_table->v_dim; ++v_idx) {
+			uint32_t *chunk = ADDR_OF(values + v_idx);
 			if (chunk == NULL) {
 				continue;
 			}
 			memory_bfree(
 				memory_context,
 				chunk,
-				VALUE_TABLE_CHUNK_SIZE * sizeof(uint32_t)
+				value_table->h_dim * sizeof(uint32_t)
 			);
-			SET_OFFSET_OF(values + chunk_idx, NULL);
+			SET_OFFSET_OF(values + v_idx, NULL);
 		}
 		memory_bfree(
-			memory_context, values, chunk_count * sizeof(uint32_t *)
+			memory_context,
+			values,
+			value_table->v_dim * sizeof(uint32_t *)
 		);
 		SET_OFFSET_OF(&value_table->values, NULL);
 	}
@@ -95,34 +95,27 @@ value_table_init(
 	value_table->h_dim = h_dim;
 	SET_OFFSET_OF(&value_table->values, NULL);
 
-	uint64_t value_count = v_dim;
-	value_count *= h_dim;
-
-	uint32_t chunk_count = (value_count + VALUE_TABLE_CHUNK_SIZE - 1) /
-			       VALUE_TABLE_CHUNK_SIZE;
-
 	uint32_t **values = (uint32_t **)memory_balloc(
-		memory_context, chunk_count * sizeof(uint32_t *)
+		memory_context, v_dim * sizeof(uint32_t *)
 	);
 	if (values == NULL) {
 		value_table_free(value_table);
 		return -1;
 	}
 
-	memset(values, 0, chunk_count * sizeof(uint32_t *));
+	memset(values, 0, v_dim * sizeof(uint32_t *));
 	SET_OFFSET_OF(&value_table->values, values);
 
-	for (uint32_t chunk_idx = 0; chunk_idx < chunk_count; ++chunk_idx) {
+	for (uint32_t v_idx = 0; v_idx < v_dim; ++v_idx) {
 		uint32_t *chunk = (uint32_t *)memory_balloc(
-			memory_context,
-			VALUE_TABLE_CHUNK_SIZE * sizeof(uint32_t)
+			memory_context, h_dim * sizeof(uint32_t)
 		);
 		if (chunk == NULL) {
 			value_table_free(value_table);
 			return -1;
 		}
-		memset(chunk, 0, VALUE_TABLE_CHUNK_SIZE * sizeof(uint32_t));
-		SET_OFFSET_OF(values + chunk_idx, chunk);
+		memset(chunk, 0, h_dim * sizeof(uint32_t));
+		SET_OFFSET_OF(values + v_idx, chunk);
 	}
 
 	return 0;
@@ -135,14 +128,10 @@ value_table_get_ptr(
 	// values and the chunk pointers are set at init and cleared only by
 	// value_table_free, which never races a lookup — so on the query path
 	// they are never NULL and the NULL test in ADDR_OF is pure per-lookup
-	// overhead.
+	// overhead. The chunk is indexed by v_idx and the h_idx stays
+	// in-chunk, so the lookup adds and never multiplies or divides.
 	uint32_t **values = ADDR_OF_NONNULL(&value_table->values);
-	uint64_t idx = v_idx;
-	idx *= value_table->h_dim;
-	idx += h_idx;
-
-	return ADDR_OF_NONNULL(values + idx / VALUE_TABLE_CHUNK_SIZE) +
-	       idx % VALUE_TABLE_CHUNK_SIZE;
+	return ADDR_OF_NONNULL(values + v_idx) + h_idx;
 }
 
 static inline uint32_t

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -102,19 +102,15 @@ config_gen_ectx_schedules_prepare(struct config_gen_ectx *config_gen_ectx) {
 // An entry parked on the processed list after running this tick is
 // moved back to the active list so it runs again, reproducing the
 // recirculation semantics; an entry already queued for this tick is
-// left where it is. Before the lists are built the packet is only
-// placed on the entry's schedule and the first full sweep picks it up.
+// left where it is. Packets are only scheduled from inside a worker
+// round, and the round's preparation builds the worklists before any
+// of them, so no readiness check is needed here.
 static inline void
 device_entry_ectx_schedule(
 	struct config_gen_ectx *config_gen_ectx,
 	struct device_entry_ectx *device_entry_ectx,
 	struct packet *packet
 ) {
-	if (!config_gen_ectx->schedules_ready) {
-		packet_front_input(&device_entry_ectx->schedule, packet);
-		return;
-	}
-
 	if (device_entry_ectx->schedule_list !=
 	    config_gen_ectx->schedule_active) {
 		rlist_remove(&device_entry_ectx->schedule_node);

--- a/tests/common/value_table.c
+++ b/tests/common/value_table.c
@@ -34,9 +34,8 @@ test_free_after_failed_init(void) {
 // no child attached to the parent.
 static void
 test_partial_failure_no_child(void) {
-	// Big enough for the context struct and the tiny values array (a
-	// single chunk pointer for these dims), too small for the first
-	// 64KB values chunk.
+	// Big enough for the context struct, too small for the values
+	// pointer array (1024 chunk pointers for these dims).
 	void *arena = malloc(1 << 12);
 	assert(arena != NULL);
 
@@ -49,7 +48,7 @@ test_partial_failure_no_child(void) {
 	assert(res == 0);
 
 	struct value_table table;
-	res = value_table_init(&table, &mem_ctx, "test-table", 1, 10);
+	res = value_table_init(&table, &mem_ctx, "test-table", 1, 1024);
 	assert(res == -1);
 
 	assert(ADDR_OF(&mem_ctx.first_child) == NULL);


### PR DESCRIPTION
Stacked on #2490 — merge that first (and #2484, #2449, #2441 beneath it).

- The schedule worklists are provably built before any packet is scheduled, so the per-packet readiness check is gone and the absolute-address contract of the schedule rlist is documented on the list itself.
- Value tables are chunked by v index, one chunk of h_dim entries per row, so every lookup indexes the chunk directly without a multiply or a divide, and allocation drops the fixed-size chunk rounding.