### PR TITLE
feat(cli): compact the inspect report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,8 +3384,9 @@ version = "0.1.0"
 dependencies = [
  "bytesize",
  "clap",
- "ptree",
  "tonic",
+ "unicode-segmentation",
+ "unicode-width",
  "yanet-cli",
  "yanet-ynpb",
 ]

--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -427,6 +427,21 @@ pub fn paint_dim(text: &str) -> String {
     text.truecolor(127, 127, 127).to_string()
 }
 
+/// Paints bold text after the caller has checked terminal colour support.
+pub fn paint_bold(text: &str) -> String {
+    text.bold().to_string()
+}
+
+/// Paints yellow text after the caller has checked terminal colour support.
+pub fn paint_warning(text: &str) -> String {
+    text.yellow().to_string()
+}
+
+/// Paints red text after the caller has checked terminal colour support.
+pub fn paint_error(text: &str) -> String {
+    text.red().to_string()
+}
+
 /// Returns `true` if the current locale advertises UTF-8 encoding.
 fn is_utf8_locale() -> bool {
     for var in ["LC_ALL", "LC_CTYPE", "LANG"] {

--- a/cli/modules/inspect/Cargo.toml
+++ b/cli/modules/inspect/Cargo.toml
@@ -14,5 +14,6 @@ ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-y
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 tonic = { version = "0.14", features = ["gzip"] }
-ptree = "0.5"
 bytesize = "2"
+unicode-segmentation = "1"
+unicode-width = "0.2"

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -1,19 +1,18 @@
 //! CLI for YANET "inspect" module.
 
-use core::cmp::Reverse;
-use std::collections::BTreeMap;
+mod memory;
+mod report;
 
-use bytesize::ByteSize;
 use clap::{ArgAction, Parser};
-use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
     output::{self, CommonFormat},
 };
-use ynpb::pb::{InspectRequest, InspectResponse, MemoryNode, inspect_service_client::InspectServiceClient};
+use ynpb::pb::{InspectRequest, InspectResponse, inspect_service_client::InspectServiceClient};
 
+/// The fully-qualified gRPC service name used in error messages.
 const INSPECT_SERVICE: &str = "controlplane.ynpb.v1.InspectService";
 
 /// Inspect module - displays system introspection information.
@@ -26,7 +25,10 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, value_enum, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Be verbose in terms of logging.
+    /// Include detailed memory contexts in human output.
+    #[arg(long)]
+    pub memory: bool,
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
@@ -39,7 +41,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     let mut service = InspectService::new(&cmd.connection).await?;
     let response = service.inspect().await?;
 
-    output::data(|| &response, || render_tree(&response));
+    output::data(|| &response, || report::render(&response, cmd.memory));
 
     Ok(())
 }
@@ -70,354 +72,5 @@ impl InspectService {
             .into_inner();
 
         Ok(response)
-    }
-}
-
-fn render_tree(response: &InspectResponse) {
-    let Some(info) = &response.instance_info else {
-        output::empty(format_args!("No instance information found."));
-        return;
-    };
-
-    let mut tree = TreeBuilder::new("YANET System".to_string());
-
-    tree.begin_child(format!("Instance {}", info.instance_idx));
-
-    tree.begin_child(format!("Attached to NUMA {}", info.numa_idx));
-    tree.end_child();
-
-    tree.begin_child("Dataplane Modules".to_string());
-    if info.dp_modules.is_empty() {
-        tree.add_empty_child("(none)".to_owned());
-    }
-
-    for (idx, module) in info.dp_modules.iter().enumerate() {
-        tree.add_empty_child(format!("{}: {}", idx, module.name));
-    }
-    tree.end_child();
-
-    tree.begin_child("Controlplane Configurations".to_string());
-    if info.cp_configs.is_empty() {
-        tree.add_empty_child("(none)".to_owned());
-    }
-
-    for cfg in &info.cp_configs {
-        tree.add_empty_child(format!("{}:{} (gen: {})", cfg.r#type, cfg.name, cfg.generation));
-    }
-    tree.end_child();
-
-    tree.begin_child("Agents".to_string());
-    if info.agents.is_empty() {
-        tree.add_empty_child("(none)".to_owned());
-    }
-
-    for agent in &info.agents {
-        tree.begin_child(agent.name.to_string());
-        if agent.instances.is_empty() {
-            tree.add_empty_child("(none)".to_owned());
-        }
-
-        for instance in &agent.instances {
-            let used = instance.memory_limit.saturating_sub(instance.free_bytes);
-            tree.begin_child(format!("Instance (PID: {})", instance.pid));
-            tree.add_empty_child(format!("Memory limit: {}", ByteSize::b(instance.memory_limit)));
-            tree.add_empty_child(format!("Used:         {}", ByteSize::b(used)));
-            tree.add_empty_child(format!("Free:         {}", ByteSize::b(instance.free_bytes)));
-            tree.add_empty_child(format!("Generation: {}", instance.generation));
-            if !instance.memory_tree.is_empty() {
-                add_memory_tree(&mut tree, &instance.memory_tree);
-            }
-            tree.end_child();
-        }
-
-        tree.end_child();
-    }
-    tree.end_child();
-
-    tree.begin_child("Functions".to_string());
-    if info.functions.is_empty() {
-        tree.add_empty_child("(none)".to_owned());
-    }
-
-    for function in &info.functions {
-        tree.begin_child(format!("Function {}", function.name));
-        if function.chains.is_empty() {
-            tree.add_empty_child("(none)".to_owned());
-        }
-
-        for chain in &function.chains {
-            tree.begin_child(format!("Chain {} (weight {})", chain.name, chain.weight));
-            if chain.modules.is_empty() {
-                tree.add_empty_child("(none)".to_owned());
-            }
-
-            for module in &chain.modules {
-                tree.add_empty_child(format!("Module {}:{}", module.r#type, module.name));
-            }
-            tree.end_child();
-        }
-        tree.end_child();
-    }
-    tree.end_child();
-
-    tree.begin_child("Pipelines".to_string());
-    if info.pipelines.is_empty() {
-        tree.add_empty_child("(none)".to_owned());
-    }
-
-    for pipeline in &info.pipelines {
-        tree.begin_child(format!("Pipeline {}", pipeline.name));
-        tree.add_empty_child("rx".to_string());
-        for function in &pipeline.functions {
-            tree.add_empty_child(function.to_string());
-        }
-        tree.add_empty_child("tx".to_string());
-        tree.end_child();
-    }
-    tree.end_child();
-
-    tree.begin_child("Devices".to_string());
-    if info.devices.is_empty() {
-        tree.add_empty_child("(none)".to_owned());
-    }
-
-    for device in &info.devices {
-        tree.begin_child(format!("Device {}:{}", device.r#type, device.name));
-
-        tree.begin_child("input".to_string());
-        if device.input_pipelines.is_empty() {
-            tree.add_empty_child("(none)".to_owned());
-        }
-
-        for pipeline in &device.input_pipelines {
-            tree.add_empty_child(format!("Pipeline {} (weight: {})", pipeline.name, pipeline.weight));
-        }
-        tree.end_child();
-
-        tree.begin_child("output".to_string());
-        if device.output_pipelines.is_empty() {
-            tree.add_empty_child("(none)".to_owned());
-        }
-
-        for pipeline in &device.output_pipelines {
-            tree.add_empty_child(format!("Pipeline {} (weight: {})", pipeline.name, pipeline.weight));
-        }
-        tree.end_child();
-
-        tree.end_child();
-    }
-    tree.end_child();
-
-    tree.end_child();
-
-    let tree = tree.build();
-    let _ = ptree::print_tree(&tree);
-}
-
-/// Live bytes held by a memory node: allocated minus freed, floored at zero.
-fn node_live(node: &MemoryNode) -> u64 {
-    node.balloc_size.saturating_sub(node.bfree_size)
-}
-
-/// Fills `totals[idx]` and every descendant's slot with its subtree total:
-/// a node's own live bytes plus the live bytes of all its descendants.
-///
-/// Post-order, so each slot is computed exactly once regardless of how many
-/// times the tree is walked afterwards.
-fn compute_subtree_totals(nodes: &[MemoryNode], children_of: &[Vec<usize>], idx: usize, totals: &mut [u64]) {
-    let mut total = node_live(&nodes[idx]);
-    for &child in &children_of[idx] {
-        compute_subtree_totals(nodes, children_of, child, totals);
-        total = total.saturating_add(totals[child]);
-    }
-
-    totals[idx] = total;
-}
-
-/// Render one node and its children into the tree builder.
-///
-/// Children are ordered by subtree total descending so the heaviest
-/// subtrees come first; zero-total subtrees are skipped. The node's own
-/// live bytes are shown alongside the subtree total only when they differ
-/// — a leaf, or a node whose children are all zero, gets one number.
-fn render_memory_node(
-    tree: &mut TreeBuilder,
-    nodes: &[MemoryNode],
-    idx: usize,
-    children_of: &[Vec<usize>],
-    totals: &[u64],
-) {
-    let node = &nodes[idx];
-    let total = totals[idx];
-    let own = node_live(node);
-
-    let label = if own == total {
-        format!("{} (Used: {})", node.name, ByteSize::b(total))
-    } else {
-        format!(
-            "{} (Used: {}, own: {})",
-            node.name,
-            ByteSize::b(total),
-            ByteSize::b(own)
-        )
-    };
-    tree.begin_child(label);
-
-    let mut children = children_of[idx].clone();
-    children.sort_by_key(|&child| Reverse(totals[child]));
-    for child in children {
-        if totals[child] > 0 {
-            render_memory_node(tree, nodes, child, children_of, totals);
-        }
-    }
-
-    tree.end_child();
-}
-
-/// Cap on the number of context names shown in the "own bytes" rollup.
-const MEMORY_ROLLUP_LIMIT: usize = 10;
-
-/// Aggregates own live bytes and node count by context `name`, across the
-/// whole flat `nodes` slice regardless of depth or parent.
-///
-/// Own bytes (not subtree totals) avoid double-counting a parent and its
-/// children under the same name. Returns entries sorted by summed bytes
-/// descending, name ascending on ties, capped at [`MEMORY_ROLLUP_LIMIT`].
-fn rollup_by_name(nodes: &[MemoryNode]) -> Vec<(String, u64, usize)> {
-    let mut totals: BTreeMap<&str, (u64, usize)> = BTreeMap::new();
-    for node in nodes {
-        let entry = totals.entry(node.name.as_str()).or_insert((0, 0));
-        entry.0 = entry.0.saturating_add(node_live(node));
-        entry.1 += 1;
-    }
-
-    let mut rows: Vec<(String, u64, usize)> = totals
-        .into_iter()
-        .map(|(name, (bytes, count))| (name.to_string(), bytes, count))
-        .collect();
-    rows.sort_by_key(|&(_, bytes, _)| Reverse(bytes));
-    rows.truncate(MEMORY_ROLLUP_LIMIT);
-    rows
-}
-
-/// Render the "own bytes" rollup as plain aligned child lines.
-///
-/// Nested under the memory tree rather than a `tabled` table: it is a
-/// two-column list capped at [`MEMORY_ROLLUP_LIMIT`] rows inside a `ptree`
-/// branch, and `tabled`'s box-drawing output has no ptree-prefix awareness
-/// for a table embedded as a single multi-line child label.
-fn add_memory_rollup(tree: &mut TreeBuilder, nodes: &[MemoryNode]) {
-    let rows = rollup_by_name(nodes);
-    let Some(name_width) = rows.iter().map(|(name, _, _)| name.chars().count()).max() else {
-        return;
-    };
-
-    tree.begin_child("Top contexts by own bytes:".to_string());
-    for (name, bytes, count) in &rows {
-        let size = ByteSize::b(*bytes);
-        tree.add_empty_child(format!("{name:<name_width$}  {size:>10}  (×{count})"));
-    }
-    tree.end_child();
-}
-
-/// Render the memory-context tree under a `Memory tree:` branch.
-fn add_memory_tree(tree: &mut TreeBuilder, nodes: &[MemoryNode]) {
-    let mut children_of: Vec<Vec<usize>> = vec![Vec::new(); nodes.len()];
-    let mut root_idx: Option<usize> = None;
-    for (idx, node) in nodes.iter().enumerate() {
-        if node.parent_idx == u32::MAX {
-            root_idx = Some(idx);
-        } else {
-            let parent = node.parent_idx as usize;
-            if parent < nodes.len() {
-                children_of[parent].push(idx);
-            }
-        }
-    }
-
-    let Some(root) = root_idx else {
-        return;
-    };
-
-    let mut totals = vec![0u64; nodes.len()];
-    compute_subtree_totals(nodes, &children_of, root, &mut totals);
-
-    tree.begin_child("Memory tree:".to_string());
-    render_memory_node(tree, nodes, root, &children_of, &totals);
-    add_memory_rollup(tree, nodes);
-    tree.end_child();
-}
-
-#[cfg(test)]
-mod test {
-    use ynpb::pb::MemoryNode;
-
-    use super::{compute_subtree_totals, node_live, rollup_by_name};
-
-    fn node(name: &str, parent_idx: u32, balloc_size: u64, bfree_size: u64) -> MemoryNode {
-        MemoryNode {
-            name: name.to_string(),
-            parent_idx,
-            balloc_count: 0,
-            bfree_count: 0,
-            balloc_size,
-            bfree_size,
-        }
-    }
-
-    /// Builds the same parent -> children index map `add_memory_tree` does,
-    /// for tests exercising `compute_subtree_totals`/`rollup_by_name` directly.
-    fn children_of(nodes: &[MemoryNode]) -> Vec<Vec<usize>> {
-        let mut children_of: Vec<Vec<usize>> = vec![Vec::new(); nodes.len()];
-        for (idx, node) in nodes.iter().enumerate() {
-            if node.parent_idx != u32::MAX {
-                children_of[node.parent_idx as usize].push(idx);
-            }
-        }
-        children_of
-    }
-
-    #[test]
-    fn subtree_total_equals_sum_of_own_bytes() {
-        let nodes = vec![
-            node("root", u32::MAX, 100, 0),
-            node("filter", 0, 50, 0),
-            node("lpm", 0, 30, 10),
-            node("value_table", 2, 15, 5),
-        ];
-        let children_of = children_of(&nodes);
-        let mut totals = vec![0u64; nodes.len()];
-        compute_subtree_totals(&nodes, &children_of, 0, &mut totals);
-
-        let sum_of_own: u64 = nodes.iter().map(node_live).sum();
-        assert_eq!(sum_of_own, totals[0]);
-        assert_eq!(180, totals[0]);
-    }
-
-    #[test]
-    fn rollup_groups_by_name_across_depths() {
-        let nodes = vec![
-            node("root", u32::MAX, 100, 0),
-            node("filter", 0, 500, 10), // own 490, first filter
-            node("lpm", 1, 20, 0),      // own 20, under the first filter
-            node("filter", 0, 20, 10),  // own 10, second filter at the same depth
-            node("lpm", 3, 30, 0),      // own 30, under the second filter
-        ];
-
-        let rows = rollup_by_name(&nodes);
-
-        let filter = rows
-            .iter()
-            .find(|(name, ..)| name == "filter")
-            .expect("filter row present");
-        assert_eq!(500, filter.1);
-        assert_eq!(2, filter.2);
-
-        let lpm = rows.iter().find(|(name, ..)| name == "lpm").expect("lpm row present");
-        assert_eq!(50, lpm.1);
-        assert_eq!(2, lpm.2);
-
-        // filter (500) outranks root (100) outranks lpm (50).
-        assert_eq!("filter", rows[0].0);
     }
 }

--- a/cli/modules/inspect/src/memory.rs
+++ b/cli/modules/inspect/src/memory.rs
@@ -1,0 +1,122 @@
+use ynpb::pb::MemoryNode;
+
+pub fn node_live(node: &MemoryNode) -> u64 {
+    node.balloc_size.saturating_sub(node.bfree_size)
+}
+
+/// Parents precede children in the snapshot, so reverse traversal includes
+/// every descendant once without consuming stack space for nested contexts.
+pub fn subtree_totals(nodes: &[MemoryNode]) -> Vec<u64> {
+    let mut totals: Vec<u64> = nodes.iter().map(node_live).collect();
+    for (idx, node) in nodes.iter().enumerate().rev() {
+        let parent = node.parent_idx as usize;
+        if parent < idx {
+            totals[parent] = totals[parent].saturating_add(totals[idx]);
+        }
+    }
+    totals
+}
+
+/// Groups contexts by parent, with larger sibling subtrees first.
+///
+/// Invalid parent links remain separate roots, keeping every context visible
+/// and preventing cycles during traversal.
+pub struct MemoryTree {
+    pub roots: Vec<usize>,
+    pub children: Vec<Vec<usize>>,
+    pub totals: Vec<u64>,
+}
+
+impl MemoryTree {
+    pub fn new(nodes: &[MemoryNode]) -> Self {
+        let totals = subtree_totals(nodes);
+        let mut roots = Vec::new();
+        let mut children = vec![Vec::new(); nodes.len()];
+        for (idx, node) in nodes.iter().enumerate() {
+            let parent = node.parent_idx as usize;
+            if parent < idx {
+                children[parent].push(idx);
+            } else {
+                roots.push(idx);
+            }
+        }
+        for siblings in core::iter::once(&mut roots).chain(children.iter_mut()) {
+            siblings.sort_by(|&left, &right| {
+                totals[right]
+                    .cmp(&totals[left])
+                    .then_with(|| nodes[left].name.cmp(&nodes[right].name))
+                    .then_with(|| left.cmp(&right))
+            });
+        }
+        Self { roots, children, totals }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ynpb::pb::MemoryNode;
+
+    use super::{MemoryTree, subtree_totals};
+
+    /// Returns a context with byte accounting and no allocation counts.
+    fn node(name: &str, parent_idx: u32, balloc_size: u64, bfree_size: u64) -> MemoryNode {
+        MemoryNode {
+            name: name.to_string(),
+            parent_idx,
+            balloc_count: 0,
+            bfree_count: 0,
+            balloc_size,
+            bfree_size,
+        }
+    }
+
+    #[test]
+    fn test_subtree_totals_root_equals_sum_of_own_bytes() {
+        let nodes = vec![
+            node("root", u32::MAX, 100, 0),
+            node("filter", 0, 50, 0),
+            node("lpm", 0, 30, 10),
+            node("value_table", 2, 15, 5),
+        ];
+        let totals = subtree_totals(&nodes);
+        assert_eq!(vec![180, 50, 30, 10], totals);
+    }
+
+    #[test]
+    fn test_memory_tree_groups_interleaved_descendants_by_subtree_size() {
+        let nodes = vec![
+            node("root", u32::MAX, 1, 0),
+            node("alpha", 0, 10, 0),
+            node("gamma", 0, 30, 0),
+            node("leaf", 1, 40, 0),
+            node("beta", 0, 30, 0),
+        ];
+        let tree = MemoryTree::new(&nodes);
+        assert_eq!(vec![0], tree.roots);
+        assert_eq!(vec![vec![1, 4, 2], vec![3], vec![], vec![], vec![]], tree.children);
+    }
+
+    #[test]
+    fn test_memory_tree_invalid_links_keep_all_contexts_reachable() {
+        let nodes = vec![
+            node("forward", 2, 10, 0),
+            node("self", 1, 20, 0),
+            node("child", 0, 30, 0),
+            node("missing", 99, 5, 0),
+        ];
+        let tree = MemoryTree::new(&nodes);
+        assert_eq!(vec![0, 1, 3], tree.roots);
+        assert_eq!(vec![vec![2], vec![], vec![], vec![]], tree.children);
+    }
+
+    #[test]
+    fn test_subtree_totals_invalid_parents_remain_separate_roots() {
+        let nodes = vec![
+            node("root", u32::MAX, 10, 0),
+            node("self", 1, 20, 0),
+            node("missing", 99, 30, 0),
+            node("child", 2, 40, 0),
+        ];
+        assert_eq!(vec![10, 20, 70, 40], subtree_totals(&nodes));
+    }
+}

--- a/cli/modules/inspect/src/report.rs
+++ b/cli/modules/inspect/src/report.rs
@@ -1,0 +1,619 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use bytesize::ByteSize;
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+use ync::{display, output};
+use ynpb::pb::{DevicePipelineInfo, InspectResponse, InstanceInfo, MemoryNode};
+
+use crate::memory::{MemoryTree, node_live};
+
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+enum Style {
+    #[default]
+    Plain,
+    Dim,
+    Bold,
+    Warning,
+    Error,
+}
+
+impl Style {
+    fn paint(self, text: &str, colored: bool) -> String {
+        if !colored {
+            return text.to_string();
+        }
+        match self {
+            Self::Plain => text.to_string(),
+            Self::Dim => output::paint_dim(text),
+            Self::Bold => output::paint_bold(text),
+            Self::Warning => output::paint_warning(text),
+            Self::Error => output::paint_error(text),
+        }
+    }
+}
+
+struct Span {
+    text: String,
+    style: Style,
+}
+
+impl Span {
+    fn new(text: impl Into<String>, style: Style) -> Self {
+        Self { text: text.into(), style }
+    }
+}
+
+struct Field {
+    label: &'static str,
+    value: String,
+    style: Style,
+}
+
+impl Field {
+    fn new(label: &'static str, value: impl Into<String>) -> Self {
+        Self {
+            label,
+            value: value.into(),
+            style: Style::Plain,
+        }
+    }
+
+    fn width(&self) -> usize {
+        self.label.width() + usize::from(!self.label.is_empty()) + self.value.width()
+    }
+}
+
+struct Record {
+    kind: &'static str,
+    prefix: String,
+    name: String,
+    fields: Vec<Field>,
+    tree: bool,
+    dimmed: bool,
+}
+
+impl Record {
+    fn new(kind: &'static str, name: impl Into<String>, fields: Vec<Field>) -> Self {
+        Self {
+            kind,
+            prefix: String::new(),
+            name: name.into(),
+            fields,
+            tree: false,
+            dimmed: false,
+        }
+    }
+
+    fn name_width(&self) -> usize {
+        self.prefix.width() + self.name.width()
+    }
+
+    fn field_group(&self) -> &'static str {
+        if self.tree { "memory" } else { self.kind }
+    }
+}
+
+pub fn render(response: &InspectResponse, memory: bool) {
+    let Some(info) = &response.instance_info else {
+        output::empty(format_args!("No instance information found."));
+        return;
+    };
+
+    let colored = output::stdout_is_terminal() && output::is_colored();
+    let groups = vec![
+        memory_records(info, memory, colored),
+        device_records(info),
+        pipeline_records(info),
+        function_records(info),
+        module_records(info),
+    ];
+
+    let width = display::terminal_width().filter(|&width| width > 0);
+    let header = format!("YANET  instance {}  NUMA {}", info.instance_idx, info.numa_idx);
+    let report = format_report(&header, &groups, width, colored);
+    print!("{report}");
+}
+
+fn bytes(value: u64) -> String {
+    ByteSize::b(value).display().iec().to_string()
+}
+
+/// Escaped control characters keep names from injecting terminal commands
+/// or creating extra report lines.
+fn name(value: &str) -> String {
+    let mut escaped = String::new();
+    for ch in value.chars() {
+        if ch.is_control() {
+            escaped.extend(ch.escape_default());
+        } else {
+            escaped.push(ch);
+        }
+    }
+    escaped
+}
+
+fn list(values: impl IntoIterator<Item = String>, separator: &str) -> String {
+    let values: Vec<_> = values.into_iter().collect();
+    if values.is_empty() {
+        "-".into()
+    } else {
+        values.join(separator)
+    }
+}
+
+fn nonempty(records: Vec<Record>, kind: &'static str) -> Vec<Record> {
+    if records.is_empty() {
+        vec![Record::new(kind, "-", vec![Field::new("", "none")])]
+    } else {
+        records
+    }
+}
+
+fn memory_records(info: &InstanceInfo, details: bool, unicode: bool) -> Vec<Record> {
+    let mut agents: Vec<_> = info.agents.iter().collect();
+    agents.sort_by_key(|agent| &agent.name);
+    let mut rows = Vec::new();
+    for agent in agents {
+        if agent.instances.is_empty() {
+            let mut fields = if details {
+                memory_fields("-".into(), "-".into(), false)
+            } else {
+                Vec::new()
+            };
+            fields.push(Field::new("instances", "0"));
+            rows.push(Record::new("memory", name(&agent.name), fields));
+        }
+        let mut instances: Vec<_> = agent.instances.iter().collect();
+        instances.sort_by_key(|instance| (instance.pid, instance.generation));
+        for instance in instances {
+            let used = instance.memory_limit.saturating_sub(instance.free_bytes);
+            let mut usage = Field::new("", "-");
+            if instance.memory_limit > 0 {
+                let percent = u128::from(used) * 100 / u128::from(instance.memory_limit);
+                usage.value = format!("{percent}%");
+                usage.style = match percent {
+                    95.. => Style::Error,
+                    80.. => Style::Warning,
+                    _ => Style::Plain,
+                };
+                if percent >= 80 {
+                    usage.value.push_str(" !");
+                }
+            }
+            let row = Record::new(
+                "memory",
+                name(&agent.name),
+                vec![
+                    Field::new("pid", instance.pid.to_string()),
+                    Field::new("gen", instance.generation.to_string()),
+                    Field::new("used", format!("{} / {}", bytes(used), bytes(instance.memory_limit))),
+                    Field::new("free", bytes(instance.free_bytes)),
+                    usage,
+                ],
+            );
+            if details {
+                rows.extend(memory_tree_records(row, &agent.name, &instance.memory_tree, unicode));
+            } else {
+                rows.push(row);
+            }
+        }
+    }
+    nonempty(rows, "memory")
+}
+
+fn bindings(pipelines: &[DevicePipelineInfo]) -> String {
+    list(
+        pipelines
+            .iter()
+            .map(|pipeline| format!("{} (w={})", name(&pipeline.name), pipeline.weight)),
+        ", ",
+    )
+}
+
+fn device_records(info: &InstanceInfo) -> Vec<Record> {
+    let mut devices: Vec<_> = info.devices.iter().collect();
+    devices.sort_by_key(|device| (device.index, &device.r#type, &device.name));
+    nonempty(
+        devices
+            .into_iter()
+            .map(|device| {
+                Record::new(
+                    "device",
+                    format!("#{} {}:{}", device.index, name(&device.r#type), name(&device.name)),
+                    vec![
+                        Field::new("input", bindings(&device.input_pipelines)),
+                        Field::new("output", bindings(&device.output_pipelines)),
+                    ],
+                )
+            })
+            .collect(),
+        "device",
+    )
+}
+
+fn pipeline_records(info: &InstanceInfo) -> Vec<Record> {
+    let mut pipelines: Vec<_> = info.pipelines.iter().collect();
+    pipelines.sort_by_key(|pipeline| &pipeline.name);
+    nonempty(
+        pipelines
+            .into_iter()
+            .map(|pipeline| {
+                Record::new(
+                    "pipeline",
+                    name(&pipeline.name),
+                    vec![Field::new("", list(pipeline.functions.iter().map(|f| name(f)), " -> "))],
+                )
+            })
+            .collect(),
+        "pipeline",
+    )
+}
+
+fn function_records(info: &InstanceInfo) -> Vec<Record> {
+    let mut functions: Vec<_> = info.functions.iter().collect();
+    functions.sort_by_key(|function| &function.name);
+    let mut rows = Vec::new();
+    for function in functions {
+        if function.chains.is_empty() {
+            rows.push(Record::new(
+                "function",
+                name(&function.name),
+                vec![Field::new("chains", "-")],
+            ));
+        }
+        let mut chains: Vec<_> = function.chains.iter().collect();
+        chains.sort_by_key(|chain| &chain.name);
+        for chain in chains {
+            let mut row = Record::new(
+                "function",
+                name(&function.name),
+                vec![
+                    Field::new("chain", name(&chain.name)),
+                    Field::new("", format!("w={}", chain.weight)),
+                    Field::new(
+                        "",
+                        list(
+                            chain
+                                .modules
+                                .iter()
+                                .map(|module| format!("{}:{}", name(&module.r#type), name(&module.name))),
+                            " -> ",
+                        ),
+                    ),
+                ],
+            );
+            if chain.weight == 0 {
+                row.dimmed = true;
+                row.fields.push(Field::new("", "[disabled]"));
+            }
+            rows.push(row);
+        }
+    }
+    nonempty(rows, "function")
+}
+
+fn module_records(info: &InstanceInfo) -> Vec<Record> {
+    let mut configs: BTreeMap<&str, Vec<_>> = BTreeMap::new();
+    for config in &info.cp_configs {
+        configs.entry(&config.r#type).or_default().push(config);
+    }
+    for group in configs.values_mut() {
+        group.sort_by_key(|config| (&config.name, config.generation));
+    }
+    let loaded: BTreeSet<_> = info.dp_modules.iter().map(|module| module.name.as_str()).collect();
+    let mut rows: Vec<_> = info
+        .dp_modules
+        .iter()
+        .enumerate()
+        .map(|(idx, module)| {
+            let values = configs
+                .get(module.name.as_str())
+                .into_iter()
+                .flatten()
+                .map(|config| format!("{} (gen {})", name(&config.name), config.generation));
+            Record::new(
+                "module",
+                name(&module.name),
+                vec![
+                    Field::new("id", idx.to_string()),
+                    Field::new("configs", list(values, ", ")),
+                ],
+            )
+        })
+        .collect();
+    for (kind, configs) in configs {
+        if !loaded.contains(kind) {
+            for config in configs {
+                rows.push(Record::new(
+                    "config",
+                    format!("{}:{}", name(kind), name(&config.name)),
+                    vec![Field::new("gen", config.generation.to_string())],
+                ));
+            }
+        }
+    }
+    nonempty(rows, "module")
+}
+
+fn memory_fields(total: String, own: String, branch: bool) -> Vec<Field> {
+    let mut total = Field::new("total", total);
+    total.style = if branch { Style::Bold } else { Style::Plain };
+    vec![total, Field::new("own", own)]
+}
+
+fn memory_tree_records(mut root: Record, agent_name: &str, nodes: &[MemoryNode], unicode: bool) -> Vec<Record> {
+    let tree = MemoryTree::new(nodes);
+    let folded_root = match tree.roots.as_slice() {
+        &[idx] if nodes[idx].parent_idx == u32::MAX && nodes[idx].name == agent_name => Some(idx),
+        _ => None,
+    };
+    if nodes.is_empty() {
+        root.name.push_str(" [no contexts]");
+    }
+    let total = tree
+        .roots
+        .iter()
+        .fold(0u64, |sum, &idx| sum.saturating_add(tree.totals[idx]));
+    root.fields.splice(
+        0..0,
+        memory_fields(
+            if nodes.is_empty() { "-".into() } else { bytes(total) },
+            folded_root
+                .map(|idx| bytes(node_live(&nodes[idx])))
+                .unwrap_or_else(|| "-".into()),
+            true,
+        ),
+    );
+    let mut rows = vec![root];
+
+    let roots = folded_root.map(|idx| &tree.children[idx]).unwrap_or(&tree.roots);
+    let mut pending: Vec<_> = roots
+        .iter()
+        .enumerate()
+        .rev()
+        .map(|(pos, &idx)| (idx, 0, pos + 1 == roots.len()))
+        .collect();
+    let mut continuation = Vec::new();
+    while let Some((idx, depth, last)) = pending.pop() {
+        continuation.truncate(depth);
+        let node = &nodes[idx];
+        let mut label = name(&node.name);
+        if node.parent_idx != u32::MAX && node.parent_idx as usize >= idx {
+            label.push_str(&format!(" [invalid parent #{}]", node.parent_idx));
+        }
+        let children = &tree.children[idx];
+        let mut row = Record::new(
+            "",
+            label,
+            memory_fields(bytes(tree.totals[idx]), bytes(node_live(node)), !children.is_empty()),
+        );
+        row.tree = true;
+        for &more in &continuation {
+            row.prefix.push_str(if more {
+                if unicode { "│  " } else { "|  " }
+            } else {
+                "   "
+            });
+        }
+        row.prefix.push_str(match (unicode, last) {
+            (true, false) => "├─ ",
+            (true, true) => "└─ ",
+            (false, false) => "|- ",
+            (false, true) => "`- ",
+        });
+        rows.push(row);
+        continuation.push(!last);
+        pending.extend(
+            children
+                .iter()
+                .enumerate()
+                .rev()
+                .map(|(pos, &child)| (child, depth + 1, pos + 1 == children.len())),
+        );
+    }
+    rows
+}
+
+fn format_report(header: &str, groups: &[Vec<Record>], width: Option<usize>, colored: bool) -> String {
+    let limit = width.unwrap_or(usize::MAX);
+    let kind_width = groups.iter().flatten().map(|row| row.kind.width()).max().unwrap_or(0);
+    let mut name_width = groups
+        .iter()
+        .flatten()
+        .filter(|row| !row.tree)
+        .map(Record::name_width)
+        .max()
+        .unwrap_or(0)
+        .min((limit / 3).min(40));
+    let mut field_widths: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+    for row in groups.iter().flatten() {
+        let widths = field_widths.entry(row.field_group()).or_default();
+        widths.resize(widths.len().max(row.fields.len()), 0);
+        for (width, field) in widths.iter_mut().zip(&row.fields) {
+            *width = (*width).max(field.width());
+        }
+    }
+    if let Some(widths) = field_widths.get("memory") {
+        let widths = &widths[..widths.len().min(2)];
+        let values_width = widths.iter().sum::<usize>() + widths.len().saturating_sub(1) * 2;
+        let available = limit.saturating_sub(kind_width + 4 + values_width);
+        name_width = name_width.max(
+            groups
+                .iter()
+                .flatten()
+                .filter(|row| row.tree)
+                .map(Record::name_width)
+                .max()
+                .unwrap_or(0)
+                .min(available),
+        );
+    }
+    let detail_indent = kind_width + name_width + 4;
+    let mut rendered_groups = Vec::new();
+    let mut longest = header.width().min(limit);
+
+    for group in groups {
+        let mut lines = Vec::new();
+        for row in group {
+            let compact = limit < 80 && (row.field_group() != "memory" || name_width < 8);
+            let widths = &field_widths[row.field_group()];
+            // Memory roots and children share their leading columns even when
+            // process details wrap onto another line.
+            let aligned_widths = if row.field_group() == "memory" {
+                &widths[..widths.len().min(2)]
+            } else {
+                widths
+            };
+            let align = !compact
+                && detail_indent
+                    .saturating_add(aligned_widths.iter().sum::<usize>())
+                    .saturating_add(aligned_widths.len().saturating_sub(1) * 2)
+                    <= limit;
+            let value_style = if row.dimmed { Style::Dim } else { Style::Plain };
+            let mut prefix = vec![
+                Span::new(format!("{:<kind_width$}  ", row.kind), Style::Dim),
+                Span::new(&row.prefix, Style::Dim),
+                Span::new(&row.name, value_style),
+            ];
+            let mut fields = Vec::new();
+            for (idx, field) in row.fields.iter().enumerate() {
+                let mut spans = Vec::new();
+                if !field.label.is_empty() {
+                    spans.push(Span::new(format!("{} ", field.label), Style::Dim));
+                }
+                spans.push(Span::new(
+                    &field.value,
+                    if row.dimmed { Style::Dim } else { field.style },
+                ));
+                if idx + 1 < row.fields.len() {
+                    let padding = if align {
+                        widths[idx].saturating_sub(field.width()) + 2
+                    } else {
+                        2
+                    };
+                    spans.push(Span::new(" ".repeat(padding), Style::Plain));
+                }
+                fields.push(spans);
+            }
+            if compact || row.name_width() > name_width {
+                lines.extend(wrap(&[prefix], limit, (kind_width + 2).min(limit / 4)));
+                let indent = if compact {
+                    (kind_width + 2).min(limit / 4)
+                } else {
+                    detail_indent
+                };
+                let mut details = vec![vec![Span::new(" ".repeat(indent), Style::Plain)]];
+                details.extend(fields);
+                lines.extend(wrap(&details, limit, indent));
+            } else {
+                prefix.push(Span::new(" ".repeat(name_width - row.name_width() + 2), Style::Plain));
+                let mut blocks = vec![prefix];
+                blocks.extend(fields);
+                lines.extend(wrap(&blocks, limit, detail_indent));
+            }
+        }
+        longest = longest.max(
+            lines
+                .iter()
+                .map(|line| line.iter().map(|s| s.text.width()).sum())
+                .max()
+                .unwrap_or(0),
+        );
+        rendered_groups.push(lines);
+    }
+
+    let mut out = String::new();
+    append_lines(
+        &mut out,
+        wrap(&[vec![Span::new(header, Style::Bold)]], limit, 0),
+        colored,
+    );
+    let separator = if colored { "─" } else { "-" }.repeat(longest.min(limit));
+    for lines in rendered_groups {
+        out.push_str(&Style::Dim.paint(&separator, colored));
+        out.push('\n');
+        append_lines(&mut out, lines, colored);
+    }
+    out
+}
+
+/// Wrapping measures plain graphemes before applying colour, preserving
+/// long identifiers and avoiding splits inside a Unicode character cluster.
+fn wrap(blocks: &[Vec<Span>], width: usize, indent: usize) -> Vec<Vec<Span>> {
+    let mut lines = Vec::new();
+    let mut line = Vec::new();
+    let mut column = 0;
+    for block in blocks {
+        // Padding between fields does not force a fitting value onto a new line.
+        let mut block_width = 0;
+        let mut trim = true;
+        for span in block.iter().rev() {
+            let text = if trim {
+                span.text.trim_end_matches(' ')
+            } else {
+                &span.text
+            };
+            block_width += text.width();
+            trim &= text.is_empty();
+        }
+        if block_width <= width.saturating_sub(indent) && column > indent && column.saturating_add(block_width) > width
+        {
+            finish_line(&mut lines, &mut line);
+            line.push(Span::new(" ".repeat(indent), Style::Plain));
+            column = indent;
+        }
+        for span in block {
+            for word in span.text.split_inclusive(' ') {
+                let word_width = word.trim_end_matches(' ').width();
+                if column > indent && column.saturating_add(word_width) > width {
+                    finish_line(&mut lines, &mut line);
+                    line.push(Span::new(" ".repeat(indent), Style::Plain));
+                    column = indent;
+                }
+                for grapheme in word.graphemes(true) {
+                    let size = grapheme.width();
+                    if grapheme == " " && column >= width {
+                        continue;
+                    }
+                    if column.saturating_add(size) > width && column > indent {
+                        finish_line(&mut lines, &mut line);
+                        line.push(Span::new(" ".repeat(indent), Style::Plain));
+                        column = indent;
+                    }
+                    if let Some(last) = line.last_mut().filter(|last| last.style == span.style) {
+                        last.text.push_str(grapheme);
+                    } else {
+                        line.push(Span::new(grapheme, span.style));
+                    }
+                    column += size;
+                }
+            }
+        }
+    }
+    finish_line(&mut lines, &mut line);
+    lines
+}
+
+fn finish_line(lines: &mut Vec<Vec<Span>>, line: &mut Vec<Span>) {
+    while let Some(last) = line.last_mut() {
+        last.text.truncate(last.text.trim_end_matches(' ').len());
+        if last.text.is_empty() {
+            line.pop();
+        } else {
+            break;
+        }
+    }
+    if !line.is_empty() {
+        lines.push(core::mem::take(line));
+    }
+}
+
+fn append_lines(out: &mut String, lines: Vec<Vec<Span>>, colored: bool) {
+    for line in lines {
+        for span in line {
+            out.push_str(&span.style.paint(&span.text, colored));
+        }
+        out.push('\n');
+    }
+}


### PR DESCRIPTION
- Replace the tree dump with a compact report sharing aligned names and properties across memory, devices, pipelines, functions and modules.
- Expand memory contexts with `--memory`, aligning `total` and `own` under a single root that includes pool usage and process metadata.
- Use muted tree connectors and memory-pressure colors, wrap to terminal width, and preserve the full JSON response and ASCII tree connectors when colors are disabled.
