### PR TITLE
fix(fwstate,cli): prevent concurrent update reverts

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -3,6 +3,27 @@
 Manual steps required when upgrading an existing deployment. The packaging
 does not perform these automatically.
 
+## FWState CLI partial updates
+
+Upgrade the fwstate control plane before using the new CLI. The CLI now sends
+only explicitly supplied settings with an update mask, without reading the
+stored configuration first. The service merges these settings under its
+mutation lock, so updates to different fields preserve each other; writes to
+the same field use the last successfully published value.
+
+An omitted flag preserves its field. An explicit zero timeout writes zero;
+an empty map-name flag unlinks that family. The resulting configuration must
+still pass validation. A present empty mask preserves every field and creates
+a missing configuration with defaults.
+
+Requests without a mask retain their legacy merging, destination-set replacement
+and endpoint-clear flags. Masked updates preserve the unselected endpoint;
+the CLI encodes `--no-multicast` and `--no-unicast` as masked clears.
+Do not combine a mask with the legacy endpoint-clear flags.
+Older servers ignore the new mask, so clears and endpoint updates can behave
+incorrectly. Older clients and the web configuration editor still send stored
+values and do not gain protection against stale-document overwrites.
+
 ## Controlplane systemd unit became a template
 
 `yanet2-controlplane.service` is replaced by the template

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -30,7 +30,7 @@ pub enum ModeCmd {
     List,
     /// Delete a fwstate configuration.
     Delete(DeleteCmd),
-    /// Update fwstate configuration (map and sync settings).
+    /// Create or update only the supplied map and sync settings.
     Update(UpdateCmd),
     /// Show fwstate configuration.
     Show(ShowCmd),
@@ -67,11 +67,11 @@ pub struct UpdateCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 
-    /// Name of the published fwstate-map (kind V4) object to link.
+    /// Name of the published V4 fwstate-map to link; empty unlinks it.
     #[arg(long)]
     pub map_name_v4: Option<String>,
 
-    /// Name of the published fwstate-map (kind V6) object to link.
+    /// Name of the published V6 fwstate-map to link; empty unlinks it.
     #[arg(long)]
     pub map_name_v6: Option<String>,
 
@@ -154,7 +154,8 @@ pub struct UpdateCmd {
 
     /// Sync suppression window: skip redundant state-sync refreshes whose
     /// new expiry lands within this window of the current one (e.g., "8s").
-    /// Omitted or zero keeps the currently configured window.
+    ///
+    /// Omitted keeps the current window; zero disables suppression.
     #[arg(long, value_parser = parse_duration)]
     pub sync_suppress_timeout: Option<Duration>,
 }

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -163,18 +163,74 @@ fn config_rows(response: &ShowConfigResponse) -> Vec<SettingRow> {
     rows
 }
 
-/// Merges the linked map object names an update should carry.
-///
-/// Each flag, when present, overrides the stored name; an absent one
-/// keeps what the pre-flight lookup reported. A config that names no map
-/// links none and inserts no synced state for that family, which is what
-/// a create left without map flags installs until a later update names
-/// them.
-fn merged_map_names(current: &ShowConfigResponse, cmd: &UpdateCmd) -> (String, String) {
-    (
-        cmd.map_name_v4.clone().unwrap_or_else(|| current.map_name_v4.clone()),
-        cmd.map_name_v6.clone().unwrap_or_else(|| current.map_name_v6.clone()),
-    )
+/// Builds a partial update from explicitly supplied flags only.
+fn update_request(cmd: &UpdateCmd) -> Result<UpdateConfigRequest, &'static str> {
+    let mut request = UpdateConfigRequest {
+        name: cmd.config_name.clone(),
+        ..Default::default()
+    };
+    let mut paths = Vec::new();
+    let mut sync_config = fwstatepb::SyncConfig::default();
+    if let Some(value) = &cmd.map_name_v4 {
+        request.map_name_v4 = value.clone();
+        paths.push("map_name_v4".to_string());
+    }
+    if let Some(value) = &cmd.map_name_v6 {
+        request.map_name_v6 = value.clone();
+        paths.push("map_name_v6".to_string());
+    }
+    if let Some(value) = cmd.src_addr {
+        sync_config.src_addr = Some(IpAddress::from(IpAddr::V6(value)));
+        paths.push("sync_config.src_addr".to_string());
+    }
+    if let Some(value) = cmd.dst_ether {
+        sync_config.dst_ether = Some(MacAddress::from(value));
+        paths.push("sync_config.dst_ether".to_string());
+    }
+    update_sync_endpoints(&mut sync_config, cmd)?;
+    if cmd.multicast.is_some() || cmd.no_multicast || cmd.dst_addr_multicast.is_some() {
+        paths.push("sync_config.dst_addr_multicast".to_string());
+    }
+    if cmd.multicast.is_some() || cmd.no_multicast || cmd.port_multicast.is_some() {
+        paths.push("sync_config.port_multicast".to_string());
+    }
+    if cmd.unicast.is_some() || cmd.no_unicast || cmd.dst_addr_unicast.is_some() {
+        paths.push("sync_config.dst_addr_unicast".to_string());
+    }
+    if cmd.unicast.is_some() || cmd.no_unicast || cmd.port_unicast.is_some() {
+        paths.push("sync_config.port_unicast".to_string());
+    }
+    if let Some(value) = cmd.tcp_syn_ack {
+        sync_config.tcp_syn_ack = value.as_nanos() as u64;
+        paths.push("sync_config.tcp_syn_ack".to_string());
+    }
+    if let Some(value) = cmd.tcp_syn {
+        sync_config.tcp_syn = value.as_nanos() as u64;
+        paths.push("sync_config.tcp_syn".to_string());
+    }
+    if let Some(value) = cmd.tcp_fin {
+        sync_config.tcp_fin = value.as_nanos() as u64;
+        paths.push("sync_config.tcp_fin".to_string());
+    }
+    if let Some(value) = cmd.tcp {
+        sync_config.tcp = value.as_nanos() as u64;
+        paths.push("sync_config.tcp".to_string());
+    }
+    if let Some(value) = cmd.udp {
+        sync_config.udp = value.as_nanos() as u64;
+        paths.push("sync_config.udp".to_string());
+    }
+    if let Some(value) = cmd.default {
+        sync_config.default = value.as_nanos() as u64;
+        paths.push("sync_config.default".to_string());
+    }
+    if let Some(value) = cmd.sync_suppress_timeout {
+        sync_config.sync_suppress_timeout = value.as_nanos() as u64;
+        paths.push("sync_config.sync_suppress_timeout".to_string());
+    }
+    request.sync_config = Some(sync_config);
+    request.update_mask = Some(fwstatepb::FieldMask { paths });
+    Ok(request)
 }
 
 fn remove_multicast_endpoint(sync_config: &mut SyncConfig) {
@@ -302,72 +358,7 @@ impl FWStateService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        // First, fetch the current config to merge with new values
-        //
-        // A failed read aborts the update: only an empty reply proves the
-        // config is missing and may take the create path.
-        let current_request = ShowConfigRequest {
-            name: cmd.config_name.clone(),
-            ok_if_not_found: true,
-        };
-        let current = self
-            .service
-            .client()
-            .show_config(current_request)
-            .await
-            .map_err(self.service.status("update"))?
-            .into_inner();
-        let (map_name_v4, map_name_v6) = merged_map_names(&current, &cmd);
-        let mut sync_config = current.sync_config.unwrap_or_default();
-
-        // Update only the fields that were provided
-        if let Some(src_addr) = cmd.src_addr {
-            sync_config.src_addr = Some(IpAddress::from(IpAddr::V6(src_addr)));
-        }
-
-        if let Some(dst_ether) = cmd.dst_ether {
-            sync_config.dst_ether = Some(MacAddress::from(dst_ether));
-        }
-
-        update_sync_endpoints(&mut sync_config, &cmd).map_err(|err| self.service.invalid("update", err))?;
-
-        // Convert timeouts from Duration to nanoseconds if provided
-        if let Some(tcp_syn_ack) = cmd.tcp_syn_ack {
-            sync_config.tcp_syn_ack = tcp_syn_ack.as_nanos() as u64;
-        }
-
-        if let Some(tcp_syn) = cmd.tcp_syn {
-            sync_config.tcp_syn = tcp_syn.as_nanos() as u64;
-        }
-
-        if let Some(tcp_fin) = cmd.tcp_fin {
-            sync_config.tcp_fin = tcp_fin.as_nanos() as u64;
-        }
-
-        if let Some(tcp) = cmd.tcp {
-            sync_config.tcp = tcp.as_nanos() as u64;
-        }
-
-        if let Some(udp) = cmd.udp {
-            sync_config.udp = udp.as_nanos() as u64;
-        }
-
-        if let Some(default) = cmd.default {
-            sync_config.default = default.as_nanos() as u64;
-        }
-
-        if let Some(suppress) = cmd.sync_suppress_timeout {
-            sync_config.sync_suppress_timeout = suppress.as_nanos() as u64;
-        }
-
-        let request = UpdateConfigRequest {
-            name: cmd.config_name.clone(),
-            map_name_v4,
-            map_name_v6,
-            sync_config: Some(sync_config),
-            clear_multicast: cmd.no_multicast,
-            clear_unicast: cmd.no_unicast,
-        };
+        let request = update_request(&cmd).map_err(|err| self.service.invalid("update", err))?;
         log::trace!("UpdateConfigRequest: {request:?}");
         self.service
             .client()
@@ -410,11 +401,6 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn cmd_is_valid() {
-        Cmd::command().debug_assert();
-    }
 
     /// Update command carrying only the config name and optional map names.
     fn update_cmd(config_name: &str, map_name_v4: Option<&str>, map_name_v6: Option<&str>) -> UpdateCmd {
@@ -552,43 +538,73 @@ mod tests {
     }
 
     #[test]
-    fn test_merged_map_names_create_without_map_names_is_rejected() {
-        let cmd = update_cmd("cfg", None, None);
-        let (map_name_v4, map_name_v6) = merged_map_names(&show_response("", "", ""), &cmd);
-
-        assert_eq!(("", ""), (map_name_v4.as_str(), map_name_v6.as_str()));
+    fn test_update_request_endpoint_flags_select_pairs_and_clear_without_legacy_flags() {
+        let mut cmd = update_cmd("cfg", None, None);
+        cmd.no_multicast = true;
+        cmd.unicast = Some("[2001:db8::1]:10000".parse().unwrap());
+        let request = update_request(&cmd).unwrap();
+        assert_eq!(
+            vec![
+                "sync_config.dst_addr_multicast",
+                "sync_config.port_multicast",
+                "sync_config.dst_addr_unicast",
+                "sync_config.port_unicast",
+            ],
+            request.update_mask.unwrap().paths
+        );
+        assert!(!request.clear_multicast);
+        assert!(!request.clear_unicast);
+        let sync_config = request.sync_config.unwrap();
+        assert_eq!(None, sync_config.dst_addr_multicast);
+        assert_eq!(0, sync_config.port_multicast);
+        assert_eq!(10000, sync_config.port_unicast);
+        assert_eq!(
+            Some(IpAddress::from(IpAddr::V6("2001:db8::1".parse().unwrap()))),
+            sync_config.dst_addr_unicast
+        );
     }
 
     #[test]
-    fn test_merged_map_names_create_with_one_map_name_links_only_it() {
-        let empty_reply = show_response("", "", "");
-        let (map_name_v4, map_name_v6) = merged_map_names(&empty_reply, &update_cmd("cfg", Some("v4"), None));
-
-        assert_eq!(("v4", ""), (map_name_v4.as_str(), map_name_v6.as_str()));
+    fn test_update_request_split_endpoint_flag_selects_only_explicit_field() {
+        let mut cmd = update_cmd("cfg", None, None);
+        cmd.port_multicast = Some(9999);
+        let request = update_request(&cmd).unwrap();
+        assert_eq!(vec!["sync_config.port_multicast"], request.update_mask.unwrap().paths);
+        let sync_config = request.sync_config.unwrap();
+        assert_eq!(9999, sync_config.port_multicast);
+        assert_eq!(None, sync_config.dst_addr_multicast);
     }
 
     #[test]
-    fn test_merged_map_names_create_with_both_map_names_uses_flags() {
-        let cmd = update_cmd("cfg", Some("map4"), Some("map6"));
-        let (map_name_v4, map_name_v6) = merged_map_names(&show_response("", "", ""), &cmd);
-
-        assert_eq!(("map4", "map6"), (map_name_v4.as_str(), map_name_v6.as_str()));
+    fn test_update_request_empty_mask_preserves_existing_fields() {
+        let request = update_request(&update_cmd("cfg", None, None)).unwrap();
+        assert!(request.update_mask.unwrap().paths.is_empty());
     }
 
     #[test]
-    fn test_merged_map_names_existing_config_keeps_stored_names_without_flags() {
-        let cmd = update_cmd("cfg", None, None);
-        let (map_name_v4, map_name_v6) = merged_map_names(&show_response("cfg", "stored4", "stored6"), &cmd);
-
-        assert_eq!(("stored4", "stored6"), (map_name_v4.as_str(), map_name_v6.as_str()));
+    fn test_update_request_explicit_zero_and_empty_are_selected() {
+        let mut cmd = update_cmd("cfg", Some(""), None);
+        cmd.sync_suppress_timeout = Some(core::time::Duration::ZERO);
+        let request = update_request(&cmd).unwrap();
+        assert_eq!(
+            vec!["map_name_v4", "sync_config.sync_suppress_timeout"],
+            request.update_mask.unwrap().paths
+        );
+        assert_eq!("", request.map_name_v4);
+        assert_eq!(0, request.sync_config.unwrap().sync_suppress_timeout);
     }
 
     #[test]
-    fn test_merged_map_names_existing_config_flag_overrides_stored_name() {
-        let reply = show_response("cfg", "stored4", "stored6");
-        let (map_name_v4, map_name_v6) = merged_map_names(&reply, &update_cmd("cfg", Some("new4"), None));
-
-        assert_eq!(("new4", "stored6"), (map_name_v4.as_str(), map_name_v6.as_str()));
+    fn test_update_request_independent_flags_select_only_their_fields() {
+        let mut cmd = update_cmd("cfg", None, Some("map6"));
+        cmd.udp = Some(core::time::Duration::from_secs(45));
+        let request = update_request(&cmd).unwrap();
+        assert_eq!(
+            vec!["map_name_v6", "sync_config.udp"],
+            request.update_mask.unwrap().paths
+        );
+        assert_eq!("map6", request.map_name_v6);
+        assert_eq!(45_000_000_000, request.sync_config.unwrap().udp);
     }
 
     #[test]

--- a/modules/fwstate/controlplane/ffi.go
+++ b/modules/fwstate/controlplane/ffi.go
@@ -1,10 +1,66 @@
 package fwstate
 
 import (
+	"fmt"
+
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 	"github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
 )
+
+// maskedUpdate merges only selected fields over the current configuration.
+//
+// The caller holds the mutation lock until publication, so independent
+// updates preserve one another regardless of their arrival order.
+func maskedUpdate(old *FwStateConfig, req *fwstatepb.UpdateConfigRequest) (*fwstatepb.UpdateConfigRequest, error) {
+	if req.ClearMulticast || req.ClearUnicast {
+		return nil, fmt.Errorf("endpoint clear flags cannot be combined with an update mask")
+	}
+	merged := &fwstatepb.UpdateConfigRequest{
+		SyncConfig: mergedSyncConfig(old, nil),
+	}
+	if old != nil {
+		merged.MapNameV4 = old.MapNameV4()
+		merged.MapNameV6 = old.MapNameV6()
+	}
+	for _, path := range req.UpdateMask.Paths {
+		switch path {
+		case "map_name_v4":
+			merged.MapNameV4 = req.MapNameV4
+		case "map_name_v6":
+			merged.MapNameV6 = req.MapNameV6
+		case "sync_config.dst_ether":
+			merged.SyncConfig.DstEther = req.GetSyncConfig().GetDstEther()
+		case "sync_config.dst_addr_unicast":
+			merged.SyncConfig.DstAddrUnicast = req.GetSyncConfig().GetDstAddrUnicast()
+		case "sync_config.port_unicast":
+			merged.SyncConfig.PortUnicast = req.GetSyncConfig().GetPortUnicast()
+		case "sync_config.src_addr":
+			merged.SyncConfig.SrcAddr = req.GetSyncConfig().GetSrcAddr()
+		case "sync_config.dst_addr_multicast":
+			merged.SyncConfig.DstAddrMulticast = req.GetSyncConfig().GetDstAddrMulticast()
+		case "sync_config.port_multicast":
+			merged.SyncConfig.PortMulticast = req.GetSyncConfig().GetPortMulticast()
+		case "sync_config.tcp_syn_ack":
+			merged.SyncConfig.TcpSynAck = req.GetSyncConfig().GetTcpSynAck()
+		case "sync_config.tcp_syn":
+			merged.SyncConfig.TcpSyn = req.GetSyncConfig().GetTcpSyn()
+		case "sync_config.tcp_fin":
+			merged.SyncConfig.TcpFin = req.GetSyncConfig().GetTcpFin()
+		case "sync_config.tcp":
+			merged.SyncConfig.Tcp = req.GetSyncConfig().GetTcp()
+		case "sync_config.udp":
+			merged.SyncConfig.Udp = req.GetSyncConfig().GetUdp()
+		case "sync_config.default":
+			merged.SyncConfig.Default = req.GetSyncConfig().GetDefault()
+		case "sync_config.sync_suppress_timeout":
+			merged.SyncConfig.SyncSuppressTimeout = req.GetSyncConfig().GetSyncSuppressTimeout()
+		default:
+			return nil, fmt.Errorf("unknown update mask path %q", path)
+		}
+	}
+	return merged, nil
+}
 
 // FwStateConfig is a service-owned fwstate module config plus the names of
 // the fwstate-map objects it links, which the service needs for ShowConfig
@@ -33,7 +89,8 @@ func NewFWStateModuleConfig(
 	syncConfig *fwstatepb.SyncConfig,
 	fw4MapName, fw6MapName string,
 ) (*FwStateConfig, error) {
-	return newFWStateModuleConfig(agent, name, old, syncConfig, false, false, fw4MapName, fw6MapName)
+	merged := mergedSyncConfigC(old, syncConfig)
+	return newFWStateModuleConfig(agent, name, merged, fw4MapName, fw6MapName)
 }
 
 // NewFWStateModuleConfigWithEndpointClears builds a replacement config while
@@ -46,23 +103,21 @@ func NewFWStateModuleConfigWithEndpointClears(
 	clearMulticast, clearUnicast bool,
 	fw4MapName, fw6MapName string,
 ) (*FwStateConfig, error) {
-	return newFWStateModuleConfig(agent, name, old, syncConfig, clearMulticast, clearUnicast, fw4MapName, fw6MapName)
+	merged := mergedSyncConfigCWithClears(old, syncConfig, clearMulticast, clearUnicast)
+	return newFWStateModuleConfig(agent, name, merged, fw4MapName, fw6MapName)
 }
 
+// newFWStateModuleConfig installs the already merged values verbatim.
 func newFWStateModuleConfig(
 	agent *ffi.Agent,
 	name string,
-	old *FwStateConfig,
-	syncConfig *fwstatepb.SyncConfig,
-	clearMulticast, clearUnicast bool,
+	syncConfig cfwstate.SyncConfig,
 	fw4MapName, fw6MapName string,
 ) (*FwStateConfig, error) {
-	merged := mergedSyncConfigCWithClears(old, syncConfig, clearMulticast, clearUnicast)
-
 	moduleCfg, err := cfwstate.NewModuleConfig(
 		agent,
 		name,
-		&merged,
+		&syncConfig,
 		fw4MapName,
 		fw6MapName,
 	)
@@ -79,7 +134,7 @@ func newFWStateModuleConfig(
 // mergedMapNames returns the map object links a replacement config
 // should declare.
 //
-// A request naming a map relinks that family; leaving it unnamed keeps
+// A legacy request naming a map relinks that family; leaving it unnamed keeps
 // the link the replaced config had, the only spelling the request has
 // for "leave this family alone". A fresh config left unnamed declares no
 // link at all, and the maps can be attached by a later update.

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.go
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.go
@@ -68,15 +68,11 @@ func (m *SyncConfig) ValidateTimeouts() error {
 	return nil
 }
 
-// ValidateFields rejects sync values stated in a form the config cannot
-// store, before they are merged over the values they update.
+// ValidateFields rejects sync values stated in a form the config cannot store.
 //
-// A request carrying no destination pair leaves the current pairs unchanged;
-// supplying a pair replaces the destination set, disabling any other omitted
-// pair. Only a stated value that cannot be stored fails here: a port too wide
-// for the stored field, or an address of any width other than an IPv6 one.
-// Whether the merged result names a usable destination is decided against the
-// config it replaces, not here.
+// Empty endpoints are representable. Whether they preserve existing values
+// or clear them depends on the update contract. A stated destination address
+// requires a port; the merged configuration must also be usable.
 func (m *SyncConfig) ValidateFields() error {
 	if m == nil {
 		return nil
@@ -107,10 +103,8 @@ func (m *SyncConfig) ValidateFields() error {
 		return fmt.Errorf("dst_ether must be an EUI-48 address")
 	}
 
-	// A non-empty destination address is an explicit update, so it must be
-	// accompanied by its port. A non-zero port without an address is checked
-	// after merging, where replacement semantics make the resulting pair
-	// explicit.
+	// A supplied destination address needs a port. Masked requests reach
+	// this check after merging, so the port may come from the stored config.
 	if len(m.GetDstAddrMulticast().GetAddr()) != 0 && m.GetPortMulticast() == 0 {
 		return fmt.Errorf("port_multicast is required with dst_addr_multicast")
 	}
@@ -228,8 +222,7 @@ func (m *SyncConfig) Validate() error {
 
 const macAddrMask uint64 = (1 << 48) - 1
 
-// validateAddrWidth rejects an address stated at a width the config
-// cannot store; an absent one asks for no change and passes.
+// validateAddrWidth accepts empty addresses and full-width IPv6 addresses.
 func validateAddrWidth(field string, addr []byte) error {
 	if len(addr) == 0 || len(addr) == syncAddrLen {
 		return nil

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
@@ -9,7 +9,7 @@ import "common/commonpb/v1/metric.proto";
 option go_package = "github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1;fwstatepb";
 
 service FWStateService {
-  // Updates the complete FWState configuration
+  // Creates or atomically updates the named FWState configuration.
   rpc UpdateConfig(UpdateConfigRequest) returns (UpdateConfigResponse);
   // Allows to delete fwstate config if it is not referenced
   // by any pipeline.
@@ -31,9 +31,9 @@ message UpdateConfigRequest {
   // Names of the published fwstate_map_v4 / fwstate_map_v6 objects whose
   // fwtables receive the synced state.
   //
-  // The module owns neither family's table itself. An empty name keeps
-  // the link the config already has, so a config created without one
-  // inserts no state for that family until a later update names its map.
+  // The module owns neither family's table itself. Without a mask, an empty
+  // name keeps the existing link. A selected empty name unlinks that family.
+  // A config without a link inserts no state for that family.
   string map_name_v4 = 2;
   string map_name_v6 = 3;
   SyncConfig sync_config = 4;
@@ -43,6 +43,19 @@ message UpdateConfigRequest {
   // replaces the destination set and disables any other omitted pair.
   bool clear_multicast = 5;
   bool clear_unicast = 6;
+  // When present, only the named fields change, including zero and empty values.
+  //
+  // An empty mask preserves all fields; a missing config starts from defaults.
+  // Paths are map_name_v4, map_name_v6 and individual
+  // sync_config fields. Unknown paths fail. Endpoint clear flags cannot be
+  // combined with a mask; select both endpoint fields with empty values instead.
+  // Without a mask, legacy merging and destination-set replacement apply.
+  FieldMask update_mask = 7;
+}
+
+// FieldMask selects fields using their protobuf names.
+message FieldMask {
+  repeated string paths = 1;
 }
 
 message UpdateConfigResponse {}
@@ -59,13 +72,17 @@ message ShowConfigResponse {
   SyncConfig sync_config = 5;
 }
 
-message DeleteConfigRequest { string name = 1; }
+message DeleteConfigRequest {
+  string name = 1;
+}
 
 message DeleteConfigResponse {}
 
 message ListConfigsRequest {}
 
-message ListConfigsResponse { repeated string configs = 1; }
+message ListConfigsResponse {
+  repeated string configs = 1;
+}
 
 // SyncConfig carries receive matching and local emission parameters:
 // incoming-packet matching, state updates, connection timeouts and the
@@ -75,24 +92,24 @@ message ListConfigsResponse { repeated string configs = 1; }
 // Synchronization is optional: a config naming no destination does not claim
 // external sync traffic; trusted internal events are still consumed and
 // dropped so their neutral outer headers cannot leak into the pipeline. Each
-// destination address-port pair is indivisible; naming only one part of a
-// pair is rejected. The source address and destination MAC are required
-// whenever an endpoint is configured because fwstate stamps emitted frames.
+// destination needs both an address and a port in the resulting config.
+// The source address and destination MAC are required whenever an endpoint
+// is configured because fwstate stamps emitted frames.
 message SyncConfig {
-  common.commonpb.v1.IPAddress src_addr = 1;           // IPv6 source stamped on emitted internal frames;
-  common.commonpb.v1.MACAddress dst_ether = 2;         // Ethernet destination MAC for emitted frames;
+  common.commonpb.v1.IPAddress src_addr = 1; // IPv6 source stamped on emitted internal frames;
+  common.commonpb.v1.MACAddress dst_ether = 2; // Ethernet destination MAC for emitted frames;
   common.commonpb.v1.IPAddress dst_addr_multicast = 3; // Multicast address matched on wire and emitted;
-  uint32 port_multicast = 4;                           // Multicast port, 1..65535;
-  common.commonpb.v1.IPAddress dst_addr_unicast = 5;   // Unicast address used for emission only;
-  uint32 port_unicast = 6;                             // Unicast port, 1..65535;
+  uint32 port_multicast = 4; // Multicast port, 1..65535;
+  common.commonpb.v1.IPAddress dst_addr_unicast = 5; // Unicast address used for emission only;
+  uint32 port_unicast = 6; // Unicast port, 1..65535;
 
   // Connection timeouts
   uint64 tcp_syn_ack = 7; // TCP SYN-ACK timeout in nanoseconds;
-  uint64 tcp_syn = 8;     // TCP SYN timeout in nanoseconds;
-  uint64 tcp_fin = 9;     // TCP FIN timeout in nanoseconds;
-  uint64 tcp = 10;        // TCP established timeout in nanoseconds;
-  uint64 udp = 11;        // UDP timeout in nanoseconds;
-  uint64 default = 12;    // Default timeout in nanoseconds;
+  uint64 tcp_syn = 8; // TCP SYN timeout in nanoseconds;
+  uint64 tcp_fin = 9; // TCP FIN timeout in nanoseconds;
+  uint64 tcp = 10; // TCP established timeout in nanoseconds;
+  uint64 udp = 11; // UDP timeout in nanoseconds;
+  uint64 default = 12; // Default timeout in nanoseconds;
 
   // Sync suppression window in nanoseconds. A sync frame for an alive entry
   // whose new expiry lands within this window of the current one is discarded

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -194,29 +194,6 @@ func (m *FWStateService) UpdateConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	// A named map must round-trip through the fixed-size C object
-	// registry, which silently truncates a longer name.
-	//
-	// A truncated name could link an entirely different map than the one
-	// reported back. An unnamed map asks for no change to that family's
-	// link.
-	if req.GetMapNameV4() != "" {
-		if err := fwstatemap.ValidateMapName(req.GetMapNameV4()); err != nil {
-			return nil, err
-		}
-	}
-	if req.GetMapNameV6() != "" {
-		if err := fwstatemap.ValidateMapName(req.GetMapNameV6()); err != nil {
-			return nil, err
-		}
-	}
-	if err := req.GetSyncConfig().ValidateFields(); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid sync config: %v", err)
-	}
-	if err := req.ValidateEndpointClears(); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid sync endpoint update: %v", err)
-	}
-
 	m.log.Debug("update fwstate config", zap.String("config", name))
 
 	err := m.withMutation("update", func() error {
@@ -271,33 +248,54 @@ func (m *FWStateService) prepareUpdate(
 
 	oldConfig := m.configs[name]
 
+	if req.UpdateMask != nil {
+		merged, err := maskedUpdate(oldConfig, req)
+		if err != nil {
+			return nil, nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		req = merged
+	} else {
+		// Validate before conversion can narrow a legacy numeric value.
+		if err := req.GetSyncConfig().ValidateFields(); err != nil {
+			return nil, nil, status.Errorf(codes.InvalidArgument, "invalid sync config: %v", err)
+		}
+		if err := req.ValidateEndpointClears(); err != nil {
+			return nil, nil, status.Errorf(codes.InvalidArgument, "invalid sync endpoint update: %v", err)
+		}
+		mapNameV4, mapNameV6 := mergedMapNames(oldConfig, req)
+		req = &fwstatepb.UpdateConfigRequest{
+			MapNameV4:  mapNameV4,
+			MapNameV6:  mapNameV6,
+			SyncConfig: mergedSyncConfigWithClears(oldConfig, req.SyncConfig, req.GetClearMulticast(), req.GetClearUnicast()),
+		}
+	}
+	for _, mapName := range []string{req.MapNameV4, req.MapNameV6} {
+		if mapName != "" {
+			if err := fwstatemap.ValidateMapName(mapName); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+	if err := req.SyncConfig.ValidateFields(); err != nil {
+		return nil, nil, status.Errorf(codes.InvalidArgument, "invalid sync config: %v", err)
+	}
 	// Validate the merged sync config before any C state is touched.
-	syncConfig := mergedSyncConfigWithClears(
-		oldConfig,
-		req.SyncConfig,
-		req.GetClearMulticast(),
-		req.GetClearUnicast(),
-	)
+	syncConfig := req.SyncConfig
 	if err := syncConfig.Validate(); err != nil {
 		m.log.Error("invalid sync config", zap.String("config", name), zap.Error(err))
 		return nil, nil, status.Errorf(codes.InvalidArgument, "invalid sync config: %v", err)
 	}
 
-	mapNameV4, mapNameV6 := mergedMapNames(oldConfig, req)
-
 	// The construction only allocates and initializes the replacement
 	// and declares the map-name links: the names resolve against
 	// published objects when the new generation installs, so an unknown
 	// name surfaces from the publish, not from here.
-	newConfig, err := NewFWStateModuleConfigWithEndpointClears(
+	newConfig, err := newFWStateModuleConfig(
 		m.agent,
 		name,
-		oldConfig,
-		req.SyncConfig,
-		req.GetClearMulticast(),
-		req.GetClearUnicast(),
-		mapNameV4,
-		mapNameV6,
+		syncConfig.ToC(),
+		req.MapNameV4,
+		req.MapNameV6,
 	)
 	if err != nil {
 		m.log.Error("failed to build fwstate config", zap.String("config", name), zap.Error(err))

--- a/modules/fwstate/controlplane/service_test.go
+++ b/modules/fwstate/controlplane/service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -12,6 +13,224 @@ import (
 	fwstate "github.com/yanet-platform/yanet2/modules/fwstate/controlplane"
 	"github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
 )
+
+// Test_FWStateService_UpdateConfig_MaskSetsAllFieldsAndClearsSync verifies
+// that every supported path installs its value and an absent selected
+// destination clears synchronization.
+func Test_FWStateService_UpdateConfig_MaskSetsAllFieldsAndClearsSync(t *testing.T) {
+	const name = "masked-all"
+	_, agent := newDeleteTestHarness(t, []string{"fwstate"}, name)
+	maps := newFWStateTestMaps(t, agent, name, 1024)
+	service := fwstate.NewFWStateService(agent)
+	syncConfig := &fwstatepb.SyncConfig{
+		SrcAddr: syncTestAddr(), DstAddrMulticast: syncTestAddr(),
+		DstEther:       &commonpb.MACAddress{Addr: 0x333300000001},
+		DstAddrUnicast: syncTestAddr(), PortUnicast: 10000,
+		PortMulticast: 9999, TcpSynAck: 11, TcpSyn: 12, TcpFin: 13,
+		Tcp: 14, Udp: 15, Default: 16, SyncSuppressTimeout: 17,
+	}
+	publishConfig(t, service, &fwstatepb.UpdateConfigRequest{
+		Name: name, MapNameV4: maps.v4Name(), MapNameV6: maps.v6Name(),
+		SyncConfig: syncConfig,
+		UpdateMask: &fwstatepb.FieldMask{Paths: []string{
+			"map_name_v4", "map_name_v6", "sync_config.src_addr",
+			"sync_config.dst_ether", "sync_config.dst_addr_unicast", "sync_config.port_unicast",
+			"sync_config.dst_addr_multicast", "sync_config.port_multicast",
+			"sync_config.tcp_syn_ack", "sync_config.tcp_syn", "sync_config.tcp_fin",
+			"sync_config.tcp", "sync_config.udp", "sync_config.default",
+			"sync_config.sync_suppress_timeout",
+		}},
+	})
+	stored := showConfig(t, service, name)
+	require.Equal(t, maps.v4Name(), stored.GetMapNameV4())
+	require.Equal(t, maps.v6Name(), stored.GetMapNameV6())
+	require.Equal(t, syncConfig, stored.GetSyncConfig())
+
+	publishConfig(t, service, &fwstatepb.UpdateConfigRequest{
+		Name: name,
+		UpdateMask: &fwstatepb.FieldMask{Paths: []string{
+			"sync_config.src_addr", "sync_config.dst_addr_multicast",
+			"sync_config.port_multicast", "map_name_v6",
+			"sync_config.dst_ether", "sync_config.dst_addr_unicast", "sync_config.port_unicast",
+		}},
+	})
+	stored = showConfig(t, service, name)
+	require.Empty(t, stored.GetMapNameV6())
+	require.Equal(t, maps.v4Name(), stored.GetMapNameV4())
+	require.Zero(t, stored.GetSyncConfig().GetPortMulticast())
+	require.Equal(t, make([]byte, 16), stored.GetSyncConfig().GetSrcAddr().GetAddr())
+	require.Nil(t, stored.GetSyncConfig().GetDstAddrMulticast())
+	require.Nil(t, stored.GetSyncConfig().GetDstAddrUnicast())
+	require.Zero(t, stored.GetSyncConfig().GetPortUnicast())
+	require.Zero(t, stored.GetSyncConfig().GetDstEther().GetAddr())
+	require.Equal(t, syncConfig.GetTcp(), stored.GetSyncConfig().GetTcp())
+}
+
+// Test_FWStateService_UpdateConfig_MaskedConcurrentWritesPreserveBothChanges
+// verifies that stale unselected values cannot revert another writer.
+func Test_FWStateService_UpdateConfig_MaskedConcurrentWritesPreserveBothChanges(t *testing.T) {
+	const name = "masked-concurrent"
+	_, agent := newDeleteTestHarness(t, []string{"fwstate"}, name)
+	service := fwstate.NewFWStateService(agent)
+	publishConfig(t, service, &fwstatepb.UpdateConfigRequest{
+		Name:       name,
+		SyncConfig: &fwstatepb.SyncConfig{Tcp: 60e9, Udp: 30e9},
+	})
+
+	requests := []*fwstatepb.UpdateConfigRequest{
+		{
+			Name:       name,
+			SyncConfig: &fwstatepb.SyncConfig{Tcp: 120e9, Udp: 30e9},
+			UpdateMask: &fwstatepb.FieldMask{Paths: []string{"sync_config.tcp"}},
+		},
+		{
+			Name:       name,
+			SyncConfig: &fwstatepb.SyncConfig{Tcp: 60e9, Udp: 45e9},
+			UpdateMask: &fwstatepb.FieldMask{Paths: []string{"sync_config.udp"}},
+		},
+	}
+	start := make(chan struct{})
+	var writers errgroup.Group
+	for _, request := range requests {
+		writers.Go(func() error {
+			<-start
+			_, err := service.UpdateConfig(t.Context(), request)
+			return err
+		})
+	}
+	close(start)
+	require.NoError(t, writers.Wait())
+	stored := showConfig(t, service, name).GetSyncConfig()
+	require.EqualValues(t, 120e9, stored.GetTcp())
+	require.EqualValues(t, 45e9, stored.GetUdp())
+}
+
+// Test_FWStateService_UpdateConfig_MaskClearsValuesAndPreservesUnselectedFields
+// verifies that explicit zero and empty values survive construction.
+func Test_FWStateService_UpdateConfig_MaskClearsValuesAndPreservesUnselectedFields(t *testing.T) {
+	const name = "masked-clear"
+	_, agent := newDeleteTestHarness(t, []string{"fwstate"}, name)
+	maps := newFWStateTestMaps(t, agent, name, 1024)
+	service := fwstate.NewFWStateService(agent)
+	publishConfig(t, service, &fwstatepb.UpdateConfigRequest{
+		Name:       name,
+		MapNameV4:  maps.v4Name(),
+		MapNameV6:  maps.v6Name(),
+		SyncConfig: &fwstatepb.SyncConfig{SyncSuppressTimeout: 8e9},
+	})
+	before := showConfig(t, service, name)
+	publishConfig(t, service, &fwstatepb.UpdateConfigRequest{
+		Name: name,
+		// Unselected invalid values must not affect the update.
+		MapNameV6:  "not-a-published-map",
+		SyncConfig: &fwstatepb.SyncConfig{PortMulticast: 65536},
+		UpdateMask: &fwstatepb.FieldMask{Paths: []string{
+			"map_name_v4", "sync_config.sync_suppress_timeout", "sync_config.udp",
+		}},
+	})
+	stored := showConfig(t, service, name)
+	require.Empty(t, stored.GetMapNameV4())
+	require.Equal(t, before.GetMapNameV6(), stored.GetMapNameV6())
+	require.Zero(t, stored.GetSyncConfig().GetSyncSuppressTimeout())
+	require.Zero(t, stored.GetSyncConfig().GetUdp())
+	require.Equal(t, before.GetSyncConfig().GetTcp(), stored.GetSyncConfig().GetTcp())
+
+	publishConfig(t, service, &fwstatepb.UpdateConfigRequest{
+		Name:       name,
+		MapNameV4:  maps.v4Name(),
+		SyncConfig: &fwstatepb.SyncConfig{Udp: 99e9},
+		UpdateMask: &fwstatepb.FieldMask{},
+	})
+	require.Equal(t, stored, showConfig(t, service, name))
+}
+
+// Test_FWStateService_UpdateConfig_InvalidMaskDoesNotPublish verifies that
+// a bad path or selected value leaves the published configuration intact.
+func Test_FWStateService_UpdateConfig_InvalidMaskDoesNotPublish(t *testing.T) {
+	const name = "masked-invalid"
+	_, agent := newDeleteTestHarness(t, []string{"fwstate"}, name)
+	service := fwstate.NewFWStateService(agent)
+	publishConfig(t, service, &fwstatepb.UpdateConfigRequest{
+		Name: name, UpdateMask: &fwstatepb.FieldMask{},
+	})
+	before := showConfig(t, service, name)
+	for _, tc := range []struct {
+		name       string
+		path       string
+		syncConfig *fwstatepb.SyncConfig
+	}{
+		{"unknown field", "unknown", nil},
+		{"whole sync config", "sync_config", nil},
+		{"unknown sync field", "sync_config.unknown", nil},
+		{"unicast port overflow", "sync_config.port_unicast", &fwstatepb.SyncConfig{PortUnicast: 65536}},
+		{"MAC overflow", "sync_config.dst_ether", &fwstatepb.SyncConfig{DstEther: &commonpb.MACAddress{Addr: 1 << 48}}},
+		{"empty path", "", nil},
+		{"port overflow", "sync_config.port_multicast", &fwstatepb.SyncConfig{PortMulticast: 65536}},
+		{"partial sync destination", "sync_config.port_multicast", &fwstatepb.SyncConfig{PortMulticast: 9999}},
+		{"timeout overflow", "sync_config.udp", &fwstatepb.SyncConfig{Udp: 1 << 48}},
+		{"invalid address width", "sync_config.src_addr", &fwstatepb.SyncConfig{SrcAddr: &commonpb.IPAddress{Addr: []byte{1}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := service.UpdateConfig(t.Context(), &fwstatepb.UpdateConfigRequest{
+				Name: name, SyncConfig: tc.syncConfig,
+				UpdateMask: &fwstatepb.FieldMask{Paths: []string{"sync_config.tcp", tc.path}},
+			})
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+			require.Equal(t, before, showConfig(t, service, name))
+		})
+	}
+}
+
+// Test_FWStateService_UpdateConfig_MaskedEndpointsPreserveOtherDestination
+// verifies that editing one endpoint leaves the other active, including clears.
+func Test_FWStateService_UpdateConfig_MaskedEndpointsPreserveOtherDestination(t *testing.T) {
+	const name = "masked-endpoints"
+	_, agent := newDeleteTestHarness(t, []string{"fwstate"}, name)
+	service := fwstate.NewFWStateService(agent)
+	publishConfig(t, service, &fwstatepb.UpdateConfigRequest{
+		Name: name,
+		SyncConfig: &fwstatepb.SyncConfig{
+			SrcAddr: syncTestAddr(), DstEther: &commonpb.MACAddress{Addr: 0x333300000001},
+			DstAddrMulticast: syncTestAddr(), PortMulticast: 9999,
+			DstAddrUnicast: syncTestAddr(), PortUnicast: 10000,
+		},
+	})
+	before := showConfig(t, service, name).GetSyncConfig()
+	publishConfig(t, service, &fwstatepb.UpdateConfigRequest{
+		Name: name, SyncConfig: &fwstatepb.SyncConfig{PortUnicast: 10001},
+		UpdateMask: &fwstatepb.FieldMask{Paths: []string{"sync_config.port_unicast"}},
+	})
+	stored := showConfig(t, service, name).GetSyncConfig()
+	require.EqualValues(t, 10001, stored.GetPortUnicast())
+	require.Equal(t, before.GetDstAddrUnicast(), stored.GetDstAddrUnicast())
+	require.Equal(t, before.GetDstAddrMulticast(), stored.GetDstAddrMulticast())
+	require.Equal(t, before.GetPortMulticast(), stored.GetPortMulticast())
+
+	publishConfig(t, service, &fwstatepb.UpdateConfigRequest{
+		Name: name,
+		UpdateMask: &fwstatepb.FieldMask{Paths: []string{
+			"sync_config.dst_addr_multicast", "sync_config.port_multicast",
+		}},
+	})
+	stored = showConfig(t, service, name).GetSyncConfig()
+	require.Nil(t, stored.GetDstAddrMulticast())
+	require.Zero(t, stored.GetPortMulticast())
+	require.Equal(t, before.GetDstAddrUnicast(), stored.GetDstAddrUnicast())
+	require.EqualValues(t, 10001, stored.GetPortUnicast())
+}
+
+// Test_FWStateService_UpdateConfig_RejectsMaskWithEndpointClearFlags verifies
+// that mixing the two update contracts never publishes a partial change.
+func Test_FWStateService_UpdateConfig_RejectsMaskWithEndpointClearFlags(t *testing.T) {
+	service := fwstate.NewFWStateService(nil)
+	for _, request := range []*fwstatepb.UpdateConfigRequest{
+		{Name: "cfg", ClearMulticast: true, UpdateMask: &fwstatepb.FieldMask{}},
+		{Name: "cfg", ClearUnicast: true, UpdateMask: &fwstatepb.FieldMask{}},
+	} {
+		_, err := service.UpdateConfig(t.Context(), request)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	}
+}
 
 // Test_SyncConfig_ValidateFields verifies that explicit values which would be
 // lost or truncated by the C representation are rejected before merging.


### PR DESCRIPTION
- Makes fwstate CLI updates send only explicitly supplied fields.
- Merges masked updates under the service mutation lock, preserving independent map, endpoint, and timeout changes.
- Keeps legacy unmasked requests and explicit zero, empty, and endpoint-clear semantics compatible with current fwstate validation.
- Closes #2442.