### PR TITLE
fix(fwstate): require sync settings only when configuring sync

### DIFF
--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -212,7 +212,6 @@ testpkg:modules/dscp/controlplane/service_test.go:dscp:1  # legacy: migrate to t
 testpkg:modules/fwstate/controlplane/fwstatepb/v1/convert_test.go:fwstatepb:1  # legacy: migrate to the external test package
 testpkg:modules/fwstate/controlplane/fwstatepb/v1/fwstate_test.go:fwstatepb:1  # legacy: migrate to the external test package
 testpkg:modules/fwstate/controlplane/metrics_test.go:fwstate:1  # legacy: migrate to the external test package
-testpkg:modules/fwstate/controlplane/service_test.go:fwstate:1  # legacy: migrate to the external test package
 testpkg:modules/fwstate/tests/dataplane/cursor_test.go:fwstate:1  # legacy: migrate to the external test package
 testpkg:modules/fwstate/tests/dataplane/fwstate_test.go:fwstate:1  # legacy: migrate to the external test package
 testpkg:modules/nat64/controlplane/service_test.go:nat64:1  # legacy: migrate to the external test package

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -47,23 +47,16 @@ pub struct Cmd {
 
 /// Merges the linked map object names an update should carry.
 ///
-/// The pre-flight lookup answers an unknown name with an empty message,
-/// while a stored config always echoes the requested one — an empty name
-/// in the reply therefore marks the create case. A create has no stored
-/// names to merge from and the server rejects empty ones, so both
-/// map-name flags are required then; otherwise each flag, when present,
-/// overrides the stored value.
-fn merged_map_names(current: &ShowConfigResponse, cmd: &UpdateCmd) -> Result<(String, String), String> {
-    if current.name.is_empty() && (cmd.map_name_v4.is_none() || cmd.map_name_v6.is_none()) {
-        return Err(format!(
-            "creating config '{}' requires --map-name-v4 and --map-name-v6",
-            cmd.config_name
-        ));
-    }
-    Ok((
+/// Each flag, when present, overrides the stored name; an absent one
+/// keeps what the pre-flight lookup reported. A config that names no map
+/// links none and inserts no synced state for that family, which is what
+/// a create left without map flags installs until a later update names
+/// them.
+fn merged_map_names(current: &ShowConfigResponse, cmd: &UpdateCmd) -> (String, String) {
+    (
         cmd.map_name_v4.clone().unwrap_or_else(|| current.map_name_v4.clone()),
         cmd.map_name_v6.clone().unwrap_or_else(|| current.map_name_v6.clone()),
-    ))
+    )
 }
 
 pub struct FWStateService {
@@ -97,9 +90,7 @@ impl FWStateService {
                 if response.configs.is_empty() {
                     output::empty_with_hint(
                         format_args!("No FWState configurations found."),
-                        format_args!(
-                            "provision maps with 'yanet-cli-fwstatemap create --name <name> --kind <v4|v6>', then create a config with 'yanet-cli-fwstate update --name <name> --map-name-v4 <map> --map-name-v6 <map> --src-addr <addr> --dst-addr-multicast <addr> --port-multicast <port>'"
-                        ),
+                        format_args!("create one with 'yanet-cli-fwstate update --name <name>'"),
                     );
                     return;
                 }
@@ -170,8 +161,7 @@ impl FWStateService {
             .await
             .map_err(self.service.status("update"))?
             .into_inner();
-        let (map_name_v4, map_name_v6) =
-            merged_map_names(&current, &cmd).map_err(|err| self.service.invalid("update", err))?;
+        let (map_name_v4, map_name_v6) = merged_map_names(&current, &cmd);
         let mut sync_config = current.sync_config.unwrap_or_default();
 
         // Update only the fields that were provided
@@ -306,24 +296,25 @@ mod tests {
     }
 
     #[test]
-    fn test_merged_map_names_create_without_map_names_is_rejected() {
+    fn test_merged_map_names_create_without_map_names_links_none() {
         let cmd = update_cmd("cfg", None, None);
-        let err = merged_map_names(&show_response("", "", ""), &cmd).unwrap_err();
+        let (map_name_v4, map_name_v6) = merged_map_names(&show_response("", "", ""), &cmd);
 
-        assert_eq!("creating config 'cfg' requires --map-name-v4 and --map-name-v6", err);
+        assert_eq!(("", ""), (map_name_v4.as_str(), map_name_v6.as_str()));
     }
 
     #[test]
-    fn test_merged_map_names_create_with_one_map_name_is_rejected() {
+    fn test_merged_map_names_create_with_one_map_name_links_only_it() {
         let empty_reply = show_response("", "", "");
-        assert!(merged_map_names(&empty_reply, &update_cmd("cfg", Some("v4"), None)).is_err());
-        assert!(merged_map_names(&empty_reply, &update_cmd("cfg", None, Some("v6"))).is_err());
+        let (map_name_v4, map_name_v6) = merged_map_names(&empty_reply, &update_cmd("cfg", Some("v4"), None));
+
+        assert_eq!(("v4", ""), (map_name_v4.as_str(), map_name_v6.as_str()));
     }
 
     #[test]
     fn test_merged_map_names_create_with_both_map_names_uses_flags() {
         let cmd = update_cmd("cfg", Some("map4"), Some("map6"));
-        let (map_name_v4, map_name_v6) = merged_map_names(&show_response("", "", ""), &cmd).unwrap();
+        let (map_name_v4, map_name_v6) = merged_map_names(&show_response("", "", ""), &cmd);
 
         assert_eq!(("map4", "map6"), (map_name_v4.as_str(), map_name_v6.as_str()));
     }
@@ -331,7 +322,7 @@ mod tests {
     #[test]
     fn test_merged_map_names_existing_config_keeps_stored_names_without_flags() {
         let cmd = update_cmd("cfg", None, None);
-        let (map_name_v4, map_name_v6) = merged_map_names(&show_response("cfg", "stored4", "stored6"), &cmd).unwrap();
+        let (map_name_v4, map_name_v6) = merged_map_names(&show_response("cfg", "stored4", "stored6"), &cmd);
 
         assert_eq!(("stored4", "stored6"), (map_name_v4.as_str(), map_name_v6.as_str()));
     }
@@ -339,7 +330,7 @@ mod tests {
     #[test]
     fn test_merged_map_names_existing_config_flag_overrides_stored_name() {
         let reply = show_response("cfg", "stored4", "stored6");
-        let (map_name_v4, map_name_v6) = merged_map_names(&reply, &update_cmd("cfg", Some("new4"), None)).unwrap();
+        let (map_name_v4, map_name_v6) = merged_map_names(&reply, &update_cmd("cfg", Some("new4"), None));
 
         assert_eq!(("new4", "stored6"), (map_name_v4.as_str(), map_name_v6.as_str()));
     }

--- a/modules/fwstate/controlplane/ffi.go
+++ b/modules/fwstate/controlplane/ffi.go
@@ -16,14 +16,16 @@ type FwStateConfig struct {
 	mapNameV6 string
 }
 
-// NewFWStateModuleConfig builds the config in one step: the request's
-// sync config merges over the replaced config's values (or the defaults
-// for a fresh config) and both map names are declared as object links,
-// resolving against published objects when the config is published.
+// NewFWStateModuleConfig builds the config in one step, ready to
+// publish.
 //
-// The map names are remembered only after the C construction succeeds,
-// so a failed construction leaves the previous linkage visible to
-// readers.
+// The request's sync settings merge over the values they replace, and
+// each named map is declared as an object link resolving against
+// published objects when the config is published. An empty map name
+// declares no link, and the module then counts and drops that family's
+// synced state. The map names are remembered only after the construction
+// succeeds, so a failed construction leaves the previous linkage visible
+// to readers.
 func NewFWStateModuleConfig(
 	agent *ffi.Agent,
 	name string,
@@ -31,21 +33,12 @@ func NewFWStateModuleConfig(
 	syncConfig *fwstatepb.SyncConfig,
 	fw4MapName, fw6MapName string,
 ) (*FwStateConfig, error) {
-	current := cfwstate.DefaultSyncConfig()
-	if old != nil {
-		current = old.ModuleConfig.GetSyncConfig()
-	}
-
-	var finalSync *cfwstate.SyncConfig
-	if syncConfig != nil {
-		merged := syncConfig.ToCWithDefaults(current)
-		finalSync = &merged
-	}
+	merged := mergedSyncConfigC(old, syncConfig)
 
 	moduleCfg, err := cfwstate.NewModuleConfig(
 		agent,
 		name,
-		finalSync,
+		&merged,
 		fw4MapName,
 		fw6MapName,
 	)
@@ -59,18 +52,57 @@ func NewFWStateModuleConfig(
 	}, nil
 }
 
-// mergedSyncConfig merges the request's sync config over the replaced
-// config's current values (or the defaults for a fresh config): the
-// exact values a construction would install.
+// mergedMapNames returns the map object links a replacement config
+// should declare.
+//
+// A request naming a map relinks that family; leaving it unnamed keeps
+// the link the replaced config had, the only spelling the request has
+// for "leave this family alone". A fresh config left unnamed declares no
+// link at all, and the maps can be attached by a later update.
+func mergedMapNames(
+	old *FwStateConfig,
+	req *fwstatepb.UpdateConfigRequest,
+) (string, string) {
+	mapNameV4, mapNameV6 := req.GetMapNameV4(), req.GetMapNameV6()
+	if old == nil {
+		return mapNameV4, mapNameV6
+	}
+	if mapNameV4 == "" {
+		mapNameV4 = old.MapNameV4()
+	}
+	if mapNameV6 == "" {
+		mapNameV6 = old.MapNameV6()
+	}
+	return mapNameV4, mapNameV6
+}
+
+// mergedSyncConfig returns the sync settings a construction would
+// install: the request merged over the values it replaces.
 func mergedSyncConfig(
 	old *FwStateConfig,
 	syncConfig *fwstatepb.SyncConfig,
 ) *fwstatepb.SyncConfig {
+	return fwstatepb.FromCSyncConfig(mergedSyncConfigC(old, syncConfig))
+}
+
+// mergedSyncConfigC is the merge in the form the construction consumes.
+//
+// A request carrying no sync settings at all asks for no sync change,
+// which is not the same as asking for the defaults: it keeps the
+// replaced config's values, so an update touching only the linked maps
+// leaves synchronization exactly as it was.
+func mergedSyncConfigC(
+	old *FwStateConfig,
+	syncConfig *fwstatepb.SyncConfig,
+) cfwstate.SyncConfig {
 	current := cfwstate.DefaultSyncConfig()
 	if old != nil {
 		current = old.ModuleConfig.GetSyncConfig()
 	}
-	return fwstatepb.FromCSyncConfig(syncConfig.ToCWithDefaults(current))
+	if syncConfig == nil {
+		return current
+	}
+	return syncConfig.ToCWithDefaults(current)
 }
 
 // MergedSyncConfig returns the request's sync config merged with the

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.go
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.go
@@ -6,6 +6,16 @@ import (
 	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 )
 
+const (
+	// maxSyncPort is the highest value accepted for port_multicast,
+	// matching the width of the C-side uint16 port field.
+	maxSyncPort uint32 = 65535
+
+	// syncAddrLen is the width every sync address is stored at: the
+	// module matches and stamps IPv6 addresses only.
+	syncAddrLen = 16
+)
+
 // ValidateTimeouts rejects timeout values that do not fit in
 // fw_state_value::last_ttl.
 //
@@ -55,4 +65,88 @@ func (m *SyncConfig) ValidateTimeouts() error {
 	}
 
 	return nil
+}
+
+// ValidateFields rejects sync values stated in a form the config cannot
+// store, before they are merged over the values they update.
+//
+// An absent address and a zero port both mean "leave this as it is" in
+// the merge, so only a value that is present and unusable fails here: a
+// port too wide for the stored field, or an address of any width other
+// than an IPv6 one. Whether the merged result names a usable destination
+// is decided against the config it replaces, not here.
+func (m *SyncConfig) ValidateFields() error {
+	if portMulticast := m.GetPortMulticast(); portMulticast > maxSyncPort {
+		return fmt.Errorf(
+			"port_multicast %d exceeds maximum allowed value %d",
+			portMulticast, maxSyncPort,
+		)
+	}
+	if err := validateAddrWidth("src_addr", m.GetSrcAddr().GetAddr()); err != nil {
+		return err
+	}
+
+	return validateAddrWidth("dst_addr_multicast", m.GetDstAddrMulticast().GetAddr())
+}
+
+// Validate reports whether the settings are installable as they stand,
+// which is what the request merged over the config it replaces must be.
+//
+// Synchronization is optional. A config naming no part of the sync
+// destination leaves the module a passthrough that matches no sync
+// packet, which is what a first create carrying no sync settings
+// installs. Naming only part of it is refused: such a module would look
+// configured while matching nothing.
+func (m *SyncConfig) Validate() error {
+	srcAddrSet := isAddrSet(m.GetSrcAddr().GetAddr())
+	multicastAddrSet := isAddrSet(m.GetDstAddrMulticast().GetAddr())
+	multicastPortSet := m.GetPortMulticast() != 0
+
+	if srcAddrSet || multicastAddrSet || multicastPortSet {
+		var missing []string
+		if !srcAddrSet {
+			missing = append(missing, "src_addr")
+		}
+		if !multicastAddrSet {
+			missing = append(missing, "dst_addr_multicast")
+		}
+		if !multicastPortSet {
+			missing = append(missing, "port_multicast")
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("missing required sync config fields: %v", missing)
+		}
+	}
+
+	return m.ValidateTimeouts()
+}
+
+// validateAddrWidth rejects an address stated at a width the config
+// cannot store; an absent one asks for no change and passes.
+func validateAddrWidth(field string, addr []byte) error {
+	if len(addr) == 0 || len(addr) == syncAddrLen {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%s must be a %d-byte IPv6 address, got %d bytes",
+		field, syncAddrLen, len(addr),
+	)
+}
+
+// isAddrSet reports whether an address is stored at full width and is
+// not the all-zero one that stands for unset.
+func isAddrSet(addr []byte) bool {
+	return len(addr) == syncAddrLen && !isAllZeroBytes(addr)
+}
+
+// isAllZeroBytes reports whether every byte of the slice is zero.
+func isAllZeroBytes(b []byte) bool {
+	for _, value := range b {
+		if value != 0 {
+			return false
+		}
+	}
+
+	return true
 }

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
@@ -29,8 +29,11 @@ service MetricsService {
 message UpdateConfigRequest {
   string name = 1;
   // Names of the published fwstate_map_v4 / fwstate_map_v6 objects whose
-  // fwtables receive the synced state. Both are required: the module owns
-  // neither family's table itself.
+  // fwtables receive the synced state.
+  //
+  // The module owns neither family's table itself. An empty name keeps
+  // the link the config already has, so a config created without one
+  // inserts no state for that family until a later update names its map.
   string map_name_v4 = 2;
   string map_name_v6 = 3;
   SyncConfig sync_config = 4;
@@ -58,18 +61,21 @@ message ListConfigsRequest {}
 
 message ListConfigsResponse { repeated string configs = 1; }
 
-// Firewall state synchronization configuration
 // SyncConfig carries the receive-side fwstate synchronization parameters:
-// incoming-packet matching, connection timeouts, and the suppression
-// window. The emission addressing for modules that synthesize sync
-// packets lives with the ACL module's own configuration.
+// incoming-packet matching, connection timeouts and the suppression window.
+//
+// The emission addressing for modules that synthesize sync packets lives
+// with the ACL module's own configuration. Synchronization itself is
+// optional: a config naming none of src_addr, dst_addr_multicast and
+// port_multicast matches no sync packet and passes every packet through.
+// Naming only part of that destination is rejected.
 message SyncConfig {
   common.commonpb.v1.IPAddress src_addr = 1; // IPv6 source address stamped on forwarded internal frames;
   // Deprecated: the emission-side destination MAC moved to the ACL
   // module's SyncConfig; fwstate ignores this field.
   common.commonpb.v1.MACAddress dst_ether = 2 [ deprecated = true ];
   common.commonpb.v1.IPAddress dst_addr_multicast = 3; // Multicast IPv6 address matched on incoming sync packets;
-  uint32 port_multicast = 4;                           // Multicast port. The applied config requires 1..65535. Zero keeps the current port on update.
+  uint32 port_multicast = 4;                           // Multicast port, 1..65535. Zero keeps the port the config already has.
   // Deprecated: the emission-side unicast destination moved to the ACL
   // module's SyncConfig; fwstate ignores this field.
   common.commonpb.v1.IPAddress dst_addr_unicast = 5 [ deprecated = true ];

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate_test.go
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 )
 
@@ -58,4 +59,110 @@ func TestValidateSyncConfigTimeoutsSuppressOverflow(t *testing.T) {
 		Tcp:                 120e9,
 		SyncSuppressTimeout: 8e9,
 	}).ValidateTimeouts())
+}
+
+// Test_SyncConfig_ValidateFields_RejectsUnusableValues verifies that a
+// value stated in a form the config cannot store is rejected.
+//
+// A port past the uint16 range and an address of a width other than an
+// IPv6 one fail; the values that stand for "leave this as it is" pass.
+func Test_SyncConfig_ValidateFields_RejectsUnusableValues(t *testing.T) {
+	addr := func(size int) *commonpb.IPAddress {
+		return &commonpb.IPAddress{Addr: make([]byte, size)}
+	}
+
+	cases := []struct {
+		name    string
+		config  *SyncConfig
+		wantErr string
+	}{
+		{
+			name:   "nothing set",
+			config: &SyncConfig{},
+		},
+		{
+			name:   "boundary port",
+			config: &SyncConfig{PortMulticast: 65535},
+		},
+		{
+			name:    "port above the boundary",
+			config:  &SyncConfig{PortMulticast: 65536},
+			wantErr: "port_multicast",
+		},
+		{
+			name:    "ipv4-width source address",
+			config:  &SyncConfig{SrcAddr: addr(4)},
+			wantErr: "src_addr",
+		},
+		{
+			name:    "truncated multicast address",
+			config:  &SyncConfig{DstAddrMulticast: addr(15)},
+			wantErr: "dst_addr_multicast",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.ValidateFields()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+// Test_SyncConfig_Validate_DestinationIsAllOrNothing verifies that a
+// merged config naming part of the sync destination is rejected.
+//
+// One naming all of that destination, or none of it, is accepted.
+func Test_SyncConfig_Validate_DestinationIsAllOrNothing(t *testing.T) {
+	addr := func() *commonpb.IPAddress {
+		return &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}}
+	}
+	zeroAddr := func() *commonpb.IPAddress {
+		return &commonpb.IPAddress{Addr: make([]byte, 16)}
+	}
+
+	t.Run("missing multicast address", func(t *testing.T) {
+		config := &SyncConfig{SrcAddr: addr(), PortMulticast: 1}
+
+		require.ErrorContains(t, config.Validate(), "dst_addr_multicast")
+	})
+
+	t.Run("zero multicast port", func(t *testing.T) {
+		config := &SyncConfig{SrcAddr: addr(), DstAddrMulticast: addr()}
+
+		require.ErrorContains(t, config.Validate(), "port_multicast")
+	})
+
+	t.Run("only the source address", func(t *testing.T) {
+		err := (&SyncConfig{SrcAddr: addr()}).Validate()
+
+		require.ErrorContains(t, err, "dst_addr_multicast")
+		require.ErrorContains(t, err, "port_multicast")
+	})
+
+	t.Run("no destination at all", func(t *testing.T) {
+		require.NoError(t, (&SyncConfig{}).Validate())
+	})
+
+	// The stored form of an unset address, which every merge over a
+	// config without synchronization produces.
+	t.Run("zero-filled addresses", func(t *testing.T) {
+		require.NoError(t, (&SyncConfig{
+			SrcAddr:          zeroAddr(),
+			DstAddrMulticast: zeroAddr(),
+		}).Validate())
+	})
+
+	t.Run("complete destination", func(t *testing.T) {
+		require.NoError(t, (&SyncConfig{
+			SrcAddr:          addr(),
+			DstAddrMulticast: addr(),
+			PortMulticast:    1,
+		}).Validate())
+	})
 }

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -92,10 +92,6 @@ func NewMetricsFactory(extra ...grpcmetrics.Option) grpcmetrics.Factory {
 const (
 	// moduleType is the registered shared-memory type for fwstate configs.
 	moduleType = "fwstate"
-
-	// maxSyncPort is the highest value accepted for port_multicast,
-	// matching the width of the C-side uint16 port field.
-	maxSyncPort uint32 = 65535
 )
 
 // FWStateServiceName and MetricsServiceName are the fully-qualified gRPC
@@ -198,27 +194,24 @@ func (m *FWStateService) UpdateConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	// Get fwstate configuration from req
-	if req.SyncConfig == nil {
-		return nil, status.Error(codes.InvalidArgument, "sync_config is required")
+	// A named map must round-trip through the fixed-size C object
+	// registry, which silently truncates a longer name.
+	//
+	// A truncated name could link an entirely different map than the one
+	// reported back. An unnamed map asks for no change to that family's
+	// link.
+	if req.GetMapNameV4() != "" {
+		if err := fwstatemap.ValidateMapName(req.GetMapNameV4()); err != nil {
+			return nil, err
+		}
 	}
-	if req.GetMapNameV4() == "" {
-		return nil, status.Error(codes.InvalidArgument, "map_name_v4 is required")
+	if req.GetMapNameV6() != "" {
+		if err := fwstatemap.ValidateMapName(req.GetMapNameV6()); err != nil {
+			return nil, err
+		}
 	}
-	if req.GetMapNameV6() == "" {
-		return nil, status.Error(codes.InvalidArgument, "map_name_v6 is required")
-	}
-	// The names must round-trip through the fixed-size C object registry:
-	// cp_module_link_object silently truncates longer ones, which could
-	// link an entirely different map than the one ShowConfig reports.
-	if err := fwstatemap.ValidateMapName(req.GetMapNameV4()); err != nil {
-		return nil, err
-	}
-	if err := fwstatemap.ValidateMapName(req.GetMapNameV6()); err != nil {
-		return nil, err
-	}
-	if err := validateSyncPorts(req.SyncConfig); err != nil {
-		return nil, err
+	if err := req.GetSyncConfig().ValidateFields(); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid sync config: %v", err)
 	}
 
 	m.log.Debug("update fwstate config", zap.String("config", name))
@@ -260,10 +253,12 @@ func (m *FWStateService) UpdateConfig(
 	return &fwstatepb.UpdateConfigResponse{}, nil
 }
 
-// prepareUpdate builds the replacement config for name in one step: the
-// old config's sync config propagates, the request's sync config merges
-// over it, and both map names are declared as object links. The state
-// lock stays held so the old handle cannot disappear mid-construction.
+// prepareUpdate builds the replacement config for name in one step.
+//
+// The old config's sync settings and map links propagate, the request
+// merges over them, and the resulting map names are declared as object
+// links. The state lock stays held so the old handle cannot disappear
+// mid-construction.
 func (m *FWStateService) prepareUpdate(
 	name string,
 	req *fwstatepb.UpdateConfigRequest,
@@ -275,10 +270,12 @@ func (m *FWStateService) prepareUpdate(
 
 	// Validate the merged sync config before any C state is touched.
 	syncConfig := mergedSyncConfig(oldConfig, req.SyncConfig)
-	if err := validateSyncConfig(syncConfig); err != nil {
+	if err := syncConfig.Validate(); err != nil {
 		m.log.Error("invalid sync config", zap.String("config", name), zap.Error(err))
 		return nil, nil, status.Errorf(codes.InvalidArgument, "invalid sync config: %v", err)
 	}
+
+	mapNameV4, mapNameV6 := mergedMapNames(oldConfig, req)
 
 	// The construction only allocates and initializes the replacement
 	// and declares the map-name links: the names resolve against
@@ -289,8 +286,8 @@ func (m *FWStateService) prepareUpdate(
 		name,
 		oldConfig,
 		req.SyncConfig,
-		req.GetMapNameV4(),
-		req.GetMapNameV6(),
+		mapNameV4,
+		mapNameV6,
 	)
 	if err != nil {
 		m.log.Error("failed to build fwstate config", zap.String("config", name), zap.Error(err))
@@ -445,58 +442,6 @@ func (m *FWStateService) unpublishConfig(name string) {
 	defer m.stateMu.Unlock()
 
 	delete(m.configs, name)
-}
-
-// validateSyncPorts rejects sync config ports that do not fit into the
-// C-side uint16 port field.
-//
-// A zero port means "unset / keep current" and is allowed here. The
-// required-destination check in validateSyncConfig rejects a request
-// that leaves the multicast destination unset.
-func validateSyncPorts(cfg *fwstatepb.SyncConfig) error {
-	if portMulticast := cfg.GetPortMulticast(); portMulticast > maxSyncPort {
-		return status.Errorf(codes.InvalidArgument, "port_multicast %d exceeds maximum allowed value %d", portMulticast, maxSyncPort)
-	}
-	return nil
-}
-
-// validateSyncConfig validates that required sync config fields are set
-func validateSyncConfig(cfg *fwstatepb.SyncConfig) error {
-	var missing []string
-
-	// Check src_addr (16 bytes for IPv6)
-	if len(cfg.GetSrcAddr().GetAddr()) != 16 || isAllZeroBytes(cfg.GetSrcAddr().GetAddr()) {
-		missing = append(missing, "src_addr")
-	}
-
-	// The module matches incoming sync packets against the multicast
-	// destination, so both the address and the port are required.
-	if len(cfg.GetDstAddrMulticast().GetAddr()) != 16 || isAllZeroBytes(cfg.GetDstAddrMulticast().GetAddr()) {
-		missing = append(missing, "dst_addr_multicast")
-	}
-	if cfg.GetPortMulticast() == 0 {
-		missing = append(missing, "port_multicast")
-	}
-
-	if len(missing) > 0 {
-		return status.Errorf(codes.InvalidArgument, "missing required sync config fields: %v", missing)
-	}
-
-	if err := cfg.ValidateTimeouts(); err != nil {
-		return status.Errorf(codes.InvalidArgument, "invalid sync config timeouts: %v", err)
-	}
-
-	return nil
-}
-
-// isAllZeroBytes checks if all bytes in the slice are zero
-func isAllZeroBytes(b []byte) bool {
-	for _, v := range b {
-		if v != 0 {
-			return false
-		}
-	}
-	return true
 }
 
 // parkOrFree frees the config when it is dangling and parks it for

--- a/modules/fwstate/controlplane/service_test.go
+++ b/modules/fwstate/controlplane/service_test.go
@@ -1,4 +1,4 @@
-package fwstate
+package fwstate_test
 
 import (
 	"strings"
@@ -9,145 +9,37 @@ import (
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	fwstate "github.com/yanet-platform/yanet2/modules/fwstate/controlplane"
 	"github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
 )
 
-// TestValidateSyncPorts verifies that ports above the uint16 range are
-// rejected with InvalidArgument, while zero and boundary values pass.
-func TestValidateSyncPorts(t *testing.T) {
-	cases := []struct {
-		name          string
-		portMulticast uint32
-		wantErr       bool
-	}{
-		{
-			name:          "zero",
-			portMulticast: 0,
-			wantErr:       false,
-		},
-		{
-			name:          "boundary value",
-			portMulticast: 65535,
-			wantErr:       false,
-		},
-		{
-			name:          "just above boundary",
-			portMulticast: 65536,
-			wantErr:       true,
-		},
-	}
+// Test_FWStateService_UpdateConfig_RejectsPartialSyncDestination verifies
+// that a request naming part of the sync destination is refused.
+//
+// The InvalidArgument it fails with names every part left out, and the
+// agent is not touched before it does.
+func Test_FWStateService_UpdateConfig_RejectsPartialSyncDestination(t *testing.T) {
+	service := fwstate.NewFWStateService(nil)
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := &fwstatepb.SyncConfig{
-				PortMulticast: tc.portMulticast,
-			}
-
-			err := validateSyncPorts(cfg)
-			if !tc.wantErr {
-				require.NoError(t, err)
-				return
-			}
-
-			require.Error(t, err)
-			require.Equal(t, codes.InvalidArgument, status.Code(err))
-		})
-	}
+	_, err := service.UpdateConfig(t.Context(), &fwstatepb.UpdateConfigRequest{
+		Name: "cfg",
+		SyncConfig: &fwstatepb.SyncConfig{
+			PortMulticast: 9999,
+		},
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "src_addr")
+	require.Contains(t, err.Error(), "dst_addr_multicast")
 }
 
-// TestValidateSyncConfigMulticastRequired checks that the multicast
-// destination pair is validated as required.
-func TestValidateSyncConfigMulticastRequired(t *testing.T) {
-	newConfig := func() *fwstatepb.SyncConfig {
-		return &fwstatepb.SyncConfig{
-			SrcAddr:       &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
-			PortMulticast: 1,
-		}
-	}
-
-	t.Run("missing multicast address", func(t *testing.T) {
-		err := validateSyncConfig(newConfig())
-		require.Error(t, err)
-		require.True(t, strings.Contains(err.Error(), "dst_addr_multicast"))
-	})
-
-	t.Run("zero multicast port", func(t *testing.T) {
-		cfg := newConfig()
-		cfg.DstAddrMulticast = &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}}
-		cfg.PortMulticast = 0
-
-		err := validateSyncConfig(cfg)
-		require.Error(t, err)
-		require.True(t, strings.Contains(err.Error(), "port_multicast"))
-	})
-
-	t.Run("valid", func(t *testing.T) {
-		cfg := newConfig()
-		cfg.DstAddrMulticast = &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}}
-
-		err := validateSyncConfig(cfg)
-		require.NoError(t, err)
-	})
-}
-
-// TestUpdateConfigRequiresMapNames checks that a request without both map
-// object names is rejected with InvalidArgument naming the missing field,
-// before any backend or agent state is touched.
-func TestUpdateConfigRequiresMapNames(t *testing.T) {
-	syncConfig := &fwstatepb.SyncConfig{
-		SrcAddr:          &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
-		DstAddrMulticast: &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
-		PortMulticast:    9999,
-	}
-
-	cases := []struct {
-		name       string
-		request    *fwstatepb.UpdateConfigRequest
-		wantDetail string
-	}{
-		{
-			name: "missing map_name_v4",
-			request: &fwstatepb.UpdateConfigRequest{
-				Name:       "cfg",
-				MapNameV6:  "maps-v6",
-				SyncConfig: syncConfig,
-			},
-			wantDetail: "map_name_v4",
-		},
-		{
-			name: "missing map_name_v6",
-			request: &fwstatepb.UpdateConfigRequest{
-				Name:       "cfg",
-				MapNameV4:  "maps-v4",
-				SyncConfig: syncConfig,
-			},
-			wantDetail: "map_name_v6",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			service := NewFWStateService(nil)
-
-			_, err := service.UpdateConfig(t.Context(), tc.request)
-			require.Error(t, err)
-			require.Equal(t, codes.InvalidArgument, status.Code(err))
-			require.Contains(t, err.Error(), tc.wantDetail)
-		})
-	}
-}
-
-// TestUpdateConfigRejectsUnrepresentableMapNames checks that map names too
-// long for the fixed-size C object registry, or containing NUL bytes, are
-// rejected before any C state is built: cp_module_link_object would
-// silently truncate them and link an unintended map.
-func TestUpdateConfigRejectsUnrepresentableMapNames(t *testing.T) {
-	syncConfig := &fwstatepb.SyncConfig{
-		SrcAddr:          &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
-		DstAddrMulticast: &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
-		PortMulticast:    9999,
-	}
-
+// Test_FWStateService_UpdateConfig_RejectsUnrepresentableMapNames verifies
+// that a map name the C object registry cannot carry is refused.
+//
+// A name too long, or one holding a NUL byte, would be truncated on the
+// way in and link an unintended map, so it is refused before any C state
+// is built.
+func Test_FWStateService_UpdateConfig_RejectsUnrepresentableMapNames(t *testing.T) {
 	cases := []struct {
 		name   string
 		mapV4  string
@@ -170,17 +62,153 @@ func TestUpdateConfigRejectsUnrepresentableMapNames(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			service := NewFWStateService(nil)
+			service := fwstate.NewFWStateService(nil)
 
 			_, err := service.UpdateConfig(t.Context(), &fwstatepb.UpdateConfigRequest{
-				Name:       "cfg",
-				MapNameV4:  tc.mapV4,
-				MapNameV6:  tc.mapV6,
-				SyncConfig: syncConfig,
+				Name:      "cfg",
+				MapNameV4: tc.mapV4,
+				MapNameV6: tc.mapV6,
 			})
 			require.Error(t, err)
 			require.Equal(t, codes.InvalidArgument, status.Code(err))
 			require.Contains(t, err.Error(), tc.detail)
 		})
 	}
+}
+
+// syncTestAddr is the address both ends of a test sync destination use;
+// only its presence matters to the validation under test.
+func syncTestAddr() *commonpb.IPAddress {
+	return &commonpb.IPAddress{
+		Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+	}
+}
+
+const syncTestPort = 9999
+
+// showConfig reads back the stored config, which must exist.
+func showConfig(
+	testingTB testing.TB,
+	service *fwstate.FWStateService,
+	name string,
+) *fwstatepb.ShowConfigResponse {
+	testingTB.Helper()
+
+	response, err := service.ShowConfig(
+		testingTB.Context(), &fwstatepb.ShowConfigRequest{Name: name},
+	)
+	require.NoError(testingTB, err)
+
+	return response
+}
+
+// Test_FWStateService_UpdateConfig_CreatesConfigWithoutSyncOrMaps
+// verifies that a create naming only the config succeeds.
+//
+// The installed module links no map and matches no sync packet, leaving
+// both to a later update.
+func Test_FWStateService_UpdateConfig_CreatesConfigWithoutSyncOrMaps(t *testing.T) {
+	const configName = "fwstate-bare"
+
+	_, agent := newDeleteTestHarness(t, []string{"fwstate"}, "fwstate-bare")
+	service := fwstate.NewFWStateService(agent)
+
+	_, err := service.UpdateConfig(t.Context(), &fwstatepb.UpdateConfigRequest{
+		Name: configName,
+	})
+	require.NoError(t, err)
+	require.True(t, hasCPConfig(agent.DPConfig().CPConfigs(), fwstateModuleType, configName))
+
+	stored := showConfig(t, service, configName)
+	require.Empty(t, stored.GetMapNameV4())
+	require.Empty(t, stored.GetMapNameV6())
+	require.Zero(t, stored.GetSyncConfig().GetPortMulticast())
+	require.Equal(t, make([]byte, 16), stored.GetSyncConfig().GetSrcAddr().GetAddr())
+	require.Equal(t, make([]byte, 16), stored.GetSyncConfig().GetDstAddrMulticast().GetAddr())
+
+	// The timeouts are not part of the sync destination and always carry
+	// the defaults, so an unconfigured config is still a usable one.
+	require.NotZero(t, stored.GetSyncConfig().GetUdp())
+}
+
+// Test_FWStateService_UpdateConfig_AttachesMapsAndSyncLater verifies
+// that a later update supplies what a bare create left out.
+func Test_FWStateService_UpdateConfig_AttachesMapsAndSyncLater(t *testing.T) {
+	const configName = "fwstate-attach-later"
+
+	_, agent := newDeleteTestHarness(t, []string{"fwstate"}, "fwstate-attach-later")
+	maps := newFWStateTestMaps(t, agent, "attach-later", 1024)
+	service := fwstate.NewFWStateService(agent)
+
+	_, err := service.UpdateConfig(t.Context(), &fwstatepb.UpdateConfigRequest{
+		Name: configName,
+	})
+	require.NoError(t, err)
+
+	_, err = service.UpdateConfig(t.Context(), &fwstatepb.UpdateConfigRequest{
+		Name:      configName,
+		MapNameV4: maps.v4Name(),
+		MapNameV6: maps.v6Name(),
+		SyncConfig: &fwstatepb.SyncConfig{
+			SrcAddr:          syncTestAddr(),
+			DstAddrMulticast: syncTestAddr(),
+			PortMulticast:    syncTestPort,
+		},
+	})
+	require.NoError(t, err)
+
+	stored := showConfig(t, service, configName)
+	require.Equal(t, maps.v4Name(), stored.GetMapNameV4())
+	require.Equal(t, maps.v6Name(), stored.GetMapNameV6())
+	require.EqualValues(t, syncTestPort, stored.GetSyncConfig().GetPortMulticast())
+	require.Equal(t, syncTestAddr().GetAddr(), stored.GetSyncConfig().GetDstAddrMulticast().GetAddr())
+}
+
+// Test_FWStateService_UpdateConfig_KeepsUnnamedLinksAndUntouchedSync
+// verifies that unnamed links and untouched sync stay as they were.
+//
+// An update naming neither a map nor a sync destination must not
+// silently unlink the maps or stop synchronization.
+func Test_FWStateService_UpdateConfig_KeepsUnnamedLinksAndUntouchedSync(t *testing.T) {
+	const (
+		configName = "fwstate-partial-update"
+		udpTimeout = 45e9
+	)
+
+	_, agent := newDeleteTestHarness(t, []string{"fwstate"}, "fwstate-partial-update")
+	maps := newFWStateTestMaps(t, agent, "partial-update", 1024)
+	service := fwstate.NewFWStateService(agent)
+
+	_, err := service.UpdateConfig(t.Context(), validDeleteTestUpdateRequest(
+		configName, maps.v4Name(), maps.v6Name(),
+	))
+	require.NoError(t, err)
+
+	// A timeout-only update: no map name, and a sync config naming no
+	// part of the destination.
+	_, err = service.UpdateConfig(t.Context(), &fwstatepb.UpdateConfigRequest{
+		Name:       configName,
+		SyncConfig: &fwstatepb.SyncConfig{Udp: udpTimeout},
+	})
+	require.NoError(t, err)
+
+	stored := showConfig(t, service, configName)
+	require.Equal(t, maps.v4Name(), stored.GetMapNameV4())
+	require.Equal(t, maps.v6Name(), stored.GetMapNameV6())
+	require.EqualValues(t, udpTimeout, stored.GetSyncConfig().GetUdp())
+	require.EqualValues(t, syncTestPort, stored.GetSyncConfig().GetPortMulticast())
+	require.Equal(t, syncTestAddr().GetAddr(), stored.GetSyncConfig().GetSrcAddr().GetAddr())
+
+	// An update carrying no sync settings at all keeps them too.
+	_, err = service.UpdateConfig(t.Context(), &fwstatepb.UpdateConfigRequest{
+		Name:      configName,
+		MapNameV4: maps.v4Name(),
+		MapNameV6: maps.v6Name(),
+	})
+	require.NoError(t, err)
+
+	stored = showConfig(t, service, configName)
+	require.EqualValues(t, udpTimeout, stored.GetSyncConfig().GetUdp())
+	require.EqualValues(t, syncTestPort, stored.GetSyncConfig().GetPortMulticast())
+	require.Equal(t, syncTestAddr().GetAddr(), stored.GetSyncConfig().GetDstAddrMulticast().GetAddr())
 }

--- a/modules/fwstate/dataplane/dataplane.c
+++ b/modules/fwstate/dataplane/dataplane.c
@@ -67,6 +67,12 @@ static bool
 is_fw_state_sync_packet(
 	struct packet *packet, struct fwstate_sync_config *sync_config
 ) {
+	// A config that names no sync destination claims no packet: the
+	// module passes everything through until one is configured.
+	if (sync_config->port_multicast == 0) {
+		return false;
+	}
+
 	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
 
 	// Check for multicast Ethernet destination

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -132,6 +132,14 @@ func SetSyncSuppressTimeout(cpModule *C.struct_cp_module, ns uint64) {
 	m.sync_config.sync_suppress_timeout = C.uint64_t(ns)
 }
 
+// ClearSyncDestination leaves the module config without a sync
+// destination, the state a config created with no sync settings carries.
+func ClearSyncDestination(cpModule *C.struct_cp_module) {
+	m := (*C.struct_fwstate_module_config)(unsafe.Pointer(cpModule))
+	m.sync_config.port_multicast = 0
+	m.sync_config.dst_addr_multicast = [16]C.uint8_t{}
+}
+
 // SetSyncTCPTimeouts overrides the TCP established (tcp) and teardown
 // (tcp_fin) timeouts so a test can distinguish an established refresh from a
 // shorter-TTL state transition.

--- a/modules/fwstate/tests/dataplane/fwstate_test.go
+++ b/modules/fwstate/tests/dataplane/fwstate_test.go
@@ -18,13 +18,15 @@ import (
 type SyncPacketOption func(*syncPacketConfig)
 
 type syncPacketConfig struct {
-	srcPort    uint16
-	dstPort    uint16
-	srcAddr    string
-	dstAddr    string
-	isExternal bool
-	flags      uint8
-	fib        uint8
+	srcPort      uint16
+	dstPort      uint16
+	srcAddr      string
+	dstAddr      string
+	outerDstAddr string
+	outerDstPort uint16
+	isExternal   bool
+	flags        uint8
+	fib          uint8
 }
 
 // WithPorts sets custom source and destination ports
@@ -40,6 +42,15 @@ func WithAddrs(srcAddr, dstAddr string) SyncPacketOption {
 	return func(c *syncPacketConfig) {
 		c.srcAddr = srcAddr
 		c.dstAddr = dstAddr
+	}
+}
+
+// WithOuterDst sets the sync destination the packet is addressed to, the
+// pair a module matches its own configuration against.
+func WithOuterDst(addr string, port uint16) SyncPacketOption {
+	return func(c *syncPacketConfig) {
+		c.outerDstAddr = addr
+		c.outerDstPort = port
 	}
 }
 
@@ -69,11 +80,13 @@ func WithFib(fib uint8) SyncPacketOption {
 func createSyncPacket(t *testing.T, proto layers.IPProtocol, opts ...SyncPacketOption) gopacket.Packet {
 	// Apply defaults
 	cfg := syncPacketConfig{
-		srcPort:    12345,
-		dstPort:    9999,
-		srcAddr:    "2001:db8::1",
-		dstAddr:    "2001:db8::2",
-		isExternal: false,
+		srcPort:      12345,
+		dstPort:      9999,
+		srcAddr:      "2001:db8::1",
+		dstAddr:      "2001:db8::2",
+		outerDstAddr: "ff02::1",
+		outerDstPort: 9999,
+		isExternal:   false,
 	}
 
 	// Apply options
@@ -104,12 +117,12 @@ func createSyncPacket(t *testing.T, proto layers.IPProtocol, opts ...SyncPacketO
 		NextHeader: layers.IPProtocolUDP,
 		HopLimit:   64,
 		SrcIP:      srcIP,
-		DstIP:      net.ParseIP("ff02::1"), // Multicast destination
+		DstIP:      net.ParseIP(cfg.outerDstAddr), // Multicast destination
 	}
 
 	udp := layers.UDP{
 		SrcPort: 12345,
-		DstPort: 9999, // Sync port
+		DstPort: layers.UDPPort(cfg.outerDstPort), // Sync port
 	}
 	udp.SetNetworkLayerForChecksum(&ip6)
 
@@ -157,6 +170,34 @@ func TestFWStateExternalPacket(t *testing.T) {
 	// External packets should be dropped
 	require.Empty(t, result.Output, "External packet should not be forwarded")
 	require.NotEmpty(t, result.Drop, "External packet should be dropped")
+}
+
+// Test_FWStateModule_UnconfiguredSync_PassesSyncPacketThrough verifies
+// that a module carrying no sync destination claims no packet at all.
+//
+// A packet an otherwise identical configured module would consume is
+// passed through instead.
+func Test_FWStateModule_UnconfiguredSync_PassesSyncPacketThrough(t *testing.T) {
+	// The packet is addressed to the unset destination itself, the only
+	// one such a config could match.
+	//
+	// It is external, and a claimed external packet is dropped after its
+	// frames are applied, so passing it through can only mean it was
+	// never claimed.
+	pkt := createSyncPacket(
+		t, layers.IPProtocolUDP, WithExternal(), WithOuterDst("::", 0),
+	)
+
+	memCtx := testutils.NewMemoryContext("fwstate_test", datasize.MB*64)
+	defer memCtx.Free()
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
+	ClearSyncDestination(cpModule)
+
+	result := xerror.Unwrap(fwstateHandlePackets(cpModule, storage, pkt))
+
+	require.NotEmpty(t, result.Output, "an unclaimed packet should be passed through")
+	require.Empty(t, result.Drop, "an unclaimed packet should not be dropped")
 }
 
 func TestFWStateNonSyncPacket(t *testing.T) {


### PR DESCRIPTION
- Synchronization is optional: a config naming no part of the sync destination is accepted and installs a module that matches no sync packet, so a first create needs nothing but a name. Naming only part of that destination is still refused, since such a module would look configured while matching nothing.
- The linked maps are optional the same way. An unnamed map keeps the link the config already has, and one never named declares no link at all, which the module answers by counting and dropping that family's synced state until a later update names its map.
- An update that leaves out the sync settings or the map names no longer resets them: the settings were reset to the defaults and the links dropped, where the request had asked for no change to either.
- An address stated at a width other than an IPv6 one is refused instead of being read as far as it goes.
- The dataplane claims no packet while no sync destination is configured, so an unconfigured module cannot be made to insert state by a packet addressed to the unset destination.
- The list hint of the module CLI names the flags a create actually needs, and the client-side requirement for both map flags is gone.