### PR TITLE
chore(deps): update pcap-file to 3.0.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,14 +1449,14 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pcap-file"
-version = "3.0.0-rc1"
+version = "3.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc44e44ff0157dd4a876d81d83ae1bdb3b031873ca042116977908b987092f44"
+checksum = "9552aee583a05913b6c6345e3c5f69a746787fd60c8fd39ca82ef882de0613b4"
 dependencies = [
  "byteorder_slice",
  "derive-into-owned",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/modules/pdump/cli/Cargo.toml
+++ b/modules/pdump/cli/Cargo.toml
@@ -20,7 +20,9 @@ prost = "0.13"
 ptree = "0.5"
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 bytesize = "2"
-pcap-file = "3.0.0-rc1"
+# Pinned exactly: semver sorts rc.2 below rc1, so a caret requirement
+# resolves back to rc1, and rc.3 needs Rust 1.93 above the 1.88 MSRV.
+pcap-file = "=3.0.0-rc.2"
 tokio-util = "0.7"
 pnet_packet = "0.35"
 

--- a/modules/pdump/cli/src/writer.rs
+++ b/modules/pdump/cli/src/writer.rs
@@ -171,7 +171,7 @@ impl PdumpWriter {
             .meta
             .ok_or_else(|| -> Box<dyn Error> { "pdump record missing metadata".into() })?;
         let ts = Duration::from_nanos(meta.timestamp);
-        let packet = PcapPacket::new_owned(ts, meta.packet_len, rec.data);
+        let packet = PcapPacket::new(ts, meta.packet_len, rec.data)?;
         Ok(writer.inner.write_packet(&packet)?)
     }
 
@@ -181,12 +181,13 @@ impl PdumpWriter {
             .ok_or_else(|| -> Box<dyn Error> { "pdump record missing metadata".into() })?;
         let ts = Duration::from_nanos(meta.timestamp);
 
-        let mut packet_block = EnhancedPacketBlock::default();
-        packet_block.interface_id = writer.interface_id;
-        packet_block.timestamp = ts;
-        packet_block.original_len = meta.packet_len;
-        packet_block.data = rec.data.into();
-        packet_block.set_write_ts_resolution(TsResolution::NANO);
+        let packet_block = EnhancedPacketBlock {
+            interface_id: writer.interface_id,
+            timestamp: ts,
+            original_len: meta.packet_len,
+            data: rec.data.into(),
+            options: vec![],
+        };
 
         Ok(writer.inner.write_block(&Block::EnhancedPacket(packet_block))?)
     }


### PR DESCRIPTION
- Pins pcap-file to exactly 3.0.0-rc.2: semver orders rc.2 below rc1, so a caret requirement would resolve back to rc1, and rc.3 needs Rust 1.93.
- Adapts the pdump writer: packets go through the fallible constructor and pcapng blocks take their timestamp resolution from the interface description block instead of a per-block setter.
- A record whose captured data is longer than its reported packet length now fails the write instead of producing an inconsistent capture.
