### PR TITLE
fix(nat64): report absent entries on removal

### DIFF
--- a/modules/nat64/controlplane/nat64pb/v1/nat64.proto
+++ b/modules/nat64/controlplane/nat64pb/v1/nat64.proto
@@ -18,13 +18,17 @@ service NAT64Service {
   // AddPrefix adds a new NAT64 prefix to the configuration
   rpc AddPrefix(AddPrefixRequest) returns (AddPrefixResponse) {}
 
-  // RemovePrefix removes a NAT64 prefix from the configuration
+  // RemovePrefix removes a NAT64 prefix from the configuration.
+  //
+  // Returns NotFound if the config or prefix is absent.
   rpc RemovePrefix(RemovePrefixRequest) returns (RemovePrefixResponse) {}
 
   // AddMapping adds a new IPv4-IPv6 address mapping
   rpc AddMapping(AddMappingRequest) returns (AddMappingResponse) {}
 
-  // RemoveMapping removes an IPv4-IPv6 address mapping
+  // RemoveMapping removes an IPv4-IPv6 address mapping.
+  //
+  // Returns NotFound if the config or IPv4 mapping is absent.
   rpc RemoveMapping(RemoveMappingRequest) returns (RemoveMappingResponse) {}
 
   // SetMTU sets MTU values for IPv4/IPv6

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -240,7 +240,7 @@ func (m *NAT64Service) RemovePrefix(ctx context.Context, req *nat64pb.RemovePref
 
 	inst, ok := m.configs[name]
 	if !ok {
-		return &nat64pb.RemovePrefixResponse{}, nil
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 	next := inst.Clone()
 
@@ -252,7 +252,7 @@ func (m *NAT64Service) RemovePrefix(ctx context.Context, req *nat64pb.RemovePref
 		}
 	}
 	if removeIdx == -1 {
-		return &nat64pb.RemovePrefixResponse{}, nil
+		return nil, status.Errorf(codes.NotFound, "prefix not found in config %q", name)
 	}
 
 	next.Config.Prefixes = slices.Delete(next.Config.Prefixes, removeIdx, removeIdx+1)
@@ -324,7 +324,7 @@ func (m *NAT64Service) RemoveMapping(ctx context.Context, req *nat64pb.RemoveMap
 
 	inst, ok := m.configs[name]
 	if !ok {
-		return &nat64pb.RemoveMappingResponse{}, nil
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 	next := inst.Clone()
 
@@ -332,7 +332,7 @@ func (m *NAT64Service) RemoveMapping(ctx context.Context, req *nat64pb.RemoveMap
 		return mapping.IPv4 == ipv4
 	})
 	if len(next.Config.Mappings) == len(inst.Config.Mappings) {
-		return &nat64pb.RemoveMappingResponse{}, nil
+		return nil, status.Errorf(codes.NotFound, "mapping for %s not found in config %q", ipv4, name)
 	}
 
 	if err := m.updateModuleConfig(name, next); err != nil {

--- a/modules/nat64/controlplane/service_test.go
+++ b/modules/nat64/controlplane/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -202,14 +203,14 @@ func Test_NAT64Service_PrefixMutation_Invalid(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 			service := NewNAT64Service(&mockBackend{})
 
 			t.Run("add", func(t *testing.T) {
 				_, err := service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{
 					Name:   "nat64-0",
-					Prefix: testCase.prefix,
+					Prefix: tc.prefix,
 				})
 				require.Equal(t, codes.InvalidArgument, status.Code(err))
 			})
@@ -217,7 +218,7 @@ func Test_NAT64Service_PrefixMutation_Invalid(t *testing.T) {
 			t.Run("remove", func(t *testing.T) {
 				_, err := service.RemovePrefix(t.Context(), &nat64pb.RemovePrefixRequest{
 					Name:   "nat64-0",
-					Prefix: testCase.prefix,
+					Prefix: tc.prefix,
 				})
 				require.Equal(t, codes.InvalidArgument, status.Code(err))
 			})
@@ -428,4 +429,63 @@ func Test_NAT64Service_DeleteConfig_ParksThenReclaims(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, service.deferred)
 	require.Equal(t, int64(1), backend.first.freed.Load())
+}
+
+// Test_NAT64Service_Remove_NotFound verifies that a missing prefix or mapping
+// leaves the published config intact, including after a successful deletion.
+func Test_NAT64Service_Remove_NotFound(t *testing.T) {
+	for _, element := range []string{"prefix", "mapping"} {
+		for _, scenario := range []string{"unknown config", "absent element", "already removed"} {
+			t.Run(element+"/"+scenario, func(t *testing.T) {
+				backend := &mockBackend{}
+				service := NewNAT64Service(backend)
+				prefix := mustIPv6Prefix(t, "64:ff9b::/96")
+				ipv4 := commonpb.NewIPv4Address([4]byte{192, 0, 2, 1})
+				name := "nat64-0"
+				_, err := service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{Name: name, Prefix: prefix})
+				require.NoError(t, err)
+				_, err = service.AddMapping(t.Context(), &nat64pb.AddMappingRequest{
+					Name: name, Ipv4: ipv4,
+					Ipv6: commonpb.NewIPv6Address(netip.MustParseAddr("2001:db8::1").As16()),
+				})
+				require.NoError(t, err)
+
+				remove := func() error {
+					if element == "prefix" {
+						_, err := service.RemovePrefix(t.Context(), &nat64pb.RemovePrefixRequest{Name: name, Prefix: prefix})
+						return err
+					}
+					_, err := service.RemoveMapping(t.Context(), &nat64pb.RemoveMappingRequest{Name: name, Ipv4: ipv4})
+					return err
+				}
+				switch scenario {
+				case "unknown config":
+					name = "missing"
+				case "absent element":
+					prefix = mustIPv6Prefix(t, "2001:db8::/96")
+					ipv4 = commonpb.NewIPv4Address([4]byte{192, 0, 2, 2})
+				case "already removed":
+					require.NoError(t, remove())
+					show, err := service.ShowConfig(t.Context(), &nat64pb.ShowConfigRequest{Name: name})
+					require.NoError(t, err)
+					if element == "prefix" {
+						require.Empty(t, show.GetConfig().GetPrefixes())
+					}
+					require.Empty(t, show.GetConfig().GetMappings())
+				}
+
+				before, err := service.ShowConfig(t.Context(), &nat64pb.ShowConfigRequest{Name: "nat64-0"})
+				require.NoError(t, err)
+				updates := len(backend.configs)
+				require.Equal(t, codes.NotFound, status.Code(remove()))
+				after, err := service.ShowConfig(t.Context(), &nat64pb.ShowConfigRequest{Name: "nat64-0"})
+				require.NoError(t, err)
+				require.True(t, proto.Equal(before, after), "a rejected removal must preserve the config")
+				require.Equal(t, updates, len(backend.configs))
+				configs, err := service.ListConfigs(t.Context(), &nat64pb.ListConfigsRequest{})
+				require.NoError(t, err)
+				require.Equal(t, []string{"nat64-0"}, configs.GetConfigs())
+			})
+		}
+	}
 }


### PR DESCRIPTION
- Return NotFound for absent NAT64 prefixes, IPv4 mappings, and configurations, using the existing CLI exit code 3.
- Cover absent and repeated removals while preserving the published configuration and avoiding backend updates on failure.
- Preserve the existing behavior of list-based removals in DSCP, neighbour, route, and route-mpls.

Closes #2390.
