### PR TITLE
fix(controlplane): stop holding service locks across module publishes

### DIFF
--- a/modules/blackhole/controlplane/service.go
+++ b/modules/blackhole/controlplane/service.go
@@ -44,26 +44,72 @@ func (m *config) Free() error {
 	return m.Module.Free()
 }
 
+// configEntry is the per-name lock anchor of a blackhole config.
+//
+// Entries are append-only: deleting a config clears its published slot
+// instead of removing the entry, keeping the entry as the lock anchor.
+// Acquiring a name's lock is a two-step operation — fetch the entry, then
+// lock it — and removing entries would let two goroutines serialize the
+// same name on two different entry objects during exactly that window.
+type configEntry struct {
+	// updateMu serializes mutations of this name for the entry's whole
+	// life, across the whole operation including the backend publish.
+	updateMu sync.Mutex
+	// published is the config currently active for this name, or nil
+	// when the name is absent. It is written only while holding both the
+	// entry's update lock and the service write lock; an update-lock
+	// holder may read it without the service lock.
+	published *config
+}
+
+func (m *configEntry) LockUpdate() {
+	m.updateMu.Lock()
+}
+
+func (m *configEntry) UnlockUpdate() {
+	m.updateMu.Unlock()
+}
+
+func (m *configEntry) Published() *config {
+	return m.published
+}
+
+func (m *configEntry) Publish(config *config) {
+	m.published = config
+}
+
 // BlackholeService implements the BlackholeService gRPC server.
 type BlackholeService struct {
 	blackholepb.UnimplementedBlackholeServiceServer
+
+	// mu guards configs and deferred. Critical sections are short map
+	// and slice work only; the backend publish runs under the target
+	// entry's update lock, outside any service-lock section, so a
+	// stalled publish never blocks a read.
+	mu sync.RWMutex
+	// reclaimMu serializes handle reclamation — draining the deferred
+	// list and parking a superseded handle — across its free attempts,
+	// so a handle refused by a draining generation is retried before the
+	// drain that could miss it completes. It is never taken by a read
+	// path, and a handle's destruction under it may block on the shared
+	// C-side configuration lock, which only stalls other reclamations.
+	reclaimMu sync.Mutex
 
 	// deferred holds superseded module handles whose free was refused
 	// because a live configuration generation still referenced them.
 	// This service is their owner: it retries them on its next update,
 	// through ReclaimDeferred, and nothing else remembers them.
 	deferred []ModuleHandle
-
-	mu      sync.Mutex
-	backend Backend
-	configs map[string]*config
+	backend  Backend
+	// configs maps a name to its append-only entry. See configEntry.
+	configs map[string]*configEntry
 }
 
 // NewBlackholeService constructs a BlackholeService backed by the given Backend.
 func NewBlackholeService(backend Backend) *BlackholeService {
 	return &BlackholeService{
 		backend: backend,
-		configs: map[string]*config{},
+		configs: map[string]*configEntry{},
 	}
 }
 
@@ -72,11 +118,14 @@ func (m *BlackholeService) ListConfigs(
 	ctx context.Context,
 	req *blackholepb.ListConfigsRequest,
 ) (*blackholepb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	names := make([]string, 0, len(m.configs))
-	for name := range m.configs {
+	for name, entry := range m.configs {
+		if entry.Published() == nil {
+			continue
+		}
 		names = append(names, name)
 	}
 
@@ -93,10 +142,11 @@ func (m *BlackholeService) ShowConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
-	if _, ok := m.configs[name]; !ok {
+	entry, ok := m.configs[name]
+	if !ok || entry.Published() == nil {
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
 
@@ -114,38 +164,32 @@ func (m *BlackholeService) UpdateConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	err := m.withEntry(name, func(entry *configEntry) error {
+		mod, err := m.backend.UpdateModule(name)
+		if err != nil {
+			return status.Errorf(
+				codes.Internal,
+				"failed to update module config %q: %v", name, err,
+			)
+		}
 
-	if err := m.updateConfig(name); err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"failed to update module config %q: %v", name, err,
-		)
+		oldConfig := entry.Published()
+
+		m.setPublished(entry, &config{Module: mod})
+
+		// The publish retired the generation holding the published
+		// module; retry the deferred ones, then retire the displaced one.
+		m.ReclaimDeferred()
+		if oldConfig != nil {
+			m.parkOrFree(oldConfig.Module)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &blackholepb.UpdateConfigResponse{}, nil
-}
-
-// updateConfig publishes a fresh config and, on success, frees the old module
-// handle and stores the new one.
-//
-// The caller must hold m.mu.
-func (m *BlackholeService) updateConfig(name string) error {
-	mod, err := m.backend.UpdateModule(name)
-	if err != nil {
-		return err
-	}
-
-	m.reclaimDeferred()
-
-	if old, ok := m.configs[name]; ok {
-		m.parkOrFree(old.Module)
-	}
-
-	m.configs[name] = &config{Module: mod}
-
-	return nil
 }
 
 // DeleteConfig removes the named config if it is not referenced by any
@@ -159,38 +203,103 @@ func (m *BlackholeService) DeleteConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	entry, ok := m.configs[name]
-	if !ok {
+	// Rejecting an unknown name here keeps the locked path from interning
+	// an entry for a name that never existed; the locked re-check below
+	// stays authoritative for the name that waited on an in-flight update.
+	if !m.hasEntry(name) {
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
 
-	if err := m.backend.DeleteModule(name); err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"failed to delete module config %q: %v", name, err,
-		)
+	err := m.withEntry(name, func(entry *configEntry) error {
+		oldConfig := entry.Published()
+		if oldConfig == nil {
+			return status.Error(codes.NotFound, "no config found")
+		}
+
+		if err := m.backend.DeleteModule(name); err != nil {
+			return status.Errorf(
+				codes.Internal,
+				"failed to delete module config %q: %v", name, err,
+			)
+		}
+
+		m.setPublished(entry, nil)
+
+		// The delete retired the generation holding the published
+		// module; retry the deferred ones, then retire this one.
+		m.ReclaimDeferred()
+		m.parkOrFree(oldConfig.Module)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-
-	// The delete retired the generation holding the published module;
-	// retry the deferred ones, then retire this one.
-	m.reclaimDeferred()
-	m.parkOrFree(entry.Module)
-
-	delete(m.configs, name)
 
 	return &blackholepb.DeleteConfigResponse{}, nil
 }
 
-// parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.mu.
-func (m *BlackholeService) parkOrFree(handle ModuleHandle) {
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
+// entry fetches or creates the lock anchor of the named config. The caller
+// must not hold the service lock.
+func (m *BlackholeService) entry(name string) *configEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if entry, ok := m.configs[name]; ok {
+		return entry
 	}
+	entry := &configEntry{}
+	m.configs[name] = entry
+	return entry
+}
+
+// hasEntry reports whether the named config already has an entry, live or
+// tombstoned. It is the read-only pre-check that keeps the deleting path
+// from interning an entry for a name that never existed.
+func (m *BlackholeService) hasEntry(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	_, ok := m.configs[name]
+	return ok
+}
+
+// withEntry fetches or creates the entry for the name, holds its update
+// lock for the duration of the call, then returns the call's error. The
+// backend publish runs here, under the entry lock only.
+func (m *BlackholeService) withEntry(name string, fn func(*configEntry) error) error {
+	entry := m.entry(name)
+	entry.LockUpdate()
+	defer entry.UnlockUpdate()
+
+	return fn(entry)
+}
+
+// setPublished swaps the entry's published config under the service lock.
+func (m *BlackholeService) setPublished(entry *configEntry, config *config) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry.Publish(config)
+}
+
+// parkOrFree frees the handle when it is dangling and parks it for
+// retry when a live generation still references it. The whole cycle runs
+// under the reclamation lock so it cannot interleave with a concurrent
+// drain that would miss the survivor.
+func (m *BlackholeService) parkOrFree(handle ModuleHandle) {
+	m.reclaimMu.Lock()
+	defer m.reclaimMu.Unlock()
+
+	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
+		m.park(handle)
+	}
+}
+
+func (m *BlackholeService) park(handle ModuleHandle) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.deferred = append(m.deferred, handle)
 }
 
 // ReclaimDeferred retries every deferred handle, dropping the ones whose
@@ -198,21 +307,30 @@ func (m *BlackholeService) parkOrFree(handle ModuleHandle) {
 // reclamation handler for this module's superseded configs; the service
 // itself runs it after each successful publish, and anything else may
 // call it at any time.
+//
+// The frees run without the service lock: a handle's destruction takes
+// the shared C-side configuration lock, which an in-flight publish of
+// another name may hold, so freeing under the service lock would let
+// that publish stall every read again. The reclamation lock still
+// serializes the whole cycle against a concurrent park, so a survivor
+// can never be missed by the drain that precedes its park.
 func (m *BlackholeService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
+	m.reclaimMu.Lock()
+	defer m.reclaimMu.Unlock()
 
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *BlackholeService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
+	handles := m.drainDeferred()
+	for _, handle := range handles {
 		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
+			m.park(handle)
 		}
 	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+}
+
+func (m *BlackholeService) drainDeferred() []ModuleHandle {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	handles := m.deferred
+	m.deferred = nil
+	return handles
 }

--- a/modules/blackhole/controlplane/service_test.go
+++ b/modules/blackhole/controlplane/service_test.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -51,6 +54,32 @@ func (m *flakyBackend) UpdateModule(name string) (ModuleHandle, error) {
 }
 
 func (m *flakyBackend) DeleteModule(name string) error {
+	return nil
+}
+
+// blockingBackend stalls every module publish until released.
+type blockingBackend struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+// newBlockingBackend returns a backend whose every publish blocks until
+// released; the returned started channel fires once a publish is inside
+// the stall.
+func newBlockingBackend() *blockingBackend {
+	return &blockingBackend{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (m *blockingBackend) UpdateModule(name string) (ModuleHandle, error) {
+	close(m.started)
+	<-m.release
+	return &mockModuleHandle{}, nil
+}
+
+func (m *blockingBackend) DeleteModule(name string) error {
 	return nil
 }
 
@@ -160,6 +189,37 @@ func Test_BlackholeService_UpdateFailureAtomic(t *testing.T) {
 	require.Equal(t, name, show.Name)
 }
 
+// Test_BlackholeService_ListDuringStalledUpdate verifies that listing
+// configs completes while another goroutine's update is still stalled
+// inside the backend publish.
+func Test_BlackholeService_ListDuringStalledUpdate(t *testing.T) {
+	backend := newBlockingBackend()
+	svc := NewBlackholeService(backend)
+
+	g, ctx := errgroup.WithContext(t.Context())
+	g.Go(func() error {
+		_, err := svc.UpdateConfig(ctx, &blackholepb.UpdateConfigRequest{Name: "blackhole0"})
+		return err
+	})
+
+	<-backend.started
+
+	listed := make(chan struct{})
+	go func() {
+		defer close(listed)
+		_, _ = svc.ListConfigs(t.Context(), &blackholepb.ListConfigsRequest{})
+	}()
+
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listing configs blocked behind a stalled module publish")
+	}
+
+	close(backend.release)
+	require.NoError(t, g.Wait())
+}
+
 // Test_BlackholeService_ConcurrentAccess verifies that interleaved creates,
 // lists, and reads from many goroutines do not race or lose entries.
 func Test_BlackholeService_ConcurrentAccess(t *testing.T) {
@@ -205,5 +265,88 @@ func Test_BlackholeService_ConcurrentAccess(t *testing.T) {
 		})
 	}
 
+	require.NoError(t, g.Wait())
+}
+
+// stallingReclaimHandle refuses its first free, which parks it, and
+// stalls the second until released.
+type stallingReclaimHandle struct {
+	numCalls atomic.Int64
+	started  chan struct{}
+	release  chan struct{}
+}
+
+func (m *stallingReclaimHandle) Free() error {
+	if m.numCalls.Add(1) == 1 {
+		return ffi.ErrStillReferenced
+	}
+	close(m.started)
+	<-m.release
+	return nil
+}
+
+// stallingReclaimBackend mints the stalling handle on its first publish
+// and plain handles thereafter.
+type stallingReclaimBackend struct {
+	numCalls atomic.Int64
+	handle   stallingReclaimHandle
+}
+
+// newStallingReclaimBackend returns a backend that mints the stalling
+// reclaim handle on the first publish; the handle's started channel
+// fires once its deferred destruction is inside the stall.
+func newStallingReclaimBackend() *stallingReclaimBackend {
+	return &stallingReclaimBackend{
+		handle: stallingReclaimHandle{
+			started: make(chan struct{}),
+			release: make(chan struct{}),
+		},
+	}
+}
+
+func (m *stallingReclaimBackend) UpdateModule(name string) (ModuleHandle, error) {
+	if m.numCalls.Add(1) == 1 {
+		return &m.handle, nil
+	}
+	return &mockModuleHandle{}, nil
+}
+
+func (m *stallingReclaimBackend) DeleteModule(name string) error {
+	return nil
+}
+
+// Test_BlackholeService_ListDuringStalledReclaim verifies that listing configs
+// completes while a superseded handle's deferred destruction is stalled
+// inside the backend.
+func Test_BlackholeService_ListDuringStalledReclaim(t *testing.T) {
+	backend := newStallingReclaimBackend()
+	svc := NewBlackholeService(backend)
+
+	_, err := svc.UpdateConfig(t.Context(), &blackholepb.UpdateConfigRequest{Name: "blackhole0"})
+	require.NoError(t, err)
+	_, err = svc.UpdateConfig(t.Context(), &blackholepb.UpdateConfigRequest{Name: "blackhole0"})
+	require.NoError(t, err)
+
+	g, _ := errgroup.WithContext(t.Context())
+	g.Go(func() error {
+		svc.ReclaimDeferred()
+		return nil
+	})
+
+	<-backend.handle.started
+
+	listed := make(chan struct{})
+	go func() {
+		defer close(listed)
+		_, _ = svc.ListConfigs(t.Context(), &blackholepb.ListConfigsRequest{})
+	}()
+
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listing configs blocked behind a stalled deferred handle destruction")
+	}
+
+	close(backend.handle.release)
 	require.NoError(t, g.Wait())
 }

--- a/modules/decap/controlplane/service.go
+++ b/modules/decap/controlplane/service.go
@@ -45,37 +45,71 @@ type config struct {
 	Module ModuleHandle
 }
 
-// Free releases the module handle held by the config.
+// configEntry is the per-name lock anchor of a decap config.
 //
-// It is safe to call even when no handle is held. The result is the
-// handle's: nil when destroyed, ffi.ErrStillReferenced when a live
-// generation still references it and the caller must remember it.
-func (m *config) Free() error {
-	if m.Module == nil {
-		return nil
-	}
-	return m.Module.Free()
+// Entries are append-only: deleting a config clears its published slot
+// instead of removing the entry, keeping the entry as the lock anchor.
+// Acquiring a name's lock is a two-step operation — fetch the entry, then
+// lock it — and removing entries would let two goroutines serialize the
+// same name on two different entry objects during exactly that window.
+type configEntry struct {
+	// updateMu serializes mutations of this name for the entry's whole
+	// life, across the whole operation including the backend publish.
+	updateMu sync.Mutex
+	// published is the config currently active for this name, or nil
+	// when the name is absent. It is written only while holding both the
+	// entry's update lock and the service write lock; an update-lock
+	// holder may read it without the service lock.
+	published *config
+}
+
+func (m *configEntry) LockUpdate() {
+	m.updateMu.Lock()
+}
+
+func (m *configEntry) UnlockUpdate() {
+	m.updateMu.Unlock()
+}
+
+func (m *configEntry) Published() *config {
+	return m.published
+}
+
+func (m *configEntry) Publish(config *config) {
+	m.published = config
 }
 
 // DecapService implements the DecapService gRPC server.
 type DecapService struct {
 	decappb.UnimplementedDecapServiceServer
 
-	mu sync.Mutex
+	// mu guards configs and deferred. Critical sections are short map
+	// and slice work only; the backend publish runs under the target
+	// entry's update lock, outside any service-lock section, so a
+	// stalled publish never blocks a read.
+	mu sync.RWMutex
+	// reclaimMu serializes handle reclamation — draining the deferred
+	// list and parking a superseded handle — across its free attempts,
+	// so a handle refused by a draining generation is retried before the
+	// drain that could miss it completes. It is never taken by a read
+	// path, and a handle's destruction under it may block on the shared
+	// C-side configuration lock, which only stalls other reclamations.
+	reclaimMu sync.Mutex
 	// deferred holds superseded module handles whose free was refused
 	// because a live configuration generation still referenced them.
 	// This service is their owner: it retries them on its next update,
 	// through ReclaimDeferred, and nothing else remembers them.
 	deferred []ModuleHandle
 	backend  Backend
-	configs  map[string]*config
+	// configs maps a name to its append-only entry. See configEntry.
+	configs map[string]*configEntry
 }
 
 // NewDecapService constructs a DecapService backed by the given Backend.
 func NewDecapService(backend Backend) *DecapService {
 	return &DecapService{
 		backend: backend,
-		configs: map[string]*config{},
+		configs: map[string]*configEntry{},
 	}
 }
 
@@ -84,11 +118,14 @@ func (m *DecapService) ListConfigs(
 	ctx context.Context,
 	req *decappb.ListConfigsRequest,
 ) (*decappb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	names := make([]string, 0, len(m.configs))
-	for name := range m.configs {
+	for name, entry := range m.configs {
+		if entry.Published() == nil {
+			continue
+		}
 		names = append(names, name)
 	}
 
@@ -105,19 +142,19 @@ func (m *DecapService) ShowConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	entry, ok := m.configs[name]
-	if !ok {
+	if !ok || entry.Published() == nil {
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
 
-	prefixes4, err := commonpb.NewIPv4PrefixesFromPrefixes(entry.Prefixes4)
+	prefixes4, err := commonpb.NewIPv4PrefixesFromPrefixes(entry.Published().Prefixes4)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to convert prefixes: %v", err)
 	}
-	prefixes6, err := commonpb.NewIPv6PrefixesFromPrefixes(entry.Prefixes6)
+	prefixes6, err := commonpb.NewIPv6PrefixesFromPrefixes(entry.Published().Prefixes6)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to convert prefixes: %v", err)
 	}
@@ -144,14 +181,15 @@ func (m *DecapService) UpdateConfig(
 		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	cfg := &config{
 		Prefixes4: normalizePrefixes(prefixes4),
 		Prefixes6: normalizePrefixes(prefixes6),
 	}
-	if err := m.updateConfig(name, cfg); err != nil {
+
+	err = m.withEntry(name, func(entry *configEntry) error {
+		return m.updateConfig(name, cfg, entry)
+	})
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
@@ -169,27 +207,37 @@ func (m *DecapService) DeleteConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	entry, ok := m.configs[name]
-	if !ok {
+	// Rejecting an unknown name here keeps the locked path from interning
+	// an entry for a name that never existed; the locked re-check below
+	// stays authoritative for the name that waited on an in-flight update.
+	if !m.hasEntry(name) {
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
 
-	if err := m.backend.DeleteModule(name); err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"failed to delete module config %q: %v", name, err,
-		)
+	err := m.withEntry(name, func(entry *configEntry) error {
+		oldConfig := entry.Published()
+		if oldConfig == nil {
+			return status.Error(codes.NotFound, "no config found")
+		}
+
+		if err := m.backend.DeleteModule(name); err != nil {
+			return status.Errorf(
+				codes.Internal,
+				"failed to delete module config %q: %v", name, err,
+			)
+		}
+
+		m.setPublished(entry, nil)
+
+		// The delete retired the generation holding the published
+		// module; retry the deferred ones, then retire this one.
+		m.ReclaimDeferred()
+		m.parkOrFree(oldConfig.Module)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-
-	// The delete retired the generation holding the published module.
-	// Retry the deferred ones, then retire this one.
-	m.reclaimDeferred()
-	m.parkOrFree(entry.Module)
-
-	delete(m.configs, name)
 
 	return &decappb.DeleteConfigResponse{}, nil
 }
@@ -214,34 +262,89 @@ func normalizePrefixes(prefixes []netip.Prefix) []netip.Prefix {
 // updateConfig calls the backend to publish cfg, retries this service's
 // deferred handles (the publish retired the generations that were
 // holding them), frees or defers the old module handle, and stores the
-// new config. The caller must hold m.mu.
-func (m *DecapService) updateConfig(name string, cfg *config) error {
+// new config. The caller must hold the entry's update lock.
+func (m *DecapService) updateConfig(name string, cfg *config, entry *configEntry) error {
 	mod, err := m.backend.UpdateModule(name, slices.Concat(cfg.Prefixes4, cfg.Prefixes6))
 	if err != nil {
 		return fmt.Errorf("failed to update module config %q: %w", name, err)
 	}
 
-	m.reclaimDeferred()
+	oldConfig := entry.Published()
 
-	if old, ok := m.configs[name]; ok {
-		m.parkOrFree(old)
-	}
-
-	m.configs[name] = &config{
+	m.setPublished(entry, &config{
 		Prefixes4: cfg.Prefixes4,
 		Prefixes6: cfg.Prefixes6,
 		Module:    mod,
+	})
+
+	// The publish retired the generation holding the published module;
+	// retry the deferred ones, then retire the displaced one.
+	m.ReclaimDeferred()
+	if oldConfig != nil {
+		m.parkOrFree(oldConfig.Module)
 	}
 
 	return nil
 }
 
+// setPublished swaps the entry's published config under the service lock.
+func (m *DecapService) setPublished(entry *configEntry, config *config) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry.Publish(config)
+}
+
+// entry fetches or creates the lock anchor of the named config. The caller
+// must not hold the service lock.
+func (m *DecapService) entry(name string) *configEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if entry, ok := m.configs[name]; ok {
+		return entry
+	}
+	entry := &configEntry{}
+	m.configs[name] = entry
+	return entry
+}
+
+// hasEntry reports whether the named config already has an entry, live or
+// tombstoned. It is the read-only pre-check that keeps the deleting path
+// from interning an entry for a name that never existed.
+func (m *DecapService) hasEntry(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	_, ok := m.configs[name]
+	return ok
+}
+
+// withEntry fetches or creates the entry for the name, holds its update
+// lock for the duration of the call, then returns the call's error. The
+// backend publish runs here, under the entry lock only.
+func (m *DecapService) withEntry(name string, fn func(*configEntry) error) error {
+	entry := m.entry(name)
+	entry.LockUpdate()
+	defer entry.UnlockUpdate()
+
+	return fn(entry)
+}
+
 // parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must hold
-// m.mu.
+// retry when a live generation still references it. The whole cycle runs
+// under the reclamation lock so it cannot interleave with a concurrent
+// drain that would miss the survivor.
 func (m *DecapService) parkOrFree(handle ModuleHandle) {
+	if handle == nil {
+		return
+	}
+
+	m.reclaimMu.Lock()
+	defer m.reclaimMu.Unlock()
+
 	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
+		m.park(handle)
 	}
 }
 
@@ -250,21 +353,37 @@ func (m *DecapService) parkOrFree(handle ModuleHandle) {
 // reclamation handler for this module's superseded configs; the service
 // itself runs it after each successful publish, and anything else may
 // call it at any time.
+//
+// The frees run without the service lock: a handle's destruction takes
+// the shared C-side configuration lock, which an in-flight publish of
+// another name may hold, so freeing under the service lock would let
+// that publish stall every read again. The reclamation lock still
+// serializes the whole cycle against a concurrent park, so a survivor
+// can never be missed by the drain that precedes its park.
 func (m *DecapService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
+	m.reclaimMu.Lock()
+	defer m.reclaimMu.Unlock()
 
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *DecapService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
+	handles := m.drainDeferred()
+	for _, handle := range handles {
 		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
+			m.park(handle)
 		}
 	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+}
+
+func (m *DecapService) park(handle ModuleHandle) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.deferred = append(m.deferred, handle)
+}
+
+func (m *DecapService) drainDeferred() []ModuleHandle {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	handles := m.deferred
+	m.deferred = nil
+	return handles
 }

--- a/modules/decap/controlplane/service_test.go
+++ b/modules/decap/controlplane/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -154,6 +155,25 @@ func (m *flakyBackend) UpdateModule(
 }
 
 func (m *flakyBackend) DeleteModule(name string) error {
+	return nil
+}
+
+// blockingBackend stalls every module publish until released.
+type blockingBackend struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (m *blockingBackend) UpdateModule(
+	name string,
+	prefixes []netip.Prefix,
+) (ModuleHandle, error) {
+	close(m.started)
+	<-m.release
+	return &mockModuleHandle{}, nil
+}
+
+func (m *blockingBackend) DeleteModule(name string) error {
 	return nil
 }
 
@@ -476,5 +496,122 @@ func Test_DecapService_ConcurrentAccess(t *testing.T) {
 		})
 	}
 
+	require.NoError(t, g.Wait())
+}
+
+// Test_DecapService_ListDuringStalledUpdate verifies that listing configs
+// completes while another goroutine's update is still stalled inside the
+// backend publish.
+func Test_DecapService_ListDuringStalledUpdate(t *testing.T) {
+	backend := &blockingBackend{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	svc := NewDecapService(backend)
+
+	g, ctx := errgroup.WithContext(t.Context())
+	g.Go(func() error {
+		_, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{Name: "decap0"})
+		return err
+	})
+
+	<-backend.started
+
+	listed := make(chan struct{})
+	go func() {
+		defer close(listed)
+		_, _ = svc.ListConfigs(t.Context(), &decappb.ListConfigsRequest{})
+	}()
+
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listing configs blocked behind a stalled module publish")
+	}
+
+	close(backend.release)
+	require.NoError(t, g.Wait())
+}
+
+// stallingReclaimHandle refuses its first free, which parks it, and
+// stalls the second until released.
+type stallingReclaimHandle struct {
+	numCalls atomic.Int64
+	started  chan struct{}
+	release  chan struct{}
+}
+
+func (m *stallingReclaimHandle) Free() error {
+	if m.numCalls.Add(1) == 1 {
+		return ffi.ErrStillReferenced
+	}
+	close(m.started)
+	<-m.release
+	return nil
+}
+
+// stallingReclaimBackend mints the stalling handle on its first publish
+// and plain handles thereafter.
+type stallingReclaimBackend struct {
+	numCalls atomic.Int64
+	handle   stallingReclaimHandle
+}
+
+// newStallingReclaimBackend returns a backend that mints the stalling
+// reclaim handle on the first publish; the handle's started channel
+// fires once its deferred destruction is inside the stall.
+func newStallingReclaimBackend() *stallingReclaimBackend {
+	return &stallingReclaimBackend{
+		handle: stallingReclaimHandle{
+			started: make(chan struct{}),
+			release: make(chan struct{}),
+		},
+	}
+}
+
+func (m *stallingReclaimBackend) UpdateModule(name string, prefixes []netip.Prefix) (ModuleHandle, error) {
+	if m.numCalls.Add(1) == 1 {
+		return &m.handle, nil
+	}
+	return &mockModuleHandle{}, nil
+}
+
+func (m *stallingReclaimBackend) DeleteModule(name string) error {
+	return nil
+}
+
+// Test_DecapService_ListDuringStalledReclaim verifies that listing configs
+// completes while a superseded handle's deferred destruction is stalled
+// inside the backend.
+func Test_DecapService_ListDuringStalledReclaim(t *testing.T) {
+	backend := newStallingReclaimBackend()
+	svc := NewDecapService(backend)
+
+	_, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{Name: "decap0", Prefixes4: mustPrefixes4(t, "10.0.0.0/24")})
+	require.NoError(t, err)
+	_, err = svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{Name: "decap0", Prefixes4: mustPrefixes4(t, "10.0.0.0/24")})
+	require.NoError(t, err)
+
+	g, _ := errgroup.WithContext(t.Context())
+	g.Go(func() error {
+		svc.ReclaimDeferred()
+		return nil
+	})
+
+	<-backend.handle.started
+
+	listed := make(chan struct{})
+	go func() {
+		defer close(listed)
+		_, _ = svc.ListConfigs(t.Context(), &decappb.ListConfigsRequest{})
+	}()
+
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listing configs blocked behind a stalled deferred handle destruction")
+	}
+
+	close(backend.handle.release)
 	require.NoError(t, g.Wait())
 }

--- a/modules/mirror/controlplane/service.go
+++ b/modules/mirror/controlplane/service.go
@@ -3,7 +3,6 @@ package mirror
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
 	"google.golang.org/grpc/codes"
@@ -44,10 +43,55 @@ func (m *mirrorConfig) Free() error {
 	return m.Module.Free()
 }
 
+// configEntry is the per-name lock anchor of a mirror config.
+//
+// Entries are append-only: deleting a config clears its published slot
+// instead of removing the entry, keeping the entry as the lock anchor.
+// Acquiring a name's lock is a two-step operation — fetch the entry, then
+// lock it — and removing entries would let two goroutines serialize the
+// same name on two different entry objects during exactly that window.
+type configEntry struct {
+	// updateMu serializes mutations of this name for the entry's whole
+	// life, across the whole operation including the backend publish.
+	updateMu sync.Mutex
+	// published is the config currently active for this name, or nil
+	// when the name is absent. It is written only while holding both the
+	// entry's update lock and the service write lock; an update-lock
+	// holder may read it without the service lock.
+	published *mirrorConfig
+}
+
+func (m *configEntry) LockUpdate() {
+	m.updateMu.Lock()
+}
+
+func (m *configEntry) UnlockUpdate() {
+	m.updateMu.Unlock()
+}
+
+func (m *configEntry) Published() *mirrorConfig {
+	return m.published
+}
+
+func (m *configEntry) Publish(config *mirrorConfig) {
+	m.published = config
+}
+
 type MirrorService struct {
 	mirrorpb.UnimplementedMirrorServiceServer
 
-	mu sync.Mutex
+	// mu guards configs and deferred. Critical sections are short map
+	// and slice work only; the backend publish runs under the target
+	// entry's update lock, outside any service-lock section, so a
+	// stalled publish never blocks a read.
+	mu sync.RWMutex
+	// reclaimMu serializes handle reclamation — draining the deferred
+	// list and parking a superseded handle — across its free attempts,
+	// so a handle refused by a draining generation is retried before the
+	// drain that could miss it completes. It is never taken by a read
+	// path, and a handle's destruction under it may block on the shared
+	// C-side configuration lock, which only stalls other reclamations.
+	reclaimMu sync.Mutex
 
 	// deferred holds superseded module handles whose free was refused
 	// because a live configuration generation still referenced them.
@@ -55,24 +99,28 @@ type MirrorService struct {
 	// through ReclaimDeferred, and nothing else remembers them.
 	deferred []ModuleHandle
 	backend  Backend
-	configs  map[string]mirrorConfig
+	// configs maps a name to its append-only entry. See configEntry.
+	configs map[string]*configEntry
 }
 
 func NewMirrorService(backend Backend) *MirrorService {
 	return &MirrorService{
 		backend: backend,
-		configs: map[string]mirrorConfig{},
+		configs: map[string]*configEntry{},
 	}
 }
 
 func (m *MirrorService) ListConfigs(
 	ctx context.Context, request *mirrorpb.ListConfigsRequest,
 ) (*mirrorpb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	configs := make([]string, 0, len(m.configs))
-	for name := range m.configs {
+	for name, entry := range m.configs {
+		if entry.Published() == nil {
+			continue
+		}
 		configs = append(configs, name)
 	}
 
@@ -92,18 +140,18 @@ func (m *MirrorService) ShowConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
-	config, ok := m.configs[req.Name]
+	entry, ok := m.configs[req.Name]
 
-	if !ok {
+	if !ok || entry.Published() == nil {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
 	response := &mirrorpb.ShowConfigResponse{
 		Name:  req.Name,
-		Rules: config.Rules,
+		Rules: entry.Published().Rules,
 	}
 
 	return response, nil
@@ -180,23 +228,29 @@ func (m *MirrorService) UpdateConfig(
 		rules = append(rules, rule)
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	err := m.withEntry(name, func(entry *configEntry) error {
+		module, err := m.backend.UpdateModule(name, rules)
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		}
 
-	module, err := m.backend.UpdateModule(name, rules)
+		oldConfig := entry.Published()
+
+		m.setPublished(entry, &mirrorConfig{
+			Rules:  reqRules,
+			Module: module,
+		})
+
+		// The publish retired the generation holding the published
+		// module; retry the deferred ones, then retire the displaced one.
+		m.ReclaimDeferred()
+		if oldConfig != nil {
+			m.parkOrFree(oldConfig.Module)
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to update module config: %w", err)
-	}
-
-	m.reclaimDeferred()
-
-	if oldModule, ok := m.configs[name]; ok {
-		m.parkOrFree(oldModule.Module)
-	}
-
-	m.configs[name] = mirrorConfig{
-		Rules:  reqRules,
-		Module: module,
+		return nil, err
 	}
 
 	return &mirrorpb.UpdateConfigResponse{}, nil
@@ -211,35 +265,96 @@ func (m *MirrorService) DeleteConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	config, ok := m.configs[name]
-	if !ok {
+	// Rejecting an unknown name here keeps the locked path from interning
+	// an entry for a name that never existed; the locked re-check below
+	// stays authoritative for the name that waited on an in-flight update.
+	if !m.hasEntry(name) {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
-	if err := m.backend.DeleteModule(name); err != nil {
-		return nil, fmt.Errorf("failed to delete module config %q: %w", name, err)
+	err := m.withEntry(name, func(entry *configEntry) error {
+		oldConfig := entry.Published()
+		if oldConfig == nil {
+			return status.Errorf(codes.NotFound, "config %q not found", name)
+		}
+
+		if err := m.backend.DeleteModule(name); err != nil {
+			return status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
+		}
+
+		m.setPublished(entry, nil)
+
+		// The delete retired the generation holding the published
+		// module; retry the deferred ones, then retire this one.
+		m.ReclaimDeferred()
+		m.parkOrFree(oldConfig.Module)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-
-	m.reclaimDeferred()
-	m.parkOrFree(config.Module)
-
-	delete(m.configs, name)
 
 	return &mirrorpb.DeleteConfigResponse{}, nil
 }
 
+// setPublished swaps the entry's published config under the service lock.
+func (m *MirrorService) setPublished(entry *configEntry, config *mirrorConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry.Publish(config)
+}
+
+// entry fetches or creates the lock anchor of the named config. The caller
+// must not hold the service lock.
+func (m *MirrorService) entry(name string) *configEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if entry, ok := m.configs[name]; ok {
+		return entry
+	}
+	entry := &configEntry{}
+	m.configs[name] = entry
+	return entry
+}
+
+// hasEntry reports whether the named config already has an entry, live or
+// tombstoned. It is the read-only pre-check that keeps the deleting path
+// from interning an entry for a name that never existed.
+func (m *MirrorService) hasEntry(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	_, ok := m.configs[name]
+	return ok
+}
+
+// withEntry fetches or creates the entry for the name, holds its update
+// lock for the duration of the call, then returns the call's error. The
+// backend publish runs here, under the entry lock only.
+func (m *MirrorService) withEntry(name string, fn func(*configEntry) error) error {
+	entry := m.entry(name)
+	entry.LockUpdate()
+	defer entry.UnlockUpdate()
+
+	return fn(entry)
+}
+
 // parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.mu.
+// retry when a live generation still references it. The whole cycle runs
+// under the reclamation lock so it cannot interleave with a concurrent
+// drain that would miss the survivor.
 func (m *MirrorService) parkOrFree(handle ModuleHandle) {
 	if handle == nil {
 		return
 	}
+
+	m.reclaimMu.Lock()
+	defer m.reclaimMu.Unlock()
+
 	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
+		m.park(handle)
 	}
 }
 
@@ -248,21 +363,37 @@ func (m *MirrorService) parkOrFree(handle ModuleHandle) {
 // reclamation handler for this module's superseded configs; the service
 // itself runs it after each successful publish, and anything else may
 // call it at any time.
+//
+// The frees run without the service lock: a handle's destruction takes
+// the shared C-side configuration lock, which an in-flight publish of
+// another name may hold, so freeing under the service lock would let
+// that publish stall every read again. The reclamation lock still
+// serializes the whole cycle against a concurrent park, so a survivor
+// can never be missed by the drain that precedes its park.
 func (m *MirrorService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
+	m.reclaimMu.Lock()
+	defer m.reclaimMu.Unlock()
 
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *MirrorService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
+	handles := m.drainDeferred()
+	for _, handle := range handles {
 		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
+			m.park(handle)
 		}
 	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+}
+
+func (m *MirrorService) park(handle ModuleHandle) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.deferred = append(m.deferred, handle)
+}
+
+func (m *MirrorService) drainDeferred() []ModuleHandle {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	handles := m.deferred
+	m.deferred = nil
+	return handles
 }

--- a/modules/mirror/controlplane/service_test.go
+++ b/modules/mirror/controlplane/service_test.go
@@ -3,7 +3,9 @@ package mirror_test
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -11,6 +13,8 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/xnetip"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/modules/mirror/bindings/go/cmirror"
 	mirror "github.com/yanet-platform/yanet2/modules/mirror/controlplane"
@@ -66,6 +70,25 @@ func (m *recordingBackend) UpdateModule(
 ) (mirror.ModuleHandle, error) {
 	m.rules = rules
 	return &mockModuleHandle{}, nil
+}
+
+// blockingBackend stalls every module publish until released.
+type blockingBackend struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (m *blockingBackend) UpdateModule(
+	name string,
+	rules []cmirror.MirrorRule,
+) (mirror.ModuleHandle, error) {
+	close(m.started)
+	<-m.release
+	return &mockModuleHandle{}, nil
+}
+
+func (m *blockingBackend) DeleteModule(name string) error {
+	return nil
 }
 
 // v4net builds an IPv4Network message from xnetip network text, in any
@@ -310,5 +333,125 @@ func TestMirrorServiceConcurrentAccess(t *testing.T) {
 		})
 	}
 
+	require.NoError(t, g.Wait())
+}
+
+// Test_MirrorService_ListDuringStalledUpdate verifies that listing configs
+// completes while another goroutine's update is still stalled inside the
+// backend publish.
+func Test_MirrorService_ListDuringStalledUpdate(t *testing.T) {
+	backend := &blockingBackend{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	svc := mirror.NewMirrorService(backend)
+
+	g, ctx := errgroup.WithContext(t.Context())
+	g.Go(func() error {
+		_, err := svc.UpdateConfig(ctx, &mirrorpb.UpdateConfigRequest{
+			Name:  "config",
+			Rules: []*mirrorpb.Rule{{Action: &mirrorpb.Action{Target: "device0"}}},
+		})
+		return err
+	})
+
+	<-backend.started
+
+	listed := make(chan struct{})
+	go func() {
+		defer close(listed)
+		_, _ = svc.ListConfigs(t.Context(), &mirrorpb.ListConfigsRequest{})
+	}()
+
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listing configs blocked behind a stalled module publish")
+	}
+
+	close(backend.release)
+	require.NoError(t, g.Wait())
+}
+
+// stallingReclaimHandle refuses its first free, which parks it, and
+// stalls the second until released.
+type stallingReclaimHandle struct {
+	numCalls atomic.Int64
+	started  chan struct{}
+	release  chan struct{}
+}
+
+func (m *stallingReclaimHandle) Free() error {
+	if m.numCalls.Add(1) == 1 {
+		return ffi.ErrStillReferenced
+	}
+	close(m.started)
+	<-m.release
+	return nil
+}
+
+// stallingReclaimBackend mints the stalling handle on its first publish
+// and plain handles thereafter.
+type stallingReclaimBackend struct {
+	numCalls atomic.Int64
+	handle   stallingReclaimHandle
+}
+
+// newStallingReclaimBackend returns a backend that mints the stalling
+// reclaim handle on the first publish; the handle's started channel
+// fires once its deferred destruction is inside the stall.
+func newStallingReclaimBackend() *stallingReclaimBackend {
+	return &stallingReclaimBackend{
+		handle: stallingReclaimHandle{
+			started: make(chan struct{}),
+			release: make(chan struct{}),
+		},
+	}
+}
+
+func (m *stallingReclaimBackend) UpdateModule(name string, rules []cmirror.MirrorRule) (mirror.ModuleHandle, error) {
+	if m.numCalls.Add(1) == 1 {
+		return &m.handle, nil
+	}
+	return &mockModuleHandle{}, nil
+}
+
+func (m *stallingReclaimBackend) DeleteModule(name string) error {
+	return nil
+}
+
+// Test_MirrorService_ListDuringStalledReclaim verifies that listing configs
+// completes while a superseded handle's deferred destruction is stalled
+// inside the backend.
+func Test_MirrorService_ListDuringStalledReclaim(t *testing.T) {
+	backend := newStallingReclaimBackend()
+	svc := mirror.NewMirrorService(backend)
+
+	_, err := svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{Name: "config", Rules: []*mirrorpb.Rule{{Action: &mirrorpb.Action{Target: "device0"}}}})
+	require.NoError(t, err)
+	_, err = svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{Name: "config", Rules: []*mirrorpb.Rule{{Action: &mirrorpb.Action{Target: "device0"}}}})
+	require.NoError(t, err)
+
+	g, _ := errgroup.WithContext(t.Context())
+	g.Go(func() error {
+		svc.ReclaimDeferred()
+		return nil
+	})
+
+	<-backend.handle.started
+
+	listed := make(chan struct{})
+	go func() {
+		defer close(listed)
+		_, _ = svc.ListConfigs(t.Context(), &mirrorpb.ListConfigsRequest{})
+	}()
+
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listing configs blocked behind a stalled deferred handle destruction")
+	}
+
+	close(backend.handle.release)
 	require.NoError(t, g.Wait())
 }

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"math"
 	"net/netip"
 	"slices"
@@ -40,11 +39,56 @@ func WithNAT64ServiceLog(log *zap.Logger) NAT64ServiceOption {
 	}
 }
 
+// configEntry is the per-name lock anchor of a nat64 config.
+//
+// Entries are append-only: deleting a config clears its published slot
+// instead of removing the entry, keeping the entry as the lock anchor.
+// Acquiring a name's lock is a two-step operation — fetch the entry, then
+// lock it — and removing entries would let two goroutines serialize the
+// same name on two different entry objects during exactly that window.
+type configEntry struct {
+	// updateMu serializes mutations of this name for the entry's whole
+	// life, across the whole operation including the backend publish.
+	updateMu sync.Mutex
+	// published is the config currently active for this name, or nil
+	// when the name is absent. It is written only while holding both the
+	// entry's update lock and the service write lock; an update-lock
+	// holder may read it without the service lock.
+	published *config
+}
+
+func (m *configEntry) LockUpdate() {
+	m.updateMu.Lock()
+}
+
+func (m *configEntry) UnlockUpdate() {
+	m.updateMu.Unlock()
+}
+
+func (m *configEntry) Published() *config {
+	return m.published
+}
+
+func (m *configEntry) Publish(config *config) {
+	m.published = config
+}
+
 // NAT64Service implements the NAT64 gRPC service
 type NAT64Service struct {
 	nat64pb.UnimplementedNAT64ServiceServer
 
-	mu sync.Mutex
+	// mu guards configs and deferred. Critical sections are short map
+	// and slice work only; the backend publish runs under the target
+	// entry's update lock, outside any service-lock section, so a
+	// stalled publish never blocks a read.
+	mu sync.RWMutex
+	// reclaimMu serializes handle reclamation — draining the deferred
+	// list and parking a superseded handle — across its free attempts,
+	// so a handle refused by a draining generation is retried before the
+	// drain that could miss it completes. It is never taken by a read
+	// path, and a handle's destruction under it may block on the shared
+	// C-side configuration lock, which only stalls other reclamations.
+	reclaimMu sync.Mutex
 
 	// deferred holds superseded module handles whose free was refused
 	// because a live configuration generation still referenced them.
@@ -52,8 +96,9 @@ type NAT64Service struct {
 	// through ReclaimDeferred, and nothing else remembers them.
 	deferred []ModuleHandle
 	backend  Backend
-	configs  map[string]config
-	log      *zap.Logger
+	// configs maps a name to its append-only entry. See configEntry.
+	configs map[string]*configEntry
+	log     *zap.Logger
 }
 
 type config struct {
@@ -140,16 +185,24 @@ func NewNAT64Service(backend Backend, options ...NAT64ServiceOption) *NAT64Servi
 	return &NAT64Service{
 		backend: backend,
 		log:     opts.Log,
-		configs: map[string]config{},
+		configs: map[string]*configEntry{},
 	}
 }
 
 func (m *NAT64Service) ListConfigs(ctx context.Context, req *nat64pb.ListConfigsRequest) (*nat64pb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	names := make([]string, 0, len(m.configs))
+	for name, entry := range m.configs {
+		if entry.Published() == nil {
+			continue
+		}
+		names = append(names, name)
+	}
 
 	return &nat64pb.ListConfigsResponse{
-		Configs: slices.Sorted(maps.Keys(m.configs)),
+		Configs: slices.Sorted(slices.Values(names)),
 	}, nil
 }
 
@@ -161,15 +214,15 @@ func (m *NAT64Service) ShowConfig(ctx context.Context, req *nat64pb.ShowConfigRe
 
 	response := &nat64pb.ShowConfigResponse{}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	inst, ok := m.configs[name]
-	if !ok {
+	m.mu.RLock()
+	entry, ok := m.configs[name]
+	if !ok || entry.Published() == nil {
+		m.mu.RUnlock()
 		return nil, status.Error(codes.NotFound, "config not found")
 	}
+	cfg := entry.Published().Config
+	m.mu.RUnlock()
 
-	cfg := inst.Config
 	response.Config = &nat64pb.Config{
 		Prefixes: make([]*commonpb.IPv6Prefix, 0, len(cfg.Prefixes)),
 		Mappings: make([]*nat64pb.Mapping, 0, len(cfg.Mappings)),
@@ -211,17 +264,17 @@ func (m *NAT64Service) AddPrefix(ctx context.Context, req *nat64pb.AddPrefixRequ
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	err = m.withEntry(name, func(entry *configEntry) error {
+		inst := instanceFor(entry).Clone()
+		if slices.ContainsFunc(inst.Config.Prefixes, func(existing []byte) bool { return bytes.Equal(existing, prefix) }) {
+			return nil
+		}
+		inst.Config.Prefixes = append(inst.Config.Prefixes, prefix)
 
-	inst := m.instanceFor(name).Clone()
-	if slices.ContainsFunc(inst.Config.Prefixes, func(existing []byte) bool { return bytes.Equal(existing, prefix) }) {
-		return &nat64pb.AddPrefixResponse{}, nil
-	}
-	inst.Config.Prefixes = append(inst.Config.Prefixes, prefix)
-
-	if err := m.updateModuleConfig(name, inst); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		return m.updateModuleConfig(name, inst, entry)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &nat64pb.AddPrefixResponse{}, nil
@@ -238,31 +291,37 @@ func (m *NAT64Service) RemovePrefix(ctx context.Context, req *nat64pb.RemovePref
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	inst, ok := m.configs[name]
-	if !ok {
+	// Rejecting an unknown name here keeps the locked path from interning
+	// an entry for a name that never existed; the locked re-check below
+	// stays authoritative for the name that waited on an in-flight update.
+	if !m.hasEntry(name) {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
-	next := inst.Clone()
 
-	removeIdx := -1
-	for idx, storedPrefix := range next.Config.Prefixes {
-		if bytes.Equal(storedPrefix, prefix) {
-			removeIdx = idx
-			break
+	err = m.withEntry(name, func(entry *configEntry) error {
+		if entry.Published() == nil {
+			return status.Errorf(codes.NotFound, "config %q not found", name)
 		}
-	}
-	if removeIdx == -1 {
-		return nil, status.Errorf(codes.NotFound, "prefix not found in config %q", name)
-	}
+		next := instanceFor(entry).Clone()
 
-	next.Config.Prefixes = slices.Delete(next.Config.Prefixes, removeIdx, removeIdx+1)
-	next.Config.Mappings = adjustMappingsAfterPrefixRemove(next.Config.Mappings, uint32(removeIdx))
+		removeIdx := -1
+		for idx, storedPrefix := range next.Config.Prefixes {
+			if bytes.Equal(storedPrefix, prefix) {
+				removeIdx = idx
+				break
+			}
+		}
+		if removeIdx == -1 {
+			return status.Errorf(codes.NotFound, "prefix not found in config %q", name)
+		}
 
-	if err := m.updateModuleConfig(name, next); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		next.Config.Prefixes = slices.Delete(next.Config.Prefixes, removeIdx, removeIdx+1)
+		next.Config.Mappings = adjustMappingsAfterPrefixRemove(next.Config.Mappings, uint32(removeIdx))
+
+		return m.updateModuleConfig(name, next, entry)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &nat64pb.RemovePrefixResponse{}, nil
@@ -286,27 +345,27 @@ func (m *NAT64Service) AddMapping(ctx context.Context, req *nat64pb.AddMappingRe
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	err := m.withEntry(name, func(entry *configEntry) error {
+		inst := instanceFor(entry).Clone()
+		if req.PrefixIndex >= uint32(len(inst.Config.Prefixes)) {
+			return status.Errorf(
+				codes.InvalidArgument,
+				"invalid prefix index: got %d, prefixes count %d",
+				req.PrefixIndex,
+				len(inst.Config.Prefixes),
+			)
+		}
+		inst.Config.Mappings = slices.DeleteFunc(inst.Config.Mappings, func(existing Mapping) bool { return existing.IPv4 == ipv4 })
+		inst.Config.Mappings = append(inst.Config.Mappings, Mapping{
+			IPv4:        ipv4,
+			IPv6:        ipv6,
+			PrefixIndex: req.PrefixIndex,
+		})
 
-	inst := m.instanceFor(name).Clone()
-	if req.PrefixIndex >= uint32(len(inst.Config.Prefixes)) {
-		return nil, status.Errorf(
-			codes.InvalidArgument,
-			"invalid prefix index: got %d, prefixes count %d",
-			req.PrefixIndex,
-			len(inst.Config.Prefixes),
-		)
-	}
-	inst.Config.Mappings = slices.DeleteFunc(inst.Config.Mappings, func(existing Mapping) bool { return existing.IPv4 == ipv4 })
-	inst.Config.Mappings = append(inst.Config.Mappings, Mapping{
-		IPv4:        ipv4,
-		IPv6:        ipv6,
-		PrefixIndex: req.PrefixIndex,
+		return m.updateModuleConfig(name, inst, entry)
 	})
-
-	if err := m.updateModuleConfig(name, inst); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+	if err != nil {
+		return nil, err
 	}
 
 	return &nat64pb.AddMappingResponse{}, nil
@@ -323,24 +382,30 @@ func (m *NAT64Service) RemoveMapping(ctx context.Context, req *nat64pb.RemoveMap
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	inst, ok := m.configs[name]
-	if !ok {
+	// Rejecting an unknown name here keeps the locked path from interning
+	// an entry for a name that never existed; the locked re-check below
+	// stays authoritative for the name that waited on an in-flight update.
+	if !m.hasEntry(name) {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
-	next := inst.Clone()
 
-	next.Config.Mappings = slices.DeleteFunc(next.Config.Mappings, func(mapping Mapping) bool {
-		return mapping.IPv4 == ipv4
+	err := m.withEntry(name, func(entry *configEntry) error {
+		if entry.Published() == nil {
+			return status.Errorf(codes.NotFound, "config %q not found", name)
+		}
+		next := instanceFor(entry).Clone()
+
+		next.Config.Mappings = slices.DeleteFunc(next.Config.Mappings, func(mapping Mapping) bool {
+			return mapping.IPv4 == ipv4
+		})
+		if len(next.Config.Mappings) == len(entry.Published().Config.Mappings) {
+			return status.Errorf(codes.NotFound, "mapping for %s not found in config %q", ipv4, name)
+		}
+
+		return m.updateModuleConfig(name, next, entry)
 	})
-	if len(next.Config.Mappings) == len(inst.Config.Mappings) {
-		return nil, status.Errorf(codes.NotFound, "mapping for %s not found in config %q", ipv4, name)
-	}
-
-	if err := m.updateModuleConfig(name, next); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+	if err != nil {
+		return nil, err
 	}
 
 	return &nat64pb.RemoveMappingResponse{}, nil
@@ -362,17 +427,17 @@ func (m *NAT64Service) SetMTU(ctx context.Context, req *nat64pb.SetMTURequest) (
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	err := m.withEntry(name, func(entry *configEntry) error {
+		inst := instanceFor(entry).Clone()
+		inst.Config.MTU = MTUConfig{
+			IPv4MTU: req.Mtu.Ipv4Mtu,
+			IPv6MTU: req.Mtu.Ipv6Mtu,
+		}
 
-	inst := m.instanceFor(name).Clone()
-	inst.Config.MTU = MTUConfig{
-		IPv4MTU: req.Mtu.Ipv4Mtu,
-		IPv6MTU: req.Mtu.Ipv6Mtu,
-	}
-
-	if err := m.updateModuleConfig(name, inst); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		return m.updateModuleConfig(name, inst, entry)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &nat64pb.SetMTUResponse{}, nil
@@ -384,15 +449,15 @@ func (m *NAT64Service) SetDropUnknown(ctx context.Context, req *nat64pb.SetDropU
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	err := m.withEntry(name, func(entry *configEntry) error {
+		inst := instanceFor(entry).Clone()
+		inst.Config.DropUnknownPrefix = req.DropUnknownPrefix
+		inst.Config.DropUnknownMapping = req.DropUnknownMapping
 
-	inst := m.instanceFor(name).Clone()
-	inst.Config.DropUnknownPrefix = req.DropUnknownPrefix
-	inst.Config.DropUnknownMapping = req.DropUnknownMapping
-
-	if err := m.updateModuleConfig(name, inst); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		return m.updateModuleConfig(name, inst, entry)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &nat64pb.SetDropUnknownResponse{}, nil
@@ -444,48 +509,114 @@ func (m *NAT64Service) DeleteConfig(ctx context.Context, req *nat64pb.DeleteConf
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	inst, ok := m.configs[name]
-	if !ok {
+	// Rejecting an unknown name here keeps the locked path from interning
+	// an entry for a name that never existed; the locked re-check below
+	// stays authoritative for the name that waited on an in-flight update.
+	if !m.hasEntry(name) {
 		return nil, status.Error(codes.NotFound, "config not found")
 	}
 
-	if err := m.backend.DeleteModule(name); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to delete module config: %v", err)
+	err := m.withEntry(name, func(entry *configEntry) error {
+		oldConfig := entry.Published()
+		if oldConfig == nil {
+			return status.Error(codes.NotFound, "config not found")
+		}
+
+		if err := m.backend.DeleteModule(name); err != nil {
+			return status.Errorf(codes.Internal, "failed to delete module config: %v", err)
+		}
+
+		m.setPublished(entry, nil)
+
+		// The delete retired the generation holding the published
+		// module; retry the deferred ones, then retire this one.
+		m.ReclaimDeferred()
+		m.parkOrFree(oldConfig.Module)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-
-	// The delete retired the generation holding the published module.
-	// Retry the deferred ones, then retire this one.
-	m.reclaimDeferred()
-	m.parkOrFree(inst.Module)
-
-	delete(m.configs, name)
 
 	return &nat64pb.DeleteConfigResponse{}, nil
 }
 
-func (m *NAT64Service) instanceFor(name string) config {
-	inst, ok := m.configs[name]
-	if !ok {
-		return config{
-			Config: defaultNAT64Config(),
-		}
-	}
-	return inst
+// setPublished swaps the entry's published config under the service lock.
+func (m *NAT64Service) setPublished(entry *configEntry, config *config) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry.Publish(config)
 }
 
-func (m *NAT64Service) updateModuleConfig(name string, inst config) error {
+// entry fetches or creates the lock anchor of the named config. The caller
+// must not hold the service lock.
+func (m *NAT64Service) entry(name string) *configEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if entry, ok := m.configs[name]; ok {
+		return entry
+	}
+	entry := &configEntry{}
+	m.configs[name] = entry
+	return entry
+}
+
+// hasEntry reports whether the named config already has an entry, live or
+// tombstoned. It is the read-only pre-check that keeps the deleting paths
+// from interning an entry for a name that never existed.
+func (m *NAT64Service) hasEntry(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	_, ok := m.configs[name]
+	return ok
+}
+
+// withEntry fetches or creates the entry for the name, holds its update
+// lock for the duration of the call, then returns the call's error. The
+// backend publish runs here, under the entry lock only.
+func (m *NAT64Service) withEntry(name string, fn func(*configEntry) error) error {
+	entry := m.entry(name)
+	entry.LockUpdate()
+	defer entry.UnlockUpdate()
+
+	return fn(entry)
+}
+
+// instanceFor returns the config an in-place mutation starts from: the
+// entry's published one, or defaults for a name seen for the first time.
+func instanceFor(entry *configEntry) config {
+	if entry.Published() != nil {
+		return *entry.Published()
+	}
+	return config{
+		Config: defaultNAT64Config(),
+	}
+}
+
+// updateModuleConfig calls the backend to publish the instance, retries
+// this service's deferred handles (the publish retired the generations
+// that were holding them), frees or defers the old module handle, and
+// stores the new config. The caller must hold the entry's update lock.
+func (m *NAT64Service) updateModuleConfig(name string, inst config, entry *configEntry) error {
 	module, err := m.backend.UpdateModule(name, &inst.Config)
 	if err != nil {
-		return err
+		return status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
 
-	m.reclaimDeferred()
-	m.parkOrFree(inst.Module)
+	oldConfig := entry.Published()
+
 	inst.Module = module
-	m.configs[name] = inst
+	m.setPublished(entry, &inst)
+
+	// The publish retired the generation holding the published module;
+	// retry the deferred ones, then retire the displaced one.
+	m.ReclaimDeferred()
+	if oldConfig != nil {
+		m.parkOrFree(oldConfig.Module)
+	}
 
 	return nil
 }
@@ -505,14 +636,19 @@ func adjustMappingsAfterPrefixRemove(mappings []Mapping, removed uint32) []Mappi
 }
 
 // parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.mu.
+// retry when a live generation still references it. The whole cycle runs
+// under the reclamation lock so it cannot interleave with a concurrent
+// drain that would miss the survivor.
 func (m *NAT64Service) parkOrFree(handle ModuleHandle) {
 	if handle == nil {
 		return
 	}
+
+	m.reclaimMu.Lock()
+	defer m.reclaimMu.Unlock()
+
 	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
+		m.park(handle)
 	}
 }
 
@@ -521,21 +657,37 @@ func (m *NAT64Service) parkOrFree(handle ModuleHandle) {
 // reclamation handler for this module's superseded configs; the service
 // itself runs it after each successful publish, and anything else may
 // call it at any time.
+//
+// The frees run without the service lock: a handle's destruction takes
+// the shared C-side configuration lock, which an in-flight publish of
+// another name may hold, so freeing under the service lock would let
+// that publish stall every read again. The reclamation lock still
+// serializes the whole cycle against a concurrent park, so a survivor
+// can never be missed by the drain that precedes its park.
 func (m *NAT64Service) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
+	m.reclaimMu.Lock()
+	defer m.reclaimMu.Unlock()
 
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *NAT64Service) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
+	handles := m.drainDeferred()
+	for _, handle := range handles {
 		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
+			m.park(handle)
 		}
 	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+}
+
+func (m *NAT64Service) park(handle ModuleHandle) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.deferred = append(m.deferred, handle)
+}
+
+func (m *NAT64Service) drainDeferred() []ModuleHandle {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	handles := m.deferred
+	m.deferred = nil
+	return handles
 }

--- a/modules/nat64/controlplane/service_test.go
+++ b/modules/nat64/controlplane/service_test.go
@@ -5,8 +5,10 @@ import (
 	"net/netip"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -611,4 +613,140 @@ func Test_NAT64Service_Remove_NotFound(t *testing.T) {
 			})
 		}
 	}
+}
+
+// blockingBackend stalls every module publish until released.
+type blockingBackend struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (m *blockingBackend) UpdateModule(name string, cfg *NAT64Config) (ModuleHandle, error) {
+	close(m.started)
+	<-m.release
+	return &mockHandle{}, nil
+}
+
+func (m *blockingBackend) DeleteModule(name string) error {
+	return nil
+}
+
+// Test_NAT64Service_ListDuringStalledUpdate verifies that listing configs
+// completes while another goroutine's update is still stalled inside the
+// backend publish.
+func Test_NAT64Service_ListDuringStalledUpdate(t *testing.T) {
+	backend := &blockingBackend{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	service := NewNAT64Service(backend)
+
+	g, ctx := errgroup.WithContext(t.Context())
+	g.Go(func() error {
+		_, err := service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{
+			Name:   "nat64-0",
+			Prefix: mustIPv6Prefix(t, "64:ff9b::/96"),
+		})
+		return err
+	})
+
+	<-backend.started
+
+	listed := make(chan struct{})
+	go func() {
+		defer close(listed)
+		_, _ = service.ListConfigs(t.Context(), &nat64pb.ListConfigsRequest{})
+	}()
+
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listing configs blocked behind a stalled module publish")
+	}
+
+	close(backend.release)
+	require.NoError(t, g.Wait())
+}
+
+// stallingReclaimHandle refuses its first free, which parks it, and
+// stalls the second until released.
+type stallingReclaimHandle struct {
+	numCalls atomic.Int64
+	started  chan struct{}
+	release  chan struct{}
+}
+
+func (m *stallingReclaimHandle) Free() error {
+	if m.numCalls.Add(1) == 1 {
+		return ffi.ErrStillReferenced
+	}
+	close(m.started)
+	<-m.release
+	return nil
+}
+
+// stallingReclaimBackend mints the stalling handle on its first publish
+// and plain handles thereafter.
+type stallingReclaimBackend struct {
+	numCalls atomic.Int64
+	handle   stallingReclaimHandle
+}
+
+// newStallingReclaimBackend returns a backend that mints the stalling
+// reclaim handle on the first publish; the handle's started channel
+// fires once its deferred destruction is inside the stall.
+func newStallingReclaimBackend() *stallingReclaimBackend {
+	return &stallingReclaimBackend{
+		handle: stallingReclaimHandle{
+			started: make(chan struct{}),
+			release: make(chan struct{}),
+		},
+	}
+}
+
+func (m *stallingReclaimBackend) UpdateModule(name string, cfg *NAT64Config) (ModuleHandle, error) {
+	if m.numCalls.Add(1) == 1 {
+		return &m.handle, nil
+	}
+	return &mockHandle{}, nil
+}
+
+func (m *stallingReclaimBackend) DeleteModule(name string) error {
+	return nil
+}
+
+// Test_NAT64Service_ListDuringStalledReclaim verifies that listing configs
+// completes while a superseded handle's deferred destruction is stalled
+// inside the backend.
+func Test_NAT64Service_ListDuringStalledReclaim(t *testing.T) {
+	backend := newStallingReclaimBackend()
+	service := NewNAT64Service(backend)
+
+	_, err := service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{Name: "nat64-0", Prefix: mustIPv6Prefix(t, "64:ff9b::/96")})
+	require.NoError(t, err)
+	_, err = service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{Name: "nat64-0", Prefix: mustIPv6Prefix(t, "2001:db8::/96")})
+	require.NoError(t, err)
+
+	g, _ := errgroup.WithContext(t.Context())
+	g.Go(func() error {
+		service.ReclaimDeferred()
+		return nil
+	})
+
+	<-backend.handle.started
+
+	listed := make(chan struct{})
+	go func() {
+		defer close(listed)
+		_, _ = service.ListConfigs(t.Context(), &nat64pb.ListConfigsRequest{})
+	}()
+
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listing configs blocked behind a stalled deferred handle destruction")
+	}
+
+	close(backend.handle.release)
+	require.NoError(t, g.Wait())
 }


### PR DESCRIPTION
- The decap, blackhole, mirror and nat64 services held an exclusive mutex across the whole module-publish cgo call, so a slow publish made every read RPC of the module wait it out — the multiplier that turned one slow call into a whole-module outage in the #1913 incident.
- Each service now serializes per-name mutations on an append-only entry lock and keeps service-lock sections to short map and slice work, mirroring the acl reference service.
- A read now completes while a publish is stalled, pinned by a per-module regression test with a blocking backend.
- Mirror update and delete failures now surface as Internal instead of Unknown, aligning it with its sibling services.

Closes #2532.
Closes #2533.
Closes #2534.
Closes #2535.