### PR TITLE
chore(deps): update tonic and prost to 0.14

### DIFF
--- a/.agents/skills/code-cli/references/new-crate.md
+++ b/.agents/skills/code-cli/references/new-crate.md
@@ -36,17 +36,23 @@ ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 netip = "0.3"
-prost = "0.13"
+prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 tabled = { version = "0.21", features = ["ansi"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
 ```
 
 Add a dependency only when the code uses it; `netip` and `tabled` are
 listed because almost every binary parses an address or prints a table.
+
+`tonic-prost-build` keeps its default features off: the default
+`cleanup-markdown` re-renders proto doc comments and fails clippy's
+`doc_lazy_continuation` on the generated code, while `transport` keeps the
+generated `connect` constructors that tonic-build 0.13 always emitted.
 
 ## build.rs
 
@@ -61,7 +67,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let proto = "<owner>/<x>/controlplane/<x>pb/v1/<x>.proto";
     println!("cargo:rerun-if-changed={root}/{proto}");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute(".", "#[derive(serde::Serialize)]")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ modules/<name>/
   bindings/go/   CGO wrapper consumed by controlplane
   controlplane/  <name>pb/ protos, mod.go (BuiltInModule, New(opts)), backend.go (shm write path), service.go (+_test), cfg.go
   dataplane/     config.h (shm config struct), dataplane.c/h (entry; hot paths are static inline in headers)
-  cli/           Rust crate, build.rs runs tonic-build (client only)
+  cli/           Rust crate, build.rs runs tonic-prost-build (client only)
   tests/  fuzzing/  [internal/]
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +910,15 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -1036,7 +1051,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1528,11 +1543,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
  "indexmap",
 ]
 
@@ -1698,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1708,16 +1724,15 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
- "petgraph 0.7.1",
+ "petgraph 0.8.3",
  "prettyplease",
  "prost",
  "prost-types",
@@ -1728,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -1741,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -2189,16 +2204,6 @@ checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -2475,7 +2480,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2570,9 +2575,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -2588,9 +2593,9 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
  "rustls-native-certs",
- "socket2 0.5.10",
+ "socket2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -2602,9 +2607,45 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.13.1"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
+dependencies = [
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2612,18 +2653,8 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "tonic-health"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
-dependencies = [
- "prost",
- "tokio",
- "tokio-stream",
- "tonic",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -3082,7 +3113,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "simple_logger",
- "socket2 0.6.5",
+ "socket2",
  "ssh-key",
  "tabled",
  "terminal_size",
@@ -3091,6 +3122,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-health",
+ "tonic-prost",
  "tower",
  "uuid",
  "yanet-commonpb",
@@ -3110,7 +3142,8 @@ dependencies = [
  "serde_yaml",
  "tabled",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
  "yanet-filterpb",
@@ -3133,7 +3166,8 @@ dependencies = [
  "serde_yaml",
  "tabled",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
  "yanet-filterpb",
@@ -3149,7 +3183,8 @@ dependencies = [
  "prost",
  "serde",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
 ]
 
@@ -3188,7 +3223,8 @@ dependencies = [
  "ptree",
  "serde",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3212,7 +3248,8 @@ dependencies = [
  "prost",
  "serde",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3226,7 +3263,8 @@ dependencies = [
  "prost",
  "serde",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3239,7 +3277,8 @@ dependencies = [
  "prost",
  "serde",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3256,7 +3295,8 @@ dependencies = [
  "ptree",
  "serde",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3271,7 +3311,8 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
  "yanet-filterpb",
@@ -3302,7 +3343,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3318,7 +3360,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3368,7 +3411,8 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
  "yanet-filterpb",
@@ -3386,7 +3430,8 @@ dependencies = [
  "ptree",
  "serde",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3403,7 +3448,8 @@ dependencies = [
  "serde_json",
  "tabled",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3429,7 +3475,8 @@ dependencies = [
  "serde_json",
  "tabled",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3451,7 +3498,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
 ]
 
@@ -3498,7 +3546,8 @@ dependencies = [
  "tabled",
  "tokio",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3514,7 +3563,8 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
 ]
@@ -3530,7 +3580,8 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
  "yanet-filterpb",
@@ -3545,7 +3596,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tonic",
- "tonic-build",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -3557,7 +3608,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tonic",
- "tonic-build",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -3569,7 +3620,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tonic",
- "tonic-build",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -3580,7 +3631,8 @@ dependencies = [
  "prost-types",
  "serde",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "yanet-commonpb",
 ]
 

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -18,9 +18,10 @@ colored = "3"
 tabled = { version = "0.21", features = ["ansi"] }
 terminal_size = "0.4"
 tokio = { version = "1", features = ["net", "io-util", "time", "sync", "rt"] }
-prost = "0.13"
-prost-types = "0.13"
-tonic = { version = "0.13", features = ["gzip", "tls-aws-lc", "tls-native-roots"] }
+prost = "0.14"
+prost-types = "0.14"
+tonic = { version = "0.14", features = ["gzip", "tls-aws-lc", "tls-native-roots"] }
+tonic-prost = "0.14"
 ynpb = { path = "../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 commonpb = { path = "../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 tower = "0.5"
@@ -43,5 +44,5 @@ libc = "0.2"
 tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1", features = ["macros", "test-util"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic-health = "0.13"
+tonic-health = "0.14"
 socket2 = "0.6"

--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -32,9 +32,10 @@ use prost::Message;
 use tonic::{
     Request, Status,
     client::Grpc,
-    codec::{CompressionEncoding, ProstCodec},
+    codec::CompressionEncoding,
     transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity},
 };
+use tonic_prost::ProstCodec;
 use tower::Layer;
 
 use crate::{

--- a/cli/modules/common/Cargo.toml
+++ b/cli/modules/common/Cargo.toml
@@ -13,4 +13,4 @@ workspace = true
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }

--- a/cli/modules/counters/Cargo.toml
+++ b/cli/modules/counters/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
 bytesize = "2"
 tabled = { version = "0.21", features = ["ansi"] }
 serde_yaml = "0.9"

--- a/cli/modules/device/Cargo.toml
+++ b/cli/modules/device/Cargo.toml
@@ -13,5 +13,5 @@ workspace = true
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
 colored = "3"

--- a/cli/modules/function/Cargo.toml
+++ b/cli/modules/function/Cargo.toml
@@ -15,5 +15,5 @@ commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = 
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
 serde_yaml = "0.9"

--- a/cli/modules/gateway/Cargo.toml
+++ b/cli/modules/gateway/Cargo.toml
@@ -13,6 +13,6 @@ workspace = true
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
-prost-types = "0.13"
-tonic = { version = "0.13", features = ["gzip"] }
+prost-types = "0.14"
+tonic = { version = "0.14", features = ["gzip"] }
 tabled = { version = "0.21", features = ["ansi"] }

--- a/cli/modules/inspect/Cargo.toml
+++ b/cli/modules/inspect/Cargo.toml
@@ -13,6 +13,6 @@ workspace = true
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
 ptree = "0.5"
 bytesize = "2"

--- a/cli/modules/pipeline/Cargo.toml
+++ b/cli/modules/pipeline/Cargo.toml
@@ -16,4 +16,4 @@ ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 serde_yaml = "0.9"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }

--- a/cli/modules/ready/Cargo.toml
+++ b/cli/modules/ready/Cargo.toml
@@ -14,7 +14,7 @@ ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 readinesspb = { path = "../../../common/rust/readinesspb", version = "0.1", package = "yanet-readinesspb" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost-types = "0.13"
+prost-types = "0.14"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 colored = "3"

--- a/common/rust/commonpb/Cargo.toml
+++ b/common/rust/commonpb/Cargo.toml
@@ -11,12 +11,12 @@ workspace = true
 
 [dependencies]
 netip = "0.3"
-prost = "0.13"
+prost = "0.14"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
 
 [dev-dependencies]
 serde_json = "1"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipv6network.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipv6prefix.proto");
 
-    let mut config = tonic_build::configure()
+    let mut config = tonic_prost_build::configure()
         .build_server(false)
         // Covers `Metric`'s `value` oneof, generated as its own enum --
         // `Metric` cannot derive `Serialize`/`Deserialize` unless that enum

--- a/common/rust/filterpb/Cargo.toml
+++ b/common/rust/filterpb/Cargo.toml
@@ -11,12 +11,12 @@ workspace = true
 
 [dependencies]
 netip = "0.3"
-prost = "0.13"
+prost = "0.14"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
 
 [dev-dependencies]
 serde_json = "1"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/common/rust/filterpb/build.rs
+++ b/common/rust/filterpb/build.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let serialize_deserialize = "#[derive(serde::Serialize, serde::Deserialize)]#[serde(default, deny_unknown_fields)]";
     let null_as_default = "#[serde(deserialize_with = \"crate::null_as_default\")]";
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute(".common.filterpb.v1.Device", serialize_deserialize)

--- a/common/rust/readinesspb/Cargo.toml
+++ b/common/rust/readinesspb/Cargo.toml
@@ -10,13 +10,13 @@ rust-version = "1.88"
 workspace = true
 
 [dependencies]
-prost = "0.13"
-prost-types = "0.13"
+prost = "0.14"
+prost-types = "0.14"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
 
 [dev-dependencies]
 serde_json = "1"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/common/rust/readinesspb/build.rs
+++ b/common/rust/readinesspb/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=common/readinesspb/v1/readiness.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute("common.readinesspb.v1.Reason", "#[derive(serde::Serialize)]")

--- a/common/rust/ynpb/Cargo.toml
+++ b/common/rust/ynpb/Cargo.toml
@@ -10,11 +10,12 @@ rust-version = "1.88"
 workspace = true
 
 [dependencies]
-prost = "0.13"
-prost-types = "0.13"
+prost = "0.14"
+prost-types = "0.14"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 commonpb = { path = "../commonpb", version = "0.1", package = "yanet-commonpb" }
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/common/rust/ynpb/build.rs
+++ b/common/rust/ynpb/build.rs
@@ -1,7 +1,7 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(false)
         .message_attribute(".", "#[derive(serde::Serialize)]")
         .field_attribute(

--- a/devices/plain/cli/Cargo.toml
+++ b/devices/plain/cli/Cargo.toml
@@ -13,9 +13,10 @@ workspace = true
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
-prost = "0.13"
+prost = "0.14"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/devices/plain/cli/build.rs
+++ b/devices/plain/cli/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/plainpb/v1/plain.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/devices/trafgen/cli/Cargo.toml
+++ b/devices/trafgen/cli/Cargo.toml
@@ -14,9 +14,10 @@ commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = 
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
-tonic = { version = "0.13", features = ["gzip"] }
+prost = "0.14"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/devices/trafgen/cli/build.rs
+++ b/devices/trafgen/cli/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/trafgenpb/v1/trafgen.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/devices/vlan/cli/Cargo.toml
+++ b/devices/vlan/cli/Cargo.toml
@@ -13,9 +13,10 @@ workspace = true
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
-prost = "0.13"
+prost = "0.14"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/devices/vlan/cli/build.rs
+++ b/devices/vlan/cli/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/vlanpb/v1/vlan.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/modules/acl/cli/Cargo.toml
+++ b/modules/acl/cli/Cargo.toml
@@ -17,11 +17,12 @@ netip = "0.3"
 log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
-tonic = { version = "0.13", features = ["gzip"] }
+prost = "0.14"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 tabled = { version = "0.21", features = ["ansi"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/acl/cli/build.rs
+++ b/modules/acl/cli/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/aclpb/v1/acl.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/modules/balancer2/cli/Cargo.toml
+++ b/modules/balancer2/cli/Cargo.toml
@@ -15,9 +15,10 @@ filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = 
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-tonic = { version = "0.13", features = ["gzip"] }
-prost = "0.13"
-prost-types = "0.13"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
+prost = "0.14"
+prost-types = "0.14"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
@@ -28,4 +29,4 @@ chrono = "0.4"
 netip = "0.3"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/balancer2/cli/build.rs
+++ b/modules/balancer2/cli/build.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/balancerpb/v1/state.proto");
     println!("cargo:rerun-if-changed=../controlplane/balancerpb/v1/filter.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .protoc_arg("--experimental_allow_proto3_optional")

--- a/modules/blackhole/cli/Cargo.toml
+++ b/modules/blackhole/cli/Cargo.toml
@@ -14,9 +14,10 @@ ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
-tonic = { version = "0.13", features = ["gzip"] }
+prost = "0.14"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/blackhole/cli/build.rs
+++ b/modules/blackhole/cli/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/blackholepb/v1/blackhole.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute(".", "#[derive(Serialize)]")

--- a/modules/decap/cli/Cargo.toml
+++ b/modules/decap/cli/Cargo.toml
@@ -16,10 +16,11 @@ netip = "0.3"
 log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
-tonic = { version = "0.13", features = ["gzip"] }
+prost = "0.14"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 ptree = "0.5"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/decap/cli/build.rs
+++ b/modules/decap/cli/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/decappb/v1/decap.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/modules/dscp/cli/Cargo.toml
+++ b/modules/dscp/cli/Cargo.toml
@@ -17,9 +17,10 @@ clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.13", features = ["gzip"] }
-prost = "0.13"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
+prost = "0.14"
 ptree = "0.5"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/dscp/cli/build.rs
+++ b/modules/dscp/cli/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/dscppb/v1/dscp.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/modules/forward/cli/Cargo.toml
+++ b/modules/forward/cli/Cargo.toml
@@ -15,10 +15,11 @@ commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = 
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
+prost = "0.14"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 serde_yaml = "0.9"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/forward/cli/build.rs
+++ b/modules/forward/cli/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/forwardpb/v1/forward.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/modules/fwstate/cli/Cargo.toml
+++ b/modules/fwstate/cli/Cargo.toml
@@ -15,11 +15,12 @@ commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = 
 log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
-tonic = { version = "0.13", features = ["gzip"] }
+prost = "0.14"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 humantime = "2"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/fwstate/cli/build.rs
+++ b/modules/fwstate/cli/build.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../../../common/commonpb/v1/macaddr.proto");
     println!("cargo:rerun-if-changed=../../../common/commonpb/v1/metric.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/modules/mirror/cli/Cargo.toml
+++ b/modules/mirror/cli/Cargo.toml
@@ -15,10 +15,11 @@ commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = 
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
+prost = "0.14"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 serde_yaml = "0.9"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/mirror/cli/build.rs
+++ b/modules/mirror/cli/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/mirrorpb/v1/mirror.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/modules/nat64/cli/Cargo.toml
+++ b/modules/nat64/cli/Cargo.toml
@@ -16,10 +16,11 @@ netip = "0.3"
 log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
-tonic = { version = "0.13", features = ["gzip"] }
+prost = "0.14"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 ptree = "0.5"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/nat64/cli/build.rs
+++ b/modules/nat64/cli/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/nat64pb/v1/nat64.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/modules/pdump/cli/Cargo.toml
+++ b/modules/pdump/cli/Cargo.toml
@@ -15,8 +15,9 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt", "macros", "signal"] }
-tonic = { version = "0.13", features = ["gzip"] }
-prost = "0.13"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
+prost = "0.14"
 ptree = "0.5"
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 bytesize = "2"
@@ -27,5 +28,5 @@ tokio-util = "0.7"
 pnet_packet = "0.35"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
 bindgen = "0.72"

--- a/modules/pdump/cli/build.rs
+++ b/modules/pdump/cli/build.rs
@@ -4,7 +4,7 @@ use std::{env, path::PathBuf};
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/pdumppb/v1/pdump.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute(".", "#[derive(Serialize)]")

--- a/modules/route-mpls/cli/Cargo.toml
+++ b/modules/route-mpls/cli/Cargo.toml
@@ -15,10 +15,11 @@ commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = 
 netip = "0.3"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
-tonic = { version = "0.13", features = ["gzip"] }
+prost = "0.14"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/route-mpls/cli/build.rs
+++ b/modules/route-mpls/cli/build.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../../../common/commonpb/v1/ipaddr.proto");
     println!("cargo:rerun-if-changed=../controlplane/routemplspb/v1/routempls.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/modules/route/cli/Cargo.toml
+++ b/modules/route/cli/Cargo.toml
@@ -14,8 +14,9 @@ commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = 
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
-tonic = { version = "0.13", features = ["gzip"] }
+prost = "0.14"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 tabled = { version = "0.21", features = ["ansi"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
@@ -26,4 +27,4 @@ netip = "0.3"
 tokio = { version = "1", features = ["macros", "net", "rt", "time"] }
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/route/cli/build.rs
+++ b/modules/route/cli/build.rs
@@ -19,7 +19,7 @@ const SERDE_MESSAGES: &[&str] = &[
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/routepb/v1/route.proto");
 
-    let mut config = tonic_build::configure()
+    let mut config = tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/modules/unrdup/cli/Cargo.toml
+++ b/modules/unrdup/cli/Cargo.toml
@@ -18,8 +18,9 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
-tonic = { version = "0.13", features = ["gzip"] }
-prost = "0.13"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
+prost = "0.14"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/unrdup/cli/build.rs
+++ b/modules/unrdup/cli/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/unrduppb/v1/unrdup.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute(".", "#[derive(Serialize)]")

--- a/objects/fwstate/cli/Cargo.toml
+++ b/objects/fwstate/cli/Cargo.toml
@@ -15,10 +15,11 @@ commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = 
 log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
-tonic = { version = "0.13", features = ["gzip"] }
+prost = "0.14"
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/objects/fwstate/cli/build.rs
+++ b/objects/fwstate/cli/build.rs
@@ -4,7 +4,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/fwstatemappb/v1/fwstatemap.proto");
     println!("cargo:rerun-if-changed=../../../common/commonpb/v1/ipaddr.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")

--- a/operators/route/cli/neighbour/Cargo.toml
+++ b/operators/route/cli/neighbour/Cargo.toml
@@ -14,14 +14,15 @@ commonpb = { path = "../../../../common/rust/commonpb", version = "0.1", package
 ync = { path = "../../../../cli/core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
+prost = "0.14"
 netip = "0.3"
 serde = { version = "1", features = ["derive"] }
 tabled = { version = "0.21", features = ["ansi"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 
 [dev-dependencies]
 serde_json = "1"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/operators/route/cli/neighbour/build.rs
+++ b/operators/route/cli/neighbour/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../../operatorpb/v1/neighbour.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute(".", "#[derive(serde::Serialize)]")

--- a/operators/route/cli/route/Cargo.toml
+++ b/operators/route/cli/route/Cargo.toml
@@ -14,15 +14,16 @@ ync = { path = "../../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-prost = "0.13"
+prost = "0.14"
 netip = "0.3"
 colored = "3"
 serde = "1"
 tabled = { version = "0.21", features = ["ansi"] }
-tonic = { version = "0.13", features = ["gzip"] }
+tonic = { version = "0.14", features = ["gzip"] }
+tonic-prost = "0.14"
 
 [dev-dependencies]
 serde_json = "1"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/operators/route/cli/route/build.rs
+++ b/operators/route/cli/route/build.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../../operatorpb/v1/route.proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute(".", "#[derive(serde::Serialize)]")


### PR DESCRIPTION
- Moves the workspace to tonic 0.14 and prost 0.14, with the prost codec and codegen now coming from the new tonic-prost and tonic-prost-build crates, and updates the new-crate template and AGENTS.md to match.
- Keeps tonic-prost-build's default features off: the new cleanup-markdown default re-renders proto doc comments and trips clippy's doc_lazy_continuation on generated code, while the transport feature keeps the generated connect constructors that tonic-build 0.13 always emitted.
- Generated code differs from before only in the codec path and in prost 0.14 deriving Eq and Hash on messages.
- The private CLI crates build against this tree's ync and commonpb and still pin tonic/prost 0.13, so they and make cli with them checked out stop compiling at the submodule bump: their migration has to land together with it.
