### PR TITLE
refactor(cli): route the module clis through the unary helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,7 +3135,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "log",
  "prost",
  "serde",
  "serde_yaml",
@@ -3351,7 +3350,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "humantime",
- "log",
  "netip",
  "prost",
  "serde",

--- a/modules/acl/cli/Cargo.toml
+++ b/modules/acl/cli/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
-log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.14"

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -266,11 +266,10 @@ impl ACLService {
     pub async fn list_configs(&mut self) -> Result<(), Error> {
         let response = self
             .service
-            .client()
-            .list_configs(ListConfigsRequest {})
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -296,11 +295,10 @@ impl ACLService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
+            .unary("show", request, async |client, request| {
+                client.show_config(request).await
+            })
+            .await?;
 
         output::data(
             || &response,
@@ -338,11 +336,10 @@ impl ACLService {
     pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
         self.service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(self.service.status("delete"))?
-            .into_inner();
+            .unary("delete", request, async |client, request| {
+                client.delete_config(request).await
+            })
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
@@ -374,15 +371,11 @@ impl ACLService {
             fwtable_name_v6,
             ..Default::default()
         };
-        log::trace!("UpdateConfigRequest: {request:?}");
-        let response = self
-            .service
-            .client()
-            .update_config(request)
-            .await
-            .map_err(self.service.status("update"))?
-            .into_inner();
-        log::debug!("UpdateConfigResponse: {response:?}");
+        self.service
+            .unary("update", request, async |client, request| {
+                client.update_config(request).await
+            })
+            .await?;
 
         output::success(
             "update",
@@ -398,11 +391,10 @@ impl ACLService {
         };
         let response = self
             .service
-            .client()
-            .get_rules_counters(request)
-            .await
-            .map_err(self.service.status("rule-counters"))?
-            .into_inner();
+            .unary("rule-counters", request, async |client, request| {
+                client.get_rules_counters(request).await
+            })
+            .await?;
 
         output::data(
             || &response.counters,
@@ -468,11 +460,10 @@ impl ACLService {
 
         let response = self
             .metrics
-            .client()
-            .get_metrics_rules(request)
-            .await
-            .map_err(self.metrics.status("metrics-rules"))?
-            .into_inner();
+            .unary("metrics-rules", request, async |client, request| {
+                client.get_metrics_rules(request).await
+            })
+            .await?;
 
         let metrics = response.metrics;
 

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -78,13 +78,11 @@ impl Balancer2Service {
             addr: parts.addr,
             wlc: parts.wlc,
         };
-        log::trace!("update config request: {request:?}");
-
         self.service
-            .client()
-            .update_config(request)
-            .await
-            .map_err(self.service.status("update"))?;
+            .unary("update", request, async |client, request| {
+                client.update_config(request).await
+            })
+            .await?;
 
         output::success("update", format_args!("Updated config '{}'.", cmd.name));
 
@@ -92,17 +90,12 @@ impl Balancer2Service {
     }
 
     async fn list(&mut self) -> Result<(), Error> {
-        let request = ListConfigsRequest {};
-        log::trace!("list configs request: {request:?}");
-
         let response = self
             .service
-            .client()
-            .list_configs(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
-        log::debug!("list configs response: {response:?}");
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.names,
@@ -130,16 +123,12 @@ impl Balancer2Service {
 
     async fn config(&mut self, cmd: ConfigCmd) -> Result<(), Error> {
         let request = GetConfigRequest { config_name: cmd.name };
-        log::trace!("get config request: {request:?}");
-
         let response = self
             .service
-            .client()
-            .get_config(request)
-            .await
-            .map_err(self.service.status("config"))?
-            .into_inner();
-        log::debug!("get config response: {response:?}");
+            .unary("config", request, async |client, request| {
+                client.get_config(request).await
+            })
+            .await?;
 
         output::data(
             || &response,
@@ -183,16 +172,10 @@ impl Balancer2Service {
             packet_handler_ref,
             filter,
         };
-        log::trace!("get state request: {request:?}");
-
         let response = self
             .service
-            .client()
-            .get_state(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
-        log::debug!("get state response: {response:?}");
+            .unary("show", request, async |client, request| client.get_state(request).await)
+            .await?;
 
         output::data(
             || &response.states,
@@ -210,17 +193,14 @@ impl Balancer2Service {
     }
 
     async fn sessions_list(&mut self) -> Result<(), Error> {
-        let request = ListSessionsStatesRequest {};
-        log::trace!("list sessions states request: {request:?}");
-
         let response = self
             .service
-            .client()
-            .list_sessions_states(request)
-            .await
-            .map_err(self.service.status("sessions list"))?
-            .into_inner();
-        log::debug!("list sessions states response: {response:?}");
+            .unary(
+                "sessions list",
+                ListSessionsStatesRequest {},
+                async |client, request| client.list_sessions_states(request).await,
+            )
+            .await?;
 
         output::data(
             || &response.names,
@@ -301,13 +281,11 @@ impl Balancer2Service {
             sessions_state_name: cmd.name.clone(),
             capacity: cmd.capacity,
         };
-        log::trace!("update sessions state request: {request:?}");
-
         self.service
-            .client()
-            .update_sessions_state(request)
-            .await
-            .map_err(self.service.status("sessions update"))?;
+            .unary("sessions update", request, async |client, request| {
+                client.update_sessions_state(request).await
+            })
+            .await?;
 
         output::success(
             "sessions update",
@@ -318,17 +296,12 @@ impl Balancer2Service {
     }
 
     async fn metrics(&mut self, _cmd: MetricsCmd) -> Result<(), Error> {
-        let request = GetMetricsRequest::default();
-        log::trace!("get metrics request: {request:?}");
-
         let response = self
             .service
-            .client()
-            .get_metrics(request)
-            .await
-            .map_err(self.service.status("metrics"))?
-            .into_inner();
-        log::debug!("get metrics response: {response:?}");
+            .unary("metrics", GetMetricsRequest::default(), async |client, request| {
+                client.get_metrics(request).await
+            })
+            .await?;
 
         output::data(
             || &response,
@@ -369,13 +342,11 @@ impl Balancer2Service {
             config_name: config_name.clone(),
             updates,
         };
-        log::trace!("update reals request: {request:?}");
-
         self.service
-            .client()
-            .update_reals(request)
-            .await
-            .map_err(self.service.status(action))?;
+            .unary(action, request, async |client, request| {
+                client.update_reals(request).await
+            })
+            .await?;
 
         output::success(action, format_args!("Updated reals of config '{config_name}'."));
 

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -207,11 +207,10 @@ impl ForwardService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
+            .unary("show", request, async |client, request| {
+                client.show_config(request).await
+            })
+            .await?;
 
         output::data(
             || &response,
@@ -237,14 +236,12 @@ impl ForwardService {
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let request = ListConfigsRequest {};
         let response = self
             .service
-            .client()
-            .list_configs(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -269,10 +266,10 @@ impl ForwardService {
     pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config.clone() };
         self.service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(self.service.status("delete"))?;
+            .unary("delete", request, async |client, request| {
+                client.delete_config(request).await
+            })
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config));
 
@@ -281,10 +278,10 @@ impl ForwardService {
 
     pub async fn update_config(&mut self, cmd: UpdateCmd, request: UpdateConfigRequest) -> Result<(), Error> {
         self.service
-            .client()
-            .update_config(request)
-            .await
-            .map_err(self.service.status("update"))?;
+            .unary("update", request, async |client, request| {
+                client.update_config(request).await
+            })
+            .await?;
 
         output::success("update", format_args!("Updated config '{}'.", cmd.config));
 

--- a/modules/fwstate/cli/Cargo.toml
+++ b/modules/fwstate/cli/Cargo.toml
@@ -14,7 +14,6 @@ ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 netip = "0.3"
-log = "0.4"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.14"

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -294,14 +294,12 @@ impl FWStateService {
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let request = ListConfigsRequest {};
         let response = self
             .service
-            .client()
-            .list_configs(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -330,11 +328,10 @@ impl FWStateService {
         };
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
+            .unary("show", request, async |client, request| {
+                client.show_config(request).await
+            })
+            .await?;
 
         output::data(
             || &response,
@@ -347,10 +344,10 @@ impl FWStateService {
     pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
         self.service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(self.service.status("delete"))?;
+            .unary("delete", request, async |client, request| {
+                client.delete_config(request).await
+            })
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
@@ -359,12 +356,11 @@ impl FWStateService {
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
         let request = update_request(&cmd).map_err(|err| self.service.invalid("update", err))?;
-        log::trace!("UpdateConfigRequest: {request:?}");
         self.service
-            .client()
-            .update_config(request)
-            .await
-            .map_err(self.service.status("update"))?;
+            .unary("update", request, async |client, request| {
+                client.update_config(request).await
+            })
+            .await?;
 
         output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -261,11 +261,10 @@ impl MirrorService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
+            .unary("show", request, async |client, request| {
+                client.show_config(request).await
+            })
+            .await?;
 
         let config = MirrorConfig::try_from(response.rules)
             .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("show", e.to_string()))?;
@@ -291,14 +290,12 @@ impl MirrorService {
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let request = ListConfigsRequest {};
         let response = self
             .service
-            .client()
-            .list_configs(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -323,10 +320,10 @@ impl MirrorService {
     pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config.clone() };
         self.service
-            .client()
-            .delete_config(request)
-            .await
-            .map_err(self.service.status("delete"))?;
+            .unary("delete", request, async |client, request| {
+                client.delete_config(request).await
+            })
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config));
 
@@ -340,10 +337,10 @@ impl MirrorService {
             .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("update", e.to_string()))?;
         let request = UpdateConfigRequest { name: cmd.config.clone(), rules };
         self.service
-            .client()
-            .update_config(request)
-            .await
-            .map_err(self.service.status("update"))?;
+            .unary("update", request, async |client, request| {
+                client.update_config(request).await
+            })
+            .await?;
 
         output::success("update", format_args!("Updated config '{}'.", cmd.config));
 

--- a/modules/route/cli/src/main.rs
+++ b/modules/route/cli/src/main.rs
@@ -11,7 +11,7 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
     yaml,
 };
@@ -195,9 +195,6 @@ pub struct FibShowCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.route.controlplane.routepb.v1.RouteService";
 
-/// Rewrites a genuine missing-config `NotFound` into a friendly message.
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested config");
-
 fn client(channel: LayeredChannel) -> RouteServiceClient<LayeredChannel> {
     RouteServiceClient::new(channel)
         .send_compressed(CompressionEncoding::Gzip)
@@ -251,10 +248,10 @@ impl RouteService {
             entries: config.entries,
         };
         self.service
-            .client()
-            .update_fib(request)
-            .await
-            .map_err(self.service.status("update"))?;
+            .unary("update", request, async |client, request| {
+                client.update_fib(request).await
+            })
+            .await?;
 
         output::success(
             "update",
@@ -266,14 +263,15 @@ impl RouteService {
     pub async fn delete_fib(&mut self, cmd: FibDeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
 
-        self.service.client().delete_config(request).await.map_err(|status| {
-            NOT_FOUND.map(
-                status,
+        self.service
+            .unary_with(
                 "delete",
-                self.service.endpoint(),
-                Some(&format!("config '{}'", cmd.config_name)),
+                request,
+                self.service
+                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.delete_config(request).await,
             )
-        })?;
+            .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
         Ok(())
@@ -282,11 +280,10 @@ impl RouteService {
     pub async fn list_fibs(&mut self) -> Result<(), Error> {
         let response = self
             .service
-            .client()
-            .list_configs(ListConfigsRequest {})
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -316,11 +313,8 @@ impl RouteService {
 
         let response = self
             .service
-            .client()
-            .show_fib(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
+            .unary("show", request, async |client, request| client.show_fib(request).await)
+            .await?;
         let entries = response.entries;
 
         output::data(

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -113,12 +113,11 @@ impl FWStateMapService {
             extra_bucket_count: cmd.extra_bucket_count.unwrap_or(0),
             worker_count: cmd.worker_count.unwrap_or(0),
         };
-        log::trace!("CreateMapRequest: {request:?}");
         self.service
-            .client()
-            .create_map(request)
-            .await
-            .map_err(self.service.status("create"))?;
+            .unary("create", request, async |client, request| {
+                client.create_map(request).await
+            })
+            .await?;
 
         output::success("create", format_args!("Created map '{}'.", cmd.map_name));
 
@@ -127,12 +126,11 @@ impl FWStateMapService {
 
     pub async fn map_delete(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteMapRequest { name: cmd.map_name.clone() };
-        log::trace!("DeleteMapRequest: {request:?}");
         self.service
-            .client()
-            .delete_map(request)
-            .await
-            .map_err(self.service.status("delete"))?;
+            .unary("delete", request, async |client, request| {
+                client.delete_map(request).await
+            })
+            .await?;
 
         output::success("delete", format_args!("Deleted map '{}'.", cmd.map_name));
 
@@ -140,14 +138,12 @@ impl FWStateMapService {
     }
 
     pub async fn map_list(&mut self, _cmd: ListCmd) -> Result<(), Error> {
-        let request = ListMapsRequest {};
         let response = self
             .service
-            .client()
-            .list_maps(request)
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
+            .unary("list", ListMapsRequest {}, async |client, request| {
+                client.list_maps(request).await
+            })
+            .await?;
 
         // The wire response's kinds map has no defined iteration order and
         // HashMap serialization is keyed by name only, so a stable payload
@@ -200,14 +196,12 @@ impl FWStateMapService {
 
     pub async fn map_stats(&mut self, cmd: StatsCmd) -> Result<(), Error> {
         let request = GetMapStatsRequest { name: cmd.map_name.clone() };
-        log::trace!("GetMapStatsRequest: {request:?}");
         let response = self
             .service
-            .client()
-            .get_map_stats(request)
-            .await
-            .map_err(self.service.status("stats"))?
-            .into_inner();
+            .unary("stats", request, async |client, request| {
+                client.get_map_stats(request).await
+            })
+            .await?;
 
         output::data(
             || &response,
@@ -233,12 +227,11 @@ impl FWStateMapService {
             worker_count: cmd.worker_count.unwrap_or(0),
             ..Default::default()
         };
-        log::trace!("InsertLayerRequest: {request:?}");
         self.service
-            .client()
-            .insert_layer(request)
-            .await
-            .map_err(self.service.status("insert-layer"))?;
+            .unary("insert-layer", request, async |client, request| {
+                client.insert_layer(request).await
+            })
+            .await?;
 
         output::success(
             "insert-layer",
@@ -263,20 +256,20 @@ impl FWStateMapService {
         // stream.
         let mut index = cmd.index as i64;
         loop {
+            let request = ListEntriesRequest {
+                map_name: cmd.map_name.clone(),
+                layer_index: cmd.layer,
+                include_expired: cmd.include_expired,
+                direction: direction as i32,
+                batch_size: cmd.batch,
+                index,
+            };
             let resp = self
                 .service
-                .client()
-                .list_entries(ListEntriesRequest {
-                    map_name: cmd.map_name.clone(),
-                    layer_index: cmd.layer,
-                    include_expired: cmd.include_expired,
-                    direction: direction as i32,
-                    batch_size: cmd.batch,
-                    index,
+                .unary("entries", request, async |client, request| {
+                    client.list_entries(request).await
                 })
-                .await
-                .map_err(self.service.status("entries"))?
-                .into_inner();
+                .await?;
 
             state.note_generation(resp.generation);
 


### PR DESCRIPTION
- Replaces the hand-written client, map_err and into_inner chain in forward, mirror, acl, fwstate, route, balancer2 and fwstate-map with Service::unary, and route's NotFound closure with Service::not_found.
- Drops the per-crate request and response log lines, which the helper now emits uniformly, and the log dependency of acl and fwstate that had no other use for it.
- Streaming calls keep the direct client path.