### PR TITLE
feat(auth,gateway): authenticate callers by tls client certificate

### DIFF
--- a/common/go/testutils/tlscert/tlscert.go
+++ b/common/go/testutils/tlscert/tlscert.go
@@ -65,6 +65,13 @@ func WithURIs(uris ...*url.URL) IssueOption {
 	}
 }
 
+// WithSerial sets the serial number of the issued certificate.
+func WithSerial(serial *big.Int) IssueOption {
+	return func(template *x509.Certificate) {
+		template.SerialNumber = serial
+	}
+}
+
 // WithExtKeyUsage replaces the extended key usages of the issued certificate.
 func WithExtKeyUsage(usages ...x509.ExtKeyUsage) IssueOption {
 	return func(template *x509.Certificate) {
@@ -236,6 +243,18 @@ func (m *CA) RevocationListFile(t *testing.T, nextUpdate time.Time, revoked ...*
 	return path
 }
 
+// SignRevocationList signs the given list template as this CA and returns
+// the DER encoding, for tests that need a list shape the helpers above do
+// not produce.
+func (m *CA) SignRevocationList(t *testing.T, template *x509.RevocationList) []byte {
+	t.Helper()
+
+	der, err := x509.CreateRevocationList(rand.Reader, template, m.certificate, m.key)
+	require.NoError(t, err)
+
+	return der
+}
+
 // revocationList signs list number revoking the given certificates.
 func (m *CA) revocationList(t *testing.T, number int64, nextUpdate time.Time, revoked ...*x509.Certificate) []byte {
 	t.Helper()
@@ -248,17 +267,12 @@ func (m *CA) revocationList(t *testing.T, number int64, nextUpdate time.Time, re
 		})
 	}
 
-	template := &x509.RevocationList{
+	return m.SignRevocationList(t, &x509.RevocationList{
 		Number:                    big.NewInt(number),
 		ThisUpdate:                nextUpdate.Add(-time.Hour),
 		NextUpdate:                nextUpdate,
 		RevokedCertificateEntries: entries,
-	}
-
-	der, err := x509.CreateRevocationList(rand.Reader, template, m.certificate, m.key)
-	require.NoError(t, err)
-
-	return der
+	})
 }
 
 // issue signs template with the CA and writes the pair under a unique name.

--- a/common/go/testutils/tlscert/tlscert.go
+++ b/common/go/testutils/tlscert/tlscert.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -38,10 +39,37 @@ type CA struct {
 type Keypair struct {
 	// Certificate is the issued certificate with its private key.
 	Certificate tls.Certificate
+	// Leaf is the issued certificate, parsed.
+	Leaf *x509.Certificate
 	// CertFile is the PEM file holding the certificate.
 	CertFile string
 	// KeyFile is the PEM file holding the private key.
 	KeyFile string
+}
+
+// IssueOption adjusts the template of a certificate about to be issued.
+type IssueOption func(template *x509.Certificate)
+
+// WithValidity sets the validity period of the issued certificate.
+func WithValidity(notBefore, notAfter time.Time) IssueOption {
+	return func(template *x509.Certificate) {
+		template.NotBefore = notBefore
+		template.NotAfter = notAfter
+	}
+}
+
+// WithURIs sets the URI subject alternative names of the issued certificate.
+func WithURIs(uris ...*url.URL) IssueOption {
+	return func(template *x509.Certificate) {
+		template.URIs = uris
+	}
+}
+
+// WithExtKeyUsage replaces the extended key usages of the issued certificate.
+func WithExtKeyUsage(usages ...x509.ExtKeyUsage) IssueOption {
+	return func(template *x509.Certificate) {
+		template.ExtKeyUsage = usages
+	}
 }
 
 // NewCA generates a CA valid for an hour and writes its PEM bundle to disk.
@@ -58,7 +86,7 @@ func NewCA(t *testing.T) *CA {
 		NotAfter:              time.Now().Add(time.Hour),
 		IsCA:                  true,
 		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
 	}
 
 	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
@@ -86,6 +114,11 @@ func NewCA(t *testing.T) *CA {
 // BundleFile returns the path of the PEM bundle holding the CA certificate.
 func (m *CA) BundleFile() string {
 	return m.bundleFile
+}
+
+// Certificate returns the CA certificate.
+func (m *CA) Certificate() *x509.Certificate {
+	return m.certificate
 }
 
 // Pool returns a pool trusting only this CA.
@@ -117,8 +150,9 @@ func (m *CA) IssueServer(t *testing.T, hosts ...string) Keypair {
 	return m.issue(t, "server", template)
 }
 
-// IssueClient issues a client certificate with the given common name.
-func (m *CA) IssueClient(t *testing.T, commonName string) Keypair {
+// IssueClient issues a client certificate with the given common name, valid
+// for an hour unless an option says otherwise.
+func (m *CA) IssueClient(t *testing.T, commonName string, options ...IssueOption) Keypair {
 	t.Helper()
 
 	template := &x509.Certificate{
@@ -129,8 +163,50 @@ func (m *CA) IssueClient(t *testing.T, commonName string) Keypair {
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
+	for _, option := range options {
+		option(template)
+	}
 
 	return m.issue(t, "client", template)
+}
+
+// RevocationList signs a DER-encoded list revoking the given certificates,
+// with the next update expected at nextUpdate.
+//
+// Passing a past nextUpdate yields a list that is already stale.
+func (m *CA) RevocationList(t *testing.T, nextUpdate time.Time, revoked ...*x509.Certificate) []byte {
+	t.Helper()
+
+	entries := make([]x509.RevocationListEntry, 0, len(revoked))
+	for _, certificate := range revoked {
+		entries = append(entries, x509.RevocationListEntry{
+			SerialNumber:   certificate.SerialNumber,
+			RevocationTime: nextUpdate.Add(-time.Hour),
+		})
+	}
+
+	template := &x509.RevocationList{
+		Number:                    big.NewInt(m.issued.Add(1)),
+		ThisUpdate:                nextUpdate.Add(-time.Hour),
+		NextUpdate:                nextUpdate,
+		RevokedCertificateEntries: entries,
+	}
+
+	der, err := x509.CreateRevocationList(rand.Reader, template, m.certificate, m.key)
+	require.NoError(t, err)
+
+	return der
+}
+
+// RevocationListFile writes the list RevocationList would sign to a file
+// under the CA's directory and returns its path.
+func (m *CA) RevocationListFile(t *testing.T, nextUpdate time.Time, revoked ...*x509.Certificate) string {
+	t.Helper()
+
+	path := filepath.Join(m.dir, fmt.Sprintf("revoked-%d.crl", m.issued.Load()+1))
+	require.NoError(t, os.WriteFile(path, m.RevocationList(t, nextUpdate, revoked...), 0o600))
+
+	return path
 }
 
 // issue signs template with the CA and writes the pair under a unique name.
@@ -155,8 +231,12 @@ func (m *CA) issue(t *testing.T, kind string, template *x509.Certificate) Keypai
 	certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
 	require.NoError(t, err)
 
+	leaf, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
 	return Keypair{
 		Certificate: certificate,
+		Leaf:        leaf,
 		CertFile:    certFile,
 		KeyFile:     keyFile,
 	}

--- a/common/go/testutils/tlscert/tlscert.go
+++ b/common/go/testutils/tlscert/tlscert.go
@@ -150,6 +150,45 @@ func (m *CA) IssueServer(t *testing.T, hosts ...string) Keypair {
 	return m.issue(t, "server", template)
 }
 
+// IssueIntermediate issues a subordinate authority with the given common
+// name that signs from the same directory.
+func (m *CA) IssueIntermediate(t *testing.T, commonName string) *CA {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          newSerial(t),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, m.certificate, &key.PublicKey, m.key)
+	require.NoError(t, err)
+
+	certificate, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(certificate)
+
+	bundleFile := filepath.Join(m.dir, fmt.Sprintf("intermediate-%d.pem", m.issued.Add(1)))
+	writePEM(t, bundleFile, "CERTIFICATE", der)
+
+	return &CA{
+		certificate: certificate,
+		key:         key,
+		pool:        pool,
+		bundleFile:  bundleFile,
+		dir:         m.dir,
+	}
+}
+
 // IssueClient issues a client certificate with the given common name, valid
 // for an hour unless an option says otherwise.
 func (m *CA) IssueClient(t *testing.T, commonName string, options ...IssueOption) Keypair {
@@ -173,8 +212,28 @@ func (m *CA) IssueClient(t *testing.T, commonName string, options ...IssueOption
 // RevocationList signs a DER-encoded list revoking the given certificates,
 // with the next update expected at nextUpdate.
 //
-// Passing a past nextUpdate yields a list that is already stale.
+// Lists are numbered in the order they are signed, so a later call yields a
+// newer list. Passing a past nextUpdate yields a list that is already stale.
 func (m *CA) RevocationList(t *testing.T, nextUpdate time.Time, revoked ...*x509.Certificate) []byte {
+	t.Helper()
+
+	return m.revocationList(t, m.issued.Add(1), nextUpdate, revoked...)
+}
+
+// RevocationListFile writes the list RevocationList would sign to a file
+// under the CA's directory and returns its path.
+func (m *CA) RevocationListFile(t *testing.T, nextUpdate time.Time, revoked ...*x509.Certificate) string {
+	t.Helper()
+
+	number := m.issued.Add(1)
+	path := filepath.Join(m.dir, fmt.Sprintf("revoked-%d.crl", number))
+	require.NoError(t, os.WriteFile(path, m.revocationList(t, number, nextUpdate, revoked...), 0o600))
+
+	return path
+}
+
+// revocationList signs list number revoking the given certificates.
+func (m *CA) revocationList(t *testing.T, number int64, nextUpdate time.Time, revoked ...*x509.Certificate) []byte {
 	t.Helper()
 
 	entries := make([]x509.RevocationListEntry, 0, len(revoked))
@@ -186,7 +245,7 @@ func (m *CA) RevocationList(t *testing.T, nextUpdate time.Time, revoked ...*x509
 	}
 
 	template := &x509.RevocationList{
-		Number:                    big.NewInt(m.issued.Add(1)),
+		Number:                    big.NewInt(number),
 		ThisUpdate:                nextUpdate.Add(-time.Hour),
 		NextUpdate:                nextUpdate,
 		RevokedCertificateEntries: entries,
@@ -196,17 +255,6 @@ func (m *CA) RevocationList(t *testing.T, nextUpdate time.Time, revoked ...*x509
 	require.NoError(t, err)
 
 	return der
-}
-
-// RevocationListFile writes the list RevocationList would sign to a file
-// under the CA's directory and returns its path.
-func (m *CA) RevocationListFile(t *testing.T, nextUpdate time.Time, revoked ...*x509.Certificate) string {
-	t.Helper()
-
-	path := filepath.Join(m.dir, fmt.Sprintf("revoked-%d.crl", m.issued.Load()+1))
-	require.NoError(t, os.WriteFile(path, m.RevocationList(t, nextUpdate, revoked...), 0o600))
-
-	return path
 }
 
 // issue signs template with the CA and writes the pair under a unique name.

--- a/common/go/testutils/tlscert/tlscert.go
+++ b/common/go/testutils/tlscert/tlscert.go
@@ -151,8 +151,9 @@ func (m *CA) IssueServer(t *testing.T, hosts ...string) Keypair {
 }
 
 // IssueIntermediate issues a subordinate authority with the given common
-// name that signs from the same directory.
-func (m *CA) IssueIntermediate(t *testing.T, commonName string) *CA {
+// name that signs from the same directory, valid for an hour unless an
+// option says otherwise.
+func (m *CA) IssueIntermediate(t *testing.T, commonName string, options ...IssueOption) *CA {
 	t.Helper()
 
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -166,6 +167,9 @@ func (m *CA) IssueIntermediate(t *testing.T, commonName string) *CA {
 		IsCA:                  true,
 		BasicConstraintsValid: true,
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+	}
+	for _, option := range options {
+		option(template)
 	}
 
 	der, err := x509.CreateCertificate(rand.Reader, template, m.certificate, &key.PublicKey, m.key)

--- a/controlplane/etc/yanet/controlplane.d/default.yaml
+++ b/controlplane/etc/yanet/controlplane.d/default.yaml
@@ -35,6 +35,17 @@ gateway:
     #   - type: basic
     #     config:
     #       credentials_path: /etc/yanet2/auth/basic_auth.yaml
+    #   # A client certificate presented in the TLS handshake identifies a
+    #   # caller that sends no token by its common name, which must be listed
+    #   # in the identities file. Requires server.tls. Revocation lists are
+    #   # optional and must be signed by one of the authorities.
+    #   - type: x509
+    #     config:
+    #       ca_sources:
+    #         - /etc/yanet2/auth/client-ca.pem
+    #       crl_sources:
+    #         - https://pki.example.com/yanet-clients.crl
+    #       refresh_interval: 5m
     # permissions_path: /etc/yanet2/auth/permissions.yaml
   registry:
     # The gateway drops backends that stopped refreshing their registration,

--- a/controlplane/gateway/auth_service.go
+++ b/controlplane/gateway/auth_service.go
@@ -26,16 +26,22 @@ func NewAuthService(manager *auth.Manager) *AuthService {
 }
 
 // IntrospectToken validates a token and returns principal information.
+//
+// An empty token introspects what the call itself presented: the token in
+// its metadata or the client certificate of its connection.
 func (m *AuthService) IntrospectToken(
 	ctx context.Context,
 	request *ynpb.IntrospectTokenRequest,
 ) (*ynpb.IntrospectTokenResponse, error) {
-	token := request.GetToken()
+	credential := core.Credential{Token: request.GetToken()}
+	if credential.Token == "" {
+		credential = auth.ExtractCredential(ctx)
+	}
 
 	// IntrospectToken is not bound to a specific method, so we pass
 	// an empty RequestInfo.
 	requestInfo := &core.RequestInfo{}
-	principal, err := m.manager.Authenticate(ctx, core.Credential{Token: token}, requestInfo)
+	principal, err := m.manager.Authenticate(ctx, credential, requestInfo)
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "authentication failed: %v", err)
 	}

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
@@ -193,6 +194,12 @@ func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 		return nil, fmt.Errorf("failed to create auth manager: %w", err)
 	}
 
+	// A client certificate is only ever verified in a TLS handshake, so an
+	// authenticator that reads one is dead without server TLS.
+	if authManager.ClientCAs() != nil && cfg.Server.TLS == nil {
+		return nil, errors.New("x509 authenticator requires server.tls")
+	}
+
 	authService := NewAuthService(authManager)
 
 	director := func(ctx context.Context, fullMethodName string) (proxy.Mode, []proxy.Backend, error) {
@@ -327,7 +334,12 @@ func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 		),
 	}
 	if cfg.Server.TLS != nil {
-		creds, err := cfg.Server.TLS.ServerCredentials()
+		var clientCAs func() *x509.CertPool
+		if authManager.ClientCAs() != nil {
+			clientCAs = authManager.ClientCAs
+		}
+
+		creds, err := cfg.Server.TLS.ServerCredentials(clientCAs)
 		if err != nil {
 			return nil, fmt.Errorf("load gateway TLS: %w", err)
 		}
@@ -350,7 +362,7 @@ func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 	readinessSvc := NewReadinessService(rdTracker)
 	ynpb.RegisterReadinessServiceServer(server, readinessSvc)
 
-	metricsService := NewMetricsService(metricsCollectors(serverMetrics, opts.Services)...)
+	metricsService := NewMetricsService(append(metricsCollectors(serverMetrics, opts.Services), authManager)...)
 	ynpb.RegisterMetricsServiceServer(server, metricsService)
 
 	// Gateway-hosted services are reached through one in-memory connection

--- a/controlplane/gateway/tls.go
+++ b/controlplane/gateway/tls.go
@@ -24,16 +24,33 @@ type TLSConfig struct {
 
 // ServerCredentials loads the cert/key pair and returns gRPC server
 // transport credentials.
-func (m *TLSConfig) ServerCredentials() (credentials.TransportCredentials, error) {
+//
+// With clientCAs set the listener asks every client for a certificate and
+// verifies the one it gets against the pool clientCAs returns for that
+// handshake, so a reloaded pool applies to new connections without a
+// restart. A client without a certificate is still accepted and
+// authenticates by other means.
+func (m *TLSConfig) ServerCredentials(clientCAs func() *x509.CertPool) (credentials.TransportCredentials, error) {
 	cert, err := tls.LoadX509KeyPair(m.CertFile.Unwrap(), m.KeyFile.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load gateway TLS keypair: %w", err)
 	}
 
-	return credentials.NewTLS(&tls.Config{
+	config := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		MinVersion:   tls.VersionTLS12,
-	}), nil
+	}
+	if clientCAs != nil {
+		config.ClientAuth = tls.VerifyClientCertIfGiven
+		config.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			perClient := config.Clone()
+			perClient.ClientCAs = clientCAs()
+
+			return perClient, nil
+		}
+	}
+
+	return credentials.NewTLS(config), nil
 }
 
 // LoopbackCredentials returns client credentials that accept exactly the

--- a/controlplane/gateway/x509_test.go
+++ b/controlplane/gateway/x509_test.go
@@ -1,0 +1,291 @@
+package gateway_test
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"gopkg.in/yaml.v3"
+
+	"github.com/yanet-platform/yanet2/common/go/testutils/tlscert"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/gateway"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// writeTestFile writes content under the test's temporary directory and
+// returns the path.
+func writeTestFile(t *testing.T, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// newX509AuthConfig builds an enabled auth config from YAML the way
+// production parses it: identities know route-operator and alice, both in
+// a group allowed every method, anonymous may only introspect and list
+// services, the x509 authenticator trusts ca and a basic authenticator knows
+// alice with the password "s3cret".
+func newX509AuthConfig(t *testing.T, ca *tlscert.CA) auth.Config {
+	t.Helper()
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("s3cret"), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	identities := writeTestFile(t, "identities.yaml", "identities:\n"+
+		"  - username: route-operator\n    groups: [operators]\n"+
+		"  - username: alice\n    groups: [operators]\n")
+	permissions := writeTestFile(t, "permissions.yaml", "permissions:\n"+
+		"  groups:\n    - name: operators\n      permissions: [\"/*/*\"]\n"+
+		"  users:\n    - username: anonymous\n      permissions:\n"+
+		"        - \"/controlplane.ynpb.v1.AuthService/IntrospectToken\"\n"+
+		"        - \"/controlplane.ynpb.v1.Gateway/ListServices\"\n")
+	credentials := writeTestFile(t, "basic_auth.yaml", "credentials:\n"+
+		"  - username: alice\n    password_hash: "+string(hash)+"\n")
+
+	text := "disabled: false\n" +
+		"identity_providers:\n  - type: file\n    path: " + identities + "\n" +
+		"permissions_path: " + permissions + "\n" +
+		"authenticators:\n" +
+		"  - type: basic\n    config:\n      credentials_path: " + credentials + "\n" +
+		"  - type: x509\n    config:\n      ca_sources:\n        - " + ca.BundleFile() + "\n"
+
+	var config auth.Config
+	require.NoError(t, yaml.Unmarshal([]byte(text), &config))
+
+	return config
+}
+
+// startX509Gateway runs a gateway serving TLS with a certificate issued by
+// ca on a pre-bound listener and returns the address to dial.
+func startX509Gateway(t *testing.T, ca *tlscert.CA, cfg gateway.Config) string {
+	t.Helper()
+
+	server := ca.IssueServer(t, "127.0.0.1")
+	cfg.Server.TLS = &gateway.TLSConfig{
+		CertFile: xcfg.MustNonEmptyString(server.CertFile),
+		KeyFile:  xcfg.MustNonEmptyString(server.KeyFile),
+	}
+
+	listener := NewTestListener(t)
+	gw, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()), gateway.WithListener(listener))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var group errgroup.Group
+	group.Go(func() error { return gw.Run(ctx) })
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, group.Wait())
+	})
+
+	return listener.Addr().String()
+}
+
+// dialAuth opens a TLS connection trusting ca, presenting the given client
+// certificates if any, and returns an auth client over it.
+func dialAuth(t *testing.T, address string, ca *tlscert.CA, certificates ...tls.Certificate) ynpb.AuthServiceClient {
+	t.Helper()
+
+	creds := credentials.NewTLS(&tls.Config{
+		RootCAs:      ca.Pool(),
+		Certificates: certificates,
+		MinVersion:   tls.VersionTLS12,
+	})
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(creds))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return ynpb.NewAuthServiceClient(conn)
+}
+
+// introspectSelf asks the gateway who the caller is, with a bounded wait.
+func introspectSelf(t *testing.T, ctx context.Context, client ynpb.AuthServiceClient) (*ynpb.Principal, error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	response, err := client.IntrospectToken(ctx, &ynpb.IntrospectTokenRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	return response.GetPrincipal(), nil
+}
+
+// Test_Gateway_X509_ClientCertificateBecomesPrincipal verifies that a call
+// over a connection with a trusted client certificate and no token is
+// authenticated as the certificate's common name, and that introspection
+// with an empty token reports that identity.
+func Test_Gateway_X509_ClientCertificateBecomesPrincipal(t *testing.T) {
+	t.Parallel()
+
+	ca := tlscert.NewCA(t)
+	cfg := gateway.DefaultConfig()
+	cfg.Auth = newX509AuthConfig(t, ca)
+	address := startX509Gateway(t, ca, cfg)
+
+	client := dialAuth(t, address, ca, ca.IssueClient(t, "route-operator").Certificate)
+	principal, err := introspectSelf(t, t.Context(), client)
+	require.NoError(t, err)
+
+	require.Equal(t, "route-operator", principal.GetUser())
+	require.Equal(t, []string{"operators"}, principal.GetGroups())
+	require.Equal(t, "x509", principal.GetAuthMethod())
+	require.False(t, principal.GetIsAnonymous())
+}
+
+// Test_Gateway_X509_NoCertificateIsAnonymous verifies that a TLS client
+// without a certificate is still accepted by the listener and ends up
+// anonymous, so the certificate stays optional at the transport.
+func Test_Gateway_X509_NoCertificateIsAnonymous(t *testing.T) {
+	t.Parallel()
+
+	ca := tlscert.NewCA(t)
+	cfg := gateway.DefaultConfig()
+	cfg.Auth = newX509AuthConfig(t, ca)
+	address := startX509Gateway(t, ca, cfg)
+
+	principal, err := introspectSelf(t, t.Context(), dialAuth(t, address, ca))
+	require.NoError(t, err)
+
+	require.True(t, principal.GetIsAnonymous())
+	require.Equal(t, "none", principal.GetAuthMethod())
+}
+
+// Test_Gateway_X509_TokenWinsOverCertificate verifies that a token in the
+// metadata identifies the call even when the connection carries a trusted
+// certificate of someone else.
+func Test_Gateway_X509_TokenWinsOverCertificate(t *testing.T) {
+	t.Parallel()
+
+	ca := tlscert.NewCA(t)
+	cfg := gateway.DefaultConfig()
+	cfg.Auth = newX509AuthConfig(t, ca)
+	address := startX509Gateway(t, ca, cfg)
+
+	client := dialAuth(t, address, ca, ca.IssueClient(t, "route-operator").Certificate)
+	token := "Basic " + base64.StdEncoding.EncodeToString([]byte("alice:s3cret"))
+	ctx := metadata.AppendToOutgoingContext(t.Context(), "x-yanet-authentication", token)
+
+	principal, err := introspectSelf(t, ctx, client)
+	require.NoError(t, err)
+
+	require.Equal(t, "alice", principal.GetUser())
+	require.Equal(t, "basic", principal.GetAuthMethod())
+}
+
+// Test_Gateway_X509_UnknownCommonNameIsRejected verifies that a trusted
+// certificate whose common name no identity provider knows is refused
+// rather than downgraded to anonymous.
+func Test_Gateway_X509_UnknownCommonNameIsRejected(t *testing.T) {
+	t.Parallel()
+
+	ca := tlscert.NewCA(t)
+	cfg := gateway.DefaultConfig()
+	cfg.Auth = newX509AuthConfig(t, ca)
+	address := startX509Gateway(t, ca, cfg)
+
+	client := dialAuth(t, address, ca, ca.IssueClient(t, "stranger").Certificate)
+	_, err := introspectSelf(t, t.Context(), client)
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// Test_Gateway_X509_UntrustedCertificateFailsHandshake verifies that a
+// client certificate from an authority outside the pool is rejected in the
+// handshake, before any RPC is served.
+func Test_Gateway_X509_UntrustedCertificateFailsHandshake(t *testing.T) {
+	t.Parallel()
+
+	ca := tlscert.NewCA(t)
+	other := tlscert.NewCA(t)
+	cfg := gateway.DefaultConfig()
+	cfg.Auth = newX509AuthConfig(t, ca)
+	address := startX509Gateway(t, ca, cfg)
+
+	client := dialAuth(t, address, ca, other.IssueClient(t, "route-operator").Certificate)
+	_, err := introspectSelf(t, t.Context(), client)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+// Test_Gateway_HTTPS_NeverRequestsClientCertificate verifies that the HTTP
+// listener does not ask for a client certificate even when the gRPC one
+// does, so a browser never sees a certificate prompt.
+func Test_Gateway_HTTPS_NeverRequestsClientCertificate(t *testing.T) {
+	t.Parallel()
+
+	ca := tlscert.NewCA(t)
+	cfg := gateway.DefaultConfig()
+	cfg.Auth = newX509AuthConfig(t, ca)
+	cfg.Server.HTTPEndpoint = newFreeAddress(t)
+	startX509Gateway(t, ca, cfg)
+
+	var requested atomic.Bool
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    ca.Pool(),
+				MinVersion: tls.VersionTLS12,
+				GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+					requested.Store(true)
+					return &tls.Certificate{}, nil
+				},
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+	url := "https://" + cfg.Server.HTTPEndpoint + "/api/controlplane.ynpb.v1.Gateway/ListServices"
+
+	var statusCode int
+	require.Eventually(t, func() bool {
+		response, postErr := client.Post(url, "application/json", strings.NewReader("{}"))
+		if postErr != nil {
+			return false
+		}
+		defer func() { _ = response.Body.Close() }()
+
+		_, postErr = io.ReadAll(response.Body)
+		statusCode = response.StatusCode
+		return postErr == nil
+	}, 5*time.Second, 50*time.Millisecond, "HTTP proxy did not answer")
+
+	require.Equal(t, http.StatusOK, statusCode)
+	require.False(t, requested.Load(), "HTTP listener requested a client certificate")
+}
+
+// Test_NewGateway_X509RequiresServerTLS verifies that an x509 authenticator
+// without server TLS is a startup error, since no handshake would ever
+// verify a certificate for it.
+func Test_NewGateway_X509RequiresServerTLS(t *testing.T) {
+	t.Parallel()
+
+	ca := tlscert.NewCA(t)
+	cfg := gateway.DefaultConfig()
+	cfg.Auth = newX509AuthConfig(t, ca)
+
+	_, err := gateway.NewGateway(cfg, gateway.WithLog(zap.NewNop()))
+	require.ErrorContains(t, err, "x509 authenticator requires server.tls")
+}

--- a/controlplane/internal/auth/manager.go
+++ b/controlplane/internal/auth/manager.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v3"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/basic"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/identity"
@@ -18,6 +20,7 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/rbac"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshcert"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshkey"
+	x509auth "github.com/yanet-platform/yanet2/controlplane/internal/auth/x509"
 )
 
 // AuthenticatorFactory creates an Authenticator from a raw YAML config node.
@@ -59,6 +62,7 @@ type Manager struct {
 	authenticators   []core.Authenticator
 	identityProvider identity.Provider
 	authorizer       Authorizer
+	clientCAs        func() *x509.CertPool
 	disabled         bool
 	log              *zap.Logger
 }
@@ -147,6 +151,21 @@ func NewManager(cfg *Config, options ...ManagerOption) (*Manager, error) {
 		},
 		"sshcert": func(rawCfg *yaml.Node) (core.Authenticator, error) {
 			return sshcert.NewFromConfig(rawCfg, sshcert.WithLog(log))
+		},
+		"x509": func(rawCfg *yaml.Node) (core.Authenticator, error) {
+			// One handshake verifies against one pool, so a second
+			// x509 entry could not be honoured.
+			if m.clientCAs != nil {
+				return nil, fmt.Errorf("x509 authenticator configured more than once")
+			}
+
+			authenticator, err := x509auth.NewFromConfig(rawCfg, x509auth.WithLog(log))
+			if err != nil {
+				return nil, err
+			}
+			m.clientCAs = authenticator.ClientCAs
+
+			return authenticator, nil
 		},
 	}
 
@@ -251,6 +270,36 @@ func (m *Manager) buildPrincipal(
 		AuthTime:    time.Now(),
 		IsAnonymous: false,
 	}, nil
+}
+
+// ClientCAs returns the authorities the x509 authenticator verifies client
+// certificates against, nil when none is configured.
+//
+// A TLS server asks for the pool on every handshake, so a reload of the
+// authenticator's sources takes effect without a restart.
+func (m *Manager) ClientCAs() *x509.CertPool {
+	if m.clientCAs == nil {
+		return nil
+	}
+
+	return m.clientCAs()
+}
+
+// metricsCollector provides collected metrics.
+type metricsCollector interface {
+	Collect() []*commonpb.Metric
+}
+
+// Collect gathers the metrics of every authenticator that reports any.
+func (m *Manager) Collect() []*commonpb.Metric {
+	var out []*commonpb.Metric
+	for _, authenticator := range m.authenticators {
+		if collector, ok := authenticator.(metricsCollector); ok {
+			out = append(out, collector.Collect()...)
+		}
+	}
+
+	return out
 }
 
 // Authorize checks if the principal has permission to execute the given

--- a/controlplane/internal/auth/x509/assertion.go
+++ b/controlplane/internal/auth/x509/assertion.go
@@ -1,0 +1,17 @@
+package x509
+
+import (
+	"crypto/x509"
+)
+
+// CertificateAssertion carries the client certificate the handshake
+// verified, for identity providers that read attributes off it.
+type CertificateAssertion struct {
+	// Leaf is the verified client certificate.
+	Leaf *x509.Certificate
+}
+
+// AssertionType identifies the assertion format for provider dispatch.
+func (m CertificateAssertion) AssertionType() string {
+	return "x509"
+}

--- a/controlplane/internal/auth/x509/authenticator.go
+++ b/controlplane/internal/auth/x509/authenticator.go
@@ -3,6 +3,7 @@ package x509
 import (
 	"context"
 	"crypto/x509"
+	"slices"
 	"time"
 
 	"go.uber.org/zap"
@@ -105,10 +106,11 @@ func (m *Authenticator) Authenticate(
 	credential core.Credential,
 	reqInfo *core.RequestInfo,
 ) (*core.AuthInfo, error) {
-	leaf, ok := verifiedLeaf(credential)
+	chain, ok := verifiedChain(credential)
 	if !ok {
 		return nil, status.Error(codes.Unauthenticated, ErrNoVerifiedCertificate.Error())
 	}
+	leaf := chain[0]
 
 	if err := checkValidity(leaf, time.Now()); err != nil {
 		return nil, status.Errorf(
@@ -117,7 +119,9 @@ func (m *Authenticator) Authenticate(
 		)
 	}
 
-	if m.store.IsRevoked(leaf) {
+	// The handshake does not consult the revocation lists, so a revoked
+	// intermediate is only caught by checking every link of the chain.
+	if slices.ContainsFunc(chain, m.store.IsRevoked) {
 		return nil, status.Error(codes.Unauthenticated, ErrCertificateRevoked.Error())
 	}
 
@@ -192,13 +196,14 @@ func (m *Authenticator) refresh() {
 	}
 }
 
-// verifiedLeaf returns the client certificate the handshake verified.
-func verifiedLeaf(credential core.Credential) (*x509.Certificate, bool) {
+// verifiedChain returns the chain the handshake verified, the client
+// certificate first.
+func verifiedChain(credential core.Credential) ([]*x509.Certificate, bool) {
 	if credential.TLS == nil || len(credential.TLS.VerifiedChains) == 0 || len(credential.TLS.VerifiedChains[0]) == 0 {
 		return nil, false
 	}
 
-	return credential.TLS.VerifiedChains[0][0], true
+	return credential.TLS.VerifiedChains[0], true
 }
 
 // checkValidity checks that now falls within the certificate's validity

--- a/controlplane/internal/auth/x509/authenticator.go
+++ b/controlplane/internal/auth/x509/authenticator.go
@@ -1,0 +1,235 @@
+package x509
+
+import (
+	"context"
+	"crypto/x509"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+)
+
+const (
+	// defaultRefreshInterval is the default period between reloads of the
+	// authorities and revocation lists.
+	defaultRefreshInterval = 5 * time.Minute
+	// spiffeScheme is the URI scheme of a SPIFFE identity.
+	spiffeScheme = "spiffe"
+)
+
+// Authenticator identifies a caller by the client certificate its TLS
+// connection presented.
+//
+// The handshake already verified the chain against the store's authorities,
+// so a request only has to pass what changes over time: the validity period
+// and revocation. The certificate's common name, or its single SPIFFE
+// identity when the name is empty, becomes the local account lookup name.
+type Authenticator struct {
+	store           *Store
+	refreshInterval time.Duration
+	stopCh          chan struct{}
+	log             *zap.Logger
+}
+
+type authenticatorOptions struct {
+	RefreshInterval time.Duration
+	Log             *zap.Logger
+}
+
+func newAuthenticatorOptions() *authenticatorOptions {
+	return &authenticatorOptions{
+		RefreshInterval: defaultRefreshInterval,
+		Log:             zap.NewNop(),
+	}
+}
+
+// Option configures the Authenticator.
+type Option func(*authenticatorOptions)
+
+// WithRefreshInterval sets the periodic refresh interval.
+func WithRefreshInterval(d time.Duration) Option {
+	return func(o *authenticatorOptions) {
+		o.RefreshInterval = d
+	}
+}
+
+// WithLog sets the logger.
+func WithLog(log *zap.Logger) Option {
+	return func(o *authenticatorOptions) {
+		o.Log = log
+	}
+}
+
+// NewAuthenticator creates an Authenticator over store and starts its
+// periodic refresh.
+func NewAuthenticator(store *Store, options ...Option) *Authenticator {
+	opts := newAuthenticatorOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	m := &Authenticator{
+		store:           store,
+		refreshInterval: opts.RefreshInterval,
+		stopCh:          make(chan struct{}),
+		log:             opts.Log,
+	}
+
+	go m.refreshLoop()
+
+	return m
+}
+
+// Name returns the authenticator name for logging.
+func (m *Authenticator) Name() string {
+	return "x509"
+}
+
+// Supports reports whether the credential is a verified client certificate
+// and nothing more explicit.
+//
+// A token is the caller's explicit choice of identity and always wins over
+// the certificate its connection happens to carry.
+func (m *Authenticator) Supports(credential core.Credential) bool {
+	return credential.Token == "" && credential.TLS != nil && len(credential.TLS.VerifiedChains) > 0
+}
+
+// Authenticate checks that the verified leaf certificate is currently valid
+// and not revoked, and derives the login from it.
+func (m *Authenticator) Authenticate(
+	ctx context.Context,
+	credential core.Credential,
+	reqInfo *core.RequestInfo,
+) (*core.AuthInfo, error) {
+	leaf, ok := verifiedLeaf(credential)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, ErrNoVerifiedCertificate.Error())
+	}
+
+	if err := checkValidity(leaf, time.Now()); err != nil {
+		return nil, status.Errorf(
+			codes.Unauthenticated,
+			"certificate validity check failed: %v", err,
+		)
+	}
+
+	if m.store.IsRevoked(leaf) {
+		return nil, status.Error(codes.Unauthenticated, ErrCertificateRevoked.Error())
+	}
+
+	login, err := subjectLogin(leaf)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Unauthenticated,
+			"failed to extract principal: %v", err,
+		)
+	}
+
+	m.log.Debug("x509 authentication successful",
+		zap.String("login", login),
+		zap.Stringer("serial", leaf.SerialNumber),
+	)
+
+	subject := core.NewLocalSubject(login)
+	subject.Assertion = CertificateAssertion{Leaf: leaf}
+
+	return &core.AuthInfo{
+		Subject:    subject,
+		AuthMethod: "x509",
+	}, nil
+}
+
+// ClientCAs returns the authorities a TLS server verifies client
+// certificates against, current as of the last successful reload.
+func (m *Authenticator) ClientCAs() *x509.CertPool {
+	return m.store.Pool()
+}
+
+// Collect reports the revocation list and refresh metrics of the store.
+func (m *Authenticator) Collect() []*commonpb.Metric {
+	return m.store.Collect()
+}
+
+// Close stops the periodic refresh.
+func (m *Authenticator) Close() {
+	close(m.stopCh)
+}
+
+// refreshLoop reloads the trust material periodically until Close.
+func (m *Authenticator) refreshLoop() {
+	ticker := time.NewTicker(m.refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+			m.refresh()
+		}
+	}
+}
+
+// refresh reloads the trust material and reports lists past their next
+// update, which stay in use so a stalled PKI does not lock callers out.
+func (m *Authenticator) refresh() {
+	if err := m.store.Reload(); err != nil {
+		m.log.Warn("failed to refresh x509 trust material", zap.Error(err))
+	}
+
+	now := time.Now()
+	for _, info := range m.store.RevocationLists() {
+		if now.After(info.NextUpdate) {
+			m.log.Warn("revocation list is past its next update",
+				zap.String("source", info.Source),
+				zap.Time("next_update", info.NextUpdate),
+			)
+		}
+	}
+}
+
+// verifiedLeaf returns the client certificate the handshake verified.
+func verifiedLeaf(credential core.Credential) (*x509.Certificate, bool) {
+	if credential.TLS == nil || len(credential.TLS.VerifiedChains) == 0 || len(credential.TLS.VerifiedChains[0]) == 0 {
+		return nil, false
+	}
+
+	return credential.TLS.VerifiedChains[0][0], true
+}
+
+// checkValidity checks that now falls within the certificate's validity
+// period.
+func checkValidity(certificate *x509.Certificate, now time.Time) error {
+	if now.Before(certificate.NotBefore) {
+		return ErrCertificateNotYetValid
+	}
+	if now.After(certificate.NotAfter) {
+		return ErrCertificateExpired
+	}
+
+	return nil
+}
+
+// subjectLogin derives the account lookup name: the common name, or the
+// single SPIFFE identity of a certificate without one.
+func subjectLogin(certificate *x509.Certificate) (string, error) {
+	if name := certificate.Subject.CommonName; name != "" {
+		return name, nil
+	}
+
+	var identities []string
+	for _, uri := range certificate.URIs {
+		if uri.Scheme == spiffeScheme {
+			identities = append(identities, uri.String())
+		}
+	}
+	if len(identities) == 1 {
+		return identities[0], nil
+	}
+
+	return "", ErrNoSubjectName
+}

--- a/controlplane/internal/auth/x509/authenticator.go
+++ b/controlplane/internal/auth/x509/authenticator.go
@@ -112,15 +112,18 @@ func (m *Authenticator) Authenticate(
 	}
 	leaf := chain[0]
 
-	if err := checkValidity(leaf, time.Now()); err != nil {
-		return nil, status.Errorf(
-			codes.Unauthenticated,
-			"certificate validity check failed: %v", err,
-		)
+	// The handshake's verdict ages with the connection and never consulted
+	// the revocation lists, so every link of the chain is checked now.
+	now := time.Now()
+	for _, certificate := range chain {
+		if err := checkValidity(certificate, now); err != nil {
+			return nil, status.Errorf(
+				codes.Unauthenticated,
+				"certificate validity check failed: %v", err,
+			)
+		}
 	}
 
-	// The handshake does not consult the revocation lists, so a revoked
-	// intermediate is only caught by checking every link of the chain.
 	if slices.ContainsFunc(chain, m.store.IsRevoked) {
 		return nil, status.Error(codes.Unauthenticated, ErrCertificateRevoked.Error())
 	}

--- a/controlplane/internal/auth/x509/authenticator_test.go
+++ b/controlplane/internal/auth/x509/authenticator_test.go
@@ -219,3 +219,24 @@ func Test_Authenticator_Authenticate_ChecksIntermediates(t *testing.T) {
 		})
 	}
 }
+
+// Test_Authenticator_Authenticate_RejectsExpiredIntermediate verifies that
+// the validity period of every link is checked at the time of the call, so
+// a chain through an authority that has since expired stops authenticating
+// without waiting for the connection to end.
+func Test_Authenticator_Authenticate_RejectsExpiredIntermediate(t *testing.T) {
+	root := tlscert.NewCA(t)
+	now := time.Now()
+	intermediate := root.IssueIntermediate(t, "test intermediate", tlscert.WithValidity(now.Add(-2*time.Hour), now.Add(-time.Hour)))
+	client := intermediate.IssueClient(t, "route-operator")
+	authenticator := newAuthenticator(t, newStore(t, root))
+
+	credential := core.Credential{
+		TLS: &tls.ConnectionState{
+			VerifiedChains: [][]*x509.Certificate{{client.Leaf, intermediate.Certificate(), root.Certificate()}},
+		},
+	}
+	_, err := authenticator.Authenticate(t.Context(), credential, &core.RequestInfo{})
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+	require.ErrorContains(t, err, x509auth.ErrCertificateExpired.Error())
+}

--- a/controlplane/internal/auth/x509/authenticator_test.go
+++ b/controlplane/internal/auth/x509/authenticator_test.go
@@ -1,0 +1,182 @@
+package x509_test
+
+import (
+	"crypto/tls"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/common/go/testutils/tlscert"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	x509auth "github.com/yanet-platform/yanet2/controlplane/internal/auth/x509"
+)
+
+// Test_Authenticator_Supports verifies that only a verified client
+// certificate presented without a token is handled, so a token of any kind
+// wins over the certificate of the connection it arrived on.
+func Test_Authenticator_Supports(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	client := ca.IssueClient(t, "route-operator")
+	authenticator := newAuthenticator(t, newStore(t, ca))
+
+	withToken := verifiedCredential(ca, client)
+	withToken.Token = "Basic YWxpY2U6czNjcmV0"
+
+	tests := []struct {
+		name       string
+		credential core.Credential
+		want       bool
+	}{
+		{name: "plaintext connection", credential: core.Credential{}, want: false},
+		{name: "tls without client certificate", credential: core.Credential{TLS: &tls.ConnectionState{}}, want: false},
+		{name: "verified certificate with token", credential: withToken, want: false},
+		{name: "verified certificate alone", credential: verifiedCredential(ca, client), want: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.want, authenticator.Supports(testCase.credential))
+		})
+	}
+}
+
+// Test_Authenticator_Authenticate_CommonNameBecomesLogin verifies that a
+// valid certificate yields a local subject whose login is its common name
+// and whose assertion carries the certificate itself.
+func Test_Authenticator_Authenticate_CommonNameBecomesLogin(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	client := ca.IssueClient(t, "route-operator")
+	authenticator := newAuthenticator(t, newStore(t, ca))
+
+	info, err := authenticator.Authenticate(t.Context(), verifiedCredential(ca, client), &core.RequestInfo{})
+	require.NoError(t, err)
+
+	require.Equal(t, "x509", info.AuthMethod)
+	require.Equal(t, core.Subject{
+		Issuer:     "local",
+		Identifier: "route-operator",
+		Login:      "route-operator",
+		Assertion:  x509auth.CertificateAssertion{Leaf: client.Leaf},
+	}, info.Subject)
+}
+
+// Test_Authenticator_Authenticate_Login verifies how the login is derived
+// from a certificate without a common name: exactly one SPIFFE identity is
+// used, anything else is rejected.
+func Test_Authenticator_Authenticate_Login(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	authenticator := newAuthenticator(t, newStore(t, ca))
+
+	spiffe := &url.URL{Scheme: "spiffe", Host: "example.org", Path: "/ns/yanet/sa/route"}
+	other := &url.URL{Scheme: "spiffe", Host: "example.org", Path: "/ns/yanet/sa/pipeline"}
+	https := &url.URL{Scheme: "https", Host: "example.org", Path: "/route"}
+
+	tests := []struct {
+		name      string
+		keypair   tlscert.Keypair
+		wantLogin string
+	}{
+		{name: "common name wins over spiffe id", keypair: ca.IssueClient(t, "route-operator", tlscert.WithURIs(spiffe)), wantLogin: "route-operator"},
+		{name: "single spiffe id without common name", keypair: ca.IssueClient(t, "", tlscert.WithURIs(spiffe)), wantLogin: spiffe.String()},
+		{name: "spiffe id beside another uri", keypair: ca.IssueClient(t, "", tlscert.WithURIs(spiffe, https)), wantLogin: spiffe.String()},
+		{name: "no name at all", keypair: ca.IssueClient(t, "")},
+		{name: "two spiffe ids", keypair: ca.IssueClient(t, "", tlscert.WithURIs(spiffe, other))},
+		{name: "only a non-spiffe uri", keypair: ca.IssueClient(t, "", tlscert.WithURIs(https))},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			info, err := authenticator.Authenticate(t.Context(), verifiedCredential(ca, testCase.keypair), &core.RequestInfo{})
+			if testCase.wantLogin == "" {
+				require.Equal(t, codes.Unauthenticated, status.Code(err))
+				require.ErrorContains(t, err, x509auth.ErrNoSubjectName.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.wantLogin, info.Subject.Login)
+		})
+	}
+}
+
+// Test_Authenticator_Authenticate_Validity verifies that the validity period
+// is checked at the time of the call, since the handshake that verified the
+// certificate may be arbitrarily old.
+func Test_Authenticator_Authenticate_Validity(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	authenticator := newAuthenticator(t, newStore(t, ca))
+	now := time.Now()
+
+	tests := []struct {
+		name    string
+		keypair tlscert.Keypair
+		wantErr error
+	}{
+		{name: "expired", keypair: ca.IssueClient(t, "route-operator", tlscert.WithValidity(now.Add(-2*time.Hour), now.Add(-time.Hour))), wantErr: x509auth.ErrCertificateExpired},
+		{name: "not yet valid", keypair: ca.IssueClient(t, "route-operator", tlscert.WithValidity(now.Add(time.Hour), now.Add(2*time.Hour))), wantErr: x509auth.ErrCertificateNotYetValid},
+		{name: "current", keypair: ca.IssueClient(t, "route-operator")},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := authenticator.Authenticate(t.Context(), verifiedCredential(ca, testCase.keypair), &core.RequestInfo{})
+			if testCase.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Equal(t, codes.Unauthenticated, status.Code(err))
+			require.ErrorContains(t, err, testCase.wantErr.Error())
+		})
+	}
+}
+
+// Test_Authenticator_Authenticate_RejectsRevokedCertificate verifies that a
+// certificate named by a loaded revocation list is rejected while another
+// certificate from the same authority is not.
+func Test_Authenticator_Authenticate_RejectsRevokedCertificate(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	revoked := ca.IssueClient(t, "route-operator")
+	current := ca.IssueClient(t, "pipeline-operator")
+	crlFile := ca.RevocationListFile(t, time.Now().Add(time.Hour), revoked.Leaf)
+	authenticator := newAuthenticator(t, newStore(t, ca, crlFile))
+
+	_, err := authenticator.Authenticate(t.Context(), verifiedCredential(ca, revoked), &core.RequestInfo{})
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+	require.ErrorContains(t, err, x509auth.ErrCertificateRevoked.Error())
+
+	_, err = authenticator.Authenticate(t.Context(), verifiedCredential(ca, current), &core.RequestInfo{})
+	require.NoError(t, err)
+}
+
+// Test_Authenticator_Authenticate_StaleRevocationListStillApplies verifies
+// that a list past its next update keeps revoking, so a stalled PKI never
+// widens what is accepted.
+func Test_Authenticator_Authenticate_StaleRevocationListStillApplies(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	revoked := ca.IssueClient(t, "route-operator")
+	crlFile := ca.RevocationListFile(t, time.Now().Add(-time.Hour), revoked.Leaf)
+	authenticator := newAuthenticator(t, newStore(t, ca, crlFile))
+
+	_, err := authenticator.Authenticate(t.Context(), verifiedCredential(ca, revoked), &core.RequestInfo{})
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+	require.ErrorContains(t, err, x509auth.ErrCertificateRevoked.Error())
+}
+
+// Test_Authenticator_Authenticate_RejectsMissingChain verifies that a
+// credential without a verified chain is refused rather than treated as
+// anonymous, whichever way it reached the authenticator.
+func Test_Authenticator_Authenticate_RejectsMissingChain(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	authenticator := newAuthenticator(t, newStore(t, ca))
+
+	for _, credential := range []core.Credential{{}, {TLS: &tls.ConnectionState{}}} {
+		_, err := authenticator.Authenticate(t.Context(), credential, &core.RequestInfo{})
+		require.Equal(t, codes.Unauthenticated, status.Code(err))
+		require.ErrorContains(t, err, x509auth.ErrNoVerifiedCertificate.Error())
+	}
+}

--- a/controlplane/internal/auth/x509/authenticator_test.go
+++ b/controlplane/internal/auth/x509/authenticator_test.go
@@ -2,6 +2,7 @@ package x509_test
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"net/url"
 	"testing"
 	"time"
@@ -178,5 +179,43 @@ func Test_Authenticator_Authenticate_RejectsMissingChain(t *testing.T) {
 		_, err := authenticator.Authenticate(t.Context(), credential, &core.RequestInfo{})
 		require.Equal(t, codes.Unauthenticated, status.Code(err))
 		require.ErrorContains(t, err, x509auth.ErrNoVerifiedCertificate.Error())
+	}
+}
+
+// Test_Authenticator_Authenticate_ChecksIntermediates verifies that a
+// revoked intermediate authority rejects every certificate issued through
+// it, since the handshake alone never consults the revocation lists.
+func Test_Authenticator_Authenticate_ChecksIntermediates(t *testing.T) {
+	root := tlscert.NewCA(t)
+	intermediate := root.IssueIntermediate(t, "test intermediate")
+	client := intermediate.IssueClient(t, "route-operator")
+	credential := core.Credential{
+		TLS: &tls.ConnectionState{
+			VerifiedChains: [][]*x509.Certificate{{client.Leaf, intermediate.Certificate(), root.Certificate()}},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		crlFiles []string
+		wantErr  error
+	}{
+		{name: "intermediate revoked", crlFiles: []string{root.RevocationListFile(t, time.Now().Add(time.Hour), intermediate.Certificate())}, wantErr: x509auth.ErrCertificateRevoked},
+		{name: "intermediate current", crlFiles: []string{root.RevocationListFile(t, time.Now().Add(time.Hour))}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			authenticator := newAuthenticator(t, newStore(t, root, testCase.crlFiles...))
+
+			_, err := authenticator.Authenticate(t.Context(), credential, &core.RequestInfo{})
+			if testCase.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Equal(t, codes.Unauthenticated, status.Code(err))
+			require.ErrorContains(t, err, testCase.wantErr.Error())
+		})
 	}
 }

--- a/controlplane/internal/auth/x509/common_test.go
+++ b/controlplane/internal/auth/x509/common_test.go
@@ -1,0 +1,51 @@
+package x509_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/testutils/tlscert"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/loader"
+	x509auth "github.com/yanet-platform/yanet2/controlplane/internal/auth/x509"
+)
+
+// newStore builds a store trusting ca and consulting the given revocation
+// list files.
+func newStore(t *testing.T, ca *tlscert.CA, crlFiles ...string) *x509auth.Store {
+	t.Helper()
+
+	crlSources := make([]loader.Loader, 0, len(crlFiles))
+	for _, file := range crlFiles {
+		crlSources = append(crlSources, loader.NewLoader(file))
+	}
+
+	store, err := x509auth.NewStore([]loader.Loader{loader.NewLoader(ca.BundleFile())}, crlSources)
+	require.NoError(t, err)
+
+	return store
+}
+
+// newAuthenticator builds an authenticator over store and stops its refresh
+// on cleanup so the goroutine does not outlive the test.
+func newAuthenticator(t *testing.T, store *x509auth.Store) *x509auth.Authenticator {
+	t.Helper()
+
+	authenticator := x509auth.NewAuthenticator(store)
+	t.Cleanup(authenticator.Close)
+
+	return authenticator
+}
+
+// verifiedCredential is the credential of a connection whose handshake
+// verified keypair against ca, carrying no token.
+func verifiedCredential(ca *tlscert.CA, keypair tlscert.Keypair) core.Credential {
+	return core.Credential{
+		TLS: &tls.ConnectionState{
+			VerifiedChains: [][]*x509.Certificate{{keypair.Leaf, ca.Certificate()}},
+		},
+	}
+}

--- a/controlplane/internal/auth/x509/config.go
+++ b/controlplane/internal/auth/x509/config.go
@@ -1,0 +1,24 @@
+package x509
+
+import (
+	"time"
+)
+
+// Config configures client certificate authentication.
+type Config struct {
+	// CASources lists the PEM bundles of the authorities client certificates
+	// are verified against, each a file path or an HTTP(S) URL.
+	//
+	// Bundles are merged. A source ending in ".zst" is decompressed.
+	CASources []string `yaml:"ca_sources"`
+	// CRLSources lists the certificate revocation lists to consult, each a
+	// file path or an HTTP(S) URL holding one DER or PEM encoded list.
+	//
+	// A list is accepted only when one of the authorities signed it.
+	CRLSources []string `yaml:"crl_sources"`
+	// RefreshInterval is the period at which the authorities and revocation
+	// lists are reloaded from their sources.
+	//
+	// Default: 5m.
+	RefreshInterval time.Duration `yaml:"refresh_interval"`
+}

--- a/controlplane/internal/auth/x509/errors.go
+++ b/controlplane/internal/auth/x509/errors.go
@@ -20,6 +20,12 @@ var (
 	ErrNoSubjectName = errors.New("certificate has neither a common name nor a single spiffe id")
 	// ErrNoAuthorities is returned when a bundle holds no certificate.
 	ErrNoAuthorities = errors.New("no certificates found")
+	// ErrNotAuthority is returned when a bundle holds a certificate that is
+	// not a certificate authority.
+	ErrNotAuthority = errors.New("certificate is not a certificate authority")
+	// ErrRevocationListRollback is returned when a source serves a list older
+	// than the one already accepted from it.
+	ErrRevocationListRollback = errors.New("revocation list is older than the accepted one")
 	// ErrUntrustedRevocationList is returned when no trusted authority signed
 	// the revocation list.
 	ErrUntrustedRevocationList = errors.New("revocation list not signed by a trusted authority")

--- a/controlplane/internal/auth/x509/errors.go
+++ b/controlplane/internal/auth/x509/errors.go
@@ -1,0 +1,26 @@
+package x509
+
+import "errors"
+
+var (
+	// ErrNoVerifiedCertificate is returned when the connection carries no
+	// client certificate chain verified in the handshake.
+	ErrNoVerifiedCertificate = errors.New("no verified client certificate")
+	// ErrCertificateNotYetValid is returned when the certificate validity
+	// period has not started.
+	ErrCertificateNotYetValid = errors.New("certificate not yet valid")
+	// ErrCertificateExpired is returned when the certificate validity period
+	// has passed.
+	ErrCertificateExpired = errors.New("certificate expired")
+	// ErrCertificateRevoked is returned when a revocation list names the
+	// certificate.
+	ErrCertificateRevoked = errors.New("certificate revoked")
+	// ErrNoSubjectName is returned when the certificate has neither a common
+	// name nor exactly one SPIFFE identity to serve as the login.
+	ErrNoSubjectName = errors.New("certificate has neither a common name nor a single spiffe id")
+	// ErrNoAuthorities is returned when a bundle holds no certificate.
+	ErrNoAuthorities = errors.New("no certificates found")
+	// ErrUntrustedRevocationList is returned when no trusted authority signed
+	// the revocation list.
+	ErrUntrustedRevocationList = errors.New("revocation list not signed by a trusted authority")
+)

--- a/controlplane/internal/auth/x509/errors.go
+++ b/controlplane/internal/auth/x509/errors.go
@@ -26,6 +26,9 @@ var (
 	// ErrRevocationListRollback is returned when a source serves a list older
 	// than the one already accepted from it.
 	ErrRevocationListRollback = errors.New("revocation list is older than the accepted one")
+	// ErrDeltaRevocationList is returned when a source serves a delta list,
+	// which only holds changes against a base list this store does not track.
+	ErrDeltaRevocationList = errors.New("delta revocation lists are not supported")
 	// ErrUntrustedRevocationList is returned when no trusted authority signed
 	// the revocation list.
 	ErrUntrustedRevocationList = errors.New("revocation list not signed by a trusted authority")

--- a/controlplane/internal/auth/x509/factory.go
+++ b/controlplane/internal/auth/x509/factory.go
@@ -1,7 +1,10 @@
 package x509
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 
 	"gopkg.in/yaml.v3"
 
@@ -11,7 +14,7 @@ import (
 // NewFromConfig creates an Authenticator from a raw YAML config node.
 func NewFromConfig(rawCfg *yaml.Node, options ...Option) (*Authenticator, error) {
 	var cfg Config
-	if err := rawCfg.Decode(&cfg); err != nil {
+	if err := decodeStrict(rawCfg, &cfg); err != nil {
 		return nil, fmt.Errorf("decode x509 config: %w", err)
 	}
 
@@ -41,4 +44,26 @@ func NewFromConfig(rawCfg *yaml.Node, options ...Option) (*Authenticator, error)
 	}
 
 	return NewAuthenticator(store, opts...), nil
+}
+
+// decodeStrict decodes the node into cfg, refusing keys the config does not
+// declare, so a misspelled revocation list key cannot silently disable
+// revocation.
+func decodeStrict(node *yaml.Node, cfg *Config) error {
+	if node.Kind == 0 {
+		return nil
+	}
+
+	data, err := yaml.Marshal(node)
+	if err != nil {
+		return err
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(cfg); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+
+	return nil
 }

--- a/controlplane/internal/auth/x509/factory.go
+++ b/controlplane/internal/auth/x509/factory.go
@@ -1,0 +1,44 @@
+package x509
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/loader"
+)
+
+// NewFromConfig creates an Authenticator from a raw YAML config node.
+func NewFromConfig(rawCfg *yaml.Node, options ...Option) (*Authenticator, error) {
+	var cfg Config
+	if err := rawCfg.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("decode x509 config: %w", err)
+	}
+
+	if len(cfg.CASources) == 0 {
+		return nil, fmt.Errorf("ca_sources is required")
+	}
+
+	caSources := make([]loader.Loader, 0, len(cfg.CASources))
+	for _, source := range cfg.CASources {
+		caSources = append(caSources, loader.NewLoader(source))
+	}
+
+	crlSources := make([]loader.Loader, 0, len(cfg.CRLSources))
+	for _, source := range cfg.CRLSources {
+		crlSources = append(crlSources, loader.NewLoader(source))
+	}
+
+	store, err := NewStore(caSources, crlSources)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := make([]Option, 0, len(options)+1)
+	opts = append(opts, options...)
+	if cfg.RefreshInterval > 0 {
+		opts = append(opts, WithRefreshInterval(cfg.RefreshInterval))
+	}
+
+	return NewAuthenticator(store, opts...), nil
+}

--- a/controlplane/internal/auth/x509/factory_test.go
+++ b/controlplane/internal/auth/x509/factory_test.go
@@ -57,3 +57,15 @@ func Test_NewFromConfig_WiresSources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "pipeline-operator", info.Subject.Login)
 }
+
+// Test_NewFromConfig_RejectsUnknownKey verifies that a key the config does
+// not declare is an error, so a misspelled revocation list key cannot
+// silently leave revocation off.
+func Test_NewFromConfig_RejectsUnknownKey(t *testing.T) {
+	ca := tlscert.NewCA(t)
+
+	_, err := x509auth.NewFromConfig(decodeConfigNode(t, "config:\n"+
+		"  ca_sources:\n    - "+ca.BundleFile()+"\n"+
+		"  crl_source: /etc/yanet2/auth/clients.crl\n"))
+	require.ErrorContains(t, err, "crl_source")
+}

--- a/controlplane/internal/auth/x509/factory_test.go
+++ b/controlplane/internal/auth/x509/factory_test.go
@@ -1,0 +1,59 @@
+package x509_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/yanet-platform/yanet2/common/go/testutils/tlscert"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	x509auth "github.com/yanet-platform/yanet2/controlplane/internal/auth/x509"
+)
+
+// decodeConfigNode parses text as the "config: ..." wrapper production uses
+// and returns the inner node the authenticator factory receives.
+func decodeConfigNode(t *testing.T, text string) *yaml.Node {
+	t.Helper()
+
+	var wrapper struct {
+		Config yaml.Node `yaml:"config"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(text), &wrapper))
+
+	return &wrapper.Config
+}
+
+// Test_NewFromConfig_RequiresCASources verifies that a configuration without
+// authorities is refused, since nothing could be verified against it.
+func Test_NewFromConfig_RequiresCASources(t *testing.T) {
+	_, err := x509auth.NewFromConfig(decodeConfigNode(t, "config:\n  refresh_interval: 1m\n"))
+	require.ErrorContains(t, err, "ca_sources is required")
+}
+
+// Test_NewFromConfig_WiresSources verifies that the configured bundle and
+// revocation list are what the authenticator verifies and revokes against.
+func Test_NewFromConfig_WiresSources(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	revoked := ca.IssueClient(t, "route-operator")
+	current := ca.IssueClient(t, "pipeline-operator")
+	crlFile := ca.RevocationListFile(t, time.Now().Add(time.Hour), revoked.Leaf)
+
+	rawConfig := decodeConfigNode(t, "config:\n"+
+		"  ca_sources:\n    - "+ca.BundleFile()+"\n"+
+		"  crl_sources:\n    - "+crlFile+"\n"+
+		"  refresh_interval: 1m\n")
+	authenticator, err := x509auth.NewFromConfig(rawConfig)
+	require.NoError(t, err)
+	t.Cleanup(authenticator.Close)
+
+	require.True(t, ca.Pool().Equal(authenticator.ClientCAs()))
+
+	_, err = authenticator.Authenticate(t.Context(), verifiedCredential(ca, revoked), &core.RequestInfo{})
+	require.ErrorContains(t, err, x509auth.ErrCertificateRevoked.Error())
+
+	info, err := authenticator.Authenticate(t.Context(), verifiedCredential(ca, current), &core.RequestInfo{})
+	require.NoError(t, err)
+	require.Equal(t, "pipeline-operator", info.Subject.Login)
+}

--- a/controlplane/internal/auth/x509/store.go
+++ b/controlplane/internal/auth/x509/store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net/url"
 	"sync/atomic"
 	"time"
 
@@ -127,8 +128,9 @@ func (m *Store) RevocationLists() []RevocationListInfo {
 // Reload rebuilds the snapshot from the sources.
 //
 // A failed authority source aborts the reload and keeps the current
-// snapshot. A failed revocation list source keeps that source's last
-// accepted list. Every failure is counted and returned, joined.
+// snapshot. A revocation list source that fails, or serves a list older
+// than the one accepted from it, keeps that last accepted list. Every
+// failure is counted and returned, joined.
 func (m *Store) Reload() error {
 	authorities, err := m.loadAuthorities()
 	if err != nil {
@@ -144,14 +146,20 @@ func (m *Store) Reload() error {
 	lists := map[string]*x509.RevocationList{}
 	previous := m.snapshot.Load()
 	for _, source := range m.crlSources {
+		var kept *x509.RevocationList
+		if previous != nil {
+			kept = previous.Lists[source.Source()]
+		}
+
 		list, err := loadRevocationList(source, authorities)
+		if err == nil && kept != nil && isOlder(list, kept) {
+			err = ErrRevocationListRollback
+		}
 		if err != nil {
 			m.refreshErrors[source.Source()].Inc()
 			errs = append(errs, fmt.Errorf("load revocation list from %q: %w", source.Source(), err))
-			if previous != nil {
-				if kept, ok := previous.Lists[source.Source()]; ok {
-					lists[source.Source()] = kept
-				}
+			if kept != nil {
+				lists[source.Source()] = kept
 			}
 			continue
 		}
@@ -170,13 +178,16 @@ func (m *Store) Reload() error {
 
 // Collect reports the next update of every loaded revocation list and the
 // failed refreshes of every source.
+//
+// A source is labeled without the credentials and query its URL may carry,
+// since metrics are read more widely than the configuration.
 func (m *Store) Collect() []*commonpb.Metric {
 	var out []*commonpb.Metric
 	for _, info := range m.RevocationLists() {
 		out = append(out, commonpb.NewMetricGauge(
 			metricCRLNextUpdate,
 			float64(info.NextUpdate.Unix()),
-			commonpb.MetricLabelsToProto(metrics.Labels{labelSource: info.Source})...,
+			commonpb.MetricLabelsToProto(metrics.Labels{labelSource: sourceLabel(info.Source)})...,
 		))
 	}
 	for _, sources := range [][]loader.Loader{m.caSources, m.crlSources} {
@@ -184,7 +195,7 @@ func (m *Store) Collect() []*commonpb.Metric {
 			out = append(out, commonpb.NewMetricCounter(
 				metricRefreshErrors,
 				m.refreshErrors[source.Source()].Load(),
-				commonpb.MetricLabelsToProto(metrics.Labels{labelSource: source.Source()})...,
+				commonpb.MetricLabelsToProto(metrics.Labels{labelSource: sourceLabel(source.Source())})...,
 			))
 		}
 	}
@@ -217,7 +228,12 @@ func loadCertificates(source loader.Loader) ([]*x509.Certificate, error) {
 	return parseCertificates(data)
 }
 
-// parseCertificates parses every certificate block of a PEM bundle.
+// parseCertificates parses every certificate block of a PEM bundle and
+// requires each to be an authority.
+//
+// A certificate placed in the pool verifies itself as a chain of one, so an
+// end-entity certificate here would authenticate itself instead of
+// reporting the misconfiguration.
 func parseCertificates(data []byte) ([]*x509.Certificate, error) {
 	var certificates []*x509.Certificate
 	for {
@@ -233,6 +249,9 @@ func parseCertificates(data []byte) ([]*x509.Certificate, error) {
 		certificate, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
 			return nil, fmt.Errorf("parse certificate: %w", err)
+		}
+		if !certificate.BasicConstraintsValid || !certificate.IsCA {
+			return nil, fmt.Errorf("%w: %s", ErrNotAuthority, certificate.Subject)
 		}
 		certificates = append(certificates, certificate)
 	}
@@ -271,6 +290,31 @@ func loadRevocationList(source loader.Loader, authorities []*x509.Certificate) (
 	}
 
 	return nil, ErrUntrustedRevocationList
+}
+
+// isOlder reports whether candidate predates accepted, by list number when
+// both carry one and by issue time otherwise.
+func isOlder(candidate, accepted *x509.RevocationList) bool {
+	if candidate.Number != nil && accepted.Number != nil {
+		return candidate.Number.Cmp(accepted.Number) < 0
+	}
+
+	return candidate.ThisUpdate.Before(accepted.ThisUpdate)
+}
+
+// sourceLabel names a source in metrics, stripping the user, query and
+// fragment off a URL.
+func sourceLabel(source string) string {
+	parsed, err := url.Parse(source)
+	if err != nil || parsed.Host == "" {
+		return source
+	}
+
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+
+	return parsed.String()
 }
 
 // indexRevoked flattens the lists into one lookup set.

--- a/controlplane/internal/auth/x509/store.go
+++ b/controlplane/internal/auth/x509/store.go
@@ -292,9 +292,17 @@ func loadRevocationList(source loader.Loader, authorities []*x509.Certificate) (
 	return nil, ErrUntrustedRevocationList
 }
 
-// isOlder reports whether candidate predates accepted, by list number when
-// both carry one and by issue time otherwise.
+// isOlder reports whether candidate predates accepted from the same
+// issuer, by list number when both carry one and by issue time otherwise.
+//
+// Lists of different issuers, by name or by signing key, are not ordered,
+// so a rotated authority may start its numbering afresh at the same source
+// even when it keeps its name.
 func isOlder(candidate, accepted *x509.RevocationList) bool {
+	if !bytes.Equal(candidate.RawIssuer, accepted.RawIssuer) ||
+		!bytes.Equal(candidate.AuthorityKeyId, accepted.AuthorityKeyId) {
+		return false
+	}
 	if candidate.Number != nil && accepted.Number != nil {
 		return candidate.Number.Cmp(accepted.Number) < 0
 	}

--- a/controlplane/internal/auth/x509/store.go
+++ b/controlplane/internal/auth/x509/store.go
@@ -1,0 +1,290 @@
+package x509
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"sync/atomic"
+	"time"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/loader"
+)
+
+const (
+	// metricCRLNextUpdate is the unix time a revocation list expects its
+	// successor to be published by.
+	metricCRLNextUpdate = "auth_x509_crl_next_update_seconds"
+	// metricRefreshErrors counts the refreshes of a source that failed.
+	metricRefreshErrors = "auth_x509_refresh_errors_total"
+	// labelSource names the configured source a metric is about.
+	labelSource = "source"
+	// pemTypeCertificate is the PEM block type of a certificate.
+	pemTypeCertificate = "CERTIFICATE"
+	// pemTypeRevocationList is the PEM block type of a revocation list.
+	pemTypeRevocationList = "X509 CRL"
+)
+
+// revocationKey identifies a certificate the way a revocation list does, by
+// issuer and serial number.
+type revocationKey struct {
+	Issuer string
+	Serial string
+}
+
+// snapshot is one immutable view of the trust material.
+type snapshot struct {
+	Pool        *x509.CertPool
+	Authorities []*x509.Certificate
+	Lists       map[string]*x509.RevocationList
+	Revoked     map[revocationKey]struct{}
+}
+
+// RevocationListInfo describes one loaded revocation list.
+type RevocationListInfo struct {
+	// Source is the configured source the list came from.
+	Source string
+	// NextUpdate is when the issuer expects to publish the next list.
+	NextUpdate time.Time
+}
+
+// Store holds the authorities client certificates are verified against and
+// the revocation lists they are checked against.
+//
+// Every read sees one consistent snapshot. A reload replaces the snapshot
+// as a whole: when an authority source fails the old snapshot stays, and a
+// revocation list that fails to load or verify keeps the last accepted one
+// for its source, so a stalled PKI never widens what is accepted.
+type Store struct {
+	snapshot      atomic.Pointer[snapshot]
+	caSources     []loader.Loader
+	crlSources    []loader.Loader
+	refreshErrors map[string]*metrics.Counter
+}
+
+// NewStore loads the authorities and revocation lists from their sources.
+//
+// Every source must load and every list must be signed by one of the
+// authorities, so a misconfigured source fails startup instead of silently
+// disabling revocation.
+func NewStore(caSources []loader.Loader, crlSources []loader.Loader) (*Store, error) {
+	m := &Store{
+		caSources:     caSources,
+		crlSources:    crlSources,
+		refreshErrors: map[string]*metrics.Counter{},
+	}
+	for _, source := range caSources {
+		m.refreshErrors[source.Source()] = &metrics.Counter{}
+	}
+	for _, source := range crlSources {
+		m.refreshErrors[source.Source()] = &metrics.Counter{}
+	}
+
+	if err := m.Reload(); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// Pool returns the authorities of the current snapshot.
+func (m *Store) Pool() *x509.CertPool {
+	return m.snapshot.Load().Pool
+}
+
+// IsRevoked reports whether a loaded revocation list names the certificate.
+func (m *Store) IsRevoked(certificate *x509.Certificate) bool {
+	key := newRevocationKey(certificate.RawIssuer, certificate.SerialNumber)
+	_, ok := m.snapshot.Load().Revoked[key]
+
+	return ok
+}
+
+// RevocationLists describes the lists of the current snapshot in source
+// order.
+func (m *Store) RevocationLists() []RevocationListInfo {
+	current := m.snapshot.Load()
+
+	infos := make([]RevocationListInfo, 0, len(current.Lists))
+	for _, source := range m.crlSources {
+		list, ok := current.Lists[source.Source()]
+		if !ok {
+			continue
+		}
+		infos = append(infos, RevocationListInfo{
+			Source:     source.Source(),
+			NextUpdate: list.NextUpdate,
+		})
+	}
+
+	return infos
+}
+
+// Reload rebuilds the snapshot from the sources.
+//
+// A failed authority source aborts the reload and keeps the current
+// snapshot. A failed revocation list source keeps that source's last
+// accepted list. Every failure is counted and returned, joined.
+func (m *Store) Reload() error {
+	authorities, err := m.loadAuthorities()
+	if err != nil {
+		return err
+	}
+
+	pool := x509.NewCertPool()
+	for _, authority := range authorities {
+		pool.AddCert(authority)
+	}
+
+	var errs []error
+	lists := map[string]*x509.RevocationList{}
+	previous := m.snapshot.Load()
+	for _, source := range m.crlSources {
+		list, err := loadRevocationList(source, authorities)
+		if err != nil {
+			m.refreshErrors[source.Source()].Inc()
+			errs = append(errs, fmt.Errorf("load revocation list from %q: %w", source.Source(), err))
+			if previous != nil {
+				if kept, ok := previous.Lists[source.Source()]; ok {
+					lists[source.Source()] = kept
+				}
+			}
+			continue
+		}
+		lists[source.Source()] = list
+	}
+
+	m.snapshot.Store(&snapshot{
+		Pool:        pool,
+		Authorities: authorities,
+		Lists:       lists,
+		Revoked:     indexRevoked(lists),
+	})
+
+	return errors.Join(errs...)
+}
+
+// Collect reports the next update of every loaded revocation list and the
+// failed refreshes of every source.
+func (m *Store) Collect() []*commonpb.Metric {
+	var out []*commonpb.Metric
+	for _, info := range m.RevocationLists() {
+		out = append(out, commonpb.NewMetricGauge(
+			metricCRLNextUpdate,
+			float64(info.NextUpdate.Unix()),
+			commonpb.MetricLabelsToProto(metrics.Labels{labelSource: info.Source})...,
+		))
+	}
+	for _, sources := range [][]loader.Loader{m.caSources, m.crlSources} {
+		for _, source := range sources {
+			out = append(out, commonpb.NewMetricCounter(
+				metricRefreshErrors,
+				m.refreshErrors[source.Source()].Load(),
+				commonpb.MetricLabelsToProto(metrics.Labels{labelSource: source.Source()})...,
+			))
+		}
+	}
+
+	return out
+}
+
+// loadAuthorities loads and merges every authority bundle.
+func (m *Store) loadAuthorities() ([]*x509.Certificate, error) {
+	var authorities []*x509.Certificate
+	for _, source := range m.caSources {
+		certificates, err := loadCertificates(source)
+		if err != nil {
+			m.refreshErrors[source.Source()].Inc()
+			return nil, fmt.Errorf("load authorities from %q: %w", source.Source(), err)
+		}
+		authorities = append(authorities, certificates...)
+	}
+
+	return authorities, nil
+}
+
+// loadCertificates reads a PEM bundle from source.
+func loadCertificates(source loader.Loader) ([]*x509.Certificate, error) {
+	data, err := source.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseCertificates(data)
+}
+
+// parseCertificates parses every certificate block of a PEM bundle.
+func parseCertificates(data []byte) ([]*x509.Certificate, error) {
+	var certificates []*x509.Certificate
+	for {
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			break
+		}
+		if block.Type != pemTypeCertificate {
+			continue
+		}
+
+		certificate, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse certificate: %w", err)
+		}
+		certificates = append(certificates, certificate)
+	}
+
+	if len(certificates) == 0 {
+		return nil, ErrNoAuthorities
+	}
+
+	return certificates, nil
+}
+
+// loadRevocationList reads one list, DER or PEM, and accepts it only when
+// one of the authorities signed it.
+func loadRevocationList(source loader.Loader, authorities []*x509.Certificate) (*x509.RevocationList, error) {
+	data, err := source.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	if block, _ := pem.Decode(data); block != nil && block.Type == pemTypeRevocationList {
+		data = block.Bytes
+	}
+
+	list, err := x509.ParseRevocationList(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse revocation list: %w", err)
+	}
+
+	for _, authority := range authorities {
+		if !bytes.Equal(authority.RawSubject, list.RawIssuer) {
+			continue
+		}
+		if err := list.CheckSignatureFrom(authority); err == nil {
+			return list, nil
+		}
+	}
+
+	return nil, ErrUntrustedRevocationList
+}
+
+// indexRevoked flattens the lists into one lookup set.
+func indexRevoked(lists map[string]*x509.RevocationList) map[revocationKey]struct{} {
+	revoked := map[revocationKey]struct{}{}
+	for _, list := range lists {
+		for _, entry := range list.RevokedCertificateEntries {
+			revoked[newRevocationKey(list.RawIssuer, entry.SerialNumber)] = struct{}{}
+		}
+	}
+
+	return revoked
+}
+
+func newRevocationKey(rawIssuer []byte, serial *big.Int) revocationKey {
+	return revocationKey{Issuer: string(rawIssuer), Serial: serial.String()}
+}

--- a/controlplane/internal/auth/x509/store.go
+++ b/controlplane/internal/auth/x509/store.go
@@ -3,6 +3,7 @@ package x509
 import (
 	"bytes"
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -30,10 +31,18 @@ const (
 	pemTypeRevocationList = "X509 CRL"
 )
 
-// revocationKey identifies a certificate the way a revocation list does, by
-// issuer and serial number.
+// oidDeltaCRLIndicator marks a list that only holds changes against a base
+// list, RFC 5280 section 5.2.4.
+var oidDeltaCRLIndicator = asn1.ObjectIdentifier{2, 5, 29, 27}
+
+// revocationKey identifies a certificate the way a revocation list does: by
+// issuer name, issuer key and serial number.
+//
+// The issuer key keeps an old and a new authority of the same name apart
+// during a rollover, when their serial sequences may overlap.
 type revocationKey struct {
 	Issuer string
+	KeyID  string
 	Serial string
 }
 
@@ -99,7 +108,7 @@ func (m *Store) Pool() *x509.CertPool {
 
 // IsRevoked reports whether a loaded revocation list names the certificate.
 func (m *Store) IsRevoked(certificate *x509.Certificate) bool {
-	key := newRevocationKey(certificate.RawIssuer, certificate.SerialNumber)
+	key := newRevocationKey(certificate.RawIssuer, certificate.AuthorityKeyId, certificate.SerialNumber)
 	_, ok := m.snapshot.Load().Revoked[key]
 
 	return ok
@@ -280,6 +289,14 @@ func loadRevocationList(source loader.Loader, authorities []*x509.Certificate) (
 		return nil, fmt.Errorf("parse revocation list: %w", err)
 	}
 
+	// A delta list indexed as a complete one would drop every revocation
+	// of its base list.
+	for _, extension := range list.Extensions {
+		if extension.Id.Equal(oidDeltaCRLIndicator) {
+			return nil, ErrDeltaRevocationList
+		}
+	}
+
 	for _, authority := range authorities {
 		if !bytes.Equal(authority.RawSubject, list.RawIssuer) {
 			continue
@@ -330,13 +347,17 @@ func indexRevoked(lists map[string]*x509.RevocationList) map[revocationKey]struc
 	revoked := map[revocationKey]struct{}{}
 	for _, list := range lists {
 		for _, entry := range list.RevokedCertificateEntries {
-			revoked[newRevocationKey(list.RawIssuer, entry.SerialNumber)] = struct{}{}
+			revoked[newRevocationKey(list.RawIssuer, list.AuthorityKeyId, entry.SerialNumber)] = struct{}{}
 		}
 	}
 
 	return revoked
 }
 
-func newRevocationKey(rawIssuer []byte, serial *big.Int) revocationKey {
-	return revocationKey{Issuer: string(rawIssuer), Serial: serial.String()}
+func newRevocationKey(rawIssuer []byte, authorityKeyID []byte, serial *big.Int) revocationKey {
+	return revocationKey{
+		Issuer: string(rawIssuer),
+		KeyID:  string(authorityKeyID),
+		Serial: serial.String(),
+	}
 }

--- a/controlplane/internal/auth/x509/store_test.go
+++ b/controlplane/internal/auth/x509/store_test.go
@@ -1,0 +1,168 @@
+package x509_test
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/testutils/tlscert"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/loader"
+	x509auth "github.com/yanet-platform/yanet2/controlplane/internal/auth/x509"
+)
+
+// verifies reports whether keypair chains to the store's current pool as a
+// client certificate.
+func verifies(store *x509auth.Store, keypair tlscert.Keypair) bool {
+	_, err := keypair.Leaf.Verify(x509.VerifyOptions{
+		Roots:     store.Pool(),
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+
+	return err == nil
+}
+
+// findMetric returns the first collected metric with the given name and
+// source label.
+func findMetric(t *testing.T, store *x509auth.Store, name, source string) *commonpb.Metric {
+	t.Helper()
+
+	for _, metric := range store.Collect() {
+		if metric.GetName() != name {
+			continue
+		}
+		for _, label := range metric.GetLabels() {
+			if label.GetName() == "source" && label.GetValue() == source {
+				return metric
+			}
+		}
+	}
+
+	require.Failf(t, "metric not found", "%s{source=%q}", name, source)
+
+	return nil
+}
+
+// Test_NewStore_RejectsUntrustedRevocationList verifies that a list signed by
+// an authority outside the pool fails construction instead of being ignored.
+func Test_NewStore_RejectsUntrustedRevocationList(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	other := tlscert.NewCA(t)
+	crlFile := other.RevocationListFile(t, time.Now().Add(time.Hour))
+
+	_, err := x509auth.NewStore(
+		[]loader.Loader{loader.NewLoader(ca.BundleFile())},
+		[]loader.Loader{loader.NewLoader(crlFile)},
+	)
+	require.ErrorIs(t, err, x509auth.ErrUntrustedRevocationList)
+}
+
+// Test_NewStore_RejectsBundleWithoutCertificates verifies that a bundle
+// holding no certificate fails construction.
+func Test_NewStore_RejectsBundleWithoutCertificates(t *testing.T) {
+	bundle := filepath.Join(t.TempDir(), "empty.pem")
+	require.NoError(t, os.WriteFile(bundle, []byte("# nothing here\n"), 0o600))
+
+	_, err := x509auth.NewStore([]loader.Loader{loader.NewLoader(bundle)}, nil)
+	require.ErrorIs(t, err, x509auth.ErrNoAuthorities)
+}
+
+// Test_NewStore_AcceptsPEMRevocationList verifies that a PEM-armored list is
+// read the same as a DER one.
+func Test_NewStore_AcceptsPEMRevocationList(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	revoked := ca.IssueClient(t, "route-operator")
+
+	crlFile := filepath.Join(t.TempDir(), "revoked.pem")
+	armored := pem.EncodeToMemory(&pem.Block{
+		Type:  "X509 CRL",
+		Bytes: ca.RevocationList(t, time.Now().Add(time.Hour), revoked.Leaf),
+	})
+	require.NoError(t, os.WriteFile(crlFile, armored, 0o600))
+
+	store := newStore(t, ca, crlFile)
+	require.True(t, store.IsRevoked(revoked.Leaf))
+}
+
+// Test_Store_Reload_KeepsSnapshotWhenAuthoritiesFail verifies that a bundle
+// that no longer loads leaves the previous authorities and revocations in
+// force and is counted against its source.
+func Test_Store_Reload_KeepsSnapshotWhenAuthoritiesFail(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	client := ca.IssueClient(t, "route-operator")
+	revoked := ca.IssueClient(t, "pipeline-operator")
+	crlFile := ca.RevocationListFile(t, time.Now().Add(time.Hour), revoked.Leaf)
+	store := newStore(t, ca, crlFile)
+
+	require.NoError(t, os.WriteFile(ca.BundleFile(), []byte("garbage"), 0o600))
+
+	require.Error(t, store.Reload())
+	require.True(t, verifies(store, client))
+	require.True(t, store.IsRevoked(revoked.Leaf))
+	require.EqualValues(t, 1, findMetric(t, store, "auth_x509_refresh_errors_total", ca.BundleFile()).GetCounter())
+	require.EqualValues(t, 0, findMetric(t, store, "auth_x509_refresh_errors_total", crlFile).GetCounter())
+}
+
+// Test_Store_Reload_KeepsRevocationListWhenSourceFails verifies that a list
+// that no longer loads or verifies keeps its last accepted content while the
+// authorities still refresh.
+func Test_Store_Reload_KeepsRevocationListWhenSourceFails(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	other := tlscert.NewCA(t)
+	revoked := ca.IssueClient(t, "route-operator")
+	crlFile := ca.RevocationListFile(t, time.Now().Add(time.Hour), revoked.Leaf)
+	store := newStore(t, ca, crlFile)
+
+	tests := []struct {
+		name    string
+		content []byte
+	}{
+		{name: "unparseable", content: []byte("garbage")},
+		{name: "signed by an untrusted authority", content: other.RevocationList(t, time.Now().Add(time.Hour))},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.NoError(t, os.WriteFile(crlFile, testCase.content, 0o600))
+
+			require.Error(t, store.Reload())
+			require.True(t, store.IsRevoked(revoked.Leaf))
+			require.True(t, verifies(store, revoked))
+		})
+	}
+
+	require.EqualValues(t, 2, findMetric(t, store, "auth_x509_refresh_errors_total", crlFile).GetCounter())
+}
+
+// Test_Store_Reload_PicksUpNewRevocations verifies that a reload of an
+// updated list revokes a certificate the previous snapshot accepted.
+func Test_Store_Reload_PicksUpNewRevocations(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	client := ca.IssueClient(t, "route-operator")
+	crlFile := ca.RevocationListFile(t, time.Now().Add(time.Hour))
+	store := newStore(t, ca, crlFile)
+	require.False(t, store.IsRevoked(client.Leaf))
+
+	require.NoError(t, os.WriteFile(crlFile, ca.RevocationList(t, time.Now().Add(time.Hour), client.Leaf), 0o600))
+
+	require.NoError(t, store.Reload())
+	require.True(t, store.IsRevoked(client.Leaf))
+}
+
+// Test_Store_Collect_ReportsNextUpdate verifies that every loaded list
+// reports the time its issuer promised the next one by, so a stale list is
+// visible without reading logs.
+func Test_Store_Collect_ReportsNextUpdate(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	nextUpdate := time.Now().Add(-time.Hour).Truncate(time.Second)
+	crlFile := ca.RevocationListFile(t, nextUpdate)
+	store := newStore(t, ca, crlFile)
+
+	require.Equal(t, []x509auth.RevocationListInfo{{Source: crlFile, NextUpdate: nextUpdate.UTC()}}, store.RevocationLists())
+	require.EqualValues(t, nextUpdate.Unix(), findMetric(t, store, "auth_x509_crl_next_update_seconds", crlFile).GetGauge())
+}

--- a/controlplane/internal/auth/x509/store_test.go
+++ b/controlplane/internal/auth/x509/store_test.go
@@ -3,8 +3,11 @@ package x509_test
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -165,4 +168,57 @@ func Test_Store_Collect_ReportsNextUpdate(t *testing.T) {
 
 	require.Equal(t, []x509auth.RevocationListInfo{{Source: crlFile, NextUpdate: nextUpdate.UTC()}}, store.RevocationLists())
 	require.EqualValues(t, nextUpdate.Unix(), findMetric(t, store, "auth_x509_crl_next_update_seconds", crlFile).GetGauge())
+}
+
+// Test_NewStore_RejectsEndEntityInBundle verifies that a bundle holding a
+// certificate that is not an authority fails construction, since such a
+// certificate in the pool would verify itself.
+func Test_NewStore_RejectsEndEntityInBundle(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	client := ca.IssueClient(t, "route-operator")
+
+	_, err := x509auth.NewStore([]loader.Loader{loader.NewLoader(client.CertFile)}, nil)
+	require.ErrorIs(t, err, x509auth.ErrNotAuthority)
+}
+
+// Test_Store_Reload_RejectsOlderRevocationList verifies that a correctly
+// signed but older list does not replace the accepted one, so a replayed
+// list cannot undo a revocation.
+func Test_Store_Reload_RejectsOlderRevocationList(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	client := ca.IssueClient(t, "route-operator")
+	older := ca.RevocationList(t, time.Now().Add(time.Hour))
+	crlFile := ca.RevocationListFile(t, time.Now().Add(time.Hour), client.Leaf)
+	store := newStore(t, ca, crlFile)
+	require.True(t, store.IsRevoked(client.Leaf))
+
+	require.NoError(t, os.WriteFile(crlFile, older, 0o600))
+
+	require.ErrorIs(t, store.Reload(), x509auth.ErrRevocationListRollback)
+	require.True(t, store.IsRevoked(client.Leaf))
+	require.EqualValues(t, 1, findMetric(t, store, "auth_x509_refresh_errors_total", crlFile).GetCounter())
+}
+
+// Test_Store_Collect_RedactsSourceURL verifies that a source fetched from a
+// URL is labeled without the credentials and query the URL carries.
+func Test_Store_Collect_RedactsSourceURL(t *testing.T) {
+	ca := tlscert.NewCA(t)
+	bundle, err := os.ReadFile(ca.BundleFile())
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(bundle)
+	}))
+	t.Cleanup(server.Close)
+
+	source := strings.Replace(server.URL, "http://", "http://user:secret@", 1) + "/ca.pem?token=secret"
+	store, err := x509auth.NewStore([]loader.Loader{loader.NewLoader(source)}, nil)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 0, findMetric(t, store, "auth_x509_refresh_errors_total", server.URL+"/ca.pem").GetCounter())
+	for _, metric := range store.Collect() {
+		for _, label := range metric.GetLabels() {
+			require.NotContains(t, label.GetValue(), "secret")
+		}
+	}
 }

--- a/controlplane/internal/auth/x509/store_test.go
+++ b/controlplane/internal/auth/x509/store_test.go
@@ -222,3 +222,45 @@ func Test_Store_Collect_RedactsSourceURL(t *testing.T) {
 		}
 	}
 }
+
+// Test_Store_Reload_AcceptsRotatedIssuerList verifies that after the
+// authority behind a source rotates, the new issuer's list is accepted even
+// though its number is below the old issuer's, since rollback is only
+// judged between lists of one issuer.
+func Test_Store_Reload_AcceptsRotatedIssuerList(t *testing.T) {
+	oldCA := tlscert.NewCA(t)
+	oldClient := oldCA.IssueClient(t, "route-operator")
+	_ = oldCA.RevocationList(t, time.Now().Add(time.Hour))
+	crlFile := oldCA.RevocationListFile(t, time.Now().Add(time.Hour), oldClient.Leaf)
+	store := newStore(t, oldCA, crlFile)
+
+	newCA := tlscert.NewCA(t)
+	newClient := newCA.IssueClient(t, "route-operator")
+	newList := newCA.RevocationList(t, time.Now().Add(time.Hour), newClient.Leaf)
+	requireLowerNumber(t, newList, crlFile)
+
+	newBundle, err := os.ReadFile(newCA.BundleFile())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(oldCA.BundleFile(), newBundle, 0o600))
+	require.NoError(t, os.WriteFile(crlFile, newList, 0o600))
+
+	require.NoError(t, store.Reload())
+	require.True(t, store.IsRevoked(newClient.Leaf))
+	require.False(t, store.IsRevoked(oldClient.Leaf))
+}
+
+// requireLowerNumber asserts that the DER list carries a lower number than
+// the list stored in file, the precondition a rotation test relies on.
+func requireLowerNumber(t *testing.T, der []byte, file string) {
+	t.Helper()
+
+	candidate, err := x509.ParseRevocationList(der)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(file)
+	require.NoError(t, err)
+	accepted, err := x509.ParseRevocationList(data)
+	require.NoError(t, err)
+
+	require.Equal(t, -1, candidate.Number.Cmp(accepted.Number))
+}

--- a/controlplane/internal/auth/x509/store_test.go
+++ b/controlplane/internal/auth/x509/store_test.go
@@ -2,7 +2,10 @@ package x509_test
 
 import (
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -263,4 +266,62 @@ func requireLowerNumber(t *testing.T, der []byte, file string) {
 	require.NoError(t, err)
 
 	require.Equal(t, -1, candidate.Number.Cmp(accepted.Number))
+}
+
+// Test_NewStore_RejectsDeltaRevocationList verifies that a delta list is
+// refused, since indexing it as a complete list would drop the revocations
+// of its base list.
+func Test_NewStore_RejectsDeltaRevocationList(t *testing.T) {
+	ca := tlscert.NewCA(t)
+
+	baseNumber, err := asn1.Marshal(big.NewInt(1))
+	require.NoError(t, err)
+	delta := ca.SignRevocationList(t, &x509.RevocationList{
+		Number:     big.NewInt(2),
+		ThisUpdate: time.Now().Add(-time.Minute),
+		NextUpdate: time.Now().Add(time.Hour),
+		ExtraExtensions: []pkix.Extension{{
+			Id:       asn1.ObjectIdentifier{2, 5, 29, 27},
+			Critical: true,
+			Value:    baseNumber,
+		}},
+	})
+	crlFile := filepath.Join(t.TempDir(), "delta.crl")
+	require.NoError(t, os.WriteFile(crlFile, delta, 0o600))
+
+	_, err = x509auth.NewStore(
+		[]loader.Loader{loader.NewLoader(ca.BundleFile())},
+		[]loader.Loader{loader.NewLoader(crlFile)},
+	)
+	require.ErrorIs(t, err, x509auth.ErrDeltaRevocationList)
+}
+
+// Test_Store_IsRevoked_DistinguishesIssuerKeys verifies that a revocation by
+// one authority does not reach a certificate of the same serial issued by
+// another authority of the same name, as happens during a key rollover.
+func Test_Store_IsRevoked_DistinguishesIssuerKeys(t *testing.T) {
+	oldCA := tlscert.NewCA(t)
+	newCA := tlscert.NewCA(t)
+	require.Equal(t, oldCA.Certificate().RawSubject, newCA.Certificate().RawSubject)
+
+	serial := big.NewInt(42)
+	oldClient := oldCA.IssueClient(t, "route-operator", tlscert.WithSerial(serial))
+	newClient := newCA.IssueClient(t, "route-operator", tlscert.WithSerial(serial))
+
+	oldBundle, err := os.ReadFile(oldCA.BundleFile())
+	require.NoError(t, err)
+	newBundle, err := os.ReadFile(newCA.BundleFile())
+	require.NoError(t, err)
+	bundle := filepath.Join(t.TempDir(), "rollover.pem")
+	require.NoError(t, os.WriteFile(bundle, append(oldBundle, newBundle...), 0o600))
+
+	crlFile := oldCA.RevocationListFile(t, time.Now().Add(time.Hour), oldClient.Leaf)
+	store, err := x509auth.NewStore(
+		[]loader.Loader{loader.NewLoader(bundle)},
+		[]loader.Loader{loader.NewLoader(crlFile)},
+	)
+	require.NoError(t, err)
+
+	require.True(t, store.IsRevoked(oldClient.Leaf))
+	require.False(t, store.IsRevoked(newClient.Leaf))
 }


### PR DESCRIPTION
- Add the x509 authenticator: a verified client certificate with no token identifies the caller by its common name, or by its single SPIFFE identity when the name is empty, through the existing identity and RBAC chain.
- Load authority bundles and revocation lists from files or URLs, refresh them periodically, accept a list only when a trusted authority signed it, keep the last accepted list when a refresh fails and report next-update times and refresh errors as metrics.
- Let the gRPC listener ask for a client certificate without requiring one and verify it against the authenticator's current pool on every handshake, refuse an x509 authenticator without server TLS, and leave the HTTP listener without a certificate request.
- Make token introspection with an empty token report the credential of the call itself.
- Extend the test CA helper with issue options and revocation lists, and cover the authenticator, the store and the gateway path with tests.
