### PR TITLE
perf(dataplane): recycle rx mbufs through the per-lcore pool cache

### DIFF
--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -59,7 +59,10 @@
 
 #include "lib/logging/log.h"
 
+#include <rte_errno.h>
 #include <rte_ethdev.h>
+#include <rte_lcore.h>
+#include <rte_mempool.h>
 #include <rte_prefetch.h>
 
 #include <string.h>
@@ -333,6 +336,25 @@ static void *
 worker_thread_start(void *arg) {
 	struct dataplane_worker *worker = (struct dataplane_worker *)arg;
 
+	// Give the thread an lcore id so the pool cache serves it.
+	//
+	// The mempool cache is indexed by lcore id, and a plain thread has
+	// none: every alloc and free then goes through the pool ring, which
+	// recycles mbufs in FIFO order over the whole pool. With the cache a
+	// freed mbuf is the next one the NIC gets back, its lines still in
+	// L2. Registering also disables DPDK multi-process support for the
+	// rest of the process, so no secondary process can attach afterwards.
+	// The call fails when EAL has no lcore id left or the multi-process
+	// channel is already in use, and the worker then runs without the
+	// cache.
+	if (rte_thread_register() != 0) {
+		LOG(ERROR,
+		    "failed to register worker core_id=%u as an lcore, running "
+		    "without the pool cache: %s",
+		    worker->config.core_id,
+		    rte_strerror(rte_errno));
+	}
+
 	while (1) {
 		worker_loop_round(worker);
 	}
@@ -466,11 +488,19 @@ dataplane_worker_init(
 
 	uint32_t num_mbufs = config->num_mbufs ? config->num_mbufs : 16384;
 
+	// Sized under both limits the pool enforces, so a small pool degrades
+	// instead of failing to start.
+	//
+	// The pool refuses a cache above its own maximum, or one whose flush
+	// threshold, one and a half times the cache, exceeds the pool.
+	uint32_t cache_size =
+		RTE_MIN((uint32_t)RTE_MEMPOOL_CACHE_MAX_SIZE, num_mbufs / 2);
+
 	worker->rx_mempool = rte_mempool_create(
 		mempool_name,
 		num_mbufs,
 		MBUF_MAX_SIZE,
-		0,
+		cache_size,
 		sizeof(struct rte_pktmbuf_pool_private),
 		rte_pktmbuf_pool_init,
 		NULL,


### PR DESCRIPTION
- Register every worker thread as a DPDK lcore and give its RX pool a cache of half the pool, at most 512 mbufs. Without an lcore id the mempool cache does not exist and every alloc and free goes through the pool ring, a FIFO over all 16384 mbufs, so the NIC gets back mbufs whose lines left the caches long ago and the PMD refill reads them from DRAM.
- Registering disables DPDK multi-process for the rest of the process, so dpdk-pdump and dpdk-procinfo can no longer attach to the dataplane. Nothing in the tree relies on it.
- Registration fails when EAL has no lcore id left, which happens on hosts with more usable CPUs than RTE_MAX_LCORE since no core list is passed to EAL. The worker then logs an error and runs without the cache, as before.
- The main lcore keeps whatever the RX ring fill left in its own cache of each pool: eight mbufs for a 4096-deep ring filled one mbuf at a time, up to 512 for a ring below 512 descriptors, 64 for a vectorized virtio queue. Those are free mbufs the owner never needed, so no flush is done for them.
- A non-zero cache size costs about 1 MB of hugepage memory per pool for the cache array.
- Measured on the lab firewall profile (Xeon Gold 6230, ConnectX-5, 86 B frames, ramp to 30 Mpps) on top of the rx prefetch: cycles per packet 1955 to 1897 with the 4096 ring the profile uses, and to 1812 with rx_queue_len 1024, where the plateau goes from 22.5 to 24.2 Mpps, the drop-free rate from 21.4 to 22.6 Mpps and DRAM loads per packet from 1.7 to 0.004.
