### PR TITLE
refactor(cli): print list commands through the shared name renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3158,7 +3158,6 @@ dependencies = [
  "netip",
  "prost",
  "prost-types",
- "ptree",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -6,7 +6,7 @@ use commonpb::pb::FunctionId;
 use tonic::{Status, codec::CompressionEncoding};
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -101,19 +101,10 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     match cmd.mode {
         ModeCmd::List => {
             let ids = service.list_functions().await?;
+            let names: Vec<String> = ids.iter().map(|id| id.name.clone()).collect();
             output::data(
                 || &ids,
-                || {
-                    if ids.is_empty() {
-                        output::empty(format_args!("No functions found."));
-                        return;
-                    }
-
-                    print!(
-                        "{}",
-                        serde_yaml::to_string(&ids).expect("function list YAML serialization must not fail")
-                    );
-                },
+                || display::print_names(&names, format_args!("No functions found.")),
             );
         }
         ModeCmd::Show(show) => {

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -6,7 +6,7 @@ use commonpb::pb::{FunctionId, PipelineId};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -99,19 +99,10 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     match cmd.mode {
         ModeCmd::List => {
             let ids = service.list_pipelines().await?;
+            let names: Vec<String> = ids.iter().map(|id| id.name.clone()).collect();
             output::data(
                 || &ids,
-                || {
-                    if ids.is_empty() {
-                        output::empty(format_args!("No pipelines found."));
-                        return;
-                    }
-
-                    print!(
-                        "{}",
-                        serde_yaml::to_string(&ids).expect("pipeline list YAML serialization must not fail")
-                    );
-                },
+                || display::print_names(&names, format_args!("No pipelines found.")),
             );
         }
         ModeCmd::Show(show) => {

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -10,7 +10,7 @@ use trafgenpb::{
 };
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -154,19 +154,13 @@ impl TrafgenService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No trafgen configurations found."),
-                        format_args!(
-                            "create one with 'yanet-cli-device-trafgen update --name <name> --input <pipeline:weight> --output <pipeline:weight>'"
-                        ),
-                    );
-                    return;
-                }
-
-                for name in &response.configs {
-                    println!("{name}");
-                }
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No trafgen configurations found."),
+                    format_args!(
+                        "create one with 'yanet-cli-device-trafgen update --name <name> --input <pipeline:weight> --output <pipeline:weight>'"
+                    ),
+                )
             },
         );
 

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -12,7 +12,7 @@ use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     metrics,
     output::{self, CommonFormat},
@@ -274,17 +274,11 @@ impl ACLService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No ACL configurations found."),
-                        format_args!("create one with 'yanet-cli-acl update --name <name> <path>'"),
-                    );
-                    return;
-                }
-
-                for name in &response.configs {
-                    println!("{name}");
-                }
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No ACL configurations found."),
+                    format_args!("create one with 'yanet-cli-acl update --name <name> <path>'"),
+                )
             },
         );
 

--- a/modules/balancer2/cli/Cargo.toml
+++ b/modules/balancer2/cli/Cargo.toml
@@ -22,7 +22,6 @@ prost-types = "0.14"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
-ptree = "0.5"
 tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 log = "0.4"
 chrono = "0.4"

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -2,10 +2,10 @@ use core::net::IpAddr;
 use std::time;
 
 use commonpb::pb::GetMetricsRequest;
-use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    display::print_names_with_hint,
     errors::Error,
     output::{self, CommonFormat},
     yaml,
@@ -100,21 +100,13 @@ impl Balancer2Service {
         output::data(
             || &response.names,
             || {
-                if response.names.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No balancer configurations found."),
-                        format_args!(
-                            "create one with 'yanet-cli-balancer2 update --name <name> --sessions <sessions-name> <path>'"
-                        ),
-                    );
-                    return;
-                }
-
-                let mut tree = TreeBuilder::new("Balancers".to_owned());
-                for name in &response.names {
-                    tree.add_empty_child(name.clone());
-                }
-                let _ = ptree::print_tree(&tree.build());
+                print_names_with_hint(
+                    &response.names,
+                    format_args!("No balancer configurations found."),
+                    format_args!(
+                        "create one with 'yanet-cli-balancer2 update --name <name> --sessions <sessions-name> <path>'"
+                    ),
+                )
             },
         );
 
@@ -205,21 +197,11 @@ impl Balancer2Service {
         output::data(
             || &response.names,
             || {
-                if response.names.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No session states found."),
-                        format_args!(
-                            "create one with 'yanet-cli-balancer2 sessions update --name <name> --capacity <n>'"
-                        ),
-                    );
-                    return;
-                }
-
-                let mut tree = TreeBuilder::new("Sessions States".to_owned());
-                for name in &response.names {
-                    tree.add_empty_child(name.clone());
-                }
-                let _ = ptree::print_tree(&tree.build());
+                print_names_with_hint(
+                    &response.names,
+                    format_args!("No session states found."),
+                    format_args!("create one with 'yanet-cli-balancer2 sessions update --name <name> --capacity <n>'"),
+                )
             },
         );
 

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -7,7 +7,7 @@ use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -127,17 +127,11 @@ impl BlackholeService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No blackhole configurations found."),
-                        format_args!("create one with 'yanet-cli-blackhole update --name <name>'"),
-                    );
-                    return;
-                }
-
-                for name in &response.configs {
-                    println!("{name}");
-                }
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No blackhole configurations found."),
+                    format_args!("create one with 'yanet-cli-blackhole update --name <name>'"),
+                )
             },
         );
 

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -10,7 +10,7 @@ use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -133,19 +133,11 @@ impl DecapService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No decap configurations found."),
-                        format_args!("create one with 'yanet-cli-decap update --name <name> --prefix <cidr>'"),
-                    );
-                    return;
-                }
-
-                let mut tree = TreeBuilder::new("List Decap Configs".to_string());
-                for config in &response.configs {
-                    tree.add_empty_child(config.clone());
-                }
-                let _ = ptree::print_tree(&tree.build());
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No decap configurations found."),
+                    format_args!("create one with 'yanet-cli-decap update --name <name> --prefix <cidr>'"),
+                )
             },
         );
 

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -10,7 +10,7 @@ use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -187,19 +187,11 @@ impl DscpService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No DSCP configurations found."),
-                        format_args!("create one with 'yanet-cli-dscp prefix-add --name <name> --prefix <cidr>'"),
-                    );
-                    return;
-                }
-
-                let mut tree = TreeBuilder::new("List DSCP Configs".to_string());
-                for config in &response.configs {
-                    tree.add_empty_child(config.clone());
-                }
-                let _ = ptree::print_tree(&tree.build());
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No DSCP configurations found."),
+                    format_args!("create one with 'yanet-cli-dscp prefix-add --name <name> --prefix <cidr>'"),
+                )
             },
         );
 

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Deserializer, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{self, ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -246,17 +246,11 @@ impl ForwardService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No forward configurations found."),
-                        format_args!("create one with 'yanet-cli-forward update --name <name> <path>'"),
-                    );
-                    return;
-                }
-
-                for name in &response.configs {
-                    println!("{name}");
-                }
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No forward configurations found."),
+                    format_args!("create one with 'yanet-cli-forward update --name <name> <path>'"),
+                )
             },
         );
 

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -12,7 +12,7 @@ use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -52,30 +52,6 @@ pub struct Cmd {
     pub verbose: u8,
 }
 
-/// Makes text that came off the wire safe to hand a terminal.
-///
-/// A name is stored as it was given, so it can carry an escape sequence or
-/// a newline. It is spelled out rather than dropped: two names that differ
-/// only in one must not read alike.
-fn escape_wire_text(value: &str) -> String {
-    value.escape_debug().to_string()
-}
-
-/// Orders the stored configuration names for a human reader.
-///
-/// The service builds its reply by walking a map, so the order it answers
-/// in changes between calls and would otherwise reshuffle the listing under
-/// an operator watching it.
-fn config_list_rows(configs: &[String]) -> Vec<ConfigRow> {
-    let mut names: Vec<&String> = configs.iter().collect();
-    names.sort();
-
-    names
-        .into_iter()
-        .map(|name| ConfigRow { config: escape_wire_text(name) })
-        .collect()
-}
-
 /// Renders a stored nanosecond timeout as the milliseconds an operator reads.
 ///
 /// Zero is a meaningful setting here, so a value below a millisecond keeps
@@ -91,12 +67,6 @@ fn format_timeout_millis(nanos: u64) -> String {
 
     let fraction = format!("{remainder:06}");
     format!("{millis}.{}", fraction.trim_end_matches('0'))
-}
-
-#[derive(Tabled)]
-struct ConfigRow {
-    #[tabled(rename = "Config")]
-    config: String,
 }
 
 #[derive(Tabled)]
@@ -116,9 +86,9 @@ impl SettingRow {
 /// Lays out one stored configuration for a human reader.
 fn config_rows(response: &ShowConfigResponse) -> Vec<SettingRow> {
     let mut rows = vec![
-        SettingRow::new("name", escape_wire_text(&response.name)),
-        SettingRow::new("map name v4", escape_wire_text(&response.map_name_v4)),
-        SettingRow::new("map name v6", escape_wire_text(&response.map_name_v6)),
+        SettingRow::new("name", display::escape_wire_text(&response.name)),
+        SettingRow::new("map name v4", display::escape_wire_text(&response.map_name_v4)),
+        SettingRow::new("map name v6", display::escape_wire_text(&response.map_name_v6)),
     ];
 
     let Some(sync_config) = response.sync_config.as_ref() else {
@@ -304,17 +274,13 @@ impl FWStateService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No FWState configurations found."),
-                        format_args!(
-                            "provision maps with 'yanet-cli-fwstatemap create --name <map> --kind <v4|v6>', then create a config with 'yanet-cli-fwstate update --name <name> --map-name-v4 <map> --map-name-v6 <map>'"
-                        ),
-                    );
-                    return;
-                }
-
-                ync::display::print_table_from_entries(config_list_rows(&response.configs));
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No FWState configurations found."),
+                    format_args!(
+                        "provision maps with 'yanet-cli-fwstatemap create --name <map> --kind <v4|v6>', then create a config with 'yanet-cli-fwstate update --name <name> --map-name-v4 <map> --map-name-v6 <map>'"
+                    ),
+                )
             },
         );
 
@@ -335,7 +301,7 @@ impl FWStateService {
 
         output::data(
             || &response,
-            || ync::display::print_table_from_entries(config_rows(&response)),
+            || display::print_table_from_entries(config_rows(&response)),
         );
 
         Ok(())
@@ -508,21 +474,6 @@ mod tests {
 
         let settings: Vec<String> = config_rows(&response).into_iter().map(|row| row.setting).collect();
         assert_eq!(vec!["name", "map name v4", "map name v6"], settings);
-    }
-
-    #[test]
-    fn test_escape_wire_text_spells_out_control_characters() {
-        assert_eq!("fwstate0", escape_wire_text("fwstate0"));
-        assert_eq!("a\\nb", escape_wire_text("a\nb"));
-        assert_eq!("\\u{1b}\\r[2J", escape_wire_text("\u{1b}\r[2J"));
-    }
-
-    #[test]
-    fn test_config_list_rows_are_ordered() {
-        let configs = ["fwstate2".to_string(), "fwstate0".to_string(), "fwstate1".to_string()];
-
-        let names: Vec<String> = config_list_rows(&configs).into_iter().map(|row| row.config).collect();
-        assert_eq!(vec!["fwstate0", "fwstate1", "fwstate2"], names);
     }
 
     #[test]

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
     yaml,
@@ -300,17 +300,11 @@ impl MirrorService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No mirror configurations found."),
-                        format_args!("create one with 'yanet-cli-mirror update --name <name> <path>'"),
-                    );
-                    return;
-                }
-
-                for name in &response.configs {
-                    println!("{name}");
-                }
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No mirror configurations found."),
+                    format_args!("create one with 'yanet-cli-mirror update --name <name> <path>'"),
+                )
             },
         );
 

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -12,7 +12,7 @@ use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -239,19 +239,11 @@ impl NAT64Service {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No NAT64 configurations found."),
-                        format_args!("create one with 'yanet-cli-nat64 prefix add --name <name> --prefix <cidr>'"),
-                    );
-                    return;
-                }
-
-                let mut tree = TreeBuilder::new("List NAT64 Configs".to_owned());
-                for config in &response.configs {
-                    tree.add_empty_child(config.clone());
-                }
-                let _ = ptree::print_tree(&tree.build());
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No NAT64 configurations found."),
+                    format_args!("create one with 'yanet-cli-nat64 prefix add --name <name> --prefix <cidr>'"),
+                )
             },
         );
 

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 use tonic::{Status, codec::CompressionEncoding};
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::{Error, ErrorKind},
     output::{self, CommonFormat},
 };
@@ -103,19 +103,11 @@ impl PdumpService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No pdump configurations found."),
-                        format_args!("create one with 'yanet-cli-pdump set --name <name>'"),
-                    );
-                    return;
-                }
-
-                let mut tree = TreeBuilder::new("List Pdump Configs".to_owned());
-                for config in &response.configs {
-                    tree.add_empty_child(config.clone());
-                }
-                let _ = ptree::print_tree(&tree.build());
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No pdump configurations found."),
+                    format_args!("create one with 'yanet-cli-pdump set --name <name>'"),
+                )
             },
         );
 

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -19,7 +19,7 @@ use routemplspb::{
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -191,17 +191,11 @@ impl RouteMplsService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No route-mpls configurations found."),
-                        format_args!("create one with 'yanet-cli-route-mpls create --name <name>'"),
-                    );
-                    return;
-                }
-
-                for name in &response.configs {
-                    println!("{name}");
-                }
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No route-mpls configurations found."),
+                    format_args!("create one with 'yanet-cli-route-mpls create --name <name>'"),
+                )
             },
         );
 

--- a/modules/route/cli/src/main.rs
+++ b/modules/route/cli/src/main.rs
@@ -10,7 +10,7 @@ use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
     yaml,
@@ -288,17 +288,11 @@ impl RouteService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No FIB configurations found."),
-                        format_args!("create one with 'yanet-cli-route fib update --name <name> <path>'"),
-                    );
-                    return;
-                }
-
-                for name in &response.configs {
-                    println!("{name}");
-                }
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No FIB configurations found."),
+                    format_args!("create one with 'yanet-cli-route fib update --name <name> <path>'"),
+                )
             },
         );
         Ok(())

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -13,7 +13,7 @@ use unrduppb::{
 };
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service as GrpcService},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
     yaml,
@@ -272,17 +272,11 @@ impl UnrdupService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No unrdup configurations found."),
-                        format_args!("create one with 'yanet-cli-unrdup update --name <name> <path>'"),
-                    );
-                    return;
-                }
-
-                for name in &response.configs {
-                    println!("{name}");
-                }
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No unrdup configurations found."),
+                    format_args!("create one with 'yanet-cli-unrdup update --name <name> <path>'"),
+                )
             },
         );
 

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -173,21 +173,11 @@ impl FWStateMapService {
         output::data(
             || &listed,
             || {
-                if response.maps.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No fwstate-map objects found."),
-                        format_args!("create one with 'yanet-cli-fwstatemap create --name <name> --kind <v4|v6>'"),
-                    );
-                    return;
-                }
-
-                // The human render keeps the plain name list; the family
-                // pairs above are the structured payload for JSON output.
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&response.maps)
-                        .expect("fwstate-map list JSON serialization must not fail")
-                );
+                display::print_names_with_hint(
+                    &response.maps,
+                    format_args!("No fwstate-map objects found."),
+                    format_args!("create one with 'yanet-cli-fwstatemap create --name <name> --kind <v4|v6>'"),
+                )
             },
         );
 

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -19,7 +19,7 @@ use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
-    completion,
+    completion, display,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -227,19 +227,13 @@ impl RouteService {
         output::data(
             || &response.configs,
             || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No route configurations found."),
-                        format_args!(
-                            "create one with 'yanet-cli-operator-route insert <prefix> --name <name> --via <addr>'"
-                        ),
-                    );
-                    return;
-                }
-
-                for config in &response.configs {
-                    println!("{config}");
-                }
+                display::print_names_with_hint(
+                    &response.configs,
+                    format_args!("No route configurations found."),
+                    format_args!(
+                        "create one with 'yanet-cli-operator-route insert <prefix> --name <name> --via <addr>'"
+                    ),
+                )
             },
         );
 


### PR DESCRIPTION
- Every list command renders its names through display::print_names, so all of them sort the names and escape control characters instead of four different renderings (plain lines, ptree, a table, a YAML or JSON dump).
- fwstate drops its own escaping and its one-column table, balancer2 drops its ptree dependency.
- The JSON payloads are unchanged.