### PR TITLE
refactor(controlplane,decap): own published configs through a shared store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ make ai/agents                                     # regenerate agent charters f
 ## Layout
 
 - `dataplane/` — DPDK binary (`main.c`, `config.c`, `dpdk.c`, `worker.c`, `drivers/`).
-- `controlplane/` — gateway (`gateway/`), built-in services (`builtin/`), CGO shm bindings (`ffi/`), root protos (`ynpb/`), control-plane package (`yncp/`), entrypoint (`cmd/yncp-director`).
+- `controlplane/` — gateway (`gateway/`), built-in services (`builtin/`), CGO shm bindings (`ffi/`), published-config store shared by module services (`configstore/`), root protos (`ynpb/`), control-plane package (`yncp/`), entrypoint (`cmd/yncp-director`).
 - `modules/` — packet-processing modules; `devices/` — device adapters (`plain`, `vlan`, `trafgen`), same layout.
 - `operators/` — long-running Go orchestration daemons above the gateway: `pipeline`, `decap`, `forward`, `route` (each `cmd/` + `internal/` + `operatorpb/` + Rust `cli/`), `bird-adapter`, `neighbours` (web only here; process in the private repo).
 - `lib/` — C support libs (`controlplane`, `counters`, `dataplane`, `dataplane_ut`, `errors`, `filter`, `fwstate`, `logging`, `utils`); `api/` — public C API headers; `bindings/go/` — root CGO agent bindings.

--- a/common/go/testutils/free.go
+++ b/common/go/testutils/free.go
@@ -1,0 +1,42 @@
+package testutils
+
+import "sync/atomic"
+
+// FreeSequence is a fake handle whose Free returns the scripted outcomes
+// in order and succeeds once they run out, counting every call.
+//
+// A test scripts a refusal with whichever sentinel the code under test
+// matches, so the fake carries no error vocabulary of its own. Calls
+// past the script succeed, mirroring a real handle, whose repeated free
+// is a no-op.
+type FreeSequence struct {
+	outcomes []error
+	calls    atomic.Int64
+	freed    atomic.Int64
+}
+
+// NewFreeSequence returns a handle that answers Free with the outcomes in
+// order.
+func NewFreeSequence(outcomes ...error) *FreeSequence {
+	return &FreeSequence{outcomes: outcomes}
+}
+
+// Free returns the next scripted outcome.
+func (m *FreeSequence) Free() error {
+	call := int(m.calls.Add(1))
+	if call <= len(m.outcomes) && m.outcomes[call-1] != nil {
+		return m.outcomes[call-1]
+	}
+	m.freed.Add(1)
+	return nil
+}
+
+// Calls returns how many times Free was called.
+func (m *FreeSequence) Calls() int64 {
+	return m.calls.Load()
+}
+
+// Freed returns how many Free calls succeeded.
+func (m *FreeSequence) Freed() int64 {
+	return m.freed.Load()
+}

--- a/controlplane/configstore/store.go
+++ b/controlplane/configstore/store.go
@@ -1,0 +1,179 @@
+package configstore
+
+import (
+	"errors"
+	"maps"
+	"slices"
+	"sync"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+// ErrNotFound is reported by Delete when nothing is published under the
+// name.
+var ErrNotFound = errors.New("config not found")
+
+// Entry is a published configuration owned by a Store.
+type Entry interface {
+	// Free releases the entry, reporting ffi.ErrStillReferenced when a
+	// live configuration generation still references it.
+	Free() error
+}
+
+// Store owns the published configurations of one control-plane service,
+// keyed by name, together with the entries whose free was refused.
+//
+// Readers never wait for shared memory: a lookup takes a read lock that
+// no writer holds across a publish, so a slow update or delete stalls
+// only other writers. Writers run one at a time across every name, and
+// the entry a writer is handed stays the published one until its own
+// publish replaces it. A superseded or deleted entry whose free is
+// refused, because a live generation still references it, is parked and
+// retried on every later successful mutation, and the store is the only
+// place that remembers it.
+//
+// A published entry is handed to readers without any lock, so it must
+// not change after it is stored. Mutation callbacks must not call back
+// into a mutation of the same store, which would deadlock, while
+// lookups from a callback are fine.
+type Store[E Entry] struct {
+	// writeMu serializes mutations for their whole duration, publish
+	// included, and guards the parked entries.
+	writeMu sync.Mutex
+	// mu guards the entries map alone and is never held across a
+	// publish or a free.
+	mu      sync.RWMutex
+	entries map[string]E
+	// deferred holds retired entries whose free was refused.
+	deferred []E
+}
+
+// NewStore returns an empty store.
+func NewStore[E Entry]() *Store[E] {
+	return &Store[E]{entries: map[string]E{}}
+}
+
+// Names returns the published names in sorted order.
+func (m *Store[E]) Names() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return slices.Sorted(maps.Keys(m.entries))
+}
+
+// Get returns the entry published under the name.
+func (m *Store[E]) Get(name string) (E, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	entry, ok := m.entries[name]
+	return entry, ok
+}
+
+// Update publishes a new entry under the name and retires the previous
+// one.
+//
+// The callback is handed the current entry, when one exists, and returns
+// the entry to store. Its error is returned unchanged and leaves the
+// store as it was. On success the new entry replaces the old one under a
+// brief write lock, then the parked entries are retried and the old one
+// is freed or parked, so a callback must build a fresh entry rather than
+// hand back the one it was given. Callbacks run one at a time across
+// every name.
+func (m *Store[E]) Update(
+	name string,
+	publish func(current E, ok bool) (E, error),
+) error {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+
+	current, ok := m.Get(name)
+	entry, err := publish(current, ok)
+	if err != nil {
+		return err
+	}
+
+	m.set(name, entry)
+
+	// The publish retired the generation holding the previous entry.
+	m.reclaimDeferred()
+	if ok {
+		m.parkOrFree(current)
+	}
+
+	return nil
+}
+
+// Delete unpublishes the entry under the name and forgets it.
+//
+// ErrNotFound is returned when the name is absent, before the callback
+// runs. The callback's error is returned unchanged and keeps the entry
+// published. On success the entry is removed under a brief write lock,
+// then the parked entries are retried and the entry is freed or parked.
+func (m *Store[E]) Delete(name string, unpublish func(current E) error) error {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+
+	current, ok := m.Get(name)
+	if !ok {
+		return ErrNotFound
+	}
+	if err := unpublish(current); err != nil {
+		return err
+	}
+
+	m.remove(name)
+
+	// The delete retired the generation holding the entry.
+	m.reclaimDeferred()
+	m.parkOrFree(current)
+
+	return nil
+}
+
+// ReclaimDeferred retries every parked entry, dropping the ones whose
+// generations have drained and keeping the rest parked.
+//
+// Every successful mutation runs it, and anything else may call it at
+// any time.
+func (m *Store[E]) ReclaimDeferred() {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+
+	m.reclaimDeferred()
+}
+
+func (m *Store[E]) set(name string, entry E) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.entries[name] = entry
+}
+
+func (m *Store[E]) remove(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.entries, name)
+}
+
+// parkOrFree frees a retired entry and parks it when the free is
+// refused. The caller must hold the write lock.
+func (m *Store[E]) parkOrFree(entry E) {
+	if err := entry.Free(); errors.Is(err, ffi.ErrStillReferenced) {
+		m.deferred = append(m.deferred, entry)
+	}
+}
+
+// reclaimDeferred is ReclaimDeferred without the lock. The caller must
+// hold the write lock.
+func (m *Store[E]) reclaimDeferred() {
+	kept := m.deferred[:0]
+	for _, entry := range m.deferred {
+		if err := entry.Free(); errors.Is(err, ffi.ErrStillReferenced) {
+			kept = append(kept, entry)
+		}
+	}
+	clear(m.deferred[len(kept):])
+	m.deferred = kept
+}

--- a/controlplane/configstore/store_test.go
+++ b/controlplane/configstore/store_test.go
@@ -1,0 +1,366 @@
+package configstore_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/yanet-platform/yanet2/common/go/testutils"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+var errInjected = errors.New("injected failure")
+
+// publishing returns a callback that stores the given entry without
+// looking at the current one.
+func publishing(entry *testutils.FreeSequence) func(*testutils.FreeSequence, bool) (*testutils.FreeSequence, error) {
+	return func(*testutils.FreeSequence, bool) (*testutils.FreeSequence, error) {
+		return entry, nil
+	}
+}
+
+// unpublishing returns a delete callback that reports the given error.
+func unpublishing(err error) func(*testutils.FreeSequence) error {
+	return func(*testutils.FreeSequence) error {
+		return err
+	}
+}
+
+// Test_Store_Update_PublishesAndLists verifies that updated entries are
+// returned by name and listed in sorted order.
+func Test_Store_Update_PublishesAndLists(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+	first := testutils.NewFreeSequence()
+	second := testutils.NewFreeSequence()
+
+	require.NoError(t, store.Update("b", publishing(first)))
+	require.NoError(t, store.Update("a", publishing(second)))
+
+	assert.Equal(t, []string{"a", "b"}, store.Names())
+
+	entry, ok := store.Get("b")
+	require.True(t, ok)
+	assert.Same(t, first, entry)
+
+	_, ok = store.Get("missing")
+	assert.False(t, ok)
+}
+
+// Test_Store_Update_CallbackSeesCurrent verifies that the publish
+// callback is handed the entry currently published under the name, and
+// nothing on a first publish.
+func Test_Store_Update_CallbackSeesCurrent(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+	first := testutils.NewFreeSequence()
+
+	err := store.Update("a", func(current *testutils.FreeSequence, ok bool) (*testutils.FreeSequence, error) {
+		assert.False(t, ok)
+		assert.Nil(t, current)
+		return first, nil
+	})
+	require.NoError(t, err)
+
+	err = store.Update("a", func(current *testutils.FreeSequence, ok bool) (*testutils.FreeSequence, error) {
+		assert.True(t, ok)
+		assert.Same(t, first, current)
+		return testutils.NewFreeSequence(), nil
+	})
+	require.NoError(t, err)
+}
+
+// Test_Store_Update_PublishFailureLeavesPrevious verifies that a failed
+// publish returns its error unchanged and keeps the previous entry
+// published and unfreed.
+func Test_Store_Update_PublishFailureLeavesPrevious(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+	first := testutils.NewFreeSequence()
+	require.NoError(t, store.Update("a", publishing(first)))
+
+	err := store.Update("a", func(*testutils.FreeSequence, bool) (*testutils.FreeSequence, error) {
+		return nil, errInjected
+	})
+	require.ErrorIs(t, err, errInjected)
+
+	entry, ok := store.Get("a")
+	require.True(t, ok)
+	assert.Same(t, first, entry)
+	assert.Equal(t, int64(0), first.Calls())
+}
+
+// Test_Store_Update_FreesSuperseded verifies that a successful publish
+// frees the entry it replaced exactly once.
+func Test_Store_Update_FreesSuperseded(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+	first := testutils.NewFreeSequence()
+	second := testutils.NewFreeSequence()
+
+	require.NoError(t, store.Update("a", publishing(first)))
+	require.NoError(t, store.Update("a", publishing(second)))
+
+	assert.Equal(t, int64(1), first.Freed())
+	assert.Equal(t, int64(0), second.Calls())
+}
+
+// Test_Store_Update_ParksRefusedThenReclaims verifies that a superseded
+// entry whose free is refused is retried by the next mutation of any
+// name and released once the refusal ends.
+func Test_Store_Update_ParksRefusedThenReclaims(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+	refusing := testutils.NewFreeSequence(ffi.ErrStillReferenced)
+
+	require.NoError(t, store.Update("a", publishing(refusing)))
+	require.NoError(t, store.Update("a", publishing(testutils.NewFreeSequence())))
+	assert.Equal(t, int64(1), refusing.Calls())
+	assert.Equal(t, int64(0), refusing.Freed())
+
+	require.NoError(t, store.Update("b", publishing(testutils.NewFreeSequence())))
+	assert.Equal(t, int64(2), refusing.Calls())
+	assert.Equal(t, int64(1), refusing.Freed())
+
+	require.NoError(t, store.Update("c", publishing(testutils.NewFreeSequence())))
+	assert.Equal(t, int64(2), refusing.Calls())
+}
+
+// Test_Store_Delete_MissingName verifies that deleting an unknown name
+// reports not found without running the callback.
+func Test_Store_Delete_MissingName(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+
+	called := false
+	err := store.Delete("a", func(*testutils.FreeSequence) error {
+		called = true
+		return nil
+	})
+	require.ErrorIs(t, err, configstore.ErrNotFound)
+	assert.False(t, called)
+}
+
+// Test_Store_Delete_UnpublishFailureKeepsEntry verifies that a refused
+// delete returns its error unchanged and leaves the entry published and
+// unfreed.
+func Test_Store_Delete_UnpublishFailureKeepsEntry(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+	first := testutils.NewFreeSequence()
+	require.NoError(t, store.Update("a", publishing(first)))
+
+	err := store.Delete("a", unpublishing(errInjected))
+	require.ErrorIs(t, err, errInjected)
+
+	assert.Equal(t, []string{"a"}, store.Names())
+	assert.Equal(t, int64(0), first.Calls())
+}
+
+// Test_Store_Delete_FreesEntry verifies that a successful delete forgets
+// the name and frees its entry.
+func Test_Store_Delete_FreesEntry(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+	first := testutils.NewFreeSequence()
+	require.NoError(t, store.Update("a", publishing(first)))
+
+	require.NoError(t, store.Delete("a", unpublishing(nil)))
+
+	assert.Empty(t, store.Names())
+	assert.Equal(t, int64(1), first.Freed())
+}
+
+// Test_Store_Delete_ParksRefusedThenReclaims verifies that a deleted
+// entry whose free is refused is parked and released by a later delete.
+func Test_Store_Delete_ParksRefusedThenReclaims(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+	refusing := testutils.NewFreeSequence(ffi.ErrStillReferenced)
+	require.NoError(t, store.Update("a", publishing(refusing)))
+	require.NoError(t, store.Update("b", publishing(testutils.NewFreeSequence())))
+
+	require.NoError(t, store.Delete("a", unpublishing(nil)))
+	assert.Equal(t, []string{"b"}, store.Names())
+	assert.Equal(t, int64(0), refusing.Freed())
+
+	require.NoError(t, store.Delete("b", unpublishing(nil)))
+	assert.Equal(t, int64(1), refusing.Freed())
+}
+
+// Test_Store_ReclaimDeferred_RetriesUntilDrained verifies that an
+// explicit reclaim retries a parked entry on every call and drops it once
+// the free succeeds.
+func Test_Store_ReclaimDeferred_RetriesUntilDrained(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+	refusing := testutils.NewFreeSequence(
+		ffi.ErrStillReferenced,
+		ffi.ErrStillReferenced,
+		ffi.ErrStillReferenced,
+	)
+	require.NoError(t, store.Update("a", publishing(refusing)))
+	require.NoError(t, store.Delete("a", unpublishing(nil)))
+	require.Equal(t, int64(1), refusing.Calls())
+
+	store.ReclaimDeferred()
+	assert.Equal(t, int64(2), refusing.Calls())
+	assert.Equal(t, int64(0), refusing.Freed())
+
+	store.ReclaimDeferred()
+	store.ReclaimDeferred()
+	assert.Equal(t, int64(4), refusing.Calls())
+	assert.Equal(t, int64(1), refusing.Freed())
+
+	store.ReclaimDeferred()
+	assert.Equal(t, int64(4), refusing.Calls())
+}
+
+// Test_Store_Reads_DoNotWaitForPublish verifies that lookups complete
+// while a publish is in flight, so a slow shared-memory write never
+// stalls the read path.
+func Test_Store_Reads_DoNotWaitForPublish(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+	first := testutils.NewFreeSequence()
+	require.NoError(t, store.Update("a", publishing(first)))
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	var group errgroup.Group
+	group.Go(func() error {
+		return store.Update("a", func(*testutils.FreeSequence, bool) (*testutils.FreeSequence, error) {
+			close(entered)
+			<-release
+			return testutils.NewFreeSequence(), nil
+		})
+	})
+	<-entered
+
+	type readResult struct {
+		entry *testutils.FreeSequence
+		ok    bool
+		names []string
+	}
+	reads := make(chan readResult, 1)
+	go func() {
+		entry, ok := store.Get("a")
+		reads <- readResult{entry: entry, ok: ok, names: store.Names()}
+	}()
+
+	var result readResult
+	select {
+	case result = <-reads:
+	case <-time.After(5 * time.Second):
+		close(release)
+		t.Fatal("reads blocked behind an in-flight publish")
+	}
+	assert.True(t, result.ok)
+	assert.Same(t, first, result.entry)
+	assert.Equal(t, []string{"a"}, result.names)
+
+	close(release)
+	require.NoError(t, group.Wait())
+}
+
+// Test_Store_Writers_Serialize verifies that a second mutation does not
+// start its callback until the first mutation has finished, whatever the
+// names involved.
+func Test_Store_Writers_Serialize(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	secondStarted := make(chan struct{})
+
+	var group errgroup.Group
+	group.Go(func() error {
+		return store.Update("a", func(*testutils.FreeSequence, bool) (*testutils.FreeSequence, error) {
+			close(entered)
+			<-release
+			return testutils.NewFreeSequence(), nil
+		})
+	})
+	<-entered
+
+	secondLaunched := make(chan struct{})
+	group.Go(func() error {
+		close(secondLaunched)
+		return store.Update("b", func(*testutils.FreeSequence, bool) (*testutils.FreeSequence, error) {
+			close(secondStarted)
+			return testutils.NewFreeSequence(), nil
+		})
+	})
+	<-secondLaunched
+
+	select {
+	case <-secondStarted:
+		close(release)
+		t.Fatal("second publish started while the first was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	require.NoError(t, group.Wait())
+	<-secondStarted
+	assert.Equal(t, []string{"a", "b"}, store.Names())
+}
+
+// Test_Store_ConcurrentMutations verifies that interleaved updates,
+// deletes and reads over shared names leave every published entry
+// consistent and free each retired entry exactly once.
+func Test_Store_ConcurrentMutations(t *testing.T) {
+	store := configstore.NewStore[*testutils.FreeSequence]()
+	names := []string{"a", "b", "c"}
+
+	const workers = 8
+	const iterations = 200
+
+	var minted []*testutils.FreeSequence
+	var group errgroup.Group
+	handles := make(chan *testutils.FreeSequence, workers*iterations)
+	for idx := range workers {
+		group.Go(func() error {
+			for jdx := range iterations {
+				name := names[(idx+jdx)%len(names)]
+				if jdx%5 == 4 {
+					err := store.Delete(name, unpublishing(nil))
+					if err != nil && !errors.Is(err, configstore.ErrNotFound) {
+						return err
+					}
+					continue
+				}
+				handle := testutils.NewFreeSequence()
+				handles <- handle
+				if err := store.Update(name, publishing(handle)); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	for range workers {
+		group.Go(func() error {
+			for range iterations {
+				for _, name := range store.Names() {
+					store.Get(name)
+				}
+			}
+			return nil
+		})
+	}
+	require.NoError(t, group.Wait())
+	close(handles)
+	for handle := range handles {
+		minted = append(minted, handle)
+	}
+
+	live := map[*testutils.FreeSequence]bool{}
+	for _, name := range store.Names() {
+		entry, ok := store.Get(name)
+		require.True(t, ok)
+		live[entry] = true
+	}
+	for _, handle := range minted {
+		if live[handle] {
+			assert.Equal(t, int64(0), handle.Calls())
+			continue
+		}
+		assert.Equal(t, int64(1), handle.Freed())
+	}
+}

--- a/modules/decap/controlplane/service.go
+++ b/modules/decap/controlplane/service.go
@@ -4,17 +4,14 @@ import (
 	"cmp"
 	"context"
 	"errors"
-	"fmt"
 	"net/netip"
 	"slices"
-	"sync"
-
-	"github.com/yanet-platform/yanet2/controlplane/ffi"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
 
@@ -61,21 +58,15 @@ func (m *config) Free() error {
 type DecapService struct {
 	decappb.UnimplementedDecapServiceServer
 
-	mu sync.Mutex
-	// deferred holds superseded module handles whose free was refused
-	// because a live configuration generation still referenced them.
-	// This service is their owner: it retries them on its next update,
-	// through ReclaimDeferred, and nothing else remembers them.
-	deferred []ModuleHandle
-	backend  Backend
-	configs  map[string]*config
+	backend Backend
+	configs *configstore.Store[*config]
 }
 
 // NewDecapService constructs a DecapService backed by the given Backend.
 func NewDecapService(backend Backend) *DecapService {
 	return &DecapService{
 		backend: backend,
-		configs: map[string]*config{},
+		configs: configstore.NewStore[*config](),
 	}
 }
 
@@ -84,15 +75,7 @@ func (m *DecapService) ListConfigs(
 	ctx context.Context,
 	req *decappb.ListConfigsRequest,
 ) (*decappb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	names := make([]string, 0, len(m.configs))
-	for name := range m.configs {
-		names = append(names, name)
-	}
-
-	return &decappb.ListConfigsResponse{Configs: names}, nil
+	return &decappb.ListConfigsResponse{Configs: m.configs.Names()}, nil
 }
 
 // ShowConfig returns the current prefix set for the named config.
@@ -105,10 +88,7 @@ func (m *DecapService) ShowConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	entry, ok := m.configs[name]
+	entry, ok := m.configs.Get(name)
 	if !ok {
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
@@ -144,14 +124,19 @@ func (m *DecapService) UpdateConfig(
 		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	cfg := &config{
 		Prefixes4: normalizePrefixes(prefixes4),
 		Prefixes6: normalizePrefixes(prefixes6),
 	}
-	if err := m.updateConfig(name, cfg); err != nil {
+	err = m.configs.Update(name, func(*config, bool) (*config, error) {
+		module, err := m.backend.UpdateModule(name, slices.Concat(cfg.Prefixes4, cfg.Prefixes6))
+		if err != nil {
+			return nil, err
+		}
+		cfg.Module = module
+		return cfg, nil
+	})
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
@@ -169,29 +154,28 @@ func (m *DecapService) DeleteConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	entry, ok := m.configs[name]
-	if !ok {
+	err := m.configs.Delete(name, func(*config) error {
+		return m.backend.DeleteModule(name)
+	})
+	if errors.Is(err, configstore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
-
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to delete module config %q: %v", name, err,
 		)
 	}
 
-	// The delete retired the generation holding the published module.
-	// Retry the deferred ones, then retire this one.
-	m.reclaimDeferred()
-	m.parkOrFree(entry.Module)
-
-	delete(m.configs, name)
-
 	return &decappb.DeleteConfigResponse{}, nil
+}
+
+// ReclaimDeferred retries every superseded config whose free was refused,
+// releasing the ones whose generations have drained. The service runs it
+// after each successful publish, and anything else may call it at any
+// time.
+func (m *DecapService) ReclaimDeferred() {
+	m.configs.ReclaimDeferred()
 }
 
 func comparePrefixes(first, second netip.Prefix) int {
@@ -209,62 +193,4 @@ func normalizePrefixes(prefixes []netip.Prefix) []netip.Prefix {
 			comparePrefixes,
 		),
 	)
-}
-
-// updateConfig calls the backend to publish cfg, retries this service's
-// deferred handles (the publish retired the generations that were
-// holding them), frees or defers the old module handle, and stores the
-// new config. The caller must hold m.mu.
-func (m *DecapService) updateConfig(name string, cfg *config) error {
-	mod, err := m.backend.UpdateModule(name, slices.Concat(cfg.Prefixes4, cfg.Prefixes6))
-	if err != nil {
-		return fmt.Errorf("failed to update module config %q: %w", name, err)
-	}
-
-	m.reclaimDeferred()
-
-	if old, ok := m.configs[name]; ok {
-		m.parkOrFree(old)
-	}
-
-	m.configs[name] = &config{
-		Prefixes4: cfg.Prefixes4,
-		Prefixes6: cfg.Prefixes6,
-		Module:    mod,
-	}
-
-	return nil
-}
-
-// parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must hold
-// m.mu.
-func (m *DecapService) parkOrFree(handle ModuleHandle) {
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every deferred handle, dropping the ones whose
-// generations have drained and keeping the rest deferred. It is the
-// reclamation handler for this module's superseded configs; the service
-// itself runs it after each successful publish, and anything else may
-// call it at any time.
-func (m *DecapService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *DecapService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
-		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
-		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
 }

--- a/modules/decap/controlplane/service_test.go
+++ b/modules/decap/controlplane/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/testutils"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
@@ -60,33 +62,9 @@ func prefixStrings[T interface{ ToPrefix() (netip.Prefix, error) }](t *testing.T
 
 var errInjectedBackend = errors.New("injected backend failure")
 
-// mockModuleHandle counts Free calls so tests can assert a release happened.
-type mockModuleHandle struct {
-	freed atomic.Int64
-}
-
-func (m *mockModuleHandle) Free() error {
-	m.freed.Add(1)
-	return nil
-}
-
-// refusingOnceHandle refuses its first Free with ffi.ErrStillReferenced, then succeeds.
-type refusingOnceHandle struct {
-	numCalls atomic.Int64
-	freed    atomic.Int64
-}
-
-func (m *refusingOnceHandle) Free() error {
-	if m.numCalls.Add(1) == 1 {
-		return ffi.ErrStillReferenced
-	}
-	m.freed.Add(1)
-	return nil
-}
-
 // mockBackend records the last handle it minted and the name it last saw in DeleteModule.
 type mockBackend struct {
-	lastHandle  atomic.Pointer[mockModuleHandle]
+	lastHandle  atomic.Pointer[testutils.FreeSequence]
 	deletedName string
 }
 
@@ -94,7 +72,7 @@ func (m *mockBackend) UpdateModule(
 	name string,
 	prefixes []netip.Prefix,
 ) (ModuleHandle, error) {
-	handle := &mockModuleHandle{}
+	handle := testutils.NewFreeSequence()
 	m.lastHandle.Store(handle)
 	return handle, nil
 }
@@ -120,12 +98,13 @@ func (m *refusingDeleteBackend) DeleteModule(name string) error {
 	return errInjectedBackend
 }
 
-// parkingBackend refuses to release the first handle it mints, then releases
-// normally, so that handle must be parked before it can be reclaimed.
+// parkingBackend hands out the given handle on its first update and fresh
+// releasable ones afterwards, so a handle that refuses its first free must
+// be parked before it can be reclaimed.
 type parkingBackend struct {
 	mockBackend
 	numCalls atomic.Int64
-	first    refusingOnceHandle
+	first    *testutils.FreeSequence
 }
 
 func (m *parkingBackend) UpdateModule(
@@ -133,9 +112,26 @@ func (m *parkingBackend) UpdateModule(
 	prefixes []netip.Prefix,
 ) (ModuleHandle, error) {
 	if m.numCalls.Add(1) == 1 {
-		return &m.first, nil
+		return m.first, nil
 	}
-	return &mockModuleHandle{}, nil
+	return testutils.NewFreeSequence(), nil
+}
+
+// blockingBackend holds every update until released, modeling a slow
+// shared-memory publish.
+type blockingBackend struct {
+	mockBackend
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (m *blockingBackend) UpdateModule(
+	name string,
+	prefixes []netip.Prefix,
+) (ModuleHandle, error) {
+	m.entered <- struct{}{}
+	<-m.release
+	return m.mockBackend.UpdateModule(name, prefixes)
 }
 
 // flakyBackend succeeds on the first UpdateModule call and fails thereafter.
@@ -150,7 +146,7 @@ func (m *flakyBackend) UpdateModule(
 	if m.numCalls.Add(1) >= 2 {
 		return nil, errInjectedBackend
 	}
-	return &mockModuleHandle{}, nil
+	return testutils.NewFreeSequence(), nil
 }
 
 func (m *flakyBackend) DeleteModule(name string) error {
@@ -345,7 +341,7 @@ func Test_DecapService_DeleteConfig_RemovesConfig(t *testing.T) {
 	require.NotNil(t, resp)
 	require.NoError(t, err)
 	assert.Equal(t, "decap0", backend.deletedName)
-	assert.Equal(t, int64(1), handle.freed.Load())
+	assert.Equal(t, int64(1), handle.Freed())
 
 	list, err := svc.ListConfigs(ctx, &decappb.ListConfigsRequest{})
 	require.NoError(t, err)
@@ -386,7 +382,7 @@ func Test_DecapService_DeleteConfig_Referenced(t *testing.T) {
 // Test_DecapService_DeleteConfig_ParksThenReclaims verifies that a handle
 // refused on delete is parked and reclaimed by the next successful update.
 func Test_DecapService_DeleteConfig_ParksThenReclaims(t *testing.T) {
-	backend := &parkingBackend{}
+	backend := &parkingBackend{first: testutils.NewFreeSequence(ffi.ErrStillReferenced)}
 	svc := NewDecapService(backend)
 	ctx := t.Context()
 
@@ -399,8 +395,8 @@ func Test_DecapService_DeleteConfig_ParksThenReclaims(t *testing.T) {
 	resp, err := svc.DeleteConfig(ctx, &decappb.DeleteConfigRequest{Name: "decap0"})
 	require.NotNil(t, resp)
 	require.NoError(t, err)
-	require.Len(t, svc.deferred, 1)
-	assert.Equal(t, int64(0), backend.first.freed.Load())
+	assert.Equal(t, int64(1), backend.first.Calls())
+	assert.Equal(t, int64(0), backend.first.Freed())
 
 	// A later successful update reclaims deferred handles first.
 	_, err = svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
@@ -408,8 +404,60 @@ func Test_DecapService_DeleteConfig_ParksThenReclaims(t *testing.T) {
 		Prefixes4: mustPrefixes4(t, "10.0.1.0/24"),
 	})
 	require.NoError(t, err)
-	assert.Empty(t, svc.deferred)
-	assert.Equal(t, int64(1), backend.first.freed.Load())
+	assert.Equal(t, int64(2), backend.first.Calls())
+	assert.Equal(t, int64(1), backend.first.Freed())
+}
+
+// Test_DecapService_ListConfigs_DuringSlowUpdate verifies that reads
+// complete while an update's publish is in flight, so a slow
+// shared-memory write never stalls the read RPCs.
+func Test_DecapService_ListConfigs_DuringSlowUpdate(t *testing.T) {
+	backend := &blockingBackend{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	svc := NewDecapService(backend)
+	ctx := t.Context()
+
+	var group errgroup.Group
+	group.Go(func() error {
+		_, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
+			Name:      "decap0",
+			Prefixes4: mustPrefixes4(t, "10.0.0.0/24"),
+		})
+		return err
+	})
+	<-backend.entered
+
+	type readResult struct {
+		list    *decappb.ListConfigsResponse
+		listErr error
+		showErr error
+	}
+	reads := make(chan readResult, 1)
+	go func() {
+		list, listErr := svc.ListConfigs(ctx, &decappb.ListConfigsRequest{})
+		_, showErr := svc.ShowConfig(ctx, &decappb.ShowConfigRequest{Name: "decap0"})
+		reads <- readResult{list: list, listErr: listErr, showErr: showErr}
+	}()
+
+	var result readResult
+	select {
+	case result = <-reads:
+	case <-time.After(5 * time.Second):
+		close(backend.release)
+		t.Fatal("reads blocked behind an in-flight publish")
+	}
+	require.NoError(t, result.listErr)
+	assert.Empty(t, result.list.GetConfigs())
+	assert.Equal(t, codes.NotFound, status.Code(result.showErr))
+
+	close(backend.release)
+	require.NoError(t, group.Wait())
+
+	list, err := svc.ListConfigs(ctx, &decappb.ListConfigsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"decap0"}, list.GetConfigs())
 }
 
 func Test_DecapService_DeduplicatePrefixes(t *testing.T) {


### PR DESCRIPTION
- Add a config store that keeps a service's published configurations by name together with the handles whose free was refused, and lets reads proceed while a shared-memory publish is in flight.
- Migrate the decap service onto the store as the reference for the remaining module services.
- Add a scripted free fake to the shared test utilities.

Closes #2532.
