### PR TITLE
perf(dataplane): run scheduled device entries first and poll the rest after

### DIFF
--- a/common/rlist.h
+++ b/common/rlist.h
@@ -44,3 +44,24 @@ static inline int
 rlist_empty(struct rlist *head) {
 	return head->next == head;
 }
+
+// Move every item of one list onto the tail of another.
+//
+// The source head is left empty and neither list is walked, so the
+// move costs the same regardless of lengths.
+static inline void
+rlist_concat(struct rlist *dst, struct rlist *src) {
+	if (rlist_empty(src)) {
+		return;
+	}
+
+	struct rlist *first = src->next;
+	struct rlist *last = src->prev;
+
+	dst->prev->next = first;
+	first->prev = dst->prev;
+	last->next = dst;
+	dst->prev = last;
+
+	rlist_init(src);
+}

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -45,82 +45,71 @@ device_entry_ectx_count_recirc_drop(
 	counter[1] += rte_pktmbuf_pkt_len(packet_to_mbuf(packet));
 }
 
-// Advance the generation's worklists to the start of a worker tick.
+// Build the generation's device-entry worklists once.
 //
-// Must run on the owning worker before any packet is scheduled in the
-// tick. Once the lists are built, a tick start only flips the roles,
-// which turns the processed list into the to-execute list with no
-// per-node work; the first build walks the devices once and links every
-// input entry before every output entry, mirroring the historical phase
-// order of the full sweep. The freshly built list is the active one for
-// the current tick, so the build path must not flip.
+// Must run on the owning worker before any packet is scheduled. Every
+// entry is linked onto the home list, each device's input entry
+// before its output one. After the first build the lists are
+// permanent state and preparation does nothing: the round itself
+// drains the home list onto its untouched list and works entries
+// back home.
 static inline void
 config_gen_ectx_schedules_prepare(struct config_gen_ectx *config_gen_ectx) {
 	if (config_gen_ectx->schedules_ready) {
-		config_gen_ectx->schedule_active ^= 1;
 		return;
 	}
 
-	rlist_init(&config_gen_ectx->schedule_lists[0]);
-	rlist_init(&config_gen_ectx->schedule_lists[1]);
+	rlist_init(&config_gen_ectx->entry_list);
+	rlist_init(&config_gen_ectx->ready_list);
 
-	for (uint64_t pass = 0; pass < 2; ++pass) {
-		for (uint64_t idx = 0; idx < config_gen_ectx->device_count;
-		     ++idx) {
-			struct device_ectx *device_ectx =
-				config_gen_ectx_get_device(
-					config_gen_ectx, idx
-				);
-			if (device_ectx == NULL) {
-				continue;
-			}
-
-			struct device_entry_ectx *device_entry_ectx;
-			if (pass == 0) {
-				device_entry_ectx =
-					device_ectx->abs_input_pipelines;
-			} else {
-				device_entry_ectx =
-					device_ectx->abs_output_pipelines;
-			}
-
-			rlist_add(
-				&config_gen_ectx->schedule_lists[0],
-				&device_entry_ectx->schedule_node
-			);
-			device_entry_ectx->schedule_list = 0;
+	for (uint64_t idx = 0; idx < config_gen_ectx->device_count; ++idx) {
+		struct device_ectx *device_ectx =
+			config_gen_ectx_get_device(config_gen_ectx, idx);
+		if (device_ectx == NULL) {
+			continue;
 		}
+
+		rlist_add(
+			&config_gen_ectx->entry_list,
+			&device_ectx->abs_input_pipelines->schedule_node
+		);
+		device_ectx->abs_input_pipelines->schedule_list =
+			device_entry_schedule_home;
+
+		rlist_add(
+			&config_gen_ectx->entry_list,
+			&device_ectx->abs_output_pipelines->schedule_node
+		);
+		device_ectx->abs_output_pipelines->schedule_list =
+			device_entry_schedule_home;
 	}
 
-	config_gen_ectx->schedule_active = 0;
 	config_gen_ectx->schedules_ready = 1;
 }
 
 // Schedule a packet onto a device entry's input list, moving the entry
-// onto the active worklist when needed.
+// onto the round's ready list when needed.
 //
-// An entry parked on the processed list after running this tick is
-// moved back to the active list so it runs again, reproducing the
-// recirculation semantics; an entry already queued for this tick is
-// left where it is. Packets are only scheduled from inside a worker
-// round, and the round's preparation builds the worklists before any
-// of them, so no readiness check is needed here.
+// An entry anywhere but ready — home, or already drained onto the
+// round's untouched list — moves to the tail of ready so the round
+// runs it, reproducing the recirculation semantics; an entry already
+// queued stays where it is. Removal needs no list head, so the entry
+// may sit on any of the round's lists. Packets are only scheduled
+// from inside a worker round, whose preparation built the worklists
+// before any of them, so no readiness check is needed here.
 static inline void
 device_entry_ectx_schedule(
 	struct config_gen_ectx *config_gen_ectx,
 	struct device_entry_ectx *device_entry_ectx,
 	struct packet *packet
 ) {
-	if (device_entry_ectx->schedule_list !=
-	    config_gen_ectx->schedule_active) {
+	if (device_entry_ectx->schedule_list != device_entry_schedule_ready) {
 		rlist_remove(&device_entry_ectx->schedule_node);
 		rlist_add(
-			&config_gen_ectx->schedule_lists
-				 [config_gen_ectx->schedule_active],
+			&config_gen_ectx->ready_list,
 			&device_entry_ectx->schedule_node
 		);
-		device_entry_ectx->schedule_list =
-			config_gen_ectx->schedule_active;
+		device_entry_ectx->schedule_list = device_entry_schedule_ready;
 	}
 
 	packet_front_input(&device_entry_ectx->schedule, packet);

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 25
+#define YANET_MODULE_ABI_VERSION 26
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -257,6 +257,17 @@ enum device_entry_direction {
 	device_entry_direction_output,
 };
 
+// Worklist state of a device entry, for the owning worker only.
+//
+// The ready state rides the generation's ready list and the home
+// state its home list. The scheduling path moves an entry to ready
+// from the home list, and the round works every ready entry back
+// home.
+enum device_entry_schedule_state {
+	device_entry_schedule_ready = 0,
+	device_entry_schedule_home = 1,
+};
+
 struct device_entry_ectx {
 	device_handler handler;
 
@@ -371,20 +382,23 @@ struct config_gen_ectx {
 	// instead of reinitializing a fresh front on each iteration.
 	struct packet_front packet_front;
 
-	// Two device-entry worklists whose roles swap every tick; the
-	// active one is the to-execute list.
+	// The device-entry home list.
 	//
-	// Every entry is linked into exactly one: the active list holds
-	// entries still to execute this tick, the other the processed
-	// ones. Tick start flips the roles, turning the whole processed
-	// list back into the to-execute list at constant cost, so every
-	// entry still runs at least once per tick; a packet routed to a
-	// processed entry moves it back so it runs again within the tick.
-	// Links are raw pointers built only by the owning worker, which
-	// also raises the ready flag on first build; the control plane
-	// leaves all three fields zeroed.
-	struct rlist schedule_lists[2];
-	uint8_t schedule_active;
+	// At rest every entry is linked onto it. The first build links
+	// each device's input entry before its output one; a round that
+	// runs entries leaves them parked in run order instead. A
+	// round drains the list onto its local untouched list and works
+	// entries back home through the ready list, so the home list is
+	// empty while a round runs. Links are raw pointers built only by
+	// the owning worker, which also raises the ready flag on first
+	// build; the control plane leaves these fields zeroed.
+	struct rlist entry_list;
+	// The queue of entries a packet was scheduled onto.
+	//
+	// Filled by the scheduling path and drained by the round, which
+	// moves each processed entry back to the home list; empty
+	// between rounds. Shares the link contract of the home list.
+	struct rlist ready_list;
 	uint8_t schedules_ready;
 
 	// Offset pointer to an array of per-slot offset pointers to the

--- a/lib/dataplane/worker/pipeline_round.c
+++ b/lib/dataplane/worker/pipeline_round.c
@@ -8,6 +8,61 @@
 #include "lib/dataplane/pipeline/econtext.h"
 #include "lib/dataplane/pipeline/pipeline.h"
 
+// Run one device entry on its own schedule.
+//
+// The batch is detached so redirects land in the reusable inbox; input
+// entry processing has no packet transmission allowed, so its whole
+// output is dropped and the only chance for a packet to survive is
+// being routed into a device entry by a module.
+static inline void
+worker_run_entry(
+	struct dp_worker *dp_worker,
+	struct device_entry_ectx *device_entry_ectx,
+	struct packet_front *packet_front
+) {
+	struct device_ectx *device_ectx = device_entry_ectx->abs_device_ectx;
+	struct packet_front *schedule = &device_entry_ectx->schedule;
+
+	struct packet_front active = *schedule;
+	packet_front_init(schedule);
+
+	if (device_entry_ectx->direction == device_entry_direction_input) {
+		device_ectx_process_input(dp_worker, device_ectx, &active);
+		packet_front_drop_output(&active);
+	} else {
+		device_ectx_process_output(dp_worker, device_ectx, &active);
+	}
+
+	packet_front_merge(packet_front, &active);
+}
+
+static inline void
+worker_pipeline_round_process_ready(
+	struct dp_worker *dp_worker,
+	struct config_gen_ectx *config_gen_ectx,
+	struct packet_front *packet_front
+) {
+	/*
+	 * Run the ready entries until the packets are exhausted.
+	 * Each entry moves back to the home list before running,
+	 * so a packet routed into it while it runs moves it to
+	 * the tail of ready and it runs again within the same
+	 * round.
+	 */
+	while (!rlist_empty(&config_gen_ectx->ready_list)) {
+		struct rlist *node = rlist_first(&config_gen_ectx->ready_list);
+		rlist_remove(node);
+
+		struct device_entry_ectx *device_entry_ectx = container_of(
+			node, struct device_entry_ectx, schedule_node
+		);
+		rlist_add(&config_gen_ectx->entry_list, node);
+		device_entry_ectx->schedule_list = device_entry_schedule_home;
+
+		worker_run_entry(dp_worker, device_entry_ectx, packet_front);
+	}
+}
+
 void
 worker_pipeline_round(
 	struct dp_worker *dp_worker,
@@ -17,70 +72,25 @@ worker_pipeline_round(
 ) {
 	(void)cp_config_gen;
 
-	struct rlist *active_head =
-		&config_gen_ectx
-			 ->schedule_lists[config_gen_ectx->schedule_active];
-	struct rlist *inactive_head =
-		&config_gen_ectx
-			 ->schedule_lists[config_gen_ectx->schedule_active ^ 1];
+	// The untouched list holds every entry no packet reached this
+	// round: the round drains the home list onto it at constant
+	// cost, in home-list order. Entries the receive path already
+	// scheduled sit on the ready list and miss the drain.
+	struct rlist untouched;
+	rlist_init(&untouched);
+	rlist_concat(&untouched, &config_gen_ectx->entry_list);
 
-	/*
-	 * Every entry executes at least once per tick.
-	 *
-	 * Tick preparation hands over a list that still holds every
-	 * entry, so all of them run even when no packets arrived and
-	 * periodic work has a chance to make progress. Within the tick,
-	 * an entry re-enters the list only when a packet is routed onto
-	 * it, and the round ends once that quiesces.
-	 */
-	while (!rlist_empty(active_head)) {
-		struct rlist *node = rlist_first(active_head);
+	worker_pipeline_round_process_ready(
+		dp_worker, config_gen_ectx, packet_front
+	);
 
-		/*
-		 * Park the entry before executing it: a packet routed
-		 * into it while it runs moves it back onto the active
-		 * list so it runs again this tick.
-		 */
-		rlist_remove(node);
-		rlist_add(inactive_head, node);
-
-		struct device_entry_ectx *device_entry_ectx = container_of(
-			node, struct device_entry_ectx, schedule_node
-		);
-		device_entry_ectx->schedule_list =
-			config_gen_ectx->schedule_active ^ 1;
-
-		struct device_ectx *device_ectx =
-			device_entry_ectx->abs_device_ectx;
-		struct packet_front *schedule = &device_entry_ectx->schedule;
-		if (schedule->input_count == 0) {
-			continue;
-		}
-
-		// Detach the batch so redirects land in the reusable
-		// inbox.
-		struct packet_front active = *schedule;
-		packet_front_init(schedule);
-
-		if (device_entry_ectx->direction ==
-		    device_entry_direction_input) {
-			device_ectx_process_input(
-				dp_worker, device_ectx, &active
-			);
-
-			/*
-			 * Input entry point processing has no packet
-			 * transmission allowed so drop the whole output.
-			 * The only chance for a packet to survive is being
-			 * routed into a device entry by a module.
-			 */
-			packet_front_drop_output(&active);
-		} else {
-			device_ectx_process_output(
-				dp_worker, device_ectx, &active
-			);
-		}
-
-		packet_front_merge(packet_front, &active);
+	if (rlist_empty(&untouched)) {
+		return;
 	}
+
+	rlist_concat(&config_gen_ectx->ready_list, &untouched);
+
+	worker_pipeline_round_process_ready(
+		dp_worker, config_gen_ectx, packet_front
+	);
 }

--- a/lib/dataplane/worker/round.h
+++ b/lib/dataplane/worker/round.h
@@ -43,8 +43,9 @@ worker_round_prepare(struct dp_worker *dp_worker, uint64_t current_time_ns) {
 	__atomic_store_n(&dp_worker->gen, acknowledged_gen, __ATOMIC_RELEASE);
 	*dp_worker->iterations += 1;
 
-	// Flip or first-build the worklists before any packet of this tick
-	// is scheduled onto them.
+	// First-build the worklists before any packet is scheduled onto
+	// them; later preparations do nothing, the round drains the
+	// worklists itself.
 	if (round.config_gen_ectx != NULL) {
 		config_gen_ectx_schedules_prepare(round.config_gen_ectx);
 	}


### PR DESCRIPTION
- The generation carries one device-entry home list and a ready list; a round drains the home list onto a stack list of untouched entries at constant cost through a new list concatenation routine.
- The scheduling path moves an entry onto the ready list from wherever it sits, and the round works each ready entry back to the home list before running it, so packets run to exhaustion first and rerouted entries rejoin the ready tail within the same round.
- When ready is exhausted the whole untouched set joins ready at constant cost and runs through the same loop, so periodic device work such as trafgen generation keeps pacing itself on being called every round and anything a poll schedules returns to ready iteration.
- Bumps YANET_MODULE_ABI_VERSION to 26 for the generation worklist layout change.

Closes #2541.