### PR TITLE
fix(nat64): dedupe prefixes and upsert mappings on add

### DIFF
--- a/modules/nat64/controlplane/nat64pb/v1/nat64.proto
+++ b/modules/nat64/controlplane/nat64pb/v1/nat64.proto
@@ -15,7 +15,9 @@ service NAT64Service {
   // ShowConfig returns the current configuration of the NAT64 module
   rpc ShowConfig(ShowConfigRequest) returns (ShowConfigResponse) {}
 
-  // AddPrefix adds a new NAT64 prefix to the configuration
+  // AddPrefix adds a NAT64 prefix to the configuration.
+  //
+  // Adding a prefix that is already present is a no-op.
   rpc AddPrefix(AddPrefixRequest) returns (AddPrefixResponse) {}
 
   // RemovePrefix removes a NAT64 prefix from the configuration.
@@ -23,7 +25,9 @@ service NAT64Service {
   // Returns NotFound if the config or prefix is absent.
   rpc RemovePrefix(RemovePrefixRequest) returns (RemovePrefixResponse) {}
 
-  // AddMapping adds a new IPv4-IPv6 address mapping
+  // AddMapping adds an IPv4-IPv6 address mapping.
+  //
+  // Mappings are keyed by IPv4, so adding one for an already mapped IPv4 replaces it.
   rpc AddMapping(AddMappingRequest) returns (AddMappingResponse) {}
 
   // RemoveMapping removes an IPv4-IPv6 address mapping.

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -215,6 +215,9 @@ func (m *NAT64Service) AddPrefix(ctx context.Context, req *nat64pb.AddPrefixRequ
 	defer m.mu.Unlock()
 
 	inst := m.instanceFor(name).Clone()
+	if slices.ContainsFunc(inst.Config.Prefixes, func(existing []byte) bool { return bytes.Equal(existing, prefix) }) {
+		return &nat64pb.AddPrefixResponse{}, nil
+	}
 	inst.Config.Prefixes = append(inst.Config.Prefixes, prefix)
 
 	if err := m.updateModuleConfig(name, inst); err != nil {
@@ -295,6 +298,7 @@ func (m *NAT64Service) AddMapping(ctx context.Context, req *nat64pb.AddMappingRe
 			len(inst.Config.Prefixes),
 		)
 	}
+	inst.Config.Mappings = slices.DeleteFunc(inst.Config.Mappings, func(existing Mapping) bool { return existing.IPv4 == ipv4 })
 	inst.Config.Mappings = append(inst.Config.Mappings, Mapping{
 		IPv4:        ipv4,
 		IPv6:        ipv6,

--- a/modules/nat64/controlplane/service_test.go
+++ b/modules/nat64/controlplane/service_test.go
@@ -184,6 +184,129 @@ func Test_NAT64Service_AddPrefixDefaultMTU(t *testing.T) {
 	require.Equal(t, MTUConfig{IPv4MTU: 1450, IPv6MTU: 1280}, backend.configs[0].MTU)
 }
 
+// Test_NAT64Service_AddPrefix_ExistingIsNoop verifies that adding a prefix
+// already in the config does not duplicate it or republish the module.
+func Test_NAT64Service_AddPrefix_ExistingIsNoop(t *testing.T) {
+	backend := &mockBackend{}
+	service := NewNAT64Service(backend)
+	prefix := mustIPv6Prefix(t, "64:ff9b::/96")
+
+	_, err := service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{
+		Name:   "nat64-0",
+		Prefix: prefix,
+	})
+	require.NoError(t, err)
+
+	_, err = service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{
+		Name:   "nat64-0",
+		Prefix: prefix,
+	})
+	require.NoError(t, err)
+
+	show, err := service.ShowConfig(t.Context(), &nat64pb.ShowConfigRequest{Name: "nat64-0"})
+	require.NoError(t, err)
+	require.Len(t, show.GetConfig().GetPrefixes(), 1)
+	require.Equal(t, prefix, show.GetConfig().GetPrefixes()[0])
+	require.Len(t, backend.configs, 1)
+}
+
+// Test_NAT64Service_AddMapping_ExistingIPv4Replaced verifies that adding a
+// mapping for an already mapped IPv4 replaces the entry instead of adding one.
+func Test_NAT64Service_AddMapping_ExistingIPv4Replaced(t *testing.T) {
+	backend := &mockBackend{}
+	service := NewNAT64Service(backend)
+	ipv4 := netip.MustParseAddr("192.0.2.1")
+	ipv6First := netip.MustParseAddr("2001:db8::1")
+	ipv6Second := netip.MustParseAddr("2001:db8::2")
+
+	_, err := service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{
+		Name:   "nat64-0",
+		Prefix: mustIPv6Prefix(t, "64:ff9b::/96"),
+	})
+	require.NoError(t, err)
+	_, err = service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{
+		Name:   "nat64-0",
+		Prefix: mustIPv6Prefix(t, "2001:db8::/96"),
+	})
+	require.NoError(t, err)
+
+	_, err = service.AddMapping(t.Context(), &nat64pb.AddMappingRequest{
+		Name:        "nat64-0",
+		Ipv4:        commonpb.NewIPv4Address(ipv4.As4()),
+		Ipv6:        commonpb.NewIPv6Address(ipv6First.As16()),
+		PrefixIndex: 0,
+	})
+	require.NoError(t, err)
+
+	_, err = service.AddMapping(t.Context(), &nat64pb.AddMappingRequest{
+		Name:        "nat64-0",
+		Ipv4:        commonpb.NewIPv4Address(ipv4.As4()),
+		Ipv6:        commonpb.NewIPv6Address(ipv6Second.As16()),
+		PrefixIndex: 1,
+	})
+	require.NoError(t, err)
+
+	show, err := service.ShowConfig(t.Context(), &nat64pb.ShowConfigRequest{Name: "nat64-0"})
+	require.NoError(t, err)
+	require.Len(t, show.GetConfig().GetMappings(), 1)
+	require.Equal(t, commonpb.NewIPv4Address(ipv4.As4()), show.GetConfig().GetMappings()[0].GetIpv4())
+	require.Equal(t, commonpb.NewIPv6Address(ipv6Second.As16()), show.GetConfig().GetMappings()[0].GetIpv6())
+	require.Equal(t, uint32(1), show.GetConfig().GetMappings()[0].GetPrefixIndex())
+
+	last := backend.configs[len(backend.configs)-1]
+	require.Len(t, last.Mappings, 1)
+	require.Equal(t, ipv4, last.Mappings[0].IPv4)
+	require.Equal(t, ipv6Second, last.Mappings[0].IPv6)
+	require.Equal(t, uint32(1), last.Mappings[0].PrefixIndex)
+}
+
+// Test_NAT64Service_AddMapping_UpsertPublishedLast verifies that an upserted
+// mapping is published last, so a shared IPv6 resolves to the newest mapping.
+func Test_NAT64Service_AddMapping_UpsertPublishedLast(t *testing.T) {
+	backend := &mockBackend{}
+	service := NewNAT64Service(backend)
+	ipv4First := netip.MustParseAddr("192.0.2.1")
+	ipv4Second := netip.MustParseAddr("192.0.2.2")
+	ipv6First := netip.MustParseAddr("2001:db8::1")
+	ipv6Second := netip.MustParseAddr("2001:db8::2")
+
+	_, err := service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{
+		Name:   "nat64-0",
+		Prefix: mustIPv6Prefix(t, "64:ff9b::/96"),
+	})
+	require.NoError(t, err)
+
+	_, err = service.AddMapping(t.Context(), &nat64pb.AddMappingRequest{
+		Name:        "nat64-0",
+		Ipv4:        commonpb.NewIPv4Address(ipv4First.As4()),
+		Ipv6:        commonpb.NewIPv6Address(ipv6First.As16()),
+		PrefixIndex: 0,
+	})
+	require.NoError(t, err)
+
+	_, err = service.AddMapping(t.Context(), &nat64pb.AddMappingRequest{
+		Name:        "nat64-0",
+		Ipv4:        commonpb.NewIPv4Address(ipv4Second.As4()),
+		Ipv6:        commonpb.NewIPv6Address(ipv6Second.As16()),
+		PrefixIndex: 0,
+	})
+	require.NoError(t, err)
+
+	_, err = service.AddMapping(t.Context(), &nat64pb.AddMappingRequest{
+		Name:        "nat64-0",
+		Ipv4:        commonpb.NewIPv4Address(ipv4First.As4()),
+		Ipv6:        commonpb.NewIPv6Address(ipv6Second.As16()),
+		PrefixIndex: 0,
+	})
+	require.NoError(t, err)
+
+	last := backend.configs[len(backend.configs)-1]
+	require.Equal(t, []Mapping{
+		{IPv4: ipv4Second, IPv6: ipv6Second, PrefixIndex: 0},
+		{IPv4: ipv4First, IPv6: ipv6Second, PrefixIndex: 0},
+	}, last.Mappings)
+}
+
 // Test_NAT64Service_PrefixMutation_Invalid verifies that both mutations reject
 // missing, malformed, and non-/96 prefixes.
 func Test_NAT64Service_PrefixMutation_Invalid(t *testing.T) {


### PR DESCRIPTION
- Adding a prefix that the config already holds is a no-op: the config keeps a single copy and nothing is republished.
- Adding a mapping for an IPv4 that already has one replaces that entry, so the config never holds two mappings for one IPv4.
- The replaced mapping is published last, so on a shared IPv6 the dataplane keeps resolving to the newest mapping exactly as the previous append did.
- The proto comments on both RPCs state the new contract.
- Go tests cover all three cases and were written first against the unfixed code.
- Assumption: a no-op prefix add returns success without publishing a new module generation, since the published config is unchanged.
- Assumption: a mapping upsert always publishes, even when the values are identical, matching how the other setters behave.
- Two mappings sharing one IPv6 are not rejected, that pre-existing gap is left for a separate issue.
- The CLI verb rename to `mapping insert` belongs to the dictionary migration and is not part of this change.
- Closes #2389.
