### PR TITLE
feat(operator): dial the gateway over tls

### DIFF
--- a/common/go/operator/cfg.go
+++ b/common/go/operator/cfg.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/common/go/xgrpc"
 )
 
 const (
@@ -54,6 +55,8 @@ type GatewayConfig struct {
 	Name string `yaml:"name"`
 	// Endpoint is the gRPC address of the Gateway.
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	// TLS enables TLS towards the Gateway when present, plaintext otherwise.
+	TLS *xgrpc.ClientTLSConfig `yaml:"tls"`
 }
 
 // RegisterConfig holds the gateway registration heartbeat parameter.

--- a/common/go/operator/cfg_test.go
+++ b/common/go/operator/cfg_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 // verifies that valid names and addresses pass without resolving their hosts,
@@ -39,4 +40,24 @@ func Test_GRPCServerConfig_Validate_AdvertiseEndpoint(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// Test_GatewayConfig_Decode_RejectsHalfKeypair verifies that loading a
+// gateway list validates its tls block, so a client certificate given
+// without its key fails at startup rather than at the first dial.
+func Test_GatewayConfig_Decode_RejectsHalfKeypair(t *testing.T) {
+	t.Parallel()
+
+	var cfg struct {
+		Gateways []operator.GatewayConfig `yaml:"gateways"`
+	}
+	err := xcfg.Decode([]byte(`
+gateways:
+  - name: numa0
+    endpoint: "[::1]:8080"
+    tls:
+      cert_file: /etc/yanet2/tls/operator.pem
+`), &cfg)
+
+	require.ErrorContains(t, err, "cert_file and key_file must be set together")
 }

--- a/common/go/operator/dial.go
+++ b/common/go/operator/dial.go
@@ -1,0 +1,29 @@
+package operator
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc"
+
+	"github.com/yanet-platform/yanet2/common/go/xgrpc"
+)
+
+// DialGateway opens a client connection to the gateway cfg describes, in
+// plaintext or over TLS as its tls block says.
+//
+// The connection dials lazily, so an unreachable gateway surfaces on the
+// first RPC rather than here.
+func DialGateway(cfg GatewayConfig) (*grpc.ClientConn, error) {
+	creds, err := xgrpc.ClientCredentials(cfg.TLS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build transport credentials for gateway %q: %w", cfg.Name, err)
+	}
+
+	endpoint := cfg.Endpoint.Unwrap()
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial gateway %q at %q: %w", cfg.Name, endpoint, err)
+	}
+
+	return conn, nil
+}

--- a/common/go/operator/dial_test.go
+++ b/common/go/operator/dial_test.go
@@ -1,0 +1,120 @@
+package operator_test
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/testutils/tlscert"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/common/go/xgrpc"
+)
+
+// serveHealth starts a gRPC health server on a loopback port with the given
+// server options, stopping it when the test ends, and returns its address.
+func serveHealth(t *testing.T, options ...grpc.ServerOption) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer(options...)
+	grpc_health_v1.RegisterHealthServer(server, health.NewServer())
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(server.Stop)
+
+	return listener.Addr().String()
+}
+
+// checkHealth dials the gateway described by cfg and reports the error of
+// one health check through it.
+func checkHealth(t *testing.T, cfg operator.GatewayConfig) error {
+	t.Helper()
+
+	conn, err := operator.DialGateway(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	_, err = grpc_health_v1.NewHealthClient(conn).Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	return err
+}
+
+// Test_DialGateway_TLS verifies that the tls block selects the transport the
+// gateway speaks: a trusted CA, a client certificate the server demands and a
+// server name override all reach a TLS gateway, while plaintext, an untrusted
+// CA and a missing client certificate do not.
+func Test_DialGateway_TLS(t *testing.T) {
+	t.Parallel()
+
+	ca := tlscert.NewCA(t)
+	other := tlscert.NewCA(t)
+	server := ca.IssueServer(t, "127.0.0.1", "gateway.test")
+	client := ca.IssueClient(t, "operator")
+
+	serverTLS := serveHealth(t, grpc.Creds(credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{server.Certificate},
+		MinVersion:   tls.VersionTLS12,
+	})))
+	mutualTLS := serveHealth(t, grpc.Creds(credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{server.Certificate},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    ca.Pool(),
+		MinVersion:   tls.VersionTLS12,
+	})))
+	plaintext := serveHealth(t)
+
+	tests := []struct {
+		name     string
+		endpoint string
+		tls      *xgrpc.ClientTLSConfig
+		wantErr  bool
+	}{
+		{name: "plaintext gateway without tls block", endpoint: plaintext},
+		{name: "tls gateway with trusted CA", endpoint: serverTLS, tls: &xgrpc.ClientTLSConfig{CAFile: ca.BundleFile()}},
+		{name: "tls gateway with server name override", endpoint: serverTLS, tls: &xgrpc.ClientTLSConfig{
+			CAFile: ca.BundleFile(), ServerName: "gateway.test",
+		}},
+		{name: "mutual tls gateway with client certificate", endpoint: mutualTLS, tls: &xgrpc.ClientTLSConfig{
+			CAFile: ca.BundleFile(), CertFile: client.CertFile, KeyFile: client.KeyFile,
+		}},
+		{name: "tls gateway without tls block", endpoint: serverTLS, wantErr: true},
+		{name: "tls gateway with untrusted CA", endpoint: serverTLS, tls: &xgrpc.ClientTLSConfig{CAFile: other.BundleFile()}, wantErr: true},
+		{name: "mutual tls gateway without client certificate", endpoint: mutualTLS, tls: &xgrpc.ClientTLSConfig{
+			CAFile: ca.BundleFile(),
+		}, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := checkHealth(t, operator.GatewayConfig{
+				Name:     "numa0",
+				Endpoint: xcfg.MustNonEmptyString(test.endpoint),
+				TLS:      test.tls,
+			})
+			if test.wantErr {
+				require.Equal(t, codes.Unavailable, status.Code(err), "%v", err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/common/go/operator/registrar.go
+++ b/common/go/operator/registrar.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/yanet-platform/yanet2/common/go/xgrpc"
 	"github.com/yanet-platform/yanet2/controlplane/gateway"
 )
 
@@ -93,9 +94,14 @@ func (m *GatewayRegRunner) Run(ctx context.Context) error {
 			zap.String("gateway_endpoint", cfg.Endpoint.Unwrap()),
 		)
 
+		creds, err := xgrpc.ClientCredentials(cfg.TLS)
+		if err != nil {
+			return fmt.Errorf("failed to build transport credentials for gateway %q: %w", cfg.Name, err)
+		}
+
 		registrar, err := gateway.NewGatewayRegistrar(
 			cfg.Endpoint.Unwrap(),
-			nil,
+			creds,
 			gateway.WithBackOff(shortBackOff),
 			gateway.WithMaxElapsedTime(m.interval/2),
 			gateway.WithRegistrarLog(log),

--- a/common/go/operator/registrar_test.go
+++ b/common/go/operator/registrar_test.go
@@ -2,6 +2,7 @@ package operator_test
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"testing"
 	"time"
@@ -9,9 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/testutils/tlscert"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/common/go/xgrpc"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
@@ -40,16 +44,17 @@ func (m *recordingGateway) Register(
 	return &ynpb.RegisterResponse{}, nil
 }
 
-// serveRecordingGateway starts a fake Gateway on a loopback port, stopping it
-// when the test ends, and returns it with the endpoint to dial.
-func serveRecordingGateway(t *testing.T) (*recordingGateway, string) {
+// serveRecordingGateway starts a fake Gateway on a loopback port with the
+// given server options, stopping it when the test ends, and returns it with
+// the endpoint to dial.
+func serveRecordingGateway(t *testing.T, options ...grpc.ServerOption) (*recordingGateway, string) {
 	t.Helper()
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	service := newRecordingGateway()
-	server := grpc.NewServer()
+	server := grpc.NewServer(options...)
 	ynpb.RegisterGatewayServer(server, service)
 
 	go func() {
@@ -102,4 +107,39 @@ func Test_GatewayRegRunner_Run_RegistersGivenEndpointVerbatim(t *testing.T) {
 	}()
 
 	require.Equal(t, advertised, awaitEndpoint(t, service))
+}
+
+// Test_GatewayRegRunner_Run_RegistersOverTLS verifies that a gateway with a
+// tls block is reached over TLS with the configured CA.
+func Test_GatewayRegRunner_Run_RegistersOverTLS(t *testing.T) {
+	t.Parallel()
+
+	ca := tlscert.NewCA(t)
+	server := ca.IssueServer(t, "127.0.0.1")
+
+	service, gatewayEndpoint := serveRecordingGateway(t, grpc.Creds(credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{server.Certificate},
+		MinVersion:   tls.VersionTLS12,
+	})))
+
+	runner := operator.NewGatewayRegRunner(
+		[]operator.GatewayConfig{{
+			Name:     "numa0",
+			Endpoint: xcfg.MustNonEmptyString(gatewayEndpoint),
+			TLS:      &xgrpc.ClientTLSConfig{CAFile: ca.BundleFile()},
+		}},
+		[]string{"fake.Service"},
+		"route-operator.yanet:8080",
+		operator.WithGatewayRegInterval(time.Second),
+		operator.WithGatewayRegLog(zap.NewNop()),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		_ = runner.Run(ctx)
+	}()
+
+	require.Equal(t, "route-operator.yanet:8080", awaitEndpoint(t, service))
 }

--- a/common/go/operator/static.go
+++ b/common/go/operator/static.go
@@ -8,7 +8,6 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -111,7 +110,7 @@ func NewStaticModuleOperator(
 			commonpb.NewLabel("gateway", gw.Name),
 		)
 		metricsCollectors = append(metricsCollectors, gatewayMetrics)
-		conn, err := dialGateway(gw)
+		conn, err := DialGateway(gw)
 		if err != nil {
 			for _, a := range actuators {
 				_ = a.Close()
@@ -312,15 +311,6 @@ type staticGatewayActuator struct {
 	conn      *grpc.ClientConn
 	functions ynpb.FunctionServiceClient
 	log       *zap.Logger
-}
-
-func dialGateway(cfg GatewayConfig) (*grpc.ClientConn, error) {
-	endpoint := cfg.Endpoint.Unwrap()
-	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial gateway %q at %q: %w", cfg.Name, endpoint, err)
-	}
-	return conn, nil
 }
 
 // Apply tries every target regardless of partial failures and joins the

--- a/common/go/testutils/tlscert/tlscert.go
+++ b/common/go/testutils/tlscert/tlscert.go
@@ -1,0 +1,182 @@
+// Package tlscert issues throwaway certificates for tests that need a TLS
+// server or client behind a private CA.
+package tlscert
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// CA is a self-signed certificate authority whose bundle lives in the test's
+// temporary directory. One CA may issue from parallel subtests.
+type CA struct {
+	certificate *x509.Certificate
+	key         *ecdsa.PrivateKey
+	pool        *x509.CertPool
+	bundleFile  string
+	dir         string
+	issued      atomic.Int64
+}
+
+// Keypair is a certificate issued by a CA together with the PEM files it was
+// written to.
+type Keypair struct {
+	// Certificate is the issued certificate with its private key.
+	Certificate tls.Certificate
+	// CertFile is the PEM file holding the certificate.
+	CertFile string
+	// KeyFile is the PEM file holding the private key.
+	KeyFile string
+}
+
+// NewCA generates a CA valid for an hour and writes its PEM bundle to disk.
+func NewCA(t *testing.T) *CA {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          newSerial(t),
+		Subject:               pkix.Name{CommonName: "test CA"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certificate, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(certificate)
+
+	dir := t.TempDir()
+	bundleFile := filepath.Join(dir, "ca.pem")
+	writePEM(t, bundleFile, "CERTIFICATE", der)
+
+	return &CA{
+		certificate: certificate,
+		key:         key,
+		pool:        pool,
+		bundleFile:  bundleFile,
+		dir:         dir,
+	}
+}
+
+// BundleFile returns the path of the PEM bundle holding the CA certificate.
+func (m *CA) BundleFile() string {
+	return m.bundleFile
+}
+
+// Pool returns a pool trusting only this CA.
+func (m *CA) Pool() *x509.CertPool {
+	return m.pool
+}
+
+// IssueServer issues a server certificate for the given hosts, each a DNS
+// name or an IP address literal.
+func (m *CA) IssueServer(t *testing.T, hosts ...string) Keypair {
+	t.Helper()
+
+	template := &x509.Certificate{
+		SerialNumber: newSerial(t),
+		Subject:      pkix.Name{CommonName: "test server"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	for _, host := range hosts {
+		if ip := net.ParseIP(host); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+			continue
+		}
+		template.DNSNames = append(template.DNSNames, host)
+	}
+
+	return m.issue(t, "server", template)
+}
+
+// IssueClient issues a client certificate with the given common name.
+func (m *CA) IssueClient(t *testing.T, commonName string) Keypair {
+	t.Helper()
+
+	template := &x509.Certificate{
+		SerialNumber: newSerial(t),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	return m.issue(t, "client", template)
+}
+
+// issue signs template with the CA and writes the pair under a unique name.
+func (m *CA) issue(t *testing.T, kind string, template *x509.Certificate) Keypair {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	der, err := x509.CreateCertificate(rand.Reader, template, m.certificate, &key.PublicKey, m.key)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+
+	issued := m.issued.Add(1)
+	certFile := filepath.Join(m.dir, fmt.Sprintf("%s-%d.pem", kind, issued))
+	keyFile := filepath.Join(m.dir, fmt.Sprintf("%s-%d.key", kind, issued))
+	writePEM(t, certFile, "CERTIFICATE", der)
+	writePEM(t, keyFile, "PRIVATE KEY", keyDER)
+
+	certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
+	require.NoError(t, err)
+
+	return Keypair{
+		Certificate: certificate,
+		CertFile:    certFile,
+		KeyFile:     keyFile,
+	}
+}
+
+// newSerial draws a 62-bit random serial, making a collision between
+// certificates issued by one CA improbable rather than impossible.
+func newSerial(t *testing.T) *big.Int {
+	t.Helper()
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 62))
+	require.NoError(t, err)
+
+	return serial
+}
+
+// writePEM writes one DER block to path in PEM armor.
+func writePEM(t *testing.T, path string, blockType string, der []byte) {
+	t.Helper()
+
+	block := pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der})
+	require.NoError(t, os.WriteFile(path, block, 0o600))
+}

--- a/common/go/xgrpc/tls.go
+++ b/common/go/xgrpc/tls.go
@@ -1,0 +1,82 @@
+package xgrpc
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// ClientTLSConfig is the TLS material a gRPC client uses towards a server.
+//
+// A nil config dials in plaintext. A present config, even an empty one,
+// dials with TLS: the server certificate is verified against the system
+// roots unless a CA bundle replaces them, and a client certificate is
+// presented only when both of its files are given. Every file is PEM.
+type ClientTLSConfig struct {
+	// CAFile is the PEM bundle that replaces the system roots for server
+	// verification.
+	CAFile string `yaml:"ca_file"`
+	// CertFile is the PEM client certificate chain for mutual TLS.
+	CertFile string `yaml:"cert_file"`
+	// KeyFile is the PEM private key matching the client certificate.
+	KeyFile string `yaml:"key_file"`
+	// ServerName is the host the server certificate is verified against
+	// and sent as SNI.
+	//
+	// Optional. Defaults to the host of the dialed endpoint.
+	ServerName string `yaml:"server_name"`
+}
+
+// Validate rejects a client certificate given without its key and a key
+// given without its certificate.
+func (m *ClientTLSConfig) Validate() error {
+	if (m.CertFile == "") != (m.KeyFile == "") {
+		return errors.New("cert_file and key_file must be set together")
+	}
+
+	return nil
+}
+
+// ClientCredentials builds the transport credentials cfg describes:
+// plaintext for nil, TLS otherwise.
+func ClientCredentials(cfg *ClientTLSConfig) (credentials.TransportCredentials, error) {
+	if cfg == nil {
+		return insecure.NewCredentials(), nil
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		ServerName: cfg.ServerName,
+	}
+
+	if cfg.CAFile != "" {
+		bundle, err := os.ReadFile(cfg.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA bundle: %w", err)
+		}
+
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(bundle) {
+			return nil, fmt.Errorf("no PEM certificates found in CA bundle %q", cfg.CAFile)
+		}
+		tlsConfig.RootCAs = pool
+	}
+
+	if cfg.CertFile != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client TLS keypair: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return credentials.NewTLS(tlsConfig), nil
+}

--- a/common/go/xgrpc/tls_test.go
+++ b/common/go/xgrpc/tls_test.go
@@ -1,0 +1,63 @@
+package xgrpc_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/testutils/tlscert"
+	"github.com/yanet-platform/yanet2/common/go/xgrpc"
+)
+
+// Test_ClientCredentials_Nil_Plaintext verifies that a missing config dials
+// in plaintext.
+func Test_ClientCredentials_Nil_Plaintext(t *testing.T) {
+	t.Parallel()
+
+	creds, err := xgrpc.ClientCredentials(nil)
+	require.NoError(t, err)
+	require.Equal(t, "insecure", creds.Info().SecurityProtocol)
+}
+
+// Test_ClientCredentials_Config verifies that a present config yields TLS
+// credentials when its files are consistent and readable, and an error
+// otherwise.
+func Test_ClientCredentials_Config(t *testing.T) {
+	t.Parallel()
+
+	ca := tlscert.NewCA(t)
+	client := ca.IssueClient(t, "operator")
+	missing := filepath.Join(t.TempDir(), "missing.pem")
+
+	tests := []struct {
+		name    string
+		config  xgrpc.ClientTLSConfig
+		wantErr bool
+	}{
+		{name: "empty config uses system roots"},
+		{name: "CA bundle", config: xgrpc.ClientTLSConfig{CAFile: ca.BundleFile()}},
+		{name: "CA bundle with client keypair", config: xgrpc.ClientTLSConfig{
+			CAFile: ca.BundleFile(), CertFile: client.CertFile, KeyFile: client.KeyFile,
+		}},
+		{name: "certificate without key", config: xgrpc.ClientTLSConfig{CertFile: client.CertFile}, wantErr: true},
+		{name: "key without certificate", config: xgrpc.ClientTLSConfig{KeyFile: client.KeyFile}, wantErr: true},
+		{name: "missing CA bundle", config: xgrpc.ClientTLSConfig{CAFile: missing}, wantErr: true},
+		{name: "CA bundle without certificates", config: xgrpc.ClientTLSConfig{CAFile: client.KeyFile}, wantErr: true},
+		{name: "missing certificate file", config: xgrpc.ClientTLSConfig{CertFile: missing, KeyFile: client.KeyFile}, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			creds, err := xgrpc.ClientCredentials(&test.config)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, "tls", creds.Info().SecurityProtocol)
+		})
+	}
+}

--- a/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
@@ -60,6 +60,9 @@ type ServerConfig struct {
 	// RouteService for RIB updates — either the route operator directly or the
 	// gateway that proxies it.
 	RouteOperatorEndpoint string `yaml:"route_operator_endpoint"`
+	// RouteOperatorTLS enables TLS towards the route operator endpoint when
+	// present, plaintext otherwise.
+	RouteOperatorTLS *xgrpc.ClientTLSConfig `yaml:"route_operator_tls"`
 	// BIRD configures the BIRD import applied at startup.
 	BIRD xcfg.Optional[BIRDConfig] `yaml:"bird"`
 }
@@ -139,8 +142,17 @@ func runServer() error {
 		zap.String("route_operator_endpoint", cfg.RouteOperatorEndpoint),
 	)
 
+	routeOperatorCreds, err := xgrpc.ClientCredentials(cfg.RouteOperatorTLS)
+	if err != nil {
+		return fmt.Errorf("failed to build transport credentials for the route operator endpoint: %w", err)
+	}
+
 	// Create the adapter service
-	adapterService := birdAdapter.NewAdapterService(cfg.RouteOperatorEndpoint, birdAdapter.WithAdapterServiceLog(log))
+	adapterService := birdAdapter.NewAdapterService(
+		cfg.RouteOperatorEndpoint,
+		birdAdapter.WithAdapterServiceLog(log),
+		birdAdapter.WithRouteOperatorCredentials(routeOperatorCreds),
+	)
 
 	// Create gRPC server
 	grpcServer := grpc.NewServer()

--- a/operators/bird-adapter/etc/yanet/bird-adapter-default.yaml
+++ b/operators/bird-adapter/etc/yanet/bird-adapter-default.yaml
@@ -12,6 +12,20 @@ listen_addr: "localhost:50051"
 # Connect directly to the route operator or to the gateway that proxies it.
 route_operator_endpoint: "[::1]:8080"
 
+# TLS towards that endpoint.
+#
+# Absent: plaintext. Present, even empty: TLS with the system roots.
+#
+#   route_operator_tls:
+#     # PEM bundle that replaces the system roots.
+#     ca_file: /etc/yanet2/tls/ca.pem
+#     # Client certificate, both files or neither.
+#     cert_file: /etc/yanet2/tls/bird-adapter.pem
+#     key_file: /etc/yanet2/tls/bird-adapter.key
+#     # Host the server certificate is checked against, defaults to the host
+#     # of the endpoint.
+#     server_name: gateway.numa0
+
 # BIRD import applied at startup. An empty name disables it, leaving the
 # server bare until the client subcommand configures it at runtime.
 bird:

--- a/operators/bird-adapter/service.go
+++ b/operators/bird-adapter/service.go
@@ -14,6 +14,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 
@@ -47,18 +48,20 @@ func (m *levelFilterCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *za
 type AdapterService struct {
 	adapterpb.UnimplementedAdapterServiceServer
 
-	importsMu             sync.Mutex
-	imports               map[string]*importHolder
-	routeOperatorEndpoint string    // gRPC endpoint of the route operator's RouteService for RIB updates
-	quitCh                chan bool // Signals all background BIRD import loops to stop
-	log                   *zap.Logger
+	importsMu                sync.Mutex
+	imports                  map[string]*importHolder
+	routeOperatorEndpoint    string                           // gRPC endpoint of the route operator's RouteService for RIB updates
+	routeOperatorCredentials credentials.TransportCredentials // Transport credentials for that endpoint
+	quitCh                   chan bool                        // Signals all background BIRD import loops to stop
+	log                      *zap.Logger
 }
 
 // AdapterServiceOption configures the AdapterService constructor.
 type AdapterServiceOption func(*adapterServiceOptions)
 
 type adapterServiceOptions struct {
-	Log *zap.Logger
+	RouteOperatorCredentials credentials.TransportCredentials
+	Log                      *zap.Logger
 }
 
 type methodLogOption func(*methodLogOptions)
@@ -81,7 +84,8 @@ func withMethodLog(log *zap.Logger) methodLogOption {
 
 func newAdapterServiceOptions() *adapterServiceOptions {
 	return &adapterServiceOptions{
-		Log: zap.NewNop(),
+		RouteOperatorCredentials: insecure.NewCredentials(),
+		Log:                      zap.NewNop(),
 	}
 }
 
@@ -89,6 +93,14 @@ func newAdapterServiceOptions() *adapterServiceOptions {
 func WithAdapterServiceLog(log *zap.Logger) AdapterServiceOption {
 	return func(o *adapterServiceOptions) {
 		o.Log = log
+	}
+}
+
+// WithRouteOperatorCredentials sets the transport credentials for the route
+// operator connection, plaintext by default.
+func WithRouteOperatorCredentials(creds credentials.TransportCredentials) AdapterServiceOption {
+	return func(o *adapterServiceOptions) {
+		o.RouteOperatorCredentials = creds
 	}
 }
 
@@ -102,10 +114,11 @@ func NewAdapterService(
 	}
 
 	return &AdapterService{
-		imports:               make(map[string]*importHolder),
-		routeOperatorEndpoint: routeOperatorEndpoint,
-		quitCh:                make(chan bool),
-		log:                   opts.Log,
+		imports:                  make(map[string]*importHolder),
+		routeOperatorEndpoint:    routeOperatorEndpoint,
+		routeOperatorCredentials: opts.RouteOperatorCredentials,
+		quitCh:                   make(chan bool),
+		log:                      opts.Log,
 	}
 }
 
@@ -226,7 +239,7 @@ func (m *AdapterService) SetupImport(params ImportParams) error {
 
 	conn, err := grpc.NewClient(
 		m.routeOperatorEndpoint,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(m.routeOperatorCredentials),
 		grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)),
 	)
 	if err != nil {

--- a/operators/generic/etc/yanet/generic-operator.d/decap-default.yaml
+++ b/operators/generic/etc/yanet/generic-operator.d/decap-default.yaml
@@ -6,6 +6,19 @@ logging:
 gateways:
   - name: numa0
     endpoint: "[::1]:8080"
+    # TLS towards the gateway.
+    #
+    # Absent: plaintext. Present, even empty: TLS with the system roots.
+    #
+    #   tls:
+    #     # PEM bundle that replaces the system roots.
+    #     ca_file: /etc/yanet2/tls/ca.pem
+    #     # Client certificate, both files or neither.
+    #     cert_file: /etc/yanet2/tls/operator.pem
+    #     key_file: /etc/yanet2/tls/operator.key
+    #     # Host the server certificate is checked against, defaults to the
+    #     # host of the endpoint.
+    #     server_name: gateway.numa0
 
 register:
   interval: 30s

--- a/operators/generic/etc/yanet/generic-operator.d/forward-default.yaml
+++ b/operators/generic/etc/yanet/generic-operator.d/forward-default.yaml
@@ -6,6 +6,19 @@ logging:
 gateways:
   - name: numa0
     endpoint: "[::1]:8080"
+    # TLS towards the gateway.
+    #
+    # Absent: plaintext. Present, even empty: TLS with the system roots.
+    #
+    #   tls:
+    #     # PEM bundle that replaces the system roots.
+    #     ca_file: /etc/yanet2/tls/ca.pem
+    #     # Client certificate, both files or neither.
+    #     cert_file: /etc/yanet2/tls/operator.pem
+    #     key_file: /etc/yanet2/tls/operator.key
+    #     # Host the server certificate is checked against, defaults to the
+    #     # host of the endpoint.
+    #     server_name: gateway.numa0
 
 register:
   interval: 30s

--- a/operators/pipeline/etc/yanet/yanet-pipeline-operator-default.yaml
+++ b/operators/pipeline/etc/yanet/yanet-pipeline-operator-default.yaml
@@ -4,6 +4,19 @@ logging:
 gateways:
   - name: numa0
     endpoint: "[::1]:8080"
+    # TLS towards the gateway.
+    #
+    # Absent: plaintext. Present, even empty: TLS with the system roots.
+    #
+    #   tls:
+    #     # PEM bundle that replaces the system roots.
+    #     ca_file: /etc/yanet2/tls/ca.pem
+    #     # Client certificate, both files or neither.
+    #     cert_file: /etc/yanet2/tls/operator.pem
+    #     key_file: /etc/yanet2/tls/operator.key
+    #     # Host the server certificate is checked against, defaults to the
+    #     # host of the endpoint.
+    #     server_name: gateway.numa0
 
 register:
   interval: 30s

--- a/operators/pipeline/internal/operator/actuator_gateway.go
+++ b/operators/pipeline/internal/operator/actuator_gateway.go
@@ -6,7 +6,6 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
@@ -46,13 +45,9 @@ func NewGatewayActuator(
 		o(opts)
 	}
 
-	endpoint := cfg.Endpoint.Unwrap()
-	conn, err := grpc.NewClient(
-		endpoint,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	conn, err := operator.DialGateway(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial gateway %q at %q: %w", cfg.Name, endpoint, err)
+		return nil, err
 	}
 
 	return &GatewayActuator{

--- a/operators/route/etc/yanet/yanet-route-operator-default.yaml
+++ b/operators/route/etc/yanet/yanet-route-operator-default.yaml
@@ -8,6 +8,19 @@ logging:
 gateways:
   - name: numa0
     endpoint: "[::1]:8080"
+    # TLS towards the gateway.
+    #
+    # Absent: plaintext. Present, even empty: TLS with the system roots.
+    #
+    #   tls:
+    #     # PEM bundle that replaces the system roots.
+    #     ca_file: /etc/yanet2/tls/ca.pem
+    #     # Client certificate, both files or neither.
+    #     cert_file: /etc/yanet2/tls/operator.pem
+    #     key_file: /etc/yanet2/tls/operator.key
+    #     # Host the server certificate is checked against, defaults to the
+    #     # host of the endpoint.
+    #     server_name: gateway.numa0
 
 # The operator's own gRPC server.
 #

--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -7,7 +7,6 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/yanet-platform/xnetip"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
@@ -45,13 +44,9 @@ func NewGatewayActuator(
 		return nil, fmt.Errorf("gateway actuator: function is required")
 	}
 
-	endpoint := cfg.Endpoint.Unwrap()
-	conn, err := grpc.NewClient(
-		endpoint,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	conn, err := operator.DialGateway(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial gateway %q at %q: %w", cfg.Name, endpoint, err)
+		return nil, err
 	}
 
 	fn := opts.Function


### PR DESCRIPTION
- Every Go client of the gateway takes a tls block per gateway: absent means plaintext, present means TLS with the system roots or a given CA bundle, and a client certificate is presented when both of its files are given.
- The route, pipeline and generic operators and the bird adapter share one dial helper instead of four plaintext dials.
- The shipped operator configs carry a commented tls example.
