### PR TITLE
refactor(cli): unify help texts, about lines, success messages and hints

### DIFF
--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -88,7 +88,8 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   `remove`; scalars `set-<x>`; the whole object `flush`. A rename keeps the old
   spelling as a hidden `alias` for a release.
 - Every command and argument has a one-sentence doc comment ending in a
-  period; `about` comes from the `Cmd` doc.
+  period; `about` comes from the `Cmd` doc, one sentence, verb first, saying
+  what the binary manages.
 - An argument naming an existing object carries `add =
   ArgValueCandidates::new(<fn>)`, the function built on
   `completion::candidates(Cmd::command, build, async move |mut client| …)` (a
@@ -118,7 +119,9 @@ no `--yes`, no `--dry-run`.
   `output::empty_with_hint(…, "create one with '<full command>'")` and an
   early return; never bare printing or a call-site guard. The primitive owns
   the marker and stays silent under JSON and on a non-TTY stdout.
-- Mutations: `output::success("<verb>", format_args!("<Sentence>."))`.
+- Mutations: `output::success("<verb>", format_args!("<Sentence>."))`, the
+  sentence `<Verb-ed> <kind> '<name>'.` (name quoted, `config` for a module
+  CLI's kind).
 - Colour and glyphs only via `output::is_colored()`, `output::dim`,
   `output::paint_dim`; no `colored` dependency in a CLI crate (#2377).
 - An unusable derived JSON shape (an enum as a number) is fixed on the wire

--- a/.agents/skills/code-cli/references/new-crate.md
+++ b/.agents/skills/code-cli/references/new-crate.md
@@ -123,7 +123,7 @@ const SERVICE_NAME: &str = "<proto package>.<X>Service";
 /// Maps a genuine "config not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "config");
 
-/// <X> CLI.
+/// Manages <x> module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version, about)]
 #[command(flatten_help = true)]
@@ -282,7 +282,7 @@ impl <X>Service {
             .await
             .map_err(self.service.status("update"))?;
 
-        output::success("update", format_args!("Updated config {}.", cmd.config_name));
+        output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -296,7 +296,7 @@ impl <X>Service {
             .await
             .map_err(|status| NOT_FOUND.map(status, "delete", self.service.endpoint(), Some(&cmd.config_name)))?;
 
-        output::success("delete", format_args!("Deleted config {}.", cmd.config_name));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
         Ok(())
     }

--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -11,7 +11,7 @@ use ynpb::pb::{UpdateLevelRequest, logging_client::LoggingClient};
 
 const LOGGING_SERVICE: &str = "controlplane.ynpb.v1.Logging";
 
-/// Common functionality.
+/// Manages the log level of the control plane.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -23,21 +23,21 @@ struct Cmd {
     /// Output format.
     #[arg(long, value_enum, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Be verbose in terms of logging.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[arg(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
 
 #[derive(Debug, Clone, Subcommand)]
 enum ModeCmd {
-    /// Logging service.
+    /// Manage the logging service.
     #[clap(subcommand)]
     Logging(LoggingCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
 enum LoggingCmd {
-    /// Sets the new minimum log level.
+    /// Set the new minimum log level.
     SetLevel(SetLogLevelCmd),
 }
 
@@ -99,7 +99,8 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                 .await
                 .map_err(service.status(action))?;
 
-            output::success(action, format_args!("Set log level to {:?}.", cmd.level));
+            let level_name = cmd.level.to_possible_value().expect("no skipped variants");
+            output::success(action, format_args!("Set log level to '{}'.", level_name.get_name()));
         }
     }
 

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -17,7 +17,7 @@ use ynpb::pb::{
 
 const COUNTERS_SERVICE: &str = "controlplane.ynpb.v1.CountersService";
 
-/// Counters module - displays counters information.
+/// Displays dataplane counters.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -31,7 +31,7 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, value_enum, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Be verbose in terms of logging.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }

--- a/cli/modules/device-delete/src/main.rs
+++ b/cli/modules/device-delete/src/main.rs
@@ -17,7 +17,7 @@ const SERVICE_NAME: &str = "controlplane.ynpb.v1.DeviceService";
 /// Maps a genuine "device not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "device");
 
-/// Device delete module - removes a configured device.
+/// Deletes a configured device.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]

--- a/cli/modules/device/src/main.rs
+++ b/cli/modules/device/src/main.rs
@@ -16,8 +16,7 @@ use ynpb::pb::{ListDevicesRequest, ListDevicesResponse, device_service_client::D
 
 const DEVICE_SERVICE: &str = "controlplane.ynpb.v1.DeviceService";
 
-/// Device list module - displays all configured devices with their registry
-/// indices.
+/// Lists the configured devices with their registry indices.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -27,7 +26,7 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, value_enum, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Be verbose in terms of logging.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -18,7 +18,7 @@ use ynpb::pb::{
 const FUNCTION_SERVICE: &str = "controlplane.ynpb.v1.FunctionService";
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(FUNCTION_SERVICE, "requested function");
 
-/// Function module.
+/// Manages functions.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -30,7 +30,7 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, value_enum, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Be verbose in terms of logging.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
@@ -124,7 +124,9 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                     if function.chains.is_empty() {
                         output::empty_with_hint(
                             format_args!("No chains found for '{}'.", show.name),
-                            format_args!("create one with 'yanet-cli function update --name <name> --chains <chain>'"),
+                            format_args!(
+                                "create one with 'yanet-cli function update --name <name> --chains <name:weight=type:name>'"
+                            ),
                         );
                     }
                 },

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -15,7 +15,7 @@ use ynpb::pb::{BackendKind, ListServicesRequest, RegisteredBackend, gateway_clie
 
 const GATEWAY_SERVICE: &str = "controlplane.ynpb.v1.Gateway";
 
-/// Gateway - inspects the gateway service registry.
+/// Inspects the gateway service registry.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -27,7 +27,7 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, value_enum, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Be verbose in terms of logging.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -15,7 +15,7 @@ use ynpb::pb::{InspectRequest, InspectResponse, inspect_service_client::InspectS
 /// The fully-qualified gRPC service name used in error messages.
 const INSPECT_SERVICE: &str = "controlplane.ynpb.v1.InspectService";
 
-/// Inspect module - displays system introspection information.
+/// Displays the dataplane introspection report.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -21,7 +21,7 @@ const AVAILABLE_SERVICES: &str = "available metrics services:";
 /// Message used in place of the hint when no metrics service is registered.
 const NO_SERVICES: &str = "no metrics services are registered with the gateway";
 
-/// Generic metrics probe — calls `GetMetrics` on any `MetricsService`.
+/// Reads metrics of the gateway services.
 ///
 /// Connects to the gateway and invokes `/<FQN>/GetMetrics` using tonic's
 /// low-level dynamic dispatcher with the shared `commonpb` message types. No

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -18,7 +18,7 @@ use ynpb::pb::{
 const PIPELINE_SERVICE: &str = "controlplane.ynpb.v1.PipelineService";
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(PIPELINE_SERVICE, "requested pipeline");
 
-/// Pipeline module.
+/// Manages pipelines.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -30,7 +30,7 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, value_enum, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Be verbose in terms of logging.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -30,7 +30,7 @@ const NO_SERVICES: &str = "no readiness services are registered with the gateway
 /// Trailing segment of every readiness service's fully-qualified name.
 const READINESS_SERVICE: &str = "ReadinessService";
 
-/// Generic readiness probe — calls `Ready` on any `ReadinessService`.
+/// Probes readiness of the gateway services.
 ///
 /// Connects to the gateway and invokes `/<FQN>/Ready` using tonic's low-level
 /// dynamic dispatcher with the shared `readinesspb` message types. No

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -15,7 +15,7 @@ pub mod plainpb {
     tonic::include_proto!("devices.plain.controlplane.plainpb.v1");
 }
 
-/// DevicePlain module.
+/// Manages plain devices.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -27,13 +27,14 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
+    /// Create or replace a device.
     Update(UpdateCmd),
 }
 
@@ -42,10 +43,10 @@ pub struct UpdateCmd {
     /// The name of the device.
     #[arg(long, short = 'n')]
     pub name: String,
-    /// Pipeline assignments in format "pipeline_name:weight"
+    /// Pipeline assignments in format "pipeline_name:weight".
     #[arg(long, short = 'i')]
     pub input: Vec<String>,
-    /// Pipeline assignments in format "pipeline_name:weight"
+    /// Pipeline assignments in format "pipeline_name:weight".
     #[arg(long, short = 'o')]
     pub output: Vec<String>,
 }
@@ -94,7 +95,7 @@ impl DevicePlainService {
             .await
             .map_err(self.service.status("update"))?;
 
-        output::success("update", format_args!("Updated device {}.", cmd.name));
+        output::success("update", format_args!("Updated device '{}'.", cmd.name));
 
         Ok(())
     }

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -22,7 +22,7 @@ pub mod trafgenpb {
     tonic::include_proto!("devices.trafgen.controlplane.trafgenpb.v1");
 }
 
-/// Traffic generator device CLI.
+/// Manages trafgen devices.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -34,7 +34,7 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
@@ -151,7 +151,7 @@ impl TrafgenService {
             .map_err(self.service.status("update"))?
             .into_inner();
 
-        output::success("update", format_args!("Updated device {}.", cmd.config_name));
+        output::success("update", format_args!("Updated device '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -171,7 +171,9 @@ impl TrafgenService {
                 if response.configs.is_empty() {
                     output::empty_with_hint(
                         format_args!("No trafgen configurations found."),
-                        format_args!("create one with 'yanet-cli-device-trafgen update --name <name>'"),
+                        format_args!(
+                            "create one with 'yanet-cli-device-trafgen update --name <name> --input <pipeline:weight> --output <pipeline:weight>'"
+                        ),
                     );
                     return;
                 }
@@ -221,7 +223,7 @@ impl TrafgenService {
             .map_err(self.service.status("upload"))?
             .into_inner();
 
-        output::success("upload", format_args!("Uploaded pcap to {}.", cmd.config_name));
+        output::success("upload", format_args!("Uploaded pcap to device '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -240,7 +242,7 @@ impl TrafgenService {
 
         output::success(
             "rate",
-            format_args!("Set rate of {} to {} pps.", cmd.config_name, cmd.rate),
+            format_args!("Set rate on device '{}' to {} pps.", cmd.config_name, cmd.rate),
         );
 
         Ok(())

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -15,7 +15,7 @@ pub mod vlanpb {
     tonic::include_proto!("devices.vlan.controlplane.vlanpb.v1");
 }
 
-/// DeviceVlan module.
+/// Manages vlan devices.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -27,25 +27,26 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
+    /// Create or replace a device.
     Update(UpdateCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
-    /// The name of the device
+    /// The name of the device.
     #[arg(long, short = 'n')]
     pub name: String,
-    /// Pipeline assignments in format "pipeline_name:weight"
+    /// Pipeline assignments in format "pipeline_name:weight".
     #[arg(long, short = 'i')]
     pub input: Vec<String>,
-    /// Pipeline assignments in format "pipeline_name:weight"
+    /// Pipeline assignments in format "pipeline_name:weight".
     #[arg(long, short = 'o')]
     pub output: Vec<String>,
     /// VLAN id in 0..=4094, where 0 makes the device emit untagged frames.
@@ -98,7 +99,7 @@ impl DeviceVlanService {
             .await
             .map_err(self.service.status("update"))?;
 
-        output::success("update", format_args!("Updated device {}.", cmd.name));
+        output::success("update", format_args!("Updated device '{}'.", cmd.name));
 
         Ok(())
     }

--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -6,17 +6,17 @@ use clap_complete::engine::ArgValueCandidates;
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
-    /// List all ACL configs
+    /// List all ACL configs.
     List,
-    /// Delete an ACL config
+    /// Delete an ACL config.
     Delete(DeleteCmd),
-    /// Upload a new ACL config from a YAML file
+    /// Upload a new ACL config from a YAML file.
     Update(UpdateCmd),
-    /// Show ACL config rules
+    /// Show ACL config rules.
     Show(ShowCmd),
-    /// Show per-rule ACL counter metrics
+    /// Show per-rule ACL counter metrics.
     MetricsRules(MetricsRulesCmd),
-    /// Show per-rule ACL counters
+    /// Show per-rule ACL counters.
     RuleCounters(RuleCountersCmd),
 }
 
@@ -35,32 +35,32 @@ impl ModeCmd {
 
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
-    /// ACL config name
+    /// ACL config name.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
-    /// ACL config name
+    /// ACL config name.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
     /// Path to the ruleset YAML file.
     #[arg(value_name = "PATH")]
     pub file: PathBuf,
     /// Name of the standalone fwstate-map (kind V4) whose fwtable this
-    /// config uses for state lookups
+    /// config uses for state lookups.
     #[arg(long = "map-name-v4", value_name = "NAME")]
     pub map_name_v4: Option<String>,
     /// Name of the standalone fwstate-map (kind V6) whose fwtable this
-    /// config uses for state lookups
+    /// config uses for state lookups.
     #[arg(long = "map-name-v6", value_name = "NAME")]
     pub map_name_v6: Option<String>,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
-    /// ACL config name
+    /// ACL config name.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 }
@@ -70,23 +70,23 @@ pub struct MetricsRulesCmd {
     /// ACL config name, omit to match every config.
     #[arg(long = "name", short = 'n', alias = "config", add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: Option<String>,
-    /// Dataplane device name; omit to match every device
+    /// Dataplane device name, omit to match every device.
     #[arg(long = "device", short = 'd')]
     pub device: Option<String>,
-    /// Pipeline name; omit to match every pipeline
+    /// Pipeline name, omit to match every pipeline.
     #[arg(long = "pipeline", short = 'p')]
     pub pipeline: Option<String>,
-    /// Pipeline function name; omit to match every function
+    /// Pipeline function name, omit to match every function.
     #[arg(long = "function", short = 'f')]
     pub function: Option<String>,
-    /// Pipeline chain name; omit to match every chain
+    /// Pipeline chain name, omit to match every chain.
     #[arg(long = "chain", short = 'c')]
     pub chain: Option<String>,
 }
 
 #[derive(Debug, Clone, Parser, Default)]
 pub struct RuleCountersCmd {
-    /// ACL config name; omit to show rule counters of every config
+    /// ACL config name, omit to show rule counters of every config.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: Option<String>,
 }

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -224,7 +224,7 @@ struct ShowConfig {
     fwtable_name_v6: Option<String>,
 }
 
-/// ACL module CLI.
+/// Manages acl module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 pub struct Cmd {
@@ -232,9 +232,10 @@ pub struct Cmd {
     pub mode: ModeCmd,
     #[command(flatten)]
     pub connection: ConnectionArgs,
+    /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
@@ -350,7 +351,7 @@ impl ACLService {
             .map_err(self.service.status("delete"))?
             .into_inner();
 
-        output::success("delete", format_args!("Deleted {}.", cmd.config_name));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -397,7 +398,7 @@ impl ACLService {
 
         output::success(
             "update",
-            format_args!("Updated {} ({} rules).", cmd.config_name, rule_count),
+            format_args!("Updated config '{}' ({} rules).", cmd.config_name, rule_count),
         );
 
         Ok(())

--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -23,7 +23,7 @@ pub mod balancerpb {
     tonic::include_proto!("modules.balancer2.controlplane.balancerpb.v1");
 }
 
-/// Balancer2 module CLI.
+/// Manages balancer2 module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -35,7 +35,7 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Be verbose in terms of logging.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -84,7 +84,7 @@ impl Balancer2Service {
             .await
             .map_err(self.service.status("update"))?;
 
-        output::success("update", format_args!("Updated balancer {}.", cmd.name));
+        output::success("update", format_args!("Updated config '{}'.", cmd.name));
 
         Ok(())
     }
@@ -309,7 +309,7 @@ impl Balancer2Service {
 
         output::success(
             "sessions update",
-            format_args!("Updated sessions state {} (capacity: {}).", cmd.name, cmd.capacity),
+            format_args!("Updated sessions state '{}' (capacity: {}).", cmd.name, cmd.capacity),
         );
 
         Ok(())
@@ -375,7 +375,7 @@ impl Balancer2Service {
             .await
             .map_err(self.service.status(action))?;
 
-        output::success(action, format_args!("Updated reals for balancer {config_name}."));
+        output::success(action, format_args!("Updated reals of config '{config_name}'."));
 
         Ok(())
     }

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -19,7 +19,7 @@ pub mod blackholepb {
     tonic::include_proto!("modules.blackhole.controlplane.blackholepb.v1");
 }
 
-/// Blackhole module.
+/// Manages blackhole module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -28,18 +28,23 @@ pub struct Cmd {
     pub mode: ModeCmd,
     #[command(flatten)]
     pub connection: ConnectionArgs,
+    /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
+    /// List configs.
     List,
+    /// Show a config.
     Show(ShowConfigCmd),
+    /// Create or replace a config.
     Update(UpdateConfigCmd),
+    /// Delete a config.
     Delete(DeleteConfigCmd),
 }
 
@@ -176,7 +181,7 @@ impl BlackholeService {
             .into_inner();
         log::debug!("update config response: {response:?}");
 
-        output::success("update", format_args!("Updated {}.", cmd.config_name));
+        output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -193,7 +198,7 @@ impl BlackholeService {
             .into_inner();
         log::debug!("delete config response: {response:?}");
 
-        output::success("delete", format_args!("Deleted {}.", cmd.config_name));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
         Ok(())
     }

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -22,7 +22,7 @@ pub mod decappb {
     tonic::include_proto!("modules.decap.controlplane.decappb.v1");
 }
 
-/// Decap module.
+/// Manages decap module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -34,17 +34,20 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
+    /// List configs.
     List,
+    /// Show a config.
     Show(ShowConfigCmd),
+    /// Create or replace a config.
     Update(UpdateConfigCmd),
-    /// Delete a decap module config.
+    /// Delete a config.
     Delete(DeleteConfigCmd),
 }
 
@@ -202,7 +205,7 @@ impl DecapService {
             .into_inner();
         log::debug!("update config response: {response:?}");
 
-        output::success("update", format_args!("Updated decap {}.", cmd.config_name));
+        output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -226,7 +229,7 @@ impl DecapService {
             .into_inner();
         log::debug!("delete config response: {response:?}");
 
-        output::success("delete", format_args!("Deleted decap {}.", cmd.config_name));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
         Ok(())
     }

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -24,7 +24,7 @@ pub mod dscppb {
     tonic::include_proto!("modules.dscp.controlplane.dscppb.v1");
 }
 
-/// DSCP module for packet marking.
+/// Manages dscp module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -36,19 +36,24 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
+    /// List configs.
     List,
+    /// Show a config.
     Show(ShowConfigCmd),
+    /// Add prefixes to the input filter of a config.
     PrefixAdd(AddPrefixesCmd),
+    /// Remove prefixes from the input filter of a config.
     PrefixRemove(RemovePrefixesCmd),
+    /// Set the DSCP marking of a config.
     SetMarking(SetDscpMarkingCmd),
-    /// Delete a dscp module config.
+    /// Delete a config.
     Delete(DeleteConfigCmd),
 }
 
@@ -256,7 +261,7 @@ impl DscpService {
 
         output::success(
             "prefix-add",
-            format_args!("Added {} prefix(es) to {}.", cmd.prefix.len(), cmd.config_name),
+            format_args!("Added {} prefix(es) to config '{}'.", cmd.prefix.len(), cmd.config_name),
         );
 
         Ok(())
@@ -281,7 +286,11 @@ impl DscpService {
 
         output::success(
             "prefix-remove",
-            format_args!("Removed {} prefix(es) from {}.", cmd.prefix.len(), cmd.config_name),
+            format_args!(
+                "Removed {} prefix(es) from config '{}'.",
+                cmd.prefix.len(),
+                cmd.config_name
+            ),
         );
 
         Ok(())
@@ -305,7 +314,10 @@ impl DscpService {
             .into_inner();
         log::debug!("SetDscpMarkingResponse: {response:?}");
 
-        output::success("set-marking", format_args!("Set DSCP marking on {}.", cmd.config_name));
+        output::success(
+            "set-marking",
+            format_args!("Set marking on config '{}'.", cmd.config_name),
+        );
 
         Ok(())
     }
@@ -329,7 +341,7 @@ impl DscpService {
             .into_inner();
         log::debug!("DeleteConfigResponse: {response:?}");
 
-        output::success("delete", format_args!("Deleted dscp {}.", cmd.config_name));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
         Ok(())
     }

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -22,7 +22,7 @@ pub mod forwardpb {
     tonic::include_proto!("modules.forward.controlplane.forwardpb.v1");
 }
 
-/// Forward module.
+/// Manages forward module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -34,16 +34,20 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
+    /// Delete a config.
     Delete(DeleteCmd),
+    /// Create or replace a config.
     Update(UpdateCmd),
+    /// Show a config.
     Show(ShowCmd),
+    /// List configs.
     List,
 }
 
@@ -222,7 +226,7 @@ impl ForwardService {
                 if response.rules.is_empty() {
                     output::empty_with_hint(
                         format_args!("No forward rules found for '{}'.", cmd.config_name),
-                        format_args!("create one with 'yanet-cli-forward update --name <name> --file <path>'"),
+                        format_args!("create one with 'yanet-cli-forward update --name <name> <path>'"),
                     );
                 }
             },
@@ -247,7 +251,7 @@ impl ForwardService {
                 if response.configs.is_empty() {
                     output::empty_with_hint(
                         format_args!("No forward configurations found."),
-                        format_args!("create one with 'yanet-cli-forward update --name <name> --file <path>'"),
+                        format_args!("create one with 'yanet-cli-forward update --name <name> <path>'"),
                     );
                     return;
                 }
@@ -269,7 +273,7 @@ impl ForwardService {
             .await
             .map_err(self.service.status("delete"))?;
 
-        output::success("delete", format_args!("Deleted forward config {}.", cmd.config));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config));
 
         Ok(())
     }
@@ -281,7 +285,7 @@ impl ForwardService {
             .await
             .map_err(self.service.status("update"))?;
 
-        output::success("update", format_args!("Updated forward config {}.", cmd.config));
+        output::success("update", format_args!("Updated config '{}'.", cmd.config));
 
         Ok(())
     }

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -26,13 +26,13 @@ fn parse_sync_endpoint(value: &str) -> Result<SocketAddrV6, String> {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
-    /// List all fwstate configurations
+    /// List all fwstate configurations.
     List,
-    /// Delete a fwstate configuration
+    /// Delete a fwstate configuration.
     Delete(DeleteCmd),
-    /// Update fwstate configuration (map and sync settings)
+    /// Update fwstate configuration (map and sync settings).
     Update(UpdateCmd),
-    /// Show fwstate configuration
+    /// Show fwstate configuration.
     Show(ShowCmd),
 }
 
@@ -49,33 +49,33 @@ impl ModeCmd {
 
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
-    /// The name of the fwstate config to delete
+    /// The name of the fwstate config to delete.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
-    /// FWState config name to show
+    /// FWState config name to show.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
-    /// FWState config name to operate on
+    /// FWState config name to operate on.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 
-    /// Name of the published fwstate-map (kind V4) object to link
+    /// Name of the published fwstate-map (kind V4) object to link.
     #[arg(long)]
     pub map_name_v4: Option<String>,
 
-    /// Name of the published fwstate-map (kind V6) object to link
+    /// Name of the published fwstate-map (kind V6) object to link.
     #[arg(long)]
     pub map_name_v6: Option<String>,
 
-    /// Source IPv6 address (e.g., "2001:db8::1")
+    /// Source IPv6 address (e.g., "2001:db8::1").
     #[arg(long)]
     pub src_addr: Option<Ipv6Addr>,
 
@@ -128,27 +128,27 @@ pub struct UpdateCmd {
     #[arg(long, conflicts_with_all = ["unicast", "dst_addr_unicast", "port_unicast"])]
     pub no_unicast: bool,
 
-    /// TCP SYN-ACK timeout (e.g., "60s", "5m", "1h")
+    /// TCP SYN-ACK timeout (e.g., "60s", "5m", "1h").
     #[arg(long, value_parser = parse_duration)]
     pub tcp_syn_ack: Option<Duration>,
 
-    /// TCP SYN timeout (e.g., "60s", "5m", "1h")
+    /// TCP SYN timeout (e.g., "60s", "5m", "1h").
     #[arg(long, value_parser = parse_duration)]
     pub tcp_syn: Option<Duration>,
 
-    /// TCP FIN timeout (e.g., "60s", "5m", "1h")
+    /// TCP FIN timeout (e.g., "60s", "5m", "1h").
     #[arg(long, value_parser = parse_duration)]
     pub tcp_fin: Option<Duration>,
 
-    /// TCP established timeout (e.g., "60s", "5m", "1h")
+    /// TCP established timeout (e.g., "60s", "5m", "1h").
     #[arg(long, value_parser = parse_duration)]
     pub tcp: Option<Duration>,
 
-    /// UDP timeout (e.g., "60s", "5m", "1h")
+    /// UDP timeout (e.g., "60s", "5m", "1h").
     #[arg(long, value_parser = parse_duration)]
     pub udp: Option<Duration>,
 
-    /// Default timeout (e.g., "60s", "5m", "1h")
+    /// Default timeout (e.g., "60s", "5m", "1h").
     #[arg(long, value_parser = parse_duration)]
     pub default: Option<Duration>,
 

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -29,7 +29,7 @@ pub mod fwstatepb {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.fwstate.controlplane.fwstatepb.v1.FWStateService";
 
-/// FWState module CLI.
+/// Manages fwstate module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -41,7 +41,7 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
@@ -251,7 +251,9 @@ impl FWStateService {
                 if response.configs.is_empty() {
                     output::empty_with_hint(
                         format_args!("No FWState configurations found."),
-                        format_args!("create one with 'yanet-cli-fwstate update --name <name>'"),
+                        format_args!(
+                            "provision maps with 'yanet-cli-fwstatemap create --name <map> --kind <v4|v6>', then create a config with 'yanet-cli-fwstate update --name <name> --map-name-v4 <map> --map-name-v6 <map>'"
+                        ),
                     );
                     return;
                 }
@@ -292,7 +294,7 @@ impl FWStateService {
             .await
             .map_err(self.service.status("delete"))?;
 
-        output::success("delete", format_args!("Deleted fwstate config {}.", cmd.config_name));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -371,7 +373,7 @@ impl FWStateService {
             .await
             .map_err(self.service.status("update"))?;
 
-        output::success("update", format_args!("Updated fwstate config {}.", cmd.config_name));
+        output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
         Ok(())
     }

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -27,7 +27,7 @@ pub mod mirrorpb {
     tonic::include_proto!("modules.mirror.controlplane.mirrorpb.v1");
 }
 
-/// Mirror module.
+/// Manages mirror module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -39,16 +39,20 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
+    /// Delete a config.
     Delete(DeleteCmd),
+    /// Create or replace a config.
     Update(UpdateCmd),
+    /// Show a config.
     Show(ShowCmd),
+    /// List configs.
     List,
 }
 
@@ -337,7 +341,7 @@ impl MirrorService {
             .await
             .map_err(self.service.status("delete"))?;
 
-        output::success("delete", format_args!("Deleted mirror config {}.", cmd.config));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config));
 
         Ok(())
     }
@@ -354,7 +358,7 @@ impl MirrorService {
             .await
             .map_err(self.service.status("update"))?;
 
-        output::success("update", format_args!("Updated mirror config {}.", cmd.config));
+        output::success("update", format_args!("Updated config '{}'.", cmd.config));
 
         Ok(())
     }

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -29,7 +29,7 @@ const SERVICE_NAME: &str = "modules.nat64.controlplane.nat64pb.v1.NAT64Service";
 /// Maps a genuine "config not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
-/// NAT64 module CLI.
+/// Manages nat64 module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -41,32 +41,32 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum ModeCmd {
-    /// List all NAT64 configurations
+    /// List all NAT64 configurations.
     List,
-    /// Show current configuration
+    /// Show current configuration.
     Show(ShowConfigCmd),
-    /// Delete a nat64 module config.
+    /// Delete a config.
     Delete(DeleteConfigCmd),
-    /// Manage NAT64 prefixes
+    /// Manage NAT64 prefixes.
     Prefix {
         #[clap(subcommand)]
         cmd: PrefixCmd,
     },
-    /// Manage NAT64 mappings
+    /// Manage NAT64 mappings.
     Mapping {
         #[clap(subcommand)]
         cmd: MappingCmd,
     },
-    /// Set MTU values
+    /// Set MTU values.
     Mtu(MtuCmd),
-    /// Set drop_unknown flags
+    /// Set drop_unknown flags.
     Drop(DropCmd),
 }
 
@@ -88,17 +88,17 @@ impl ModeCmd {
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum PrefixCmd {
-    /// Add a new NAT64 prefix
+    /// Add a new NAT64 prefix.
     Add(AddPrefixCmd),
-    /// Remove NAT64 prefix
+    /// Remove NAT64 prefix.
     Remove(RemovePrefixCmd),
 }
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum MappingCmd {
-    /// Add a new IPv4-IPv6 mapping
+    /// Add a new IPv4-IPv6 mapping.
     Add(AddMappingCmd),
-    /// Remove IPv4-IPv6 mapping
+    /// Remove IPv4-IPv6 mapping.
     Remove(RemoveMappingCmd),
 }
 
@@ -181,10 +181,10 @@ pub struct DropCmd {
     /// The name of the config to operate on.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
-    /// Drop packets with unknown prefix
+    /// Drop packets with unknown prefix.
     #[arg(long)]
     pub drop_unknown_prefix: bool,
-    /// Drop packets with unknown mapping
+    /// Drop packets with unknown mapping.
     #[arg(long)]
     pub drop_unknown_mapping: bool,
 }
@@ -320,7 +320,7 @@ impl NAT64Service {
             .into_inner();
         log::debug!("delete config response: {response:?}");
 
-        output::success("delete", format_args!("Deleted nat64 {}.", cmd.config_name));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -339,7 +339,7 @@ impl NAT64Service {
 
         output::success(
             "add prefix",
-            format_args!("Added prefix {} to {}.", cmd.prefix, cmd.config_name),
+            format_args!("Added prefix {} to config '{}'.", cmd.prefix, cmd.config_name),
         );
 
         Ok(())
@@ -359,7 +359,7 @@ impl NAT64Service {
 
         output::success(
             "remove prefix",
-            format_args!("Removed prefix {} from {}.", cmd.prefix, cmd.config_name),
+            format_args!("Removed prefix {} from config '{}'.", cmd.prefix, cmd.config_name),
         );
 
         Ok(())
@@ -382,7 +382,7 @@ impl NAT64Service {
         output::success(
             "add mapping",
             format_args!(
-                "Added mapping {} -> {} (prefix {}) to {}.",
+                "Added mapping {} -> {} (prefix {}) to config '{}'.",
                 cmd.ipv4, cmd.ipv6, cmd.prefix_index, cmd.config_name
             ),
         );
@@ -404,7 +404,7 @@ impl NAT64Service {
 
         output::success(
             "remove mapping",
-            format_args!("Removed mapping for {} from {}.", cmd.ipv4, cmd.config_name),
+            format_args!("Removed mapping for {} from config '{}'.", cmd.ipv4, cmd.config_name),
         );
 
         Ok(())
@@ -428,7 +428,7 @@ impl NAT64Service {
         output::success(
             "set mtu",
             format_args!(
-                "Set MTU for {} (IPv4: {}, IPv6: {}).",
+                "Set MTU on config '{}' (IPv4: {}, IPv6: {}).",
                 cmd.config_name, cmd.ipv4_mtu, cmd.ipv6_mtu
             ),
         );
@@ -452,7 +452,7 @@ impl NAT64Service {
         output::success(
             "set drop",
             format_args!(
-                "Set drop flags for {} (unknown prefix: {}, unknown mapping: {}).",
+                "Set drop flags on config '{}' (unknown prefix: {}, unknown mapping: {}).",
                 cmd.config_name, cmd.drop_unknown_prefix, cmd.drop_unknown_mapping
             ),
         );

--- a/modules/pdump/cli/src/args.rs
+++ b/modules/pdump/cli/src/args.rs
@@ -6,10 +6,15 @@ use clap_complete::engine::ArgValueCandidates;
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
+    /// List configs.
     List,
+    /// Show a config.
     Show(ShowConfigCmd),
+    /// Create or replace a config.
     Set(SetConfigCmd),
+    /// Delete a config.
     Delete(DeleteCmd),
+    /// Read the packet dump stream of a config.
     Read(ReadCmd),
 }
 
@@ -45,7 +50,7 @@ pub struct SetConfigCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 
-    /// Filter represents a pcap-style filter expression
+    /// Filter represents a pcap-style filter expression.
     #[arg(long)]
     pub filter: Option<String>,
 
@@ -57,7 +62,7 @@ pub struct SetConfigCmd {
     #[arg(long = "snaplen", short_alias = 's')]
     pub snaplen: Option<u32>,
 
-    /// Per-worker ring buffer size
+    /// Per-worker ring buffer size.
     #[arg(long = "ring-size")]
     pub ring_size: Option<RingBufferSize>,
 }
@@ -133,13 +138,14 @@ impl FromStr for RingBufferSize {
 /// Dump Output format options.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum DumpOutputFormat {
-    /// Simple one-line human-readable output of the packet metadata and content
+    /// Simple one-line human-readable output of the packet metadata and
+    /// content.
     Text,
     /// Pretty multi-line human-readable output of the packet metadata and
-    /// content
+    /// content.
     Pretty,
-    /// PCAP Capture File Format
+    /// PCAP Capture File Format.
     Pcap,
-    /// PCAP Next Generation (pcapng) Capture File Format
+    /// PCAP Next Generation (pcapng) Capture File Format.
     PcapNg,
 }

--- a/modules/pdump/cli/src/dump_mode.rs
+++ b/modules/pdump/cli/src/dump_mode.rs
@@ -27,15 +27,15 @@ pub const ALL: pdump_mode = mode::pdump_mode_PDUMP_ALL;
 #[derive(Args, Debug, Clone, Copy)]
 #[group(required = false, multiple = true)]
 pub struct Mode {
-    /// Capture input packets
+    /// Capture input packets.
     #[arg(long)]
     pub input: bool,
 
-    /// Capture dropped packets
+    /// Capture dropped packets.
     #[arg(long)]
     pub drops: bool,
 
-    /// Capture all packets (input and drops)
+    /// Capture all packets (input and drops).
     #[arg(long)]
     pub all: bool,
 }

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -33,7 +33,7 @@ pub mod pdumppb {
     tonic::include_proto!("modules.pdump.controlplane.pdumppb.v1");
 }
 
-/// Pdump - packet dump module
+/// Manages pdump module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -45,7 +45,7 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
@@ -188,7 +188,7 @@ impl PdumpService {
             .await
             .map_err(self.service.status("set"))?;
 
-        output::success("set", format_args!("Set pdump config {}.", cmd.config_name));
+        output::success("set", format_args!("Updated config '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -202,7 +202,7 @@ impl PdumpService {
             .await
             .map_err(self.service.status("delete"))?;
 
-        output::success("delete", format_args!("Deleted pdump config {}.", cmd.config_name));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
         Ok(())
     }

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -24,7 +24,7 @@ use ync::{
     output::{self, CommonFormat},
 };
 
-/// Route module.
+/// Manages route-mpls module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -36,24 +36,24 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Be verbose in terms of logging.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
-    /// List all route configurations.
+    /// List configs.
     List,
-    /// Show routes currently stored in RIB (route information base).
+    /// Show the MPLS routes of a config.
     Show(RouteShowCmd),
-    /// Create route mpls config
+    /// Create a config.
     Create(RouteCreateCmd),
-    /// Delete route mpls config
+    /// Delete a config.
     Delete(RouteDeleteCmd),
-    /// Update route
+    /// Update a route in a config.
     Update(RouteUpdateCmd),
-    /// Withdraw route
+    /// Withdraw a route from a config.
     Withdraw(RouteWithdrawCmd),
 }
 
@@ -80,7 +80,7 @@ pub struct RouteShowCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RouteCreateCmd {
     /// Route config name.
-    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 
@@ -96,7 +96,7 @@ pub struct RouteUpdateCmd {
     /// Route config name.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
-    /// Route prefix
+    /// Route prefix.
     #[arg(long = "prefix", short = 'p')]
     pub prefix: Contiguous<IpNetwork>,
     /// The IP address of the tunnel destination.
@@ -111,7 +111,7 @@ pub struct RouteUpdateCmd {
     /// The ECMP weight.
     #[arg(long = "weight")]
     pub weight: u64,
-    /// Nexthop counter name
+    /// Nexthop counter name.
     #[arg(long = "counter")]
     pub counter: String,
 }
@@ -121,7 +121,7 @@ pub struct RouteWithdrawCmd {
     /// Route config name.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
-    /// Route prefix
+    /// Route prefix.
     #[arg(long = "prefix", short = 'p')]
     pub prefix: Contiguous<IpNetwork>,
     /// The IP address of the tunnel destination.
@@ -259,7 +259,7 @@ impl RouteMplsService {
             .map_err(self.service.status("create"))?
             .into_inner();
 
-        output::success("create", format_args!("Created route-mpls config {}.", cmd.config_name));
+        output::success("create", format_args!("Created config '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -273,7 +273,7 @@ impl RouteMplsService {
             .map_err(self.service.status("delete"))?
             .into_inner();
 
-        output::success("delete", format_args!("Deleted route-mpls config {}.", cmd.config_name));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -302,7 +302,7 @@ impl RouteMplsService {
             .map_err(self.service.status("update"))?
             .into_inner();
 
-        output::success("update", format_args!("Updated route in {}.", cmd.config_name));
+        output::success("update", format_args!("Updated route in config '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -331,7 +331,10 @@ impl RouteMplsService {
             .map_err(self.service.status("withdraw"))?
             .into_inner();
 
-        output::success("withdraw", format_args!("Withdrew route from {}.", cmd.config_name));
+        output::success(
+            "withdraw",
+            format_args!("Withdrew route from config '{}'.", cmd.config_name),
+        );
 
         Ok(())
     }

--- a/modules/route/cli/src/main.rs
+++ b/modules/route/cli/src/main.rs
@@ -113,7 +113,7 @@ impl FibConfig {
     }
 }
 
-/// Route module CLI.
+/// Manages route module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -122,9 +122,10 @@ pub struct Cmd {
     pub mode: ModeCmd,
     #[command(flatten)]
     pub connection: ConnectionArgs,
+    /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Be verbose in terms of logging.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
@@ -162,7 +163,7 @@ pub enum FibAction {
     Show(FibShowCmd),
     /// Replace the FIB atomically with entries from a YAML file.
     Update(FibUpdateCmd),
-    /// Delete a route module config.
+    /// Delete a config.
     Delete(FibDeleteCmd),
 }
 
@@ -267,7 +268,7 @@ impl RouteService {
 
         output::success(
             "update",
-            format_args!("Updated FIB '{}' ({} entries).", cmd.config_name, entry_count),
+            format_args!("Updated config '{}' ({} entries).", cmd.config_name, entry_count),
         );
         Ok(())
     }
@@ -284,7 +285,7 @@ impl RouteService {
             )
         })?;
 
-        output::success("delete", format_args!("Deleted FIB '{}'.", cmd.config_name));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
         Ok(())
     }
 

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -28,7 +28,7 @@ pub mod unrduppb {
     tonic::include_proto!("modules.unrdup.controlplane.unrduppb.v1");
 }
 
-/// Unrdup module.
+/// Manages unrdup module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -37,19 +37,23 @@ pub struct Cmd {
     pub mode: ModeCmd,
     #[command(flatten)]
     pub connection: ConnectionArgs,
+    /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
+    /// List configs.
     List,
+    /// Show a config.
     Show(ShowConfigCmd),
+    /// Create or replace a config.
     Update(UpdateConfigCmd),
-    /// Delete an unrdup module config.
+    /// Delete a config.
     Delete(DeleteConfigCmd),
 }
 
@@ -351,7 +355,7 @@ impl UnrdupService {
             .into_inner();
         log::debug!("update config response: {response:?}");
 
-        output::success("update", format_args!("Updated {}.", cmd.config_name));
+        output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
         Ok(())
     }
@@ -375,7 +379,7 @@ impl UnrdupService {
             .into_inner();
         log::debug!("delete config response: {response:?}");
 
-        output::success("delete", format_args!("Deleted unrdup {}.", cmd.config_name));
+        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
         Ok(())
     }

--- a/objects/fwstate/cli/src/args.rs
+++ b/objects/fwstate/cli/src/args.rs
@@ -3,17 +3,17 @@ use clap_complete::engine::ArgValueCandidates;
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
-    /// List registered fwstate-map objects
+    /// List registered fwstate-map objects.
     List,
-    /// Create a named fwstate-map and publish it
+    /// Create a named fwstate-map and publish it.
     Create(CreateCmd),
-    /// Delete a named fwstate-map
+    /// Delete a named fwstate-map.
     Delete(DeleteCmd),
-    /// Show statistics for a named fwstate-map
+    /// Show statistics for a named fwstate-map.
     Stats(StatsCmd),
-    /// List entries from a named fwstate-map
+    /// List entries from a named fwstate-map.
     Entries(EntriesCmd),
-    /// Insert a new layer into a named fwstate-map's table chain
+    /// Insert a new layer into a named fwstate-map's table chain.
     InsertLayer(InsertLayerCmd),
 }
 
@@ -33,31 +33,31 @@ impl ModeCmd {
 /// Address family of a fwstate-map object.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum MapKind {
-    /// IPv4 state table
+    /// IPv4 state table.
     V4,
-    /// IPv6 state table
+    /// IPv6 state table.
     V6,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct CreateCmd {
-    /// Name of the fwstate-map to create
+    /// Name of the fwstate-map to create.
     #[arg(long = "name", short = 'n')]
     pub map_name: String,
 
-    /// Address family of the state table this map owns
+    /// Address family of the state table this map owns.
     #[arg(long)]
     pub kind: MapKind,
 
-    /// Size of the hash table index (0 uses the service default)
+    /// Size of the hash table index (0 uses the service default).
     #[arg(long)]
     pub index_size: Option<u32>,
 
-    /// Number of extra collision buckets (0 uses the service default)
+    /// Number of extra collision buckets (0 uses the service default).
     #[arg(long)]
     pub extra_bucket_count: Option<u32>,
 
-    /// Per-worker state sizing (0 derives the dataplane worker count)
+    /// Per-worker state sizing (0 derives the dataplane worker count).
     #[arg(long)]
     pub worker_count: Option<u32>,
 }
@@ -66,26 +66,26 @@ pub struct CreateCmd {
 /// tails are reclaimed after a generation barrier.
 #[derive(Debug, Clone, Parser)]
 pub struct InsertLayerCmd {
-    /// Name of the fwstate-map to rotate
+    /// Name of the fwstate-map to rotate.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::map_candidates))]
     pub map_name: String,
 
-    /// Size of the hash table index (0 uses the service default)
+    /// Size of the hash table index (0 uses the service default).
     #[arg(long)]
     pub index_size: Option<u32>,
 
-    /// Number of extra collision buckets (0 uses the service default)
+    /// Number of extra collision buckets (0 uses the service default).
     #[arg(long)]
     pub extra_bucket_count: Option<u32>,
 
-    /// Per-worker state sizing (0 derives the dataplane worker count)
+    /// Per-worker state sizing (0 derives the dataplane worker count).
     #[arg(long)]
     pub worker_count: Option<u32>,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
-    /// Name of the fwstate-map to delete
+    /// Name of the fwstate-map to delete.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::map_candidates))]
     pub map_name: String,
 }
@@ -95,7 +95,7 @@ pub struct ListCmd;
 
 #[derive(Debug, Clone, Parser)]
 pub struct StatsCmd {
-    /// Name of the fwstate-map to show statistics for
+    /// Name of the fwstate-map to show statistics for.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::map_candidates))]
     pub map_name: String,
 }
@@ -110,31 +110,31 @@ pub enum DirectionArg {
 /// so no family selection is needed.
 #[derive(Debug, Clone, Parser)]
 pub struct EntriesCmd {
-    /// Name of the fwstate-map to iterate
+    /// Name of the fwstate-map to iterate.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::map_candidates))]
     pub map_name: String,
 
-    /// Layer index to iterate (0 = active layer)
+    /// Layer index to iterate (0 = active layer).
     #[arg(long, default_value = "0")]
     pub layer: u32,
 
-    /// Include expired entries
+    /// Include expired entries.
     #[arg(long)]
     pub include_expired: bool,
 
-    /// Max entries per gRPC batch
+    /// Max entries per gRPC batch.
     #[arg(long, default_value = "128")]
     pub batch: u32,
 
-    /// Total number of entries to return (0 = unlimited)
+    /// Total number of entries to return (0 = unlimited).
     #[arg(long, default_value = "0")]
     pub count: u32,
 
-    /// Iteration direction
+    /// Iteration direction.
     #[arg(long, default_value = "forward")]
     pub direction: DirectionArg,
 
-    /// Starting cursor position (0 = beginning)
+    /// Starting cursor position (0 = beginning).
     #[arg(long, default_value = "0")]
     pub index: u32,
 }

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -29,8 +29,7 @@ pub mod fwstatemappb {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "objects.fwstate.controlplane.fwstatemappb.v1.FWStateMapService";
 
-/// FWState-map CLI: manages the standalone fwstate-map objects module
-/// configs (fwstate sync, ACL) link by name.
+/// Manages fwstate-map objects that fwstate and acl configs link by name.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -42,7 +41,7 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Log verbosity level.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
@@ -119,7 +118,7 @@ impl FWStateMapService {
             .await
             .map_err(self.service.status("create"))?;
 
-        output::success("create", format_args!("Created fwstate-map {}.", cmd.map_name));
+        output::success("create", format_args!("Created map '{}'.", cmd.map_name));
 
         Ok(())
     }
@@ -133,7 +132,7 @@ impl FWStateMapService {
             .await
             .map_err(self.service.status("delete"))?;
 
-        output::success("delete", format_args!("Deleted fwstate-map {}.", cmd.map_name));
+        output::success("delete", format_args!("Deleted map '{}'.", cmd.map_name));
 
         Ok(())
     }
@@ -241,7 +240,7 @@ impl FWStateMapService {
 
         output::success(
             "insert-layer",
-            format_args!("Inserted layer into fwstate-map {}.", cmd.map_name),
+            format_args!("Inserted layer into map '{}'.", cmd.map_name),
         );
 
         Ok(())

--- a/operators/pipeline/cli/src/main.rs
+++ b/operators/pipeline/cli/src/main.rs
@@ -8,7 +8,7 @@
 use clap::{ArgAction, Parser};
 use ync::{client::ConnectionArgs, errors::Error, output::CommonFormat};
 
-/// Pipeline operator CLI.
+/// Manages the pipeline operator (no commands yet).
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true, subcommand_required = true, arg_required_else_help = true)]

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -42,7 +42,7 @@ const SERVICE_NAME: &str = "operators.route.operatorpb.v1.NeighbourService";
 /// Maps a genuine "table not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested table");
 
-/// Neighbour operator CLI (neighbour table management).
+/// Manages the neighbour tables of the route operator.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -54,7 +54,7 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
-    /// Be verbose in terms of logging.
+    /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
 }
@@ -67,7 +67,7 @@ pub enum ModeCmd {
     Add(AddCmd),
     /// Remove one or more neighbour entries.
     Remove(RemoveCmd),
-    /// Neighbour table operations.
+    /// Manage neighbour tables.
     Table(TableCmd),
 }
 
@@ -148,7 +148,6 @@ pub struct RemoveCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct CreateTableCmd {
     /// Neighbour table name.
-    #[arg(add = ArgValueCandidates::new(table_candidates))]
     pub name: String,
     /// Default priority for entries in this table.
     #[arg(long)]
@@ -274,7 +273,7 @@ impl NeighbourService {
         output::success(
             "add",
             format_args!(
-                "Added neighbour {} ({}) to table {}.",
+                "Added neighbour {} ({}) to table '{}'.",
                 cmd.next_hop, cmd.link_addr, table
             ),
         );
@@ -302,7 +301,7 @@ impl NeighbourService {
             .map(ToString::to_string)
             .collect::<Vec<_>>()
             .join(", ");
-        output::success("remove", format_args!("Removed {next_hops} from table {table}."));
+        output::success("remove", format_args!("Removed {next_hops} from table '{table}'."));
 
         Ok(())
     }
@@ -349,7 +348,7 @@ impl NeighbourService {
             .await
             .map_err(self.service.status("create table"))?;
 
-        output::success("create table", format_args!("Created neighbour table {}.", cmd.name));
+        output::success("create table", format_args!("Created table '{}'.", cmd.name));
 
         Ok(())
     }
@@ -369,7 +368,7 @@ impl NeighbourService {
         output::success(
             "update table",
             format_args!(
-                "Updated neighbour table {} (default priority {}).",
+                "Updated table '{}' (default priority {}).",
                 cmd.name, cmd.default_priority
             ),
         );
@@ -386,7 +385,7 @@ impl NeighbourService {
             .await
             .map_err(self.service.status("remove table"))?;
 
-        output::success("remove table", format_args!("Removed neighbour table {}.", cmd.name));
+        output::success("remove table", format_args!("Removed table '{}'.", cmd.name));
 
         Ok(())
     }

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -37,7 +37,7 @@ pub mod operatorpb {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "operators.route.operatorpb.v1.RouteService";
 
-/// Route operator CLI (RIB management).
+/// Manages the RIB of the route operator.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -46,6 +46,7 @@ pub struct Cmd {
     pub mode: ModeCmd,
     #[command(flatten)]
     pub connection: ConnectionArgs,
+    /// Output format.
     #[arg(long, default_value = "human", global = true)]
     pub format: CommonFormat,
     /// Be verbose: shows debug log lines and raw gRPC error details.
@@ -341,7 +342,7 @@ impl RouteService {
         output::success(
             "insert",
             format_args!(
-                "Inserted {} via {} in {} (source: {}).",
+                "Inserted {} via {} in config '{}' (source: {}).",
                 cmd.prefix,
                 via,
                 cmd.name,
@@ -379,7 +380,7 @@ impl RouteService {
         output::success(
             "remove",
             format_args!(
-                "Removed {} via {} from {} (source: {}).",
+                "Removed {} via {} from config '{}' (source: {}).",
                 cmd.prefix,
                 via,
                 cmd.name,
@@ -399,7 +400,7 @@ impl RouteService {
             .await
             .map_err(self.service.status("flush"))?;
 
-        output::success("flush", format_args!("Flushed {}.", cmd.name));
+        output::success("flush", format_args!("Flushed config '{}'.", cmd.name));
 
         Ok(())
     }


### PR DESCRIPTION
- Every `yanet-cli-*` binary now documents `--format` as `Output format.` and `-v` as `Be verbose: shows debug log lines and raw gRPC error details.`, the wording the dispatcher already used.
- Every subcommand and argument carries a one-sentence description ending in a period (blackhole, decap, dscp, forward, mirror, pdump, unrdup, plain and vlan had undocumented subcommands, many arguments lacked the final period).
- About lines say what the binary manages, verb first: `Manages decap module configs.`, `Manages vlan devices.`, `Manages the RIB of the route operator.`, `Lists the configured devices with their registry indices.` and so on, replacing `Route module.`, `DevicePlain module.`, `FWState module CLI.` and similar.
- Success messages take one form, `<Verb-ed> <kind> '<name>'.`, with the name quoted and the kind being the object the binary manages (`config` for module CLIs, `device`, `pipeline`, `function`, `table`, `map`); element messages read `<Verb-ed> <element> in|from|on <kind> '<name>'.` and keep the detail they already carried, such as an entry count or a default priority.
- Empty-result hints name a complete invocation that parses under the named binary today: forward no longer advertises a retired `--file` flag, trafgen recommends `update` with `--input`/`--output` instead of a bare `update` that binds nothing, fwstate names `yanet-cli-fwstatemap create` as the first step.
- `route-mpls create --name` and `neighbour table create <name>` no longer complete existing names for the object they create.
- route-mpls's `show` description no longer claims to show the RIB, a sentence copied from the route module.
- The code-cli skill states the same forms so new crates start from them.

Assumptions taken:
- The kind in a module CLI's success message is `config` rather than `<module> config`, since the binary name already names the module.
- ValueEnum variant lists (`[possible values: ...]`) are values, not flags, and stay as they are.
- No tests: the change is text and two attribute removals with no own logic, and human-readable output is not tested by convention.
- Private CLI crates (nat44, neigh, lldp, tcpproxy, announcer) carry the old wording and follow in yanet2-private at the next submodule advance.

Closes #2376.
