### PR TITLE
refactor(auth): pass a credential instead of a token string

### DIFF
--- a/controlplane/gateway/auth_service.go
+++ b/controlplane/gateway/auth_service.go
@@ -35,7 +35,7 @@ func (m *AuthService) IntrospectToken(
 	// IntrospectToken is not bound to a specific method, so we pass
 	// an empty RequestInfo.
 	requestInfo := &core.RequestInfo{}
-	principal, err := m.manager.Authenticate(ctx, token, requestInfo)
+	principal, err := m.manager.Authenticate(ctx, core.Credential{Token: token}, requestInfo)
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "authentication failed: %v", err)
 	}

--- a/controlplane/internal/auth/basic/authenticator.go
+++ b/controlplane/internal/auth/basic/authenticator.go
@@ -28,19 +28,19 @@ func (m *BasicAuthenticator) Name() string {
 	return "basic"
 }
 
-// IsTokenSupported checks if the token is a Basic Auth token.
-func (m *BasicAuthenticator) IsTokenSupported(token string) bool {
-	return strings.HasPrefix(strings.ToLower(token), "basic ")
+// Supports checks if the credential carries a Basic Auth token.
+func (m *BasicAuthenticator) Supports(credential core.Credential) bool {
+	return strings.HasPrefix(strings.ToLower(credential.Token), "basic ")
 }
 
 // Authenticate validates the Basic Auth token.
 func (m *BasicAuthenticator) Authenticate(
 	ctx context.Context,
-	token string,
+	credential core.Credential,
 	reqInfo *core.RequestInfo,
 ) (*core.AuthInfo, error) {
 	// Extract base64 part.
-	parts := strings.SplitN(token, " ", 2)
+	parts := strings.SplitN(credential.Token, " ", 2)
 	if len(parts) != 2 {
 		return nil, status.Error(codes.Unauthenticated, "invalid token format")
 	}

--- a/controlplane/internal/auth/basic/factory_test.go
+++ b/controlplane/internal/auth/basic/factory_test.go
@@ -62,12 +62,12 @@ func TestNewFromConfig(t *testing.T) {
 	require.Equal(t, "basic", authenticator.Name())
 
 	validToken := basicToken("alice", "s3cret")
-	require.True(t, authenticator.IsTokenSupported(validToken))
-	require.False(t, authenticator.IsTokenSupported("sshkey abc"))
+	require.True(t, authenticator.Supports(core.Credential{Token: validToken}))
+	require.False(t, authenticator.Supports(core.Credential{Token: "sshkey abc"}))
 
 	requestInfo := &core.RequestInfo{FullMethod: "/test.Service/Method"}
 
-	authInfo, err := authenticator.Authenticate(t.Context(), validToken, requestInfo)
+	authInfo, err := authenticator.Authenticate(t.Context(), core.Credential{Token: validToken}, requestInfo)
 	require.NoError(t, err)
 	require.Equal(t, &core.AuthInfo{
 		Subject:    core.NewLocalSubject("alice"),
@@ -75,7 +75,7 @@ func TestNewFromConfig(t *testing.T) {
 	}, authInfo)
 
 	wrongToken := basicToken("alice", "wrong-password")
-	_, err = authenticator.Authenticate(t.Context(), wrongToken, requestInfo)
+	_, err = authenticator.Authenticate(t.Context(), core.Credential{Token: wrongToken}, requestInfo)
 	require.Error(t, err)
 }
 

--- a/controlplane/internal/auth/context.go
+++ b/controlplane/internal/auth/context.go
@@ -29,8 +29,8 @@ func ExtractCredential(ctx context.Context) core.Credential {
 		}
 	}
 
-	if p, ok := peer.FromContext(ctx); ok {
-		if info, ok := p.AuthInfo.(credentials.TLSInfo); ok {
+	if peerInfo, ok := peer.FromContext(ctx); ok {
+		if info, ok := peerInfo.AuthInfo.(credentials.TLSInfo); ok {
 			state := info.State
 			credential.TLS = &state
 		}

--- a/controlplane/internal/auth/context.go
+++ b/controlplane/internal/auth/context.go
@@ -3,7 +3,11 @@ package auth
 import (
 	"context"
 
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
 )
 
 const (
@@ -11,19 +15,26 @@ const (
 	authMetadataKey = "x-yanet-authentication"
 )
 
-// ExtractToken extracts the authentication token from gRPC metadata.
-// Returns empty string if no token is present.
-func ExtractToken(ctx context.Context) string {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return ""
+// ExtractCredential collects what the request presents for authentication:
+// the token from gRPC metadata and the TLS state of the peer connection.
+//
+// Either part is left empty when absent.
+func ExtractCredential(ctx context.Context) core.Credential {
+	var credential core.Credential
+
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		// TODO: should we allow passing multiple tokens at once?
+		if values := md.Get(authMetadataKey); len(values) > 0 {
+			credential.Token = values[0]
+		}
 	}
 
-	values := md.Get(authMetadataKey)
-	if len(values) == 0 {
-		return ""
+	if p, ok := peer.FromContext(ctx); ok {
+		if info, ok := p.AuthInfo.(credentials.TLSInfo); ok {
+			state := info.State
+			credential.TLS = &state
+		}
 	}
 
-	// TODO: should we allow passing multiple tokens at once?
-	return values[0]
+	return credential
 }

--- a/controlplane/internal/auth/core/authenticator.go
+++ b/controlplane/internal/auth/core/authenticator.go
@@ -8,12 +8,11 @@ import (
 type Authenticator interface {
 	// Name returns the authenticator name for logging.
 	Name() string
-	// IsTokenSupported checks if this authenticator can handle the given token
-	// format.
-	IsTokenSupported(token string) bool
-	// Authenticate validates the token and returns authentication info.
+	// Supports checks if this authenticator can handle the given credential.
+	Supports(credential Credential) bool
+	// Authenticate validates the credential and returns authentication info.
 	//
 	// The requestInfo provides request context such as the gRPC method being
 	// called.
-	Authenticate(ctx context.Context, token string, requestInfo *RequestInfo) (*AuthInfo, error)
+	Authenticate(ctx context.Context, credential Credential, requestInfo *RequestInfo) (*AuthInfo, error)
 }

--- a/controlplane/internal/auth/core/credential.go
+++ b/controlplane/internal/auth/core/credential.go
@@ -1,0 +1,18 @@
+package core
+
+import (
+	"crypto/tls"
+)
+
+// Credential is what a request presents for authentication: the token from
+// its metadata and the state of the TLS connection it arrived on.
+//
+// Either part may be absent. A request without a token has an empty Token,
+// a request over plaintext has a nil TLS.
+type Credential struct {
+	// Token is the value of the authentication metadata header, empty when
+	// absent.
+	Token string
+	// TLS is the connection state of a TLS transport, nil on plaintext.
+	TLS *tls.ConnectionState
+}

--- a/controlplane/internal/auth/interceptor.go
+++ b/controlplane/internal/auth/interceptor.go
@@ -18,14 +18,14 @@ func UnaryServerInterceptor(
 	log *zap.Logger,
 ) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		token := ExtractToken(ctx)
+		credential := ExtractCredential(ctx)
 
 		requestInfo := &core.RequestInfo{
 			FullMethod: info.FullMethod,
 		}
 
 		// Authenticate the request.
-		principal, err := manager.Authenticate(ctx, token, requestInfo)
+		principal, err := manager.Authenticate(ctx, credential, requestInfo)
 		if err != nil {
 			log.Warn("authentication failed",
 				zap.String("method", info.FullMethod),
@@ -53,14 +53,14 @@ func StreamServerInterceptor(manager *Manager, log *zap.Logger) grpc.StreamServe
 	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := ss.Context()
 
-		token := ExtractToken(ctx)
+		credential := ExtractCredential(ctx)
 
 		requestInfo := &core.RequestInfo{
 			FullMethod: info.FullMethod,
 		}
 
 		// Authenticate the request.
-		principal, err := manager.Authenticate(ctx, token, requestInfo)
+		principal, err := manager.Authenticate(ctx, credential, requestInfo)
 		if err != nil {
 			log.Warn("authentication failed",
 				zap.String("method", info.FullMethod),

--- a/controlplane/internal/auth/interceptor_test.go
+++ b/controlplane/internal/auth/interceptor_test.go
@@ -133,7 +133,7 @@ func TestStreamServerInterceptor(t *testing.T) {
 	}
 }
 
-func TestExtractToken(t *testing.T) {
+func TestExtractCredential_Token(t *testing.T) {
 	tests := []struct {
 		name string
 		md   metadata.MD
@@ -158,20 +158,20 @@ func TestExtractToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := metadata.NewIncomingContext(context.Background(), tt.md)
-			got := auth.ExtractToken(ctx)
+			ctx := metadata.NewIncomingContext(t.Context(), tt.md)
+			got := auth.ExtractCredential(ctx).Token
 			if got != tt.want {
-				t.Errorf("extractToken() = %q, want %q", got, tt.want)
+				t.Errorf("ExtractCredential().Token = %q, want %q", got, tt.want)
 			}
 		})
 	}
 
 	// Test without metadata in context.
 	t.Run("no metadata", func(t *testing.T) {
-		ctx := context.Background()
-		got := auth.ExtractToken(ctx)
+		ctx := t.Context()
+		got := auth.ExtractCredential(ctx).Token
 		if got != "" {
-			t.Errorf("extractToken() = %q, want empty", got)
+			t.Errorf("ExtractCredential().Token = %q, want empty", got)
 		}
 	})
 }

--- a/controlplane/internal/auth/loader/loader.go
+++ b/controlplane/internal/auth/loader/loader.go
@@ -1,4 +1,4 @@
-package sshcert
+package loader
 
 import (
 	"strings"

--- a/controlplane/internal/auth/loader/loader_file.go
+++ b/controlplane/internal/auth/loader/loader_file.go
@@ -1,4 +1,4 @@
-package sshcert
+package loader
 
 import (
 	"fmt"

--- a/controlplane/internal/auth/loader/loader_http.go
+++ b/controlplane/internal/auth/loader/loader_http.go
@@ -1,4 +1,4 @@
-package sshcert
+package loader
 
 import (
 	"fmt"

--- a/controlplane/internal/auth/loader/loader_test.go
+++ b/controlplane/internal/auth/loader/loader_test.go
@@ -1,4 +1,4 @@
-package sshcert_test
+package loader_test
 
 import (
 	"crypto/tls"
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshcert"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/loader"
 )
 
 func TestNewLoader_FileAutoDetect(t *testing.T) {
@@ -19,7 +19,7 @@ func TestNewLoader_FileAutoDetect(t *testing.T) {
 	path := t.TempDir() + "/ca.pub"
 	require.NoError(t, os.WriteFile(path, expectedData, 0o600))
 
-	loader := sshcert.NewLoader(path)
+	loader := loader.NewLoader(path)
 	data, err := loader.Load()
 	require.NoError(t, err)
 	assert.Equal(t, expectedData, data)
@@ -35,7 +35,7 @@ func TestNewLoader_HTTPAutoDetect(t *testing.T) {
 	)
 	defer server.Close()
 
-	loader := sshcert.NewLoader(server.URL + "/ca.yaml")
+	loader := loader.NewLoader(server.URL + "/ca.yaml")
 	_, err := loader.Load()
 	require.Error(t, err)
 	var verificationError *tls.CertificateVerificationError
@@ -43,7 +43,7 @@ func TestNewLoader_HTTPAutoDetect(t *testing.T) {
 }
 
 func TestNewLoader_HTTPAutoDetect_NoTLS(t *testing.T) {
-	loader := sshcert.NewLoader("http://example.com/ca.yaml")
+	loader := loader.NewLoader("http://example.com/ca.yaml")
 	assert.Equal(t, "http://example.com/ca.yaml", loader.Source())
 }
 
@@ -58,7 +58,7 @@ func TestHTTPLoader_Success(t *testing.T) {
 	)
 	defer server.Close()
 
-	loader := sshcert.NewLoader(server.URL + "/ca.yaml")
+	loader := loader.NewLoader(server.URL + "/ca.yaml")
 	data, err := loader.Load()
 	require.NoError(t, err)
 	assert.Equal(t, expectedData, data)
@@ -72,7 +72,7 @@ func TestHTTPLoader_Non200Status(t *testing.T) {
 	)
 	defer server.Close()
 
-	loader := sshcert.NewLoader(server.URL + "/missing")
+	loader := loader.NewLoader(server.URL + "/missing")
 	_, err := loader.Load()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected status 404")

--- a/controlplane/internal/auth/loader/loader_zstd.go
+++ b/controlplane/internal/auth/loader/loader_zstd.go
@@ -1,4 +1,4 @@
-package sshcert
+package loader
 
 import (
 	"fmt"

--- a/controlplane/internal/auth/manager.go
+++ b/controlplane/internal/auth/manager.go
@@ -175,18 +175,18 @@ func NewManager(cfg *Config, options ...ManagerOption) (*Manager, error) {
 	return m, nil
 }
 
-// Authenticate attempts to authenticate the given token using registered
-// authenticators.
+// Authenticate attempts to authenticate the given credential using
+// registered authenticators.
 //
 // Returns the authenticated Principal on success.
 func (m *Manager) Authenticate(
 	ctx context.Context,
-	token string,
+	credential core.Credential,
 	reqInfo *core.RequestInfo,
 ) (*core.Principal, error) {
 	// Iterate through authenticators, first match wins.
 	for _, auth := range m.authenticators {
-		if !auth.IsTokenSupported(token) {
+		if !auth.Supports(credential) {
 			continue
 		}
 
@@ -194,7 +194,7 @@ func (m *Manager) Authenticate(
 			zap.String("authenticator", auth.Name()),
 		)
 
-		authInfo, err := auth.Authenticate(ctx, token, reqInfo)
+		authInfo, err := auth.Authenticate(ctx, credential, reqInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -204,7 +204,7 @@ func (m *Manager) Authenticate(
 
 	// This shouldn't happen with NoneAuthenticator registered, because it
 	// accepts everything.
-	return nil, fmt.Errorf("no authenticator supports the given token")
+	return nil, fmt.Errorf("no authenticator supports the given credential")
 }
 
 // buildPrincipal resolves an authenticated subject into its authorization

--- a/controlplane/internal/auth/manager_test.go
+++ b/controlplane/internal/auth/manager_test.go
@@ -46,7 +46,7 @@ func TestManager_Authenticate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			requestInfo := &core.RequestInfo{FullMethod: "/test.Service/Method"}
-			principal, err := m.Authenticate(ctx, tt.token, requestInfo)
+			principal, err := m.Authenticate(ctx, core.Credential{Token: tt.token}, requestInfo)
 			if err != nil {
 				t.Fatalf("Authenticate() error = %v, want nil", err)
 			}
@@ -83,7 +83,7 @@ func TestManager_Authorize(t *testing.T) {
 
 	// Create a test principal.
 	requestInfo := &core.RequestInfo{FullMethod: "/test.Service/Method"}
-	principal, err := m.Authenticate(ctx, "", requestInfo)
+	principal, err := m.Authenticate(ctx, core.Credential{Token: ""}, requestInfo)
 	if err != nil {
 		t.Fatalf("Authenticate() error = %v", err)
 	}
@@ -213,7 +213,7 @@ func TestNewManagerEnabled(t *testing.T) {
 	requestInfo := &core.RequestInfo{FullMethod: "/test.Service/Method"}
 
 	t.Run("known active user authenticates with group and method", func(t *testing.T) {
-		principal, err := manager.Authenticate(t.Context(), basicToken("alice", "s3cret"), requestInfo)
+		principal, err := manager.Authenticate(t.Context(), core.Credential{Token: basicToken("alice", "s3cret")}, requestInfo)
 		require.NoError(t, err)
 		assert.Equal(t, "alice", principal.User)
 		assert.Equal(t, []string{"operators"}, principal.Groups)
@@ -229,7 +229,7 @@ func TestNewManagerEnabled(t *testing.T) {
 	})
 
 	t.Run("unsupported token falls through to none authenticator", func(t *testing.T) {
-		principal, err := manager.Authenticate(t.Context(), "bearer whatever", requestInfo)
+		principal, err := manager.Authenticate(t.Context(), core.Credential{Token: "bearer whatever"}, requestInfo)
 		require.NoError(t, err)
 		assert.True(t, principal.IsAnonymous)
 		assert.Equal(t, "none", principal.AuthMethod)
@@ -241,7 +241,7 @@ func TestNewManagerEnabled(t *testing.T) {
 	})
 
 	t.Run("disabled identity fails authentication", func(t *testing.T) {
-		_, err := manager.Authenticate(t.Context(), basicToken("mallory", "s3cret"), requestInfo)
+		_, err := manager.Authenticate(t.Context(), core.Credential{Token: basicToken("mallory", "s3cret")}, requestInfo)
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.Unauthenticated, st.Code())
@@ -249,7 +249,7 @@ func TestNewManagerEnabled(t *testing.T) {
 	})
 
 	t.Run("valid credentials without an identity entry fail authentication", func(t *testing.T) {
-		_, err := manager.Authenticate(t.Context(), basicToken("ghost", "s3cret"), requestInfo)
+		_, err := manager.Authenticate(t.Context(), core.Credential{Token: basicToken("ghost", "s3cret")}, requestInfo)
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.Unauthenticated, st.Code())

--- a/controlplane/internal/auth/none/authenticator.go
+++ b/controlplane/internal/auth/none/authenticator.go
@@ -22,15 +22,15 @@ func (m *NoneAuthenticator) Name() string {
 	return "none"
 }
 
-// IsTokenSupported always returns true.
-func (m *NoneAuthenticator) IsTokenSupported(token string) bool {
+// Supports always returns true.
+func (m *NoneAuthenticator) Supports(credential core.Credential) bool {
 	return true
 }
 
 // Authenticate always succeeds and returns anonymous authentication info.
 func (m *NoneAuthenticator) Authenticate(
 	ctx context.Context,
-	token string,
+	credential core.Credential,
 	reqInfo *core.RequestInfo,
 ) (*core.AuthInfo, error) {
 	return &core.AuthInfo{

--- a/controlplane/internal/auth/none/authenticator_test.go
+++ b/controlplane/internal/auth/none/authenticator_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/none"
 )
 
-func TestNoneAuthenticator_IsTokenSupported(t *testing.T) {
+func TestNoneAuthenticator_Supports(t *testing.T) {
 	authenticator := none.NewNoneAuthenticator()
 
 	tests := []struct {
@@ -30,8 +30,8 @@ func TestNoneAuthenticator_IsTokenSupported(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := authenticator.IsTokenSupported(tt.token); got != tt.want {
-				t.Errorf("IsTokenSupported() = %v, want %v", got, tt.want)
+			if got := authenticator.Supports(core.Credential{Token: tt.token}); got != tt.want {
+				t.Errorf("Supports() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -58,7 +58,7 @@ func TestNoneAuthenticator_Authenticate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			requestInfo := &core.RequestInfo{FullMethod: "/test.Service/Method"}
-			authInfo, err := authenticator.Authenticate(ctx, tt.token, requestInfo)
+			authInfo, err := authenticator.Authenticate(ctx, core.Credential{Token: tt.token}, requestInfo)
 			if err != nil {
 				t.Fatalf("Authenticate() error = %v, want nil", err)
 			}

--- a/controlplane/internal/auth/sshcert/authenticator.go
+++ b/controlplane/internal/auth/sshcert/authenticator.go
@@ -104,9 +104,10 @@ func (m *Authenticator) Name() string {
 	return "sshcert"
 }
 
-// IsTokenSupported checks if the token has the "sshcert " prefix.
-func (m *Authenticator) IsTokenSupported(token string) bool {
-	return strings.HasPrefix(strings.ToLower(token), tokenPrefix)
+// Supports checks if the credential carries a token with the "sshcert "
+// prefix.
+func (m *Authenticator) Supports(credential core.Credential) bool {
+	return strings.HasPrefix(strings.ToLower(credential.Token), tokenPrefix)
 }
 
 // Authenticate validates the SSH certificate token and returns authentication
@@ -117,10 +118,10 @@ func (m *Authenticator) IsTokenSupported(token string) bool {
 // principal becomes the local account lookup name.
 func (m *Authenticator) Authenticate(
 	ctx context.Context,
-	rawToken string,
+	credential core.Credential,
 	reqInfo *core.RequestInfo,
 ) (*core.AuthInfo, error) {
-	token, err := parseToken(rawToken)
+	token, err := parseToken(credential.Token)
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Unauthenticated,

--- a/controlplane/internal/auth/sshcert/authenticator_test.go
+++ b/controlplane/internal/auth/sshcert/authenticator_test.go
@@ -27,7 +27,7 @@ func TestAuthenticator_Name(t *testing.T) {
 	assert.Equal(t, "sshcert", auth.Name())
 }
 
-func TestAuthenticator_IsTokenSupported(t *testing.T) {
+func TestAuthenticator_Supports(t *testing.T) {
 	ca := generateTestCA(t)
 	store := sshcert.NewCAStore([]sshcert.CAEntry{
 		{PublicKey: ca.PublicKey()},
@@ -36,9 +36,9 @@ func TestAuthenticator_IsTokenSupported(t *testing.T) {
 	auth := sshcert.NewAuthenticator(store, sshcert.NewNopRevocationChecker())
 	defer auth.Close()
 
-	assert.True(t, auth.IsTokenSupported("sshcert eyJ0ZXN0Ig=="))
-	assert.False(t, auth.IsTokenSupported("sshkey eyJ0ZXN0Ig=="))
-	assert.False(t, auth.IsTokenSupported("basic dGVzdA=="))
+	assert.True(t, auth.Supports(core.Credential{Token: "sshcert eyJ0ZXN0Ig=="}))
+	assert.False(t, auth.Supports(core.Credential{Token: "sshkey eyJ0ZXN0Ig=="}))
+	assert.False(t, auth.Supports(core.Credential{Token: "basic dGVzdA=="}))
 }
 
 func TestAuthenticator_HappyPath(t *testing.T) {
@@ -70,9 +70,8 @@ func TestAuthenticator_HappyPath(t *testing.T) {
 
 	authInfo, err := auth.Authenticate(
 		context.Background(),
-		rawToken,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: rawToken},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 	assert.Equal(t, "sshcert", authInfo.AuthMethod)
@@ -107,9 +106,8 @@ func TestAuthenticator_ExpiredTimestamp(t *testing.T) {
 
 	_, err := auth.Authenticate(
 		context.Background(),
-		rawToken,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: rawToken},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -142,9 +140,8 @@ func TestAuthenticator_MethodBindingMismatch(t *testing.T) {
 
 	_, err := auth.Authenticate(
 		context.Background(),
-		rawToken,
-		&core.RequestInfo{FullMethod: "/test.Service/OtherMethod"},
-	)
+		core.Credential{Token: rawToken},
+		&core.RequestInfo{FullMethod: "/test.Service/OtherMethod"})
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -180,9 +177,8 @@ func TestAuthenticator_UntrustedCA(t *testing.T) {
 
 	_, err := auth.Authenticate(
 		context.Background(),
-		rawToken,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: rawToken},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -215,9 +211,8 @@ func TestAuthenticator_ExpiredCertificate(t *testing.T) {
 
 	_, err := auth.Authenticate(
 		context.Background(),
-		rawToken,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: rawToken},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -255,9 +250,8 @@ func TestAuthenticator_RevokedCertificate(t *testing.T) {
 
 	_, err = auth.Authenticate(
 		context.Background(),
-		rawToken,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: rawToken},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -285,9 +279,8 @@ func TestAuthenticator_HostCertRejected(t *testing.T) {
 
 	_, err := auth.Authenticate(
 		context.Background(),
-		rawToken,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: rawToken},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -321,9 +314,8 @@ func TestAuthenticator_NopRevocationChecker(t *testing.T) {
 
 	authInfo, err := auth.Authenticate(
 		context.Background(),
-		rawToken,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: rawToken},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 	assert.Equal(t, "sshcert", authInfo.AuthMethod)

--- a/controlplane/internal/auth/sshcert/authenticator_test.go
+++ b/controlplane/internal/auth/sshcert/authenticator_test.go
@@ -71,7 +71,8 @@ func TestAuthenticator_HappyPath(t *testing.T) {
 	authInfo, err := auth.Authenticate(
 		context.Background(),
 		core.Credential{Token: rawToken},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 	assert.Equal(t, "sshcert", authInfo.AuthMethod)
@@ -107,7 +108,8 @@ func TestAuthenticator_ExpiredTimestamp(t *testing.T) {
 	_, err := auth.Authenticate(
 		context.Background(),
 		core.Credential{Token: rawToken},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -141,7 +143,8 @@ func TestAuthenticator_MethodBindingMismatch(t *testing.T) {
 	_, err := auth.Authenticate(
 		context.Background(),
 		core.Credential{Token: rawToken},
-		&core.RequestInfo{FullMethod: "/test.Service/OtherMethod"})
+		&core.RequestInfo{FullMethod: "/test.Service/OtherMethod"},
+	)
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -178,7 +181,8 @@ func TestAuthenticator_UntrustedCA(t *testing.T) {
 	_, err := auth.Authenticate(
 		context.Background(),
 		core.Credential{Token: rawToken},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -212,7 +216,8 @@ func TestAuthenticator_ExpiredCertificate(t *testing.T) {
 	_, err := auth.Authenticate(
 		context.Background(),
 		core.Credential{Token: rawToken},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -251,7 +256,8 @@ func TestAuthenticator_RevokedCertificate(t *testing.T) {
 	_, err = auth.Authenticate(
 		context.Background(),
 		core.Credential{Token: rawToken},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -280,7 +286,8 @@ func TestAuthenticator_HostCertRejected(t *testing.T) {
 	_, err := auth.Authenticate(
 		context.Background(),
 		core.Credential{Token: rawToken},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.Error(t, err)
 	assertGRPCCode(t, err, codes.Unauthenticated)
 }
@@ -315,7 +322,8 @@ func TestAuthenticator_NopRevocationChecker(t *testing.T) {
 	authInfo, err := auth.Authenticate(
 		context.Background(),
 		core.Credential{Token: rawToken},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 	assert.Equal(t, "sshcert", authInfo.AuthMethod)

--- a/controlplane/internal/auth/sshcert/ca_store.go
+++ b/controlplane/internal/auth/sshcert/ca_store.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 
 	"golang.org/x/crypto/ssh"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/loader"
 )
 
 const (
@@ -34,7 +36,7 @@ type CAEntry struct {
 // CAStore stores trusted certificate authority public keys.
 type CAStore struct {
 	snapshot atomic.Pointer[[]CAEntry]
-	loader   Loader
+	source   loader.Loader
 }
 
 // NewCAStore creates a CAStore from an in-memory slice.
@@ -47,8 +49,8 @@ func NewCAStore(entries []CAEntry) *CAStore {
 
 // NewCAStoreFromLoader creates a CAStore by loading CA data from
 // the given loader.
-func NewCAStoreFromLoader(loader Loader) (*CAStore, error) {
-	data, err := loader.Load()
+func NewCAStoreFromLoader(source loader.Loader) (*CAStore, error) {
+	data, err := source.Load()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load CA data: %w", err)
 	}
@@ -58,7 +60,7 @@ func NewCAStoreFromLoader(loader Loader) (*CAStore, error) {
 		return nil, err
 	}
 
-	m := &CAStore{loader: loader}
+	m := &CAStore{source: source}
 	m.snapshot.Store(&entries)
 
 	return m, nil
@@ -103,11 +105,11 @@ func (m *CAStore) VerifyCA(cert *ssh.Certificate) error {
 //
 // On error the old data is preserved.
 func (m *CAStore) Reload() error {
-	if m.loader == nil {
+	if m.source == nil {
 		return nil
 	}
 
-	data, err := m.loader.Load()
+	data, err := m.source.Load()
 	if err != nil {
 		return fmt.Errorf("failed to reload CA data: %w", err)
 	}

--- a/controlplane/internal/auth/sshcert/certificate_test.go
+++ b/controlplane/internal/auth/sshcert/certificate_test.go
@@ -41,7 +41,8 @@ func authenticateCertificate(
 	_, err := authenticator.Authenticate(
 		t.Context(),
 		core.Credential{Token: token},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	return err
 }
 
@@ -73,7 +74,8 @@ func TestParseCertificate_InvalidBase64(t *testing.T) {
 	_, err := authenticator.Authenticate(
 		t.Context(),
 		core.Credential{Token: certificateToken(t, "!!!invalid!!!")},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid certificate: invalid base64")
 }
@@ -92,7 +94,8 @@ func TestParseCertificate_NotACert(t *testing.T) {
 	_, err := authenticator.Authenticate(
 		t.Context(),
 		core.Credential{Token: certificateToken(t, certificate)},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid certificate: not a certificate")
 }

--- a/controlplane/internal/auth/sshcert/certificate_test.go
+++ b/controlplane/internal/auth/sshcert/certificate_test.go
@@ -40,9 +40,8 @@ func authenticateCertificate(
 	)
 	_, err := authenticator.Authenticate(
 		t.Context(),
-		token,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: token},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	return err
 }
 
@@ -73,9 +72,8 @@ func TestParseCertificate_InvalidBase64(t *testing.T) {
 
 	_, err := authenticator.Authenticate(
 		t.Context(),
-		certificateToken(t, "!!!invalid!!!"),
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: certificateToken(t, "!!!invalid!!!")},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid certificate: invalid base64")
 }
@@ -93,9 +91,8 @@ func TestParseCertificate_NotACert(t *testing.T) {
 
 	_, err := authenticator.Authenticate(
 		t.Context(),
-		certificateToken(t, certificate),
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: certificateToken(t, certificate)},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid certificate: not a certificate")
 }

--- a/controlplane/internal/auth/sshcert/factory.go
+++ b/controlplane/internal/auth/sshcert/factory.go
@@ -6,6 +6,8 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/loader"
 )
 
 // NewFromConfig creates an SSH certificate Authenticator from a raw YAML.
@@ -24,7 +26,7 @@ func NewFromConfig(
 
 	caStores := make([]*CAStore, len(cfg.CASources))
 	for idx, src := range cfg.CASources {
-		store, err := NewCAStoreFromLoader(NewLoader(src))
+		store, err := NewCAStoreFromLoader(loader.NewLoader(src))
 		if err != nil {
 			return nil, fmt.Errorf(
 				"create CA store from %q: %w", src, err,
@@ -38,7 +40,7 @@ func NewFromConfig(
 
 	var revChecker RevocationChecker = NewNopRevocationChecker()
 	if cfg.KRLSource != "" {
-		krlLoader := NewLoader(cfg.KRLSource)
+		krlLoader := loader.NewLoader(cfg.KRLSource)
 		var err error
 		revChecker, err = NewKRLRevocationCheckerFromLoader(krlLoader)
 		if err != nil {

--- a/controlplane/internal/auth/sshcert/factory_test.go
+++ b/controlplane/internal/auth/sshcert/factory_test.go
@@ -204,7 +204,7 @@ func TestNewFromConfigCASources(t *testing.T) {
 			cert, userSigner := generateUserCert(t, testCase.ca, "alice", 1)
 			token := signCertToken(t, userSigner, cert, method, time.Now().UnixNano(), "nonce-1")
 
-			authInfo, err := authenticator.Authenticate(t.Context(), token, requestInfo)
+			authInfo, err := authenticator.Authenticate(t.Context(), core.Credential{Token: token}, requestInfo)
 			require.NoError(t, err)
 			require.Equal(t, &core.AuthInfo{
 				Subject:    core.NewLocalSubject("alice"),
@@ -217,7 +217,7 @@ func TestNewFromConfigCASources(t *testing.T) {
 		cert, userSigner := generateUserCert(t, caThree, "alice", 2)
 		token := signCertToken(t, userSigner, cert, method, time.Now().UnixNano(), "nonce-1")
 
-		_, err := authenticator.Authenticate(t.Context(), token, requestInfo)
+		_, err := authenticator.Authenticate(t.Context(), core.Credential{Token: token}, requestInfo)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "CA verification failed")
 	})
@@ -242,7 +242,7 @@ func TestNewFromConfigKRLSource(t *testing.T) {
 		authenticator := newAuthenticator(t, rawConfig)
 		token := signCertToken(t, userSigner, cert, method, time.Now().UnixNano(), "nonce-1")
 
-		_, err := authenticator.Authenticate(t.Context(), token, requestInfo)
+		_, err := authenticator.Authenticate(t.Context(), core.Credential{Token: token}, requestInfo)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "certificate revocation check failed")
 	})
@@ -253,7 +253,7 @@ func TestNewFromConfigKRLSource(t *testing.T) {
 		authenticator := newAuthenticator(t, rawConfig)
 		token := signCertToken(t, userSigner, cert, method, time.Now().UnixNano(), "nonce-1")
 
-		authInfo, err := authenticator.Authenticate(t.Context(), token, requestInfo)
+		authInfo, err := authenticator.Authenticate(t.Context(), core.Credential{Token: token}, requestInfo)
 		require.NoError(t, err)
 		require.Equal(t, &core.AuthInfo{
 			Subject:    core.NewLocalSubject("alice"),

--- a/controlplane/internal/auth/sshcert/revocation.go
+++ b/controlplane/internal/auth/sshcert/revocation.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stripe/krl"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/loader"
 )
 
 // RevocationChecker checks whether a certificate has been revoked.
@@ -39,7 +41,7 @@ func (m *nopRevocationChecker) Reload() error {
 // KRLRevocationChecker checks certificates against an OpenSSH KRL.
 type KRLRevocationChecker struct {
 	krlData atomic.Pointer[krl.KRL]
-	loader  Loader
+	source  loader.Loader
 }
 
 // NewKRLRevocationChecker creates a RevocationChecker from a parsed
@@ -54,9 +56,9 @@ func NewKRLRevocationChecker(k *krl.KRL) *KRLRevocationChecker {
 // NewKRLRevocationCheckerFromLoader creates a RevocationChecker by
 // loading KRL data from the given loader.
 func NewKRLRevocationCheckerFromLoader(
-	loader Loader,
+	source loader.Loader,
 ) (*KRLRevocationChecker, error) {
-	data, err := loader.Load()
+	data, err := source.Load()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load KRL data: %w", err)
 	}
@@ -66,7 +68,7 @@ func NewKRLRevocationCheckerFromLoader(
 		return nil, fmt.Errorf("failed to parse KRL: %w", err)
 	}
 
-	m := &KRLRevocationChecker{loader: loader}
+	m := &KRLRevocationChecker{source: source}
 	m.krlData.Store(k)
 
 	return m, nil
@@ -86,11 +88,11 @@ func (m *KRLRevocationChecker) IsRevoked(cert *ssh.Certificate) error {
 //
 // On error the old data is preserved.
 func (m *KRLRevocationChecker) Reload() error {
-	if m.loader == nil {
+	if m.source == nil {
 		return nil
 	}
 
-	data, err := m.loader.Load()
+	data, err := m.source.Load()
 	if err != nil {
 		return fmt.Errorf("failed to reload KRL data: %w", err)
 	}

--- a/controlplane/internal/auth/sshcert/signature_test.go
+++ b/controlplane/internal/auth/sshcert/signature_test.go
@@ -41,9 +41,8 @@ func authenticateWithSignature(
 
 	_, err = authenticator.Authenticate(
 		t.Context(),
-		"sshcert "+base64.StdEncoding.EncodeToString(encoded),
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: "sshcert " + base64.StdEncoding.EncodeToString(encoded)},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	return err
 }
 

--- a/controlplane/internal/auth/sshcert/signature_test.go
+++ b/controlplane/internal/auth/sshcert/signature_test.go
@@ -42,7 +42,8 @@ func authenticateWithSignature(
 	_, err = authenticator.Authenticate(
 		t.Context(),
 		core.Credential{Token: "sshcert " + base64.StdEncoding.EncodeToString(encoded)},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	return err
 }
 

--- a/controlplane/internal/auth/sshcert/token_test.go
+++ b/controlplane/internal/auth/sshcert/token_test.go
@@ -25,7 +25,8 @@ func authenticateRawToken(t *testing.T, raw string) error {
 	_, err := authenticator.Authenticate(
 		t.Context(),
 		core.Credential{Token: raw},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	return err
 }
 
@@ -55,7 +56,8 @@ func TestParseToken(t *testing.T) {
 
 	authInfo, err := authenticator.Authenticate(
 		t.Context(), core.Credential{Token: raw},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 }
@@ -133,7 +135,8 @@ func TestToken_CanonicalSignedDataAuthenticates(t *testing.T) {
 
 	_, err := authenticator.Authenticate(
 		t.Context(), core.Credential{Token: raw},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.NoError(t, err)
 }
 

--- a/controlplane/internal/auth/sshcert/token_test.go
+++ b/controlplane/internal/auth/sshcert/token_test.go
@@ -24,9 +24,8 @@ func authenticateRawToken(t *testing.T, raw string) error {
 
 	_, err := authenticator.Authenticate(
 		t.Context(),
-		raw,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: raw},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	return err
 }
 
@@ -55,9 +54,8 @@ func TestParseToken(t *testing.T) {
 	t.Cleanup(authenticator.Close)
 
 	authInfo, err := authenticator.Authenticate(
-		t.Context(), raw,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		t.Context(), core.Credential{Token: raw},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 }
@@ -134,9 +132,8 @@ func TestToken_CanonicalSignedDataAuthenticates(t *testing.T) {
 	t.Cleanup(authenticator.Close)
 
 	_, err := authenticator.Authenticate(
-		t.Context(), raw,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		t.Context(), core.Credential{Token: raw},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.NoError(t, err)
 }
 

--- a/controlplane/internal/auth/sshkey/authenticator.go
+++ b/controlplane/internal/auth/sshkey/authenticator.go
@@ -75,9 +75,10 @@ func (m *Authenticator) Name() string {
 	return "sshkey"
 }
 
-// IsTokenSupported checks if the token has the "sshkey " prefix.
-func (m *Authenticator) IsTokenSupported(token string) bool {
-	return strings.HasPrefix(strings.ToLower(token), tokenPrefix)
+// Supports checks if the credential carries a token with the "sshkey "
+// prefix.
+func (m *Authenticator) Supports(credential core.Credential) bool {
+	return strings.HasPrefix(strings.ToLower(credential.Token), tokenPrefix)
 }
 
 // Authenticate validates the SSH key token and returns authentication info.
@@ -87,10 +88,10 @@ func (m *Authenticator) IsTokenSupported(token string) bool {
 // the local account lookup name.
 func (m *Authenticator) Authenticate(
 	ctx context.Context,
-	rawToken string,
+	credential core.Credential,
 	reqInfo *core.RequestInfo,
 ) (*core.AuthInfo, error) {
-	token, err := parseToken(rawToken)
+	token, err := parseToken(credential.Token)
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Unauthenticated, "invalid sshkey token: %v", err,

--- a/controlplane/internal/auth/sshkey/authenticator_test.go
+++ b/controlplane/internal/auth/sshkey/authenticator_test.go
@@ -58,7 +58,7 @@ func setupAuthenticator(t *testing.T) (*sshkey.Authenticator, map[string]ssh.Sig
 	return auth, signers
 }
 
-func TestAuthenticator_IsTokenSupported(t *testing.T) {
+func TestAuthenticator_Supports(t *testing.T) {
 	auth := &sshkey.Authenticator{}
 
 	tests := []struct {
@@ -75,7 +75,7 @@ func TestAuthenticator_IsTokenSupported(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, auth.IsTokenSupported(tt.token))
+			assert.Equal(t, tt.want, auth.Supports(core.Credential{Token: tt.token}))
 		})
 	}
 }
@@ -89,7 +89,7 @@ func TestAuthenticate_Ed25519(t *testing.T) {
 
 	token := signTestToken(t, signers["alice"], "alice", method, now.UnixNano(), "nonce-1")
 
-	authInfo, err := auth.Authenticate(context.Background(), token, reqInfo)
+	authInfo, err := auth.Authenticate(context.Background(), core.Credential{Token: token}, reqInfo)
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 	assert.Equal(t, "sshkey", authInfo.AuthMethod)
@@ -104,7 +104,7 @@ func TestAuthenticate_RSA(t *testing.T) {
 
 	token := signTestToken(t, signers["bob"], "bob", method, now.UnixNano(), "nonce-1")
 
-	authInfo, err := auth.Authenticate(context.Background(), token, reqInfo)
+	authInfo, err := auth.Authenticate(context.Background(), core.Credential{Token: token}, reqInfo)
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("bob"), authInfo.Subject)
 	assert.Equal(t, "sshkey", authInfo.AuthMethod)
@@ -119,7 +119,7 @@ func TestAuthenticate_ECDSA(t *testing.T) {
 
 	token := signTestToken(t, signers["charlie"], "charlie", method, now.UnixNano(), "nonce-1")
 
-	authInfo, err := auth.Authenticate(context.Background(), token, reqInfo)
+	authInfo, err := auth.Authenticate(context.Background(), core.Credential{Token: token}, reqInfo)
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("charlie"), authInfo.Subject)
 	assert.Equal(t, "sshkey", authInfo.AuthMethod)
@@ -135,7 +135,7 @@ func TestAuthenticate_ExpiredTimestamp(t *testing.T) {
 	oldTimestamp := now.Add(-10 * time.Second).UnixNano()
 	token := signTestToken(t, signers["alice"], "alice", method, oldTimestamp, "nonce-1")
 
-	_, err := auth.Authenticate(context.Background(), token, reqInfo)
+	_, err := auth.Authenticate(context.Background(), core.Credential{Token: token}, reqInfo)
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.Unauthenticated, st.Code())
@@ -152,7 +152,7 @@ func TestAuthenticate_MethodBindingMismatch(t *testing.T) {
 		"/other.Service/OtherMethod", now.UnixNano(), "nonce-1",
 	)
 
-	_, err := auth.Authenticate(context.Background(), token, reqInfo)
+	_, err := auth.Authenticate(context.Background(), core.Credential{Token: token}, reqInfo)
 	requireGRPCError(t, err, codes.Unauthenticated,
 		`method binding mismatch: token method "/other.Service/OtherMethod" != request method "/test.Service/TestMethod"`,
 	)
@@ -167,7 +167,7 @@ func TestAuthenticate_UnknownUser(t *testing.T) {
 
 	token := signTestToken(t, signers["alice"], "unknown_user", method, now.UnixNano(), "nonce-1")
 
-	_, err := auth.Authenticate(context.Background(), token, reqInfo)
+	_, err := auth.Authenticate(context.Background(), core.Credential{Token: token}, reqInfo)
 	requireGRPCError(t, err, codes.Unauthenticated,
 		`no SSH keys found for user "unknown_user"`,
 	)
@@ -183,7 +183,7 @@ func TestAuthenticate_WrongSignature(t *testing.T) {
 	// Sign with bob's key but claim to be alice.
 	token := signTestToken(t, signers["bob"], "alice", method, now.UnixNano(), "nonce-1")
 
-	_, err := auth.Authenticate(context.Background(), token, reqInfo)
+	_, err := auth.Authenticate(context.Background(), core.Credential{Token: token}, reqInfo)
 	requireGRPCError(t, err, codes.Unauthenticated,
 		"signature verification failed: signature verification failed",
 	)
@@ -193,7 +193,7 @@ func TestAuthenticate_InvalidTokenFormat(t *testing.T) {
 	auth, _ := setupAuthenticator(t)
 	reqInfo := &core.RequestInfo{FullMethod: "/test.Service/TestMethod"}
 
-	_, err := auth.Authenticate(context.Background(), "sshkey invalid", reqInfo)
+	_, err := auth.Authenticate(context.Background(), core.Credential{Token: "sshkey invalid"}, reqInfo)
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.Unauthenticated, st.Code())
@@ -207,7 +207,7 @@ func TestAuthenticate_NilRequestInfo(t *testing.T) {
 
 	token := signTestToken(t, signers["alice"], "alice", method, now.UnixNano(), "nonce-1")
 
-	authInfo, err := auth.Authenticate(context.Background(), token, nil)
+	authInfo, err := auth.Authenticate(context.Background(), core.Credential{Token: token}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 }
@@ -221,7 +221,7 @@ func TestAuthenticate_EmptyFullMethod(t *testing.T) {
 	token := signTestToken(t, signers["alice"], "alice", method, now.UnixNano(), "nonce-1")
 
 	emptyReqInfo := &core.RequestInfo{}
-	authInfo, err := auth.Authenticate(context.Background(), token, emptyReqInfo)
+	authInfo, err := auth.Authenticate(context.Background(), core.Credential{Token: token}, emptyReqInfo)
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 }

--- a/controlplane/internal/auth/sshkey/factory_test.go
+++ b/controlplane/internal/auth/sshkey/factory_test.go
@@ -111,7 +111,7 @@ func TestNewFromConfig(t *testing.T) {
 	requestInfo := &core.RequestInfo{FullMethod: method}
 	token := signToken(t, signer, "alice", method, time.Now().UnixNano(), "nonce-1")
 
-	authInfo, err := authenticator.Authenticate(t.Context(), token, requestInfo)
+	authInfo, err := authenticator.Authenticate(t.Context(), core.Credential{Token: token}, requestInfo)
 	require.NoError(t, err)
 	require.Equal(t, &core.AuthInfo{
 		Subject:    core.NewLocalSubject("alice"),
@@ -138,7 +138,7 @@ func TestNewFromConfigTimeWindow(t *testing.T) {
 		authenticator, err := sshkey.NewFromConfig(rawConfig)
 		require.NoError(t, err)
 
-		_, err = authenticator.Authenticate(t.Context(), token, requestInfo)
+		_, err = authenticator.Authenticate(t.Context(), core.Credential{Token: token}, requestInfo)
 		require.NoError(t, err)
 	})
 
@@ -148,7 +148,7 @@ func TestNewFromConfigTimeWindow(t *testing.T) {
 		authenticator, err := sshkey.NewFromConfig(rawConfig)
 		require.NoError(t, err)
 
-		_, err = authenticator.Authenticate(t.Context(), token, requestInfo)
+		_, err = authenticator.Authenticate(t.Context(), core.Credential{Token: token}, requestInfo)
 		require.Error(t, err)
 	})
 }

--- a/controlplane/internal/auth/sshkey/signature_test.go
+++ b/controlplane/internal/auth/sshkey/signature_test.go
@@ -26,7 +26,8 @@ func authenticateKeyToken(
 	_, err := authenticator.Authenticate(
 		t.Context(),
 		core.Credential{Token: rawToken},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	return err
 }
 

--- a/controlplane/internal/auth/sshkey/signature_test.go
+++ b/controlplane/internal/auth/sshkey/signature_test.go
@@ -25,9 +25,8 @@ func authenticateKeyToken(
 	)
 	_, err := authenticator.Authenticate(
 		t.Context(),
-		rawToken,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		core.Credential{Token: rawToken},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	return err
 }
 

--- a/controlplane/internal/auth/sshkey/token_test.go
+++ b/controlplane/internal/auth/sshkey/token_test.go
@@ -26,7 +26,8 @@ func TestParseToken(t *testing.T) {
 
 	authInfo, err := authenticator.Authenticate(
 		t.Context(), core.Credential{Token: raw},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 }
@@ -37,7 +38,8 @@ func authenticateRawKeyToken(t *testing.T, raw string) error {
 	authenticator := sshkey.NewAuthenticator(sshkey.NewKeyStore(map[string][]sshkey.KeyEntry{}))
 	_, err := authenticator.Authenticate(
 		t.Context(), core.Credential{Token: raw},
-		&core.RequestInfo{FullMethod: "/test.Service/Method"})
+		&core.RequestInfo{FullMethod: "/test.Service/Method"},
+	)
 	return err
 }
 

--- a/controlplane/internal/auth/sshkey/token_test.go
+++ b/controlplane/internal/auth/sshkey/token_test.go
@@ -25,9 +25,8 @@ func TestParseToken(t *testing.T) {
 	)
 
 	authInfo, err := authenticator.Authenticate(
-		t.Context(), raw,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		t.Context(), core.Credential{Token: raw},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	require.NoError(t, err)
 	assert.Equal(t, core.NewLocalSubject("alice"), authInfo.Subject)
 }
@@ -37,9 +36,8 @@ func authenticateRawKeyToken(t *testing.T, raw string) error {
 
 	authenticator := sshkey.NewAuthenticator(sshkey.NewKeyStore(map[string][]sshkey.KeyEntry{}))
 	_, err := authenticator.Authenticate(
-		t.Context(), raw,
-		&core.RequestInfo{FullMethod: "/test.Service/Method"},
-	)
+		t.Context(), core.Credential{Token: raw},
+		&core.RequestInfo{FullMethod: "/test.Service/Method"})
 	return err
 }
 

--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -150,8 +150,6 @@ receiver:modules/pdump/controlplane/ring.go:workerArea.read:1  # legacy: rename 
 receiver:operators/bird-adapter/cmd/yanet-bird-adapter/client.go:logLevelFlag.Type:1  # legacy: rename the receiver to m
 sugar:modules/pdump/controlplane/ffi.go:pdumpGoControlplaneLog:Sugar():1  # legacy: migrate off zap.SugaredLogger
 sugar:modules/pdump/controlplane/ffi.go:pdumpGoControlplaneLog:Sugar():2  # legacy: migrate off zap.SugaredLogger
-testctx:controlplane/internal/auth/interceptor_test.go:TestExtractToken:Background:1  # legacy: migrate to t.Context()
-testctx:controlplane/internal/auth/interceptor_test.go:TestExtractToken:Background:2  # legacy: migrate to t.Context()
 testctx:controlplane/internal/auth/interceptor_test.go:TestStreamServerInterceptor:Background:1  # legacy: migrate to t.Context()
 testctx:controlplane/internal/auth/interceptor_test.go:TestUnaryServerInterceptor:Background:1  # legacy: migrate to t.Context()
 testctx:controlplane/internal/auth/none/authenticator_test.go:TestNoneAuthenticator_Authenticate:Background:1  # legacy: migrate to t.Context()


### PR DESCRIPTION
- Authenticators receive what a request presents as one credential, the metadata token together with the TLS state of the connection, so an authenticator may inspect the transport as well as the header.
- The file, HTTP and zstd loaders leave the SSH certificate authenticator for a package of their own, ready for a second consumer.
- No behaviour changes, the existing authenticators still dispatch on the token prefix alone.
