### PR TITLE
refactor(cli): carry the connection, format and verbosity flags in one ync struct

### DIFF
--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -22,13 +22,12 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   `yanet-cli operator <x>` dispatch to `yanet-cli-device-<x>` /
   `yanet-cli-operator-<x>` by name; the dispatcher needs no registration.
 - `Cmd`: `#[derive(Debug, Clone, Parser)]`, `#[command(version, about)]`,
-  `#[command(flatten_help = true)]`, fields `#[clap(subcommand)] mode: ModeCmd`,
-  `#[command(flatten)] connection: ConnectionArgs`, `--format`
-  (`CommonFormat`, `default_value = "human"`, `global = true`, doc
-  `Output format.`) and `-v` (`ArgAction::Count`, `global = true`, doc
-  `Be verbose: shows debug log lines and raw gRPC error details.`).
+  `#[command(flatten_help = true)]`, fields `#[clap(subcommand)] mode: ModeCmd`
+  and `#[command(flatten)] globals: GlobalArgs`. `ync::GlobalArgs` carries
+  the connection flags, `--format` and `-v` for every binary, a crate never
+  declares them itself.
 - `fn main() -> std::process::ExitCode` delegates the lifecycle to
-  `ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)`. The scaffold
+  `ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)`. The scaffold
   owns completion before Tokio, parsing, output initialisation, the
   current-thread runtime, error rendering and the process status.
 - `run(cmd)` determines the action, builds the service object once and matches
@@ -41,14 +40,14 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   pull it into `fn client(channel: LayeredChannel) ->
   <X>ServiceClient<LayeredChannel>`, named `<x>_client` only when the crate
   imports the `ync::client` module under that name. One service:
-  `Service::connect_for(&cmd.connection, action, SERVICE_NAME,
+  `Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME,
   client).await?`, reused unchanged by completion. Several:
-  `Connection::connect_for(&cmd.connection, action).await?` once, then
+  `Connection::connect_for(&cmd.globals.connection, action).await?` once, then
   `Service::new(&connection, NAME, build)` per client. The action is the same
   user-facing verb passed to the command's RPC error mapping.
 - Connection settings resolve inside `ync`, from flags, environment and the
   configuration file (`ync::config`). A CLI never reads
-  `cmd.connection.endpoint` itself. A pre-connect error label comes from
+  `cmd.globals.connection.endpoint` itself. A pre-connect error label comes from
   `client::resolve_label`, a post-connect one from `Service::endpoint()` /
   `Connection::endpoint()`.
 - Every unary RPC of a command handler: `self.service.unary("<verb>",

--- a/.agents/skills/code-cli/references/new-crate.md
+++ b/.agents/skills/code-cli/references/new-crate.md
@@ -93,18 +93,19 @@ Shared packages (`common.commonpb.v1`, `common.filterpb.v1`) are always
 
 use std::borrow::Cow;
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::{
     engine::{ArgValueCandidates, CompletionCandidate},
 };
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
     display::print_table_from_entries,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 use crate::<x>pb::{
@@ -134,13 +135,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -191,12 +186,12 @@ pub struct DeleteCmd {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = <X>Service::new(&cmd.connection, action).await?;
+    let mut service = <X>Service::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,

--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -12,10 +12,10 @@
 //! #[derive(clap::Parser)]
 //! struct Cmd {
 //!     #[command(flatten)]
-//!     connection: ConnectionArgs,
+//!     globals: ync::GlobalArgs,
 //! }
 //!
-//! let channel = connect(&cmd.connection).await?;
+//! let channel = connect(&cmd.globals.connection).await?;
 //! let client = MyServiceClient::new(channel)
 //!     .send_compressed(CompressionEncoding::Gzip)
 //!     .accept_compressed(CompressionEncoding::Gzip);
@@ -77,7 +77,8 @@ impl Settings {
 
 /// Common CLI arguments for gRPC connection.
 ///
-/// Embed this in your module's `Cmd` struct with `#[command(flatten)]`.
+/// A command reaches them through [`crate::GlobalArgs`], which it flattens
+/// into its `Cmd` together with the output format and verbosity flags.
 #[derive(Debug, Clone, clap::Args)]
 pub struct ConnectionArgs {
     /// Gateway endpoint (grpc://, grpcs://, or unix://) or an alias from the

--- a/cli/core/src/completion.rs
+++ b/cli/core/src/completion.rs
@@ -133,6 +133,7 @@ mod test {
     use clap::{CommandFactory, Parser};
 
     use super::*;
+    use crate::GlobalArgs;
 
     fn words(raw: &[&str]) -> Vec<OsString> {
         raw.iter().map(OsString::from).collect()
@@ -165,7 +166,7 @@ mod test {
     }
 
     /// A faithful replica of a module CLI's `Cmd`: a required subcommand
-    /// plus globally flattened [`ConnectionArgs`], the exact shape that
+    /// plus the globally flattened [`GlobalArgs`], the exact shape that
     /// made a `ConnectionArgs`-only wrapper miss a global flag typed after
     /// the subcommand.
     #[derive(Parser)]
@@ -173,7 +174,7 @@ mod test {
         #[command(subcommand)]
         mode: TestModeCmd,
         #[command(flatten)]
-        connection: ConnectionArgs,
+        globals: GlobalArgs,
     }
 
     #[derive(Parser)]

--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -1,10 +1,14 @@
 use core::future::Future;
 use std::process::{ExitCode, Termination};
 
-use clap::Parser;
+use clap::{ArgAction, Args, Parser};
 use clap_complete::CompleteEnv;
 
-use crate::{errors::Error, output::Format};
+use crate::{
+    client::ConnectionArgs,
+    errors::Error,
+    output::{CommonFormat, Format},
+};
 
 pub mod auth;
 pub mod client;
@@ -22,6 +26,28 @@ pub mod timeout;
 pub mod yaml;
 
 mod signal;
+
+/// The flags every yanet CLI carries: the connection, the output format and
+/// the verbosity.
+#[derive(Debug, Clone, Args)]
+pub struct GlobalArgs {
+    #[command(flatten)]
+    pub connection: ConnectionArgs,
+    /// Output format.
+    #[arg(long, value_enum, default_value = "human", global = true)]
+    pub format: CommonFormat,
+    /// Be verbose: shows debug log lines and raw gRPC error details.
+    #[arg(short, action = ArgAction::Count, global = true)]
+    pub verbose: u8,
+}
+
+impl GlobalArgs {
+    /// The verbosity and format pair [`entrypoint`] initialises the output
+    /// with.
+    pub fn options(&self) -> (u8, CommonFormat) {
+        (self.verbose, self.format)
+    }
+}
 
 /// Initialise the logger and selected output backend.
 ///

--- a/cli/core/src/main.rs
+++ b/cli/core/src/main.rs
@@ -4,18 +4,18 @@
 
 use std::{collections::HashSet, path::PathBuf, sync::LazyLock};
 
-use clap::{Arg, ArgAction, ArgMatches, Args as _, Command, FromArgMatches, crate_name, parser::ValueSource};
+use clap::{ArgMatches, Args as _, Command, FromArgMatches, crate_name, parser::ValueSource};
 use colored::{ColoredString, Colorize};
 use serde::Serialize;
 use tonic::{Status, codec::CompressionEncoding};
 use yanet_cli::{
+    GlobalArgs,
     auth::AuthMethod,
     client::{ConnectionArgs, Service},
     config::{self, Origin, Settings},
     dispatcher::{self, Dispatch, Namespace},
     errors::Error,
-    init,
-    output::{self, CommonFormat},
+    init, output,
 };
 use ynpb::pb::{IntrospectTokenRequest, Principal, auth_service_client::AuthServiceClient};
 
@@ -145,42 +145,10 @@ impl Dispatch for Dispatcher {
     }
 }
 
-/// Adds the `--format` and `-v` arguments every command carries, for a
-/// built-in that embeds [`ConnectionArgs`] instead of a derived `Cmd`.
-fn output_args(command: Command) -> Command {
-    command
-        .arg(
-            Arg::new("format")
-                .long("format")
-                .value_parser(clap::value_parser!(CommonFormat))
-                .default_value("human")
-                .global(true)
-                .help("Output format."),
-        )
-        .arg(
-            Arg::new("verbose")
-                .short('v')
-                .long("verbose")
-                .action(ArgAction::Count)
-                .global(true)
-                .help("Be verbose: shows debug log lines and raw gRPC error details."),
-        )
-}
-
-/// Reads the arguments added by [`output_args`].
-fn output_options(matches: &ArgMatches) -> (CommonFormat, u8) {
-    let format = matches
-        .get_one::<CommonFormat>("format")
-        .copied()
-        .unwrap_or(CommonFormat::Human);
-
-    (format, matches.get_count("verbose"))
-}
-
 /// Builds the `config show` subcommand tree.
 ///
-/// `show` embeds [`ConnectionArgs`] directly (rather than a dedicated
-/// `Cmd`) so its flags, environment variables and completion candidates stay
+/// `show` embeds [`GlobalArgs`] directly (rather than a dedicated `Cmd`) so
+/// its flags, environment variables and completion candidates stay
 /// identical to every other command's.
 fn config_command() -> Command {
     const SHOW_ABOUT: &str = "Prints the effective connection settings and where each came from.";
@@ -188,11 +156,9 @@ fn config_command() -> Command {
         from. Reads /etc/yanet2/cli.yaml merged with $XDG_CONFIG_HOME/yanet2/cli.yaml \
         (~/.config by default), or the single file named by YANET_CONFIG.";
 
-    let show = output_args(
-        ConnectionArgs::augment_args(Command::new("show"))
-            .about(SHOW_ABOUT)
-            .long_about(SHOW_LONG_ABOUT),
-    );
+    let show = GlobalArgs::augment_args(Command::new("show"))
+        .about(SHOW_ABOUT)
+        .long_about(SHOW_LONG_ABOUT);
 
     Command::new("config")
         .about("Configuration file inspection.")
@@ -203,9 +169,10 @@ fn config_command() -> Command {
 /// Runs `config show`: resolves the connection settings and reports them
 /// through the shared output backend, exactly like any other command.
 fn run_config_show(matches: &ArgMatches) -> i32 {
-    let connection =
-        ConnectionArgs::from_arg_matches(matches).expect("show's own augmented matches must parse into ConnectionArgs");
-    let (format, verbose) = output_options(matches);
+    let globals =
+        GlobalArgs::from_arg_matches(matches).expect("show's own augmented matches must parse into GlobalArgs");
+    let (verbose, format) = globals.options();
+    let connection = globals.connection;
 
     init(verbose, format);
 
@@ -228,19 +195,17 @@ fn run_config_show(matches: &ArgMatches) -> i32 {
 
 /// Builds the `auth whoami` subcommand tree.
 ///
-/// `whoami` embeds [`ConnectionArgs`] like `config show`, so the very flags
-/// that select a token or a certificate are the ones it reports on.
+/// `whoami` embeds [`GlobalArgs`] like `config show`, so the very flags that
+/// select a token or a certificate are the ones it reports on.
 fn auth_command() -> Command {
     const WHOAMI_ABOUT: &str = "Prints the identity the gateway resolves for the current connection settings.";
     const WHOAMI_LONG_ABOUT: &str = "Prints the identity the gateway resolves for the current connection \
         settings: the token of --auth when one is sent, else the client certificate of --client-cert, \
         else anonymous.";
 
-    let whoami = output_args(
-        ConnectionArgs::augment_args(Command::new("whoami"))
-            .about(WHOAMI_ABOUT)
-            .long_about(WHOAMI_LONG_ABOUT),
-    );
+    let whoami = GlobalArgs::augment_args(Command::new("whoami"))
+        .about(WHOAMI_ABOUT)
+        .long_about(WHOAMI_LONG_ABOUT);
 
     Command::new("auth")
         .about("Authentication inspection.")
@@ -251,9 +216,10 @@ fn auth_command() -> Command {
 /// Runs `auth whoami`: asks the gateway to introspect the call's own
 /// credential and reports the principal through the shared output backend.
 fn run_auth_whoami(matches: &ArgMatches) -> i32 {
-    let connection = ConnectionArgs::from_arg_matches(matches)
-        .expect("whoami's own augmented matches must parse into ConnectionArgs");
-    let (format, verbose) = output_options(matches);
+    let globals =
+        GlobalArgs::from_arg_matches(matches).expect("whoami's own augmented matches must parse into GlobalArgs");
+    let (verbose, format) = globals.options();
+    let connection = globals.connection;
 
     init(verbose, format);
 

--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -1,16 +1,17 @@
 //! CLI for the YANET core services.
 
 use bytesize::ByteSize;
-use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
     display::print_table_from_entries,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 use ynpb::pb::{
     ArenaInfo, ExtendAgentRequest, GetLevelRequest, ListArenasRequest, UpdateLevelRequest,
@@ -36,13 +37,7 @@ struct Cmd {
     #[command(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, value_enum, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[arg(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -114,7 +109,7 @@ impl From<LogLevel> for ynpb::pb::LogLevel {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 impl LoggingCmd {
@@ -137,8 +132,8 @@ impl MemoryCmd {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     match cmd.mode {
-        ModeCmd::Logging(mode) => run_logging(&cmd.connection, mode).await,
-        ModeCmd::Memory(mode) => run_memory(&cmd.connection, mode).await,
+        ModeCmd::Logging(mode) => run_logging(&cmd.globals.connection, mode).await,
+        ModeCmd::Memory(mode) => run_memory(&cmd.globals.connection, mode).await,
     }
 }
 

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -1,14 +1,14 @@
 //! CLI for YANET "counters" module.
 
 use bytesize::ByteSize;
-use clap::{ArgAction, Parser};
+use clap::Parser;
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
-    metrics,
-    output::{self, CommonFormat},
+    metrics, output,
 };
 use ynpb::pb::{
     CounterTag, CountersByTagsRequest, CountersByTagsResponse, PortCountersRequest, PortCountersResponse,
@@ -28,13 +28,7 @@ pub struct Cmd {
     #[command(flatten)]
     pub by_tags: ByTagsCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, value_enum, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, clap::Args, Default)]
@@ -120,12 +114,12 @@ impl ModeCmd {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.as_ref().map_or("show counters", ModeCmd::action);
-    let mut service = CountersService::new(&cmd.connection, action).await?;
+    let mut service = CountersService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         Some(ModeCmd::Workers) => {

--- a/cli/modules/device-delete/src/main.rs
+++ b/cli/modules/device-delete/src/main.rs
@@ -1,13 +1,14 @@
 //! CLI for YANET "device delete" command.
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, LayeredChannel, Service},
+    GlobalArgs,
+    client::{LayeredChannel, Service},
     completion,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 use ynpb::pb::{DeleteDeviceRequest, ListDevicesRequest, device_service_client::DeviceServiceClient};
 
@@ -29,22 +30,16 @@ pub struct Cmd {
     #[arg(add = ArgValueCandidates::new(device_candidates))]
     pub name: String,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, value_enum, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = "delete";
-    let mut service = Service::connect_for(&cmd.connection, action, SERVICE_NAME, client).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     let name = cmd.name;
     service

--- a/cli/modules/device/src/main.rs
+++ b/cli/modules/device/src/main.rs
@@ -4,13 +4,14 @@
 //! consumers to resolve numeric device_id values (e.g. from pdump
 //! RecordMeta.rx_device_id) to human-readable names.
 
-use clap::{ArgAction, Parser};
+use clap::Parser;
 use colored::Colorize;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 use ynpb::pb::{ListDevicesRequest, ListDevicesResponse, device_service_client::DeviceServiceClient};
 
@@ -22,21 +23,15 @@ const DEVICE_SERVICE: &str = "controlplane.ynpb.v1.DeviceService";
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, value_enum, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = DeviceService::new(&cmd.connection).await?;
+    let mut service = DeviceService::new(&cmd.globals.connection).await?;
     let response = service.list().await?;
 
     output::data(|| &response, || render(&response));

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -1,14 +1,15 @@
 //! CLI for YANET "function" module.
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::FunctionId;
 use tonic::{Status, codec::CompressionEncoding};
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 use ynpb::pb::{
     DeleteFunctionRequest, Function, FunctionChain, GetFunctionRequest, ListFunctionsRequest, UpdateFunctionRequest,
@@ -31,13 +32,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, value_enum, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -91,12 +86,12 @@ pub struct DeleteCmd {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = FunctionService::new(&cmd.connection, action).await?;
+    let mut service = FunctionService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => {

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -2,14 +2,14 @@
 
 use std::time::SystemTime;
 
-use clap::{ArgAction, Parser};
+use clap::Parser;
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
-    humanfmt,
-    output::{self, CommonFormat},
+    humanfmt, output,
 };
 use ynpb::pb::{BackendKind, ListServicesRequest, RegisteredBackend, gateway_client::GatewayClient};
 
@@ -23,13 +23,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, value_enum, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -39,11 +33,11 @@ pub enum ModeCmd {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = GatewayService::new(&cmd.connection).await?;
+    let mut service = GatewayService::new(&cmd.globals.connection).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_services().await,

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -3,12 +3,13 @@
 mod memory;
 mod report;
 
-use clap::{ArgAction, Parser};
+use clap::Parser;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 use ynpb::pb::{InspectRequest, InspectResponse, inspect_service_client::InspectServiceClient};
 
@@ -20,25 +21,19 @@ const INSPECT_SERVICE: &str = "controlplane.ynpb.v1.InspectService";
 #[command(version = ync::version(), about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
-    #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, value_enum, default_value = "human", global = true)]
-    pub format: CommonFormat,
     /// Include detailed memory contexts in human output.
     #[arg(long)]
     pub memory: bool,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    #[command(flatten)]
+    pub globals: GlobalArgs,
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = InspectService::new(&cmd.connection).await?;
+    let mut service = InspectService::new(&cmd.globals.connection).await?;
     let response = service.inspect().await?;
 
     output::data(|| &response, || report::render(&response, cmd.memory));

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -1,14 +1,15 @@
 //! Generic metrics probe CLI.
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{GetMetricsRequest, GetMetricsResponse, Histogram, Label, Metric, MetricTag, metric::Value};
 use tabled::Tabled;
 use ync::{
-    client::{self, Connection, ConnectionArgs},
+    GlobalArgs,
+    client::{self, Connection},
     discovery::Family,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 /// The family of metrics services this CLI probes and discovers.
@@ -33,8 +34,6 @@ pub struct Cmd {
     /// Omitting it lists the available services as a usage error.
     #[arg(value_name = "SERVICE", add = ArgValueCandidates::new(service_candidates))]
     pub name: Option<String>,
-    #[command(flatten)]
-    pub connection: ConnectionArgs,
     /// Server-side tag filter: `NAME=VALUE`, repeatable — a metric is
     /// returned only if it satisfies every tag (logical AND).
     ///
@@ -44,16 +43,12 @@ pub struct Cmd {
     /// `--tag 'config=*'`.
     #[arg(long = "tag", short = 't', value_name = "NAME=VALUE", global = true)]
     pub tags: Vec<String>,
-    /// Output format.
-    #[arg(long, value_enum, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    #[command(flatten)]
+    pub globals: GlobalArgs,
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Run the metrics probe against the named service.
@@ -67,7 +62,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         return Err(require_service(&cmd).await);
     };
 
-    let endpoint = client::resolve_label(&cmd.connection, "metrics")?;
+    let endpoint = client::resolve_label(&cmd.globals.connection, "metrics")?;
 
     METRICS.require_name(&endpoint, &name)?;
 
@@ -78,7 +73,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         .collect::<Result<Vec<_>, String>>()
         .map_err(|message| Error::invalid_argument("metrics", endpoint, message))?;
 
-    let connection = Connection::connect_for(&cmd.connection, "metrics").await?;
+    let connection = Connection::connect_for(&cmd.globals.connection, "metrics").await?;
 
     let name = METRICS.resolve(&connection, &name).await?;
 
@@ -108,13 +103,13 @@ fn parse_tag(entry: &str) -> Result<MetricTag, String> {
 /// or slower than the budget simply leaves the error hintless, since the
 /// usage mistake stands on its own.
 async fn require_service(cmd: &Cmd) -> Error {
-    let endpoint = match client::resolve_label(&cmd.connection, "metrics") {
+    let endpoint = match client::resolve_label(&cmd.globals.connection, "metrics") {
         Ok(endpoint) => endpoint,
         Err(err) => return err,
     };
     let err = Error::invalid_argument("metrics", endpoint, "no metrics service specified");
 
-    METRICS.suggest_within(&cmd.connection, err).await
+    METRICS.suggest_within(&cmd.globals.connection, err).await
 }
 
 /// Probes one metrics service's `GetMetrics` over the shared connection, and

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -1,14 +1,15 @@
 //! CLI for YANET "pipeline" module.
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{FunctionId, PipelineId};
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 use ynpb::pb::{
     DeletePipelineRequest, GetPipelineRequest, ListPipelinesRequest, Pipeline, UpdatePipelineRequest,
@@ -31,13 +32,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, value_enum, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -89,12 +84,12 @@ pub struct DeleteCmd {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = PipelineService::new(&cmd.connection, action).await?;
+    let mut service = PipelineService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => {

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -2,16 +2,17 @@
 
 use std::{collections::BTreeMap, process::ExitCode, time::SystemTime};
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use colored::Colorize;
 use readinesspb::pb::{ReadyRequest, ReadyResponse, Scope, State};
 use serde::Serialize;
 use ync::{
-    client::{self, Connection, ConnectionArgs},
+    GlobalArgs,
+    client::{self, Connection},
     discovery::Family,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 mod render;
@@ -52,13 +53,7 @@ pub struct Cmd {
     #[arg(long, default_value_t = false, conflicts_with = "name")]
     pub all: bool,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, value_enum, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
     /// Stream readiness changes until interrupted instead of exiting after one
     /// snapshot.
     ///
@@ -105,7 +100,7 @@ struct ServiceReport {
 }
 
 fn main() -> ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Run the readiness probe, dispatching to aggregate or single-service mode.
@@ -120,9 +115,9 @@ async fn run(cmd: Cmd) -> Result<ExitCode, Error> {
     } else {
         let name = cmd.name.clone().expect("a non-aggregate command names a service");
 
-        READINESS.require_name(&client::resolve_label(&cmd.connection, "ready")?, &name)?;
+        READINESS.require_name(&client::resolve_label(&cmd.globals.connection, "ready")?, &name)?;
 
-        let connection = Connection::connect_for(&cmd.connection, "ready").await?;
+        let connection = Connection::connect_for(&cmd.globals.connection, "ready").await?;
 
         let name = READINESS.resolve(&connection, &name).await?;
 
@@ -273,7 +268,7 @@ async fn run_aggregate(cmd: Cmd) -> Result<bool, Error> {
         return watch::run(&cmd).await;
     }
 
-    let connection = Connection::connect_for(&cmd.connection, "ready").await?;
+    let connection = Connection::connect_for(&cmd.globals.connection, "ready").await?;
     let services = READINESS.list(&connection).await?;
 
     let mut reports = Vec::with_capacity(services.len());

--- a/cli/modules/ready/src/watch.rs
+++ b/cli/modules/ready/src/watch.rs
@@ -69,7 +69,7 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 /// close likewise maps to `Ok(true)` rather than reporting the readiness
 /// observed at startup.
 pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
-    let connection = Arc::new(Connection::connect_for(&cmd.connection, "ready").await?);
+    let connection = Arc::new(Connection::connect_for(&cmd.globals.connection, "ready").await?);
     let services = READINESS.list(&connection).await?;
 
     let mut reports = Vec::with_capacity(services.len());

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{Device, DevicePipeline};
 use plainpb::{
@@ -9,10 +9,11 @@ use plainpb::{
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 use ynpb::pb::{ListDevicesRequest, device_service_client::DeviceServiceClient};
 
@@ -31,13 +32,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -152,7 +147,7 @@ impl DevicePlainService {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = DevicePlainService::new(&cmd.connection, action).await?;
+    let mut service = DevicePlainService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Show(cmd) => service.show_device(cmd).await,
@@ -161,7 +156,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// One row of a device's pipeline bindings table.

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{Device, DevicePipeline};
 use tonic::codec::CompressionEncoding;
@@ -9,10 +9,11 @@ use trafgenpb::{
     trafgen_service_client::TrafgenServiceClient,
 };
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
@@ -30,13 +31,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -228,7 +223,7 @@ impl TrafgenService {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = TrafgenService::new(&cmd.connection, action).await?;
+    let mut service = TrafgenService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Update(cmd) => service.update_device(cmd).await,
@@ -240,7 +235,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Completion candidates for a `--name` argument: the generator device

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -1,16 +1,17 @@
 use std::borrow::Cow;
 
-use clap::{ArgAction, CommandFactory, Parser, value_parser};
+use clap::{CommandFactory, Parser, value_parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{Device, DevicePipeline};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use vlanpb::{ShowDeviceVlanRequest, UpdateDeviceVlanRequest, device_vlan_service_client::DeviceVlanServiceClient};
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 use ynpb::pb::{ListDevicesRequest, device_service_client::DeviceServiceClient};
 
@@ -29,13 +30,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -160,7 +155,7 @@ impl DeviceVlanService {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = DeviceVlanService::new(&cmd.connection, action).await?;
+    let mut service = DeviceVlanService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Show(cmd) => service.show_device(cmd).await,
@@ -169,7 +164,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// One row of a device's pipeline bindings table.
@@ -263,7 +258,7 @@ mod test {
     fn test_update_verbosity_after_subcommand_counts() {
         let cmd = Cmd::try_parse_from(["yanet-cli-device-vlan", "update", "-n", "x", "--vlan", "5", "-vv"]).unwrap();
 
-        assert_eq!(2, cmd.verbose);
+        assert_eq!(2, cmd.globals.verbose);
     }
 
     #[test]

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -5,18 +5,17 @@ use aclpb::{
     UpdateConfigRequest, acl_service_client::AclServiceClient, metrics_service_client::MetricsServiceClient,
 };
 use args::{DeleteCmd, MetricsRulesCmd, ModeCmd, RuleCountersCmd, ShowCmd, UpdateCmd};
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::CompletionCandidate;
 use serde::{Deserialize, Serialize};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    metrics,
-    output::{self, CommonFormat},
-    yaml,
+    metrics, output, yaml,
 };
 
 mod args;
@@ -220,13 +219,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 /// The fully-qualified gRPC service name used in error messages.
@@ -482,7 +475,7 @@ impl ACLService {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = ACLService::new(&cmd.connection, action).await?;
+    let mut service = ACLService::new(&cmd.globals.connection, action).await?;
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
         ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
@@ -494,7 +487,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Completion candidates for a `--name` argument: the ACL configs the

--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -11,9 +11,9 @@ use core::{
 };
 use std::path::PathBuf;
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
-use ync::{client::ConnectionArgs, completion, errors::Error, output::CommonFormat};
+use ync::{GlobalArgs, completion, errors::Error};
 
 use crate::service::{Balancer2Service, client};
 
@@ -30,13 +30,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -322,12 +316,12 @@ impl FilterFlags {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = Balancer2Service::connect(&cmd.connection, action).await?;
-    service.handle(cmd.mode, cmd.format).await
+    let mut service = Balancer2Service::connect(&cmd.globals.connection, action).await?;
+    service.handle(cmd.mode, cmd.globals.format).await
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Completion candidates for a `--name` argument: the balancer configs the

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -2,14 +2,15 @@ use blackholepb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     blackhole_service_client::BlackholeServiceClient,
 };
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
@@ -27,13 +28,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -90,12 +85,12 @@ fn client(channel: LayeredChannel) -> BlackholeServiceClient<LayeredChannel> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = BlackholeService::new(&cmd.connection, action).await?;
+    let mut service = BlackholeService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::partition_prefixes;
 use decappb::{
@@ -9,10 +9,11 @@ use netip::{Contiguous, IpNetwork};
 use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
@@ -30,13 +31,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -96,12 +91,12 @@ fn client(channel: LayeredChannel) -> DecapServiceClient<LayeredChannel> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = DecapService::new(&cmd.connection, action).await?;
+    let mut service = DecapService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{ArgAction, CommandFactory, Parser, ValueEnum, value_parser};
+use clap::{CommandFactory, Parser, ValueEnum, value_parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::partition_prefixes;
 use dscppb::{
@@ -9,10 +9,11 @@ use netip::{Contiguous, IpNetwork};
 use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 use crate::dscppb::ListConfigsRequest;
@@ -32,13 +33,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -148,12 +143,12 @@ fn client(channel: LayeredChannel) -> DscpServiceClient<LayeredChannel> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = DscpService::new(&cmd.connection, action).await?;
+    let mut service = DscpService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use forwardpb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
@@ -9,10 +9,11 @@ use forwardpb::{
 use serde::{Deserialize, Deserializer, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{self, ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
@@ -30,13 +31,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -291,7 +286,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     // gateway.
     let update = match &cmd.mode {
         ModeCmd::Update(update) => {
-            let endpoint = client::resolve_label(&cmd.connection, action)?;
+            let endpoint = client::resolve_label(&cmd.globals.connection, action)?;
             let mut request = load_request(&update.file)
                 .map_err(|e| Error::invalid_argument("update", endpoint.clone(), e.to_string()))?;
             bind_request_name(&mut request, &update.config)
@@ -301,7 +296,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         _ => None,
     };
 
-    let mut service = ForwardService::new(&cmd.connection, action).await?;
+    let mut service = ForwardService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
@@ -315,7 +310,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Completion candidates for a `--name` argument: the forward configs the

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -1,7 +1,7 @@
 use core::net::IpAddr;
 
 use args::{DeleteCmd, ModeCmd, ShowCmd, UpdateCmd};
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::CompletionCandidate;
 use commonpb::pb::{IpAddress, MacAddress};
 use fwstatepb::{
@@ -11,10 +11,11 @@ use fwstatepb::{
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 mod args;
@@ -43,13 +44,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 /// Renders a stored nanosecond timeout as the milliseconds an operator reads.
@@ -336,7 +331,7 @@ impl FWStateService {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = FWStateService::new(&cmd.connection, action).await?;
+    let mut service = FWStateService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -347,7 +342,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Completion candidates for a `--name` argument: the fwstate configs the

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -1,7 +1,7 @@
 use core::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{IPv4Network, IPv6Network};
 use mirrorpb::{
@@ -11,11 +11,11 @@ use mirrorpb::{
 use serde::{Deserialize, Serialize, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
-    yaml,
+    output, yaml,
 };
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
@@ -33,13 +33,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -344,7 +338,7 @@ impl MirrorService {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = MirrorService::new(&cmd.connection, action).await?;
+    let mut service = MirrorService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
@@ -355,7 +349,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Completion candidates for a `--name` argument: the mirror configs the

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -1,6 +1,6 @@
 use core::net::{Ipv4Addr, Ipv6Addr};
 
-use clap::{ArgAction, CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use nat64pb::{
     AddMappingRequest, AddPrefixRequest, DeleteConfigRequest, ListConfigsRequest, RemoveMappingRequest,
@@ -11,10 +11,11 @@ use netip::{Contiguous, Ipv6Network};
 use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
@@ -40,13 +41,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -193,12 +188,12 @@ pub struct DropCmd {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = NAT64Service::new(&cmd.connection, action).await?;
+    let mut service = NAT64Service::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -1,5 +1,5 @@
 use args::{DeleteCmd, ModeCmd, ReadCmd, SetConfigCmd, ShowConfigCmd};
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::CompletionCandidate;
 use pdumppb::{
     DeleteConfigRequest, ListConfigsRequest, ReadDumpRequest, ShowConfigRequest, ShowConfigResponse,
@@ -13,10 +13,11 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tonic::{Status, codec::CompressionEncoding};
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::{Error, ErrorKind},
-    output::{self, CommonFormat},
+    output,
 };
 
 use crate::{pdumppb::SetConfigRequest, writer::PdumpWriter};
@@ -41,18 +42,12 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = PdumpService::new(&cmd.connection, action).await?;
+    let mut service = PdumpService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
@@ -302,7 +297,7 @@ fn print_tree(resp: &ShowConfigResponse) {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Completion candidates for a `--name` argument: the pdump configs the

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -9,7 +9,7 @@ pub mod routemplspb {
     tonic::include_proto!("modules.route_mpls.controlplane.routemplspb.v1");
 }
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use netip::{Contiguous, IpNetwork};
 use routemplspb::{
@@ -18,10 +18,11 @@ use routemplspb::{
 };
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 /// Manages route-mpls module configs.
@@ -32,13 +33,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -142,7 +137,7 @@ fn client(channel: LayeredChannel) -> RouteMplsServiceClient<LayeredChannel> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Completion candidates for a `--name` argument: the route-mpls configs
@@ -157,7 +152,7 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = RouteMplsService::new(&cmd.connection, action).await?;
+    let mut service = RouteMplsService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,

--- a/modules/route/cli/src/main.rs
+++ b/modules/route/cli/src/main.rs
@@ -5,15 +5,15 @@ mod fib;
 use core::error::Error as StdError;
 use std::path::{Path, PathBuf};
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
-    yaml,
+    output, yaml,
 };
 
 use crate::{
@@ -116,13 +116,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -202,7 +196,7 @@ fn client(channel: LayeredChannel) -> RouteServiceClient<LayeredChannel> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Completion candidates for a `--name` argument: the route configs the
@@ -217,7 +211,7 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = RouteService::new(&cmd.connection, action).await?;
+    let mut service = RouteService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Fib(cmd) => match cmd.action {

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -1,7 +1,7 @@
 use core::{error::Error as StdError, net::IpAddr};
 use std::path::PathBuf;
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::IpAddress;
 use filterpb::pb::IpNet;
@@ -12,11 +12,11 @@ use unrduppb::{
     UpdateConfigRequest, unrdup_service_client::UnrdupServiceClient,
 };
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service as GrpcService},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
-    yaml,
+    output, yaml,
 };
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
@@ -34,13 +34,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -235,12 +229,12 @@ fn client(channel: LayeredChannel) -> UnrdupServiceClient<LayeredChannel> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = UnrdupService::new(&cmd.connection, action).await?;
+    let mut service = UnrdupService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -1,7 +1,7 @@
 use core::{fmt, net::IpAddr};
 
 use args::{CreateCmd, DeleteCmd, DirectionArg, EntriesCmd, InsertLayerCmd, ListCmd, ModeCmd, StatsCmd};
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::CompletionCandidate;
 use commonpb::pb::IpAddress;
 use fwstatemappb::{
@@ -11,6 +11,7 @@ use fwstatemappb::{
 use serde::Serialize;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
@@ -43,13 +44,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 pub struct FWStateMapService {
@@ -418,8 +413,8 @@ fn print_entry(entry: &fwstatemappb::FwStateEntry) {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = FWStateMapService::new(&cmd.connection, action).await?;
-    let format = cmd.format;
+    let mut service = FWStateMapService::new(&cmd.globals.connection, action).await?;
+    let format = cmd.globals.format;
 
     match cmd.mode {
         ModeCmd::List => service.map_list(args::ListCmd).await,
@@ -432,7 +427,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Completion candidates for a `--name` argument: the fwstate-map objects

--- a/operators/pipeline/cli/src/main.rs
+++ b/operators/pipeline/cli/src/main.rs
@@ -5,8 +5,8 @@
 //! invocation ends in help or a usage error. Operator metrics are read
 //! with `yanet-cli metrics`.
 
-use clap::{ArgAction, Parser};
-use ync::{client::ConnectionArgs, errors::Error, output::CommonFormat};
+use clap::Parser;
+use ync::{GlobalArgs, errors::Error};
 
 /// Manages the pipeline operator (no commands yet).
 #[derive(Debug, Clone, Parser)]
@@ -14,17 +14,11 @@ use ync::{client::ConnectionArgs, errors::Error, output::CommonFormat};
 #[command(flatten_help = true, subcommand_required = true, arg_required_else_help = true)]
 pub struct Cmd {
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(_: Cmd) -> Result<(), Error> {

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -10,18 +10,19 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::pb::{IpAddress, MacAddress};
 use netip::MacAddr;
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
     display::print_table_from_entries,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 use crate::operatorpb::{
@@ -53,13 +54,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -175,12 +170,12 @@ pub struct RemoveTableCmd {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = NeighbourService::new(&cmd.connection, action).await?;
+    let mut service = NeighbourService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Show(args) => service.show_neighbours(args).await,

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -10,7 +10,7 @@ use core::{
 };
 use std::collections::HashMap;
 
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use colored::Colorize;
 use commonpb::pb::IpPrefix;
@@ -18,10 +18,11 @@ use netip::{Contiguous, IpNetwork};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
+    GlobalArgs,
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 use crate::operatorpb::{
@@ -51,13 +52,7 @@ pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
     #[command(flatten)]
-    pub connection: ConnectionArgs,
-    /// Output format.
-    #[arg(long, default_value = "human", global = true)]
-    pub format: CommonFormat,
-    /// Be verbose: shows debug log lines and raw gRPC error details.
-    #[clap(short, action = ArgAction::Count, global = true)]
-    pub verbose: u8,
+    pub globals: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -173,7 +168,7 @@ impl RouteSource {
 }
 
 fn main() -> std::process::ExitCode {
-    ync::entrypoint(|cmd: &Cmd| (cmd.verbose, cmd.format), run)
+    ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
 /// Completion candidates for a `--name` argument: the route operator
@@ -192,7 +187,7 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 /// failure.
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = RouteService::new(&cmd.connection, action).await?;
+    let mut service = RouteService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,


### PR DESCRIPTION
- Adds ync::GlobalArgs, the connection flags, --format and -v every binary carries, and flattens it into the Cmd of all 30 binaries instead of repeating the three-field block.
- The dispatcher's config show and auth whoami build their flags from the same struct, so the built-ins no longer accept --verbose as a long form, only -v like every other binary.
- Help output is unchanged apart from inspect's --memory and metrics' --tag moving ahead of the connection flags.
- The code-cli skill and its skeleton describe the new shape.