### PR TITLE
perf(dataplane)!: absolutize remaining pipeline hot-path pointers

### DIFF
--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -40,11 +40,11 @@ _Static_assert(
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct module_ectx) == 184,
+	sizeof(struct module_ectx) == 208,
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct device_entry_ectx) == 264,
+	sizeof(struct device_entry_ectx) == 272,
 	"struct device_entry_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 26
+#define YANET_MODULE_ABI_VERSION 27
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -25,6 +25,13 @@ struct dp_config;
 struct module_ectx {
 	module_handler handler;
 	struct cp_module *cp_module;
+	// The same module, as an absolute address for the packet hot
+	// path.
+	//
+	// The publishing process copies it from the relative field above
+	// before the context is released to workers; it is zero until
+	// then.
+	struct cp_module *abs_cp_module;
 
 	// The module's counters, as absolute addresses for the packet hot
 	// path.
@@ -62,6 +69,13 @@ struct module_ectx {
 	// the relative one before the context is released to workers; it
 	// is zero until then.
 	struct counter_storage **abs_runtime_counter_storages;
+	// The array of absolute storages above, as an absolute address
+	// for the packet hot path.
+	//
+	// The publishing process copies it from the relative field above
+	// before the context is released to workers; it is zero until
+	// then.
+	struct counter_storage **abs_runtime_counter_storages_base;
 	// Offset pointer to the owning generation, owned by the control
 	// plane.
 	struct config_gen_ectx *config_gen_ectx;
@@ -99,6 +113,13 @@ struct module_ectx {
 	// references that object's per-worker execution context.
 	uint64_t object_link_count;
 	struct module_object_link_ectx *object_links;
+	// The same link array, as an absolute address for the packet hot
+	// path.
+	//
+	// The publishing process copies it from the relative field above
+	// before the context is released to workers; it is zero until
+	// then.
+	struct module_object_link_ectx *abs_object_links;
 };
 
 // Per-worker, per-link state for a module's link to a cp_object.
@@ -125,9 +146,7 @@ object_link_get_address(struct module_ectx *module_ectx, uint64_t index) {
 	if (index >= module_ectx->object_link_count) {
 		return NULL;
 	}
-	struct module_object_link_ectx *links =
-		ADDR_OF(&module_ectx->object_links);
-	return links + index;
+	return module_ectx->abs_object_links + index;
 }
 
 // Return the per-worker counter storage for the module's runtime counter
@@ -137,9 +156,7 @@ module_ectx_counter_storage(struct module_ectx *module_ectx, uint64_t index) {
 	if (index >= module_ectx->runtime_counter_storage_count) {
 		return NULL;
 	}
-	struct counter_storage **storages =
-		ADDR_OF(&module_ectx->abs_runtime_counter_storages);
-	return storages[index];
+	return module_ectx->abs_runtime_counter_storages_base[index];
 }
 
 static inline uint64_t
@@ -210,6 +227,13 @@ struct function_ectx {
 	// before the context is released to workers; they are zero until
 	// then, and the packet hot path loads them directly.
 	struct chain_ectx **chains;
+	// The chains array, as an absolute address for the packet hot
+	// path.
+	//
+	// The publishing process copies it from the relative field above
+	// before the context is released to workers; it is zero until
+	// then.
+	struct chain_ectx **abs_chains;
 	uint64_t chain_map_size;
 	// The function's chains, indexed by packet hash for the demux.
 	//
@@ -320,6 +344,13 @@ struct device_entry_ectx {
 	// array before the context is released to workers; they are zero
 	// until then, and the packet hot path loads them directly.
 	struct pipeline_ectx **pipelines;
+	// The pipelines array, as an absolute address for the packet hot
+	// path.
+	//
+	// The publishing process copies it from the relative field above
+	// before the context is released to workers; it is zero until
+	// then.
+	struct pipeline_ectx **abs_pipelines;
 	uint64_t pipeline_map_size;
 	// Per-entry inbox for packets awaiting processing.
 	//
@@ -359,6 +390,13 @@ struct device_ectx {
 // registry under the object_type and object_name tags.
 struct object_ectx {
 	struct cp_object *cp_object;
+	// The same object, as an absolute address for the packet hot
+	// path.
+	//
+	// The publishing process copies it from the relative field above
+	// before the context is released to workers; it is zero until
+	// then.
+	struct cp_object *abs_cp_object;
 	struct counter_storage *counter_storage;
 };
 

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -105,6 +105,8 @@ module_ectx_resolve_absolutes(struct module_ectx *module_ectx) {
 	struct counter_storage *counter_storage =
 		ADDR_OF(&module_ectx->counter_storage);
 
+	module_ectx->abs_cp_module = cp_module;
+
 	module_ectx->rx_counter = counter_get_value_handle(
 		cp_module->rx_counter_id, counter_storage
 	);
@@ -130,6 +132,7 @@ module_ectx_resolve_absolutes(struct module_ectx *module_ectx) {
 
 	struct counter_storage **abs_runtime =
 		ADDR_OF(&module_ectx->abs_runtime_counter_storages);
+	module_ectx->abs_runtime_counter_storages_base = abs_runtime;
 	if (abs_runtime != NULL) {
 		struct counter_storage **runtime =
 			ADDR_OF(&module_ectx->runtime_counter_storages);
@@ -142,6 +145,7 @@ module_ectx_resolve_absolutes(struct module_ectx *module_ectx) {
 
 	struct module_object_link_ectx *object_links =
 		ADDR_OF(&module_ectx->object_links);
+	module_ectx->abs_object_links = object_links;
 	for (uint64_t idx = 0; idx < module_ectx->object_link_count; ++idx) {
 		object_links[idx].abs_object_ectx =
 			ADDR_OF(&object_links[idx].object_ectx);
@@ -198,6 +202,7 @@ function_ectx_resolve_absolutes(struct function_ectx *function_ectx) {
 
 	struct chain_ectx **chain_ptrs = ADDR_OF(&function_ectx->chain_ptrs);
 	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
+	function_ectx->abs_chains = chains;
 	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
 		chains[idx] = ADDR_OF(chain_ptrs + idx);
 		chain_ectx_resolve_absolutes(chains[idx]);
@@ -287,6 +292,7 @@ device_entry_ectx_resolve_absolutes(
 	struct pipeline_ectx **pipeline_ptrs =
 		ADDR_OF(&entry_ectx->pipeline_ptrs);
 	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
+	entry_ectx->abs_pipelines = pipelines;
 	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
 		pipelines[idx] = ADDR_OF(pipeline_ptrs + idx);
 		pipeline_ectx_resolve_absolutes(pipelines[idx]);
@@ -312,14 +318,25 @@ device_entry_ectx_resolve_absolutes(
 
 // Derive the absolute addresses the packet hot path runs on: the
 // counter pointers of every stage, resolved from the counter registry
-// ids and the stage counter storages, and the stage hop addresses,
-// copied or recoded from the controlplane-owned relative arrays.
+// ids and the stage counter storages; the stage hop addresses, copied
+// or recoded from the controlplane-owned relative arrays; and every
+// object's controlplane counterpart, copied from the generation's
+// relative object array.
 //
 // Runs in the dataplane process before the context is released to the
 // worker, and recomputes everything from controlplane-owned data, so a
 // re-run never corrupts a previous derivation.
 void
 config_gen_ectx_resolve_counters(struct config_gen_ectx *config_gen_ectx) {
+	struct object_ectx **objects = ADDR_OF(&config_gen_ectx->objects);
+	for (uint64_t idx = 0; idx < config_gen_ectx->object_count; ++idx) {
+		struct object_ectx *object_ectx = ADDR_OF(objects + idx);
+		if (object_ectx == NULL) {
+			continue;
+		}
+		object_ectx->abs_cp_object = ADDR_OF(&object_ectx->cp_object);
+	}
+
 	struct device_ectx **device_ptrs =
 		ADDR_OF(&config_gen_ectx->device_ptrs);
 	for (uint64_t idx = 0; idx < config_gen_ectx->device_count; ++idx) {
@@ -405,8 +422,7 @@ function_ectx_run_single_chain(
 	struct function_ectx *function_ectx,
 	struct packet_front *packet_front
 ) {
-	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
-	struct chain_ectx *chain_ectx = chains[0];
+	struct chain_ectx *chain_ectx = function_ectx->abs_chains[0];
 
 	struct packet_front *schedule = &chain_ectx->schedule;
 	packet_front_take_input(schedule, packet_front);
@@ -439,7 +455,7 @@ function_ectx_run_chains(
 	packet_front->output_count = 0;
 	packet_front->output_bytes = 0;
 
-	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
+	struct chain_ectx **chains = function_ectx->abs_chains;
 
 	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
 		struct chain_ectx *chain_ectx = chains[idx];
@@ -586,8 +602,7 @@ device_entry_ectx_dispatch_single(
 	struct device_entry_ectx *entry_ectx,
 	struct packet_front *packet_front
 ) {
-	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
-	struct pipeline_ectx *pipeline_ectx = pipelines[0];
+	struct pipeline_ectx *pipeline_ectx = entry_ectx->abs_pipelines[0];
 
 	struct packet_front *schedule = &pipeline_ectx->schedule;
 	packet_front_take_output(schedule, packet_front);
@@ -607,7 +622,7 @@ device_entry_ectx_dispatch_many(
 	struct device_entry_ectx *entry_ectx,
 	struct packet_front *packet_front
 ) {
-	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
+	struct pipeline_ectx **pipelines = entry_ectx->abs_pipelines;
 
 	struct packet *packet = packet_list_pop(&packet_front->output);
 	while (packet != NULL) {

--- a/lib/fuzzing/fuzzing.h
+++ b/lib/fuzzing/fuzzing.h
@@ -172,8 +172,9 @@ fuzzing_process_packet(
 	}
 
 	// Use module_ectx from params (can be customized per module)
-	// Always set cp_module pointer
+	// Always set cp_module pointer, relative and absolute
 	SET_OFFSET_OF(&params->module_ectx.cp_module, params->cp_module);
+	params->module_ectx.abs_cp_module = params->cp_module;
 
 	// Process packet through module
 	// Some modules (like fwstate) need a worker context

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -134,9 +134,7 @@ acl_handle_packets(
 	struct packet_front *packet_front
 ) {
 	struct acl_module_config *acl_config = container_of(
-		ADDR_OF(&module_ectx->cp_module),
-		struct acl_module_config,
-		cp_module
+		module_ectx->abs_cp_module, struct acl_module_config, cp_module
 	);
 
 	// When the compile side built the union tries, both v6 filters are
@@ -168,7 +166,7 @@ acl_handle_packets(
 		);
 		if (link != NULL) {
 			struct object_ectx *oectx = link->abs_object_ectx;
-			struct cp_object *cp_obj = ADDR_OF(&oectx->cp_object);
+			struct cp_object *cp_obj = oectx->abs_cp_object;
 			fw4table = fwstate_map_v4_object_table(cp_obj);
 		}
 	}
@@ -178,7 +176,7 @@ acl_handle_packets(
 		);
 		if (link != NULL) {
 			struct object_ectx *oectx = link->abs_object_ectx;
-			struct cp_object *cp_obj = ADDR_OF(&oectx->cp_object);
+			struct cp_object *cp_obj = oectx->abs_cp_object;
 			fw6table = fwstate_map_v6_object_table(cp_obj);
 		}
 	}

--- a/modules/decap/dataplane/dataplane.c
+++ b/modules/decap/dataplane/dataplane.c
@@ -64,7 +64,7 @@ decap_handle_packets(
 ) {
 	(void)dp_worker;
 	struct decap_module_config *decap_config = container_of(
-		ADDR_OF(&module_ectx->cp_module),
+		module_ectx->abs_cp_module,
 		struct decap_module_config,
 		cp_module
 	);

--- a/modules/dscp/dataplane/dataplane.c
+++ b/modules/dscp/dataplane/dataplane.c
@@ -64,9 +64,7 @@ dscp_handle_packets(
 ) {
 	(void)dp_worker;
 	struct dscp_module_config *dscp_config = container_of(
-		ADDR_OF(&module_ectx->cp_module),
-		struct dscp_module_config,
-		cp_module
+		module_ectx->abs_cp_module, struct dscp_module_config, cp_module
 	);
 
 	if (dscp_config->dscp.flag != DSCP_MARK_NEVER) {

--- a/modules/dscp/tests/dataplane/dscp.go
+++ b/modules/dscp/tests/dataplane/dscp.go
@@ -31,6 +31,7 @@ test_dscp_handle_packets(
 ) {
 	struct module_ectx module_ectx = {};
 	SET_OFFSET_OF(&module_ectx.cp_module, cp_module);
+	module_ectx.abs_cp_module = cp_module;
 	dscp_handle_packets(dp_worker, &module_ectx, packet_front);
 }
 

--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -28,7 +28,7 @@ forward_handle_packets(
 	(void)dp_worker;
 
 	struct forward_module_config *forward_config = container_of(
-		ADDR_OF(&module_ectx->cp_module),
+		module_ectx->abs_cp_module,
 		struct forward_module_config,
 		cp_module
 	);
@@ -128,7 +128,7 @@ forward_handle_packets(
 		if (target != NULL) {
 			uint64_t *counters = counter_get_address(
 				target->counter_id,
-				ADDR_OF_NONNULL(&module_ectx->counter_storage)
+				module_ectx->abs_counter_storage
 			);
 			counters[0] += 1;
 			counters[1] += packet_data_len(packet);

--- a/modules/forward/fuzzing/forward.c
+++ b/modules/forward/fuzzing/forward.c
@@ -152,6 +152,7 @@ forward_test_config(struct cp_module **cp_module, yanet_error **err) {
 		goto fail;
 	}
 	SET_OFFSET_OF(&fuzz_params.module_ectx.counter_storage, cs);
+	fuzz_params.module_ectx.abs_counter_storage = cs;
 
 	// Set up "mc_index" so "module_ectx_encode_device" returns invalid
 	// device, causing all matched packets to be dropped safely.

--- a/modules/fwstate/dataplane/dataplane.c
+++ b/modules/fwstate/dataplane/dataplane.c
@@ -451,7 +451,7 @@ fwstate_handle_packets(
 	struct packet_front *packet_front
 ) {
 	struct fwstate_module_config *fwstate_module = container_of(
-		ADDR_OF(&module_ectx->cp_module),
+		module_ectx->abs_cp_module,
 		struct fwstate_module_config,
 		cp_module
 	);
@@ -466,8 +466,8 @@ fwstate_handle_packets(
 			module_ectx, fwstate_module->v4_object_link_idx
 		);
 		if (link != NULL) {
-			struct object_ectx *oectx = ADDR_OF(&link->object_ectx);
-			struct cp_object *cp_obj = ADDR_OF(&oectx->cp_object);
+			struct object_ectx *oectx = link->abs_object_ectx;
+			struct cp_object *cp_obj = oectx->abs_cp_object;
 			fw4table = fwstate_map_v4_object_table(cp_obj);
 		}
 	}
@@ -476,8 +476,8 @@ fwstate_handle_packets(
 			module_ectx, fwstate_module->v6_object_link_idx
 		);
 		if (link != NULL) {
-			struct object_ectx *oectx = ADDR_OF(&link->object_ectx);
-			struct cp_object *cp_obj = ADDR_OF(&oectx->cp_object);
+			struct object_ectx *oectx = link->abs_object_ectx;
+			struct cp_object *cp_obj = oectx->abs_cp_object;
 			fw6table = fwstate_map_v6_object_table(cp_obj);
 		}
 	}
@@ -488,7 +488,7 @@ fwstate_handle_packets(
 	// size=2 counters: [0]=packets, [1]=bytes; size=1 counters:
 	// [0]=packets.
 	struct counter_storage *counter_storage =
-		ADDR_OF_NONNULL(&module_ectx->counter_storage);
+		module_ectx->abs_counter_storage;
 
 	uint64_t *sync_packets_cnt = counter_get_address(
 		fwstate_module->sync_packets_counter_id, counter_storage

--- a/modules/fwstate/fuzzing/fwstate.c
+++ b/modules/fwstate/fuzzing/fwstate.c
@@ -182,6 +182,7 @@ fwstate_test_config(struct cp_module **cp_module) {
 		goto error_registry;
 	}
 	SET_OFFSET_OF(&fuzz_params.module_ectx.counter_storage, cs);
+	fuzz_params.module_ectx.abs_counter_storage = cs;
 
 	// Give each stand-in map object one table layer, grown with the
 	// fwtable control-plane helper into the module's memory context.
@@ -234,16 +235,23 @@ fwstate_test_config(struct cp_module **cp_module) {
 
 	// Wire the config's link indices to the stand-in objects through the
 	// execution context: slot 0 names the v4 map, slot 1 the v6 map.
+	// Both the relative and the absolute hops are set, the way a
+	// published context carries them.
 	memset(fuzz_object_ectxs, 0, sizeof(fuzz_object_ectxs));
 	memset(fuzz_object_links, 0, sizeof(fuzz_object_links));
 	SET_OFFSET_OF(&fuzz_object_ectxs[0].cp_object, &fuzz_map_v4.cp_object);
+	fuzz_object_ectxs[0].abs_cp_object = &fuzz_map_v4.cp_object;
 	SET_OFFSET_OF(&fuzz_object_ectxs[1].cp_object, &fuzz_map_v6.cp_object);
+	fuzz_object_ectxs[1].abs_cp_object = &fuzz_map_v6.cp_object;
 	SET_OFFSET_OF(&fuzz_object_links[0].object_ectx, &fuzz_object_ectxs[0]);
+	fuzz_object_links[0].abs_object_ectx = &fuzz_object_ectxs[0];
 	SET_OFFSET_OF(&fuzz_object_links[1].object_ectx, &fuzz_object_ectxs[1]);
+	fuzz_object_links[1].abs_object_ectx = &fuzz_object_ectxs[1];
 	fuzz_params.module_ectx.object_link_count = 2;
 	SET_OFFSET_OF(
 		&fuzz_params.module_ectx.object_links, &fuzz_object_links[0]
 	);
+	fuzz_params.module_ectx.abs_object_links = &fuzz_object_links[0];
 
 	config->v4_object_link_idx = 0;
 	config->v6_object_link_idx = 1;
@@ -279,6 +287,7 @@ error_table_v4:
 error_storage:
 	counter_storage_free(ADDR_OF(&fuzz_params.module_ectx.counter_storage));
 	SET_OFFSET_OF(&fuzz_params.module_ectx.counter_storage, NULL);
+	fuzz_params.module_ectx.abs_counter_storage = NULL;
 
 error_registry:
 	counter_registry_fini(&config->cp_module.counter_registry);

--- a/modules/fwstate/tests/dataplane/harness.c
+++ b/modules/fwstate/tests/dataplane/harness.c
@@ -156,7 +156,9 @@ test_fwstate_handle_packets(
 ) {
 	struct module_ectx module_ectx = {};
 	SET_OFFSET_OF(&module_ectx.cp_module, cp_module);
+	module_ectx.abs_cp_module = cp_module;
 	SET_OFFSET_OF(&module_ectx.counter_storage, counter_storage);
+	module_ectx.abs_counter_storage = counter_storage;
 
 	// Populate the ectx's object links the way the production build does:
 	// one entry per declaration, each pointing at the registered object.
@@ -191,12 +193,15 @@ test_fwstate_handle_packets(
 		}
 
 		SET_OFFSET_OF(&object_ectxs[idx].cp_object, cp_object);
+		object_ectxs[idx].abs_cp_object = cp_object;
 		SET_OFFSET_OF(&links[idx].object_ectx, &object_ectxs[idx]);
+		links[idx].abs_object_ectx = &object_ectxs[idx];
 	}
 
 	if (all_resolved) {
 		module_ectx.object_link_count = object_count;
 		SET_OFFSET_OF(&module_ectx.object_links, &links[0]);
+		module_ectx.abs_object_links = &links[0];
 	}
 
 	fwstate_handle_packets(dp_worker, &module_ectx, packet_front);

--- a/modules/mirror/dataplane/dataplane.c
+++ b/modules/mirror/dataplane/dataplane.c
@@ -48,7 +48,7 @@ mirror_handle_packets(
 	struct packet_front *packet_front
 ) {
 	struct mirror_module_config *mirror_config = container_of(
-		ADDR_OF(&module_ectx->cp_module),
+		module_ectx->abs_cp_module,
 		struct mirror_module_config,
 		cp_module
 	);
@@ -145,7 +145,7 @@ mirror_handle_packets(
 		if (target != NULL) {
 			uint64_t *counters = counter_get_address(
 				target->counter_id,
-				ADDR_OF_NONNULL(&module_ectx->counter_storage)
+				module_ectx->abs_counter_storage
 			);
 			counters[0] += 1;
 			counters[1] += packet_data_len(packet);

--- a/modules/mirror/fuzzing/mirror.c
+++ b/modules/mirror/fuzzing/mirror.c
@@ -151,6 +151,7 @@ mirror_test_config(struct cp_module **cp_module, yanet_error **err) {
 		goto fail;
 	}
 	SET_OFFSET_OF(&fuzz_params.module_ectx.counter_storage, cs);
+	fuzz_params.module_ectx.abs_counter_storage = cs;
 
 	// Set up "mc_index" so "module_ectx_encode_device" returns invalid
 	// device, causing all matched packets to be dropped safely.

--- a/modules/nat64/dataplane/nat64dp.c
+++ b/modules/nat64/dataplane/nat64dp.c
@@ -3208,7 +3208,7 @@ nat64_handle_packets(
 	(void)dp_worker;
 
 	struct nat64_module_config *nat64_config = container_of(
-		ADDR_OF(&module_ectx->cp_module),
+		module_ectx->abs_cp_module,
 		struct nat64_module_config,
 		cp_module
 	);

--- a/modules/nat64/tests/dataplane/nat64.go
+++ b/modules/nat64/tests/dataplane/nat64.go
@@ -91,6 +91,7 @@ test_nat64_handle_packets(
 ) {
 	struct module_ectx module_ectx = {};
 	SET_OFFSET_OF(&module_ectx.cp_module, cp_module);
+	module_ectx.abs_cp_module = cp_module;
 	nat64_handle_packets(dp_worker, &module_ectx, packet_front);
 }
 */

--- a/modules/nat64/tests/unittest/nat64_test.c
+++ b/modules/nat64/tests/unittest/nat64_test.c
@@ -4085,6 +4085,7 @@ test_nat64_udp_checksum() {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);
@@ -4164,6 +4165,7 @@ process_test_case(struct test_case *tc) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);
@@ -4857,6 +4859,8 @@ test_nat64_bounds_validation(void) {
 			&module_ectx.cp_module,
 			&test_params.module_config.cp_module
 		);
+		module_ectx.abs_cp_module =
+			&test_params.module_config.cp_module;
 		test_params.module->handler(
 			NULL, &module_ectx, &test_params.packet_front
 		);
@@ -4938,6 +4942,8 @@ test_nat64_bounds_validation(void) {
 			&module_ectx.cp_module,
 			&test_params.module_config.cp_module
 		);
+		module_ectx.abs_cp_module =
+			&test_params.module_config.cp_module;
 		test_params.module->handler(
 			NULL, &module_ectx, &test_params.packet_front
 		);
@@ -5111,6 +5117,7 @@ test_nat64_icmp_embedded_overflow(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(NULL, &module_ectx, &pf);
 
 	// Packet should be dropped due to payload_len overflow
@@ -5354,6 +5361,7 @@ test_nat64_icmp_v4tov6_embedded_cksum_overflow(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);
@@ -5425,6 +5433,7 @@ test_nat64_icmp_v4tov6_memmove_overflow(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);
@@ -5530,6 +5539,7 @@ test_nat64_icmp_v6tov4_empty_embedded_transport(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);
@@ -5627,6 +5637,7 @@ test_nat64_icmp_v4tov6_empty_embedded_transport(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);
@@ -5732,6 +5743,7 @@ test_nat64_icmp_v4tov6_valid_error_translates(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);
@@ -5837,6 +5849,7 @@ test_nat64_icmp_v4tov6_fuzz_crash_regression(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(NULL, &module_ectx, &pf);
 
 	// The packet must be dropped, not cause a crash or OOB read
@@ -5966,6 +5979,7 @@ test_nat64_icmp_v6tov4_truncated_embedded_tcp(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);
@@ -6064,6 +6078,7 @@ test_nat64_icmp_v4tov6_truncated_embedded_tcp(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);
@@ -6184,6 +6199,7 @@ test_nat64_icmp_v6tov4_nested_icmp_zero_payload(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);
@@ -6306,6 +6322,7 @@ test_nat64_icmp_v6tov4_nontransport_embedded_translated(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);
@@ -6401,6 +6418,7 @@ test_nat64_icmp_v4tov6_nontransport_embedded_translated(void) {
 	SET_OFFSET_OF(
 		&module_ectx.cp_module, &test_params.module_config.cp_module
 	);
+	module_ectx.abs_cp_module = &test_params.module_config.cp_module;
 	test_params.module->handler(
 		NULL, &module_ectx, &test_params.packet_front
 	);

--- a/modules/pdump/dataplane/dataplane.c
+++ b/modules/pdump/dataplane/dataplane.c
@@ -66,7 +66,7 @@ pdump_handle_packets(
 	struct packet_front *packet_front
 ) {
 	struct pdump_module_config *config = container_of(
-		ADDR_OF(&module_ectx->cp_module),
+		module_ectx->abs_cp_module,
 		struct pdump_module_config,
 		cp_module
 	);

--- a/modules/route-mpls/dataplane/dataplane.c
+++ b/modules/route-mpls/dataplane/dataplane.c
@@ -37,9 +37,7 @@ route_mpls_handle_packets(
 	(void)dp_worker;
 
 	struct module_config *module_config = container_of(
-		ADDR_OF(&module_ectx->cp_module),
-		struct module_config,
-		cp_module
+		module_ectx->abs_cp_module, struct module_config, cp_module
 	);
 
 	// The worker's per-tick force-poll can reach this handler with an empty

--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -153,13 +153,13 @@ route_handle_packets(
 	(void)dp_worker;
 
 	struct route_module_config *route_config = container_of(
-		ADDR_OF(&module_ectx->cp_module),
+		module_ectx->abs_cp_module,
 		struct route_module_config,
 		cp_module
 	);
 
 	struct counter_storage *counter_storage =
-		ADDR_OF_NONNULL(&module_ectx->counter_storage);
+		module_ectx->abs_counter_storage;
 	// Per-route counters live in the "routes" runtime registry, resolved
 	// through its own per-worker storage.
 	struct counter_storage *routes_storage = module_ectx_counter_storage(

--- a/modules/route/fuzzing/route.c
+++ b/modules/route/fuzzing/route.c
@@ -130,6 +130,7 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 		goto error_lpm_v6;
 	}
 	SET_OFFSET_OF(&fuzz_params.module_ectx.counter_storage, cs);
+	fuzz_params.module_ectx.abs_counter_storage = cs;
 
 	*cp_module = (struct cp_module *)config;
 	return 0;

--- a/modules/unrdup/dataplane/dataplane.c
+++ b/modules/unrdup/dataplane/dataplane.c
@@ -739,13 +739,13 @@ unrdup_handle_packets(
 	struct packet_front *packet_front
 ) {
 	struct unrdup_module_config *config = container_of(
-		ADDR_OF(&module_ectx->cp_module),
+		module_ectx->abs_cp_module,
 		struct unrdup_module_config,
 		cp_module
 	);
 
 	struct counter_storage *counter_storage =
-		ADDR_OF_NONNULL(&module_ectx->counter_storage);
+		module_ectx->abs_counter_storage;
 
 	struct unrdup_fanout fanout = {
 		.dp_worker = dp_worker,

--- a/modules/unrdup/fuzzing/unrdup.c
+++ b/modules/unrdup/fuzzing/unrdup.c
@@ -180,6 +180,7 @@ unrdup_test_config(struct cp_module **cp_module, yanet_error **err) {
 	SET_OFFSET_OF(
 		&fuzz_params.module_ectx.counter_storage, counter_storage
 	);
+	fuzz_params.module_ectx.abs_counter_storage = counter_storage;
 
 	*cp_module = &config->cp_module;
 	return 0;

--- a/modules/unrdup/tests/dataplane/unrdup_test.c
+++ b/modules/unrdup/tests/dataplane/unrdup_test.c
@@ -337,7 +337,9 @@ run_module(struct packet *packet, struct packet_front *packet_front) {
 	struct module_ectx module_ectx;
 	memset(&module_ectx, 0, sizeof(module_ectx));
 	SET_OFFSET_OF(&module_ectx.cp_module, &config.cp_module);
+	module_ectx.abs_cp_module = &config.cp_module;
 	SET_OFFSET_OF(&module_ectx.counter_storage, test_counter_storage);
+	module_ectx.abs_counter_storage = test_counter_storage;
 
 	unrdup_handle_packets(&worker, &module_ectx, packet_front);
 }


### PR DESCRIPTION
- The module, function, device-entry and object execution contexts carry publish-resolved absolute counterparts of the module configuration pointer, the chain and pipeline dispatch arrays, the object link array, the runtime counter storages and the linked objects' controlplane counterparts, so the packet hot path and every module handler load them without offset translation.
- The relative fields stay authoritative for the controlplane free and link paths, and the publishing process re-derives every absolute address from them, so repeated passes stay correct across restarts and re-publications.
- Every hand-built execution context in the fuzz drivers and dataplane test harnesses sets the absolute twins alongside the relative pointers.
- Bumps YANET_MODULE_ABI_VERSION to 27.