### PR TITLE
refactor(cli): move duplicated discovery, completion and client helpers into ync

### DIFF
--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -34,10 +34,15 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
 - `run(cmd)` determines the action, builds the service object once and matches
   `cmd.mode`; every handler returns `Result<(), Error>`.
 - `const SERVICE_NAME: &str = "<proto package>.<Service>";` with the doc
-  `/// The fully-qualified gRPC service name used in error messages.`. One
-  service: `Service::connect_for(&cmd.connection, action, SERVICE_NAME,
-  |channel| Client::new(channel).send_compressed(Gzip)
-  .accept_compressed(Gzip)).await?`. Several:
+  `/// The fully-qualified gRPC service name used in error messages.`. A crate
+  that builds its client at a single site keeps the builder inline:
+  `|channel| <X>ServiceClient::new(channel).send_compressed(Gzip)
+  .accept_compressed(Gzip)`. Once the crate builds it at more than one site,
+  pull it into `fn client(channel: LayeredChannel) ->
+  <X>ServiceClient<LayeredChannel>`, named `<x>_client` only when the crate
+  imports the `ync::client` module under that name. One service:
+  `Service::connect_for(&cmd.connection, action, SERVICE_NAME,
+  client).await?`, reused unchanged by completion. Several:
   `Connection::connect_for(&cmd.connection, action).await?` once, then
   `Service::new(&connection, NAME, build)` per client. The action is the same
   user-facing verb passed to the command's RPC error mapping.
@@ -61,18 +66,21 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
 - Type ladder, in order: `core`/`std` (`IpAddr`, `Ipv4Addr`, `Ipv6Addr`, `u16`
   for ports, `PathBuf`), then `netip` (`IpNetwork`, `Contiguous<IpNetwork>` for
   prefixes, `MacAddr`), then `common/rust` types with `FromStr`
-  (`commonpb::pb::DevicePipeline`). Inside a crate only `ValueEnum` enums and
-  clap arg groups. A `value_parser = <fn>` that constrains an existing type (a
-  range, a fixed prefix length) is fine. A new `FromStr` type anywhere, in the
-  crate or in `common/rust`, is a decision for the owner: stop and ask before
-  writing it.
+  (`commonpb::pb::DevicePipeline`, `Vec<DevicePipeline>` on `-i`/`-o`). Inside
+  a crate only `ValueEnum` enums and clap arg groups. A `value_parser = <fn>`
+  that constrains an existing type (a range, a fixed prefix length) is fine.
+  A new `FromStr` type anywhere, in the crate or in `common/rust`, is a
+  decision for the owner: stop and ask before writing it.
 - Wire values are built with `From` when the request is made
   (`IpAddress::from(addr)`), never parsed from text there.
 - Positional arguments carry the key of an element (`insert <prefix>
   --via …`, `remove <next-hop>…`, `table create <name>`), the file a
   command consumes (`update -n <name> <path>`, `upload -n <name>
   <path>`) or a filter pattern (`counters [PATTERN]…`); everything else
-  is a flag. A file never has a flag.
+  is a flag. A file never has a flag. A YAML file positional loads with
+  `ync::yaml::load::<T>(&path)`, its error already naming the path, mapped
+  with `self.service.invalid("<verb>", err.to_string())`; no private `load`
+  that opens and parses on its own.
 - Flags: `--name/-n` names the object the binary manages (a config, a map,
   a sessions state) and nothing else; `-4/-6` family filters, mutually
   exclusive (nat64's address pair excepted); `--endpoint` and `--auth`
@@ -92,9 +100,14 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   what the binary manages.
 - An argument naming an existing object carries `add =
   ArgValueCandidates::new(<fn>)`, the function built on
-  `completion::candidates(Cmd::command, build, async move |mut client| …)` (a
-  genuine `async move` closure). Never on a `value_delimiter` argument, never
-  on the new name of a `create`.
+  `completion::candidates(Cmd::command, client, async move |mut client| …)`,
+  the named builder from `SERVICE_NAME`'s bullet (a genuine `async move`
+  closure). Never on a `value_delimiter` argument, never on the new name of a
+  `create`. A positional naming a service of a family (readiness, metrics)
+  declares `const <FAMILY>: Family = Family::new("<Suffix>Service", "<verb>",
+  "<noun>")` and uses `<FAMILY>.candidates(Cmd::command)` for completion,
+  `.require_name`, `.resolve` and `.suggest` for the probe, never a private
+  alias resolver.
 
 ## Boundary with the service
 
@@ -124,10 +137,13 @@ no `--yes`, no `--dry-run`.
   CLI's kind).
 - Colour and glyphs only via `output::is_colored()`, `output::dim`,
   `output::paint_dim`; no `colored` dependency in a CLI crate (#2377).
+  `ync::init`, called by `entrypoint`, decides colour once for the process; a
+  crate never calls `colored::control` outside its tests.
 - An unusable derived JSON shape (an enum as a number) is fixed on the wire
   type: `field_attribute` in `build.rs` adds `#[serde(serialize_with = "…")]`,
   the function lives in `main.rs`, the exception is owner-approved.
-- Ages, durations, sizes: `ync::humanfmt`; metrics: `ync::metrics`.
+- Ages, durations, sizes: `ync::humanfmt`; metrics: `ync::metrics`, its
+  `format_number` the one thousands-separator formatter.
 
 ## Errors and exit codes
 
@@ -160,3 +176,5 @@ test_<what>_<case>` in `mod test`.
 - `CompleteEnv` inside a tokio runtime.
 - Swallow a stream or writer error and exit 0.
 - Heuristics over a library error: take the root of the `source()` chain.
+- A private copy of a ync helper (alias resolver, YAML loader, client
+  builder closure repeated per site).

--- a/.agents/skills/code-cli/references/new-crate.md
+++ b/.agents/skills/code-cli/references/new-crate.md
@@ -123,6 +123,12 @@ const SERVICE_NAME: &str = "<proto package>.<X>Service";
 /// Maps a genuine "config not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "config");
 
+fn client(channel: LayeredChannel) -> <X>ServiceClient<LayeredChannel> {
+    <X>ServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 /// Manages <x> module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version, about)]
@@ -209,12 +215,7 @@ pub struct <X>Service {
 
 impl <X>Service {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            <X>ServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }
@@ -324,11 +325,7 @@ impl Tabled for Config {
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(
         Cmd::command,
-        |channel| {
-            <X>ServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
+        client,
         async move |mut client| {
             Ok(client
                 .list_configs(ListConfigsRequest {})

--- a/cli/core/src/discovery.rs
+++ b/cli/core/src/discovery.rs
@@ -11,12 +11,14 @@
 use core::time::Duration;
 use std::collections::BTreeMap;
 
+use clap::Command;
+use clap_complete::engine::CompletionCandidate;
 use tonic::codec::CompressionEncoding;
 use ynpb::pb::{ListServicesRequest, gateway_client::GatewayClient};
 
 use crate::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
-    config,
+    completion, config,
     errors::{Error, ErrorKind},
 };
 
@@ -47,6 +49,167 @@ pub enum Resolution {
     Ambiguous(Vec<String>),
     /// No service matched.
     Unknown,
+}
+
+/// A family of gRPC services sharing one trailing name segment (readiness,
+/// metrics, and so on), and the vocabulary a CLI needs to probe, resolve and
+/// hint about it.
+#[derive(Debug, Clone, Copy)]
+pub struct Family {
+    /// Trailing segment of every service's fully-qualified name (e.g.
+    /// `ReadinessService`).
+    suffix: &'static str,
+    /// User-facing verb every error from this family carries (e.g.
+    /// `"ready"`).
+    action: &'static str,
+    /// Noun used in captions and messages (e.g. `"readiness"`).
+    noun: &'static str,
+}
+
+impl Family {
+    pub const fn new(suffix: &'static str, action: &'static str, noun: &'static str) -> Self {
+        Self { suffix, action, noun }
+    }
+
+    pub fn hint(&self, services: &[String]) -> String {
+        services_hint(
+            &format!("available {} services:", self.noun),
+            &self.no_services(),
+            services,
+        )
+    }
+
+    fn no_services(&self) -> String {
+        format!("no {} services are registered with the gateway", self.noun)
+    }
+
+    /// Rejects a blank service name before anything is discovered.
+    ///
+    /// An empty name is a substring of every service, so as an alias it
+    /// matches them all — and with a single service of this family
+    /// registered it would resolve to that one and hand its outcome to a
+    /// caller who never named a service. That is bad input rather than a
+    /// registry condition, so it is rejected as such, before any lookup.
+    // The async siblings hide the same-sized `Result` inside their desugared
+    // `Future` output, so only this synchronous method trips the lint.
+    #[allow(clippy::result_large_err)]
+    pub fn require_name(&self, endpoint: &str, name: &str) -> Result<(), Error> {
+        if name.trim().is_empty() {
+            return Err(Error::invalid_argument(
+                self.action,
+                endpoint,
+                "service name must not be empty",
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Lists the fully-qualified names of the registered services in this
+    /// family, sorted.
+    pub async fn list(&self, connection: &Connection) -> Result<Vec<String>, Error> {
+        list_services(connection, self.suffix).await
+    }
+
+    /// Resolves a short alias against `services`.
+    ///
+    /// A name containing `.` is assumed already fully qualified and returned
+    /// unchanged. An alias that matches nothing describes the same
+    /// operational condition as a fully-qualified name the gateway does not
+    /// know — that service is not registered, its operator down or not yet
+    /// up — because the alias is resolved against the live registry, so it
+    /// carries the same kind the gateway's own answer would map to. An
+    /// ambiguous alias, in contrast, really is bad input.
+    // The async siblings hide the same-sized `Result` inside their desugared
+    // `Future` output, so only this synchronous method trips the lint.
+    #[allow(clippy::result_large_err)]
+    pub fn resolve_among(&self, endpoint: &str, name: &str, services: &[String]) -> Result<String, Error> {
+        if name.contains('.') {
+            return Ok(name.to_owned());
+        }
+
+        match resolve_alias(name, services) {
+            Resolution::Resolved(resolved) => Ok(resolved),
+            Resolution::Ambiguous(candidates) => {
+                let message = format!("service name \"{name}\" is ambiguous");
+                let hint = services_hint(
+                    &format!("matching {} services:", self.noun),
+                    &self.no_services(),
+                    &candidates,
+                );
+
+                Err(Error::invalid_argument(self.action, endpoint, message).with_hint(hint))
+            }
+            Resolution::Unknown => {
+                let message = format!("unknown {} service \"{name}\"", self.noun);
+
+                Err(
+                    Error::new(ErrorKind::ServiceUnregistered, self.action, endpoint, message)
+                        .with_hint(self.hint(services)),
+                )
+            }
+        }
+    }
+
+    /// Resolves `name` against the services discovered over `connection`.
+    ///
+    /// A name containing `.` is assumed already fully qualified and returned
+    /// without any lookup.
+    pub async fn resolve(&self, connection: &Connection, name: &str) -> Result<String, Error> {
+        if name.contains('.') {
+            return Ok(name.to_owned());
+        }
+
+        let services = self.list(connection).await?;
+
+        self.resolve_among(connection.endpoint(), name, &services)
+    }
+
+    /// Adds the discovered services to `err`'s hint when it reads like the
+    /// named service is simply not registered.
+    ///
+    /// Best-effort: a failed discovery leaves `err` exactly as it was, so a
+    /// gateway that is down still surfaces the original probe error rather
+    /// than a second, more confusing one.
+    pub async fn suggest(&self, connection: &Connection, err: Error) -> Error {
+        if !matches!(err.kind(), ErrorKind::ServiceUnregistered | ErrorKind::NotFound) {
+            return err;
+        }
+
+        match self.list(connection).await {
+            Ok(services) => err.with_hint(self.hint(&services)),
+            Err(..) => err,
+        }
+    }
+
+    /// Adds the discovered services to `err`'s hint, discovering them fresh
+    /// over their own best-effort, budgeted connection.
+    ///
+    /// For an error raised before any [`Connection`] exists — such as no
+    /// service named at all — where [`Family::suggest`] has nothing to reuse.
+    pub async fn suggest_within(&self, args: &ConnectionArgs, err: Error) -> Error {
+        match discover_within(args, self.suffix, DISCOVERY_TIMEOUT).await {
+            Ok(services) => err.with_hint(self.hint(&services)),
+            Err(..) => err,
+        }
+    }
+
+    /// Completion candidates for a positional naming a service of this
+    /// family: the services the gateway currently knows.
+    ///
+    /// Strictly best-effort — a tab-completion must never print an error nor
+    /// hang — so a gateway that is down, slow or refusing us auth yields no
+    /// candidates at all, [`DISCOVERY_TIMEOUT`] covering the slow case. The
+    /// endpoint is recovered from the connection flags the user has actually
+    /// typed so far, `YANET_ENDPOINT` included as the fallback.
+    pub fn candidates(&self, command: impl FnOnce() -> Command) -> Vec<CompletionCandidate> {
+        let args = completion::connection_args(command);
+
+        candidates(&args, self.suffix, DISCOVERY_TIMEOUT)
+            .into_iter()
+            .map(CompletionCandidate::new)
+            .collect()
+    }
 }
 
 /// Lists the fully-qualified names of the services registered with the
@@ -410,5 +573,90 @@ mod test {
 
         assert_eq!(Some(&services[0]), aliases.get(&services[0]));
         assert_eq!(Some(&services[1]), aliases.get(&services[1]));
+    }
+
+    const READINESS: Family = Family::new("ReadinessService", "ready", "readiness");
+
+    #[test]
+    fn test_resolve_among_fully_qualified_name_skips_lookup() {
+        let resolved = READINESS
+            .resolve_among("grpc://[::1]:8080", "already.qualified.ReadinessService", &[])
+            .expect("a fully-qualified name never fails to resolve");
+
+        assert_eq!("already.qualified.ReadinessService", resolved);
+    }
+
+    #[test]
+    fn test_resolve_among_single_match_resolves() {
+        let services = services("ReadinessService");
+
+        let resolved = READINESS
+            .resolve_among("grpc://[::1]:8080", "route", &services)
+            .expect("a single match resolves");
+
+        assert_eq!("operators.route.operatorpb.v1.ReadinessService", resolved);
+    }
+
+    #[test]
+    fn test_resolve_among_ambiguous_alias_lists_every_candidate() {
+        let services = services("ReadinessService");
+
+        let err = READINESS
+            .resolve_among("grpc://[::1]:8080", "operatorpb", &services)
+            .expect_err("several services share the operatorpb segment");
+
+        assert_eq!(ErrorKind::InvalidArgument, err.kind());
+        let hint = err.hint().expect("an ambiguous alias carries a hint");
+        for service in &services[1..] {
+            assert!(hint.contains(service.as_str()), "hint missing {service}: {hint}");
+        }
+    }
+
+    #[test]
+    fn test_resolve_among_unknown_alias_hints_available_services() {
+        let services = services("ReadinessService");
+
+        let err = READINESS
+            .resolve_among("grpc://[::1]:8080", "balancer", &services)
+            .expect_err("no service matches the balancer alias");
+
+        assert_eq!(ErrorKind::ServiceUnregistered, err.kind());
+        let hint = err.hint().expect("an unknown alias carries the available services");
+        for service in &services {
+            assert!(hint.contains(service.as_str()), "hint missing {service}: {hint}");
+        }
+    }
+
+    #[test]
+    fn test_hint_on_empty_services_states_the_registry_is_empty() {
+        assert_eq!(
+            "no readiness services are registered with the gateway",
+            READINESS.hint(&[])
+        );
+    }
+
+    #[test]
+    fn test_require_name_rejects_empty_and_whitespace() {
+        assert_eq!(
+            ErrorKind::InvalidArgument,
+            READINESS
+                .require_name("grpc://[::1]:8080", "")
+                .expect_err("an empty name is rejected")
+                .kind()
+        );
+        assert_eq!(
+            ErrorKind::InvalidArgument,
+            READINESS
+                .require_name("grpc://[::1]:8080", "   ")
+                .expect_err("a whitespace-only name is rejected")
+                .kind()
+        );
+    }
+
+    #[test]
+    fn test_require_name_accepts_a_real_name() {
+        READINESS
+            .require_name("grpc://[::1]:8080", "route")
+            .expect("a non-blank name is accepted");
     }
 }

--- a/cli/core/src/errors.rs
+++ b/cli/core/src/errors.rs
@@ -250,6 +250,10 @@ impl Error {
         &self.message
     }
 
+    pub fn hint(&self) -> Option<&str> {
+        self.hint.as_deref()
+    }
+
     /// Process exit code for this error.
     pub fn exit_code(&self) -> i32 {
         self.kind.exit_code()

--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod logging;
 pub mod metrics;
 pub mod output;
 pub mod timeout;
+pub mod yaml;
 
 mod signal;
 

--- a/cli/core/src/metrics.rs
+++ b/cli/core/src/metrics.rs
@@ -152,4 +152,12 @@ mod test {
             assert!(Metric::from_proto(m).kind == expected);
         }
     }
+
+    #[test]
+    fn test_format_number_groups_thousands() {
+        assert_eq!("0", format_number(0));
+        assert_eq!("999", format_number(999));
+        assert_eq!("1,000", format_number(1000));
+        assert_eq!("1,234,567", format_number(1234567));
+    }
 }

--- a/cli/core/src/yaml.rs
+++ b/cli/core/src/yaml.rs
@@ -1,0 +1,85 @@
+//! Generic YAML config file loader shared by the CLI crates that read a
+//! whole module configuration from one document.
+
+use core::error::Error as StdError;
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+use serde::de::DeserializeOwned;
+
+/// The underlying `std::io::Error` or `serde_yaml::Error`, type-erased so
+/// both failure modes fit one struct.
+type Source = Box<dyn StdError + Send + Sync>;
+
+/// Loads and deserializes one YAML document at `path` as `T`.
+pub fn load<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T, Error> {
+    let path = path.as_ref();
+
+    let at_path = |source: Source| Error { path: path.to_owned(), source };
+
+    let file = File::open(path).map_err(|source| at_path(Box::new(source)))?;
+
+    serde_yaml::from_reader(file).map_err(|source| at_path(Box::new(source)))
+}
+
+/// A YAML file that failed to open or to parse, naming the offending path.
+#[derive(Debug, thiserror::Error)]
+#[error("{}: {source}", path.display())]
+pub struct Error {
+    path: PathBuf,
+    #[source]
+    source: Source,
+}
+
+#[cfg(test)]
+mod test {
+    use std::{env, fs, process};
+
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct Doc {
+        name: String,
+    }
+
+    /// Builds a scratch path under the process id so parallel test runs
+    /// never collide on the same file.
+    fn scratch_path(case: &str) -> PathBuf {
+        env::temp_dir().join(format!("yanet-cli-core-yaml-{case}-{}.yaml", process::id()))
+    }
+
+    #[test]
+    fn test_load_missing_file_names_the_path() {
+        let path = scratch_path("missing");
+
+        let err = load::<Doc>(&path).expect_err("no file exists at this path");
+
+        assert!(err.to_string().starts_with(&path.display().to_string()), "{err}");
+    }
+
+    #[test]
+    fn test_load_invalid_document_names_the_path() {
+        let path = scratch_path("invalid");
+        fs::write(&path, "name: [unterminated\n").unwrap();
+
+        let err = load::<Doc>(&path).expect_err("the document is not valid YAML");
+        fs::remove_file(&path).unwrap();
+
+        assert!(err.to_string().starts_with(&path.display().to_string()), "{err}");
+    }
+
+    #[test]
+    fn test_load_valid_document_parses() {
+        let path = scratch_path("valid");
+        fs::write(&path, "name: route\n").unwrap();
+
+        let doc: Doc = load(&path).unwrap();
+        fs::remove_file(&path).unwrap();
+
+        assert_eq!("route", doc.name);
+    }
+}

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -7,6 +7,7 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
+    metrics,
     output::{self, CommonFormat},
 };
 use ynpb::pb::{
@@ -281,24 +282,24 @@ impl From<&WorkerCounter> for WorkerRow {
             core: w.core_id,
             device: w.device_id,
             queue: w.queue_id,
-            iterations: format_number(w.iterations),
+            iterations: format_compact(w.iterations),
             rx: if w.rx_bytes > 0 {
-                format!("{} ({})", format_number(w.rx_packets), ByteSize::b(w.rx_bytes))
+                format!("{} ({})", format_compact(w.rx_packets), ByteSize::b(w.rx_bytes))
             } else {
-                format_number(w.rx_packets)
+                format_compact(w.rx_packets)
             },
             tx: if w.tx_bytes > 0 {
-                format!("{} ({})", format_number(w.tx_packets), ByteSize::b(w.tx_bytes))
+                format!("{} ({})", format_compact(w.tx_packets), ByteSize::b(w.tx_bytes))
             } else {
-                format_number(w.tx_packets)
+                format_compact(w.tx_packets)
             },
             empty_pct,
             avg_burst,
-            remote_rx: format_number(w.remote_rx_packets),
-            remote_tx: format_number(w.remote_tx_packets),
-            local_tx_drops: format_number(w.local_tx_drops),
-            remote_tx_drops: format_number(w.remote_tx_drops),
-            disposed: format_number(w.disposed),
+            remote_rx: format_compact(w.remote_rx_packets),
+            remote_tx: format_compact(w.remote_tx_packets),
+            local_tx_drops: format_compact(w.local_tx_drops),
+            remote_tx_drops: format_compact(w.remote_tx_drops),
+            disposed: format_compact(w.disposed),
             rx_pool_free: format_rx_pool_free(w.rx_mempool.as_ref()),
         }
     }
@@ -354,7 +355,7 @@ fn print_worker_histogram(worker: &WorkerCounter) {
 
 /// Format large numbers with thousand separators or K/M/G/T suffixes for very
 /// large numbers
-fn format_number(n: u64) -> String {
+fn format_compact(n: u64) -> String {
     const THOUSAND: f64 = 1_000.0;
     const MILLION: f64 = 1_000_000.0;
     const BILLION: f64 = 1_000_000_000.0;
@@ -372,18 +373,7 @@ fn format_number(n: u64) -> String {
     } else if n_f >= 100_000.0 {
         format!("{:.2}K", n_f / THOUSAND)
     } else {
-        // For smaller numbers, use thousand separators
-        let s = n.to_string();
-        let mut result = String::new();
-
-        for (count, c) in s.chars().rev().enumerate() {
-            if count > 0 && count % 3 == 0 {
-                result.push(',');
-            }
-            result.push(c);
-        }
-
-        result.chars().rev().collect()
+        metrics::format_number(n)
     }
 }
 

--- a/cli/modules/device-delete/src/main.rs
+++ b/cli/modules/device-delete/src/main.rs
@@ -4,7 +4,7 @@ use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, Service},
+    client::{ConnectionArgs, LayeredChannel, Service},
     completion,
     errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
@@ -16,6 +16,12 @@ const SERVICE_NAME: &str = "controlplane.ynpb.v1.DeviceService";
 
 /// Maps a genuine "device not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "device");
+
+fn client(channel: LayeredChannel) -> DeviceServiceClient<LayeredChannel> {
+    DeviceServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
 
 /// Deletes a configured device.
 #[derive(Debug, Clone, Parser)]
@@ -41,12 +47,7 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = "delete";
-    let mut service = Service::connect_for(&cmd.connection, action, SERVICE_NAME, |channel| {
-        DeviceServiceClient::new(channel)
-            .send_compressed(CompressionEncoding::Gzip)
-            .accept_compressed(CompressionEncoding::Gzip)
-    })
-    .await?;
+    let mut service = Service::connect_for(&cmd.connection, action, SERVICE_NAME, client).await?;
 
     let name = cmd.name;
     service
@@ -65,22 +66,14 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn device_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            DeviceServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| {
-            Ok(client
-                .list(ListDevicesRequest {})
-                .await?
-                .into_inner()
-                .ids
-                .into_iter()
-                .map(|id| id.name)
-                .collect())
-        },
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client
+            .list(ListDevicesRequest {})
+            .await?
+            .into_inner()
+            .ids
+            .into_iter()
+            .map(|id| id.name)
+            .collect())
+    })
 }

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -18,6 +18,12 @@ use ynpb::pb::{
 const FUNCTION_SERVICE: &str = "controlplane.ynpb.v1.FunctionService";
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(FUNCTION_SERVICE, "requested function");
 
+fn client(channel: LayeredChannel) -> FunctionServiceClient<LayeredChannel> {
+    FunctionServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 /// Manages functions.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
@@ -153,12 +159,7 @@ pub struct FunctionService {
 
 impl FunctionService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, FUNCTION_SERVICE, |channel| {
-            FunctionServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, FUNCTION_SERVICE, client).await?;
 
         Ok(Self { service })
     }
@@ -255,22 +256,14 @@ impl FunctionService {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn function_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            FunctionServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| {
-            Ok(client
-                .list(ListFunctionsRequest {})
-                .await?
-                .into_inner()
-                .ids
-                .into_iter()
-                .map(|id| id.name)
-                .collect())
-        },
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client
+            .list(ListFunctionsRequest {})
+            .await?
+            .into_inner()
+            .ids
+            .into_iter()
+            .map(|id| id.name)
+            .collect())
+    })
 }

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -6,20 +6,13 @@ use commonpb::pb::{GetMetricsRequest, GetMetricsResponse, Histogram, Label, Metr
 use tabled::Tabled;
 use ync::{
     client::{self, Connection, ConnectionArgs},
-    completion,
-    discovery::{self, Resolution},
-    errors::{Error, ErrorKind},
+    discovery::Family,
+    errors::Error,
     output::{self, CommonFormat},
 };
 
-/// Trailing segment of every metrics service's fully-qualified name.
-const METRICS_SERVICE: &str = "MetricsService";
-
-/// Caption of the hint that lists every discovered metrics service.
-const AVAILABLE_SERVICES: &str = "available metrics services:";
-
-/// Message used in place of the hint when no metrics service is registered.
-const NO_SERVICES: &str = "no metrics services are registered with the gateway";
+/// The family of metrics services this CLI probes and discovers.
+const METRICS: Family = Family::new("MetricsService", "metrics", "metrics");
 
 /// Reads metrics of the gateway services.
 ///
@@ -76,13 +69,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 
     let endpoint = client::resolve_label(&cmd.connection, "metrics")?;
 
-    if is_blank(&name) {
-        return Err(Error::invalid_argument(
-            "metrics",
-            endpoint.clone(),
-            "service name must not be empty",
-        ));
-    }
+    METRICS.require_name(&endpoint, &name)?;
 
     let tags = cmd
         .tags
@@ -93,11 +80,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 
     let connection = Connection::connect_for(&cmd.connection, "metrics").await?;
 
-    let name = if name.contains('.') {
-        name
-    } else {
-        resolve_alias(&connection, &name).await?
-    };
+    let name = METRICS.resolve(&connection, &name).await?;
 
     run_probe(&connection, &name, tags).await
 }
@@ -117,18 +100,6 @@ fn parse_tag(entry: &str) -> Result<MetricTag, String> {
     })
 }
 
-/// Whether a service name is empty or whitespace only.
-///
-/// An empty name is a substring of every service, so as an alias it matches
-/// them all — and with a single metrics service registered it would resolve
-/// to that one and dump its metrics for a caller who never asked for a probe.
-/// `yanet-cli metrics "$SERVICE"` on an unset variable is bad input rather
-/// than a registry condition, so it is rejected as such, and before anything
-/// is discovered.
-fn is_blank(name: &str) -> bool {
-    name.trim().is_empty()
-}
-
 /// Builds the error shown when the command names no metrics service.
 ///
 /// A service is required — probing every one is never attempted — so this is
@@ -143,10 +114,7 @@ async fn require_service(cmd: &Cmd) -> Error {
     };
     let err = Error::invalid_argument("metrics", endpoint, "no metrics service specified");
 
-    match discovery::discover_within(&cmd.connection, METRICS_SERVICE, discovery::DISCOVERY_TIMEOUT).await {
-        Ok(services) => err.with_hint(discovery::services_hint(AVAILABLE_SERVICES, NO_SERVICES, &services)),
-        Err(..) => err,
-    }
+    METRICS.suggest_within(&cmd.connection, err).await
 }
 
 /// Probes one metrics service's `GetMetrics` over the shared connection, and
@@ -159,7 +127,7 @@ async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>) ->
 
     let response = match result {
         Ok(response) => response,
-        Err(err) => return Err(suggest_services(connection, err).await),
+        Err(err) => return Err(METRICS.suggest(connection, err).await),
     };
 
     let total = response.metrics.len();
@@ -210,73 +178,10 @@ async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>) ->
     Ok(())
 }
 
-/// Resolves a short alias against the services the gateway knows.
-///
-/// An alias that matches nothing describes the same operational condition as
-/// a fully-qualified name the gateway does not know — that metrics service is
-/// not registered, its operator down or not yet up — because the alias is
-/// resolved against the live registry. It therefore carries the same kind the
-/// gateway's own answer would map to, so that a monitoring script gets one
-/// exit code for both spellings of the condition. An ambiguous alias, in
-/// contrast, really is bad input.
-async fn resolve_alias(connection: &Connection, alias: &str) -> Result<String, Error> {
-    let services = discovery::list_services(connection, METRICS_SERVICE).await?;
-    let endpoint = connection.endpoint();
-
-    match discovery::resolve_alias(alias, &services) {
-        Resolution::Resolved(name) => Ok(name),
-        Resolution::Ambiguous(candidates) => {
-            let message = format!("service name \"{alias}\" is ambiguous");
-
-            Err(
-                Error::invalid_argument("metrics", endpoint, message).with_hint(discovery::services_hint(
-                    "matching metrics services:",
-                    NO_SERVICES,
-                    &candidates,
-                )),
-            )
-        }
-        Resolution::Unknown => {
-            let message = format!("unknown metrics service \"{alias}\"");
-
-            Err(Error::new(ErrorKind::ServiceUnregistered, "metrics", endpoint, message)
-                .with_hint(discovery::services_hint(AVAILABLE_SERVICES, NO_SERVICES, &services)))
-        }
-    }
-}
-
-/// Adds the discovered services to `err`'s hint when it reads like the named
-/// service is simply not registered.
-///
-/// Best-effort: a failed discovery leaves `err` exactly as it was, so a
-/// gateway that is down still surfaces the original probe error rather than a
-/// second, more confusing one.
-async fn suggest_services(connection: &Connection, err: Error) -> Error {
-    if !matches!(err.kind(), ErrorKind::ServiceUnregistered | ErrorKind::NotFound) {
-        return err;
-    }
-
-    match discovery::list_services(connection, METRICS_SERVICE).await {
-        Ok(services) => err.with_hint(discovery::services_hint(AVAILABLE_SERVICES, NO_SERVICES, &services)),
-        Err(..) => err,
-    }
-}
-
 /// Completion candidates for the service positional: the metrics services
 /// the gateway currently knows.
-///
-/// Strictly best-effort — a tab-completion must never print an error nor hang
-/// — so a gateway that is down, slow or refusing us auth yields no candidates
-/// at all, `discovery::DISCOVERY_TIMEOUT` covering the slow case. The
-/// endpoint is recovered from the connection flags the user has actually
-/// typed so far, `YANET_ENDPOINT` included as the fallback.
 fn service_candidates() -> Vec<CompletionCandidate> {
-    let connection = completion::connection_args(Cmd::command);
-
-    discovery::candidates(&connection, METRICS_SERVICE, discovery::DISCOVERY_TIMEOUT)
-        .into_iter()
-        .map(CompletionCandidate::new)
-        .collect()
+    METRICS.candidates(Cmd::command)
 }
 
 /// A displayable row for the metrics table.
@@ -390,21 +295,6 @@ fn print_histogram(name: &str, labels: &[Label], histogram: &Histogram) {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn an_empty_service_name_is_blank() {
-        assert!(is_blank(""));
-    }
-
-    #[test]
-    fn a_whitespace_only_service_name_is_blank() {
-        assert!(is_blank("  \t "));
-    }
-
-    #[test]
-    fn a_named_service_is_not_blank() {
-        assert!(!is_blank("route"));
-    }
 
     #[test]
     fn no_arguments_leaves_the_service_unset() {

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -18,6 +18,12 @@ use ynpb::pb::{
 const PIPELINE_SERVICE: &str = "controlplane.ynpb.v1.PipelineService";
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(PIPELINE_SERVICE, "requested pipeline");
 
+fn client(channel: LayeredChannel) -> PipelineServiceClient<LayeredChannel> {
+    PipelineServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 /// Manages pipelines.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
@@ -152,12 +158,7 @@ pub struct PipelineService {
 
 impl PipelineService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, PIPELINE_SERVICE, |channel| {
-            PipelineServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, PIPELINE_SERVICE, client).await?;
 
         Ok(Self { service, action })
     }
@@ -255,22 +256,14 @@ impl PipelineService {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn pipeline_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            PipelineServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| {
-            Ok(client
-                .list(ListPipelinesRequest {})
-                .await?
-                .into_inner()
-                .ids
-                .into_iter()
-                .map(|id| id.name)
-                .collect())
-        },
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client
+            .list(ListPipelinesRequest {})
+            .await?
+            .into_inner()
+            .ids
+            .into_iter()
+            .map(|id| id.name)
+            .collect())
+    })
 }

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -9,9 +9,8 @@ use readinesspb::pb::{ReadyRequest, ReadyResponse, Scope, State};
 use serde::Serialize;
 use ync::{
     client::{self, Connection, ConnectionArgs},
-    completion,
-    discovery::{self, Resolution},
-    errors::{Error, ErrorKind},
+    discovery::Family,
+    errors::Error,
     output::{self, CommonFormat},
 };
 
@@ -21,14 +20,8 @@ mod watch;
 /// Exit code used when the RPC succeeds but not all scopes are `STATE_READY`.
 const EXIT_NOT_READY: u8 = 2;
 
-/// Caption of the hint that lists every discovered readiness service.
-const AVAILABLE_SERVICES: &str = "available readiness services:";
-
-/// Message used in place of the hint when no readiness service is registered.
-const NO_SERVICES: &str = "no readiness services are registered with the gateway";
-
-/// Trailing segment of every readiness service's fully-qualified name.
-const READINESS_SERVICE: &str = "ReadinessService";
+/// The family of readiness services this CLI probes and discovers.
+const READINESS: Family = Family::new("ReadinessService", "ready", "readiness");
 
 /// Probes readiness of the gateway services.
 ///
@@ -127,21 +120,11 @@ async fn run(cmd: Cmd) -> Result<ExitCode, Error> {
     } else {
         let name = cmd.name.clone().expect("a non-aggregate command names a service");
 
-        if is_blank(&name) {
-            return Err(Error::invalid_argument(
-                "ready",
-                client::resolve_label(&cmd.connection, "ready")?,
-                "service name must not be empty",
-            ));
-        }
+        READINESS.require_name(&client::resolve_label(&cmd.connection, "ready")?, &name)?;
 
         let connection = Connection::connect_for(&cmd.connection, "ready").await?;
 
-        let name = if name.contains('.') {
-            name
-        } else {
-            resolve_alias(&connection, &name).await?
-        };
+        let name = READINESS.resolve(&connection, &name).await?;
 
         run_service(&cmd, &connection, &name).await?
     };
@@ -151,18 +134,6 @@ async fn run(cmd: Cmd) -> Result<ExitCode, Error> {
     } else {
         ExitCode::from(EXIT_NOT_READY)
     })
-}
-
-/// Whether a service name is empty or whitespace only.
-///
-/// An empty name is a substring of every service, so as an alias it matches
-/// them all — and with a single readiness service registered it would resolve
-/// to that one and hand its readiness to the caller as the exit code of a probe
-/// they never asked for. `yanet-cli ready "$SERVICE"` on an unset variable is
-/// bad input rather than a registry condition, so it is rejected as such, and
-/// before anything is discovered.
-fn is_blank(name: &str) -> bool {
-    name.trim().is_empty()
 }
 
 /// Probes one service, one-shot or streaming, and suggests the services that
@@ -176,7 +147,7 @@ async fn run_service(cmd: &Cmd, connection: &Connection, name: &str) -> Result<b
 
     match result {
         Ok(ready) => Ok(ready),
-        Err(err) => Err(suggest_services(connection, err).await),
+        Err(err) => Err(READINESS.suggest(connection, err).await),
     }
 }
 
@@ -303,7 +274,7 @@ async fn run_aggregate(cmd: Cmd) -> Result<bool, Error> {
     }
 
     let connection = Connection::connect_for(&cmd.connection, "ready").await?;
-    let services = discovery::list_services(&connection, READINESS_SERVICE).await?;
+    let services = READINESS.list(&connection).await?;
 
     let mut reports = Vec::with_capacity(services.len());
     for service in services {
@@ -414,73 +385,10 @@ fn print_missing(missing: &[&str]) {
     }
 }
 
-/// Resolves a short alias against the services the gateway knows.
-///
-/// An alias that matches nothing describes the same operational condition as a
-/// fully-qualified name the gateway does not know — that readiness service is
-/// not registered, its operator down or not yet up — because the alias is
-/// resolved against the live registry. It therefore carries the same kind the
-/// gateway's own answer would map to, so that a monitoring script gets one exit
-/// code for both spellings of the condition. An ambiguous alias, in contrast,
-/// really is bad input.
-async fn resolve_alias(connection: &Connection, alias: &str) -> Result<String, Error> {
-    let services = discovery::list_services(connection, READINESS_SERVICE).await?;
-    let endpoint = connection.endpoint();
-
-    match discovery::resolve_alias(alias, &services) {
-        Resolution::Resolved(name) => Ok(name),
-        Resolution::Ambiguous(candidates) => {
-            let message = format!("service name \"{alias}\" is ambiguous");
-
-            Err(
-                Error::invalid_argument("ready", endpoint, message).with_hint(discovery::services_hint(
-                    "matching readiness services:",
-                    NO_SERVICES,
-                    &candidates,
-                )),
-            )
-        }
-        Resolution::Unknown => {
-            let message = format!("unknown readiness service \"{alias}\"");
-
-            Err(Error::new(ErrorKind::ServiceUnregistered, "ready", endpoint, message)
-                .with_hint(discovery::services_hint(AVAILABLE_SERVICES, NO_SERVICES, &services)))
-        }
-    }
-}
-
-/// Adds the discovered services to `err`'s hint when it reads like the named
-/// service is simply not registered.
-///
-/// Best-effort: a failed discovery leaves `err` exactly as it was, so a
-/// gateway that is down still surfaces the original probe error rather than a
-/// second, more confusing one.
-async fn suggest_services(connection: &Connection, err: Error) -> Error {
-    if !matches!(err.kind(), ErrorKind::ServiceUnregistered | ErrorKind::NotFound) {
-        return err;
-    }
-
-    match discovery::list_services(connection, READINESS_SERVICE).await {
-        Ok(services) => err.with_hint(discovery::services_hint(AVAILABLE_SERVICES, NO_SERVICES, &services)),
-        Err(..) => err,
-    }
-}
-
 /// Completion candidates for the service positional: the readiness services
 /// the gateway currently knows.
-///
-/// Strictly best-effort — a tab-completion must never print an error nor hang
-/// — so a gateway that is down, slow or refusing us auth yields no candidates
-/// at all, `discovery::DISCOVERY_TIMEOUT` covering the slow case. The
-/// endpoint is recovered from the connection flags the user has actually
-/// typed so far, `YANET_ENDPOINT` included as the fallback.
 fn service_candidates() -> Vec<CompletionCandidate> {
-    let connection = completion::connection_args(Cmd::command);
-
-    discovery::candidates(&connection, READINESS_SERVICE, discovery::DISCOVERY_TIMEOUT)
-        .into_iter()
-        .map(CompletionCandidate::new)
-        .collect()
+    READINESS.candidates(Cmd::command)
 }
 
 #[cfg(test)]
@@ -544,21 +452,6 @@ mod test {
     #[test]
     fn not_ready_without_any_discovered_service() {
         assert!(!all_ready(&[]));
-    }
-
-    #[test]
-    fn an_empty_service_name_is_blank() {
-        assert!(is_blank(""));
-    }
-
-    #[test]
-    fn a_whitespace_only_service_name_is_blank() {
-        assert!(is_blank("  \t "));
-    }
-
-    #[test]
-    fn a_named_service_is_not_blank() {
-        assert!(!is_blank("route"));
     }
 
     #[test]

--- a/cli/modules/ready/src/watch.rs
+++ b/cli/modules/ready/src/watch.rs
@@ -22,7 +22,7 @@ use tokio::{sync::mpsc, task::AbortHandle};
 use ync::{client::Connection, discovery, errors::Error, output};
 
 use crate::{
-    Cmd, READINESS_SERVICE, ServiceReport, print_report, probe,
+    Cmd, READINESS, ServiceReport, print_report, probe,
     render::{self, ServiceColumn, Transition},
 };
 
@@ -70,7 +70,7 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 /// observed at startup.
 pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
     let connection = Arc::new(Connection::connect_for(&cmd.connection, "ready").await?);
-    let services = discovery::list_services(&connection, READINESS_SERVICE).await?;
+    let services = READINESS.list(&connection).await?;
 
     let mut reports = Vec::with_capacity(services.len());
     for service in &services {
@@ -504,7 +504,7 @@ async fn rediscover(
     loop {
         tokio::time::sleep(REDISCOVER_INTERVAL).await;
 
-        let sweep = discovery::list_services(&connection, READINESS_SERVICE);
+        let sweep = READINESS.list(&connection);
         let Ok(Ok(services)) = tokio::time::timeout(REDISCOVER_INTERVAL, sweep).await else {
             continue;
         };

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -14,7 +14,7 @@ pub mod pb {
 }
 
 impl FromStr for pb::DevicePipeline {
-    type Err = Box<dyn Error>;
+    type Err = Box<dyn Error + Send + Sync>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (name, weight) = s
@@ -806,6 +806,24 @@ pub fn partition_prefixes(
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_device_pipeline_from_str_accepts_name_and_weight() {
+        let pipeline: pb::DevicePipeline = "eth0:3".parse().expect("a valid 'name:weight' pair must parse");
+
+        assert_eq!("eth0", pipeline.name);
+        assert_eq!(3, pipeline.weight);
+    }
+
+    #[test]
+    fn test_device_pipeline_from_str_rejects_missing_weight() {
+        assert!("eth0".parse::<pb::DevicePipeline>().is_err());
+    }
+
+    #[test]
+    fn test_device_pipeline_from_str_rejects_non_numeric_weight() {
+        assert!("eth0:many".parse::<pb::DevicePipeline>().is_err());
+    }
 
     #[test]
     fn partition_prefixes_splits_by_family_preserving_order() {

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{ArgAction, Parser};
-use commonpb::pb::Device;
+use commonpb::pb::{Device, DevicePipeline};
 use plainpb::{UpdateDevicePlainRequest, device_plain_service_client::DevicePlainServiceClient};
 use tonic::codec::CompressionEncoding;
 use ync::{
@@ -45,10 +45,10 @@ pub struct UpdateCmd {
     pub name: String,
     /// Pipeline assignments in format "pipeline_name:weight".
     #[arg(long, short = 'i')]
-    pub input: Vec<String>,
+    pub input: Vec<DevicePipeline>,
     /// Pipeline assignments in format "pipeline_name:weight".
     #[arg(long, short = 'o')]
-    pub output: Vec<String>,
+    pub output: Vec<DevicePipeline>,
 }
 
 /// The fully-qualified gRPC service name used in error messages.
@@ -71,22 +71,9 @@ impl DevicePlainService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let input = cmd
-            .input
-            .into_iter()
-            .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| self.service.invalid("update", err.to_string()))?;
-        let output = cmd
-            .output
-            .into_iter()
-            .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| self.service.invalid("update", err.to_string()))?;
-
         let request = UpdateDevicePlainRequest {
             name: cmd.name.clone(),
-            device: Some(Device { input, output }),
+            device: Some(Device { input: cmd.input, output: cmd.output }),
         };
 
         self.service

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
-use commonpb::pb::Device;
+use commonpb::pb::{Device, DevicePipeline};
 use tonic::codec::CompressionEncoding;
 use trafgenpb::{
     ListConfigsRequest, SetRateRequest, ShowConfigRequest, UpdateDeviceRequest, UploadPcapRequest,
@@ -72,10 +72,10 @@ pub struct UpdateCmd {
     pub config_name: String,
     /// Input pipeline assignments in "pipeline:weight" format.
     #[arg(long, short = 'i')]
-    pub input: Vec<String>,
+    pub input: Vec<DevicePipeline>,
     /// Output pipeline assignments in "pipeline:weight" format.
     #[arg(long, short = 'o')]
-    pub output: Vec<String>,
+    pub output: Vec<DevicePipeline>,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -108,41 +108,29 @@ pub struct SetRateCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "devices.trafgen.controlplane.trafgenpb.v1.TrafgenService";
 
+fn client(channel: LayeredChannel) -> TrafgenServiceClient<LayeredChannel> {
+    TrafgenServiceClient::new(channel)
+        .max_decoding_message_size(256 * 1024 * 1024)
+        .max_encoding_message_size(256 * 1024 * 1024)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 pub struct TrafgenService {
     service: Service<TrafgenServiceClient<LayeredChannel>>,
 }
 
 impl TrafgenService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            TrafgenServiceClient::new(channel)
-                .max_decoding_message_size(256 * 1024 * 1024)
-                .max_encoding_message_size(256 * 1024 * 1024)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }
 
     pub async fn update_device(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let input = cmd
-            .input
-            .into_iter()
-            .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| self.service.invalid("update", err.to_string()))?;
-        let output = cmd
-            .output
-            .into_iter()
-            .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| self.service.invalid("update", err.to_string()))?;
-
         let request = UpdateDeviceRequest {
             name: cmd.config_name.clone(),
-            device: Some(Device { input, output }),
+            device: Some(Device { input: cmd.input, output: cmd.output }),
         };
         self.service
             .client()
@@ -271,15 +259,7 @@ fn main() -> std::process::ExitCode {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            TrafgenServiceClient::new(channel)
-                .max_decoding_message_size(256 * 1024 * 1024)
-                .max_encoding_message_size(256 * 1024 * 1024)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{ArgAction, Parser, value_parser};
-use commonpb::pb::Device;
+use commonpb::pb::{Device, DevicePipeline};
 use tonic::codec::CompressionEncoding;
 use vlanpb::{UpdateDeviceVlanRequest, device_vlan_service_client::DeviceVlanServiceClient};
 use ync::{
@@ -45,10 +45,10 @@ pub struct UpdateCmd {
     pub name: String,
     /// Pipeline assignments in format "pipeline_name:weight".
     #[arg(long, short = 'i')]
-    pub input: Vec<String>,
+    pub input: Vec<DevicePipeline>,
     /// Pipeline assignments in format "pipeline_name:weight".
     #[arg(long, short = 'o')]
-    pub output: Vec<String>,
+    pub output: Vec<DevicePipeline>,
     /// VLAN id in 0..=4094, where 0 makes the device emit untagged frames.
     #[arg(long, value_parser = value_parser!(u16).range(0..=4094))]
     pub vlan: u16,
@@ -74,22 +74,9 @@ impl DeviceVlanService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let input = cmd
-            .input
-            .into_iter()
-            .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| self.service.invalid("update", err.to_string()))?;
-        let output = cmd
-            .output
-            .into_iter()
-            .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| self.service.invalid("update", err.to_string()))?;
-
         let request = UpdateDeviceVlanRequest {
             name: cmd.name.clone(),
-            device: Some(Device { input, output }),
+            device: Some(Device { input: cmd.input, output: cmd.output }),
             vlan: cmd.vlan as u32,
         };
 

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs::File, path::Path};
+use std::collections::HashMap;
 
 use aclpb::{
     DeleteConfigRequest, GetMetricsRulesRequest, GetRulesCountersRequest, ListConfigsRequest, ShowConfigRequest,
@@ -16,6 +16,7 @@ use ync::{
     errors::Error,
     metrics,
     output::{self, CommonFormat},
+    yaml,
 };
 
 mod args;
@@ -200,18 +201,6 @@ pub struct ACLConfig {
     fwtable_name_v6: Option<String>,
 }
 
-impl ACLConfig {
-    pub fn load<P>(path: P) -> Result<Self, Box<dyn core::error::Error>>
-    where
-        P: AsRef<Path>,
-    {
-        let file = File::open(path)?;
-        let config = serde_yaml::from_reader(file)?;
-
-        Ok(config)
-    }
-}
-
 /// Display view of an ACL config returned by the show command.
 ///
 /// Map names are omitted when absent.
@@ -244,6 +233,22 @@ pub struct Cmd {
 const SERVICE_NAME: &str = "modules.acl.controlplane.aclpb.v1.ACLService";
 const METRICS_SERVICE_NAME: &str = "modules.acl.controlplane.aclpb.v1.MetricsService";
 
+fn client(channel: LayeredChannel) -> AclServiceClient<LayeredChannel> {
+    AclServiceClient::new(channel)
+        .max_decoding_message_size(256 * 1024 * 1024)
+        .max_encoding_message_size(256 * 1024 * 1024)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
+fn metrics_client(channel: LayeredChannel) -> MetricsServiceClient<LayeredChannel> {
+    MetricsServiceClient::new(channel)
+        .max_decoding_message_size(256 * 1024 * 1024)
+        .max_encoding_message_size(256 * 1024 * 1024)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 pub struct ACLService {
     service: Service<AclServiceClient<LayeredChannel>>,
     metrics: Service<MetricsServiceClient<LayeredChannel>>,
@@ -252,20 +257,8 @@ pub struct ACLService {
 impl ACLService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
         let conn = Connection::connect_for(connection, action).await?;
-        let service = Service::new(&conn, SERVICE_NAME, |channel| {
-            AclServiceClient::new(channel)
-                .max_decoding_message_size(256 * 1024 * 1024)
-                .max_encoding_message_size(256 * 1024 * 1024)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        });
-        let metrics = Service::new(&conn, METRICS_SERVICE_NAME, |channel| {
-            MetricsServiceClient::new(channel)
-                .max_decoding_message_size(256 * 1024 * 1024)
-                .max_encoding_message_size(256 * 1024 * 1024)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        });
+        let service = Service::new(&conn, SERVICE_NAME, client);
+        let metrics = Service::new(&conn, METRICS_SERVICE_NAME, metrics_client);
 
         Ok(Self { service, metrics })
     }
@@ -357,12 +350,7 @@ impl ACLService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let config = ACLConfig::load(&cmd.file).map_err(|err| {
-            self.service.invalid(
-                "update",
-                format!("failed to load rules from {}: {err}", cmd.file.display()),
-            )
-        })?;
+        let config: ACLConfig = yaml::load(&cmd.file).map_err(|err| self.service.invalid("update", err.to_string()))?;
         let rule_count = config.rules.len();
 
         // A flag wins for that field whenever it is passed, even as an
@@ -529,17 +517,9 @@ fn main() -> std::process::ExitCode {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            AclServiceClient::new(channel)
-                .max_decoding_message_size(256 * 1024 * 1024)
-                .max_encoding_message_size(256 * 1024 * 1024)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }
 
 #[cfg(test)]

--- a/modules/balancer2/cli/src/config.rs
+++ b/modules/balancer2/cli/src/config.rs
@@ -4,7 +4,6 @@ use core::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     str::FromStr,
 };
-use std::{fs::File, path::Path};
 
 use filterpb::pb::PortRange;
 use netip::IpNetwork;
@@ -36,12 +35,6 @@ pub struct BalancerConfig {
     pub sessions_timeouts: Option<SessionsTimeouts>,
     #[serde(default)]
     pub wlc: Option<WlcConfig>,
-}
-
-impl BalancerConfig {
-    pub fn from_yaml_file(path: &Path) -> Result<Self, Box<dyn Error>> {
-        Ok(serde_yaml::from_reader(File::open(path)?)?)
-    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -13,10 +13,9 @@ use std::path::PathBuf;
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
-use tonic::codec::CompressionEncoding;
 use ync::{client::ConnectionArgs, completion, errors::Error, output::CommonFormat};
 
-use crate::service::Balancer2Service;
+use crate::service::{Balancer2Service, client};
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod balancerpb {
@@ -336,21 +335,13 @@ fn main() -> std::process::ExitCode {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            balancerpb::balancer_client::BalancerClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| {
-            Ok(client
-                .list_configs(balancerpb::ListConfigsRequest {})
-                .await?
-                .into_inner()
-                .names)
-        },
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client
+            .list_configs(balancerpb::ListConfigsRequest {})
+            .await?
+            .into_inner()
+            .names)
+    })
 }
 
 /// Completion candidates for a sessions-state name argument: the sessions
@@ -358,19 +349,11 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn sessions_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            balancerpb::balancer_client::BalancerClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| {
-            Ok(client
-                .list_sessions_states(balancerpb::ListSessionsStatesRequest {})
-                .await?
-                .into_inner()
-                .names)
-        },
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client
+            .list_sessions_states(balancerpb::ListSessionsStatesRequest {})
+            .await?
+            .into_inner()
+            .names)
+    })
 }

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -8,6 +8,7 @@ use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
     output::{self, CommonFormat},
+    yaml,
 };
 
 use crate::{
@@ -26,18 +27,19 @@ use crate::{
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.balancer2.controlplane.balancerpb.v1.Balancer";
 
+pub fn client(channel: LayeredChannel) -> BalancerClient<LayeredChannel> {
+    BalancerClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 pub struct Balancer2Service {
     service: Service<BalancerClient<LayeredChannel>>,
 }
 
 impl Balancer2Service {
     pub async fn connect(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            BalancerClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }
@@ -62,8 +64,8 @@ impl Balancer2Service {
     }
 
     async fn update(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let yaml_config =
-            BalancerConfig::from_yaml_file(&cmd.file).map_err(|err| self.service.invalid("update", err.to_string()))?;
+        let yaml_config: BalancerConfig =
+            yaml::load(&cmd.file).map_err(|err| self.service.invalid("update", err.to_string()))?;
         let parts: ConfigParts = yaml_config
             .try_into()
             .map_err(|err: Box<dyn core::error::Error>| self.service.invalid("update", err.to_string()))?;

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -83,6 +83,12 @@ pub struct DeleteConfigCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.blackhole.controlplane.blackholepb.v1.BlackholeService";
 
+fn client(channel: LayeredChannel) -> BlackholeServiceClient<LayeredChannel> {
+    BlackholeServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
@@ -105,12 +111,7 @@ pub struct BlackholeService {
 
 impl BlackholeService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            BlackholeServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }
@@ -209,13 +210,7 @@ impl BlackholeService {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            BlackholeServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -92,6 +92,12 @@ const SERVICE_NAME: &str = "modules.decap.controlplane.decappb.v1.DecapService";
 /// Maps a genuine "config not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
+fn client(channel: LayeredChannel) -> DecapServiceClient<LayeredChannel> {
+    DecapServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
@@ -114,12 +120,7 @@ pub struct DecapService {
 
 impl DecapService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            DecapServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }
@@ -255,13 +256,7 @@ fn print_tree(resp: &ShowConfigResponse) {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            DecapServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -144,6 +144,12 @@ const SERVICE_NAME: &str = "modules.dscp.controlplane.dscppb.v1.DscpService";
 /// Maps a genuine "config not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
+fn client(channel: LayeredChannel) -> DscpServiceClient<LayeredChannel> {
+    DscpServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
@@ -168,12 +174,7 @@ pub struct DscpService {
 
 impl DscpService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            DscpServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }
@@ -391,13 +392,7 @@ fn flag_to_string(flag: u32) -> String {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            DscpServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -186,18 +186,19 @@ fn bind_request_name(request: &mut UpdateConfigRequest, name: &str) -> Result<()
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.forward.controlplane.forwardpb.v1.ForwardService";
 
+fn forward_client(channel: LayeredChannel) -> ForwardServiceClient<LayeredChannel> {
+    ForwardServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 pub struct ForwardService {
     service: Service<ForwardServiceClient<LayeredChannel>>,
 }
 
 impl ForwardService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            ForwardServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, forward_client).await?;
 
         Ok(Self { service })
     }
@@ -331,15 +332,9 @@ fn main() -> std::process::ExitCode {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            ForwardServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, forward_client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }
 
 #[cfg(test)]

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -29,6 +29,12 @@ pub mod fwstatepb {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.fwstate.controlplane.fwstatepb.v1.FWStateService";
 
+fn client(channel: LayeredChannel) -> FwStateServiceClient<LayeredChannel> {
+    FwStateServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 /// Manages fwstate module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
@@ -227,11 +233,7 @@ pub struct FWStateService {
 impl FWStateService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
         let conn = Connection::connect_for(connection, action).await?;
-        let service = Service::new(&conn, SERVICE_NAME, |channel| {
-            FwStateServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        });
+        let service = Service::new(&conn, SERVICE_NAME, client);
         Ok(Self { service })
     }
 
@@ -400,15 +402,9 @@ fn main() -> std::process::ExitCode {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            FwStateServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }
 
 #[cfg(test)]

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -1,8 +1,5 @@
 use core::fmt::{self, Display, Formatter};
-use std::{
-    fs::File,
-    path::{Path, PathBuf},
-};
+use std::path::PathBuf;
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
@@ -18,6 +15,7 @@ use ync::{
     completion,
     errors::Error,
     output::{self, CommonFormat},
+    yaml,
 };
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
@@ -239,20 +237,14 @@ impl TryFrom<Vec<mirrorpb::Rule>> for MirrorConfig {
     }
 }
 
-impl MirrorConfig {
-    pub fn load<P>(path: P) -> Result<Self, Box<dyn core::error::Error>>
-    where
-        P: AsRef<Path>,
-    {
-        let file = File::open(path)?;
-        let config = serde_yaml::from_reader(file)?;
-
-        Ok(config)
-    }
-}
-
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.mirror.controlplane.mirrorpb.v1.MirrorService";
+
+fn client(channel: LayeredChannel) -> MirrorServiceClient<LayeredChannel> {
+    MirrorServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
 
 pub struct MirrorService {
     service: Service<MirrorServiceClient<LayeredChannel>>,
@@ -260,12 +252,7 @@ pub struct MirrorService {
 
 impl MirrorService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            MirrorServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }
@@ -347,7 +334,7 @@ impl MirrorService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let config = MirrorConfig::load(&cmd.file).map_err(|e| self.service.invalid("update", e.to_string()))?;
+        let config: MirrorConfig = yaml::load(&cmd.file).map_err(|e| self.service.invalid("update", e.to_string()))?;
         let rules: Vec<mirrorpb::Rule> = config
             .try_into()
             .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("update", e.to_string()))?;
@@ -385,15 +372,9 @@ fn main() -> std::process::ExitCode {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            MirrorServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }
 
 #[cfg(test)]

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -29,6 +29,12 @@ const SERVICE_NAME: &str = "modules.nat64.controlplane.nat64pb.v1.NAT64Service";
 /// Maps a genuine "config not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
+fn client(channel: LayeredChannel) -> Nat64ServiceClient<LayeredChannel> {
+    Nat64ServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 /// Manages nat64 module configs.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
@@ -220,12 +226,7 @@ pub struct NAT64Service {
 
 impl NAT64Service {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            Nat64ServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }
@@ -522,15 +523,9 @@ fn parse_prefix(value: &str) -> Result<Contiguous<Ipv6Network>, String> {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            Nat64ServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }
 
 #[cfg(test)]

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -66,18 +66,19 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.pdump.controlplane.pdumppb.v1.PdumpService";
 
+fn client(channel: LayeredChannel) -> PdumpServiceClient<LayeredChannel> {
+    PdumpServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 pub struct PdumpService {
     service: Service<PdumpServiceClient<LayeredChannel>>,
 }
 
 impl PdumpService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            PdumpServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }
@@ -330,13 +331,7 @@ fn main() -> std::process::ExitCode {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            PdumpServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -135,6 +135,12 @@ pub struct RouteWithdrawCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.route_mpls.controlplane.routemplspb.v1.RouteMPLSService";
 
+fn client(channel: LayeredChannel) -> RouteMplsServiceClient<LayeredChannel> {
+    RouteMplsServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
@@ -144,15 +150,9 @@ fn main() -> std::process::ExitCode {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            RouteMplsServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
@@ -175,12 +175,7 @@ pub struct RouteMplsService {
 
 impl RouteMplsService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            RouteMplsServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }

--- a/modules/route/cli/Cargo.toml
+++ b/modules/route/cli/Cargo.toml
@@ -19,10 +19,10 @@ tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
 
 [dev-dependencies]
 serde_json = "1"
+serde_yaml = "0.9"
 netip = "0.3"
 tokio = { version = "1", features = ["macros", "net", "rt", "time"] }
 

--- a/modules/route/cli/src/main.rs
+++ b/modules/route/cli/src/main.rs
@@ -3,10 +3,7 @@
 mod fib;
 
 use core::error::Error as StdError;
-use std::{
-    fs::File,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
@@ -16,6 +13,7 @@ use ync::{
     completion,
     errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
+    yaml,
 };
 
 use crate::{
@@ -64,11 +62,8 @@ impl FibConfig {
         P: AsRef<Path>,
     {
         let path = path.as_ref();
-        let at_path = |err: LoadError| -> LoadError { format!("{}: {err}", path.display()).into() };
-
-        let file = File::open(path).map_err(|err| at_path(err.into()))?;
-        let config: Self = serde_yaml::from_reader(file).map_err(|err| at_path(err.into()))?;
-        config.validate().map_err(at_path)?;
+        let config: Self = yaml::load(path)?;
+        config.validate().map_err(|err| format!("{}: {err}", path.display()))?;
         Ok(config)
     }
 
@@ -203,6 +198,12 @@ const SERVICE_NAME: &str = "modules.route.controlplane.routepb.v1.RouteService";
 /// Rewrites a genuine missing-config `NotFound` into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
+fn client(channel: LayeredChannel) -> RouteServiceClient<LayeredChannel> {
+    RouteServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
@@ -212,15 +213,9 @@ fn main() -> std::process::ExitCode {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            RouteServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
@@ -243,12 +238,7 @@ pub struct RouteService {
 
 impl RouteService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            RouteServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -1,8 +1,5 @@
 use core::{error::Error as StdError, net::IpAddr};
-use std::{
-    fs::File,
-    path::{Path, PathBuf},
-};
+use std::path::PathBuf;
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
@@ -19,6 +16,7 @@ use ync::{
     completion,
     errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
+    yaml,
 };
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
@@ -133,15 +131,6 @@ pub struct UnrdupConfig {
     pub services: Vec<ServiceConfig>,
 }
 
-impl UnrdupConfig {
-    pub fn load(path: &Path) -> Result<Self, Box<dyn StdError>> {
-        let file = File::open(path)?;
-        let config = serde_yaml::from_reader(file)?;
-
-        Ok(config)
-    }
-}
-
 impl From<UnrdupConfig> for Config {
     fn from(value: UnrdupConfig) -> Self {
         Self {
@@ -242,6 +231,12 @@ const SERVICE_NAME: &str = "modules.unrdup.controlplane.unrduppb.v1.UnrdupServic
 /// Maps a genuine "config not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
+fn client(channel: LayeredChannel) -> UnrdupServiceClient<LayeredChannel> {
+    UnrdupServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
 }
@@ -264,12 +259,7 @@ pub struct UnrdupService {
 
 impl UnrdupService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = GrpcService::connect_for(connection, action, SERVICE_NAME, |channel| {
-            UnrdupServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = GrpcService::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }
@@ -339,7 +329,8 @@ impl UnrdupService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Error> {
-        let config = UnrdupConfig::load(&cmd.file).map_err(|err| self.service.invalid("update", err.to_string()))?;
+        let config: UnrdupConfig =
+            yaml::load(&cmd.file).map_err(|err| self.service.invalid("update", err.to_string()))?;
 
         let request = UpdateConfigRequest {
             name: cmd.config_name.clone(),
@@ -386,15 +377,9 @@ impl UnrdupService {
 }
 
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            UnrdupServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }
 
 #[cfg(test)]

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -29,6 +29,12 @@ pub mod fwstatemappb {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "objects.fwstate.controlplane.fwstatemappb.v1.FWStateMapService";
 
+fn client(channel: LayeredChannel) -> FwStateMapServiceClient<LayeredChannel> {
+    FwStateMapServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 /// Manages fwstate-map objects that fwstate and acl configs link by name.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
@@ -91,11 +97,7 @@ impl DumpState {
 impl FWStateMapService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
         let conn = Connection::connect_for(connection, action).await?;
-        let service = Service::new(&conn, SERVICE_NAME, |channel| {
-            FwStateMapServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        });
+        let service = Service::new(&conn, SERVICE_NAME, client);
 
         Ok(Self { service })
     }
@@ -455,15 +457,9 @@ fn main() -> std::process::ExitCode {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn map_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            FwStateMapServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_maps(ListMapsRequest {}).await?.into_inner().maps),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_maps(ListMapsRequest {}).await?.into_inner().maps)
+    })
 }
 
 #[cfg(test)]

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -42,6 +42,12 @@ const SERVICE_NAME: &str = "operators.route.operatorpb.v1.NeighbourService";
 /// Maps a genuine "table not found" status into a friendly message.
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested table");
 
+fn client(channel: LayeredChannel) -> NeighbourServiceClient<LayeredChannel> {
+    NeighbourServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 /// Manages the neighbour tables of the route operator.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
@@ -198,12 +204,7 @@ pub struct NeighbourService {
 
 impl NeighbourService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            NeighbourServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
 
         Ok(Self { service })
     }
@@ -477,24 +478,16 @@ impl Tabled for NeighbourTableInfo {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn table_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            NeighbourServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| {
-            Ok(client
-                .list_tables(ListNeighbourTablesRequest {})
-                .await?
-                .into_inner()
-                .tables
-                .into_iter()
-                .map(|table| table.name)
-                .collect())
-        },
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client
+            .list_tables(ListNeighbourTablesRequest {})
+            .await?
+            .into_inner()
+            .tables
+            .into_iter()
+            .map(|table| table.name)
+            .collect())
+    })
 }
 
 #[cfg(test)]

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -37,6 +37,12 @@ pub mod operatorpb {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "operators.route.operatorpb.v1.RouteService";
 
+fn client(channel: LayeredChannel) -> RouteServiceClient<LayeredChannel> {
+    RouteServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
 /// Manages the RIB of the route operator.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
@@ -175,15 +181,9 @@ fn main() -> std::process::ExitCode {
 ///
 /// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
-    completion::candidates(
-        Cmd::command,
-        |channel| {
-            RouteServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        },
-        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
-    )
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
+    })
 }
 
 /// Run the requested subcommand.
@@ -211,11 +211,7 @@ pub struct RouteService {
 impl RouteService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
         let conn = Connection::connect_for(connection, action).await?;
-        let service = Service::new(&conn, SERVICE_NAME, |channel| {
-            RouteServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        });
+        let service = Service::new(&conn, SERVICE_NAME, client);
 
         Ok(Self { service })
     }


### PR DESCRIPTION
- Adds `discovery::Family` to `ync` and moves the readiness and metrics probes onto it, deleting their two copies of alias resolution, hints and completion.
- Adds `ync::yaml::load`, whose error names the path, and drops the private YAML loaders of acl, unrdup, mirror, balancer2 and route. The forward CLI keeps its multi-document merge-key loader, which has different semantics.
- Types the `-i`/`-o` pipeline flags of the plain, vlan and trafgen device CLIs as `Vec<DevicePipeline>`. A malformed value now exits 2 from clap before any connection instead of 1 after connecting. The `FromStr` error of `DevicePipeline` is widened to `Send + Sync` for that.
- Builds each generated client once per crate through a named `client` function instead of repeating the gzip closure at every site. A channel-level `client::gzip` is impossible in tonic, compression is an inherent method of every generated client, and a generic `config_candidates_for::<Client>()` would need a per-client trait of the same size, so the per-crate `config_candidates` wrappers stay on `completion::candidates`.
- Delegates the thousands separator of the counters CLI to `ync::metrics::format_number`. Output is unchanged, the compact K/M/G/T notation stays private to counters.
- The acl update error for an unreadable file now reads `<path>: <cause>` instead of `failed to load rules from <path>: <cause>`.
- The acl rule-metrics table and the hand-rolled `Service` wrappers named in the issue were already gone on main, and every binary already sets colour through `ync::init`. Dropping the `colored` dependency of ready, device-list and the route operator CLI is left for a follow-up issue.
- Updates the code-cli skill recipes for completion, client builders, YAML files and colour.
- Closes #2377.
