### PR TITLE
fix(lab): emit one json result for scenario runs

### DIFF
--- a/cmd/yanet-lab/main.go
+++ b/cmd/yanet-lab/main.go
@@ -774,48 +774,56 @@ func doctorAccelerationCheck(platform string, kvmAvailable func() bool) doctorCh
 }
 
 func (m *application) up() error {
-	dir, _, err := sessionPaths(m.session)
+	response, err := m.startSession()
 	if err != nil {
 		return err
 	}
+	return m.printResponse(response)
+}
+
+func (m *application) startSession() (*response, error) {
+	dir, _, err := sessionPaths(m.session)
+	if err != nil {
+		return nil, err
+	}
 	if err := ensureSessionDirectory(dir); err != nil {
-		return err
+		return nil, err
 	}
 	logPath := filepath.Join(dir, "supervisor.log")
 	if err := shutdownMarkerCheck(dir); err != nil {
-		return err
+		return nil, err
 	}
 	reuse, replacedFrom, err := m.shutdownStaleSupervisor()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if reuse != nil {
 		if !reuse.OK {
 			if reuse.Error == labBusyError {
-				return errLabBusy
+				return nil, errLabBusy
 			}
-			return sessionUnhealthy(reuse.Error, logPath)
+			return nil, sessionUnhealthy(reuse.Error, logPath)
 		}
-		return m.printResponse(reuse)
+		return reuse, nil
 	}
 	if err := probeSessionLock(dir); err != nil {
 		if errors.Is(err, errLabBusy) {
-			return errLabBusy
+			return nil, errLabBusy
 		}
-		return sessionUnhealthy(err.Error(), logPath)
+		return nil, sessionUnhealthy(err.Error(), logPath)
 	}
 	// Re-check the shutdown marker immediately before spawning serve so a
 	// concurrent `down` that wrote the marker between the initial check and
 	// the spawn still blocks `up` instead of clobbering the failed session.
 	if err := shutdownMarkerCheck(dir); err != nil {
-		return err
+		return nil, err
 	}
 	response, err := serveRunner(m, logPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	annotateReplacement(response, replacedFrom)
-	return m.printResponse(response)
+	return response, nil
 }
 
 // sessionUnhealthy wraps the exact AC2 error form: a non-zero prefix naming
@@ -954,7 +962,17 @@ func exitedDuringStartupError(directory string, directoryErr error, processErr e
 }
 
 func (m *application) ensureUp() error {
-	return m.up()
+	if !m.json {
+		return m.up()
+	}
+	response, err := m.startSession()
+	if err != nil {
+		return err
+	}
+	if !response.OK {
+		return errors.New(response.Error)
+	}
+	return nil
 }
 
 type staleSupervisorDecision int

--- a/cmd/yanet-lab/main_test.go
+++ b/cmd/yanet-lab/main_test.go
@@ -2424,3 +2424,63 @@ func TestDownRemovesPriorMarkerOnSuccess(t *testing.T) {
 	_, err = os.Stat(filepath.Join(directory, shutdownMarkerName))
 	require.True(t, os.IsNotExist(err), "prior marker should be gone after successful down, got err=%v", err)
 }
+
+// Test_ApplicationRun_JSONManifestEmitsOnlyFinalResult verifies that automatic
+// startup never adds a second JSON document or masks a later transport error.
+func Test_ApplicationRun_JSONManifestEmitsOnlyFinalResult(t *testing.T) {
+	for _, command := range []string{"manifest", "scenario"} {
+		for _, running := range []bool{false, true} {
+			for _, outcome := range []string{"success", "manifest failure", "transport failure"} {
+				t.Run(fmt.Sprintf("%s/running=%t/%s", command, running, outcome), func(t *testing.T) {
+					_, cleanup := tempUp(t, "json-manifest")
+					defer cleanup()
+					path := filepath.Join("lab", "scenarios", "example", "manifest.yaml")
+					require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+					require.NoError(t, os.WriteFile(path, []byte("version: 1\nname: example\nsteps:\n  - name: inspect\n    argv: [/bin/true]\n"), 0o644))
+					ready := &response{OK: true, Status: statusReady, SupervisorProtocolVersion: supervisorProtocolVersion}
+					stubCallAndServe(t, func(_ *application, value request) (*response, error) {
+						if value.Action == "status" {
+							if !running {
+								return nil, errors.New("not running")
+							}
+							return ready, nil
+						}
+						require.Equal(t, "manifest", value.Action)
+						if outcome == "transport failure" {
+							return nil, errors.New(outcome)
+						}
+						result := &response{OK: outcome == "success", Report: &lab.RunReport{Success: outcome == "success"}}
+						if !result.OK {
+							result.Error = outcome
+						}
+						return result, nil
+					}, func(*application, string) (*response, error) {
+						require.False(t, running)
+						return ready, nil
+					})
+					argument := path
+					if command == "scenario" {
+						argument = "example"
+					}
+					originalArguments := os.Args
+					t.Cleanup(func() { os.Args = originalArguments })
+					os.Args = []string{"yanet-lab", "--json", "--session", "json-manifest", command, "run", argument}
+					stdout, stderr, exitCode := captureApplicationOutput(t, newApplication().Run)
+					require.Empty(t, stderr)
+					var decoded response
+					require.NoError(t, json.Unmarshal(stdout, &decoded))
+					require.Equal(t, cliProtocolVersion, decoded.Protocol)
+					if outcome == "success" {
+						require.Zero(t, exitCode)
+						require.True(t, decoded.OK)
+						require.NotNil(t, decoded.Report)
+					} else {
+						require.Equal(t, 1, exitCode)
+						require.False(t, decoded.OK)
+						require.Equal(t, outcome, decoded.Error)
+					}
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Emit only the final manifest or scenario result in JSON mode, keeping successful session startup from producing an extra document or hiding a subsequent transport error.
- Preserve explicit startup output and cover new and reused sessions with regression tests for success, manifest failure, and transport failure.
- Validate the change against the QEMU NAT64 scenario and confirm that the response parses as one JSON document.