### PR TITLE
chore(deps): disable tabled default features

### DIFF
--- a/.agents/skills/code-cli/references/new-crate.md
+++ b/.agents/skills/code-cli/references/new-crate.md
@@ -38,7 +38,7 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 netip = "0.3"
 prost = "0.14"
 serde = { version = "1", features = ["derive"] }
-tabled = { version = "0.21", features = ["ansi"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 
@@ -48,6 +48,9 @@ tonic-prost-build = { version = "0.14", default-features = false, features = ["t
 
 Add a dependency only when the code uses it; `netip` and `tabled` are
 listed because almost every binary parses an address or prints a table.
+`tabled` keeps its default features off, since the default `assert`
+feature links `testing_table` into the binary, and lists `derive` only
+when a row type derives `Tabled`.
 
 `tonic-prost-build` keeps its default features off: the default
 `cleanup-markdown` re-renders proto doc comments and fails clippy's

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -15,7 +15,7 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 log = "0.4"
 simple_logger = { version = "5", features = ["timestamps", "stderr"] }
 colored = "3"
-tabled = { version = "0.21", features = ["ansi"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi"] }
 terminal_size = "0.4"
 tokio = { version = "1", features = ["net", "io-util", "time", "sync", "rt"] }
 prost = "0.14"

--- a/cli/modules/counters/Cargo.toml
+++ b/cli/modules/counters/Cargo.toml
@@ -15,5 +15,5 @@ ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 tonic = { version = "0.14", features = ["gzip"] }
 bytesize = "2"
-tabled = { version = "0.21", features = ["ansi"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 serde_yaml = "0.9"

--- a/cli/modules/gateway/Cargo.toml
+++ b/cli/modules/gateway/Cargo.toml
@@ -15,4 +15,4 @@ ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 prost-types = "0.14"
 tonic = { version = "0.14", features = ["gzip"] }
-tabled = { version = "0.21", features = ["ansi"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }

--- a/cli/modules/metrics/Cargo.toml
+++ b/cli/modules/metrics/Cargo.toml
@@ -14,4 +14,4 @@ ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-tabled = { version = "0.21", features = ["ansi"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }

--- a/modules/acl/cli/Cargo.toml
+++ b/modules/acl/cli/Cargo.toml
@@ -20,7 +20,7 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.14"
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
-tabled = { version = "0.21", features = ["ansi"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 

--- a/modules/balancer2/cli/Cargo.toml
+++ b/modules/balancer2/cli/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 ptree = "0.5"
-tabled = { version = "0.21", features = ["ansi"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 log = "0.4"
 chrono = "0.4"
 netip = "0.3"

--- a/modules/route/cli/Cargo.toml
+++ b/modules/route/cli/Cargo.toml
@@ -17,7 +17,7 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.14"
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
-tabled = { version = "0.21", features = ["ansi"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 

--- a/operators/route/cli/neighbour/Cargo.toml
+++ b/operators/route/cli/neighbour/Cargo.toml
@@ -17,7 +17,7 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.14"
 netip = "0.3"
 serde = { version = "1", features = ["derive"] }
-tabled = { version = "0.21", features = ["ansi"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi"] }
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 

--- a/operators/route/cli/route/Cargo.toml
+++ b/operators/route/cli/route/Cargo.toml
@@ -18,7 +18,7 @@ prost = "0.14"
 netip = "0.3"
 colored = "3"
 serde = "1"
-tabled = { version = "0.21", features = ["ansi"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 


### PR DESCRIPTION
- Turns off tabled's default feature set in every manifest and in the new-crate template, keeping ansi everywhere and derive only where a Tabled row is derived.
- Drops testing_table from the build graph of every CLI binary, which the default assert feature had been pulling in since the 0.21 bump.
- Cargo.lock stays as it is because cargo resolves it with every optional dependency enabled.
