### PR TITLE
feat(controlplane,cli): read back the logging level and name the affected process

### DIFF
--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -7,11 +7,12 @@ use ync::{
     errors::Error,
     output::{self, CommonFormat},
 };
-use ynpb::pb::{UpdateLevelRequest, logging_client::LoggingClient};
+use ynpb::pb::{GetLevelRequest, UpdateLevelRequest, logging_client::LoggingClient};
 
 const LOGGING_SERVICE: &str = "controlplane.ynpb.v1.Logging";
 
-/// Manages the log level of the control plane.
+/// Manages the log level of the control plane process (`yanet-controlplane`),
+/// covering its Go logger and the hosted C libraries but not the dataplane.
 #[derive(Debug, Clone, Parser)]
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
@@ -30,15 +31,17 @@ struct Cmd {
 
 #[derive(Debug, Clone, Subcommand)]
 enum ModeCmd {
-    /// Manage the logging service.
+    /// Manage the control plane's logging level.
     #[clap(subcommand)]
     Logging(LoggingCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
 enum LoggingCmd {
-    /// Set the new minimum log level.
+    /// Set the control plane's minimum log level.
     SetLevel(SetLogLevelCmd),
+    /// Show the control plane's current minimum log level.
+    Show,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -75,6 +78,7 @@ impl ModeCmd {
     pub fn action(&self) -> &'static str {
         match self {
             ModeCmd::Logging(LoggingCmd::SetLevel(..)) => "set-level",
+            ModeCmd::Logging(LoggingCmd::Show) => "show",
         }
     }
 }
@@ -100,7 +104,23 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                 .map_err(service.status(action))?;
 
             let level_name = cmd.level.to_possible_value().expect("no skipped variants");
-            output::success(action, format_args!("Set log level to '{}'.", level_name.get_name()));
+            output::success(
+                action,
+                format_args!("Set the control plane log level to '{}'.", level_name.get_name()),
+            );
+        }
+        ModeCmd::Logging(LoggingCmd::Show) => {
+            let response = service
+                .client()
+                .get_level(GetLevelRequest {})
+                .await
+                .map_err(service.status(action))?
+                .into_inner();
+
+            output::data(
+                || &response,
+                || println!("level: {}", ynpb::log_level_name(response.level)),
+            );
         }
     }
 

--- a/common/rust/ynpb/build.rs
+++ b/common/rust/ynpb/build.rs
@@ -12,6 +12,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             ".controlplane.ynpb.v1.RegisteredBackend.kind",
             "#[serde(serialize_with = \"crate::serialize_backend_kind\")]",
         )
+        .field_attribute(
+            ".controlplane.ynpb.v1.GetLevelResponse.level",
+            "#[serde(serialize_with = \"crate::serialize_log_level\")]",
+        )
         .extern_path(".common.commonpb.v1", "::commonpb::pb")
         .compile_protos(
             &[

--- a/common/rust/ynpb/src/lib.rs
+++ b/common/rust/ynpb/src/lib.rs
@@ -21,6 +21,24 @@ where
     serializer.serialize_str(&name)
 }
 
+/// Returns the lowercase name of a logging-level wire value (e.g. `debug`,
+/// `info`), or its decimal text when the value is unknown.
+pub fn log_level_name(value: i32) -> String {
+    match pb::LogLevel::try_from(value) {
+        Ok(level) => level.as_str_name().to_lowercase(),
+        Err(_) => value.to_string(),
+    }
+}
+
+/// Serializes a logging-level wire value as its lowercase name, or as its
+/// decimal text when the value is unknown.
+pub fn serialize_log_level<S>(value: &i32, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&log_level_name(*value))
+}
+
 /// Serializes an `Option<prost_types::Timestamp>` as `{"seconds": i64, "nanos":
 /// i32}` or `null` when absent.
 pub fn serialize_timestamp<S>(value: &Option<prost_types::Timestamp>, serializer: S) -> Result<S::Ok, S::Error>
@@ -39,5 +57,20 @@ where
             Ts { seconds: ts.seconds, nanos: ts.nanos }.serialize(serializer)
         }
         None => serializer.serialize_none(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_log_level_name_known_value() {
+        assert_eq!("debug", log_level_name(pb::LogLevel::Debug as i32));
+    }
+
+    #[test]
+    fn test_log_level_name_unknown_discriminant() {
+        assert_eq!("7", log_level_name(7));
     }
 }

--- a/controlplane/builtin/logging.go
+++ b/controlplane/builtin/logging.go
@@ -119,6 +119,23 @@ func (m *Logging) UpdateLevel(
 	return &ynpb.UpdateLevelResponse{}, nil
 }
 
+// GetLevel returns the minimum logging level currently in effect.
+func (m *Logging) GetLevel(
+	ctx context.Context,
+	req *ynpb.GetLevelRequest,
+) (*ynpb.GetLevelResponse, error) {
+	if m.atom == nil {
+		return nil, status.Errorf(codes.Unimplemented, "service doesn't support reading log level dynamically")
+	}
+
+	level, err := convertZapLevel(m.atom.Level())
+	if err != nil {
+		return nil, err
+	}
+
+	return &ynpb.GetLevelResponse{Level: level}, nil
+}
+
 func convertLevel(v ynpb.LogLevel) (zapcore.Level, error) {
 	switch v {
 	case ynpb.LogLevel_DEBUG:
@@ -131,5 +148,26 @@ func convertLevel(v ynpb.LogLevel) (zapcore.Level, error) {
 		return zapcore.ErrorLevel, nil
 	default:
 		return zapcore.InvalidLevel, fmt.Errorf("unexpected value: %v", v)
+	}
+}
+
+func convertZapLevel(level zapcore.Level) (ynpb.LogLevel, error) {
+	switch level {
+	case zapcore.DebugLevel:
+		return ynpb.LogLevel_DEBUG, nil
+	case zapcore.InfoLevel:
+		return ynpb.LogLevel_INFO, nil
+	case zapcore.WarnLevel:
+		return ynpb.LogLevel_WARN, nil
+	case zapcore.ErrorLevel:
+		return ynpb.LogLevel_ERROR, nil
+	default:
+		// DPanic, Panic and Fatal come only from the startup config, the API enum
+		// has no value for them.
+		return 0, status.Errorf(
+			codes.FailedPrecondition,
+			"current log level %s has no equivalent among DEBUG, INFO, WARN, ERROR",
+			level,
+		)
 	}
 }

--- a/controlplane/builtin/logging_test.go
+++ b/controlplane/builtin/logging_test.go
@@ -1,0 +1,127 @@
+package builtin_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/controlplane/builtin"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// Test_Logging_GetLevel_ReportsStartupLevel verifies that the level read back
+// is the one the service started with, for every level the API represents.
+func Test_Logging_GetLevel_ReportsStartupLevel(t *testing.T) {
+	cases := []struct {
+		name         string
+		zapLevel     zapcore.Level
+		wantAPILevel ynpb.LogLevel
+	}{
+		{
+			name:         "debug",
+			zapLevel:     zapcore.DebugLevel,
+			wantAPILevel: ynpb.LogLevel_DEBUG,
+		},
+		{
+			name:         "info",
+			zapLevel:     zapcore.InfoLevel,
+			wantAPILevel: ynpb.LogLevel_INFO,
+		},
+		{
+			name:         "warn",
+			zapLevel:     zapcore.WarnLevel,
+			wantAPILevel: ynpb.LogLevel_WARN,
+		},
+		{
+			name:         "error",
+			zapLevel:     zapcore.ErrorLevel,
+			wantAPILevel: ynpb.LogLevel_ERROR,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			atom := zap.NewAtomicLevelAt(tc.zapLevel)
+			svc := builtin.NewLogging(&atom)
+
+			resp, err := svc.GetLevel(t.Context(), &ynpb.GetLevelRequest{})
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantAPILevel, resp.GetLevel())
+		})
+	}
+}
+
+// Test_Logging_UpdateLevel_GetLevel_RoundTrips verifies that a level just set is
+// read back unchanged and reaches the observer exactly once.
+func Test_Logging_UpdateLevel_GetLevel_RoundTrips(t *testing.T) {
+	cases := []struct {
+		name  string
+		level ynpb.LogLevel
+	}{
+		{
+			name:  "debug",
+			level: ynpb.LogLevel_DEBUG,
+		},
+		{
+			name:  "info",
+			level: ynpb.LogLevel_INFO,
+		},
+		{
+			name:  "warn",
+			level: ynpb.LogLevel_WARN,
+		},
+		{
+			name:  "error",
+			level: ynpb.LogLevel_ERROR,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			atom := zap.NewAtomicLevelAt(zapcore.InfoLevel)
+
+			var observed zapcore.Level
+			var observedCount int
+			svc := builtin.NewLogging(&atom, builtin.WithLoggingLevelObserver(func(level zapcore.Level) {
+				observed = level
+				observedCount++
+			}))
+
+			_, err := svc.UpdateLevel(t.Context(), &ynpb.UpdateLevelRequest{Level: tc.level})
+			require.NoError(t, err)
+
+			resp, err := svc.GetLevel(t.Context(), &ynpb.GetLevelRequest{})
+			require.NoError(t, err)
+
+			require.Equal(t, tc.level, resp.GetLevel())
+			require.Equal(t, 1, observedCount)
+			require.Equal(t, atom.Level(), observed)
+		})
+	}
+}
+
+// Test_Logging_GetLevel_NilAtomicLevel verifies that reading the level without a
+// dynamic level in place answers Unimplemented.
+func Test_Logging_GetLevel_NilAtomicLevel(t *testing.T) {
+	svc := builtin.NewLogging(nil)
+
+	_, err := svc.GetLevel(t.Context(), &ynpb.GetLevelRequest{})
+
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+}
+
+// Test_Logging_GetLevel_UnrepresentableLevel verifies that a startup level the
+// API cannot represent answers FailedPrecondition.
+func Test_Logging_GetLevel_UnrepresentableLevel(t *testing.T) {
+	atom := zap.NewAtomicLevelAt(zapcore.FatalLevel)
+	svc := builtin.NewLogging(&atom)
+
+	_, err := svc.GetLevel(t.Context(), &ynpb.GetLevelRequest{})
+
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}

--- a/controlplane/ynpb/v1/logging.proto
+++ b/controlplane/ynpb/v1/logging.proto
@@ -7,6 +7,8 @@ option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb"
 service Logging {
   // UpdateLevel updates the minimum logging level.
   rpc UpdateLevel(UpdateLevelRequest) returns (UpdateLevelResponse) {}
+  // GetLevel reports the current minimum logging level.
+  rpc GetLevel(GetLevelRequest) returns (GetLevelResponse) {}
 }
 
 // UpdateLevelRequest is the request to update the minimum logging level.
@@ -37,3 +39,12 @@ enum LogLevel {
 
 // UpdateLevelResponse is the response to the UpdateLevelRequest.
 message UpdateLevelResponse {}
+
+// GetLevelRequest carries no fields, the level in effect is process-wide.
+message GetLevelRequest {}
+
+// GetLevelResponse carries the minimum logging level currently in effect.
+message GetLevelResponse {
+  // Level is the current minimum logging level.
+  LogLevel level = 1;
+}


### PR DESCRIPTION
- Adds a `GetLevel` RPC to the control plane `Logging` service that reports the minimum level currently in effect, the one `UpdateLevel` sets and the one configured at startup.
- Adds `yanet-cli common logging show`, which prints the current level as `level: <name>` and as `{"level":"<name>"}` under `--format json`.
- The `set-level` success line now names the process and echoes the level as typed: `Set the control plane log level to 'debug'.`.
- `--help` names the affected components: the control plane process (`yanet-controlplane`), its Go logger and the C control-plane libraries it hosts, and states that the dataplane is not affected.
- Assumption: a level only the startup config can set (`dpanic`, `panic`, `fatal`) has no value in the `LogLevel` enum, so `GetLevel` answers `FailedPrecondition` naming the current level instead of extending the enum or collapsing it onto `ERROR`.
- Assumption: the JSON payload renders the level as its lowercase name rather than the enum number, following the `RegisteredBackend.kind` serializer precedent in the same crate.
- Closes #2358.
