### PR TITLE
feat(devices,cli): show the pipeline bindings of plain and vlan devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,13 +3255,16 @@ name = "yanet-cli-device-plain"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "prost",
  "serde",
+ "tabled",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
+ "yanet-ynpb",
 ]
 
 [[package]]
@@ -3284,13 +3287,16 @@ name = "yanet-cli-device-vlan"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "prost",
  "serde",
+ "tabled",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
  "yanet-cli",
  "yanet-commonpb",
+ "yanet-ynpb",
 ]
 
 [[package]]

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -525,6 +525,17 @@ func (m *DPConfig) Devices() []DeviceInfo {
 	return out
 }
 
+// Device returns the device of the given type and name from the dataplane
+// registry, or false when none matches.
+func (m *DPConfig) Device(deviceType, name string) (DeviceInfo, bool) {
+	for _, device := range m.Devices() {
+		if device.Type == deviceType && device.Name == name {
+			return device, true
+		}
+	}
+	return DeviceInfo{}, false
+}
+
 type ModuleReference struct {
 	Device     string
 	Pipeline   string

--- a/devices/plain/cli/Cargo.toml
+++ b/devices/plain/cli/Cargo.toml
@@ -11,10 +11,13 @@ workspace = true
 
 [dependencies]
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
+ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.14"
 serde = { version = "1", features = ["derive"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi"] }
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -1,12 +1,20 @@
-use clap::{ArgAction, Parser};
+use std::borrow::Cow;
+
+use clap::{ArgAction, CommandFactory, Parser};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{Device, DevicePipeline};
-use plainpb::{UpdateDevicePlainRequest, device_plain_service_client::DevicePlainServiceClient};
+use plainpb::{
+    ShowDevicePlainRequest, UpdateDevicePlainRequest, device_plain_service_client::DevicePlainServiceClient,
+};
+use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    errors::Error,
+    completion, display,
+    errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
 };
+use ynpb::pb::{ListDevicesRequest, device_service_client::DeviceServiceClient};
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod plainpb {
@@ -34,8 +42,26 @@ pub struct Cmd {
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
+    /// Show the pipeline bindings of a device.
+    Show(ShowCmd),
     /// Create or replace a device.
     Update(UpdateCmd),
+}
+
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::Show(..) => "show",
+            Self::Update(..) => "update",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct ShowCmd {
+    /// Name of the device to show.
+    #[arg(add = ArgValueCandidates::new(device_candidates))]
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -54,13 +80,16 @@ pub struct UpdateCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "devices.plain.controlplane.plainpb.v1.DevicePlainService";
 
+/// Maps a genuine "device not found" status into a friendly message.
+const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "device");
+
 pub struct DevicePlainService {
     service: Service<DevicePlainServiceClient<LayeredChannel>>,
 }
 
 impl DevicePlainService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, "update", SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             DevicePlainServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
@@ -68,6 +97,47 @@ impl DevicePlainService {
         .await?;
 
         Ok(Self { service })
+    }
+
+    pub async fn show_device(&mut self, cmd: ShowCmd) -> Result<(), Error> {
+        let name = cmd.name;
+        let request = ShowDevicePlainRequest { name: name.clone() };
+
+        let response = self
+            .service
+            .client()
+            .show_device(request)
+            .await
+            .map_err(|status| {
+                NOT_FOUND.map(
+                    status,
+                    "show",
+                    self.service.endpoint(),
+                    Some(&format!("plain device '{name}'")),
+                )
+            })?
+            .into_inner();
+
+        output::data(
+            || &response,
+            || {
+                let rows = response.device.as_ref().map(binding_rows).unwrap_or_default();
+
+                if rows.is_empty() {
+                    output::empty_with_hint(
+                        format_args!("No pipeline bindings found for '{name}'."),
+                        format_args!(
+                            "bind one with 'yanet-cli device plain update -n <name> -i <pipeline:weight> -o <pipeline:weight>'"
+                        ),
+                    );
+                    return;
+                }
+
+                display::print_table_from_entries(rows);
+            },
+        );
+
+        Ok(())
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
@@ -89,13 +159,113 @@ impl DevicePlainService {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = DevicePlainService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = DevicePlainService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
+        ModeCmd::Show(cmd) => service.show_device(cmd).await,
         ModeCmd::Update(cmd) => service.update_config(cmd).await,
     }
 }
 
 fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+}
+
+/// One row of a device's pipeline bindings table.
+struct BindingRow {
+    direction: &'static str,
+    pipeline: String,
+    weight: u64,
+}
+
+impl Tabled for BindingRow {
+    const LENGTH: usize = 3;
+
+    fn fields(&self) -> Vec<Cow<'_, str>> {
+        vec![
+            Cow::Borrowed(self.direction),
+            Cow::Borrowed(self.pipeline.as_str()),
+            Cow::Owned(self.weight.to_string()),
+        ]
+    }
+
+    fn headers() -> Vec<Cow<'static, str>> {
+        vec![
+            Cow::Borrowed("DIRECTION"),
+            Cow::Borrowed("PIPELINE"),
+            Cow::Borrowed("WEIGHT"),
+        ]
+    }
+}
+
+/// Flattens a device's input and output pipeline bindings into rows sorted
+/// by direction, then pipeline name.
+fn binding_rows(device: &Device) -> Vec<BindingRow> {
+    let mut rows: Vec<BindingRow> = device
+        .input
+        .iter()
+        .map(|binding| BindingRow {
+            direction: "input",
+            pipeline: binding.name.clone(),
+            weight: binding.weight,
+        })
+        .chain(device.output.iter().map(|binding| BindingRow {
+            direction: "output",
+            pipeline: binding.name.clone(),
+            weight: binding.weight,
+        }))
+        .collect();
+
+    rows.sort_by(|a, b| a.direction.cmp(b.direction).then_with(|| a.pipeline.cmp(&b.pipeline)));
+
+    rows
+}
+
+/// Completion candidates for the device-name argument: the plain devices
+/// the device service currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn device_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(Cmd::command, device_client, async move |mut client| {
+        Ok(client
+            .list(ListDevicesRequest {})
+            .await?
+            .into_inner()
+            .ids
+            .into_iter()
+            .filter(|id| id.r#type == "plain")
+            .map(|id| id.name)
+            .collect())
+    })
+}
+
+fn device_client(channel: LayeredChannel) -> DeviceServiceClient<LayeredChannel> {
+    DeviceServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_binding_rows_sorts_by_direction_then_pipeline() {
+        let device = Device {
+            input: vec![
+                DevicePipeline { name: "b".to_string(), weight: 2 },
+                DevicePipeline { name: "a".to_string(), weight: 1 },
+            ],
+            output: vec![DevicePipeline { name: "a".to_string(), weight: 3 }],
+        };
+
+        let rows = binding_rows(&device);
+        let got: Vec<(&str, &str, u64)> = rows
+            .iter()
+            .map(|row| (row.direction, row.pipeline.as_str(), row.weight))
+            .collect();
+
+        assert_eq!(vec![("input", "a", 1), ("input", "b", 2), ("output", "a", 3)], got);
+    }
 }

--- a/devices/plain/controlplane/plainpb/v1/plain.proto
+++ b/devices/plain/controlplane/plainpb/v1/plain.proto
@@ -6,7 +6,12 @@ import "common/commonpb/v1/target.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1;plainpb";
 
-service DevicePlainService { rpc UpdateDevice(UpdateDevicePlainRequest) returns (UpdateDevicePlainResponse); }
+service DevicePlainService {
+  rpc UpdateDevice(UpdateDevicePlainRequest) returns (UpdateDevicePlainResponse);
+
+  // ShowDevice returns the pipeline bindings of the plain device with the given name.
+  rpc ShowDevice(ShowDevicePlainRequest) returns (ShowDevicePlainResponse);
+}
 
 message UpdateDevicePlainRequest {
   // Accepted range: at most 79 bytes.
@@ -15,3 +20,10 @@ message UpdateDevicePlainRequest {
 }
 
 message UpdateDevicePlainResponse {}
+
+message ShowDevicePlainRequest {
+  // Accepted range: at most 79 bytes.
+  string name = 1;
+}
+
+message ShowDevicePlainResponse { common.commonpb.v1.Device device = 1; }

--- a/devices/plain/controlplane/service.go
+++ b/devices/plain/controlplane/service.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
 )
@@ -81,6 +82,43 @@ func (m *DevicePlainService) UpdateDevice(
 	m.configs[name] = *deviceConfig
 
 	return &plainpb.UpdateDevicePlainResponse{}, nil
+}
+
+// ShowDevice returns the pipeline bindings of the plain device with the
+// given name, read from the dataplane's live device registry rather than
+// this service's in-memory state.
+func (m *DevicePlainService) ShowDevice(
+	ctx context.Context,
+	request *plainpb.ShowDevicePlainRequest,
+) (*plainpb.ShowDevicePlainResponse, error) {
+	name := request.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "device name is required")
+	}
+	if err := ffi.ValidateDeviceName(name); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	info, ok := m.agent.DPConfig().Device("plain", name)
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "plain device '%s' not found", name)
+	}
+
+	return &plainpb.ShowDevicePlainResponse{Device: deviceProto(info)}, nil
+}
+
+func deviceProto(info ffi.DeviceInfo) *commonpb.Device {
+	device := &commonpb.Device{
+		Input:  make([]*commonpb.DevicePipeline, len(info.InputPipelines)),
+		Output: make([]*commonpb.DevicePipeline, len(info.OutputPipelines)),
+	}
+	for idx, pipeline := range info.InputPipelines {
+		device.Input[idx] = &commonpb.DevicePipeline{Name: pipeline.Name, Weight: pipeline.Weight}
+	}
+	for idx, pipeline := range info.OutputPipelines {
+		device.Output[idx] = &commonpb.DevicePipeline{Name: pipeline.Name, Weight: pipeline.Weight}
+	}
+	return device
 }
 
 // parkOrFree frees the device when it is dangling and parks it for

--- a/devices/plain/controlplane/service_test.go
+++ b/devices/plain/controlplane/service_test.go
@@ -8,11 +8,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
+	vlan "github.com/yanet-platform/yanet2/devices/vlan/controlplane"
+	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )
 
 // Test_DevicePlainService_UpdateDevice_RejectsInvalidWeights verifies that model
@@ -171,6 +174,150 @@ func Test_DevicePlainService_UpdateDevice_AcceptsNameAtLimit(t *testing.T) {
 		Device: &commonpb.Device{},
 	})
 	require.NoError(t, err)
+}
+
+// Test_DevicePlainService_ShowDevice_RejectsInvalidName verifies that
+// ShowDevice rejects a name that is empty, contains an interior NUL, or
+// exceeds the C-side buffer, before the agent is ever touched.
+func Test_DevicePlainService_ShowDevice_RejectsInvalidName(t *testing.T) {
+	cases := []struct {
+		name       string
+		deviceName string
+	}{
+		{name: "empty name", deviceName: ""},
+		{name: "interior NUL", deviceName: "extra\x00keep"},
+		{name: "overlong name", deviceName: strings.Repeat("d", ffi.MaxDeviceNameLen)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			service := NewDevicePlainService(nil)
+
+			resp, err := service.ShowDevice(t.Context(), &plainpb.ShowDevicePlainRequest{Name: tc.deviceName})
+
+			require.Nil(t, resp)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// Test_DevicePlainService_ShowDevice_UnknownName verifies that ShowDevice
+// reports NotFound for a name absent from the dataplane device registry.
+func Test_DevicePlainService_ShowDevice_UnknownName(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	agent, err := shm.AgentAttach("plain", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	service := NewDevicePlainService(agent)
+
+	resp, err := service.ShowDevice(t.Context(), &plainpb.ShowDevicePlainRequest{Name: "absent"})
+
+	require.Nil(t, resp)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// Test_DevicePlainService_ShowDevice_ReportsLiveBindings verifies that
+// ShowDevice follows the latest published generation.
+//
+// The device is republished with a different binding set between two
+// reads, so the second read must report the replacement.
+func Test_DevicePlainService_ShowDevice_ReportsLiveBindings(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	agent, err := shm.AgentAttach("plain", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "p-in"}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "p-out"}))
+
+	service := NewDevicePlainService(agent)
+
+	_, err = service.UpdateDevice(t.Context(), &plainpb.UpdateDevicePlainRequest{
+		Name: "d0",
+		Device: &commonpb.Device{
+			Input:  []*commonpb.DevicePipeline{{Name: "p-in", Weight: 3}},
+			Output: []*commonpb.DevicePipeline{{Name: "p-out", Weight: 1}},
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := service.ShowDevice(t.Context(), &plainpb.ShowDevicePlainRequest{Name: "d0"})
+	require.NoError(t, err)
+	require.True(t, proto.Equal(&commonpb.Device{
+		Input:  []*commonpb.DevicePipeline{{Name: "p-in", Weight: 3}},
+		Output: []*commonpb.DevicePipeline{{Name: "p-out", Weight: 1}},
+	}, resp.GetDevice()))
+
+	_, err = service.UpdateDevice(t.Context(), &plainpb.UpdateDevicePlainRequest{
+		Name: "d0",
+		Device: &commonpb.Device{
+			Output: []*commonpb.DevicePipeline{{Name: "p-out", Weight: 5}},
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err = service.ShowDevice(t.Context(), &plainpb.ShowDevicePlainRequest{Name: "d0"})
+	require.NoError(t, err)
+	require.True(t, proto.Equal(&commonpb.Device{
+		Output: []*commonpb.DevicePipeline{{Name: "p-out", Weight: 5}},
+	}, resp.GetDevice()))
+}
+
+// Test_DevicePlainService_ShowDevice_IgnoresOtherDeviceTypes verifies that
+// ShowDevice reports NotFound for a name registered by a device of a
+// different type, exercising the registry type filter.
+func Test_DevicePlainService_ShowDevice_IgnoresOtherDeviceTypes(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		DevicesToLoad: []string{"plain", "vlan"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+
+	vlanAgent, err := shm.AgentAttach("vlan", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = vlanAgent.CleanUp() })
+
+	_, err = vlan.NewDeviceVlanService(vlanAgent).UpdateDevice(t.Context(), &vlanpb.UpdateDeviceVlanRequest{
+		Name:   "v0",
+		Device: &commonpb.Device{},
+		Vlan:   100,
+	})
+	require.NoError(t, err)
+
+	plainAgent, err := shm.AgentAttach("plain", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = plainAgent.CleanUp() })
+
+	service := NewDevicePlainService(plainAgent)
+
+	resp, err := service.ShowDevice(t.Context(), &plainpb.ShowDevicePlainRequest{Name: "v0"})
+
+	require.Nil(t, resp)
+	require.Equal(t, codes.NotFound, status.Code(err))
 }
 
 // freeBytesForAgent returns the free byte count reported for the named

--- a/devices/vlan/api/controlplane.c
+++ b/devices/vlan/api/controlplane.c
@@ -66,6 +66,35 @@ cp_device_vlan_free(struct cp_device *cp_device, yanet_error **err) {
 	return 0;
 }
 
+int
+cp_device_vlan_get_vlan(
+	struct agent *agent, const char *name, uint16_t *vlan, yanet_error **err
+) {
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+	cp_config_lock(cp_config);
+
+	struct cp_config_gen *cp_config_gen =
+		ADDR_OF(&cp_config->cp_config_gen);
+	struct cp_device *cp_device = cp_device_registry_lookup(
+		&cp_config_gen->device_registry, "vlan", name
+	);
+	if (cp_device == NULL) {
+		yanet_error_add_kind(
+			err,
+			YANET_ERROR_NOT_FOUND,
+			"vlan device '%s' not found",
+			name
+		);
+		cp_config_unlock(cp_config);
+		return -1;
+	}
+
+	*vlan = container_of(cp_device, struct cp_device_vlan, cp_device)->vlan;
+
+	cp_config_unlock(cp_config);
+	return 0;
+}
+
 struct cp_device_vlan_config *
 cp_device_vlan_config_new(
 	const char *name,

--- a/devices/vlan/api/controlplane.h
+++ b/devices/vlan/api/controlplane.h
@@ -27,6 +27,16 @@ cp_device_vlan_new(
 int
 cp_device_vlan_free(struct cp_device *cp_device, yanet_error **err);
 
+// Read the vlan id of the live vlan device with the given name from
+// the active configuration generation.
+//
+// Returns 0 after storing the id, -1 with a not-found error when no
+// vlan device goes by that name.
+int
+cp_device_vlan_get_vlan(
+	struct agent *agent, const char *name, uint16_t *vlan, yanet_error **err
+);
+
 struct cp_device_vlan_config *
 cp_device_vlan_config_new(
 	const char *name,

--- a/devices/vlan/cli/Cargo.toml
+++ b/devices/vlan/cli/Cargo.toml
@@ -11,10 +11,13 @@ workspace = true
 
 [dependencies]
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
+ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.14"
 serde = { version = "1", features = ["derive"] }
+tabled = { version = "0.21", default-features = false, features = ["ansi"] }
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -1,12 +1,18 @@
-use clap::{ArgAction, Parser, value_parser};
+use std::borrow::Cow;
+
+use clap::{ArgAction, CommandFactory, Parser, value_parser};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{Device, DevicePipeline};
+use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
-use vlanpb::{UpdateDeviceVlanRequest, device_vlan_service_client::DeviceVlanServiceClient};
+use vlanpb::{ShowDeviceVlanRequest, UpdateDeviceVlanRequest, device_vlan_service_client::DeviceVlanServiceClient};
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    errors::Error,
+    completion, display,
+    errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
 };
+use ynpb::pb::{ListDevicesRequest, device_service_client::DeviceServiceClient};
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod vlanpb {
@@ -34,8 +40,26 @@ pub struct Cmd {
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
+    /// Show the pipeline bindings and the vlan id of a device.
+    Show(ShowCmd),
     /// Create or replace a device.
     Update(UpdateCmd),
+}
+
+impl ModeCmd {
+    fn action(&self) -> &'static str {
+        match self {
+            Self::Show(..) => "show",
+            Self::Update(..) => "update",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct ShowCmd {
+    /// Name of the device to show.
+    #[arg(add = ArgValueCandidates::new(device_candidates))]
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -57,13 +81,16 @@ pub struct UpdateCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "devices.vlan.controlplane.vlanpb.v1.DeviceVlanService";
 
+/// Maps a genuine "device not found" status into a friendly message.
+const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "device");
+
 pub struct DeviceVlanService {
     service: Service<DeviceVlanServiceClient<LayeredChannel>>,
 }
 
 impl DeviceVlanService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, "update", SERVICE_NAME, |channel| {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
+        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
             DeviceVlanServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
@@ -71,6 +98,53 @@ impl DeviceVlanService {
         .await?;
 
         Ok(Self { service })
+    }
+
+    pub async fn show_device(&mut self, cmd: ShowCmd) -> Result<(), Error> {
+        let name = cmd.name;
+        let request = ShowDeviceVlanRequest { name: name.clone() };
+
+        let response = self
+            .service
+            .client()
+            .show_device(request)
+            .await
+            .map_err(|status| {
+                NOT_FOUND.map(
+                    status,
+                    "show",
+                    self.service.endpoint(),
+                    Some(&format!("vlan device '{name}'")),
+                )
+            })?
+            .into_inner();
+
+        output::data(
+            || &response,
+            || {
+                let rows = response.device.as_ref().map(binding_rows).unwrap_or_default();
+
+                if output::is_colored() {
+                    println!("{}: {}", output::paint_bold("VLAN"), response.vlan);
+                } else {
+                    println!("VLAN: {}", response.vlan);
+                }
+
+                if rows.is_empty() {
+                    output::empty_with_hint(
+                        format_args!("No pipeline bindings found for '{name}'."),
+                        format_args!(
+                            "bind one with 'yanet-cli device vlan update -n <name> -i <pipeline:weight> -o <pipeline:weight> --vlan <id>'"
+                        ),
+                    );
+                    return;
+                }
+
+                display::print_table_from_entries(rows);
+            },
+        );
+
+        Ok(())
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
@@ -93,15 +167,91 @@ impl DeviceVlanService {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = DeviceVlanService::new(&cmd.connection).await?;
+    let action = cmd.mode.action();
+    let mut service = DeviceVlanService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
+        ModeCmd::Show(cmd) => service.show_device(cmd).await,
         ModeCmd::Update(cmd) => service.update_config(cmd).await,
     }
 }
 
 fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+}
+
+/// One row of a device's pipeline bindings table.
+struct BindingRow {
+    direction: &'static str,
+    pipeline: String,
+    weight: u64,
+}
+
+impl Tabled for BindingRow {
+    const LENGTH: usize = 3;
+
+    fn fields(&self) -> Vec<Cow<'_, str>> {
+        vec![
+            Cow::Borrowed(self.direction),
+            Cow::Borrowed(self.pipeline.as_str()),
+            Cow::Owned(self.weight.to_string()),
+        ]
+    }
+
+    fn headers() -> Vec<Cow<'static, str>> {
+        vec![
+            Cow::Borrowed("DIRECTION"),
+            Cow::Borrowed("PIPELINE"),
+            Cow::Borrowed("WEIGHT"),
+        ]
+    }
+}
+
+/// Flattens a device's input and output pipeline bindings into rows sorted
+/// by direction, then pipeline name.
+fn binding_rows(device: &Device) -> Vec<BindingRow> {
+    let mut rows: Vec<BindingRow> = device
+        .input
+        .iter()
+        .map(|binding| BindingRow {
+            direction: "input",
+            pipeline: binding.name.clone(),
+            weight: binding.weight,
+        })
+        .chain(device.output.iter().map(|binding| BindingRow {
+            direction: "output",
+            pipeline: binding.name.clone(),
+            weight: binding.weight,
+        }))
+        .collect();
+
+    rows.sort_by(|a, b| a.direction.cmp(b.direction).then_with(|| a.pipeline.cmp(&b.pipeline)));
+
+    rows
+}
+
+/// Completion candidates for the device-name argument: the vlan devices the
+/// device service currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn device_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(Cmd::command, device_client, async move |mut client| {
+        Ok(client
+            .list(ListDevicesRequest {})
+            .await?
+            .into_inner()
+            .ids
+            .into_iter()
+            .filter(|id| id.r#type == "vlan")
+            .map(|id| id.name)
+            .collect())
+    })
+}
+
+fn device_client(channel: LayeredChannel) -> DeviceServiceClient<LayeredChannel> {
+    DeviceServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
 }
 
 #[cfg(test)]
@@ -128,7 +278,9 @@ mod test {
     fn test_update_vlan_accepts_range_boundaries() {
         for (arg, expected) in [("0", 0), ("4094", 4094)] {
             let cmd = Cmd::try_parse_from(["yanet-cli-device-vlan", "update", "-n", "x", "--vlan", arg]).unwrap();
-            let ModeCmd::Update(update) = cmd.mode;
+            let ModeCmd::Update(update) = cmd.mode else {
+                panic!("expected ModeCmd::Update");
+            };
 
             assert_eq!(expected, update.vlan);
         }
@@ -139,5 +291,24 @@ mod test {
         let err = Cmd::try_parse_from(["yanet-cli-device-vlan", "update", "-n", "x", "--vlan", "4095"]).unwrap_err();
 
         assert_eq!(ErrorKind::ValueValidation, err.kind());
+    }
+
+    #[test]
+    fn test_binding_rows_sorts_by_direction_then_pipeline() {
+        let device = Device {
+            input: vec![
+                DevicePipeline { name: "b".to_string(), weight: 2 },
+                DevicePipeline { name: "a".to_string(), weight: 1 },
+            ],
+            output: vec![DevicePipeline { name: "a".to_string(), weight: 3 }],
+        };
+
+        let rows = binding_rows(&device);
+        let got: Vec<(&str, &str, u64)> = rows
+            .iter()
+            .map(|row| (row.direction, row.pipeline.as_str(), row.weight))
+            .collect();
+
+        assert_eq!(vec![("input", "a", 1), ("input", "b", 2), ("output", "a", 3)], got);
     }
 }

--- a/devices/vlan/controlplane/ffi.go
+++ b/devices/vlan/controlplane/ffi.go
@@ -84,6 +84,28 @@ func NewDeviceConfig(
 	}, nil
 }
 
+// LookupVlan returns the vlan id of the live vlan device with the given
+// name.
+//
+// A name with no vlan device reports ffi.ErrNotFound.
+func LookupVlan(agent *ffi.Agent, name string) (uint16, error) {
+	if agent == nil {
+		return 0, fmt.Errorf("agent cannot be nil")
+	}
+
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var cVlan C.uint16_t
+	var cErr *C.struct_yanet_error
+	rc := C.cp_device_vlan_get_vlan((*C.struct_agent)(agent.AsRawPtr()), cName, &cVlan, &cErr)
+	if rc != 0 {
+		return 0, fmt.Errorf("failed to look up vlan device: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	}
+
+	return uint16(cVlan), nil
+}
+
 func (m *DeviceConfig) asRawPtr() *C.struct_cp_device {
 	return (*C.struct_cp_device)(m.ptr.AsRawPtr())
 }

--- a/devices/vlan/controlplane/service.go
+++ b/devices/vlan/controlplane/service.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )
@@ -93,6 +94,54 @@ func (m *DeviceVlanService) UpdateDevice(
 	m.configs[name] = *deviceConfig
 
 	return &vlanpb.UpdateDeviceVlanResponse{}, nil
+}
+
+// ShowDevice returns the pipeline bindings and vlan id of the vlan device
+// with the given name, read from the dataplane's live device registry
+// rather than this service's in-memory state.
+func (m *DeviceVlanService) ShowDevice(
+	ctx context.Context,
+	request *vlanpb.ShowDeviceVlanRequest,
+) (*vlanpb.ShowDeviceVlanResponse, error) {
+	name := request.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "device name is required")
+	}
+	if err := ffi.ValidateDeviceName(name); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	vlan, err := LookupVlan(m.agent, name)
+	if err != nil {
+		if errors.Is(err, ffi.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	// The bindings come from a second registry read, so a device deleted
+	// in between reports not found and one replaced in between pairs the
+	// id above with the replacement's bindings.
+	info, ok := m.agent.DPConfig().Device("vlan", name)
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "vlan device '%s' not found", name)
+	}
+
+	return &vlanpb.ShowDeviceVlanResponse{Device: deviceProto(info), Vlan: uint32(vlan)}, nil
+}
+
+func deviceProto(info ffi.DeviceInfo) *commonpb.Device {
+	device := &commonpb.Device{
+		Input:  make([]*commonpb.DevicePipeline, len(info.InputPipelines)),
+		Output: make([]*commonpb.DevicePipeline, len(info.OutputPipelines)),
+	}
+	for idx, pipeline := range info.InputPipelines {
+		device.Input[idx] = &commonpb.DevicePipeline{Name: pipeline.Name, Weight: pipeline.Weight}
+	}
+	for idx, pipeline := range info.OutputPipelines {
+		device.Output[idx] = &commonpb.DevicePipeline{Name: pipeline.Name, Weight: pipeline.Weight}
+	}
+	return device
 }
 
 // parkOrFree frees the device when it is dangling and parks it for

--- a/devices/vlan/controlplane/service_test.go
+++ b/devices/vlan/controlplane/service_test.go
@@ -8,10 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	plain "github.com/yanet-platform/yanet2/devices/plain/controlplane"
+	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
 	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )
 
@@ -138,6 +141,153 @@ func Test_DeviceVlanService_UpdateDevice_AcceptsNameAtLimit(t *testing.T) {
 		Vlan:   100,
 	})
 	require.NoError(t, err)
+}
+
+// Test_DeviceVlanService_ShowDevice_RejectsInvalidName verifies that
+// ShowDevice rejects a name that is empty, contains an interior NUL, or
+// exceeds the C-side buffer, before the agent is ever touched.
+func Test_DeviceVlanService_ShowDevice_RejectsInvalidName(t *testing.T) {
+	cases := []struct {
+		name       string
+		deviceName string
+	}{
+		{name: "empty name", deviceName: ""},
+		{name: "interior NUL", deviceName: "extra\x00keep"},
+		{name: "overlong name", deviceName: strings.Repeat("d", ffi.MaxDeviceNameLen)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			service := NewDeviceVlanService(nil)
+
+			resp, err := service.ShowDevice(t.Context(), &vlanpb.ShowDeviceVlanRequest{Name: tc.deviceName})
+
+			require.Nil(t, resp)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// Test_DeviceVlanService_ShowDevice_UnknownName verifies that ShowDevice
+// reports NotFound for a name absent from the dataplane device registry.
+func Test_DeviceVlanService_ShowDevice_UnknownName(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		DevicesToLoad: []string{"vlan"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	agent, err := shm.AgentAttach("vlan", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	service := NewDeviceVlanService(agent)
+
+	resp, err := service.ShowDevice(t.Context(), &vlanpb.ShowDeviceVlanRequest{Name: "absent"})
+
+	require.Nil(t, resp)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// Test_DeviceVlanService_ShowDevice_ReportsVlanAndBindings verifies that
+// ShowDevice follows the latest published generation.
+//
+// The device is republished with a different vlan id and binding set
+// between two reads, so the second read must report the replacement.
+func Test_DeviceVlanService_ShowDevice_ReportsVlanAndBindings(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		DevicesToLoad: []string{"vlan"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	agent, err := shm.AgentAttach("vlan", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "p-in"}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "p-out"}))
+
+	service := NewDeviceVlanService(agent)
+
+	_, err = service.UpdateDevice(t.Context(), &vlanpb.UpdateDeviceVlanRequest{
+		Name: "d0",
+		Device: &commonpb.Device{
+			Input:  []*commonpb.DevicePipeline{{Name: "p-in", Weight: 3}},
+			Output: []*commonpb.DevicePipeline{{Name: "p-out", Weight: 1}},
+		},
+		Vlan: 100,
+	})
+	require.NoError(t, err)
+
+	resp, err := service.ShowDevice(t.Context(), &vlanpb.ShowDeviceVlanRequest{Name: "d0"})
+	require.NoError(t, err)
+	require.Equal(t, uint32(100), resp.GetVlan())
+	require.True(t, proto.Equal(&commonpb.Device{
+		Input:  []*commonpb.DevicePipeline{{Name: "p-in", Weight: 3}},
+		Output: []*commonpb.DevicePipeline{{Name: "p-out", Weight: 1}},
+	}, resp.GetDevice()))
+
+	_, err = service.UpdateDevice(t.Context(), &vlanpb.UpdateDeviceVlanRequest{
+		Name: "d0",
+		Device: &commonpb.Device{
+			Output: []*commonpb.DevicePipeline{{Name: "p-out", Weight: 5}},
+		},
+		Vlan: 200,
+	})
+	require.NoError(t, err)
+
+	resp, err = service.ShowDevice(t.Context(), &vlanpb.ShowDeviceVlanRequest{Name: "d0"})
+	require.NoError(t, err)
+	require.Equal(t, uint32(200), resp.GetVlan())
+	require.True(t, proto.Equal(&commonpb.Device{
+		Output: []*commonpb.DevicePipeline{{Name: "p-out", Weight: 5}},
+	}, resp.GetDevice()))
+}
+
+// Test_DeviceVlanService_ShowDevice_IgnoresOtherDeviceTypes verifies that
+// ShowDevice reports NotFound for a name registered by a device of a
+// different type, exercising the C reader's type filter.
+func Test_DeviceVlanService_ShowDevice_IgnoresOtherDeviceTypes(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		DevicesToLoad: []string{"plain", "vlan"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+
+	plainAgent, err := shm.AgentAttach("plain", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = plainAgent.CleanUp() })
+
+	_, err = plain.NewDevicePlainService(plainAgent).UpdateDevice(t.Context(), &plainpb.UpdateDevicePlainRequest{
+		Name:   "p0",
+		Device: &commonpb.Device{},
+	})
+	require.NoError(t, err)
+
+	vlanAgent, err := shm.AgentAttach("vlan", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = vlanAgent.CleanUp() })
+
+	service := NewDeviceVlanService(vlanAgent)
+
+	resp, err := service.ShowDevice(t.Context(), &vlanpb.ShowDeviceVlanRequest{Name: "p0"})
+
+	require.Nil(t, resp)
+	require.Equal(t, codes.NotFound, status.Code(err))
 }
 
 // freeBytesForAgent returns the free byte count reported for the named

--- a/devices/vlan/controlplane/vlanpb/v1/vlan.proto
+++ b/devices/vlan/controlplane/vlanpb/v1/vlan.proto
@@ -6,7 +6,12 @@ import "common/commonpb/v1/target.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1;vlanpb";
 
-service DeviceVlanService { rpc UpdateDevice(UpdateDeviceVlanRequest) returns (UpdateDeviceVlanResponse); }
+service DeviceVlanService {
+  rpc UpdateDevice(UpdateDeviceVlanRequest) returns (UpdateDeviceVlanResponse);
+
+  // ShowDevice returns the pipeline bindings and the vlan id of the vlan device with the given name.
+  rpc ShowDevice(ShowDeviceVlanRequest) returns (ShowDeviceVlanResponse);
+}
 
 message UpdateDeviceVlanRequest {
   // Accepted range: at most 79 bytes.
@@ -17,3 +22,13 @@ message UpdateDeviceVlanRequest {
 }
 
 message UpdateDeviceVlanResponse {}
+
+message ShowDeviceVlanRequest {
+  // Accepted range: at most 79 bytes.
+  string name = 1;
+}
+
+message ShowDeviceVlanResponse {
+  common.commonpb.v1.Device device = 1;
+  uint32 vlan = 2;
+}


### PR DESCRIPTION
- Adds a `ShowDevice` RPC to `DevicePlainService` and `DeviceVlanService` returning the device's input and output pipeline bindings with weights, plus the vlan id for vlan devices.
- Adds `yanet-cli device plain show <NAME>` and `yanet-cli device vlan show <NAME>`: a DIRECTION/PIPELINE/WEIGHT table (vlan prints its id first), the wire message under `--format json`, exit 3 for a missing device, name completion from the common device list.
- The read path is the dataplane's shared-memory device registry, the same source `device list` and `inspect` use, not the service's in-memory map, so the answer stays correct after a control-plane restart and for devices published by the YAML bootstrap.
- The vlan id is read by a new `cp_device_vlan_get_vlan` in the vlan C API under the configuration lock; the bindings come from a second registry read, so a device replaced between the two reads pairs the id with the replacement's bindings, accepted for a read-only view instead of a combined C reader.
- The RPC lives on each device service rather than on the common `ynpb.DeviceService` because the vlan id is type-specific and the CLI surface is per type.
- Completion for the positional name queries `ynpb.DeviceService.List` filtered by type, since the device services have no list RPC of their own.
- Go tests cover name validation, not found, live bindings after a replacement and the type filter through the in-process dataplane harness; the CLI tests only its row flattening, per the CLI test policy.
- Closes #2363.
