### PR TITLE
fix(controlplane): stop reporting port counters per instance

### DIFF
--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -234,7 +234,7 @@ func (m *Counters) Ports(
 	return response, nil
 }
 
-// Collect returns a generic metrics snapshot for port and worker counters.
+// Collect returns a generic metrics snapshot for worker counters.
 //
 // A family that fails to collect is omitted from the snapshot, so a
 // consumer sees a gap for that scrape rather than stale values.
@@ -242,12 +242,6 @@ func (m *Counters) Collect() []*commonpb.Metric {
 	dpConfig := m.shm.DPConfig(m.instanceID)
 
 	metrics := make([]*commonpb.Metric, 0)
-
-	if ports, err := dpConfig.PortCounters(); err == nil {
-		metrics = append(metrics, portMetrics(ports)...)
-	} else {
-		m.log.Warn("failed to collect port counters", zap.Error(err))
-	}
 
 	if workers, err := dpConfig.WorkerCounters(); err == nil {
 		metrics = append(metrics, workerMetrics(workers, m.instanceID)...)
@@ -258,7 +252,28 @@ func (m *Counters) Collect() []*commonpb.Metric {
 	return metrics
 }
 
-func portMetrics(ports []ffi.PortGroup) []*commonpb.Metric {
+// CollectPortMetrics returns a metrics snapshot of the hardware port
+// counters, which describe the ports themselves and read the same from
+// every instance.
+//
+// A snapshot that fails to collect comes back empty, so a consumer sees a
+// gap for that scrape rather than stale values.
+func (m *Counters) CollectPortMetrics() []*commonpb.Metric {
+	dpConfig := m.shm.DPConfig(m.instanceID)
+
+	metrics := make([]*commonpb.Metric, 0)
+
+	if ports, err := dpConfig.PortCounters(); err == nil {
+		metrics = append(metrics, PortMetrics(ports)...)
+	} else {
+		m.log.Warn("failed to collect port counters", zap.Error(err))
+	}
+
+	return metrics
+}
+
+// PortMetrics converts a port counter snapshot into cumulative counters.
+func PortMetrics(ports []ffi.PortGroup) []*commonpb.Metric {
 	metrics := make([]*commonpb.Metric, 0)
 	for _, port := range ports {
 		portID := strconv.FormatUint(uint64(port.PortID), 10)

--- a/controlplane/builtin/counters_test.go
+++ b/controlplane/builtin/counters_test.go
@@ -16,8 +16,14 @@ import (
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/builtin"
+	"github.com/yanet-platform/yanet2/controlplane/gateway"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
+
+// The gateway picks the services that report port metrics out of the ones
+// it hosts by their method set alone, so a rename on either side would
+// drop the port counters from that snapshot unnoticed.
+var _ = gateway.NewPortMetricsService((*builtin.Counters)(nil))
 
 // newCountersHarness builds a one-instance in-process dataplane harness
 // with the given worker count and registers its teardown. Worker pool

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -365,6 +365,9 @@ func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 	metricsService := NewMetricsService(append(metricsCollectors(serverMetrics, opts.Services), authManager)...)
 	ynpb.RegisterMetricsServiceServer(server, metricsService)
 
+	portMetricsService := NewPortMetricsService(portMetricsCollectors(opts.Services)...)
+	ynpb.RegisterPortMetricsServiceServer(server, portMetricsService)
+
 	// Gateway-hosted services are reached through one in-memory connection
 	// back into this server, a backend for the HTTP surface and the registry.
 	//
@@ -393,6 +396,7 @@ func NewGateway(cfg Config, options ...GatewayOption) (*Gateway, error) {
 		"controlplane.ynpb.v1.Auth",
 		ynpb.ReadinessService_ServiceDesc.ServiceName,
 		ynpb.MetricsService_ServiceDesc.ServiceName,
+		ynpb.PortMetricsService_ServiceDesc.ServiceName,
 	} {
 		registry.RegisterBackend(service, loopback, BackendKindBuiltin)
 		log.Info("registered service in registry",

--- a/controlplane/gateway/metrics_service.go
+++ b/controlplane/gateway/metrics_service.go
@@ -13,6 +13,12 @@ type metricsCollector interface {
 	Collect() []*commonpb.Metric
 }
 
+// portMetricsCollector provides collected metrics that describe the ports
+// rather than the dataplane instance the gateway serves.
+type portMetricsCollector interface {
+	CollectPortMetrics() []*commonpb.Metric
+}
+
 // MetricsService exposes gateway gRPC server metrics and service-specific
 // metrics over its own gRPC service.
 type MetricsService struct {
@@ -21,7 +27,7 @@ type MetricsService struct {
 	collectors []metricsCollector
 }
 
-// NewMetricsService creates a MetricsService backed by collector.
+// NewMetricsService creates a MetricsService backed by the given collectors.
 func NewMetricsService(collectors ...metricsCollector) *MetricsService {
 	return &MetricsService{collectors: collectors}
 }
@@ -40,10 +46,49 @@ func (m *MetricsService) GetMetrics(
 	return &commonpb.GetMetricsResponse{Metrics: metrics.Filter(all, req.GetTags())}, nil
 }
 
+// PortMetricsService serves hardware port counters over its own gRPC
+// service.
+//
+// Every gateway returns the same values, so scraping any one of them
+// records a port's counters once.
+type PortMetricsService struct {
+	ynpb.UnimplementedPortMetricsServiceServer
+
+	collectors []portMetricsCollector
+}
+
+// NewPortMetricsService creates a service backed by the given collectors.
+func NewPortMetricsService(collectors ...portMetricsCollector) *PortMetricsService {
+	return &PortMetricsService{collectors: collectors}
+}
+
+// GetMetrics returns a snapshot of all port metrics.
+func (m *PortMetricsService) GetMetrics(
+	ctx context.Context,
+	req *commonpb.GetMetricsRequest,
+) (*commonpb.GetMetricsResponse, error) {
+	all := make([]*commonpb.Metric, 0)
+	for _, collector := range m.collectors {
+		all = append(all, collector.CollectPortMetrics()...)
+	}
+
+	return &commonpb.GetMetricsResponse{Metrics: metrics.Filter(all, req.GetTags())}, nil
+}
+
 func metricsCollectors(server metricsCollector, entries []serviceEntry) []metricsCollector {
 	collectors := []metricsCollector{server}
 	for _, entry := range entries {
 		if collector, ok := entry.Service.(metricsCollector); ok {
+			collectors = append(collectors, collector)
+		}
+	}
+	return collectors
+}
+
+func portMetricsCollectors(entries []serviceEntry) []portMetricsCollector {
+	collectors := make([]portMetricsCollector, 0, len(entries))
+	for _, entry := range entries {
+		if collector, ok := entry.Service.(portMetricsCollector); ok {
 			collectors = append(collectors, collector)
 		}
 	}

--- a/controlplane/gateway/metrics_service_test.go
+++ b/controlplane/gateway/metrics_service_test.go
@@ -1,0 +1,113 @@
+package gateway_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/gateway"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// bothScopes is a gateway-hosted service reporting one port metric and one
+// metric of the dataplane instance behind the gateway, the shape the
+// counters service has.
+type bothScopes struct{}
+
+func (bothScopes) Name() string                   { return "both-scopes" }
+func (bothScopes) Endpoint() string               { return "" }
+func (bothScopes) ServicesNames() []string        { return nil }
+func (bothScopes) RegisterService(_ *grpc.Server) {}
+
+func (bothScopes) Collect() []*commonpb.Metric {
+	return []*commonpb.Metric{commonpb.NewMetricCounter("worker_rx_packets", 1)}
+}
+
+func (bothScopes) CollectPortMetrics() []*commonpb.Metric {
+	return []*commonpb.Metric{
+		commonpb.NewMetricCounter(
+			"port_counter_value",
+			2,
+			commonpb.NewLabel("port_name", "port0"),
+		),
+	}
+}
+
+// Test_NewGateway_PortMetricsServiceReachable verifies that a gateway
+// answers port metrics over the wire and lists the service in its
+// registry.
+func Test_NewGateway_PortMetricsServiceReachable(t *testing.T) {
+	t.Parallel()
+
+	listener := NewTestListener(t)
+	gw, err := gateway.NewGateway(
+		gateway.DefaultConfig(),
+		gateway.WithListener(listener),
+		gateway.WithBuiltinService(bothScopes{}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var group errgroup.Group
+	group.Go(func() error { return gw.Run(ctx) })
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, group.Wait())
+	})
+
+	conn, err := grpc.NewClient(
+		listener.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	registered := ynpb.NewGatewayClient(conn)
+	kinds := map[string]ynpb.BackendKind{}
+	require.Eventually(t, func() bool {
+		response, listErr := registered.ListServices(t.Context(), &ynpb.ListServicesRequest{})
+		if listErr != nil {
+			return false
+		}
+
+		kinds = map[string]ynpb.BackendKind{}
+		for _, entry := range response.GetServices() {
+			kinds[entry.GetBackend().GetName()] = entry.GetKind()
+		}
+
+		_, seen := kinds[ynpb.PortMetricsService_ServiceDesc.ServiceName]
+		return seen
+	}, 5*time.Second, 50*time.Millisecond, "gateway did not register the port metrics service")
+
+	require.Equal(
+		t,
+		ynpb.BackendKind_BACKEND_KIND_BUILTIN,
+		kinds[ynpb.PortMetricsService_ServiceDesc.ServiceName],
+	)
+
+	callCtx, callCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer callCancel()
+
+	response, err := ynpb.NewPortMetricsServiceClient(conn).GetMetrics(
+		callCtx, &commonpb.GetMetricsRequest{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"port_counter_value"}, metricNames(response.GetMetrics()))
+}
+
+// metricNames returns the name of each metric in order, so a response is
+// compared by the families it carries rather than by value.
+func metricNames(metrics []*commonpb.Metric) []string {
+	names := make([]string, 0, len(metrics))
+	for _, metric := range metrics {
+		names = append(names, metric.GetName())
+	}
+	return names
+}

--- a/controlplane/ynpb/meson.build
+++ b/controlplane/ynpb/meson.build
@@ -13,6 +13,7 @@ ynpb_proto_files = [
     join_paths(ynpb_dir, 'v1', 'auth.proto'),
     join_paths(ynpb_dir, 'v1', 'readiness.proto'),
     join_paths(ynpb_dir, 'v1', 'metrics.proto'),
+    join_paths(ynpb_dir, 'v1', 'port.proto'),
     join_paths(ynpb_dir, 'v1', 'memory.proto'),
 ]
 
@@ -40,6 +41,8 @@ ynpb_gen = custom_target(
         'readiness_grpc.pb.go',
         'metrics.pb.go',
         'metrics_grpc.pb.go',
+        'port.pb.go',
+        'port_grpc.pb.go',
         'memory.pb.go',
         'memory_grpc.pb.go',
     ],

--- a/controlplane/ynpb/v1/port.proto
+++ b/controlplane/ynpb/v1/port.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package controlplane.ynpb.v1;
+
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
+
+import "common/commonpb/v1/metric.proto";
+
+// PortMetricsService exposes hardware port counters.
+//
+// A port counter describes the port, not a dataplane instance, so every
+// gateway returns the same values. Serving them apart from the instance
+// metrics keeps one series per port.
+service PortMetricsService {
+  // GetMetrics returns a snapshot of port metrics.
+  rpc GetMetrics(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
+}

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,10 +1,22 @@
 # Metrics reference
 
 Operator-facing metrics exported by the built-in counters service and
-collected through the gateway metrics endpoint. All worker and port
+collected through the gateway metrics endpoints. All worker and port
 families come from the dataplane shared-memory counter storage; a family
 whose collection fails is omitted from the snapshot with a logged
 warning — values are never synthesized as zeros.
+
+The metrics are split across two gRPC services, one per scope. Worker
+metrics describe the dataplane instance behind the gateway that answers,
+and one gateway runs per instance, so a collector may record which
+gateway it scraped them from:
+
+    /controlplane.ynpb.v1.MetricsService/GetMetrics
+
+Port metrics describe the hardware itself and read the same from every
+gateway, so no gateway identity belongs on them:
+
+    /controlplane.ynpb.v1.PortMetricsService/GetMetrics
 
 ## Worker metrics
 
@@ -64,3 +76,20 @@ One series per DPDK port and xstat counter, cumulative:
 
 - `port_counter_value` (counter) — labels `port_id`, `port_name`,
   `counter`.
+
+Every gateway answers with the same values, so any one of them can be
+scraped and a gateway that is down costs nothing as long as another is.
+Scraping several is equally correct only where the collector attaches
+nothing that identifies the gateway it asked: a collector that labels a
+series by its scrape target must either take this endpoint from one
+gateway or drop that label, or a summed counter counts one port once per
+gateway. That is what divides the two scopes — a series an aggregator
+would sum belongs here.
+
+Only the port endpoint serves them. A collector configured against the
+instance endpoint alone gets no port series and no error saying so, and a
+deployment that grants metrics access per method has to grant this one.
+
+The same values are exposed per port through the
+`controlplane.ynpb.v1.CountersService/Ports` RPC, which reports every port
+from whichever instance is asked.


### PR DESCRIPTION
- A port counter describes the hardware it is read from, not a dataplane instance, but every gateway reported it alongside the metrics of the instance it serves, so a collector that identifies a series by the endpoint it scraped recorded one physical counter once per instance.
- Serve port counters from a service of their own, `controlplane.ynpb.v1.PortMetricsService`, which every gateway answers with the same values, so deduplication is a scrape-config choice and no gateway identity reaches a port series.
- Leave the instance-scoped metrics service to the worker counters, and leave the dataplane mirroring untouched, so any gateway can still answer when another is down.
- Document both endpoints and the label contract for port series.

Closes #2284.
