### PR TITLE
perf(dataplane): interleave packet rx and tx

### DIFF
--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -67,52 +67,49 @@
 
 #include <string.h>
 
-// Lookahead that hides the two cache misses every received packet costs.
+// Receive the next batch and warm its coldest lines ahead of the parse.
 //
 // Every received packet costs two cache lines nobody has touched lately:
 // its metadata in the headroom, last written a whole pool rotation ago,
-// and the first line of the frame, written by the NIC. The out-of-order
-// window overlaps that latency for two or three packets on its own. Eight
-// was measured rather than derived: on the firewall profile it is where
-// the parser stops waiting on the frame line, while the prefetches are
-// still few enough not to be dropped.
-#define WORKER_RX_PREFETCH_DISTANCE 8
-
+// and the first line of the frame, written by the NIC. The batch is held
+// until the next round and parsed only after this round transmits its
+// predecessor, giving the prefetches a whole transmit to land.
 static void
-worker_read(
-	struct dataplane_worker *worker, struct config_gen_ectx *config_gen_ectx
-) {
+worker_rx_stage(struct dataplane_worker *worker) {
 	struct worker_read_ctx *ctx = &worker->read_ctx;
-	struct rte_mbuf *mbufs[ctx->read_size];
 
 	uint16_t read = rte_eth_rx_burst(
-		worker->port_id, worker->queue_id, mbufs, ctx->read_size
+		worker->port_id, worker->queue_id, ctx->staged, ctx->read_size
 	);
+	ctx->staged_count = read;
+
 	*(worker->dp_worker->rx_count) += read;
 	if (worker->dp_worker->rx_bursts != NULL) {
 		worker->dp_worker->rx_bursts[read] += 1;
 	}
 
-	// Keep the lookahead full: the first packets up front, then one more
-	// for every packet parsed.
-	for (uint32_t idx = 0; idx < read && idx < WORKER_RX_PREFETCH_DISTANCE;
-	     ++idx) {
-		rte_prefetch0(mbufs[idx]->buf_addr);
-		rte_prefetch0(rte_pktmbuf_mtod(mbufs[idx], void *));
+	for (uint16_t idx = 0; idx < read; ++idx) {
+		rte_prefetch0(ctx->staged[idx]->buf_addr);
+		rte_prefetch0(rte_pktmbuf_mtod(ctx->staged[idx], void *));
 	}
+}
 
-	for (uint32_t idx = 0; idx < read; ++idx) {
-		if (idx + WORKER_RX_PREFETCH_DISTANCE < read) {
-			struct rte_mbuf *ahead =
-				mbufs[idx + WORKER_RX_PREFETCH_DISTANCE];
-			rte_prefetch0(ahead->buf_addr);
-			rte_prefetch0(rte_pktmbuf_mtod(ahead, void *));
-		}
+// Parse the staged batch and schedule it into the pipeline.
+//
+// The batch was received at the end of the previous round and prefetched
+// then. The execution context is the one this round snapshotted and must
+// be non-NULL.
+static void
+worker_process_staged(
+	struct dataplane_worker *worker, struct config_gen_ectx *config_gen_ectx
+) {
+	struct worker_read_ctx *ctx = &worker->read_ctx;
 
-		struct packet *packet = mbuf_to_packet(mbufs[idx]);
+	for (uint16_t idx = 0; idx < ctx->staged_count; ++idx) {
+		struct packet *packet = mbuf_to_packet(ctx->staged[idx]);
 		memset(packet, 0, sizeof(struct packet));
 		// FIXME update packet fields
-		packet->mbuf = mbufs[idx];
+		packet->mbuf = ctx->staged[idx];
 
 		packet->rx_device_id = worker->device_id;
 		// Preserve device by default
@@ -125,20 +122,11 @@ worker_read(
 			continue;
 		}
 
-		// With no active config there is no device schedule to route
-		// into, so free the mbuf and account it as a drop rather than
-		// letting pre-config traffic accumulate in the NIC RX ring.
-		if (config_gen_ectx == NULL) {
-			rte_pktmbuf_free(mbufs[idx]);
-			*(worker->dp_worker->drop_count) += 1;
-			continue;
-		}
-
 		struct device_ectx *device_ectx = config_gen_ectx_get_device(
 			config_gen_ectx, packet->tx_device_id
 		);
 		if (device_ectx == NULL) {
-			rte_pktmbuf_free(mbufs[idx]);
+			rte_pktmbuf_free(ctx->staged[idx]);
 			*(worker->dp_worker->drop_count) += 1;
 			continue;
 		}
@@ -148,6 +136,20 @@ worker_read(
 			packet
 		);
 	}
+
+	ctx->staged_count = 0;
+}
+
+static void
+worker_drop_staged(struct dataplane_worker *worker) {
+	struct worker_read_ctx *ctx = &worker->read_ctx;
+
+	for (uint16_t idx = 0; idx < ctx->staged_count; ++idx) {
+		rte_pktmbuf_free(ctx->staged[idx]);
+	}
+
+	*(worker->dp_worker->drop_count) += ctx->staged_count;
+	ctx->staged_count = 0;
 }
 
 static size_t
@@ -297,16 +299,21 @@ worker_loop_round(struct dataplane_worker *worker) {
 	struct cp_config_gen *cp_config_gen = round.cp_config_gen;
 	struct config_gen_ectx *config_gen_ectx = round.config_gen_ectx;
 
-	// No configuration has been installed yet (startup). worker_read frees
-	// the RX mbufs itself when handed a NULL config_gen_ectx, so pre-config
-	// traffic does not accumulate and get processed stale once a
-	// configuration appears. worker_write still runs to drain remote rx
-	// pipes and reclaim tx pipes.
+	// No configuration has been installed yet (startup): free the
+	// staged batch and keep the ring drained.
+	//
+	// The batch polled during the last configuration-less round is the
+	// only pre-configuration traffic that survives the transition, and
+	// it is parsed by a round that already holds the new configuration,
+	// never stale. The write side still runs to drain remote rx pipes
+	// and reclaim tx pipes.
 	if (config_gen_ectx == NULL) {
-		worker_read(worker, NULL);
+		worker_drop_staged(worker);
 
 		struct packet_front packet_front;
 		packet_front_init(&packet_front);
+
+		worker_rx_stage(worker);
 
 		worker_write(worker, &packet_front);
 		return;
@@ -314,11 +321,16 @@ worker_loop_round(struct dataplane_worker *worker) {
 
 	struct packet_front *packet_front = &config_gen_ectx->packet_front;
 
-	worker_read(worker, config_gen_ectx);
+	worker_process_staged(worker, config_gen_ectx);
 
 	worker_pipeline_round(
 		worker->dp_worker, cp_config_gen, config_gen_ectx, packet_front
 	);
+
+	// Poll the next batch and warm its lines just before the transmit:
+	// parsing waits for the next round, so the prefetches overlap the
+	// whole transmit instead of stalling the parse.
+	worker_rx_stage(worker);
 
 	worker_write(worker, packet_front);
 
@@ -455,6 +467,7 @@ dataplane_worker_init(
 	dp_config->worker_count += 1;
 
 	worker->read_ctx.read_size = WORKER_RX_BURST_SIZE;
+	worker->read_ctx.staged_count = 0;
 	worker->write_ctx.write_size = 32;
 	worker->write_ctx.rx_pipes = NULL;
 

--- a/dataplane/worker.h
+++ b/dataplane/worker.h
@@ -9,6 +9,7 @@
 
 #include "common/data_pipe.h"
 #include "lib/dataplane/packet/packet.h"
+#include "lib/dataplane/worker/counters.h"
 #include "lib/dataplane/worker/rx_pool_sampler.h"
 #include "lib/dataplane/worker/tx_stage.h"
 
@@ -19,6 +20,16 @@ struct dp_worker;
 
 struct worker_read_ctx {
 	uint16_t read_size;
+
+	// Batch received at the end of the previous round, parsed at the
+	// start of the current one.
+	//
+	// The batch is polled and its coldest lines prefetched before the
+	// transmit of its predecessor, so the parse runs on lines the caches
+	// already hold. A non-zero count means the batch is still pending:
+	// every consumer resets the count once the mbufs leave its hands.
+	struct rte_mbuf *staged[WORKER_RX_BURST_SIZE];
+	uint16_t staged_count;
 };
 
 struct worker_write_ctx {

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -631,7 +631,8 @@ dataplane_ut_run(
 	}
 
 	// Feed input straight onto each packet's target device input entry,
-	// the same way worker_read deposits RX into the pipeline.
+	// the same way the worker deposits its staged RX batch into the
+	// pipeline.
 	struct packet *packet;
 	while ((packet = packet_list_pop(input)) != NULL) {
 		struct device_ectx *device_ectx = config_gen_ectx_get_device(


### PR DESCRIPTION
- Receive the next batch and prefetch its cold lines just before transmitting the previous one; parsing waits for the next round, so the prefetches overlap a whole transmit instead of an in-burst lookahead of eight.
- The received batch is held raw in a per-worker staging array across the round boundary, so no configuration pointers outlive the generation acknowledgement; the batch is parsed and scheduled at the start of the next round under that round's snapshot.
- The no-config startup path drops the staged batch and still drains the ring every round; every consumer resets the staging count once the mbufs leave its hands.

Closes #2527.