### PR TITLE
feat(controlplane,cli): delete a device through the service and cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,6 +3230,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "yanet-cli-device-delete"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "tonic",
+ "yanet-cli",
+ "yanet-ynpb",
+]
+
+[[package]]
 name = "yanet-cli-device-list"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "cli/modules/ready",
     "cli/modules/metrics",
     "cli/modules/device",
+    "cli/modules/device-delete",
     "modules/acl/cli",
     "modules/balancer2/cli",
     "modules/blackhole/cli",

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ RELEASE_DIR := $(TARGET_DIR)/release
 CLI_CORE_MODULES := \
 	common \
 	device-list \
+	device-delete \
 	inspect \
 	pipeline \
 	function \

--- a/cli/modules/device-delete/Cargo.toml
+++ b/cli/modules/device-delete/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "yanet-cli-device-delete"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+rust-version = "1.88"
+
+[lints]
+workspace = true
+
+[dependencies]
+ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
+ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
+tonic = { version = "0.14", features = ["gzip"] }

--- a/cli/modules/device-delete/src/main.rs
+++ b/cli/modules/device-delete/src/main.rs
@@ -1,0 +1,86 @@
+//! CLI for YANET "device delete" command.
+
+use clap::{ArgAction, CommandFactory, Parser};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
+use tonic::codec::CompressionEncoding;
+use ync::{
+    client::{ConnectionArgs, Service},
+    completion,
+    errors::{Error, NotFoundMapper},
+    output::{self, CommonFormat},
+};
+use ynpb::pb::{DeleteDeviceRequest, ListDevicesRequest, device_service_client::DeviceServiceClient};
+
+/// The fully-qualified gRPC service name used in error messages.
+const SERVICE_NAME: &str = "controlplane.ynpb.v1.DeviceService";
+
+/// Maps a genuine "device not found" status into a friendly message.
+const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "device");
+
+/// Device delete module - removes a configured device.
+#[derive(Debug, Clone, Parser)]
+#[command(version = ync::version(), about)]
+#[command(flatten_help = true)]
+pub struct Cmd {
+    /// Name of the device to delete.
+    #[arg(add = ArgValueCandidates::new(device_candidates))]
+    pub name: String,
+    #[command(flatten)]
+    pub connection: ConnectionArgs,
+    /// Output format.
+    #[arg(long, value_enum, default_value = "human", global = true)]
+    pub format: CommonFormat,
+    /// Be verbose: shows debug log lines and raw gRPC error details.
+    #[clap(short, action = ArgAction::Count, global = true)]
+    pub verbose: u8,
+}
+
+fn main() -> std::process::ExitCode {
+    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+}
+
+async fn run(cmd: Cmd) -> Result<(), Error> {
+    let action = "delete";
+    let mut service = Service::connect_for(&cmd.connection, action, SERVICE_NAME, |channel| {
+        DeviceServiceClient::new(channel)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip)
+    })
+    .await?;
+
+    let name = cmd.name;
+    service
+        .client()
+        .delete(DeleteDeviceRequest { name: name.clone() })
+        .await
+        .map_err(|status| NOT_FOUND.map(status, action, service.endpoint(), Some(&format!("device '{name}'"))))?;
+
+    output::success(action, format_args!("Deleted device '{name}'."));
+
+    Ok(())
+}
+
+/// Completion candidates for the device-name argument: the devices the
+/// service currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn device_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            DeviceServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| {
+            Ok(client
+                .list(ListDevicesRequest {})
+                .await?
+                .into_inner()
+                .ids
+                .into_iter()
+                .map(|id| id.name)
+                .collect())
+        },
+    )
+}

--- a/controlplane/builtin/device.go
+++ b/controlplane/builtin/device.go
@@ -2,16 +2,35 @@ package builtin
 
 import (
 	"context"
+	"errors"
+	"sync"
 
+	"github.com/c2h5oh/datasize"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
-// Device is an in-process gRPC service for listing dataplane devices.
+const deviceAgentName = "device"
+
+// Each call attaches a fresh agent whose 1MB covers a delete's
+// temporary allocations.
+//
+// The arena persists until a later attach under the same name
+// reclaims it.
+const deviceAgentMemory = datasize.MB
+
+// Device is an in-process gRPC service for listing and deleting dataplane
+// devices.
 type Device struct {
 	ynpb.UnimplementedDeviceServiceServer
+
+	// mu serializes the attach-through-delete lifetime: a concurrent
+	// attach under the same agent name reclaims the agent still in use.
+	mu sync.Mutex
 
 	instanceID uint32
 	shm        *ffi.SharedMemory
@@ -57,4 +76,41 @@ func (m *Device) List(
 	}
 
 	return &ynpb.ListDevicesResponse{Ids: ids}, nil
+}
+
+// Delete removes a device by name. A predefined topology device is
+// refused and an absent name is reported as not found.
+func (m *Device) Delete(
+	ctx context.Context,
+	request *ynpb.DeleteDeviceRequest,
+) (*ynpb.DeleteDeviceResponse, error) {
+	name := request.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "device name is required")
+	}
+	if err := ffi.ValidateDeviceName(name); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	agent, err := m.shm.AgentAttach(deviceAgentName, m.instanceID, deviceAgentMemory)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	defer agent.Close()
+
+	if err := agent.DeleteDevice(name); err != nil {
+		switch {
+		case errors.Is(err, ffi.ErrNotFound):
+			return nil, status.Error(codes.NotFound, err.Error())
+		case errors.Is(err, ffi.ErrInvalidArgument):
+			// A predefined topology device cannot be deleted.
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &ynpb.DeleteDeviceResponse{}, nil
 }

--- a/controlplane/builtin/device_test.go
+++ b/controlplane/builtin/device_test.go
@@ -1,0 +1,134 @@
+package builtin_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/builtin"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+	plain "github.com/yanet-platform/yanet2/devices/plain/controlplane"
+)
+
+// newDeviceHarness builds a one-instance in-process dataplane harness with
+// a single predefined topology device "d0" of type "plain" and registers
+// its teardown.
+func newDeviceHarness(t *testing.T) *dataplaneut.Harness {
+	t.Helper()
+
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		Devices:       []string{"d0"},
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	return harness
+}
+
+// deviceNames returns the registry names of the given devices in order.
+func deviceNames(devices []ffi.DeviceInfo) []string {
+	names := make([]string, len(devices))
+	for idx, device := range devices {
+		names[idx] = device.Name
+	}
+	return names
+}
+
+// Test_Device_Delete_RejectsInvalidName verifies that Delete rejects a
+// name that is empty, contains an interior NUL, or exceeds the C-side
+// buffer, before any shared memory is touched.
+func Test_Device_Delete_RejectsInvalidName(t *testing.T) {
+	cases := []struct {
+		name       string
+		deviceName string
+	}{
+		{
+			name:       "empty name",
+			deviceName: "",
+		},
+		{
+			name:       "interior NUL",
+			deviceName: "extra\x00keep",
+		},
+		{
+			name:       "overlong name",
+			deviceName: strings.Repeat("d", ffi.MaxDeviceNameLen),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := builtin.NewDevice(0, nil)
+
+			_, err := svc.Delete(t.Context(), &ynpb.DeleteDeviceRequest{Name: tc.deviceName})
+
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// Test_Device_Delete_RemovesDevice verifies that Delete removes a
+// non-topology device from the dataplane registry while leaving the
+// predefined topology device in place.
+func Test_Device_Delete_RemovesDevice(t *testing.T) {
+	harness := newDeviceHarness(t)
+	shm := harness.SharedMemory()
+
+	agent, err := shm.AgentAttach("plain", 0, datasize.MB*4)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	deviceConfig, err := plain.NewDeviceConfig(agent, "extra", &commonpb.Device{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = deviceConfig.Free() })
+
+	require.NoError(t, agent.UpdateDevices([]ffi.ShmDeviceConfig{deviceConfig.AsFFIDevice()}))
+	require.Contains(t, deviceNames(shm.DPConfig(0).Devices()), "extra")
+
+	svc := builtin.NewDevice(0, shm)
+
+	_, err = svc.Delete(t.Context(), &ynpb.DeleteDeviceRequest{Name: "extra"})
+	require.NoError(t, err)
+
+	names := deviceNames(shm.DPConfig(0).Devices())
+	require.NotContains(t, names, "extra")
+	require.Contains(t, names, "d0")
+}
+
+// Test_Device_Delete_RefusesTopologyDevice verifies that Delete refuses to
+// remove a predefined topology device and leaves the registry unchanged.
+func Test_Device_Delete_RefusesTopologyDevice(t *testing.T) {
+	harness := newDeviceHarness(t)
+	shm := harness.SharedMemory()
+
+	svc := builtin.NewDevice(0, shm)
+
+	_, err := svc.Delete(t.Context(), &ynpb.DeleteDeviceRequest{Name: "d0"})
+
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, deviceNames(shm.DPConfig(0).Devices()), "d0")
+}
+
+// Test_Device_Delete_MissingDevice verifies that Delete reports NotFound
+// for a device name absent from the registry.
+func Test_Device_Delete_MissingDevice(t *testing.T) {
+	harness := newDeviceHarness(t)
+	shm := harness.SharedMemory()
+
+	svc := builtin.NewDevice(0, shm)
+
+	_, err := svc.Delete(t.Context(), &ynpb.DeleteDeviceRequest{Name: "absent"})
+
+	require.Equal(t, codes.NotFound, status.Code(err))
+}

--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -296,6 +296,19 @@ func (m *Agent) DeletePipeline(name string) error {
 	return nil
 }
 
+func (m *Agent) DeleteDevice(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var cErr *C.yanet_error
+	rc := C.agent_delete_device(m.ptr, cName, &cErr)
+	if rc != 0 {
+		return fmt.Errorf("failed to delete device %q: %w", name, cerrors.FromC(unsafe.Pointer(cErr)))
+	}
+
+	return nil
+}
+
 func (m *Agent) DeleteModuleConfig(moduleType, configName string) error {
 	cTypeName := C.CString(moduleType)
 	defer C.free(unsafe.Pointer(cTypeName))

--- a/controlplane/ynpb/v1/device.proto
+++ b/controlplane/ynpb/v1/device.proto
@@ -4,11 +4,15 @@ package controlplane.ynpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
-// DeviceService provides information about network devices configured
-// in the dataplane.
+// DeviceService lists and deletes network devices configured in the
+// dataplane.
 service DeviceService {
   // List returns all configured devices.
   rpc List(ListDevicesRequest) returns (ListDevicesResponse);
+  // Delete removes the device with the given name.
+  //
+  // Predefined topology devices cannot be deleted.
+  rpc Delete(DeleteDeviceRequest) returns (DeleteDeviceResponse);
 }
 
 message ListDevicesRequest {}
@@ -21,3 +25,12 @@ message DeviceId {
   // Device registry index.
   uint32 index = 3;
 }
+
+// DeleteDeviceRequest specifies which device to delete.
+message DeleteDeviceRequest {
+  // Name of the device to delete.
+  string name = 1;
+}
+
+// DeleteDeviceResponse is returned after successful deletion.
+message DeleteDeviceResponse {}

--- a/debian/yanet2-cli.install
+++ b/debian/yanet2-cli.install
@@ -20,6 +20,7 @@ usr/bin/yanet-cli-ready
 usr/bin/yanet-cli-metrics
 usr/bin/yanet-cli-counters
 usr/bin/yanet-cli-device-list
+usr/bin/yanet-cli-device-delete
 usr/bin/yanet-cli-device-plain
 usr/bin/yanet-cli-device-vlan
 usr/bin/yanet-cli-device-trafgen


### PR DESCRIPTION
- Adds a Delete RPC to the device service that removes a device by name through the existing C entry point.
- Refuses a predefined topology device with InvalidArgument, the kind recorded for it in the error-kinds design, and reports an absent name as NotFound.
- Validates the name before it reaches C, so an interior NUL cannot truncate it into another device's name.
- Adds `yanet-cli device delete <NAME>` as its own core crate with name completion from the device list, registered in the workspace, the Makefile and the Debian install list.
- Placement is the common device service rather than per-type RPCs because the C entry point is type-agnostic.
- Serializes delete calls, since a concurrent attach under the same agent name would reclaim an agent still in use.
- The owning plain, vlan and trafgen services keep the config handle of a device deleted this way until the same name is updated again or the process restarts, and the trafgen config list still shows the name.

Closes #2387.
