### PR TITLE
refactor(cli): route the small config clis through the unary helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,7 +3178,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "log",
  "prost",
  "serde",
  "tonic",
@@ -3216,7 +3215,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "log",
  "netip",
  "prost",
  "ptree",
@@ -3305,7 +3303,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "log",
  "netip",
  "prost",
  "ptree",
@@ -3442,7 +3439,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "log",
  "netip",
  "prost",
  "ptree",
@@ -3593,7 +3589,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "log",
  "prost",
  "serde",
  "serde_yaml",

--- a/modules/blackhole/cli/Cargo.toml
+++ b/modules/blackhole/cli/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
-log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.14"

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -117,16 +117,12 @@ impl BlackholeService {
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let request = ListConfigsRequest {};
-        log::trace!("list configs request: {request:?}");
         let response = self
             .service
-            .client()
-            .list_configs(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
-        log::debug!("list configs response: {response:?}");
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -150,15 +146,12 @@ impl BlackholeService {
 
     pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
-        log::trace!("show config request: {request:?}");
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
-        log::debug!("show config response: {response:?}");
+            .unary("show", request, async |client, request| {
+                client.show_config(request).await
+            })
+            .await?;
 
         output::data(
             || &response,
@@ -172,15 +165,11 @@ impl BlackholeService {
 
     pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Error> {
         let request = UpdateConfigRequest { name: cmd.config_name.clone() };
-        log::trace!("update config request: {request:?}");
-        let response = self
-            .service
-            .client()
-            .update_config(request)
-            .await
-            .map_err(self.service.status("update"))?
-            .into_inner();
-        log::debug!("update config response: {response:?}");
+        self.service
+            .unary("update", request, async |client, request| {
+                client.update_config(request).await
+            })
+            .await?;
 
         output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
@@ -189,15 +178,11 @@ impl BlackholeService {
 
     pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        log::trace!("delete config request: {request:?}");
-        let response = self
-            .service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(self.service.status("delete"))?
-            .into_inner();
-        log::debug!("delete config response: {response:?}");
+        self.service
+            .unary("delete", request, async |client, request| {
+                client.delete_config(request).await
+            })
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 

--- a/modules/decap/cli/Cargo.toml
+++ b/modules/decap/cli/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 netip = "0.3"
-log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.14"

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -11,7 +11,7 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
 };
 
@@ -89,9 +89,6 @@ pub struct DeleteConfigCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.decap.controlplane.decappb.v1.DecapService";
 
-/// Maps a genuine "config not found" status into a friendly message.
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
-
 fn client(channel: LayeredChannel) -> DecapServiceClient<LayeredChannel> {
     DecapServiceClient::new(channel)
         .send_compressed(CompressionEncoding::Gzip)
@@ -126,16 +123,12 @@ impl DecapService {
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let request = ListConfigsRequest {};
-        log::trace!("list configs request: {request:?}");
         let response = self
             .service
-            .client()
-            .list_configs(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
-        log::debug!("list configs response: {response:?}");
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -161,15 +154,12 @@ impl DecapService {
 
     pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
         let request = ShowConfigRequest { name: cmd.config_name.to_owned() };
-        log::trace!("show config request: {request:?}");
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
-        log::debug!("show config response: {response:?}");
+            .unary("show", request, async |client, request| {
+                client.show_config(request).await
+            })
+            .await?;
 
         output::data(
             || &response,
@@ -196,15 +186,11 @@ impl DecapService {
             prefixes4,
             prefixes6,
         };
-        log::trace!("update config request: {request:?}");
-        let response = self
-            .service
-            .client()
-            .update_config(request)
-            .await
-            .map_err(self.service.status("update"))?
-            .into_inner();
-        log::debug!("update config response: {response:?}");
+        self.service
+            .unary("update", request, async |client, request| {
+                client.update_config(request).await
+            })
+            .await?;
 
         output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
@@ -213,22 +199,15 @@ impl DecapService {
 
     pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        log::trace!("delete config request: {request:?}");
-        let response = self
-            .service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(|status| {
-                NOT_FOUND.map(
-                    status,
-                    "delete",
-                    self.service.endpoint(),
-                    Some(&format!("config '{}'", cmd.config_name)),
-                )
-            })?
-            .into_inner();
-        log::debug!("delete config response: {response:?}");
+        self.service
+            .unary_with(
+                "delete",
+                request,
+                self.service
+                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.delete_config(request).await,
+            )
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 

--- a/modules/dscp/cli/Cargo.toml
+++ b/modules/dscp/cli/Cargo.toml
@@ -15,7 +15,6 @@ commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = 
 netip = "0.3"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-log = "0.4"
 serde = { version = "1", features = ["derive"] }
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -11,7 +11,7 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
 };
 
@@ -141,9 +141,6 @@ pub struct DeleteConfigCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.dscp.controlplane.dscppb.v1.DscpService";
 
-/// Maps a genuine "config not found" status into a friendly message.
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
-
 fn client(channel: LayeredChannel) -> DscpServiceClient<LayeredChannel> {
     DscpServiceClient::new(channel)
         .send_compressed(CompressionEncoding::Gzip)
@@ -180,16 +177,12 @@ impl DscpService {
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let request = ListConfigsRequest {};
-        log::trace!("list configs request: {request:?}");
         let response = self
             .service
-            .client()
-            .list_configs(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
-        log::debug!("list configs response: {response:?}");
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -215,15 +208,12 @@ impl DscpService {
 
     pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
         let request = ShowConfigRequest { name: cmd.config_name.to_owned() };
-        log::trace!("show config request: {request:?}");
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
-        log::debug!("show config response: {response:?}");
+            .unary("show", request, async |client, request| {
+                client.show_config(request).await
+            })
+            .await?;
 
         output::data(
             || &response,
@@ -250,15 +240,11 @@ impl DscpService {
             prefixes4,
             prefixes6,
         };
-        log::trace!("AddPrefixesRequest: {request:?}");
-        let response = self
-            .service
-            .client()
-            .add_prefixes(request)
-            .await
-            .map_err(self.service.status("prefix-add"))?
-            .into_inner();
-        log::debug!("AddPrefixesResponse: {response:?}");
+        self.service
+            .unary("prefix-add", request, async |client, request| {
+                client.add_prefixes(request).await
+            })
+            .await?;
 
         output::success(
             "prefix-add",
@@ -275,15 +261,11 @@ impl DscpService {
             prefixes4,
             prefixes6,
         };
-        log::trace!("RemovePrefixesRequest: {request:?}");
-        let response = self
-            .service
-            .client()
-            .remove_prefixes(request)
-            .await
-            .map_err(self.service.status("prefix-remove"))?
-            .into_inner();
-        log::debug!("RemovePrefixesResponse: {response:?}");
+        self.service
+            .unary("prefix-remove", request, async |client, request| {
+                client.remove_prefixes(request).await
+            })
+            .await?;
 
         output::success(
             "prefix-remove",
@@ -305,15 +287,11 @@ impl DscpService {
                 mark: cmd.mark,
             }),
         };
-        log::trace!("SetDscpMarkingRequest: {request:?}");
-        let response = self
-            .service
-            .client()
-            .set_dscp_marking(request)
-            .await
-            .map_err(self.service.status("set-marking"))?
-            .into_inner();
-        log::debug!("SetDscpMarkingResponse: {response:?}");
+        self.service
+            .unary("set-marking", request, async |client, request| {
+                client.set_dscp_marking(request).await
+            })
+            .await?;
 
         output::success(
             "set-marking",
@@ -325,22 +303,15 @@ impl DscpService {
 
     pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        log::trace!("DeleteConfigRequest: {request:?}");
-        let response = self
-            .service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(|status| {
-                NOT_FOUND.map(
-                    status,
-                    "delete",
-                    self.service.endpoint(),
-                    Some(&format!("config '{}'", cmd.config_name)),
-                )
-            })?
-            .into_inner();
-        log::debug!("DeleteConfigResponse: {response:?}");
+        self.service
+            .unary_with(
+                "delete",
+                request,
+                self.service
+                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.delete_config(request).await,
+            )
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 

--- a/modules/nat64/cli/Cargo.toml
+++ b/modules/nat64/cli/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 netip = "0.3"
-log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.14"

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -13,7 +13,7 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
 };
 
@@ -25,9 +25,6 @@ pub mod nat64pb {
 
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.nat64.controlplane.nat64pb.v1.NAT64Service";
-
-/// Maps a genuine "config not found" status into a friendly message.
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
 
 fn client(channel: LayeredChannel) -> Nat64ServiceClient<LayeredChannel> {
     Nat64ServiceClient::new(channel)
@@ -232,16 +229,12 @@ impl NAT64Service {
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let request = ListConfigsRequest {};
-        log::trace!("list configs request: {request:?}");
         let response = self
             .service
-            .client()
-            .list_configs(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
-        log::debug!("list configs response: {response:?}");
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -267,22 +260,15 @@ impl NAT64Service {
 
     pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
-        log::trace!("show config request: {request:?}");
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(|status| {
-                NOT_FOUND.map(
-                    status,
-                    "show",
-                    self.service.endpoint(),
-                    Some(&format!("config '{}'", cmd.config_name)),
-                )
-            })?
-            .into_inner();
-        log::debug!("show config response: {response:?}");
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
+            .await?;
 
         output::data(
             || &response,
@@ -304,22 +290,15 @@ impl NAT64Service {
 
     pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        log::trace!("delete config request: {request:?}");
-        let response = self
-            .service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(|status| {
-                NOT_FOUND.map(
-                    status,
-                    "delete",
-                    self.service.endpoint(),
-                    Some(&format!("config '{}'", cmd.config_name)),
-                )
-            })?
-            .into_inner();
-        log::debug!("delete config response: {response:?}");
+        self.service
+            .unary_with(
+                "delete",
+                request,
+                self.service
+                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.delete_config(request).await,
+            )
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
@@ -331,12 +310,11 @@ impl NAT64Service {
             name: cmd.config_name.clone(),
             prefix: Some(cmd.prefix.into()),
         };
-        log::debug!("AddPrefixRequest: {request:?}");
         self.service
-            .client()
-            .add_prefix(request)
-            .await
-            .map_err(self.service.status("add prefix"))?;
+            .unary("add prefix", request, async |client, request| {
+                client.add_prefix(request).await
+            })
+            .await?;
 
         output::success(
             "add prefix",
@@ -351,12 +329,11 @@ impl NAT64Service {
             name: cmd.config_name.clone(),
             prefix: Some(cmd.prefix.into()),
         };
-        log::debug!("RemovePrefixRequest: {request:?}");
         self.service
-            .client()
-            .remove_prefix(request)
-            .await
-            .map_err(self.service.status("remove prefix"))?;
+            .unary("remove prefix", request, async |client, request| {
+                client.remove_prefix(request).await
+            })
+            .await?;
 
         output::success(
             "remove prefix",
@@ -373,12 +350,11 @@ impl NAT64Service {
             ipv6: Some(cmd.ipv6.into()),
             prefix_index: cmd.prefix_index,
         };
-        log::debug!("AddMappingRequest: {request:?}");
         self.service
-            .client()
-            .add_mapping(request)
-            .await
-            .map_err(self.service.status("add mapping"))?;
+            .unary("add mapping", request, async |client, request| {
+                client.add_mapping(request).await
+            })
+            .await?;
 
         output::success(
             "add mapping",
@@ -396,12 +372,11 @@ impl NAT64Service {
             name: cmd.config_name.clone(),
             ipv4: Some(cmd.ipv4.into()),
         };
-        log::debug!("RemoveMappingRequest: {request:?}");
         self.service
-            .client()
-            .remove_mapping(request)
-            .await
-            .map_err(self.service.status("remove mapping"))?;
+            .unary("remove mapping", request, async |client, request| {
+                client.remove_mapping(request).await
+            })
+            .await?;
 
         output::success(
             "remove mapping",
@@ -419,12 +394,11 @@ impl NAT64Service {
                 ipv6_mtu: cmd.ipv6_mtu,
             }),
         };
-        log::debug!("SetMtuRequest: {request:?}");
         self.service
-            .client()
-            .set_mtu(request)
-            .await
-            .map_err(self.service.status("set mtu"))?;
+            .unary("set mtu", request, async |client, request| {
+                client.set_mtu(request).await
+            })
+            .await?;
 
         output::success(
             "set mtu",
@@ -443,12 +417,11 @@ impl NAT64Service {
             drop_unknown_prefix: cmd.drop_unknown_prefix,
             drop_unknown_mapping: cmd.drop_unknown_mapping,
         };
-        log::debug!("SetDropUnknownRequest: {request:?}");
         self.service
-            .client()
-            .set_drop_unknown(request)
-            .await
-            .map_err(self.service.status("set drop"))?;
+            .unary("set drop", request, async |client, request| {
+                client.set_drop_unknown(request).await
+            })
+            .await?;
 
         output::success(
             "set drop",

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -85,29 +85,20 @@ impl PdumpService {
 
     async fn get_config(&mut self, name: &str, action: &'static str) -> Result<ShowConfigResponse, Error> {
         let request = ShowConfigRequest { name: name.to_owned() };
-        log::trace!("show config request: {request:?}");
-        let response = self
-            .service
-            .client()
-            .show_config(request)
+        self.service
+            .unary(action, request, async |client, request| {
+                client.show_config(request).await
+            })
             .await
-            .map_err(self.service.status(action))?
-            .into_inner();
-        log::debug!("show config response: {response:?}");
-        Ok(response)
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let request = ListConfigsRequest {};
-        log::trace!("list configs request: {request:?}");
         let response = self
             .service
-            .client()
-            .list_configs(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
-        log::debug!("list configs response: {response:?}");
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -182,12 +173,9 @@ impl PdumpService {
 
         request.config = Some(cfg);
         request.update_mask = Some(mask);
-        log::trace!("set config request: {request:?}");
         self.service
-            .client()
-            .set_config(request)
-            .await
-            .map_err(self.service.status("set"))?;
+            .unary("set", request, async |client, request| client.set_config(request).await)
+            .await?;
 
         output::success("set", format_args!("Updated config '{}'.", cmd.config_name));
 
@@ -196,12 +184,11 @@ impl PdumpService {
 
     pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        log::trace!("delete config request: {request:?}");
         self.service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(self.service.status("delete"))?;
+            .unary("delete", request, async |client, request| {
+                client.delete_config(request).await
+            })
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -181,14 +181,12 @@ impl RouteMplsService {
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let request = ListConfigsRequest {};
         let response = self
             .service
-            .client()
-            .list_configs(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -214,11 +212,10 @@ impl RouteMplsService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
+            .unary("show", request, async |client, request| {
+                client.show_config(request).await
+            })
+            .await?;
 
         output::data(
             || &response,
@@ -248,11 +245,10 @@ impl RouteMplsService {
             rules: Vec::<Rule>::new(),
         };
         self.service
-            .client()
-            .create_config(request)
-            .await
-            .map_err(self.service.status("create"))?
-            .into_inner();
+            .unary("create", request, async |client, request| {
+                client.create_config(request).await
+            })
+            .await?;
 
         output::success("create", format_args!("Created config '{}'.", cmd.config_name));
 
@@ -262,11 +258,10 @@ impl RouteMplsService {
     pub async fn delete_config(&mut self, cmd: RouteDeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
         self.service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(self.service.status("delete"))?
-            .into_inner();
+            .unary("delete", request, async |client, request| {
+                client.delete_config(request).await
+            })
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
@@ -291,11 +286,10 @@ impl RouteMplsService {
             }],
         };
         self.service
-            .client()
-            .update_config(request)
-            .await
-            .map_err(self.service.status("update"))?
-            .into_inner();
+            .unary("update", request, async |client, request| {
+                client.update_config(request).await
+            })
+            .await?;
 
         output::success("update", format_args!("Updated route in config '{}'.", cmd.config_name));
 
@@ -320,11 +314,10 @@ impl RouteMplsService {
             }],
         };
         self.service
-            .client()
-            .update_config(request)
-            .await
-            .map_err(self.service.status("withdraw"))?
-            .into_inner();
+            .unary("withdraw", request, async |client, request| {
+                client.update_config(request).await
+            })
+            .await?;
 
         output::success(
             "withdraw",

--- a/modules/unrdup/cli/Cargo.toml
+++ b/modules/unrdup/cli/Cargo.toml
@@ -15,7 +15,6 @@ commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = 
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 tonic = { version = "0.14", features = ["gzip"] }

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -14,7 +14,7 @@ use unrduppb::{
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service as GrpcService},
     completion,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
     yaml,
 };
@@ -228,9 +228,6 @@ fn addr_to_proto(addr: IpAddr) -> IpAddress {
 
 const SERVICE_NAME: &str = "modules.unrdup.controlplane.unrduppb.v1.UnrdupService";
 
-/// Maps a genuine "config not found" status into a friendly message.
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
-
 fn client(channel: LayeredChannel) -> UnrdupServiceClient<LayeredChannel> {
     UnrdupServiceClient::new(channel)
         .send_compressed(CompressionEncoding::Gzip)
@@ -265,16 +262,12 @@ impl UnrdupService {
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let request = ListConfigsRequest {};
-        log::trace!("list configs request: {request:?}");
         let response = self
             .service
-            .client()
-            .list_configs(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
-        log::debug!("list configs response: {response:?}");
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -298,15 +291,12 @@ impl UnrdupService {
 
     pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
-        log::trace!("show config request: {request:?}");
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
-        log::debug!("show config response: {response:?}");
+            .unary("show", request, async |client, request| {
+                client.show_config(request).await
+            })
+            .await?;
 
         let config = response
             .config
@@ -336,15 +326,11 @@ impl UnrdupService {
             name: cmd.config_name.clone(),
             config: Some(Config::from(config)),
         };
-        log::trace!("update config request: {request:?}");
-        let response = self
-            .service
-            .client()
-            .update_config(request)
-            .await
-            .map_err(self.service.status("update"))?
-            .into_inner();
-        log::debug!("update config response: {response:?}");
+        self.service
+            .unary("update", request, async |client, request| {
+                client.update_config(request).await
+            })
+            .await?;
 
         output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
@@ -353,22 +339,15 @@ impl UnrdupService {
 
     pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        log::trace!("delete config request: {request:?}");
-        let response = self
-            .service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(|status| {
-                NOT_FOUND.map(
-                    status,
-                    "delete",
-                    self.service.endpoint(),
-                    Some(&format!("config '{}'", cmd.config_name)),
-                )
-            })?
-            .into_inner();
-        log::debug!("delete config response: {response:?}");
+        self.service
+            .unary_with(
+                "delete",
+                request,
+                self.service
+                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.delete_config(request).await,
+            )
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 


### PR DESCRIPTION
- Replaces the hand-written client, map_err and into_inner chain in blackhole, decap, dscp, unrdup, nat64, route-mpls and pdump with Service::unary, and the NotFound closures with Service::not_found.
- Drops the per-crate request and response log lines, which the helper now emits uniformly, and the log dependency of the crates that had no other use for it.
- Behaviour is unchanged apart from the log level of the request line in nat64, which moves from debug to trace like everywhere else.