### PR TITLE
perf(devices)!: absolutize the vlan and trafgen device pointers

### DIFF
--- a/devices/trafgen/dataplane/dataplane.c
+++ b/devices/trafgen/dataplane/dataplane.c
@@ -94,9 +94,7 @@ trafgen_input_handle(
 	struct packet_front *packet_front
 ) {
 	struct cp_device_trafgen *config = container_of(
-		ADDR_OF(&device_ectx->cp_device),
-		struct cp_device_trafgen,
-		cp_device
+		device_ectx->abs_cp_device, struct cp_device_trafgen, cp_device
 	);
 
 	// Forward anything that arrived on this device unchanged; a generator

--- a/devices/vlan/dataplane/dataplane.c
+++ b/devices/vlan/dataplane/dataplane.c
@@ -35,7 +35,7 @@ vlan_output_handle(
 ) {
 	(void)dp_worker;
 
-	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
+	struct cp_device *cp_device = device_ectx->abs_cp_device;
 	struct cp_device_vlan *cp_device_vlan =
 		container_of(cp_device, struct cp_device_vlan, cp_device);
 

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 27
+#define YANET_MODULE_ABI_VERSION 28
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -369,6 +369,13 @@ struct device_entry_ectx {
 
 struct device_ectx {
 	struct cp_device *cp_device;
+	// The same device, as an absolute address for the packet hot
+	// path.
+	//
+	// The publishing process copies it from the relative field above
+	// before the context is released to workers; it is zero until
+	// then.
+	struct cp_device *abs_cp_device;
 	struct counter_storage *counter_storage;
 	struct device_entry_ectx *input_pipelines;
 	struct device_entry_ectx *output_pipelines;

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -347,6 +347,7 @@ config_gen_ectx_resolve_counters(struct config_gen_ectx *config_gen_ectx) {
 		}
 
 		struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
+		device_ectx->abs_cp_device = cp_device;
 		struct counter_storage *counter_storage =
 			ADDR_OF(&device_ectx->counter_storage);
 


### PR DESCRIPTION
- The device execution context carries a publish-resolved absolute counterpart of the controlplane device pointer, so the vlan and trafgen handlers load it without offset translation; the relative field stays authoritative for the controlplane free and link paths.
- The publishing process re-derives the absolute address from the relative field on every pass, so repeated publications and dataplane restarts stay correct.
- No harness builds a device context by hand, so none needed updating.
- Bumps YANET_MODULE_ABI_VERSION to 28.
- Assumption: no measured-throughput claim is made — the win is one offset translation per handler invocation; acceptance is structural, per the issue.

Closes #2576.