### PR TITLE
fix(controlplane): serialize per-call agent attach in pipeline and function services

### DIFF
--- a/controlplane/builtin/function.go
+++ b/controlplane/builtin/function.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/c2h5oh/datasize"
 	"go.uber.org/zap"
@@ -17,17 +18,22 @@ import (
 
 const functionAgentName = "function"
 
-// Function agent is not persistent: it is created
-// on every call of update/assign/delete.
-// Memory, allocated for function agent, will be free after
-// corresponding call is done. So, on every call we need to allocate
-// memory for temporary operations only. For now, 1MB is
-// sufficient.
-const functionAgentMemory = datasize.MB
+// A token reservation: attaching refuses a zero size, and an arena that can
+// hand back no block at all is reported as fully occupied.
+//
+// An update or a delete clones the touched generation from the global
+// configuration pool, so no call ever allocates from the agent's own arena.
+// The arena outlives its call — detaching releases nothing — and is
+// reclaimed only when the next attach under the same name supersedes it.
+const functionAgentMemory = 4 * datasize.KB
 
 // Function is an in-process gRPC service for managing functions.
 type Function struct {
 	ynpb.UnimplementedFunctionServiceServer
+
+	// One attach-through-mutation lifetime at a time under the fixed agent
+	// name, because a concurrent attach reclaims the agent still in use.
+	mu sync.Mutex
 
 	instanceID uint32
 	shm        *ffi.SharedMemory
@@ -190,6 +196,9 @@ func (m *Function) Update(
 		function.Chains = append(function.Chains, functionChain)
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	agent, err := m.shm.AgentAttach(functionAgentName, m.instanceID, functionAgentMemory)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -219,6 +228,9 @@ func (m *Function) Delete(
 		return nil, status.Error(codes.InvalidArgument, "function name is required")
 	}
 	functionName := reqId.Name
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	agent, err := m.shm.AgentAttach(functionAgentName, m.instanceID, functionAgentMemory)
 	if err != nil {

--- a/controlplane/builtin/function_test.go
+++ b/controlplane/builtin/function_test.go
@@ -1,12 +1,16 @@
 package builtin_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/builtin"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
@@ -125,4 +129,99 @@ func TestFunctionGetRejectsMissingID(t *testing.T) {
 
 	_, err := svc.Get(t.Context(), &ynpb.GetFunctionRequest{})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Test_Function_UpdateAndDelete_Concurrent verifies that overlapping update
+// and delete calls all succeed and leave the registry empty.
+//
+// Every call attaches an agent under one fixed name, and an attach reclaims
+// the shared memory of the agent it supersedes, so calls that are not
+// serialized would release an arena another call is still using.
+func Test_Function_UpdateAndDelete_Concurrent(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		Devices:       []string{"d0"},
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	svc := builtin.NewFunction(0, harness.SharedMemory())
+
+	const callers = 32
+	const rounds = 64
+
+	// Callers open their windows together and then repeat the round, so an
+	// agent lifetime that is not serialized overlaps another one within a
+	// single run.
+	gate := make(chan struct{})
+
+	group, ctx := errgroup.WithContext(t.Context())
+	for caller := range callers {
+		group.Go(func() error {
+			id := &commonpb.FunctionId{Name: fmt.Sprintf("f%d", caller)}
+
+			<-gate
+
+			for range rounds {
+				_, err := svc.Update(ctx, &ynpb.UpdateFunctionRequest{
+					Function: &ynpb.Function{Id: id},
+				})
+				if err != nil {
+					return err
+				}
+				if _, err := svc.Delete(ctx, &ynpb.DeleteFunctionRequest{Id: id}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	close(gate)
+	require.NoError(t, group.Wait())
+
+	response, err := svc.List(t.Context(), &ynpb.ListFunctionsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, response.GetIds())
+}
+
+// Test_Function_Update_LeavesArenaSpare verifies that the agent an update
+// leaves behind still reports spare room in its arena.
+//
+// Occupancy is reported as the reserved size minus what the allocator can
+// still hand back, so an arena that yields no block at all reads as
+// permanently full and puts this service at the top of the arena pressure
+// readout while no call allocates from it at all.
+func Test_Function_Update_LeavesArenaSpare(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		Devices:       []string{"d0"},
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	svc := builtin.NewFunction(0, shm)
+
+	_, err = svc.Update(t.Context(), &ynpb.UpdateFunctionRequest{
+		Function: &ynpb.Function{Id: &commonpb.FunctionId{Name: "spare"}},
+	})
+	require.NoError(t, err)
+
+	var attached bool
+	for _, agent := range shm.DPConfig(0).Agents() {
+		if agent.Name != "function" {
+			continue
+		}
+		attached = true
+		for _, instance := range agent.Instances {
+			require.NotZero(t, instance.FreeBytes, "arena reports no spare room")
+		}
+	}
+	require.True(t, attached, "update left no attached agent behind")
 }

--- a/controlplane/builtin/pipeline.go
+++ b/controlplane/builtin/pipeline.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/c2h5oh/datasize"
 	"go.uber.org/zap"
@@ -15,19 +16,24 @@ import (
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
-const agentName = "pipeline"
+const pipelineAgentName = "pipeline"
 
-// Pipeline agent is not persistent: it is created
-// on every call of update/assign/delete.
-// Memory, allocated for pipeline agent, will be free after
-// corresponding call is done. So, on every call we need to allocate
-// memory for temporary operations only. For now, 1MB is
-// sufficient.
-const defaultAgentMemory = datasize.MB
+// A token reservation: attaching refuses a zero size, and an arena that can
+// hand back no block at all is reported as fully occupied.
+//
+// An update or a delete clones the touched generation from the global
+// configuration pool, so no call ever allocates from the agent's own arena.
+// The arena outlives its call — detaching releases nothing — and is
+// reclaimed only when the next attach under the same name supersedes it.
+const pipelineAgentMemory = 4 * datasize.KB
 
 // Pipeline is an in-process gRPC service for managing pipelines.
 type Pipeline struct {
 	ynpb.UnimplementedPipelineServiceServer
+
+	// One attach-through-mutation lifetime at a time under the fixed agent
+	// name, because a concurrent attach reclaims the agent still in use.
+	mu sync.Mutex
 
 	instanceID uint32
 	shm        *ffi.SharedMemory
@@ -171,7 +177,10 @@ func (m *Pipeline) Update(
 		pipeline.Functions[idx] = reqFunctionId.Name
 	}
 
-	agent, err := m.shm.AgentAttach(agentName, m.instanceID, defaultAgentMemory)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	agent, err := m.shm.AgentAttach(pipelineAgentName, m.instanceID, pipelineAgentMemory)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -201,7 +210,10 @@ func (m *Pipeline) Delete(
 	}
 	pipelineName := reqId.Name
 
-	agent, err := m.shm.AgentAttach(agentName, m.instanceID, defaultAgentMemory)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	agent, err := m.shm.AgentAttach(pipelineAgentName, m.instanceID, pipelineAgentMemory)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/controlplane/builtin/pipeline_test.go
+++ b/controlplane/builtin/pipeline_test.go
@@ -1,12 +1,16 @@
 package builtin_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/builtin"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
@@ -91,4 +95,99 @@ func TestPipelineGetRejectsMissingID(t *testing.T) {
 
 	_, err := svc.Get(t.Context(), &ynpb.GetPipelineRequest{})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Test_Pipeline_UpdateAndDelete_Concurrent verifies that overlapping update
+// and delete calls all succeed and leave the registry empty.
+//
+// Every call attaches an agent under one fixed name, and an attach reclaims
+// the shared memory of the agent it supersedes, so calls that are not
+// serialized would release an arena another call is still using.
+func Test_Pipeline_UpdateAndDelete_Concurrent(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		Devices:       []string{"d0"},
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	svc := builtin.NewPipeline(0, harness.SharedMemory())
+
+	const callers = 32
+	const rounds = 64
+
+	// Callers open their windows together and then repeat the round, so an
+	// agent lifetime that is not serialized overlaps another one within a
+	// single run.
+	gate := make(chan struct{})
+
+	group, ctx := errgroup.WithContext(t.Context())
+	for caller := range callers {
+		group.Go(func() error {
+			id := &commonpb.PipelineId{Name: fmt.Sprintf("p%d", caller)}
+
+			<-gate
+
+			for range rounds {
+				_, err := svc.Update(ctx, &ynpb.UpdatePipelineRequest{
+					Pipeline: &ynpb.Pipeline{Id: id},
+				})
+				if err != nil {
+					return err
+				}
+				if _, err := svc.Delete(ctx, &ynpb.DeletePipelineRequest{Id: id}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	close(gate)
+	require.NoError(t, group.Wait())
+
+	response, err := svc.List(t.Context(), &ynpb.ListPipelinesRequest{})
+	require.NoError(t, err)
+	require.Empty(t, response.GetIds())
+}
+
+// Test_Pipeline_Update_LeavesArenaSpare verifies that the agent an update
+// leaves behind still reports spare room in its arena.
+//
+// Occupancy is reported as the reserved size minus what the allocator can
+// still hand back, so an arena that yields no block at all reads as
+// permanently full and puts this service at the top of the arena pressure
+// readout while no call allocates from it at all.
+func Test_Pipeline_Update_LeavesArenaSpare(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		Devices:       []string{"d0"},
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	svc := builtin.NewPipeline(0, shm)
+
+	_, err = svc.Update(t.Context(), &ynpb.UpdatePipelineRequest{
+		Pipeline: &ynpb.Pipeline{Id: &commonpb.PipelineId{Name: "spare"}},
+	})
+	require.NoError(t, err)
+
+	var attached bool
+	for _, agent := range shm.DPConfig(0).Agents() {
+		if agent.Name != "pipeline" {
+			continue
+		}
+		attached = true
+		for _, instance := range agent.Instances {
+			require.NotZero(t, instance.FreeBytes, "arena reports no spare room")
+		}
+	}
+	require.True(t, attached, "update left no attached agent behind")
 }


### PR DESCRIPTION
- Serialize the attach-through-call lifetime of the pipeline and function services, so two overlapping RPCs can no longer free the shared-memory arena the other call is still using, mirroring the device service.
- Drop the per-call reservation from a megabyte to a single page, since neither the update nor the delete path allocates from the agent's own arena: the touched generation is cloned from the global configuration pool.
- Replace the comments claiming the agent's memory is released once the call completes with the lifetime the code actually has.
- Cover both services with a concurrency test over overlapping updates and deletes, and with a test pinning that the reservation still leaves the arena a spare block, so the services do not surface as permanently full in the arena occupancy readout.

Closes #2525.
