### PR TITLE
feat(cli): add unary call and not-found mapping helpers to ync

### DIFF
--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -51,8 +51,9 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   `cmd.connection.endpoint` itself. A pre-connect error label comes from
   `client::resolve_label`, a post-connect one from `Service::endpoint()` /
   `Connection::endpoint()`.
-- Every RPC: `self.service.client().<rpc>(request).await
-  .map_err(self.service.status("<verb>"))?.into_inner()`.
+- Every RPC: `self.service.unary("<verb>", request, async |client, request|
+  client.<rpc>(request).await).await?`; a mapper other than `status` goes
+  through `unary_with("<verb>", request, mapper, call)`.
 - Generated code: `#[allow(clippy::std_instead_of_core, non_snake_case)]
   pub mod <x>pb { tonic::include_proto!("…"); }`; shared protos come
   through `extern_path` to `::commonpb::pb`.
@@ -153,9 +154,9 @@ no `--yes`, no `--dry-run`.
   "not ready" is legacy until #2354).
 - A local rejection is `self.service.invalid("<verb>", message)` or
   `Error::invalid_argument(verb, endpoint, message)`; a command addressing an
-  existing object maps its status through `NotFoundMapper::new(SERVICE_NAME,
-  "<resource>")` and `.map(status, verb, endpoint, resource)`, so a missing
-  object reads `<resource> not found` and exits 3. Hints via `.with_hint(…)`.
+  existing object passes `self.service.not_found("<verb>", "<resource>")` as
+  the mapper of `unary_with`, so a missing object reads `<resource> not found`
+  and exits 3. Hints via `.with_hint(…)`.
 
 ## Tests
 

--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -51,11 +51,12 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   `cmd.connection.endpoint` itself. A pre-connect error label comes from
   `client::resolve_label`, a post-connect one from `Service::endpoint()` /
   `Connection::endpoint()`.
-- Every unary RPC: `self.service.unary("<verb>", request, async |client,
-  request| client.<rpc>(request).await).await?`; a mapper other than
-  `status` goes through `unary_with("<verb>", request, mapper, call)`. A
-  streaming RPC keeps `self.service.client().<rpc>(request).await
-  .map_err(self.service.status("<verb>"))?.into_inner()`.
+- Every unary RPC of a command handler: `self.service.unary("<verb>",
+  request, async |client, request| client.<rpc>(request).await).await?`; a
+  mapper other than `status` goes through `unary_with("<verb>", request,
+  mapper, call)`. A streaming RPC keeps `self.service.client().<rpc>(request)
+  .await.map_err(self.service.status("<verb>"))?.into_inner()`, and a
+  completion lookup calls the raw client it is handed.
 - Generated code: `#[allow(clippy::std_instead_of_core, non_snake_case)]
   pub mod <x>pb { tonic::include_proto!("…"); }`; shared protos come
   through `extern_path` to `::commonpb::pb`.

--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -51,9 +51,11 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   `cmd.connection.endpoint` itself. A pre-connect error label comes from
   `client::resolve_label`, a post-connect one from `Service::endpoint()` /
   `Connection::endpoint()`.
-- Every RPC: `self.service.unary("<verb>", request, async |client, request|
-  client.<rpc>(request).await).await?`; a mapper other than `status` goes
-  through `unary_with("<verb>", request, mapper, call)`.
+- Every unary RPC: `self.service.unary("<verb>", request, async |client,
+  request| client.<rpc>(request).await).await?`; a mapper other than
+  `status` goes through `unary_with("<verb>", request, mapper, call)`. A
+  streaming RPC keeps `self.service.client().<rpc>(request).await
+  .map_err(self.service.status("<verb>"))?.into_inner()`.
 - Generated code: `#[allow(clippy::std_instead_of_core, non_snake_case)]
   pub mod <x>pb { tonic::include_proto!("…"); }`; shared protos come
   through `extern_path` to `::commonpb::pb`.

--- a/.agents/skills/code-cli/references/new-crate.md
+++ b/.agents/skills/code-cli/references/new-crate.md
@@ -103,7 +103,7 @@ use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
     display::print_table_from_entries,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
 };
 
@@ -119,9 +119,6 @@ pub mod <x>pb {
 
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "<proto package>.<X>Service";
-
-/// Maps a genuine "config not found" status into a friendly message.
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "config");
 
 fn client(channel: LayeredChannel) -> <X>ServiceClient<LayeredChannel> {
     <X>ServiceClient::new(channel)
@@ -223,11 +220,10 @@ impl <X>Service {
     pub async fn list_configs(&mut self) -> Result<(), Error> {
         let response = self
             .service
-            .client()
-            .list_configs(ListConfigsRequest {})
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -254,11 +250,13 @@ impl <X>Service {
 
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(|status| NOT_FOUND.map(status, "show", self.service.endpoint(), Some(&cmd.config_name)))?
-            .into_inner();
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
+            .await?;
 
         output::data(
             || &response,
@@ -278,10 +276,8 @@ impl <X>Service {
         };
 
         self.service
-            .client()
-            .update_config(request)
-            .await
-            .map_err(self.service.status("update"))?;
+            .unary("update", request, async |client, request| client.update_config(request).await)
+            .await?;
 
         output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
@@ -292,10 +288,13 @@ impl <X>Service {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
 
         self.service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(|status| NOT_FOUND.map(status, "delete", self.service.endpoint(), Some(&cmd.config_name)))?;
+            .unary_with(
+                "delete",
+                request,
+                self.service.not_found("delete", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.delete_config(request).await,
+            )
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 

--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -21,7 +21,7 @@
 //!     .accept_compressed(CompressionEncoding::Gzip);
 //! ```
 
-use core::time::Duration;
+use core::{fmt::Debug, time::Duration};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -30,7 +30,7 @@ use std::{
 use http::{Uri, uri::PathAndQuery};
 use prost::Message;
 use tonic::{
-    Request, Status,
+    Request, Response, Status,
     client::Grpc,
     codec::CompressionEncoding,
     transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity},
@@ -41,7 +41,7 @@ use tower::Layer;
 use crate::{
     auth::{self, AuthArgs, interceptor::AuthService},
     config::{self, Settings},
-    errors::{Error, root_cause},
+    errors::{Error, map_not_found, root_cause},
     timeout::{TimeoutLayer, TimeoutService},
 };
 
@@ -537,6 +537,58 @@ impl<C> Service<C> {
             self.name,
         )
     }
+
+    /// Issues one unary RPC, mapping a failure through
+    /// [`status`](Service::status) under `action`.
+    ///
+    /// The request and the unwrapped response are logged at trace and debug.
+    pub async fn unary<Req, Resp, Call>(
+        &mut self,
+        action: &'static str,
+        request: Req,
+        call: Call,
+    ) -> Result<Resp, Error>
+    where
+        Req: Debug,
+        Resp: Debug,
+        Call: AsyncFnOnce(&mut C, Req) -> Result<Response<Resp>, Status>,
+    {
+        let map = self.status(action);
+
+        self.unary_with(action, request, map, call).await
+    }
+
+    /// [`unary`](Service::unary) with an explicit status mapper, such as
+    /// [`not_found`](Service::not_found).
+    pub async fn unary_with<Req, Resp, Map, Call>(
+        &mut self,
+        action: &'static str,
+        request: Req,
+        map: Map,
+        call: Call,
+    ) -> Result<Resp, Error>
+    where
+        Req: Debug,
+        Resp: Debug,
+        Map: FnOnce(Status) -> Error,
+        Call: AsyncFnOnce(&mut C, Req) -> Result<Response<Resp>, Status>,
+    {
+        log::trace!("{action} request: {request:?}");
+        let response = call(&mut self.client, request).await.map_err(map)?.into_inner();
+        log::debug!("{action} response: {response:?}");
+
+        Ok(response)
+    }
+
+    /// A closure mapping a gRPC [`Status`] to an [`Error`] that reads a genuine
+    /// resource `NotFound` as `<resource> not found`.
+    pub fn not_found(&self, action: &'static str, resource: &str) -> impl FnOnce(Status) -> Error + use<C> {
+        let endpoint = self.endpoint.clone();
+        let name = self.name;
+        let resource = resource.to_owned();
+
+        move |status| map_not_found(status, action, endpoint, name, &resource)
+    }
 }
 
 /// Invoke a unary RPC on an arbitrary gRPC service by its fully-qualified
@@ -603,7 +655,8 @@ mod test {
     use tokio::task::JoinHandle;
     use tokio_stream::wrappers::TcpListenerStream;
     use tonic::{
-        Status,
+        Code, Response, Status,
+        metadata::MetadataMap,
         transport::{Certificate, Identity, Server, ServerTlsConfig},
     };
     use tonic_health::pb::{HealthCheckRequest, health_client::HealthClient};
@@ -893,5 +946,70 @@ mod test {
         let service = Service::from_parts((), "grpc://[::1]:8080", "test.Service");
 
         assert_eq!("grpc://[::1]:8080", service.endpoint());
+    }
+
+    #[tokio::test]
+    async fn test_unary_unwraps_the_response() {
+        let mut service = Service::from_parts((), "grpc://[::1]:8080", "test.Service");
+
+        let doubled = service
+            .unary("show", 21u8, async |_, request| Ok(Response::new(request * 2)))
+            .await
+            .unwrap();
+
+        assert_eq!(42, doubled);
+    }
+
+    #[tokio::test]
+    async fn test_unary_maps_a_status_under_the_action() {
+        let mut service = Service::from_parts((), "grpc://[::1]:8080", "test.Service");
+
+        let err = service
+            .unary("show", (), async |_, ()| {
+                Err::<Response<()>, _>(Status::unavailable("down"))
+            })
+            .await
+            .unwrap_err();
+
+        assert_eq!(ErrorKind::Unavailable, err.kind());
+        assert_eq!("show", err.action);
+    }
+
+    #[tokio::test]
+    async fn test_unary_with_uses_the_given_mapper() {
+        let mut service = Service::from_parts((), "grpc://[::1]:8080", "test.Service");
+        let not_found = service.not_found("show", "config 'x'");
+
+        let err = service
+            .unary_with("show", (), not_found, async |_, ()| {
+                Err::<Response<()>, _>(Status::not_found("missing"))
+            })
+            .await
+            .unwrap_err();
+
+        assert_eq!(ErrorKind::NotFound, err.kind());
+        assert_eq!("config 'x' not found", err.message());
+    }
+
+    #[test]
+    fn test_not_found_passes_other_statuses_through() {
+        let service = Service::from_parts((), "grpc://[::1]:8080", "test.Service");
+
+        let err = (service.not_found("show", "config 'x'"))(Status::unavailable("down"));
+
+        assert_eq!(ErrorKind::Unavailable, err.kind());
+        assert_eq!("down", err.message());
+    }
+
+    #[test]
+    fn test_not_found_passes_a_registry_miss_through() {
+        let service = Service::from_parts((), "grpc://[::1]:8080", "test.Service");
+        let mut metadata = MetadataMap::new();
+        metadata.insert("x-yanet-error-reason", "service-unregistered".parse().unwrap());
+        let status = Status::with_metadata(Code::NotFound, "unknown service test.Service", metadata);
+
+        let err = (service.not_found("show", "config 'x'"))(status);
+
+        assert_eq!(ErrorKind::ServiceUnregistered, err.kind());
     }
 }

--- a/cli/core/src/errors.rs
+++ b/cli/core/src/errors.rs
@@ -379,19 +379,35 @@ impl NotFoundMapper {
         endpoint: impl Into<String>,
         resource: Option<&str>,
     ) -> Error {
-        if status.code() == Code::NotFound && !is_unknown_service_status(&status) {
-            let resource = resource.unwrap_or(self.default_resource);
-
-            return Error::from_status(
-                Status::not_found(format!("{resource} not found")),
-                action,
-                endpoint,
-                self.service,
-            );
-        }
-
-        Error::from_status(status, action, endpoint, self.service)
+        map_not_found(
+            status,
+            action,
+            endpoint,
+            self.service,
+            resource.unwrap_or(self.default_resource),
+        )
     }
+}
+
+/// Maps `status` to an [`Error`] for `service`, rewriting a genuine resource
+/// `NotFound` into `<resource> not found` and passing the rest through.
+pub(crate) fn map_not_found(
+    status: Status,
+    action: impl Into<String>,
+    endpoint: impl Into<String>,
+    service: &'static str,
+    resource: &str,
+) -> Error {
+    if status.code() == Code::NotFound && !is_unknown_service_status(&status) {
+        return Error::from_status(
+            Status::not_found(format!("{resource} not found")),
+            action,
+            endpoint,
+            service,
+        );
+    }
+
+    Error::from_status(status, action, endpoint, service)
 }
 
 #[cfg(test)]

--- a/cli/core/src/errors.rs
+++ b/cli/core/src/errors.rs
@@ -391,7 +391,7 @@ impl NotFoundMapper {
 
 /// Maps `status` to an [`Error`] for `service`, rewriting a genuine resource
 /// `NotFound` into `<resource> not found` and passing the rest through.
-pub(crate) fn map_not_found(
+pub fn map_not_found(
     status: Status,
     action: impl Into<String>,
     endpoint: impl Into<String>,


### PR DESCRIPTION
- Adds Service::unary and Service::unary_with, which issue one unary RPC, log the request and the response and map a failed status to the CLI error.
- Adds Service::not_found, a status mapper that reads a genuine resource NotFound as "<resource> not found" without threading the endpoint by hand.
- Extracts the NotFound rewrite behind NotFoundMapper::map into one shared function so both paths stay identical.
- Describes the new idiom in the code-cli skill and its new-crate skeleton.
- First step of the CLI decomposition plan, existing callers migrate in the following PRs.