### PR TITLE
perf(dataplane)!: absolutize pipeline stage hops at publish time

### DIFF
--- a/common/rlist.h
+++ b/common/rlist.h
@@ -5,6 +5,11 @@
 // A member embeds a node and is reached back through the node; a head is
 // a plain node that points at itself when empty. Insertion appends at
 // the tail, so first-out order matches insertion order.
+//
+// A node embedded in shared memory keeps absolute addresses in its
+// links: only the process that builds the list ever writes or walks
+// them, and that process leaves them zeroed until the first build, so
+// no other mapping ever dereferences a foreign address.
 struct rlist {
 	struct rlist *prev;
 	struct rlist *next;

--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -5,6 +5,7 @@ package ffi
 //#cgo LDFLAGS: -L../../build/lib/controlplane/config -lconfig_cp
 //#cgo LDFLAGS: -L../../build/lib/counters/ -lcounters
 //#cgo LDFLAGS: -L../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../build/lib/dataplane/pipeline -lpipeline
 //#cgo LDFLAGS: -L../../build/devices/plain/api -ldev_plain_api
 //#cgo LDFLAGS: -L../../build/devices/vlan/api -ldev_vlan_api
 //#cgo LDFLAGS: -L../../build/lib/logging/ -llogging

--- a/controlplane/ffi/counter.go
+++ b/controlplane/ffi/counter.go
@@ -5,6 +5,7 @@ package ffi
 //#cgo LDFLAGS: -L../../build/lib/controlplane/config -lconfig_cp
 //#cgo LDFLAGS: -L../../build/lib/counters -lcounters
 //#cgo LDFLAGS: -L../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../build/lib/dataplane/pipeline -lpipeline
 //#cgo LDFLAGS: -L../../build/lib/errors -lerrors
 //#include "api/agent.h"
 //#include "api/counter.h"

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -6,6 +6,7 @@ package ffi
 //#cgo LDFLAGS: -L../../build/lib/controlplane/config -lconfig_cp
 //#cgo LDFLAGS: -L../../build/lib/counters -lcounters
 //#cgo LDFLAGS: -L../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../build/lib/dataplane/pipeline -lpipeline
 //#cgo LDFLAGS: -L../../build/lib/errors -lerrors
 //#cgo LDFLAGS: -L../../build/lib/counters -lcounter_pattern
 //#cgo LDFLAGS: -L../../build/lib/counters -lrure

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -144,7 +144,7 @@ worker_read(
 		}
 		device_entry_ectx_schedule(
 			config_gen_ectx,
-			ADDR_OF(&device_ectx->input_pipelines),
+			device_ectx->abs_input_pipelines,
 			packet
 		);
 	}

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -39,6 +39,17 @@ module_ectx_free(
 		);
 	}
 
+	struct counter_storage **abs_runtime_storages =
+		ADDR_OF(&module_ectx->abs_runtime_counter_storages);
+	if (abs_runtime_storages != NULL) {
+		memory_bfree(
+			memory_context,
+			abs_runtime_storages,
+			sizeof(struct counter_storage *) *
+				module_ectx->runtime_counter_storage_count
+		);
+	}
+
 	uint64_t *cm_index = ADDR_OF(&module_ectx->cm_index);
 	if (cm_index != NULL) {
 		memory_bfree(
@@ -153,37 +164,6 @@ module_ectx_create(
 		goto error;
 	}
 
-	SET_OFFSET_OF(
-		&module_ectx->rx_counter,
-		counter_get_value_handle(
-			cp_module->rx_counter_id, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&module_ectx->tx_counter,
-		counter_get_value_handle(
-			cp_module->tx_counter_id, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&module_ectx->drop_counter,
-		counter_get_value_handle(
-			cp_module->drop_counter_id, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&module_ectx->pending_input_counter,
-		counter_get_value_handle(
-			cp_module->pending_input_counter_id, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&module_ectx->pending_output_counter,
-		counter_get_value_handle(
-			cp_module->pending_output_counter_id, counter_storage
-		)
-	);
-
 	if (cp_config_counter_storage_registry_insert_module(
 		    ADDR_OF(&config_gen_ectx->counter_storage_registry),
 		    cp_device->name,
@@ -232,6 +212,29 @@ module_ectx_create(
 			cp_module->runtime_counter_registry_count;
 		SET_OFFSET_OF(
 			&module_ectx->runtime_counter_storages, runtime_storages
+		);
+
+		struct counter_storage **abs_runtime_storages =
+			(struct counter_storage **)memory_balloc(
+				memory_context,
+				sizeof(struct counter_storage *) *
+					cp_module
+						->runtime_counter_registry_count
+			);
+		if (abs_runtime_storages == NULL &&
+		    cp_module->runtime_counter_registry_count > 0) {
+			yanet_error_add(
+				err,
+				"failed to allocate memory for the runtime "
+				"storage addresses of module '%s:%s'",
+				cp_module->type,
+				cp_module->name
+			);
+			goto error;
+		}
+		SET_OFFSET_OF(
+			&module_ectx->abs_runtime_counter_storages,
+			abs_runtime_storages
 		);
 
 		struct cp_module_counter_registry **runtime_registries =
@@ -467,27 +470,37 @@ chain_ectx_free(
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
-	for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
-		struct module_ectx *module_ectx =
-			ADDR_OF(&chain_ectx->modules[idx].module_ectx);
-		if (module_ectx == NULL) {
-			continue;
+	struct module_ectx **module_ptrs = ADDR_OF(&chain_ectx->module_ptrs);
+	if (module_ptrs != NULL) {
+		for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
+			struct module_ectx *module_ectx =
+				ADDR_OF(module_ptrs + idx);
+			if (module_ectx == NULL) {
+				continue;
+			}
+
+			module_ectx_free(cp_config_gen, module_ectx);
 		}
-
-		module_ectx_free(cp_config_gen, module_ectx);
 	}
-
 	struct counter_storage *counter_storage =
 		ADDR_OF(&chain_ectx->counter_storage);
 	if (counter_storage != NULL) {
 		counter_storage_free(counter_storage);
 	}
 
+	if (module_ptrs != NULL) {
+		memory_bfree(
+			memory_context,
+			module_ptrs,
+			sizeof(struct module_ectx *) * chain_ectx->length
+		);
+	}
+
 	memory_bfree(
 		memory_context,
 		chain_ectx,
 		sizeof(struct chain_ectx) +
-			sizeof(struct chain_module_ectx) * chain_ectx->length
+			sizeof(struct module_ectx *) * chain_ectx->length
 	);
 }
 
@@ -506,9 +519,8 @@ chain_ectx_create(
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
-	uint64_t ectx_size =
-		sizeof(struct chain_ectx) +
-		sizeof(struct chain_module_ectx) * cp_chain->length;
+	uint64_t ectx_size = sizeof(struct chain_ectx) +
+			     sizeof(struct module_ectx *) * cp_chain->length;
 	struct chain_ectx *chain_ectx =
 		(struct chain_ectx *)memory_balloc(memory_context, ectx_size);
 	if (chain_ectx == NULL) {
@@ -522,6 +534,25 @@ chain_ectx_create(
 	memset(chain_ectx, 0, ectx_size);
 	SET_OFFSET_OF(&chain_ectx->cp_chain, cp_chain);
 	chain_ectx->length = cp_chain->length;
+
+	struct module_ectx **module_ptrs = (struct module_ectx **)memory_balloc(
+		memory_context, sizeof(struct module_ectx *) * cp_chain->length
+	);
+	if (module_ptrs == NULL && cp_chain->length > 0) {
+		yanet_error_add(
+			err,
+			"failed to allocate memory for the module "
+			"addresses of chain '%s'",
+			cp_chain->name
+		);
+		goto error;
+	}
+	if (cp_chain->length > 0) {
+		memset(module_ptrs,
+		       0,
+		       sizeof(struct module_ectx *) * cp_chain->length);
+	}
+	SET_OFFSET_OF(&chain_ectx->module_ptrs, module_ptrs);
 
 	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
 	struct cp_pipeline *cp_pipeline = ADDR_OF(&pipeline_ectx->cp_pipeline);
@@ -574,19 +605,6 @@ chain_ectx_create(
 		goto error;
 	}
 
-	SET_OFFSET_OF(
-		&chain_ectx->counter_packet_pending_input,
-		counter_get_value_handle(
-			cp_chain->counter_packet_pending_input, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&chain_ectx->counter_packet_pending_output,
-		counter_get_value_handle(
-			cp_chain->counter_packet_pending_output, counter_storage
-		)
-	);
-
 	for (uint64_t idx = 0; idx < cp_chain->length; ++idx) {
 		struct cp_module *cp_module = cp_config_gen_lookup_module(
 			cp_config_gen,
@@ -633,9 +651,7 @@ chain_ectx_create(
 			goto error;
 		}
 
-		SET_OFFSET_OF(
-			&chain_ectx->modules[idx].module_ectx, module_ectx
-		);
+		SET_OFFSET_OF(module_ptrs + idx, module_ectx);
 	}
 
 	return chain_ectx;
@@ -652,11 +668,12 @@ function_ectx_free(
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
-	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
-	if (chains != NULL) {
+	struct chain_ectx **chain_ptrs = ADDR_OF(&function_ectx->chain_ptrs);
+	if (chain_ptrs != NULL) {
 		for (uint64_t idx = 0; idx < function_ectx->chain_count;
 		     ++idx) {
-			struct chain_ectx *chain_ectx = ADDR_OF(chains + idx);
+			struct chain_ectx *chain_ectx =
+				ADDR_OF(chain_ptrs + idx);
 			if (chain_ectx == NULL) {
 				continue;
 			}
@@ -665,7 +682,16 @@ function_ectx_free(
 		}
 		memory_bfree(
 			memory_context,
-			chains,
+			chain_ptrs,
+			sizeof(struct chain_ectx *) * function_ectx->chain_count
+		);
+	}
+
+	struct chain_ectx **abs_chains = ADDR_OF(&function_ectx->chains);
+	if (abs_chains != NULL) {
+		memory_bfree(
+			memory_context,
+			abs_chains,
 			sizeof(struct chain_ectx *) * function_ectx->chain_count
 		);
 	}
@@ -732,9 +758,32 @@ function_ectx_create(
 		);
 		goto error;
 	}
-	memset(chains, 0, sizeof(struct chain_ectx *) * cp_function->chain_count
+	if (cp_function->chain_count > 0) {
+		memset(chains,
+		       0,
+		       sizeof(struct chain_ectx *) * cp_function->chain_count);
+	}
+	SET_OFFSET_OF(&function_ectx->chain_ptrs, chains);
+
+	struct chain_ectx **abs_chains = (struct chain_ectx **)memory_balloc(
+		memory_context,
+		sizeof(struct chain_ectx *) * cp_function->chain_count
 	);
-	SET_OFFSET_OF(&function_ectx->chains, chains);
+	if (abs_chains == NULL && cp_function->chain_count > 0) {
+		yanet_error_add(
+			err,
+			"failed to allocate memory for the chain "
+			"addresses of function '%s'",
+			cp_function->name
+		);
+		goto error;
+	}
+	if (cp_function->chain_count > 0) {
+		memset(abs_chains,
+		       0,
+		       sizeof(struct chain_ectx *) * cp_function->chain_count);
+	}
+	SET_OFFSET_OF(&function_ectx->chains, abs_chains);
 	function_ectx->chain_count = cp_function->chain_count;
 
 	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
@@ -785,39 +834,6 @@ function_ectx_create(
 		goto error;
 	}
 
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_in,
-		counter_get_value_handle(
-			cp_function->counter_packet_in, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_out,
-		counter_get_value_handle(
-			cp_function->counter_packet_out, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_drop,
-		counter_get_value_handle(
-			cp_function->counter_packet_drop, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_pending_input,
-		counter_get_value_handle(
-			cp_function->counter_packet_pending_input,
-			counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_pending_output,
-		counter_get_value_handle(
-			cp_function->counter_packet_pending_output,
-			counter_storage
-		)
-	);
-
 	uint64_t pos = 0;
 	for (uint64_t idx = 0; idx < cp_function->chain_count; ++idx) {
 		struct cp_chain *cp_chain =
@@ -863,20 +879,32 @@ pipeline_ectx_free(
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
-	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
-		struct function_ectx *function_ectx =
-			ADDR_OF(pipeline_ectx->functions + idx);
-		if (function_ectx == NULL) {
-			continue;
-		}
+	struct function_ectx **function_ptrs =
+		ADDR_OF(&pipeline_ectx->function_ptrs);
+	if (function_ptrs != NULL) {
+		for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
+			struct function_ectx *function_ectx =
+				ADDR_OF(function_ptrs + idx);
+			if (function_ectx == NULL) {
+				continue;
+			}
 
-		function_ectx_free(cp_config_gen, function_ectx);
+			function_ectx_free(cp_config_gen, function_ectx);
+		}
 	}
 
 	struct counter_storage *counter_storage =
 		ADDR_OF(&pipeline_ectx->counter_storage);
 	if (counter_storage != NULL) {
 		counter_storage_free(counter_storage);
+	}
+
+	if (function_ptrs != NULL) {
+		memory_bfree(
+			memory_context,
+			function_ptrs,
+			sizeof(struct function_ectx *) * pipeline_ectx->length
+		);
 	}
 
 	size_t ectx_size =
@@ -914,6 +942,27 @@ pipeline_ectx_create(
 	memset(pipeline_ectx, 0, ectx_size);
 	SET_OFFSET_OF(&pipeline_ectx->cp_pipeline, cp_pipeline);
 	pipeline_ectx->length = cp_pipeline->length;
+
+	struct function_ectx **function_ptrs =
+		(struct function_ectx **)memory_balloc(
+			memory_context,
+			sizeof(struct function_ectx *) * cp_pipeline->length
+		);
+	if (function_ptrs == NULL && cp_pipeline->length > 0) {
+		yanet_error_add(
+			err,
+			"failed to allocate memory for the function "
+			"addresses of pipeline '%s'",
+			cp_pipeline->name
+		);
+		goto error;
+	}
+	if (cp_pipeline->length > 0) {
+		memset(function_ptrs,
+		       0,
+		       sizeof(struct function_ectx *) * cp_pipeline->length);
+	}
+	SET_OFFSET_OF(&pipeline_ectx->function_ptrs, function_ptrs);
 
 	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
 
@@ -960,39 +1009,6 @@ pipeline_ectx_create(
 		goto error;
 	}
 
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_in,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_in, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_out,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_out, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_drop,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_drop, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_pending_input,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_pending_input,
-			counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_pending_output,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_pending_output,
-			counter_storage
-		)
-	);
-
 	for (uint64_t idx = 0; idx < cp_pipeline->length; ++idx) {
 		struct cp_function *cp_function = cp_config_gen_lookup_function(
 			cp_config_gen, cp_pipeline->functions[idx].name
@@ -1022,7 +1038,7 @@ pipeline_ectx_create(
 			goto error;
 		}
 
-		SET_OFFSET_OF(pipeline_ectx->functions + idx, function_ectx);
+		SET_OFFSET_OF(function_ptrs + idx, function_ectx);
 	}
 
 	return pipeline_ectx;
@@ -1041,13 +1057,13 @@ device_entry_ectx_free(
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
-	struct pipeline_ectx **pipelines =
-		ADDR_OF(&device_entry_ectx->pipelines);
-	if (pipelines != NULL) {
+	struct pipeline_ectx **pipeline_ptrs =
+		ADDR_OF(&device_entry_ectx->pipeline_ptrs);
+	if (pipeline_ptrs != NULL) {
 		for (uint64_t idx = 0; idx < device_entry_ectx->pipeline_count;
 		     ++idx) {
 			struct pipeline_ectx *pipeline_ectx =
-				ADDR_OF(pipelines + idx);
+				ADDR_OF(pipeline_ptrs + idx);
 			if (pipeline_ectx == NULL) {
 				continue;
 			}
@@ -1056,7 +1072,18 @@ device_entry_ectx_free(
 
 		memory_bfree(
 			memory_context,
-			pipelines,
+			pipeline_ptrs,
+			sizeof(struct pipeline_ectx *) *
+				device_entry_ectx->pipeline_count
+		);
+	}
+
+	struct pipeline_ectx **abs_pipelines =
+		ADDR_OF(&device_entry_ectx->pipelines);
+	if (abs_pipelines != NULL) {
+		memory_bfree(
+			memory_context,
+			abs_pipelines,
 			sizeof(struct pipeline_ectx *) *
 				device_entry_ectx->pipeline_count
 		);
@@ -1107,54 +1134,6 @@ device_entry_ectx_create(
 	memset(device_entry_ectx, 0, ectx_size);
 	device_entry_ectx->handler = handler;
 
-	struct counter_storage *counter_storage =
-		ADDR_OF(&device_ectx->counter_storage);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_rx,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_rx, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_entry,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_entry, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_tx,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_tx, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_drop,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_drop, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_recirc_drop,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_recirc_drop,
-			counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_pending_input,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_pending_input,
-			counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_entry_ectx->counter_packet_pending_output,
-		counter_get_value_handle(
-			cp_device_entry->counter_packet_pending_output,
-			counter_storage
-		)
-	);
-
 	struct pipeline_ectx **pipelines =
 		(struct pipeline_ectx **)memory_balloc(
 			memory_context,
@@ -1175,11 +1154,35 @@ device_entry_ectx_create(
 		return device_entry_ectx;
 	}
 
-	memset(pipelines,
-	       0,
-	       sizeof(struct pipeline_ectx *) *
-		       device_entry_ectx->pipeline_count);
-	SET_OFFSET_OF(&device_entry_ectx->pipelines, pipelines);
+	if (cp_device_entry->pipeline_count > 0) {
+		memset(pipelines,
+		       0,
+		       sizeof(struct pipeline_ectx *) *
+			       cp_device_entry->pipeline_count);
+	}
+	SET_OFFSET_OF(&device_entry_ectx->pipeline_ptrs, pipelines);
+
+	struct pipeline_ectx **abs_pipelines =
+		(struct pipeline_ectx **)memory_balloc(
+			memory_context,
+			sizeof(struct pipeline_ectx *) *
+				cp_device_entry->pipeline_count
+		);
+	if (abs_pipelines == NULL && cp_device_entry->pipeline_count > 0) {
+		yanet_error_add(
+			err,
+			"failed to allocate memory for the pipeline "
+			"addresses in device entry"
+		);
+		goto error;
+	}
+	if (cp_device_entry->pipeline_count > 0) {
+		memset(abs_pipelines,
+		       0,
+		       sizeof(struct pipeline_ectx *) *
+			       cp_device_entry->pipeline_count);
+	}
+	SET_OFFSET_OF(&device_entry_ectx->pipelines, abs_pipelines);
 
 	device_entry_ectx->pipeline_map_size = weight_sum;
 	uint64_t pos = 0;
@@ -1214,7 +1217,10 @@ device_entry_ectx_create(
 		for (uint64_t weight_idx = 0;
 		     weight_idx < cp_device_entry->pipelines[idx].weight;
 		     ++weight_idx) {
-			device_entry_ectx->pipeline_map[pos] = idx;
+			SET_OFFSET_OF(
+				device_entry_ectx->pipeline_map + pos,
+				pipeline_ectx
+			);
 			++pos;
 		}
 	}
@@ -1477,16 +1483,26 @@ config_gen_ectx_free(
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
-	for (uint64_t device_idx = 0;
-	     device_idx < config_gen_ectx->device_count;
-	     ++device_idx) {
+	struct device_ectx **device_ptrs =
+		ADDR_OF(&config_gen_ectx->device_ptrs);
+	if (device_ptrs != NULL) {
+		for (uint64_t device_idx = 0;
+		     device_idx < config_gen_ectx->device_count;
+		     ++device_idx) {
 
-		struct device_ectx *device_ectx =
-			ADDR_OF(config_gen_ectx->devices + device_idx);
+			struct device_ectx *device_ectx =
+				ADDR_OF(device_ptrs + device_idx);
 
-		if (device_ectx != NULL) {
-			device_ectx_free(cp_config_gen, device_ectx);
+			if (device_ectx != NULL) {
+				device_ectx_free(cp_config_gen, device_ectx);
+			}
 		}
+		memory_bfree(
+			memory_context,
+			device_ptrs,
+			sizeof(struct device_ectx *) *
+				config_gen_ectx->device_count
+		);
 	}
 
 	struct object_ectx **objects = ADDR_OF(&config_gen_ectx->objects);
@@ -1594,7 +1610,8 @@ link_module_ectx(
 		for (uint64_t c_idx = 0; c_idx < config_gen_ectx->device_count;
 		     ++c_idx) {
 			struct device_ectx *device_ectx =
-				ADDR_OF(config_gen_ectx->devices + c_idx);
+				ADDR_OF(ADDR_OF(&config_gen_ectx->device_ptrs) +
+					c_idx);
 			if (device_ectx == NULL) {
 				continue;
 			}
@@ -1627,9 +1644,9 @@ link_chain_ectx(
 	struct chain_ectx *chain_ectx,
 	yanet_error **err
 ) {
+	struct module_ectx **module_ptrs = ADDR_OF(&chain_ectx->module_ptrs);
 	for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
-		struct module_ectx *module_ectx =
-			ADDR_OF(&chain_ectx->modules[idx].module_ectx);
+		struct module_ectx *module_ectx = ADDR_OF(module_ptrs + idx);
 		if (module_ectx == NULL) {
 			continue;
 		}
@@ -1665,9 +1682,9 @@ link_function_ectx(
 	struct function_ectx *function_ectx,
 	yanet_error **err
 ) {
-	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
+	struct chain_ectx **chain_ptrs = ADDR_OF(&function_ectx->chain_ptrs);
 	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
-		struct chain_ectx *chain_ectx = ADDR_OF(chains + idx);
+		struct chain_ectx *chain_ectx = ADDR_OF(chain_ptrs + idx);
 		if (chain_ectx == NULL) {
 			continue;
 		}
@@ -1701,9 +1718,11 @@ link_pipeline_ectx(
 	struct pipeline_ectx *pipeline_ectx,
 	yanet_error **err
 ) {
+	struct function_ectx **function_ptrs =
+		ADDR_OF(&pipeline_ectx->function_ptrs);
 	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
 		struct function_ectx *function_ectx =
-			ADDR_OF(pipeline_ectx->functions + idx);
+			ADDR_OF(function_ptrs + idx);
 		if (function_ectx == NULL) {
 			continue;
 		}
@@ -1735,10 +1754,11 @@ link_device_entry_ectx(
 	struct device_entry_ectx *device_entry_ectx,
 	yanet_error **err
 ) {
-	struct pipeline_ectx **pipelines =
-		ADDR_OF(&device_entry_ectx->pipelines);
+	struct pipeline_ectx **pipeline_ptrs =
+		ADDR_OF(&device_entry_ectx->pipeline_ptrs);
 	for (uint64_t idx = 0; idx < device_entry_ectx->pipeline_count; ++idx) {
-		struct pipeline_ectx *pipeline_ectx = ADDR_OF(pipelines + idx);
+		struct pipeline_ectx *pipeline_ectx =
+			ADDR_OF(pipeline_ptrs + idx);
 		if (pipeline_ectx == NULL) {
 			continue;
 		}
@@ -1803,9 +1823,10 @@ static int
 link_config_gen_ectx(
 	struct config_gen_ectx *config_gen_ectx, yanet_error **err
 ) {
+	struct device_ectx **device_ptrs =
+		ADDR_OF(&config_gen_ectx->device_ptrs);
 	for (uint64_t idx = 0; idx < config_gen_ectx->device_count; ++idx) {
-		struct device_ectx *device_ectx =
-			ADDR_OF(config_gen_ectx->devices + idx);
+		struct device_ectx *device_ectx = ADDR_OF(device_ptrs + idx);
 		if (device_ectx == NULL) {
 			continue;
 		}
@@ -1857,6 +1878,24 @@ config_gen_ectx_create(
 	config_gen_ectx->device_count = device_count;
 	config_gen_ectx->object_count =
 		cp_object_registry_capacity(&cp_config_gen->object_registry);
+
+	struct device_ectx **device_ptrs = (struct device_ectx **)memory_balloc(
+		memory_context, sizeof(struct device_ectx *) * device_count
+	);
+	if (device_ptrs == NULL && device_count > 0) {
+		yanet_error_add(
+			err,
+			"failed to allocate memory for the device "
+			"addresses of the config generation"
+		);
+		goto error;
+	}
+	if (device_count > 0) {
+		memset(device_ptrs,
+		       0,
+		       sizeof(struct device_ectx *) * device_count);
+	}
+	SET_OFFSET_OF(&config_gen_ectx->device_ptrs, device_ptrs);
 
 	struct cp_config_counter_storage_registry *registry =
 		(struct cp_config_counter_storage_registry *)memory_balloc(
@@ -1952,9 +1991,7 @@ config_gen_ectx_create(
 		if (device_ectx == NULL) {
 			goto error;
 		}
-		SET_OFFSET_OF(
-			config_gen_ectx->devices + device_idx, device_ectx
-		);
+		SET_OFFSET_OF(device_ptrs + device_idx, device_ectx);
 	}
 
 	if (link_config_gen_ectx(config_gen_ectx, err)) {

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -14,7 +14,7 @@ config_gen_ectx_get_device(
 	if (index >= config_gen_ectx->device_count) {
 		return NULL;
 	}
-	return ADDR_OF(config_gen_ectx->devices + index);
+	return config_gen_ectx->devices[index];
 }
 
 // Return the object execution context installed at the given object index, or
@@ -38,9 +38,9 @@ static inline void
 device_entry_ectx_count_recirc_drop(
 	struct device_entry_ectx *entry_ectx, const struct packet *packet
 ) {
-	uint64_t *counter = counter_handle_get_value(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_recirc_drop)
-	);
+	uint64_t *counter =
+		counter_handle_get_value(entry_ectx->counter_packet_recirc_drop
+		);
 	counter[0] += 1;
 	counter[1] += rte_pktmbuf_pkt_len(packet_to_mbuf(packet));
 }
@@ -78,10 +78,10 @@ config_gen_ectx_schedules_prepare(struct config_gen_ectx *config_gen_ectx) {
 			struct device_entry_ectx *device_entry_ectx;
 			if (pass == 0) {
 				device_entry_ectx =
-					ADDR_OF(&device_ectx->input_pipelines);
+					device_ectx->abs_input_pipelines;
 			} else {
 				device_entry_ectx =
-					ADDR_OF(&device_ectx->output_pipelines);
+					device_ectx->abs_output_pipelines;
 			}
 
 			rlist_add(
@@ -151,7 +151,7 @@ module_ectx_route_input(
 	packet_front->pending_input_bytes += packet->data_len;
 
 	struct config_gen_ectx *config_gen_ectx =
-		ADDR_OF(&module_ectx->config_gen_ectx);
+		module_ectx->abs_config_gen_ectx;
 	struct device_ectx *device_ectx = config_gen_ectx_get_device(
 		config_gen_ectx, packet->tx_device_id
 	);
@@ -159,8 +159,7 @@ module_ectx_route_input(
 		packet_front_drop(packet_front, packet);
 		return;
 	}
-	struct device_entry_ectx *entry_ectx =
-		ADDR_OF(&device_ectx->input_pipelines);
+	struct device_entry_ectx *entry_ectx = device_ectx->abs_input_pipelines;
 	if (!packet_recirc_try_redirect(
 		    packet, module_ectx->packet_recirc_limit
 	    )) {
@@ -191,7 +190,7 @@ module_ectx_route_output(
 	packet_front->pending_output_bytes += packet->data_len;
 
 	struct config_gen_ectx *config_gen_ectx =
-		ADDR_OF(&module_ectx->config_gen_ectx);
+		module_ectx->abs_config_gen_ectx;
 	struct device_ectx *device_ectx = config_gen_ectx_get_device(
 		config_gen_ectx, packet->tx_device_id
 	);
@@ -200,7 +199,7 @@ module_ectx_route_output(
 		return;
 	}
 	struct device_entry_ectx *entry_ectx =
-		ADDR_OF(&device_ectx->output_pipelines);
+		device_ectx->abs_output_pipelines;
 	if (!packet_recirc_try_redirect(
 		    packet, module_ectx->packet_recirc_limit
 	    )) {

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -102,19 +102,15 @@ config_gen_ectx_schedules_prepare(struct config_gen_ectx *config_gen_ectx) {
 // An entry parked on the processed list after running this tick is
 // moved back to the active list so it runs again, reproducing the
 // recirculation semantics; an entry already queued for this tick is
-// left where it is. Before the lists are built the packet is only
-// placed on the entry's schedule and the first full sweep picks it up.
+// left where it is. Packets are only scheduled from inside a worker
+// round, and the round's preparation builds the worklists before any
+// of them, so no readiness check is needed here.
 static inline void
 device_entry_ectx_schedule(
 	struct config_gen_ectx *config_gen_ectx,
 	struct device_entry_ectx *device_entry_ectx,
 	struct packet *packet
 ) {
-	if (!config_gen_ectx->schedules_ready) {
-		packet_front_input(&device_entry_ectx->schedule, packet);
-		return;
-	}
-
 	if (device_entry_ectx->schedule_list !=
 	    config_gen_ectx->schedule_active) {
 		rlist_remove(&device_entry_ectx->schedule_node);

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -40,15 +40,15 @@ _Static_assert(
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct module_ectx) == 144,
+	sizeof(struct module_ectx) == 184,
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct device_entry_ectx) == 248,
+	sizeof(struct device_entry_ectx) == 264,
 	"struct device_entry_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct config_gen_ectx) == 216,
+	sizeof(struct config_gen_ectx) == 224,
 	"struct config_gen_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/config/zone.c
+++ b/lib/dataplane/config/zone.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include "lib/controlplane/config/zone.h"
+#include "lib/dataplane/pipeline/pipeline.h"
 
 struct dp_config *
 dp_config_nextk(struct dp_config *current, uint32_t k) {
@@ -76,6 +77,16 @@ dp_config_assign_worker_ectxs(
 		struct dp_worker *worker = ADDR_OF(workers + idx);
 		struct config_gen_ectx *expected =
 			cp_config_gen_worker_ectx(config_gen, idx);
+		// Derive the absolute stage addresses before the release
+		// store.
+		//
+		// The store pairs with the acquire load at the worker's
+		// round start, so the derived addresses are complete before
+		// any stage runs. The derivation is idempotent, so a worker
+		// already holding this context is unaffected.
+		if (expected != NULL) {
+			config_gen_ectx_resolve_counters(expected);
+		}
 		// Skip workers already holding the expected context: the
 		// release store exists for the switch, and re-issuing it on
 		// every assignment pass would make the field flap for

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 22
+#define YANET_MODULE_ABI_VERSION 25
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -26,6 +26,12 @@ struct module_ectx {
 	module_handler handler;
 	struct cp_module *cp_module;
 
+	// The module's counters, as absolute addresses for the packet hot
+	// path.
+	//
+	// The publishing process derives them from the counter registry
+	// ids of the cp_module and the module's counter storage before
+	// the context is released to workers; they are zero until then.
 	struct counter_value_handle *rx_counter;
 	struct counter_value_handle *tx_counter;
 	struct counter_value_handle *drop_counter;
@@ -33,21 +39,60 @@ struct module_ectx {
 	struct counter_value_handle *pending_output_counter;
 
 	struct counter_storage *counter_storage;
+	// The same storage, as an absolute address for the packet hot
+	// path.
+	//
+	// The publishing process copies it from the relative field above
+	// before the context is released to workers; it is zero until
+	// then.
+	struct counter_storage *abs_counter_storage;
 
 	// Per-worker storages for the module's runtime counter registries, in
 	// parallel with cp_module.runtime_counter_registries. Offset pointer
 	// to a separately allocated array of offset pointers, one per
 	// registry.
 	uint64_t runtime_counter_storage_count;
+	// Offset pointer to the module's per-registry runtime storages,
+	// owned by the control plane.
 	struct counter_storage **runtime_counter_storages;
+	// The same storages, as absolute addresses for the packet hot
+	// path.
+	//
+	// Offset pointer to an array the publishing process fills from
+	// the relative one before the context is released to workers; it
+	// is zero until then.
+	struct counter_storage **abs_runtime_counter_storages;
+	// Offset pointer to the owning generation, owned by the control
+	// plane.
 	struct config_gen_ectx *config_gen_ectx;
+	// The same generation, as an absolute address for the packet hot
+	// path.
+	//
+	// The publishing process copies it from the relative field above
+	// before the context is released to workers; it is zero until
+	// then.
+	struct config_gen_ectx *abs_config_gen_ectx;
 	uint16_t packet_recirc_limit;
 
 	uint64_t mc_index_size;
+	// Offset pointer to the module-to-config device index table,
+	// owned by the control plane.
 	uint64_t *mc_index;
+	// The same table, as an absolute address for the packet hot path.
+	//
+	// The publishing process copies it from the relative field before
+	// the context is released to workers; it is zero until then.
+	uint64_t *abs_mc_index;
 
 	uint64_t cm_index_size;
+	// Offset pointer to the config-to-module device index table,
+	// owned by the control plane.
 	uint64_t *cm_index;
+	// The same table, as an absolute address for the packet hot path.
+	//
+	// The publishing process copies it from the relative field before
+	// the context is released to workers; it is zero until then.
+	uint64_t *abs_cm_index;
 
 	// One entry per object this module links to. Each entry owns a counter
 	// storage spawned from the linked object's link counter registry and
@@ -64,6 +109,13 @@ struct module_ectx {
 struct module_object_link_ectx {
 	struct counter_storage *counter_storage;
 	struct object_ectx *object_ectx;
+	// The linked object's context, as an absolute address for the
+	// packet hot path.
+	//
+	// The publishing process copies it from the relative field above
+	// before the context is released to workers; it is zero until
+	// then.
+	struct object_ectx *abs_object_ectx;
 };
 
 // Return the object link execution context at the given link index, or NULL
@@ -86,60 +138,117 @@ module_ectx_counter_storage(struct module_ectx *module_ectx, uint64_t index) {
 		return NULL;
 	}
 	struct counter_storage **storages =
-		ADDR_OF(&module_ectx->runtime_counter_storages);
-	return ADDR_OF(storages + index);
+		ADDR_OF(&module_ectx->abs_runtime_counter_storages);
+	return storages[index];
 }
 
 static inline uint64_t
 module_ectx_encode_device(struct module_ectx *module_ectx, uint64_t index) {
-	uint64_t *mc_index = ADDR_OF(&module_ectx->mc_index);
-	return mc_index[index];
+	return module_ectx->abs_mc_index[index];
 }
 
 static inline uint64_t
 module_ectx_decode_device(struct module_ectx *module_ectx, uint64_t index) {
-	uint64_t *cm_index = ADDR_OF(&module_ectx->cm_index);
-	return cm_index[index];
+	return module_ectx->abs_cm_index[index];
 }
-
-struct chain_module_ectx {
-	struct module_ectx *module_ectx;
-};
 
 struct chain_ectx {
 	struct cp_chain *cp_chain;
 	struct counter_storage *counter_storage;
-	struct counter_value_handle *counter_packet_pending_input;
-	struct counter_value_handle *counter_packet_pending_output;
+	// Absolute counterparts of the chain's counters, for the packet
+	// hot path.
+	//
+	// The publishing process derives them from the counter registry
+	// ids of the cp_chain and the chain's counter storage before the
+	// context is released to workers; they are zero until then.
+	struct counter_value_handle *abs_counter_packet_pending_input;
+	struct counter_value_handle *abs_counter_packet_pending_output;
+	// Offset pointer to an array of per-slot offset pointers to the
+	// chain's module contexts, mirroring the tail below.
+	//
+	// Owned by the control plane: creation fills it and the free path
+	// walks it, so the relative addresses stay available after the
+	// tail is turned into absolute ones.
+	struct module_ectx **module_ptrs;
 	uint64_t length;
 	struct packet_front schedule;
-	struct chain_module_ectx modules[];
+	// Absolute addresses of the chain's module contexts.
+	//
+	// The publishing process copies them from the module_ptrs array
+	// before the context is released to workers; they are zero until
+	// then, and the packet hot path loads them directly.
+	struct module_ectx *modules[];
 };
 
 struct function_ectx {
 	struct cp_function *cp_function;
-	struct counter_value_handle *counter_packet_in;
-	struct counter_value_handle *counter_packet_out;
-	struct counter_value_handle *counter_packet_drop;
-	struct counter_value_handle *counter_packet_pending_input;
-	struct counter_value_handle *counter_packet_pending_output;
+	// Absolute counterparts of the function's counters, for the packet
+	// hot path.
+	//
+	// The publishing process derives them from the counter registry
+	// ids of the cp_function and the function's counter storage
+	// before the context is released to workers; they are zero until
+	// then.
+	struct counter_value_handle *abs_counter_packet_in;
+	struct counter_value_handle *abs_counter_packet_out;
+	struct counter_value_handle *abs_counter_packet_drop;
+	struct counter_value_handle *abs_counter_packet_pending_input;
+	struct counter_value_handle *abs_counter_packet_pending_output;
 	struct counter_storage *counter_storage;
 	uint64_t chain_count;
+	// Offset pointer to an array of per-slot offset pointers to the
+	// function's chains, mirroring the chains array.
+	//
+	// Owned by the control plane: creation fills it and the free and
+	// link paths walk it, so the relative addresses stay available
+	// after the chains array holds absolute ones.
+	struct chain_ectx **chain_ptrs;
+	// The function's chains, as absolute addresses for the packet hot
+	// path.
+	//
+	// The publishing process copies them from the chain_ptrs array
+	// before the context is released to workers; they are zero until
+	// then, and the packet hot path loads them directly.
 	struct chain_ectx **chains;
 	uint64_t chain_map_size;
+	// The function's chains, indexed by packet hash for the demux.
+	//
+	// Creation writes relative addresses; the publishing process
+	// recodes them to absolute ones in place, re-deriving the
+	// weighted expansion from the chains array and the controlplane
+	// weights so repeated passes stay correct.
 	struct chain_ectx *chain_map[];
 };
 
 struct pipeline_ectx {
 	struct cp_pipeline *cp_pipeline;
-	struct counter_value_handle *counter_packet_in;
-	struct counter_value_handle *counter_packet_out;
-	struct counter_value_handle *counter_packet_drop;
-	struct counter_value_handle *counter_packet_pending_input;
-	struct counter_value_handle *counter_packet_pending_output;
+	// Absolute counterparts of the pipeline's counters, for the packet
+	// hot path.
+	//
+	// The publishing process derives them from the counter registry
+	// ids of the cp_pipeline and the pipeline's counter storage
+	// before the context is released to workers; they are zero until
+	// then.
+	struct counter_value_handle *abs_counter_packet_in;
+	struct counter_value_handle *abs_counter_packet_out;
+	struct counter_value_handle *abs_counter_packet_drop;
+	struct counter_value_handle *abs_counter_packet_pending_input;
+	struct counter_value_handle *abs_counter_packet_pending_output;
 	struct counter_storage *counter_storage;
+	// Offset pointer to an array of per-slot offset pointers to the
+	// pipeline's functions, mirroring the tail below.
+	//
+	// Owned by the control plane: creation fills it and the free and
+	// link paths walk it, so the relative addresses stay available
+	// after the tail is turned into absolute ones.
+	struct function_ectx **function_ptrs;
 	uint64_t length;
 	struct packet_front schedule;
+	// Absolute addresses of the pipeline's functions.
+	//
+	// The publishing process copies them from the function_ptrs
+	// array before the context is released to workers; they are zero
+	// until then, and the packet hot path loads them directly.
 	struct function_ectx *functions[];
 };
 
@@ -161,8 +270,23 @@ struct device_entry_ectx {
 	struct rlist schedule_node;
 	uint8_t schedule_list;
 	uint8_t direction;
+	// Offset pointer to the owning device, kept by the control plane.
 	struct device_ectx *device_ectx;
+	// The same device, as an absolute address for the packet hot
+	// path.
+	//
+	// The publishing process copies it from the relative field above
+	// before the context is released to workers; it is zero until
+	// then.
+	struct device_ectx *abs_device_ectx;
 
+	// The entry's counters, as absolute addresses for the packet hot
+	// path.
+	//
+	// The publishing process derives them from the counter registry
+	// ids of the entry's controlplane counterpart and the device's
+	// counter storage before the context is released to workers; they
+	// are zero until then.
 	struct counter_value_handle *counter_packet_rx;
 	struct counter_value_handle *counter_packet_entry;
 	struct counter_value_handle *counter_packet_tx;
@@ -171,6 +295,19 @@ struct device_entry_ectx {
 	struct counter_value_handle *counter_packet_pending_input;
 	struct counter_value_handle *counter_packet_pending_output;
 	uint64_t pipeline_count;
+	// Offset pointer to an array of per-slot offset pointers to the
+	// entry's pipelines, mirroring the pipelines array.
+	//
+	// Owned by the control plane: creation fills it and the free and
+	// link paths walk it, so the relative addresses stay available
+	// after the pipelines array holds absolute ones.
+	struct pipeline_ectx **pipeline_ptrs;
+	// The entry's pipelines, as absolute addresses for the packet hot
+	// path.
+	//
+	// The publishing process copies them from the pipeline_ptrs
+	// array before the context is released to workers; they are zero
+	// until then, and the packet hot path loads them directly.
 	struct pipeline_ectx **pipelines;
 	uint64_t pipeline_map_size;
 	// Per-entry inbox for packets awaiting processing.
@@ -179,7 +316,13 @@ struct device_entry_ectx {
 	// routed back here during processing remain queued for the next
 	// traversal.
 	struct packet_front schedule;
-	uint64_t pipeline_map[];
+	// The entry's pipelines, indexed by packet hash for the demux.
+	//
+	// Creation writes relative addresses; the publishing process
+	// recodes them to absolute ones in place, re-deriving the
+	// weighted expansion from the pipelines array and the
+	// controlplane weights so repeated passes stay correct.
+	struct pipeline_ectx *pipeline_map[];
 };
 
 struct device_ectx {
@@ -187,6 +330,14 @@ struct device_ectx {
 	struct counter_storage *counter_storage;
 	struct device_entry_ectx *input_pipelines;
 	struct device_entry_ectx *output_pipelines;
+	// The device's entries, as absolute addresses for the packet hot
+	// path.
+	//
+	// The publishing process copies them from the relative fields
+	// above before the context is released to workers; they are zero
+	// until then, and the packet hot path loads them directly.
+	struct device_entry_ectx *abs_input_pipelines;
+	struct device_entry_ectx *abs_output_pipelines;
 };
 
 // Per-worker execution context for a cp_object.
@@ -236,7 +387,20 @@ struct config_gen_ectx {
 	uint8_t schedule_active;
 	uint8_t schedules_ready;
 
+	// Offset pointer to an array of per-slot offset pointers to the
+	// devices, mirroring the tail below.
+	//
+	// Owned by the control plane: creation fills it and the free,
+	// link and module-build paths walk it, so the relative addresses
+	// stay available after the tail is turned into absolute ones.
+	struct device_ectx **device_ptrs;
 	uint64_t device_count;
+	// The generation's devices, as absolute addresses for the packet
+	// hot path.
+	//
+	// The publishing process copies them from the device_ptrs array
+	// before the context is released to workers; they are zero until
+	// then, and the packet hot path loads them directly.
 	struct device_ectx *devices[];
 };
 

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -51,32 +51,30 @@ module_ectx_process(
 
 	const uint64_t input_bytes = packet_front_input_bytes(packet_front);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&module_ectx->rx_counter),
-		packets_count,
-		input_bytes
+		module_ectx->rx_counter, packets_count, input_bytes
 	);
 
 	module_ectx->handler(dp_worker, module_ectx, packet_front);
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&module_ectx->tx_counter),
+		module_ectx->tx_counter,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&module_ectx->drop_counter),
+		module_ectx->drop_counter,
 		packet_front_drop_count(packet_front) - drop_count,
 		packet_front_drop_bytes(packet_front) - drop_bytes
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&module_ectx->pending_input_counter),
+		module_ectx->pending_input_counter,
 		packet_front_pending_input_count(packet_front) -
 			pending_input_count,
 		packet_front_pending_input_bytes(packet_front) -
 			pending_input_bytes
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&module_ectx->pending_output_counter),
+		module_ectx->pending_output_counter,
 		packet_front_pending_output_count(packet_front) -
 			pending_output_count,
 		packet_front_pending_output_bytes(packet_front) -
@@ -87,7 +85,7 @@ module_ectx_process(
 struct dp_config *
 module_ectx_dp_config(struct module_ectx *module_ectx) {
 	struct config_gen_ectx *config_gen_ectx =
-		ADDR_OF(&module_ectx->config_gen_ectx);
+		module_ectx->abs_config_gen_ectx;
 	if (config_gen_ectx == NULL) {
 		return NULL;
 	}
@@ -99,6 +97,264 @@ module_ectx_dp_config(struct module_ectx *module_ectx) {
 	}
 
 	return ADDR_OF(&cp_config_gen->dp_config);
+}
+
+static void
+module_ectx_resolve_absolutes(struct module_ectx *module_ectx) {
+	struct cp_module *cp_module = ADDR_OF(&module_ectx->cp_module);
+	struct counter_storage *counter_storage =
+		ADDR_OF(&module_ectx->counter_storage);
+
+	module_ectx->rx_counter = counter_get_value_handle(
+		cp_module->rx_counter_id, counter_storage
+	);
+	module_ectx->tx_counter = counter_get_value_handle(
+		cp_module->tx_counter_id, counter_storage
+	);
+	module_ectx->drop_counter = counter_get_value_handle(
+		cp_module->drop_counter_id, counter_storage
+	);
+	module_ectx->pending_input_counter = counter_get_value_handle(
+		cp_module->pending_input_counter_id, counter_storage
+	);
+	module_ectx->pending_output_counter = counter_get_value_handle(
+		cp_module->pending_output_counter_id, counter_storage
+	);
+
+	module_ectx->abs_mc_index = ADDR_OF(&module_ectx->mc_index);
+	module_ectx->abs_cm_index = ADDR_OF(&module_ectx->cm_index);
+	module_ectx->abs_counter_storage =
+		ADDR_OF(&module_ectx->counter_storage);
+	module_ectx->abs_config_gen_ectx =
+		ADDR_OF(&module_ectx->config_gen_ectx);
+
+	struct counter_storage **abs_runtime =
+		ADDR_OF(&module_ectx->abs_runtime_counter_storages);
+	if (abs_runtime != NULL) {
+		struct counter_storage **runtime =
+			ADDR_OF(&module_ectx->runtime_counter_storages);
+		for (uint64_t idx = 0;
+		     idx < module_ectx->runtime_counter_storage_count;
+		     ++idx) {
+			abs_runtime[idx] = ADDR_OF(runtime + idx);
+		}
+	}
+
+	struct module_object_link_ectx *object_links =
+		ADDR_OF(&module_ectx->object_links);
+	for (uint64_t idx = 0; idx < module_ectx->object_link_count; ++idx) {
+		object_links[idx].abs_object_ectx =
+			ADDR_OF(&object_links[idx].object_ectx);
+	}
+}
+
+static void
+chain_ectx_resolve_absolutes(struct chain_ectx *chain_ectx) {
+	struct cp_chain *cp_chain = ADDR_OF(&chain_ectx->cp_chain);
+	struct counter_storage *counter_storage =
+		ADDR_OF(&chain_ectx->counter_storage);
+
+	chain_ectx->abs_counter_packet_pending_input = counter_get_value_handle(
+		cp_chain->counter_packet_pending_input, counter_storage
+	);
+	chain_ectx->abs_counter_packet_pending_output =
+		counter_get_value_handle(
+			cp_chain->counter_packet_pending_output, counter_storage
+		);
+
+	struct module_ectx **module_ptrs = ADDR_OF(&chain_ectx->module_ptrs);
+	for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
+		struct module_ectx *module_ectx = ADDR_OF(module_ptrs + idx);
+		chain_ectx->modules[idx] = module_ectx;
+		module_ectx_resolve_absolutes(module_ectx);
+	}
+}
+
+static void
+function_ectx_resolve_absolutes(struct function_ectx *function_ectx) {
+	struct cp_function *cp_function = ADDR_OF(&function_ectx->cp_function);
+	struct counter_storage *counter_storage =
+		ADDR_OF(&function_ectx->counter_storage);
+
+	function_ectx->abs_counter_packet_in = counter_get_value_handle(
+		cp_function->counter_packet_in, counter_storage
+	);
+	function_ectx->abs_counter_packet_out = counter_get_value_handle(
+		cp_function->counter_packet_out, counter_storage
+	);
+	function_ectx->abs_counter_packet_drop = counter_get_value_handle(
+		cp_function->counter_packet_drop, counter_storage
+	);
+	function_ectx->abs_counter_packet_pending_input =
+		counter_get_value_handle(
+			cp_function->counter_packet_pending_input,
+			counter_storage
+		);
+	function_ectx->abs_counter_packet_pending_output =
+		counter_get_value_handle(
+			cp_function->counter_packet_pending_output,
+			counter_storage
+		);
+
+	struct chain_ectx **chain_ptrs = ADDR_OF(&function_ectx->chain_ptrs);
+	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
+	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
+		chains[idx] = ADDR_OF(chain_ptrs + idx);
+		chain_ectx_resolve_absolutes(chains[idx]);
+	}
+
+	// Recode the chain map to absolute addresses in place.
+	//
+	// The recode re-derives the weighted expansion from the relative
+	// chain addresses and the controlplane weights, in the order
+	// creation used, so a repeated pass never transforms an
+	// already-absolute entry.
+	uint64_t pos = 0;
+	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
+		for (uint64_t weight_idx = 0;
+		     weight_idx < cp_function->chains[idx].weight;
+		     ++weight_idx) {
+			function_ectx->chain_map[pos] =
+				ADDR_OF(chain_ptrs + idx);
+			++pos;
+		}
+	}
+}
+
+static void
+pipeline_ectx_resolve_absolutes(struct pipeline_ectx *pipeline_ectx) {
+	struct cp_pipeline *cp_pipeline = ADDR_OF(&pipeline_ectx->cp_pipeline);
+	struct counter_storage *counter_storage =
+		ADDR_OF(&pipeline_ectx->counter_storage);
+
+	pipeline_ectx->abs_counter_packet_in = counter_get_value_handle(
+		cp_pipeline->counter_packet_in, counter_storage
+	);
+	pipeline_ectx->abs_counter_packet_out = counter_get_value_handle(
+		cp_pipeline->counter_packet_out, counter_storage
+	);
+	pipeline_ectx->abs_counter_packet_drop = counter_get_value_handle(
+		cp_pipeline->counter_packet_drop, counter_storage
+	);
+	pipeline_ectx->abs_counter_packet_pending_input =
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_pending_input,
+			counter_storage
+		);
+	pipeline_ectx->abs_counter_packet_pending_output =
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_pending_output,
+			counter_storage
+		);
+
+	struct function_ectx **function_ptrs =
+		ADDR_OF(&pipeline_ectx->function_ptrs);
+	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
+		pipeline_ectx->functions[idx] = ADDR_OF(function_ptrs + idx);
+		function_ectx_resolve_absolutes(pipeline_ectx->functions[idx]);
+	}
+}
+
+static void
+device_entry_ectx_resolve_absolutes(
+	struct device_entry_ectx *entry_ectx,
+	struct cp_device_entry *cp_device_entry,
+	struct counter_storage *counter_storage
+) {
+	entry_ectx->counter_packet_rx = counter_get_value_handle(
+		cp_device_entry->counter_packet_rx, counter_storage
+	);
+	entry_ectx->counter_packet_entry = counter_get_value_handle(
+		cp_device_entry->counter_packet_entry, counter_storage
+	);
+	entry_ectx->counter_packet_tx = counter_get_value_handle(
+		cp_device_entry->counter_packet_tx, counter_storage
+	);
+	entry_ectx->counter_packet_drop = counter_get_value_handle(
+		cp_device_entry->counter_packet_drop, counter_storage
+	);
+	entry_ectx->counter_packet_recirc_drop = counter_get_value_handle(
+		cp_device_entry->counter_packet_recirc_drop, counter_storage
+	);
+	entry_ectx->counter_packet_pending_input = counter_get_value_handle(
+		cp_device_entry->counter_packet_pending_input, counter_storage
+	);
+	entry_ectx->counter_packet_pending_output = counter_get_value_handle(
+		cp_device_entry->counter_packet_pending_output, counter_storage
+	);
+	entry_ectx->abs_device_ectx = ADDR_OF(&entry_ectx->device_ectx);
+
+	struct pipeline_ectx **pipeline_ptrs =
+		ADDR_OF(&entry_ectx->pipeline_ptrs);
+	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
+	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
+		pipelines[idx] = ADDR_OF(pipeline_ptrs + idx);
+		pipeline_ectx_resolve_absolutes(pipelines[idx]);
+	}
+
+	// Recode the pipeline map to absolute addresses in place.
+	//
+	// The recode re-derives the weighted expansion from the relative
+	// pipeline addresses and the controlplane weights, in the order
+	// creation used, so a repeated pass never transforms an
+	// already-absolute entry.
+	uint64_t pos = 0;
+	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
+		for (uint64_t weight_idx = 0;
+		     weight_idx < cp_device_entry->pipelines[idx].weight;
+		     ++weight_idx) {
+			entry_ectx->pipeline_map[pos] =
+				ADDR_OF(pipeline_ptrs + idx);
+			++pos;
+		}
+	}
+}
+
+// Derive the absolute addresses the packet hot path runs on: the
+// counter pointers of every stage, resolved from the counter registry
+// ids and the stage counter storages, and the stage hop addresses,
+// copied or recoded from the controlplane-owned relative arrays.
+//
+// Runs in the dataplane process before the context is released to the
+// worker, and recomputes everything from controlplane-owned data, so a
+// re-run never corrupts a previous derivation.
+void
+config_gen_ectx_resolve_counters(struct config_gen_ectx *config_gen_ectx) {
+	struct device_ectx **device_ptrs =
+		ADDR_OF(&config_gen_ectx->device_ptrs);
+	for (uint64_t idx = 0; idx < config_gen_ectx->device_count; ++idx) {
+		config_gen_ectx->devices[idx] = ADDR_OF(device_ptrs + idx);
+		struct device_ectx *device_ectx = config_gen_ectx->devices[idx];
+		if (device_ectx == NULL) {
+			continue;
+		}
+
+		struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
+		struct counter_storage *counter_storage =
+			ADDR_OF(&device_ectx->counter_storage);
+
+		struct device_entry_ectx *input =
+			ADDR_OF(&device_ectx->input_pipelines);
+		device_ectx->abs_input_pipelines = input;
+		if (input != NULL) {
+			device_entry_ectx_resolve_absolutes(
+				input,
+				ADDR_OF(&cp_device->input_pipelines),
+				counter_storage
+			);
+		}
+
+		struct device_entry_ectx *output =
+			ADDR_OF(&device_ectx->output_pipelines);
+		device_ectx->abs_output_pipelines = output;
+		if (output != NULL) {
+			device_entry_ectx_resolve_absolutes(
+				output,
+				ADDR_OF(&cp_device->output_pipelines),
+				counter_storage
+			);
+		}
+	}
 }
 
 static inline void
@@ -119,19 +375,18 @@ chain_ectx_process(
 			packet_front_switch(packet_front);
 		}
 
-		struct module_ectx *module_ectx =
-			ADDR_OF(&chain_ectx->modules[idx].module_ectx);
-
-		module_ectx_process(dp_worker, module_ectx, packet_front);
+		module_ectx_process(
+			dp_worker, chain_ectx->modules[idx], packet_front
+		);
 	}
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&chain_ectx->counter_packet_pending_input),
+		chain_ectx->abs_counter_packet_pending_input,
 		packet_front_pending_input_count(packet_front),
 		packet_front_pending_input_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&chain_ectx->counter_packet_pending_output),
+		chain_ectx->abs_counter_packet_pending_output,
 		packet_front_pending_output_count(packet_front),
 		packet_front_pending_output_bytes(packet_front)
 	);
@@ -151,7 +406,7 @@ function_ectx_run_single_chain(
 	struct packet_front *packet_front
 ) {
 	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
-	struct chain_ectx *chain_ectx = ADDR_OF(chains);
+	struct chain_ectx *chain_ectx = chains[0];
 
 	struct packet_front *schedule = &chain_ectx->schedule;
 	packet_front_take_input(schedule, packet_front);
@@ -176,7 +431,7 @@ function_ectx_run_chains(
 		uint64_t map_idx = packet->hash % function_ectx->chain_map_size;
 
 		struct chain_ectx *chain_ectx =
-			ADDR_OF(function_ectx->chain_map + map_idx);
+			function_ectx->chain_map[map_idx];
 		packet_front_input(&chain_ectx->schedule, packet);
 
 		packet = packet_list_pop(&packet_front->output);
@@ -187,7 +442,7 @@ function_ectx_run_chains(
 	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
 
 	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
-		struct chain_ectx *chain_ectx = ADDR_OF(chains + idx);
+		struct chain_ectx *chain_ectx = chains[idx];
 
 		chain_ectx_process(
 			dp_worker, chain_ectx, &chain_ectx->schedule
@@ -234,7 +489,7 @@ function_ectx_process(
 		packet_front_pending_output_bytes(packet_front);
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_in),
+		function_ectx->abs_counter_packet_in,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -252,24 +507,24 @@ function_ectx_process(
 	}
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_out),
+		function_ectx->abs_counter_packet_out,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_drop),
+		function_ectx->abs_counter_packet_drop,
 		packet_front_drop_count(packet_front) - drop_count,
 		packet_front_drop_bytes(packet_front) - drop_bytes
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_pending_input),
+		function_ectx->abs_counter_packet_pending_input,
 		packet_front_pending_input_count(packet_front) -
 			pending_input_count,
 		packet_front_pending_input_bytes(packet_front) -
 			pending_input_bytes
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_pending_output),
+		function_ectx->abs_counter_packet_pending_output,
 		packet_front_pending_output_count(packet_front) -
 			pending_output_count,
 		packet_front_pending_output_bytes(packet_front) -
@@ -285,35 +540,34 @@ pipeline_ectx_process(
 ) {
 	// Packets arrive in output list, count them before processing
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_in),
+		pipeline_ectx->abs_counter_packet_in,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 
 	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
-		struct function_ectx *function_ectx =
-			ADDR_OF(pipeline_ectx->functions + idx);
-
-		function_ectx_process(dp_worker, function_ectx, packet_front);
+		function_ectx_process(
+			dp_worker, pipeline_ectx->functions[idx], packet_front
+		);
 	}
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_out),
+		pipeline_ectx->abs_counter_packet_out,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_drop),
+		pipeline_ectx->abs_counter_packet_drop,
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_pending_input),
+		pipeline_ectx->abs_counter_packet_pending_input,
 		packet_front_pending_input_count(packet_front),
 		packet_front_pending_input_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_pending_output),
+		pipeline_ectx->abs_counter_packet_pending_output,
 		packet_front_pending_output_count(packet_front),
 		packet_front_pending_output_bytes(packet_front)
 	);
@@ -333,7 +587,7 @@ device_entry_ectx_dispatch_single(
 	struct packet_front *packet_front
 ) {
 	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
-	struct pipeline_ectx *pipeline_ectx = ADDR_OF(pipelines);
+	struct pipeline_ectx *pipeline_ectx = pipelines[0];
 
 	struct packet_front *schedule = &pipeline_ectx->schedule;
 	packet_front_take_output(schedule, packet_front);
@@ -357,12 +611,9 @@ device_entry_ectx_dispatch_many(
 
 	struct packet *packet = packet_list_pop(&packet_front->output);
 	while (packet != NULL) {
-		uint64_t pipeline_idx =
+		struct pipeline_ectx *pipeline_ectx =
 			entry_ectx->pipeline_map
 				[packet->hash % entry_ectx->pipeline_map_size];
-
-		struct pipeline_ectx *pipeline_ectx =
-			ADDR_OF(pipelines + pipeline_idx);
 		packet_front_output(&pipeline_ectx->schedule, packet);
 
 		packet = packet_list_pop(&packet_front->output);
@@ -371,7 +622,7 @@ device_entry_ectx_dispatch_many(
 	packet_front->output_bytes = 0;
 
 	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
-		struct pipeline_ectx *pipeline_ectx = ADDR_OF(pipelines + idx);
+		struct pipeline_ectx *pipeline_ectx = pipelines[idx];
 
 		pipeline_ectx_process(
 			dp_worker, pipeline_ectx, &pipeline_ectx->schedule
@@ -433,7 +684,7 @@ device_ectx_process_entry(
 	struct packet_front *packet_front
 ) {
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_rx),
+		entry_ectx->counter_packet_rx,
 		packet_front_input_count(packet_front),
 		packet_front_input_bytes(packet_front)
 	);
@@ -441,7 +692,7 @@ device_ectx_process_entry(
 	entry_ectx->handler(dp_worker, device_ectx, packet_front);
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_entry),
+		entry_ectx->counter_packet_entry,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -449,22 +700,22 @@ device_ectx_process_entry(
 	device_entry_ectx_dispatch(dp_worker, entry_ectx, packet_front);
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_tx),
+		entry_ectx->counter_packet_tx,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_drop),
+		entry_ectx->counter_packet_drop,
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_pending_input),
+		entry_ectx->counter_packet_pending_input,
 		packet_front_pending_input_count(packet_front),
 		packet_front_pending_input_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&entry_ectx->counter_packet_pending_output),
+		entry_ectx->counter_packet_pending_output,
 		packet_front_pending_output_count(packet_front),
 		packet_front_pending_output_bytes(packet_front)
 	);
@@ -476,8 +727,7 @@ device_ectx_process_input(
 	struct device_ectx *device_ectx,
 	struct packet_front *packet_front
 ) {
-	struct device_entry_ectx *entry_ectx =
-		ADDR_OF(&device_ectx->input_pipelines);
+	struct device_entry_ectx *entry_ectx = device_ectx->abs_input_pipelines;
 
 	device_ectx_process_entry(
 		dp_worker, device_ectx, entry_ectx, packet_front
@@ -491,7 +741,7 @@ device_ectx_process_output(
 	struct packet_front *packet_front
 ) {
 	struct device_entry_ectx *entry_ectx =
-		ADDR_OF(&device_ectx->output_pipelines);
+		device_ectx->abs_output_pipelines;
 
 	device_ectx_process_entry(
 		dp_worker, device_ectx, entry_ectx, packet_front

--- a/lib/dataplane/pipeline/pipeline.h
+++ b/lib/dataplane/pipeline/pipeline.h
@@ -6,7 +6,11 @@ struct dp_config;
 struct dp_worker;
 struct packet_front;
 
+struct config_gen_ectx;
 struct device_ectx;
+
+void
+config_gen_ectx_resolve_counters(struct config_gen_ectx *config_gen_ectx);
 
 void
 device_ectx_process_input(

--- a/lib/dataplane/worker/pipeline_round.c
+++ b/lib/dataplane/worker/pipeline_round.c
@@ -51,8 +51,11 @@ worker_pipeline_round(
 			config_gen_ectx->schedule_active ^ 1;
 
 		struct device_ectx *device_ectx =
-			ADDR_OF(&device_entry_ectx->device_ectx);
+			device_entry_ectx->abs_device_ectx;
 		struct packet_front *schedule = &device_entry_ectx->schedule;
+		if (schedule->input_count == 0) {
+			continue;
+		}
 
 		// Detach the batch so redirects land in the reusable
 		// inbox.

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -643,7 +643,7 @@ dataplane_ut_run(
 		}
 		device_entry_ectx_schedule(
 			config_gen_ectx,
-			ADDR_OF(&device_ectx->input_pipelines),
+			device_ectx->abs_input_pipelines,
 			packet
 		);
 	}

--- a/lib/tests/dataplane/worker_clone_test.c
+++ b/lib/tests/dataplane/worker_clone_test.c
@@ -262,10 +262,8 @@ test_recirc_drop_counts_full_packet(struct rte_mempool *pool) {
 	};
 	struct device_entry_ectx entry = {0};
 	uint64_t counters[2] = {0, 0};
-	SET_OFFSET_OF(
-		&entry.counter_packet_recirc_drop,
-		(struct counter_value_handle *)counters
-	);
+	entry.counter_packet_recirc_drop =
+		(struct counter_value_handle *)counters;
 
 	device_entry_ectx_count_recirc_drop(&entry, &packet);
 

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -169,7 +169,7 @@ acl_handle_packets(
 			module_ectx, acl_config->v4_object_link_idx
 		);
 		if (link != NULL) {
-			struct object_ectx *oectx = ADDR_OF(&link->object_ectx);
+			struct object_ectx *oectx = link->abs_object_ectx;
 			struct cp_object *cp_obj = ADDR_OF(&oectx->cp_object);
 			fw4table = fwstate_map_v4_object_table(cp_obj);
 		}
@@ -179,14 +179,14 @@ acl_handle_packets(
 			module_ectx, acl_config->v6_object_link_idx
 		);
 		if (link != NULL) {
-			struct object_ectx *oectx = ADDR_OF(&link->object_ectx);
+			struct object_ectx *oectx = link->abs_object_ectx;
 			struct cp_object *cp_obj = ADDR_OF(&oectx->cp_object);
 			fw6table = fwstate_map_v6_object_table(cp_obj);
 		}
 	}
 
 	struct counter_storage *counter_storage =
-		ADDR_OF_NONNULL(&module_ectx->counter_storage);
+		module_ectx->abs_counter_storage;
 
 	struct counter_storage *rules_storage = module_ectx_counter_storage(
 		module_ectx, acl_config->rules_registry_idx

--- a/modules/forward/fuzzing/forward.c
+++ b/modules/forward/fuzzing/forward.c
@@ -164,6 +164,7 @@ forward_test_config(struct cp_module **cp_module, yanet_error **err) {
 	mc_index[1] = LPM_VALUE_INVALID;
 	fuzz_params.module_ectx.mc_index_size = 2;
 	SET_OFFSET_OF(&fuzz_params.module_ectx.mc_index, mc_index);
+	fuzz_params.module_ectx.abs_mc_index = mc_index;
 
 	*cp_module = (struct cp_module *)config;
 	return 0;

--- a/modules/fwstate/bindings/go/cfwstate/cgo.go
+++ b/modules/fwstate/bindings/go/cfwstate/cgo.go
@@ -5,6 +5,7 @@ package cfwstate
 //#cgo LDFLAGS: -L../../../../../build/objects/fwstate/api -lfwstate_objects
 //#cgo LDFLAGS: -L../../../../../build/lib/controlplane/config -lconfig_cp
 //#cgo LDFLAGS: -L../../../../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../../../../build/lib/dataplane/pipeline -lpipeline
 //#cgo LDFLAGS: -L../../../../../build/lib/counters -lcounters
 //
 //#include "api/agent.h"

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -6,6 +6,7 @@ package fwstate
 //#cgo LDFLAGS: -L../../../../build/objects/fwstate/api -lfwstate_objects
 //#cgo LDFLAGS: -L../../../../build/lib/controlplane/config -lconfig_cp
 //#cgo LDFLAGS: -L../../../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../../../build/lib/dataplane/pipeline -lpipeline
 //#cgo LDFLAGS: -L../../../../build/lib/counters -lcounters
 //#cgo LDFLAGS: -L../../../../build/lib/dataplane/packet -lpacket
 //#cgo LDFLAGS: -L../../../../build/lib/fwstate -lfwstate

--- a/modules/mirror/fuzzing/mirror.c
+++ b/modules/mirror/fuzzing/mirror.c
@@ -163,6 +163,7 @@ mirror_test_config(struct cp_module **cp_module, yanet_error **err) {
 	mc_index[1] = LPM_VALUE_INVALID;
 	fuzz_params.module_ectx.mc_index_size = 2;
 	SET_OFFSET_OF(&fuzz_params.module_ectx.mc_index, mc_index);
+	fuzz_params.module_ectx.abs_mc_index = mc_index;
 
 	*cp_module = (struct cp_module *)config;
 	return 0;

--- a/modules/route/fuzzing/route.c
+++ b/modules/route/fuzzing/route.c
@@ -168,10 +168,13 @@ fuzz_setup(yanet_error **err) {
 	SET_OFFSET_OF(
 		&fuzz_params.module_ectx.mc_index, &fuzz_params.mc_index_stub
 	);
+	fuzz_params.module_ectx.abs_mc_index = &fuzz_params.mc_index_stub;
 	SET_OFFSET_OF(
 		&fuzz_params.module_ectx.config_gen_ectx,
 		&fuzz_params.config_gen_ectx_stub
 	);
+	fuzz_params.module_ectx.abs_config_gen_ectx =
+		&fuzz_params.config_gen_ectx_stub;
 
 	return 0;
 }


### PR DESCRIPTION
Stacked on #2441 — merge that first.

- Every stage counter, the chains, pipelines, functions, modules and device entries each stage walk, the module device index tables, the module generation back-pointer and storages, and every object link's object context are absolute addresses for the packet hot path, resolved by the publishing process from the counter registry ids and the controlplane-owned relative arrays when a generation is assigned to workers.
- The relative arrays stay authoritative for the free and link paths and as derivation sources, so repeated passes stay correct across dataplane restarts and re-publications.
- Zero-length stage arrays skip their clearing to keep the undefined NULL memset out of the controlplane install path.
- The schedule worklists are provably built before any packet is scheduled, so the per-packet readiness check is gone and the absolute-address contract of the schedule rlist is documented on the list itself.
- Bumps YANET_MODULE_ABI_VERSION to 25.