### PR TITLE
fix(dataplane): mark instances ready only after all are set up

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -846,7 +846,16 @@ dataplane_init(
 				return -1;
 			}
 		}
+	}
 
+	// Mark instances ready only after all of them are set up, so a
+	// failure cannot leave a ready instance that no dataplane serves.
+	for (uint32_t instance_idx = 0;
+	     instance_idx < dataplane->instance_count;
+	     ++instance_idx) {
+		struct dataplane_instance *instance =
+			dataplane->instances + instance_idx;
+		struct dp_config *dp_config = instance->dp_config;
 		dp_config_mark_ready(dp_config);
 	}
 


### PR DESCRIPTION
- The dataplane set up each instance and marked it ready in the same loop, so instances were advertised in shared memory one at a time.
- If a later instance failed to set up, the process exited but the earlier instances stayed marked ready, and a control plane could attach to an instance that no dataplane was serving.
- The ready flag is now set in a second pass that runs only after every instance is set up, so either all instances are advertised or none are.

Closes #1900.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaxLia1ktwB7118q338LCz
