### PR TITLE
fix(cli): match the certificate tag against the key id exactly

### DIFF
--- a/cli/core/src/auth/agent.rs
+++ b/cli/core/src/auth/agent.rs
@@ -24,6 +24,16 @@ const MAX_RESPONSE_SIZE: usize = 1 << 20;
 /// Maximum number of identities accepted from agent.
 const MAX_IDENTITIES: usize = 1024;
 
+/// Names the certificates an agent holds, for the error raised when none
+/// carries the requested key id.
+fn agent_key_ids(key_ids: &[String]) -> String {
+    if key_ids.is_empty() {
+        "it holds no certificate".to_owned()
+    } else {
+        format!("it holds: {}", key_ids.join(", "))
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum AgentError {
     #[error("SSH_AUTH_SOCK environment variable not set")]
@@ -44,8 +54,8 @@ pub enum AgentError {
     #[error("SSH key parse error: {0}")]
     SshKey(#[from] ssh_key::Error),
 
-    #[error("no suitable certificate found in SSH agent")]
-    NoCertificateFound,
+    #[error("no certificate with key id {key_id} in the SSH agent, {}", agent_key_ids(.key_ids))]
+    NoCertificateFound { key_id: String, key_ids: Vec<String> },
 
     #[error("payload too large for SSH agent protocol")]
     PayloadTooLarge,
@@ -114,23 +124,28 @@ impl SshAgent {
         parse_identities_answer(&response)
     }
 
-    /// Find the first certificate matching the given tag.
-    pub async fn find_certificate(&mut self, tag: &str) -> Result<(Certificate, Vec<u8>), AgentError> {
+    /// Find the certificate whose key id is exactly `key_id`.
+    pub async fn find_certificate(&mut self, key_id: &str) -> Result<(Certificate, Vec<u8>), AgentError> {
         let identities = self.identities().await?;
+        let mut key_ids = Vec::new();
 
         for identity in identities {
-            if let Some(cert) = identity.certificate()
-                && cert.key_id().contains(tag)
-            {
-                let blob = identity.to_bytes()?;
+            let Some(cert) = identity.certificate() else {
+                continue;
+            };
+            let found = cert.key_id().to_owned();
+            if found != key_id {
+                key_ids.push(found);
+                continue;
+            }
 
-                if let SshIdentity::Certificate(cert) = identity {
-                    return Ok((*cert, blob));
-                }
+            let blob = identity.to_bytes()?;
+            if let SshIdentity::Certificate(cert) = identity {
+                return Ok((*cert, blob));
             }
         }
 
-        Err(AgentError::NoCertificateFound)
+        Err(AgentError::NoCertificateFound { key_id: key_id.to_owned(), key_ids })
     }
 
     /// Sign data using the key identified by `key_blob`.

--- a/cli/core/src/auth/agent.rs
+++ b/cli/core/src/auth/agent.rs
@@ -24,16 +24,6 @@ const MAX_RESPONSE_SIZE: usize = 1 << 20;
 /// Maximum number of identities accepted from agent.
 const MAX_IDENTITIES: usize = 1024;
 
-/// Names the certificates an agent holds, for the error raised when none
-/// carries the requested key id.
-fn agent_key_ids(key_ids: &[String]) -> String {
-    if key_ids.is_empty() {
-        "it holds no certificate".to_owned()
-    } else {
-        format!("it holds: {}", key_ids.join(", "))
-    }
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum AgentError {
     #[error("SSH_AUTH_SOCK environment variable not set")]
@@ -54,8 +44,8 @@ pub enum AgentError {
     #[error("SSH key parse error: {0}")]
     SshKey(#[from] ssh_key::Error),
 
-    #[error("no certificate with key id {key_id} in the SSH agent, {}", agent_key_ids(.key_ids))]
-    NoCertificateFound { key_id: String, key_ids: Vec<String> },
+    #[error("no suitable certificate found in SSH agent")]
+    NoCertificateFound,
 
     #[error("payload too large for SSH agent protocol")]
     PayloadTooLarge,
@@ -124,28 +114,23 @@ impl SshAgent {
         parse_identities_answer(&response)
     }
 
-    /// Find the certificate whose key id is exactly `key_id`.
-    pub async fn find_certificate(&mut self, key_id: &str) -> Result<(Certificate, Vec<u8>), AgentError> {
+    /// Find the certificate whose key id is the given tag.
+    pub async fn find_certificate(&mut self, tag: &str) -> Result<(Certificate, Vec<u8>), AgentError> {
         let identities = self.identities().await?;
-        let mut key_ids = Vec::new();
 
         for identity in identities {
-            let Some(cert) = identity.certificate() else {
-                continue;
-            };
-            let found = cert.key_id().to_owned();
-            if found != key_id {
-                key_ids.push(found);
-                continue;
-            }
+            if let Some(cert) = identity.certificate()
+                && cert.key_id() == tag
+            {
+                let blob = identity.to_bytes()?;
 
-            let blob = identity.to_bytes()?;
-            if let SshIdentity::Certificate(cert) = identity {
-                return Ok((*cert, blob));
+                if let SshIdentity::Certificate(cert) = identity {
+                    return Ok((*cert, blob));
+                }
             }
         }
 
-        Err(AgentError::NoCertificateFound { key_id: key_id.to_owned(), key_ids })
+        Err(AgentError::NoCertificateFound)
     }
 
     /// Sign data using the key identified by `key_blob`.

--- a/cli/core/src/auth/mod.rs
+++ b/cli/core/src/auth/mod.rs
@@ -40,8 +40,8 @@ pub struct AuthArgs {
     /// `none`.
     #[arg(long, global = true, env = "YANET_AUTH")]
     pub auth: Option<AuthMethod>,
-    /// Substring matched against a certificate's key id to select it from
-    /// the SSH agent, required when `--auth sshcert` is in effect.
+    /// Key id of the certificate to use from the SSH agent, matched
+    /// exactly, required when `--auth sshcert` is in effect.
     ///
     /// Falls back to the `cert_tag` key of the configuration file.
     #[arg(long, global = true, env = "YANET_CERT_TAG")]

--- a/cli/core/src/config.rs
+++ b/cli/core/src/config.rs
@@ -157,8 +157,6 @@ impl Settings {
             AuthMethod::None => Ok(auth::ResolvedAuth::None),
             AuthMethod::Sshcert => match self.cert_tag.value.as_deref().map(str::trim) {
                 Some(tag) if !tag.is_empty() => Ok(auth::ResolvedAuth::Sshcert { tag: tag.to_owned() }),
-                // An empty tag matches every identity in the agent through
-                // `contains("")`, so it is treated the same as no tag at all.
                 _ => Err(Error::MissingCertTag),
             },
         }


### PR DESCRIPTION
- Select the SSH agent certificate whose key id equals the tag instead of the first one containing it, so a partial tag can no longer pick an unintended certificate.
- Describe the tag as an exact key id in the flag help.
