### PR TITLE
fix(controlplane): validate pipeline and chain weights

### DIFF
--- a/common/commonpb/v1/device.go
+++ b/common/commonpb/v1/device.go
@@ -1,0 +1,32 @@
+package commonpb
+
+import "fmt"
+
+// MaxWeightSum bounds each chain or pipeline selection table to 512 KiB per
+// worker and occurrence in the execution graph.
+const MaxWeightSum = 65535
+
+// Validate checks the input and output weight sums independently.
+//
+// A nil device is an empty configuration. Zero weights disable entries.
+func (m *Device) Validate() error {
+	if err := validateDevicePipelines("device.input", m.GetInput()); err != nil {
+		return err
+	}
+	return validateDevicePipelines("device.output", m.GetOutput())
+}
+
+func validateDevicePipelines(field string, pipelines []*DevicePipeline) error {
+	var sum uint64
+	for idx, pipeline := range pipelines {
+		weight := pipeline.GetWeight()
+		if weight > MaxWeightSum {
+			return fmt.Errorf("%s[%d].weight %d must be in range 0..%d", field, idx, weight, MaxWeightSum)
+		}
+		if weight > MaxWeightSum-sum {
+			return fmt.Errorf("%s weight sum %d must be in range 0..%d", field, sum+weight, MaxWeightSum)
+		}
+		sum += weight
+	}
+	return nil
+}

--- a/common/commonpb/v1/device_test.go
+++ b/common/commonpb/v1/device_test.go
@@ -1,0 +1,71 @@
+package commonpb_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+)
+
+// Test_Device_Validate verifies that each direction has an independent budget
+// and validation preserves the supplied message, including absent entries.
+func Test_Device_Validate(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		device *commonpb.Device
+		field  string
+	}{
+		{name: "nil device"},
+		{name: "empty device", device: &commonpb.Device{}},
+		{name: "nil pipeline", device: &commonpb.Device{Input: []*commonpb.DevicePipeline{nil}}},
+		{name: "disabled pipeline", device: &commonpb.Device{Input: []*commonpb.DevicePipeline{{Weight: 0}}}},
+		{
+			name: "independent limits",
+			device: &commonpb.Device{
+				Input:  []*commonpb.DevicePipeline{{Weight: 65535}},
+				Output: []*commonpb.DevicePipeline{{Weight: 65535}},
+			},
+		},
+		{
+			name: "sum at limit with disabled entry",
+			device: &commonpb.Device{
+				Input: []*commonpb.DevicePipeline{{Weight: 0}, {Weight: 65534}, {Weight: 1}},
+			},
+		},
+		{
+			name:   "input above limit",
+			device: &commonpb.Device{Input: []*commonpb.DevicePipeline{{Weight: 65536}}},
+			field:  "device.input[0].weight",
+		},
+		{
+			name:   "input sum above limit",
+			device: &commonpb.Device{Input: []*commonpb.DevicePipeline{{Weight: 65535}, {Weight: 1}}},
+			field:  "device.input weight sum",
+		},
+		{
+			name:   "output sum above limit",
+			device: &commonpb.Device{Output: []*commonpb.DevicePipeline{{Weight: 65535}, {Weight: 1}}},
+			field:  "device.output weight sum",
+		},
+		{
+			name:   "overflowing input sum",
+			device: &commonpb.Device{Input: []*commonpb.DevicePipeline{{Weight: 1}, {Weight: math.MaxUint64}}},
+			field:  "device.input[1].weight",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			before := proto.Clone(test.device)
+			err := test.device.Validate()
+			if test.field == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.field)
+				require.ErrorContains(t, err, "0..65535")
+			}
+			require.True(t, proto.Equal(before, test.device))
+		})
+	}
+}

--- a/common/commonpb/v1/target.proto
+++ b/common/commonpb/v1/target.proto
@@ -14,11 +14,14 @@ message FunctionId { string name = 1; }
 message PipelineId { string name = 1; }
 
 message Device {
+  // Input pipeline weights must sum to 0..65535.
   repeated DevicePipeline input = 2;
+  // Output pipeline weights must sum to 0..65535, independently of input.
   repeated DevicePipeline output = 3;
 }
 
 message DevicePipeline {
   string name = 1;
+  // Accepted range: 0..65535. Zero disables this pipeline assignment.
   uint64 weight = 2;
 }

--- a/controlplane/builtin/function.go
+++ b/controlplane/builtin/function.go
@@ -161,32 +161,18 @@ func (m *Function) Update(
 	request *ynpb.UpdateFunctionRequest,
 ) (*ynpb.UpdateFunctionResponse, error) {
 	reqFunction := request.GetFunction()
-	if reqFunction == nil {
-		return nil, status.Error(codes.InvalidArgument, "function is required")
-	}
-
-	reqFunctionId := reqFunction.GetId()
-	if reqFunctionId == nil {
-		return nil, status.Error(codes.InvalidArgument, "function id is required")
-	}
-	if reqFunctionId.Name == "" {
-		return nil, status.Error(codes.InvalidArgument, "function name is required")
+	if err := reqFunction.Validate(); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	function := ffi.FunctionConfig{
-		Name: reqFunctionId.Name,
+		Name: reqFunction.Id.Name,
 	}
 	for _, reqFunctionChain := range reqFunction.Chains {
 		reqChain := reqFunctionChain.GetChain()
-		if reqChain == nil {
-			return nil, status.Error(codes.InvalidArgument, "function chain is required")
-		}
 
 		modules := make([]ffi.ChainModuleConfig, 0, len(reqChain.Modules))
 		for _, reqChainModule := range reqChain.Modules {
-			if reqChainModule == nil {
-				return nil, status.Error(codes.InvalidArgument, "module id is required")
-			}
 			modules = append(modules, ffi.ChainModuleConfig{
 				Type: reqChainModule.Type,
 				Name: reqChainModule.Name,

--- a/controlplane/builtin/function_test.go
+++ b/controlplane/builtin/function_test.go
@@ -83,6 +83,21 @@ func Test_Function_Update_EmptyName(t *testing.T) {
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+// Test_Function_Update_RejectsInvalidWeights verifies that model validation
+// produces InvalidArgument before accessing shared memory.
+func Test_Function_Update_RejectsInvalidWeights(t *testing.T) {
+	service := builtin.NewFunction(0, nil)
+	_, err := service.Update(t.Context(), &ynpb.UpdateFunctionRequest{
+		Function: &ynpb.Function{
+			Id: &commonpb.FunctionId{Name: "weights"},
+			Chains: []*ynpb.FunctionChain{{
+				Chain: &ynpb.Chain{Name: "chain"}, Weight: 65536,
+			}},
+		},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
 // TestFunctionDeleteRejectsMissingID verifies that Delete rejects a request
 // with no id instead of dereferencing it to build the function name.
 func TestFunctionDeleteRejectsMissingID(t *testing.T) {

--- a/controlplane/ynpb/v1/function.go
+++ b/controlplane/ynpb/v1/function.go
@@ -1,12 +1,51 @@
 package ynpb
 
 import (
+	"errors"
+	"fmt"
 	"slices"
 
 	"google.golang.org/protobuf/proto"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 )
+
+// Validate checks the function identity, required nested messages, and chain
+// weights.
+func (m *Function) Validate() error {
+	if m == nil {
+		return errors.New("function is required")
+	}
+	if m.GetId() == nil {
+		return errors.New("function id is required")
+	}
+	if m.GetId().GetName() == "" {
+		return errors.New("function name is required")
+	}
+
+	var sum uint64
+	for idx, functionChain := range m.GetChains() {
+		chain := functionChain.GetChain()
+		if chain == nil {
+			return errors.New("function chain is required")
+		}
+		for _, module := range chain.GetModules() {
+			if module == nil {
+				return errors.New("module id is required")
+			}
+		}
+
+		weight := functionChain.GetWeight()
+		if weight > commonpb.MaxWeightSum {
+			return fmt.Errorf("function.chains[%d].weight %d must be in range 0..%d", idx, weight, commonpb.MaxWeightSum)
+		}
+		if weight > commonpb.MaxWeightSum-sum {
+			return fmt.Errorf("function.chains weight sum %d must be in range 0..%d", sum+weight, commonpb.MaxWeightSum)
+		}
+		sum += weight
+	}
+	return nil
+}
 
 // Equal reports whether both functions carry the same definition.
 func (m *Function) Equal(other *Function) bool {

--- a/controlplane/ynpb/v1/function.proto
+++ b/controlplane/ynpb/v1/function.proto
@@ -81,6 +81,7 @@ message Function {
   //
   // At least one chain is required.
   // Traffic is distributed across chains based on their weights.
+  // The sum of chain weights must be in 0..65535.
   repeated FunctionChain chains = 2;
 }
 
@@ -89,7 +90,7 @@ message Function {
 message FunctionChain {
   // The processing chain defining the module sequence.
   Chain chain = 1;
-  // Weight for load balancing.
+  // Weight for load balancing in the accepted range 0..65535.
   //
   // Higher weight means more traffic is directed to this chain. A weight
   // of 0 effectively disables the chain without removing it from the

--- a/controlplane/ynpb/v1/function_test.go
+++ b/controlplane/ynpb/v1/function_test.go
@@ -1,6 +1,8 @@
 package ynpb_test
 
 import (
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,6 +11,55 @@ import (
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
+
+// Test_Function_Validate verifies that chain weights obey a shared budget
+// without changing the supplied definition.
+func Test_Function_Validate(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		function *ynpb.Function
+		message  string
+	}{
+		{name: "empty chain list", function: functionWithWeights()},
+		{name: "disabled chain", function: functionWithWeights(0)},
+		{name: "individual limit", function: functionWithWeights(65535)},
+		{name: "sum at limit", function: functionWithWeights(0, 65534, 1)},
+		{
+			name: "individual above limit", function: functionWithWeights(65536),
+			message: "function.chains[0].weight 65536 must be in range 0..65535",
+		},
+		{
+			name: "sum above limit", function: functionWithWeights(65535, 1),
+			message: "function.chains weight sum 65536 must be in range 0..65535",
+		},
+		{
+			name: "overflowing sum", function: functionWithWeights(1, math.MaxUint64),
+			message: "function.chains[1].weight 18446744073709551615 must be in range 0..65535",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			before := proto.Clone(test.function)
+			err := test.function.Validate()
+			if test.message == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, test.message)
+			}
+			require.True(t, proto.Equal(before, test.function))
+		})
+	}
+}
+
+// functionWithWeights creates a named function whose chains have no modules.
+func functionWithWeights(weights ...uint64) *ynpb.Function {
+	function := &ynpb.Function{Id: &commonpb.FunctionId{Name: "f"}}
+	for idx, weight := range weights {
+		function.Chains = append(function.Chains, &ynpb.FunctionChain{
+			Chain: &ynpb.Chain{Name: fmt.Sprintf("c%d", idx)}, Weight: weight,
+		})
+	}
+	return function
+}
 
 // Test_Function_WithoutModules_DropsExactTypeFromEveryChain verifies that
 // only exact type matches leave each chain and the original stays untouched.

--- a/devices/plain/controlplane/service.go
+++ b/devices/plain/controlplane/service.go
@@ -48,6 +48,9 @@ func (m *DevicePlainService) UpdateDevice(
 	if err := ffi.ValidateDeviceName(name); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	if err := request.GetDevice().Validate(); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	deviceConfig, err := NewDeviceConfig(m.agent, name, request.GetDevice())
 	if err != nil {

--- a/devices/plain/controlplane/service_test.go
+++ b/devices/plain/controlplane/service_test.go
@@ -15,6 +15,19 @@ import (
 	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
 )
 
+// Test_DevicePlainService_UpdateDevice_RejectsInvalidWeights verifies that model
+// validation produces InvalidArgument before allocating a device through FFI.
+func Test_DevicePlainService_UpdateDevice_RejectsInvalidWeights(t *testing.T) {
+	service := NewDevicePlainService(nil)
+	_, err := service.UpdateDevice(t.Context(), &plainpb.UpdateDevicePlainRequest{
+		Name: "weights",
+		Device: &commonpb.Device{
+			Input: []*commonpb.DevicePipeline{{Name: "pipeline", Weight: 65536}},
+		},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
 // TestUpdateDevice_ReclaimsSupersededDevice verifies that repeated
 // UpdateDevice calls do not leak shared-memory arena space.
 //

--- a/devices/trafgen/controlplane/service.go
+++ b/devices/trafgen/controlplane/service.go
@@ -90,6 +90,9 @@ func (m *TrafgenService) UpdateDevice(
 	if err := ffi.ValidateDeviceName(name); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	if err := req.GetDevice().Validate(); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	input := pipelinesFromProto(req.GetDevice().GetInput())
 	output := pipelinesFromProto(req.GetDevice().GetOutput())

--- a/devices/vlan/controlplane/service.go
+++ b/devices/vlan/controlplane/service.go
@@ -55,6 +55,9 @@ func (m *DeviceVlanService) UpdateDevice(
 	if err := ffi.ValidateDeviceName(name); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	if err := request.GetDevice().Validate(); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	vlan := request.GetVlan()
 	if vlan > maxVlanID {


### PR DESCRIPTION
- Reject function chain and device pipeline weight sums above 65535 with field-specific `InvalidArgument` errors before services access shared memory.
- Validate protobuf messages without reading or changing live configuration, checking device input and output independently and preserving zero weights.
- Document the accepted ranges and cover the boundaries in shared model tests with focused service checks.

Closes #2388.
