### PR TITLE
refactor(cli): route the core, device and operator clis through the unary helper

### DIFF
--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -541,7 +541,7 @@ impl<C> Service<C> {
     /// Issues one unary RPC, mapping a failure through
     /// [`status`](Service::status) under `action`.
     ///
-    /// The request and the unwrapped response are logged at trace and debug.
+    /// The request and the unwrapped response are logged at trace level.
     pub async fn unary<Req, Resp, Call>(
         &mut self,
         action: &'static str,
@@ -575,7 +575,7 @@ impl<C> Service<C> {
     {
         log::trace!("{action} request: {request:?}");
         let response = call(&mut self.client, request).await.map_err(map)?.into_inner();
-        log::debug!("{action} response: {response:?}");
+        log::trace!("{action} response: {response:?}");
 
         Ok(response)
     }

--- a/cli/core/src/discovery.rs
+++ b/cli/core/src/discovery.rs
@@ -225,11 +225,10 @@ pub async fn list_services(connection: &Connection, suffix: &str) -> Result<Vec<
     });
 
     let response = service
-        .client()
-        .list_services(ListServicesRequest {})
-        .await
-        .map_err(service.status("discover"))?
-        .into_inner();
+        .unary("discover", ListServicesRequest {}, async |client, request| {
+            client.list_services(request).await
+        })
+        .await?;
 
     let mut services: Vec<String> = response
         .services

--- a/cli/core/src/main.rs
+++ b/cli/core/src/main.rs
@@ -286,11 +286,12 @@ async fn whoami(connection: &ConnectionArgs) -> Result<(String, Principal), Erro
     .await?;
 
     let response = service
-        .client()
-        .introspect_token(IntrospectTokenRequest { token: String::new() })
-        .await
-        .map_err(service.status("whoami"))?
-        .into_inner();
+        .unary(
+            "whoami",
+            IntrospectTokenRequest { token: String::new() },
+            async |client, request| client.introspect_token(request).await,
+        )
+        .await?;
 
     let principal = response.principal.ok_or_else(|| {
         Error::from_status(

--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -98,10 +98,10 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                 level: ynpb::pb::LogLevel::from(cmd.level.clone()).into(),
             };
             service
-                .client()
-                .update_level(request)
-                .await
-                .map_err(service.status(action))?;
+                .unary(action, request, async |client, request| {
+                    client.update_level(request).await
+                })
+                .await?;
 
             let level_name = cmd.level.to_possible_value().expect("no skipped variants");
             output::success(
@@ -111,11 +111,10 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         }
         ModeCmd::Logging(LoggingCmd::Show) => {
             let response = service
-                .client()
-                .get_level(GetLevelRequest {})
-                .await
-                .map_err(service.status(action))?
-                .into_inner();
+                .unary(action, GetLevelRequest {}, async |client, request| {
+                    client.get_level(request).await
+                })
+                .await?;
 
             output::data(
                 || &response,

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -194,33 +194,27 @@ impl CountersService {
     }
 
     pub async fn by_tags(&mut self, request: CountersByTagsRequest) -> Result<CountersByTagsResponse, Error> {
-        Ok(self
-            .service
-            .client()
-            .by_tags(request)
+        self.service
+            .unary(self.action, request, async |client, request| {
+                client.by_tags(request).await
+            })
             .await
-            .map_err(self.service.status(self.action))?
-            .into_inner())
     }
 
     pub async fn workers(&mut self) -> Result<WorkerCountersResponse, Error> {
-        Ok(self
-            .service
-            .client()
-            .workers(WorkerCountersRequest {})
+        self.service
+            .unary(self.action, WorkerCountersRequest {}, async |client, request| {
+                client.workers(request).await
+            })
             .await
-            .map_err(self.service.status(self.action))?
-            .into_inner())
     }
 
     pub async fn ports(&mut self) -> Result<PortCountersResponse, Error> {
-        Ok(self
-            .service
-            .client()
-            .ports(PortCountersRequest {})
+        self.service
+            .unary(self.action, PortCountersRequest {}, async |client, request| {
+                client.ports(request).await
+            })
             .await
-            .map_err(self.service.status(self.action))?
-            .into_inner())
     }
 }
 

--- a/cli/modules/device-delete/src/main.rs
+++ b/cli/modules/device-delete/src/main.rs
@@ -6,16 +6,13 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
 };
 use ynpb::pb::{DeleteDeviceRequest, ListDevicesRequest, device_service_client::DeviceServiceClient};
 
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "controlplane.ynpb.v1.DeviceService";
-
-/// Maps a genuine "device not found" status into a friendly message.
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "device");
 
 fn client(channel: LayeredChannel) -> DeviceServiceClient<LayeredChannel> {
     DeviceServiceClient::new(channel)
@@ -51,10 +48,13 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 
     let name = cmd.name;
     service
-        .client()
-        .delete(DeleteDeviceRequest { name: name.clone() })
-        .await
-        .map_err(|status| NOT_FOUND.map(status, action, service.endpoint(), Some(&format!("device '{name}'"))))?;
+        .unary_with(
+            action,
+            DeleteDeviceRequest { name: name.clone() },
+            service.not_found(action, &format!("device '{name}'")),
+            async |client, request| client.delete(request).await,
+        )
+        .await?;
 
     output::success(action, format_args!("Deleted device '{name}'."));
 

--- a/cli/modules/device/src/main.rs
+++ b/cli/modules/device/src/main.rs
@@ -63,11 +63,10 @@ impl DeviceService {
     pub async fn list(&mut self) -> Result<ListDevicesResponse, Error> {
         let response = self
             .service
-            .client()
-            .list(ListDevicesRequest {})
-            .await
-            .map_err(self.service.status("device-list"))?
-            .into_inner();
+            .unary("device-list", ListDevicesRequest {}, async |client, request| {
+                client.list(request).await
+            })
+            .await?;
 
         Ok(response)
     }

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -7,7 +7,7 @@ use tonic::{Status, codec::CompressionEncoding};
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
 };
 use ynpb::pb::{
@@ -16,7 +16,6 @@ use ynpb::pb::{
 };
 
 const FUNCTION_SERVICE: &str = "controlplane.ynpb.v1.FunctionService";
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(FUNCTION_SERVICE, "requested function");
 
 fn client(channel: LayeredChannel) -> FunctionServiceClient<LayeredChannel> {
     FunctionServiceClient::new(channel)
@@ -167,11 +166,13 @@ impl FunctionService {
     pub async fn list_functions(&mut self) -> Result<Vec<FunctionId>, Error> {
         let response = self
             .service
-            .client()
-            .list(ListFunctionsRequest {})
-            .await
-            .map_err(|status| NOT_FOUND.map(status, "list functions", self.service.endpoint(), None))?
-            .into_inner();
+            .unary_with(
+                "list functions",
+                ListFunctionsRequest {},
+                self.service.not_found("list functions", "requested function"),
+                async |client, request| client.list(request).await,
+            )
+            .await?;
 
         Ok(response.ids)
     }
@@ -183,18 +184,13 @@ impl FunctionService {
 
         let response = self
             .service
-            .client()
-            .get(request)
-            .await
-            .map_err(|status| {
-                NOT_FOUND.map(
-                    status,
-                    "show function",
-                    self.service.endpoint(),
-                    Some(&format!("function '{name}'")),
-                )
-            })?
-            .into_inner();
+            .unary_with(
+                "show function",
+                request,
+                self.service.not_found("show function", &format!("function '{name}'")),
+                async |client, request| client.get(request).await,
+            )
+            .await?;
 
         let function = response.function.ok_or_else(|| {
             Error::from_status(
@@ -221,10 +217,10 @@ impl FunctionService {
         //
         // The backend message is kept verbatim.
         self.service
-            .client()
-            .update(request)
-            .await
-            .map_err(self.service.status("update function"))?;
+            .unary("update function", request, async |client, request| {
+                client.update(request).await
+            })
+            .await?;
 
         Ok(())
     }
@@ -232,20 +228,17 @@ impl FunctionService {
     pub async fn delete_function(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let name = cmd.name;
 
+        let request = DeleteFunctionRequest {
+            id: Some(FunctionId { name: name.clone() }),
+        };
         self.service
-            .client()
-            .delete(DeleteFunctionRequest {
-                id: Some(FunctionId { name: name.clone() }),
-            })
-            .await
-            .map_err(|status| {
-                NOT_FOUND.map(
-                    status,
-                    "delete function",
-                    self.service.endpoint(),
-                    Some(&format!("function '{name}'")),
-                )
-            })?;
+            .unary_with(
+                "delete function",
+                request,
+                self.service.not_found("delete function", &format!("function '{name}'")),
+                async |client, request| client.delete(request).await,
+            )
+            .await?;
 
         Ok(())
     }

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -69,11 +69,10 @@ impl GatewayService {
     pub async fn list_services(&mut self) -> Result<(), Error> {
         let response = self
             .service
-            .client()
-            .list_services(ListServicesRequest {})
-            .await
-            .map_err(self.service.status("gateway"))?
-            .into_inner();
+            .unary("gateway", ListServicesRequest {}, async |client, request| {
+                client.list_services(request).await
+            })
+            .await?;
 
         output::data(
             || &response.services,

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -65,11 +65,10 @@ impl InspectService {
     pub async fn inspect(&mut self) -> Result<InspectResponse, Error> {
         let response = self
             .service
-            .client()
-            .inspect(InspectRequest {})
-            .await
-            .map_err(self.service.status("inspect"))?
-            .into_inner();
+            .unary("inspect", InspectRequest {}, async |client, request| {
+                client.inspect(request).await
+            })
+            .await?;
 
         Ok(response)
     }

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -7,7 +7,7 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
 };
 use ynpb::pb::{
@@ -16,7 +16,6 @@ use ynpb::pb::{
 };
 
 const PIPELINE_SERVICE: &str = "controlplane.ynpb.v1.PipelineService";
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(PIPELINE_SERVICE, "requested pipeline");
 
 fn client(channel: LayeredChannel) -> PipelineServiceClient<LayeredChannel> {
     PipelineServiceClient::new(channel)
@@ -166,11 +165,13 @@ impl PipelineService {
     pub async fn list_pipelines(&mut self) -> Result<Vec<PipelineId>, Error> {
         let response = self
             .service
-            .client()
-            .list(ListPipelinesRequest {})
-            .await
-            .map_err(|status| NOT_FOUND.map(status, self.action, self.service.endpoint(), Some("pipeline service")))?
-            .into_inner();
+            .unary_with(
+                self.action,
+                ListPipelinesRequest {},
+                self.service.not_found(self.action, "pipeline service"),
+                async |client, request| client.list(request).await,
+            )
+            .await?;
 
         Ok(response.ids)
     }
@@ -181,18 +182,13 @@ impl PipelineService {
         };
         let response = self
             .service
-            .client()
-            .get(request)
-            .await
-            .map_err(|status| {
-                NOT_FOUND.map(
-                    status,
-                    self.action,
-                    self.service.endpoint(),
-                    Some(&format!("pipeline '{name}'")),
-                )
-            })?
-            .into_inner();
+            .unary_with(
+                self.action,
+                request,
+                self.service.not_found(self.action, &format!("pipeline '{name}'")),
+                async |client, request| client.get(request).await,
+            )
+            .await?;
 
         let pipeline = response.pipeline.ok_or_else(|| {
             Error::from_status(
@@ -224,10 +220,10 @@ impl PipelineService {
         //
         // The backend message is kept verbatim.
         self.service
-            .client()
-            .update(request)
-            .await
-            .map_err(self.service.status(self.action))?;
+            .unary(self.action, request, async |client, request| {
+                client.update(request).await
+            })
+            .await?;
 
         Ok(())
     }
@@ -238,14 +234,14 @@ impl PipelineService {
         };
 
         let name = request.id.as_ref().expect("pipeline id").name.clone();
-        self.service.client().delete(request).await.map_err(|status| {
-            NOT_FOUND.map(
-                status,
+        self.service
+            .unary_with(
                 self.action,
-                self.service.endpoint(),
-                Some(&format!("pipeline '{name}'")),
+                request,
+                self.service.not_found(self.action, &format!("pipeline '{name}'")),
+                async |client, request| client.delete(request).await,
             )
-        })?;
+            .await?;
 
         Ok(())
     }

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -11,7 +11,7 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
 };
 use ynpb::pb::{ListDevicesRequest, device_service_client::DeviceServiceClient};
@@ -80,9 +80,6 @@ pub struct UpdateCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "devices.plain.controlplane.plainpb.v1.DevicePlainService";
 
-/// Maps a genuine "device not found" status into a friendly message.
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "device");
-
 pub struct DevicePlainService {
     service: Service<DevicePlainServiceClient<LayeredChannel>>,
 }
@@ -105,18 +102,13 @@ impl DevicePlainService {
 
         let response = self
             .service
-            .client()
-            .show_device(request)
-            .await
-            .map_err(|status| {
-                NOT_FOUND.map(
-                    status,
-                    "show",
-                    self.service.endpoint(),
-                    Some(&format!("plain device '{name}'")),
-                )
-            })?
-            .into_inner();
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("plain device '{name}'")),
+                async |client, request| client.show_device(request).await,
+            )
+            .await?;
 
         output::data(
             || &response,
@@ -147,10 +139,10 @@ impl DevicePlainService {
         };
 
         self.service
-            .client()
-            .update_device(request)
-            .await
-            .map_err(self.service.status("update"))?;
+            .unary("update", request, async |client, request| {
+                client.update_device(request).await
+            })
+            .await?;
 
         output::success("update", format_args!("Updated device '{}'.", cmd.name));
 

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -133,11 +133,10 @@ impl TrafgenService {
             device: Some(Device { input: cmd.input, output: cmd.output }),
         };
         self.service
-            .client()
-            .update_device(request)
-            .await
-            .map_err(self.service.status("update"))?
-            .into_inner();
+            .unary("update", request, async |client, request| {
+                client.update_device(request).await
+            })
+            .await?;
 
         output::success("update", format_args!("Updated device '{}'.", cmd.config_name));
 
@@ -147,11 +146,10 @@ impl TrafgenService {
     pub async fn list_configs(&mut self) -> Result<(), Error> {
         let response = self
             .service
-            .client()
-            .list_configs(ListConfigsRequest {})
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -179,11 +177,10 @@ impl TrafgenService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .client()
-            .show_config(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
+            .unary("show", request, async |client, request| {
+                client.show_config(request).await
+            })
+            .await?;
 
         output::data(
             || &response,
@@ -205,11 +202,10 @@ impl TrafgenService {
 
         let request = UploadPcapRequest { name: cmd.config_name.clone(), pcap };
         self.service
-            .client()
-            .upload_pcap(request)
-            .await
-            .map_err(self.service.status("upload"))?
-            .into_inner();
+            .unary("upload", request, async |client, request| {
+                client.upload_pcap(request).await
+            })
+            .await?;
 
         output::success("upload", format_args!("Uploaded pcap to device '{}'.", cmd.config_name));
 
@@ -222,11 +218,8 @@ impl TrafgenService {
             rate_pps: cmd.rate,
         };
         self.service
-            .client()
-            .set_rate(request)
-            .await
-            .map_err(self.service.status("rate"))?
-            .into_inner();
+            .unary("rate", request, async |client, request| client.set_rate(request).await)
+            .await?;
 
         output::success(
             "rate",

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -200,12 +200,14 @@ impl TrafgenService {
                 .invalid("upload", format!("failed to read pcap {}: {err}", cmd.pcap.display()))
         })?;
 
+        // The request carries the whole capture, which the unary helper
+        // would trace-log byte by byte.
         let request = UploadPcapRequest { name: cmd.config_name.clone(), pcap };
         self.service
-            .unary("upload", request, async |client, request| {
-                client.upload_pcap(request).await
-            })
-            .await?;
+            .client()
+            .upload_pcap(request)
+            .await
+            .map_err(self.service.status("upload"))?;
 
         output::success("upload", format_args!("Uploaded pcap to device '{}'.", cmd.config_name));
 

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -200,8 +200,8 @@ impl TrafgenService {
                 .invalid("upload", format!("failed to read pcap {}: {err}", cmd.pcap.display()))
         })?;
 
-        // The request carries the whole capture, which the unary helper
-        // would trace-log byte by byte.
+        // The capture itself must never reach the log, so the upload
+        // bypasses the logged call path.
         let request = UploadPcapRequest { name: cmd.config_name.clone(), pcap };
         self.service
             .client()

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -9,7 +9,7 @@ use vlanpb::{ShowDeviceVlanRequest, UpdateDeviceVlanRequest, device_vlan_service
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
 };
 use ynpb::pb::{ListDevicesRequest, device_service_client::DeviceServiceClient};
@@ -81,9 +81,6 @@ pub struct UpdateCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "devices.vlan.controlplane.vlanpb.v1.DeviceVlanService";
 
-/// Maps a genuine "device not found" status into a friendly message.
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "device");
-
 pub struct DeviceVlanService {
     service: Service<DeviceVlanServiceClient<LayeredChannel>>,
 }
@@ -106,18 +103,13 @@ impl DeviceVlanService {
 
         let response = self
             .service
-            .client()
-            .show_device(request)
-            .await
-            .map_err(|status| {
-                NOT_FOUND.map(
-                    status,
-                    "show",
-                    self.service.endpoint(),
-                    Some(&format!("vlan device '{name}'")),
-                )
-            })?
-            .into_inner();
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("vlan device '{name}'")),
+                async |client, request| client.show_device(request).await,
+            )
+            .await?;
 
         output::data(
             || &response,
@@ -155,10 +147,10 @@ impl DeviceVlanService {
         };
 
         self.service
-            .client()
-            .update_device(request)
-            .await
-            .map_err(self.service.status("update"))?;
+            .unary("update", request, async |client, request| {
+                client.update_device(request).await
+            })
+            .await?;
 
         output::success("update", format_args!("Updated device '{}'.", cmd.name));
 

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -20,7 +20,7 @@ use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
     display::print_table_from_entries,
-    errors::{Error, NotFoundMapper},
+    errors::Error,
     output::{self, CommonFormat},
 };
 
@@ -38,9 +38,6 @@ pub mod operatorpb {
 
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "operators.route.operatorpb.v1.NeighbourService";
-
-/// Maps a genuine "table not found" status into a friendly message.
-const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(SERVICE_NAME, "requested table");
 
 fn client(channel: LayeredChannel) -> NeighbourServiceClient<LayeredChannel> {
     NeighbourServiceClient::new(channel)
@@ -217,11 +214,14 @@ impl NeighbourService {
 
         let response = self
             .service
-            .client()
-            .list(request)
-            .await
-            .map_err(|status| NOT_FOUND.map(status, "show", self.service.endpoint(), resource.as_deref()))?
-            .into_inner();
+            .unary_with(
+                "show",
+                request,
+                self.service
+                    .not_found("show", resource.as_deref().unwrap_or("requested table")),
+                async |client, request| client.list(request).await,
+            )
+            .await?;
 
         output::data(
             || &response.neighbours,
@@ -266,10 +266,10 @@ impl NeighbourService {
         };
 
         self.service
-            .client()
-            .update_neighbours(request)
-            .await
-            .map_err(self.service.status("add"))?;
+            .unary("add", request, async |client, request| {
+                client.update_neighbours(request).await
+            })
+            .await?;
 
         output::success(
             "add",
@@ -291,10 +291,10 @@ impl NeighbourService {
         };
 
         self.service
-            .client()
-            .remove_neighbours(request)
-            .await
-            .map_err(self.service.status("remove"))?;
+            .unary("remove", request, async |client, request| {
+                client.remove_neighbours(request).await
+            })
+            .await?;
 
         let next_hops = cmd
             .next_hops
@@ -310,11 +310,10 @@ impl NeighbourService {
     pub async fn list_tables(&mut self) -> Result<(), Error> {
         let response = self
             .service
-            .client()
-            .list_tables(ListNeighbourTablesRequest {})
-            .await
-            .map_err(self.service.status("list tables"))?
-            .into_inner();
+            .unary("list tables", ListNeighbourTablesRequest {}, async |client, request| {
+                client.list_tables(request).await
+            })
+            .await?;
 
         output::data(
             || &response.tables,
@@ -344,10 +343,10 @@ impl NeighbourService {
         };
 
         self.service
-            .client()
-            .create_table(request)
-            .await
-            .map_err(self.service.status("create table"))?;
+            .unary("create table", request, async |client, request| {
+                client.create_table(request).await
+            })
+            .await?;
 
         output::success("create table", format_args!("Created table '{}'.", cmd.name));
 
@@ -361,10 +360,10 @@ impl NeighbourService {
         };
 
         self.service
-            .client()
-            .update_table(request)
-            .await
-            .map_err(self.service.status("update table"))?;
+            .unary("update table", request, async |client, request| {
+                client.update_table(request).await
+            })
+            .await?;
 
         output::success(
             "update table",
@@ -381,10 +380,10 @@ impl NeighbourService {
         let request = RemoveNeighbourTableRequest { name: cmd.name.clone() };
 
         self.service
-            .client()
-            .remove_table(request)
-            .await
-            .map_err(self.service.status("remove table"))?;
+            .unary("remove table", request, async |client, request| {
+                client.remove_table(request).await
+            })
+            .await?;
 
         output::success("remove table", format_args!("Removed table '{}'.", cmd.name));
 

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -219,11 +219,10 @@ impl RouteService {
     pub async fn list_configs(&mut self) -> Result<(), Error> {
         let response = self
             .service
-            .client()
-            .list_configs(ListConfigsRequest {})
-            .await
-            .map_err(self.service.status("list"))?
-            .into_inner();
+            .unary("list", ListConfigsRequest {}, async |client, request| {
+                client.list_configs(request).await
+            })
+            .await?;
 
         output::data(
             || &response.configs,
@@ -256,11 +255,10 @@ impl RouteService {
 
         let response = self
             .service
-            .client()
-            .show_routes(request)
-            .await
-            .map_err(self.service.status("show"))?
-            .into_inner();
+            .unary("show", request, async |client, request| {
+                client.show_routes(request).await
+            })
+            .await?;
 
         output::data(
             || &response.routes,
@@ -288,11 +286,10 @@ impl RouteService {
 
         let response = self
             .service
-            .client()
-            .lookup_route(request)
-            .await
-            .map_err(self.service.status("lookup"))?
-            .into_inner();
+            .unary("lookup", request, async |client, request| {
+                client.lookup_route(request).await
+            })
+            .await?;
 
         output::data(
             || &response.routes,
@@ -323,10 +320,10 @@ impl RouteService {
         };
 
         self.service
-            .client()
-            .insert_route(request)
-            .await
-            .map_err(self.service.status("insert"))?;
+            .unary("insert", request, async |client, request| {
+                client.insert_route(request).await
+            })
+            .await?;
 
         let via = cmd
             .nexthop_addrs
@@ -361,10 +358,10 @@ impl RouteService {
         };
 
         self.service
-            .client()
-            .delete_route(request)
-            .await
-            .map_err(self.service.status("remove"))?;
+            .unary("remove", request, async |client, request| {
+                client.delete_route(request).await
+            })
+            .await?;
 
         let via = cmd
             .nexthop_addrs
@@ -391,10 +388,10 @@ impl RouteService {
         let request = FlushRoutesRequest { name: cmd.name.clone() };
 
         self.service
-            .client()
-            .flush_routes(request)
-            .await
-            .map_err(self.service.status("flush"))?;
+            .unary("flush", request, async |client, request| {
+                client.flush_routes(request).await
+            })
+            .await?;
 
         output::success("flush", format_args!("Flushed config '{}'.", cmd.name));
 


### PR DESCRIPTION
- Replaces the hand-written client, map_err and into_inner chain in the core binaries, the device CLIs, the route operator CLIs and ync's own gateway calls with Service::unary.
- Replaces the NotFound closures of function, pipeline, device delete and neighbour with Service::not_found, keeping each mapper's default resource label.
- Leaves ready and metrics untouched, they dispatch through Connection::invoke_unary.