### PR TITLE
refactor(gateway): host every service through one runner slice

### DIFF
--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -51,12 +51,6 @@ type BackgroundService interface {
 	Run(ctx context.Context) error
 }
 
-// ClosableService is an optional interface for services that hold resources
-// that must be released on shutdown.
-type ClosableService interface {
-	Close() error
-}
-
 // serviceEntry pairs a service with its declared backend kind.
 type serviceEntry struct {
 	Service Service
@@ -137,6 +131,24 @@ func WithListener(listener net.Listener) GatewayOption {
 	}
 }
 
+// serviceRunner runs one hosted Service for the gateway's lifetime.
+//
+// The gateway starts every runner, waits for every runner to become ready
+// before it publishes its own readiness, and closes every runner on
+// shutdown, without caring whether the service shares the gateway's gRPC
+// server or has one of its own.
+type serviceRunner interface {
+	// Ready returns a channel closed once the runner's services are
+	// reachable through the gateway.
+	Ready() <-chan struct{}
+	// ServiceType returns the concrete service type used in diagnostics.
+	ServiceType() string
+	// Run runs the runner until the context is canceled.
+	Run(ctx context.Context) error
+	// Close releases the hosted service's resources.
+	Close() error
+}
+
 // Gateway is the Gateway API to YANET modules.
 //
 // It is a gRPC server that acts as a proxy for each YANET module's
@@ -153,9 +165,7 @@ type Gateway struct {
 	server           *grpc.Server
 	listener         net.Listener
 	memoryListener   *bufconn.Listener
-	services         []Service
-	sharedServices   []Service
-	serviceRunners   []*ServiceRunner
+	runners          []serviceRunner
 	registry         *BackendRegistry
 	readinessTracker *readiness.Tracker
 	log              *zap.Logger
@@ -378,12 +388,11 @@ func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 		)
 	}
 
-	var services []Service
-	var sharedServices []Service
-	var serviceRunners []*ServiceRunner
+	var runners []serviceRunner
 
 	for _, entry := range opts.Services {
-		if entry.Kind == BackendKindBuiltin {
+		switch entry.Kind {
+		case BackendKindBuiltin:
 			// Shared-server service: register on the gateway's gRPC server and
 			// point every service name at the shared loopback backend.
 			entry.Service.RegisterService(server)
@@ -396,13 +405,14 @@ func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 				)
 			}
 
-			sharedServices = append(sharedServices, entry.Service)
-		} else {
-			runner := NewServiceRunner(entry.Service, registry, endpoint, WithServiceRunnerLog(log))
-			serviceRunners = append(serviceRunners, runner)
+			runners = append(runners, newBuiltinServiceRunner(entry.Service))
+		case BackendKindInProcess:
+			runners = append(runners, NewInProcessServiceRunner(entry.Service, registry, endpoint, WithInProcessServiceRunnerLog(log)))
+		case BackendKindExternal:
+			return nil, fmt.Errorf("service %q is external and cannot be hosted inside the gateway", entry.Service.Name())
+		default:
+			return nil, fmt.Errorf("service %q has unknown backend kind %s", entry.Service.Name(), entry.Kind)
 		}
-
-		services = append(services, entry.Service)
 	}
 
 	return &Gateway{
@@ -410,9 +420,7 @@ func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 		server:           server,
 		listener:         opts.Listener,
 		memoryListener:   memoryListener,
-		services:         services,
-		sharedServices:   sharedServices,
-		serviceRunners:   serviceRunners,
+		runners:          runners,
 		registry:         registry,
 		readinessTracker: rdTracker,
 		log:              log,
@@ -423,14 +431,9 @@ func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 func (m *Gateway) Close() error {
 	var errs []error
 
-	for _, service := range m.services {
-		closer, ok := service.(ClosableService)
-		if !ok {
-			continue
-		}
-
-		if err := closer.Close(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to close service %T: %w", service, err))
+	for _, runner := range m.runners {
+		if err := runner.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close service %s: %w", runner.ServiceType(), err))
 		}
 	}
 
@@ -439,6 +442,20 @@ func (m *Gateway) Close() error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// pendingRunners returns the runners that are not ready yet.
+func (m *Gateway) pendingRunners() []serviceRunner {
+	var pending []serviceRunner
+	for _, runner := range m.runners {
+		select {
+		case <-runner.Ready():
+		default:
+			pending = append(pending, runner)
+		}
+	}
+
+	return pending
 }
 
 // Run runs the gateway API until the specified context is canceled.
@@ -470,9 +487,8 @@ func (m *Gateway) Run(ctx context.Context) error {
 		})
 	}
 
-	for _, runner := range m.serviceRunners {
+	for _, runner := range m.runners {
 		wg.Go(func() error {
-			m.log.Info("starting in-process service", zap.String("service", runner.ServiceType()))
 			return runner.Run(ctx)
 		})
 	}
@@ -481,29 +497,18 @@ func (m *Gateway) Run(ctx context.Context) error {
 		return m.runRegistrySweeper(ctx)
 	})
 
-	// Runners schedule the background jobs of their own services, so only the
-	// shared-server ones are scheduled here.
-	for _, service := range m.sharedServices {
-		if background, ok := service.(BackgroundService); ok {
-			wg.Go(func() error {
-				return background.Run(ctx)
-			})
-		}
-	}
-
-	// The readiness marker is published once every in-process service
-	// runner has finished its initial service registration, and
-	// immediately when there are none. Both branches emit the identical
-	// "all built-in modules ready" message, so a run publishes at most
-	// one readiness marker: the waiting branch publishes none if the
+	// The readiness marker is published once every runner still registering
+	// has finished, and immediately when none is. Both branches emit the
+	// identical "all built-in modules ready" message, so a run publishes at
+	// most one readiness marker: the waiting branch publishes none if the
 	// context is canceled before every runner has registered.
 	//
 	// That message text is matched verbatim by an external observer to
 	// decide the gateway is ready to accept module RPCs, so its wording is a
 	// contract and must stay identical between the branches.
-	if len(m.serviceRunners) > 0 {
+	if pending := m.pendingRunners(); len(pending) > 0 {
 		wg.Go(func() error {
-			for _, runner := range m.serviceRunners {
+			for _, runner := range pending {
 				select {
 				case <-ctx.Done():
 					return nil
@@ -511,7 +516,7 @@ func (m *Gateway) Run(ctx context.Context) error {
 				}
 			}
 			m.log.Info("all built-in modules ready",
-				zap.Int("count", len(m.serviceRunners)),
+				zap.Int("count", len(pending)),
 			)
 			m.readinessTracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
 			return nil

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -143,7 +143,8 @@ type serviceRunner interface {
 	Ready() <-chan struct{}
 	// ServiceType returns the concrete service type used in diagnostics.
 	ServiceType() string
-	// Run runs the runner until the context is canceled.
+	// Run runs the runner's work and returns once it is done or the context
+	// is canceled. A runner without background work returns at once.
 	Run(ctx context.Context) error
 	// Close releases the hosted service's resources.
 	Close() error
@@ -444,7 +445,10 @@ func (m *Gateway) Close() error {
 	return errors.Join(errs...)
 }
 
-// pendingRunners returns the runners that are not ready yet.
+// pendingRunners returns the runners not ready at the time of the call.
+//
+// Taken before any runner starts, the result is exactly the in-process
+// runners, since a framework runner is ready from construction.
 func (m *Gateway) pendingRunners() []serviceRunner {
 	var pending []serviceRunner
 	for _, runner := range m.runners {
@@ -487,6 +491,11 @@ func (m *Gateway) Run(ctx context.Context) error {
 		})
 	}
 
+	// The runners still registering are snapshotted before any runner
+	// starts, so a runner that registers instantly still leaves readiness to
+	// the waiting goroutine below and the log it emits never blocks this one.
+	pending := m.pendingRunners()
+
 	for _, runner := range m.runners {
 		wg.Go(func() error {
 			return runner.Run(ctx)
@@ -506,7 +515,7 @@ func (m *Gateway) Run(ctx context.Context) error {
 	// That message text is matched verbatim by an external observer to
 	// decide the gateway is ready to accept module RPCs, so its wording is a
 	// contract and must stay identical between the branches.
-	if pending := m.pendingRunners(); len(pending) > 0 {
+	if len(pending) > 0 {
 		wg.Go(func() error {
 			for _, runner := range pending {
 				select {

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -229,6 +229,79 @@ func Test_Gateway_HTTPProxy_ReachesBuiltinOverTLS(t *testing.T) {
 	require.Contains(t, string(body), "controlplane.ynpb.v1.Gateway")
 }
 
+// lifecycleService is a Service recording that its background job ran and
+// that it was closed, under a unique gRPC service name.
+type lifecycleService struct {
+	name   string
+	ran    chan struct{}
+	closed chan struct{}
+}
+
+func newLifecycleService(name string) *lifecycleService {
+	return &lifecycleService{
+		name:   name,
+		ran:    make(chan struct{}),
+		closed: make(chan struct{}),
+	}
+}
+
+func (m *lifecycleService) Name() string                   { return m.name }
+func (m *lifecycleService) Endpoint() string               { return "" }
+func (m *lifecycleService) ServicesNames() []string        { return []string{"test." + m.name} }
+func (m *lifecycleService) RegisterService(_ *grpc.Server) {}
+
+func (m *lifecycleService) Run(ctx context.Context) error {
+	close(m.ran)
+	<-ctx.Done()
+	return nil
+}
+
+func (m *lifecycleService) Close() error {
+	close(m.closed)
+	return nil
+}
+
+// Test_Gateway_HostsRunAndCloseEveryService verifies that the gateway runs
+// the background job of a framework service and of a module service alike,
+// and closes both on shutdown.
+func Test_Gateway_HostsRunAndCloseEveryService(t *testing.T) {
+	t.Parallel()
+
+	builtin := newLifecycleService("builtin")
+	module := newLifecycleService("module")
+
+	gw, err := gateway.NewGateway(gateway.DefaultConfig(),
+		gateway.WithListener(NewTestListener(t)),
+		gateway.WithBuiltinService(builtin),
+		gateway.WithService(module),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var group errgroup.Group
+	group.Go(func() error { return gw.Run(ctx) })
+
+	for _, service := range []*lifecycleService{builtin, module} {
+		select {
+		case <-service.ran:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("background job of %s did not start", service.name)
+		}
+	}
+
+	cancel()
+	require.NoError(t, group.Wait())
+	require.NoError(t, gw.Close())
+
+	for _, service := range []*lifecycleService{builtin, module} {
+		select {
+		case <-service.closed:
+		default:
+			t.Fatalf("%s was not closed", service.name)
+		}
+	}
+}
+
 // NewTestListener opens an ephemeral loopback TCP listener for a test to
 // pass into WithListener or hold open to occupy a port, registering a
 // cleanup that closes it.

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -237,6 +237,8 @@ type lifecycleService struct {
 	closed chan struct{}
 }
 
+// newLifecycleService returns a service whose run and close markers fire
+// exactly once, so it expects one gateway run and one close.
 func newLifecycleService(name string) *lifecycleService {
 	return &lifecycleService{
 		name:   name,

--- a/controlplane/gateway/runner.go
+++ b/controlplane/gateway/runner.go
@@ -18,13 +18,14 @@ import (
 // UnaryInterceptedService is implemented by services that contribute their own
 // unary interceptors to the gRPC server the runner gives them.
 //
-// InProcessServiceRunner appends these after the framework access-log interceptor.
+// InProcessServiceRunner appends these after the framework access-log
+// interceptor.
 type UnaryInterceptedService interface {
 	UnaryServerInterceptors() []grpc.UnaryServerInterceptor
 }
 
-// InProcessServiceRunner serves an in-process Service on its own gRPC server behind an
-// in-memory listener and registers it with the gateway's registry directly.
+// InProcessServiceRunner serves an in-process Service on its own gRPC server
+// behind an in-memory listener and registers it with the registry directly.
 //
 // The service never touches the network: its server is reachable only
 // through the connection the runner hands to the registry, so no transport
@@ -39,7 +40,7 @@ type InProcessServiceRunner struct {
 	log      *zap.Logger
 }
 
-// InProcessServiceRunnerOption configures the InProcessServiceRunner constructor.
+// InProcessServiceRunnerOption configures the in-process runner constructor.
 type InProcessServiceRunnerOption func(*inProcessServiceRunnerOptions)
 
 type inProcessServiceRunnerOptions struct {
@@ -59,8 +60,8 @@ func WithInProcessServiceRunnerLog(log *zap.Logger) InProcessServiceRunnerOption
 	}
 }
 
-// NewInProcessServiceRunner creates a runner that registers module's services in
-// registry under endpoint, the address the gateway itself serves.
+// NewInProcessServiceRunner creates a runner that registers module's
+// services in registry under endpoint, the address the gateway itself serves.
 //
 // That address is where the services are reachable from outside. An endpoint
 // the module carries for itself only applies when it runs in a separate

--- a/controlplane/gateway/runner.go
+++ b/controlplane/gateway/runner.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -17,19 +18,19 @@ import (
 // UnaryInterceptedService is implemented by services that contribute their own
 // unary interceptors to the gRPC server the runner gives them.
 //
-// ServiceRunner appends these after the framework access-log interceptor.
+// InProcessServiceRunner appends these after the framework access-log interceptor.
 type UnaryInterceptedService interface {
 	UnaryServerInterceptors() []grpc.UnaryServerInterceptor
 }
 
-// ServiceRunner serves an in-process Service on its own gRPC server behind an
+// InProcessServiceRunner serves an in-process Service on its own gRPC server behind an
 // in-memory listener and registers it with the gateway's registry directly.
 //
 // The service never touches the network: its server is reachable only
 // through the connection the runner hands to the registry, so no transport
 // security and no authentication apply on that hop. The gateway's own
 // listeners stay the only entry points from outside.
-type ServiceRunner struct {
+type InProcessServiceRunner struct {
 	module   Service
 	registry *BackendRegistry
 	endpoint string
@@ -38,39 +39,39 @@ type ServiceRunner struct {
 	log      *zap.Logger
 }
 
-// ServiceRunnerOption configures the ServiceRunner constructor.
-type ServiceRunnerOption func(*serviceRunnerOptions)
+// InProcessServiceRunnerOption configures the InProcessServiceRunner constructor.
+type InProcessServiceRunnerOption func(*inProcessServiceRunnerOptions)
 
-type serviceRunnerOptions struct {
+type inProcessServiceRunnerOptions struct {
 	Log *zap.Logger
 }
 
-func newServiceRunnerOptions() *serviceRunnerOptions {
-	return &serviceRunnerOptions{
+func newInProcessServiceRunnerOptions() *inProcessServiceRunnerOptions {
+	return &inProcessServiceRunnerOptions{
 		Log: zap.NewNop(),
 	}
 }
 
-// WithServiceRunnerLog sets the logger for the service runner.
-func WithServiceRunnerLog(log *zap.Logger) ServiceRunnerOption {
-	return func(o *serviceRunnerOptions) {
+// WithInProcessServiceRunnerLog sets the logger for the service runner.
+func WithInProcessServiceRunnerLog(log *zap.Logger) InProcessServiceRunnerOption {
+	return func(o *inProcessServiceRunnerOptions) {
 		o.Log = log
 	}
 }
 
-// NewServiceRunner creates a runner that registers module's services in
+// NewInProcessServiceRunner creates a runner that registers module's services in
 // registry under endpoint, the address the gateway itself serves.
 //
 // That address is where the services are reachable from outside. An endpoint
 // the module carries for itself only applies when it runs in a separate
 // process, so it is logged and ignored here.
-func NewServiceRunner(
+func NewInProcessServiceRunner(
 	module Service,
 	registry *BackendRegistry,
 	endpoint string,
-	options ...ServiceRunnerOption,
-) *ServiceRunner {
-	opts := newServiceRunnerOptions()
+	options ...InProcessServiceRunnerOption,
+) *InProcessServiceRunner {
+	opts := newInProcessServiceRunnerOptions()
 	for _, o := range options {
 		o(opts)
 	}
@@ -88,7 +89,7 @@ func NewServiceRunner(
 		interceptors = append(interceptors, provider.UnaryServerInterceptors()...)
 	}
 
-	return &ServiceRunner{
+	return &InProcessServiceRunner{
 		module:   module,
 		registry: registry,
 		endpoint: endpoint,
@@ -103,25 +104,27 @@ func NewServiceRunner(
 
 // Ready returns a channel closed exactly once, when the runner has registered
 // its services and the module is reachable through the gateway.
-func (m *ServiceRunner) Ready() <-chan struct{} {
+func (m *InProcessServiceRunner) Ready() <-chan struct{} {
 	return m.ready
 }
 
 // ServiceType returns the concrete service type used in runner diagnostics.
-func (m *ServiceRunner) ServiceType() string {
+func (m *InProcessServiceRunner) ServiceType() string {
 	return fmt.Sprintf("%T", m.module)
 }
 
-// Close closes the underlying service if it implements ClosableService.
-func (m *ServiceRunner) Close() error {
-	if c, ok := m.module.(ClosableService); ok {
+// Close closes the underlying service if it implements io.Closer.
+func (m *InProcessServiceRunner) Close() error {
+	if c, ok := m.module.(io.Closer); ok {
 		return c.Close()
 	}
 	return nil
 }
 
 // Run runs the service until the context is canceled.
-func (m *ServiceRunner) Run(ctx context.Context) error {
+func (m *InProcessServiceRunner) Run(ctx context.Context) error {
+	m.log.Info("starting in-process service", zap.String("service", m.ServiceType()))
+
 	listener := newMemoryListener()
 
 	m.module.RegisterService(m.server)
@@ -165,7 +168,7 @@ func (m *ServiceRunner) Run(ctx context.Context) error {
 //
 // A service exposing no gRPC services has nothing to register, so no
 // connection is opened for it.
-func (m *ServiceRunner) register(listener *bufconn.Listener) error {
+func (m *InProcessServiceRunner) register(listener *bufconn.Listener) error {
 	names := m.module.ServicesNames()
 	if len(names) == 0 {
 		return nil
@@ -182,6 +185,56 @@ func (m *ServiceRunner) register(listener *bufconn.Listener) error {
 			zap.String("service", name),
 			zap.Stringer("kind", BackendKindInProcess),
 		)
+	}
+
+	return nil
+}
+
+// builtinServiceRunner runs a framework service registered on the gateway's
+// own gRPC server.
+//
+// Such a service is reachable as soon as the gateway serves, so the runner is
+// ready from construction and only runs the service's background job, if it
+// has one.
+type builtinServiceRunner struct {
+	service Service
+	ready   chan struct{}
+}
+
+func newBuiltinServiceRunner(service Service) *builtinServiceRunner {
+	ready := make(chan struct{})
+	close(ready)
+
+	return &builtinServiceRunner{
+		service: service,
+		ready:   ready,
+	}
+}
+
+// Ready returns a channel that is already closed.
+func (m *builtinServiceRunner) Ready() <-chan struct{} {
+	return m.ready
+}
+
+// ServiceType returns the concrete service type used in diagnostics.
+func (m *builtinServiceRunner) ServiceType() string {
+	return fmt.Sprintf("%T", m.service)
+}
+
+// Run runs the service's background job, returning at once for a service
+// without one.
+func (m *builtinServiceRunner) Run(ctx context.Context) error {
+	if background, ok := m.service.(BackgroundService); ok {
+		return background.Run(ctx)
+	}
+
+	return nil
+}
+
+// Close closes the service if it implements io.Closer.
+func (m *builtinServiceRunner) Close() error {
+	if closer, ok := m.service.(io.Closer); ok {
+		return closer.Close()
 	}
 
 	return nil

--- a/controlplane/gateway/runner_test.go
+++ b/controlplane/gateway/runner_test.go
@@ -50,12 +50,12 @@ func startServiceRunner(t *testing.T, runner *gateway.InProcessServiceRunner) {
 	}
 }
 
-// Test_ServiceRunner_Run_ServesThroughRegistry verifies that a runner answers
+// Test_InProcessServiceRunner_Run_ServesThroughRegistry verifies that a runner answers
 // RPCs through the registry's connection to it.
 //
 // The services are recorded as in-process backends labeled with the
 // gateway's endpoint, the address they are reachable at from outside.
-func Test_ServiceRunner_Run_ServesThroughRegistry(t *testing.T) {
+func Test_InProcessServiceRunner_Run_ServesThroughRegistry(t *testing.T) {
 	t.Parallel()
 
 	const gatewayEndpoint = "gateway.test:8080"
@@ -82,13 +82,13 @@ func Test_ServiceRunner_Run_ServesThroughRegistry(t *testing.T) {
 	require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, response.GetStatus())
 }
 
-// Test_ServiceRunner_Run_ShutsDownWithOpenStream verifies that the runner
+// Test_InProcessServiceRunner_Run_ShutsDownWithOpenStream verifies that the runner
 // returns within a bounded time after its context is canceled.
 //
 // A client keeps a server-streaming RPC open on the runner's own gRPC server
 // meanwhile, reproducing the hang an unattended readiness watch causes on
 // shutdown.
-func Test_ServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
+func Test_InProcessServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
 	t.Parallel()
 
 	registry := gateway.NewBackendRegistry()

--- a/controlplane/gateway/runner_test.go
+++ b/controlplane/gateway/runner_test.go
@@ -50,8 +50,8 @@ func startServiceRunner(t *testing.T, runner *gateway.InProcessServiceRunner) {
 	}
 }
 
-// Test_InProcessServiceRunner_Run_ServesThroughRegistry verifies that a runner answers
-// RPCs through the registry's connection to it.
+// Test_InProcessServiceRunner_Run_ServesThroughRegistry verifies that a
+// runner answers RPCs through the registry's connection to it.
 //
 // The services are recorded as in-process backends labeled with the
 // gateway's endpoint, the address they are reachable at from outside.
@@ -82,8 +82,8 @@ func Test_InProcessServiceRunner_Run_ServesThroughRegistry(t *testing.T) {
 	require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, response.GetStatus())
 }
 
-// Test_InProcessServiceRunner_Run_ShutsDownWithOpenStream verifies that the runner
-// returns within a bounded time after its context is canceled.
+// Test_InProcessServiceRunner_Run_ShutsDownWithOpenStream verifies that the
+// runner returns within a bounded time after its context is canceled.
 //
 // A client keeps a server-streaming RPC open on the runner's own gRPC server
 // meanwhile, reproducing the hang an unattended readiness watch causes on

--- a/controlplane/gateway/runner_test.go
+++ b/controlplane/gateway/runner_test.go
@@ -32,7 +32,7 @@ func (m *healthService) RegisterService(server *grpc.Server) {
 
 // startServiceRunner runs runner until the test ends, failing the test if
 // it does not register within a bounded time or exits with an error.
-func startServiceRunner(t *testing.T, runner *gateway.ServiceRunner) {
+func startServiceRunner(t *testing.T, runner *gateway.InProcessServiceRunner) {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -64,7 +64,7 @@ func Test_ServiceRunner_Run_ServesThroughRegistry(t *testing.T) {
 	registry := gateway.NewBackendRegistry()
 	t.Cleanup(func() { _ = registry.Close() })
 
-	startServiceRunner(t, gateway.NewServiceRunner(&healthService{}, registry, gatewayEndpoint))
+	startServiceRunner(t, gateway.NewInProcessServiceRunner(&healthService{}, registry, gatewayEndpoint))
 
 	entry := getBackendEntry(t, registry, serviceName)
 	require.Equal(t, gateway.BackendKindInProcess, entry.Kind())
@@ -94,7 +94,7 @@ func Test_ServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
 	registry := gateway.NewBackendRegistry()
 	t.Cleanup(func() { _ = registry.Close() })
 
-	runner := gateway.NewServiceRunner(&blockingReadinessService{}, registry, "gateway.test:8080")
+	runner := gateway.NewInProcessServiceRunner(&blockingReadinessService{}, registry, "gateway.test:8080")
 
 	ctx, cancel := context.WithCancel(t.Context())
 	var group errgroup.Group


### PR DESCRIPTION
- The gateway keeps one list of service runners instead of three slices for closing, background jobs and readiness, each runner owning its own start, readiness and close.
- A framework service on the shared gRPC server is a runner that is ready from construction and only runs its background job.
- A service registered with an unsupported backend kind is refused when the gateway is built.
- The optional closer interface is the standard io.Closer.
