### PR TITLE
feat(cli): filter and order the gateway listing, select inspect sections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3382,7 +3382,10 @@ name = "yanet-cli-gateway"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
+ "humantime",
  "prost-types",
+ "serde",
  "tabled",
  "tonic",
  "yanet-cli",
@@ -3395,6 +3398,7 @@ version = "0.1.0"
 dependencies = [
  "bytesize",
  "clap",
+ "clap_complete",
  "tonic",
  "unicode-segmentation",
  "unicode-width",

--- a/cli/core/src/discovery.rs
+++ b/cli/core/src/discovery.rs
@@ -245,11 +245,17 @@ pub async fn list_services(connection: &Connection, suffix: &str) -> Result<Vec<
     Ok(services)
 }
 
-/// Reports whether `name`'s last dot-separated segment is exactly `suffix`,
-/// so that a service merely mentioning it elsewhere in its name is not
-/// mistaken for a match.
-fn has_suffix(name: &str, suffix: &str) -> bool {
-    name.rsplit('.').next() == Some(suffix)
+/// Returns the last dot-separated segment of a service name, the segment that
+/// names the family it belongs to.
+pub fn suffix_of(name: &str) -> &str {
+    name.rsplit('.').next().unwrap_or(name)
+}
+
+/// Reports whether a service name's last dot-separated segment is exactly the
+/// one given, so that a service merely mentioning it elsewhere in its name is
+/// not mistaken for a match.
+pub fn has_suffix(name: &str, suffix: &str) -> bool {
+    suffix_of(name) == suffix
 }
 
 /// Resolves a short alias (e.g. `route`) against the discovered `services`.
@@ -428,6 +434,13 @@ mod test {
             format!("operators.pipeline.operatorpb.v1.{suffix}"),
             format!("operators.route.operatorpb.v1.{suffix}"),
         ]
+    }
+
+    #[test]
+    fn test_suffix_of_returns_the_trailing_segment() {
+        assert_eq!("ReadinessService", suffix_of("controlplane.ynpb.v1.ReadinessService"));
+        assert_eq!("Gateway", suffix_of("Gateway"));
+        assert_eq!("", suffix_of(""));
     }
 
     #[test]

--- a/cli/core/src/humanfmt.rs
+++ b/cli/core/src/humanfmt.rs
@@ -5,9 +5,31 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use prost_types::Timestamp;
 
+const NANOS_PER_SECOND: i32 = 1_000_000_000;
 const SECONDS_PER_MINUTE: u64 = 60;
 const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
 const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;
+
+/// Returns how long ago an observation was made, against a reading of the
+/// local clock.
+///
+/// Returns nothing when the observation carries no time or the zero
+/// sentinel, leaving the caller to decide what an unknown age means.
+/// Subsecond precision survives, so a threshold falling between two whole
+/// seconds is not crossed early, and an observation stamped ahead of the
+/// local clock, as skew between two hosts produces, reads as a zero age
+/// rather than a negative one.
+pub fn age(ts: Option<&Timestamp>, now: SystemTime) -> Option<Duration> {
+    let ts = match ts {
+        Some(ts) if ts.seconds != 0 || ts.nanos != 0 => ts,
+        _ => return None,
+    };
+
+    let now = now.duration_since(UNIX_EPOCH).unwrap_or_default();
+    let stamped = Duration::new(ts.seconds.max(0) as u64, ts.nanos.clamp(0, NANOS_PER_SECOND - 1) as u32);
+
+    Some(now.saturating_sub(stamped))
+}
 
 /// Formats a `Timestamp` as an age string relative to `now`.
 ///
@@ -16,14 +38,7 @@ const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;
 /// units because humantime's year/month decomposition would otherwise leave
 /// a minute/second tail.
 pub fn format_age(ts: Option<&Timestamp>, now: SystemTime) -> Option<String> {
-    let ts = match ts {
-        Some(ts) if ts.seconds != 0 || ts.nanos != 0 => ts,
-        _ => return None,
-    };
-
-    let now_secs = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-    let ts_secs = ts.seconds.max(0) as u64;
-    let age = now_secs.saturating_sub(ts_secs);
+    let age = age(ts, now)?.as_secs();
 
     let rendered = humantime::format_duration(Duration::from_secs(round_age(age))).to_string();
     Some(rendered.split_whitespace().take(2).collect::<Vec<_>>().join(" "))
@@ -73,6 +88,37 @@ mod test {
             round_age(3 * SECONDS_PER_DAY + 5 * SECONDS_PER_HOUR + 40 * SECONDS_PER_MINUTE)
         );
         assert_eq!(SECONDS_PER_DAY, round_age(SECONDS_PER_DAY));
+    }
+
+    #[test]
+    fn test_age_reports_elapsed_time() {
+        let now = UNIX_EPOCH + Duration::from_secs(1_000);
+        let ts = Timestamp { seconds: 910, nanos: 0 };
+
+        assert_eq!(Some(Duration::from_secs(90)), age(Some(&ts), now));
+    }
+
+    #[test]
+    fn test_age_keeps_subsecond_precision() {
+        let now = UNIX_EPOCH + Duration::new(1_000, 100_000_000);
+        let ts = Timestamp { seconds: 999, nanos: 900_000_000 };
+
+        assert_eq!(Some(Duration::from_millis(200)), age(Some(&ts), now));
+    }
+
+    #[test]
+    fn test_age_future_timestamp_saturates_to_zero() {
+        let now = UNIX_EPOCH + Duration::from_secs(1_000);
+        let ts = Timestamp { seconds: 1_060, nanos: 0 };
+
+        assert_eq!(Some(Duration::ZERO), age(Some(&ts), now));
+    }
+
+    #[test]
+    fn test_age_zero_sentinel_returns_none() {
+        let ts = Timestamp { seconds: 0, nanos: 0 };
+
+        assert_eq!(None, age(Some(&ts), SystemTime::now()));
     }
 
     #[test]

--- a/cli/modules/gateway/Cargo.toml
+++ b/cli/modules/gateway/Cargo.toml
@@ -13,6 +13,9 @@ workspace = true
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
+humantime = "2"
 prost-types = "0.14"
+serde = { version = "1", features = ["derive"] }
 tonic = { version = "0.14", features = ["gzip"] }
 tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -1,19 +1,47 @@
 //! CLI for the YANET gateway service registry.
 
+use core::{
+    fmt::{self, Display, Formatter},
+    time::Duration,
+};
 use std::time::SystemTime;
 
-use clap::{ArgAction, Parser};
+use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
+use prost_types::Timestamp;
+use serde::Serialize;
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    completion, discovery, display,
     errors::Error,
     humanfmt,
     output::{self, CommonFormat},
 };
-use ynpb::pb::{BackendKind, ListServicesRequest, RegisteredBackend, gateway_client::GatewayClient};
+use ynpb::pb::{
+    BackendKind, ListServicesRequest, ListServicesResponse, RegisteredBackend, gateway_client::GatewayClient,
+};
 
+/// The fully-qualified gRPC service name used in error messages.
 const GATEWAY_SERVICE: &str = "controlplane.ynpb.v1.Gateway";
+
+/// Cell standing for a value that carries no meaning for the row's kind.
+const NOT_APPLICABLE: &str = "\u{2014}";
+
+/// Cell standing for a value the registry did not report.
+const UNKNOWN: &str = "-";
+
+/// Age past which a backend that stopped refreshing its registration is
+/// reported stale.
+///
+/// This is the gateway's own default registration lifetime: the age at which
+/// it stops counting a registration as current. Dropping the entry happens on
+/// a sweep of its own, so a backend can still be listed for a while after
+/// crossing the line, and a deployment that keeps stale entries on purpose
+/// lists it indefinitely — both are what this column is here to name. A
+/// deployment that tunes the lifetime passes its own value.
+const DEFAULT_STALE_AFTER: &str = "5m";
 
 /// Inspects the gateway service registry.
 #[derive(Debug, Clone, Parser)]
@@ -35,7 +63,110 @@ pub struct Cmd {
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
     /// List all services registered with the gateway.
-    List,
+    List(ListCmd),
+}
+
+/// Narrows the registry listing and sets when a heartbeat counts as overdue.
+#[derive(Debug, Clone, Parser)]
+pub struct ListCmd {
+    /// Show only backends hosted this way.
+    #[arg(long, value_enum)]
+    pub kind: Option<Kind>,
+    /// Show only services whose name ends with this segment.
+    #[arg(long, add = ArgValueCandidates::new(suffix_candidates))]
+    pub suffix: Option<String>,
+    /// Age at which a backend that stopped registering counts as stale.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = DEFAULT_STALE_AFTER)]
+    pub stale_after: Duration,
+}
+
+impl ListCmd {
+    /// Reports whether a registry entry survives the listing filters.
+    fn matches(&self, entry: &RegisteredBackend) -> bool {
+        if let Some(kind) = self.kind
+            && kind != Kind::of(entry)
+        {
+            return false;
+        }
+
+        if let Some(suffix) = &self.suffix
+            && !discovery::has_suffix(service_name(entry), suffix)
+        {
+            return false;
+        }
+
+        true
+    }
+
+    /// Reports whether the listing was narrowed at all.
+    fn narrowed(&self) -> bool {
+        self.kind.is_some() || self.suffix.is_some()
+    }
+}
+
+/// How a registered backend is hosted, as spelled on the command line and in
+/// the table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Kind {
+    #[value(name = "built-in")]
+    Builtin,
+    InProcess,
+    External,
+    Unspecified,
+}
+
+impl Kind {
+    /// Reads the kind off a registry entry, treating a value this build does
+    /// not know as unspecified.
+    fn of(entry: &RegisteredBackend) -> Self {
+        Self::from(BackendKind::try_from(entry.kind).unwrap_or(BackendKind::Unspecified))
+    }
+
+    /// Reports whether an age is worth showing for this kind.
+    ///
+    /// A backend that never refreshes its registration carries the age of
+    /// gateway startup, which would read as a sign of life it is not. An
+    /// unclassified backend keeps its age because a gateway too old to
+    /// classify its backends leaves every one of them unclassified, and the
+    /// age was the only signal that gateway ever offered.
+    fn shows_age(self) -> bool {
+        matches!(self, Self::External | Self::Unspecified)
+    }
+
+    /// Reports whether an age can settle whether this kind's backend is
+    /// stale.
+    ///
+    /// Only a backend running in a process of its own is known to refresh
+    /// its registration. An unclassified one may equally be a backend that
+    /// never refreshes, whose age would then read as overdue for as long as
+    /// the gateway has been up, so its age is shown but never judged.
+    fn judges_staleness(self) -> bool {
+        matches!(self, Self::External)
+    }
+}
+
+impl From<BackendKind> for Kind {
+    fn from(kind: BackendKind) -> Self {
+        match kind {
+            BackendKind::Builtin => Self::Builtin,
+            BackendKind::InProcess => Self::InProcess,
+            BackendKind::External => Self::External,
+            BackendKind::Unspecified => Self::Unspecified,
+        }
+    }
+}
+
+impl Display for Kind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        let label = match self {
+            Self::Builtin => "built-in",
+            Self::InProcess => "in-process",
+            Self::External => "external",
+            Self::Unspecified => "unspecified",
+        };
+
+        f.write_str(label)
+    }
 }
 
 fn main() -> std::process::ExitCode {
@@ -45,9 +176,15 @@ fn main() -> std::process::ExitCode {
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let mut service = GatewayService::new(&cmd.connection).await?;
 
-    match cmd.mode {
-        ModeCmd::List => service.list_services().await,
+    match &cmd.mode {
+        ModeCmd::List(list) => service.list_services(list).await,
     }
+}
+
+fn client(channel: LayeredChannel) -> GatewayClient<LayeredChannel> {
+    GatewayClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
 }
 
 pub struct GatewayService {
@@ -56,39 +193,103 @@ pub struct GatewayService {
 
 impl GatewayService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, "gateway", GATEWAY_SERVICE, |channel| {
-            GatewayClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, "gateway", GATEWAY_SERVICE, client).await?;
 
         Ok(Self { service })
     }
 
-    pub async fn list_services(&mut self) -> Result<(), Error> {
-        let response = self
+    pub async fn list_services(&mut self, cmd: &ListCmd) -> Result<(), Error> {
+        let response: ListServicesResponse = self
             .service
             .unary("gateway", ListServicesRequest {}, async |client, request| {
                 client.list_services(request).await
             })
             .await?;
 
-        output::data(
-            || &response.services,
-            || {
-                let rows: Vec<ServiceRow> = response.services.iter().map(ServiceRow::from).collect();
+        let now = SystemTime::now();
+        let mut selected: Vec<&RegisteredBackend> =
+            response.services.iter().filter(|entry| cmd.matches(entry)).collect();
+        selected.sort_by(|left, right| order_key(left).cmp(&order_key(right)));
 
-                if rows.is_empty() {
-                    output::empty(format_args!("No services registered."));
+        let entries: Vec<ServiceEntry> = selected
+            .into_iter()
+            .map(|entry| ServiceEntry::new(entry, now, cmd.stale_after))
+            .collect();
+
+        output::data(
+            || &entries,
+            || {
+                if entries.is_empty() {
+                    if cmd.narrowed() && !response.services.is_empty() {
+                        output::empty(format_args!("No services matched the filters."));
+                    } else {
+                        output::empty(format_args!("No services registered."));
+                    }
                     return;
                 }
 
-                ync::display::print_table_from_entries(&rows);
+                let rows: Vec<ServiceRow> = entries.iter().map(|entry| ServiceRow::new(entry, now)).collect();
+
+                display::print_table_from_entries(&rows);
             },
         );
 
         Ok(())
+    }
+}
+
+/// Returns the service name a registry entry was registered under.
+fn service_name(entry: &RegisteredBackend) -> &str {
+    entry
+        .backend
+        .as_ref()
+        .map(|backend| backend.name.as_str())
+        .unwrap_or_default()
+}
+
+/// Returns the key the listing is ordered by.
+///
+/// Nothing in the registry contract promises an order, so the table settles
+/// one of its own rather than inheriting whatever the gateway it reached
+/// happens to return. Endpoint and kind join the name only to make that
+/// order total.
+fn order_key(entry: &RegisteredBackend) -> (&str, &str, i32) {
+    let endpoint = entry
+        .backend
+        .as_ref()
+        .map(|backend| backend.endpoint.as_str())
+        .unwrap_or_default();
+
+    (service_name(entry), endpoint, entry.kind)
+}
+
+/// Reports whether a registration aged past the point where the gateway stops
+/// counting it as current, or nothing when the age carries no such verdict.
+///
+/// A kind whose backends are not known to refresh their registration is never
+/// judged, and neither is an entry the registry gave no timestamp for.
+fn staleness(kind: Kind, ts: Option<&Timestamp>, now: SystemTime, stale_after: Duration) -> Option<bool> {
+    if !kind.judges_staleness() {
+        return None;
+    }
+
+    humanfmt::age(ts, now).map(|age| age > stale_after)
+}
+
+/// A registry entry as this CLI reports it: the record the gateway returned
+/// plus the staleness judged from its age.
+#[derive(Debug, Serialize)]
+pub struct ServiceEntry<'a> {
+    #[serde(flatten)]
+    pub registered: &'a RegisteredBackend,
+    pub stale: Option<bool>,
+}
+
+impl<'a> ServiceEntry<'a> {
+    pub fn new(registered: &'a RegisteredBackend, now: SystemTime, stale_after: Duration) -> Self {
+        let stale = staleness(Kind::of(registered), registered.last_seen_at.as_ref(), now, stale_after);
+
+        Self { registered, stale }
     }
 }
 
@@ -103,95 +304,333 @@ pub struct ServiceRow {
     pub endpoint: String,
     #[tabled(rename = "Last seen")]
     pub last_seen: String,
+    #[tabled(rename = "Stale")]
+    pub stale: String,
 }
 
-impl From<&RegisteredBackend> for ServiceRow {
-    fn from(backend: &RegisteredBackend) -> Self {
-        let (name, endpoint) = backend
+impl ServiceRow {
+    pub fn new(entry: &ServiceEntry<'_>, now: SystemTime) -> Self {
+        let (name, endpoint) = entry
+            .registered
             .backend
             .as_ref()
-            .map(|b| (b.name.clone(), b.endpoint.clone()))
+            .map(|backend| (backend.name.clone(), backend.endpoint.clone()))
             .unwrap_or_default();
 
-        let kind = BackendKind::try_from(backend.kind).unwrap_or(BackendKind::Unspecified);
+        let kind = Kind::of(entry.registered);
 
         Self {
             name,
-            kind: kind_display(kind),
+            kind: kind.to_string(),
             endpoint,
-            last_seen: last_seen_cell(kind, backend.last_seen_at.as_ref()),
+            last_seen: last_seen_cell(kind, entry.registered.last_seen_at.as_ref(), now),
+            stale: stale_cell(kind, entry.stale),
         }
-    }
-}
-
-/// Returns the human-readable label for a `BackendKind`.
-fn kind_display(kind: BackendKind) -> String {
-    match kind {
-        BackendKind::Builtin => "built-in".to_string(),
-        BackendKind::InProcess => "in-process".to_string(),
-        BackendKind::External => "external".to_string(),
-        BackendKind::Unspecified => "unspecified".to_string(),
     }
 }
 
 /// Returns the last-seen cell value for a row.
 ///
-/// `Builtin` and `InProcess` register once and never heartbeat, so showing an
-/// age would be misleading — those arms return `—`. `External` backends
-/// heartbeat and always show the age. `Unspecified` also shows the age: when a
-/// newer CLI talks to an older gateway that predates the `kind` field, proto3
-/// decodes every backend's `kind` as `Unspecified`, so falling back to
-/// `format_age` preserves the pre-kind staleness signal for external services.
-fn last_seen_cell(kind: BackendKind, ts: Option<&prost_types::Timestamp>) -> String {
-    match kind {
-        BackendKind::Builtin | BackendKind::InProcess => "\u{2014}".to_string(),
-        BackendKind::External | BackendKind::Unspecified => {
-            humanfmt::format_age(ts, SystemTime::now()).unwrap_or_else(|| "-".to_string())
-        }
+/// A backend that never refreshes its registration would otherwise show the
+/// age of gateway startup as if it were a sign of life, so those rows carry
+/// no age at all.
+fn last_seen_cell(kind: Kind, ts: Option<&Timestamp>, now: SystemTime) -> String {
+    if !kind.shows_age() {
+        return NOT_APPLICABLE.to_owned();
     }
+
+    humanfmt::format_age(ts, now).unwrap_or_else(|| UNKNOWN.to_owned())
+}
+
+/// Returns the staleness cell value for a row.
+fn stale_cell(kind: Kind, stale: Option<bool>) -> String {
+    if !kind.judges_staleness() {
+        return NOT_APPLICABLE.to_owned();
+    }
+
+    match stale {
+        Some(true) => "yes".to_owned(),
+        Some(false) => "no".to_owned(),
+        None => UNKNOWN.to_owned(),
+    }
+}
+
+/// Completion candidates for a `--suffix` argument: the trailing segments of
+/// the service names the gateway currently serves.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn suffix_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        let response = client.list_services(ListServicesRequest {}).await?.into_inner();
+
+        let mut suffixes: Vec<String> = response
+            .services
+            .iter()
+            .map(|entry| discovery::suffix_of(service_name(entry)).to_owned())
+            .filter(|suffix| !suffix.is_empty())
+            .collect();
+        suffixes.sort();
+        suffixes.dedup();
+
+        Ok(suffixes)
+    })
 }
 
 #[cfg(test)]
 mod test {
+    use ynpb::pb::BackendDesc;
+
     use super::*;
 
-    #[test]
-    fn kind_display_all_variants() {
-        assert_eq!("built-in", kind_display(BackendKind::Builtin));
-        assert_eq!("in-process", kind_display(BackendKind::InProcess));
-        assert_eq!("external", kind_display(BackendKind::External));
-        assert_eq!("unspecified", kind_display(BackendKind::Unspecified));
+    /// Returns a registry entry of the given kind, last registered the given
+    /// number of seconds before the reference instant, or with no
+    /// registration time at all.
+    fn entry(name: &str, kind: BackendKind, now: SystemTime, age: Option<u64>) -> RegisteredBackend {
+        let now_secs = now.duration_since(std::time::UNIX_EPOCH).unwrap().as_secs() as i64;
+
+        RegisteredBackend {
+            backend: Some(BackendDesc {
+                name: name.to_owned(),
+                endpoint: "[::1]:8080".to_owned(),
+            }),
+            last_seen_at: age.map(|age| Timestamp {
+                seconds: now_secs - age as i64,
+                nanos: 0,
+            }),
+            kind: kind as i32,
+        }
+    }
+
+    /// Returns a listing narrowed by the given filters, judging staleness at
+    /// five minutes.
+    fn list(kind: Option<Kind>, suffix: Option<&str>) -> ListCmd {
+        ListCmd {
+            kind,
+            suffix: suffix.map(str::to_owned),
+            stale_after: Duration::from_secs(300),
+        }
     }
 
     #[test]
-    fn last_seen_cell_builtin_shows_em_dash() {
-        let ts = prost_types::Timestamp { seconds: 1_000_000, nanos: 0 };
-        assert_eq!("\u{2014}", last_seen_cell(BackendKind::Builtin, Some(&ts)));
+    fn test_kind_display_all_variants() {
+        assert_eq!("built-in", Kind::Builtin.to_string());
+        assert_eq!("in-process", Kind::InProcess.to_string());
+        assert_eq!("external", Kind::External.to_string());
+        assert_eq!("unspecified", Kind::Unspecified.to_string());
     }
 
     #[test]
-    fn last_seen_cell_in_process_shows_em_dash() {
-        let ts = prost_types::Timestamp { seconds: 1_000_000, nanos: 0 };
-        assert_eq!("\u{2014}", last_seen_cell(BackendKind::InProcess, Some(&ts)));
+    fn test_kind_of_unknown_wire_value_is_unspecified() {
+        let mut backend = entry(
+            "controlplane.ynpb.v1.Gateway",
+            BackendKind::External,
+            SystemTime::now(),
+            None,
+        );
+        backend.kind = 99;
+
+        assert_eq!(Kind::Unspecified, Kind::of(&backend));
     }
 
     #[test]
-    fn last_seen_cell_external_shows_age() {
-        let now = SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap();
-        let ts = prost_types::Timestamp {
-            seconds: now.as_secs() as i64 - 5,
-            nanos: 0,
-        };
-        assert_ne!("\u{2014}", last_seen_cell(BackendKind::External, Some(&ts)));
+    fn test_last_seen_cell_builtin_shows_no_age() {
+        let now = SystemTime::now();
+        let backend = entry("built-in", BackendKind::Builtin, now, Some(5));
+
+        assert_eq!(
+            NOT_APPLICABLE,
+            last_seen_cell(Kind::Builtin, backend.last_seen_at.as_ref(), now)
+        );
     }
 
     #[test]
-    fn last_seen_cell_unspecified_shows_age() {
-        let now = SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap();
-        let ts = prost_types::Timestamp {
-            seconds: now.as_secs() as i64 - 5,
-            nanos: 0,
-        };
-        assert_ne!("\u{2014}", last_seen_cell(BackendKind::Unspecified, Some(&ts)));
+    fn test_last_seen_cell_in_process_shows_no_age() {
+        let now = SystemTime::now();
+        let backend = entry("in-process", BackendKind::InProcess, now, Some(5));
+
+        assert_eq!(
+            NOT_APPLICABLE,
+            last_seen_cell(Kind::InProcess, backend.last_seen_at.as_ref(), now)
+        );
+    }
+
+    #[test]
+    fn test_last_seen_cell_external_shows_age() {
+        let now = SystemTime::now();
+        let backend = entry("external", BackendKind::External, now, Some(5));
+
+        let cell = last_seen_cell(Kind::External, backend.last_seen_at.as_ref(), now);
+
+        assert_ne!(NOT_APPLICABLE, cell);
+        assert_ne!(UNKNOWN, cell);
+    }
+
+    #[test]
+    fn test_last_seen_cell_unspecified_shows_age() {
+        let now = SystemTime::now();
+        let backend = entry("legacy", BackendKind::Unspecified, now, Some(5));
+
+        let cell = last_seen_cell(Kind::Unspecified, backend.last_seen_at.as_ref(), now);
+
+        assert_ne!(NOT_APPLICABLE, cell);
+        assert_ne!(UNKNOWN, cell);
+    }
+
+    #[test]
+    fn test_last_seen_cell_without_timestamp_is_unknown() {
+        assert_eq!(UNKNOWN, last_seen_cell(Kind::External, None, SystemTime::now()));
+    }
+
+    #[test]
+    fn test_staleness_external_past_threshold_is_stale() {
+        let now = SystemTime::now();
+        let backend = entry("external", BackendKind::External, now, Some(301));
+
+        let stale = staleness(
+            Kind::External,
+            backend.last_seen_at.as_ref(),
+            now,
+            Duration::from_secs(300),
+        );
+
+        assert_eq!(Some(true), stale);
+    }
+
+    #[test]
+    fn test_staleness_external_within_threshold_is_fresh() {
+        let now = SystemTime::now();
+        let backend = entry("external", BackendKind::External, now, Some(299));
+
+        let stale = staleness(
+            Kind::External,
+            backend.last_seen_at.as_ref(),
+            now,
+            Duration::from_secs(300),
+        );
+
+        assert_eq!(Some(false), stale);
+    }
+
+    #[test]
+    fn test_staleness_unspecified_has_no_verdict() {
+        let now = SystemTime::now();
+        let backend = entry("legacy", BackendKind::Unspecified, now, Some(3600));
+
+        let stale = staleness(
+            Kind::Unspecified,
+            backend.last_seen_at.as_ref(),
+            now,
+            Duration::from_secs(300),
+        );
+
+        assert_eq!(None, stale);
+    }
+
+    #[test]
+    fn test_staleness_builtin_has_no_verdict() {
+        let now = SystemTime::now();
+        let backend = entry("built-in", BackendKind::Builtin, now, Some(3600));
+
+        let stale = staleness(
+            Kind::Builtin,
+            backend.last_seen_at.as_ref(),
+            now,
+            Duration::from_secs(300),
+        );
+
+        assert_eq!(None, stale);
+    }
+
+    #[test]
+    fn test_staleness_without_timestamp_has_no_verdict() {
+        let stale = staleness(Kind::External, None, SystemTime::now(), Duration::from_secs(300));
+
+        assert_eq!(None, stale);
+    }
+
+    #[test]
+    fn test_stale_cell_separates_a_verdict_from_its_absence() {
+        assert_ne!(
+            stale_cell(Kind::External, Some(true)),
+            stale_cell(Kind::External, Some(false))
+        );
+        assert_eq!(UNKNOWN, stale_cell(Kind::External, None));
+        assert_eq!(NOT_APPLICABLE, stale_cell(Kind::Builtin, Some(true)));
+        assert_eq!(NOT_APPLICABLE, stale_cell(Kind::Unspecified, Some(true)));
+    }
+
+    #[test]
+    fn test_order_key_sorts_registry_by_name() {
+        let now = SystemTime::now();
+        let entries = [
+            entry("controlplane.ynpb.v1.Gateway", BackendKind::Builtin, now, None),
+            entry(
+                "operators.route.operatorpb.v1.RouteService",
+                BackendKind::External,
+                now,
+                None,
+            ),
+            entry("controlplane.ynpb.v1.CounterService", BackendKind::Builtin, now, None),
+        ];
+
+        let mut selected: Vec<&RegisteredBackend> = entries.iter().collect();
+        selected.sort_by(|left, right| order_key(left).cmp(&order_key(right)));
+
+        let names: Vec<&str> = selected.into_iter().map(service_name).collect();
+
+        assert_eq!(
+            vec![
+                "controlplane.ynpb.v1.CounterService",
+                "controlplane.ynpb.v1.Gateway",
+                "operators.route.operatorpb.v1.RouteService",
+            ],
+            names
+        );
+    }
+
+    #[test]
+    fn test_matches_kind_filter_rejects_other_kinds() {
+        let now = SystemTime::now();
+        let external = entry(
+            "operators.route.operatorpb.v1.RouteService",
+            BackendKind::External,
+            now,
+            None,
+        );
+        let builtin = entry("controlplane.ynpb.v1.Gateway", BackendKind::Builtin, now, None);
+
+        let cmd = list(Some(Kind::External), None);
+
+        assert!(cmd.matches(&external));
+        assert!(!cmd.matches(&builtin));
+    }
+
+    #[test]
+    fn test_matches_suffix_filter_requires_the_trailing_segment() {
+        let now = SystemTime::now();
+        let readiness = entry("controlplane.ynpb.v1.ReadinessService", BackendKind::Builtin, now, None);
+        let gateway = entry("controlplane.ynpb.v1.Gateway", BackendKind::Builtin, now, None);
+
+        let cmd = list(None, Some("ReadinessService"));
+
+        assert!(cmd.matches(&readiness));
+        assert!(!cmd.matches(&gateway));
+    }
+
+    #[test]
+    fn test_matches_combines_kind_and_suffix() {
+        let now = SystemTime::now();
+        let external = entry(
+            "operators.route.operatorpb.v1.ReadinessService",
+            BackendKind::External,
+            now,
+            None,
+        );
+        let builtin = entry("controlplane.ynpb.v1.ReadinessService", BackendKind::Builtin, now, None);
+
+        let cmd = list(Some(Kind::External), Some("ReadinessService"));
+
+        assert!(cmd.matches(&external));
+        assert!(!cmd.matches(&builtin));
     }
 }

--- a/cli/modules/inspect/Cargo.toml
+++ b/cli/modules/inspect/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tonic = { version = "0.14", features = ["gzip"] }
 bytesize = "2"
 unicode-segmentation = "1"

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -3,14 +3,18 @@
 mod memory;
 mod report;
 
-use clap::{ArgAction, Parser};
+use clap::{ArgAction, CommandFactory, Parser};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    completion,
     errors::Error,
     output::{self, CommonFormat},
 };
 use ynpb::pb::{InspectRequest, InspectResponse, inspect_service_client::InspectServiceClient};
+
+use crate::report::{Section, View};
 
 /// The fully-qualified gRPC service name used in error messages.
 const INSPECT_SERVICE: &str = "controlplane.ynpb.v1.InspectService";
@@ -25,9 +29,19 @@ pub struct Cmd {
     /// Output format.
     #[arg(long, value_enum, default_value = "human", global = true)]
     pub format: CommonFormat,
+    /// Report only these sections, repeat the flag for several.
+    #[arg(long, value_enum)]
+    pub only: Vec<Section>,
+    /// Report only this agent's memory.
+    #[arg(long, add = ArgValueCandidates::new(agent_candidates))]
+    pub agent: Option<String>,
     /// Include detailed memory contexts in human output.
     #[arg(long)]
     pub memory: bool,
+    /// Show memory contexts, printing at most this many levels of each
+    /// agent's tree.
+    #[arg(long)]
+    pub depth: Option<usize>,
     /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
@@ -39,11 +53,49 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let mut service = InspectService::new(&cmd.connection).await?;
-    let response = service.inspect().await?;
+    let mut response = service.inspect().await?;
 
-    output::data(|| &response, || report::render(&response, cmd.memory));
+    let view = View::new(cmd.only, cmd.memory, cmd.depth);
+    select(&mut response, &view, cmd.agent.as_deref());
+
+    output::data(|| &response, || report::render(&response, &view));
 
     Ok(())
+}
+
+/// Drops everything the selectors leave out, so that both renderings report
+/// the same subset of the instance.
+fn select(response: &mut InspectResponse, view: &View, agent: Option<&str>) {
+    let Some(info) = response.instance_info.as_mut() else {
+        return;
+    };
+
+    if let Some(agent) = agent {
+        info.agents.retain(|candidate| candidate.name == agent);
+    }
+
+    if !view.shows(Section::Memory) {
+        info.agents.clear();
+    }
+    if !view.shows(Section::Device) {
+        info.devices.clear();
+    }
+    if !view.shows(Section::Pipeline) {
+        info.pipelines.clear();
+    }
+    if !view.shows(Section::Function) {
+        info.functions.clear();
+    }
+    if !view.shows(Section::Module) {
+        info.dp_modules.clear();
+        info.cp_configs.clear();
+    }
+}
+
+fn client(channel: LayeredChannel) -> InspectServiceClient<LayeredChannel> {
+    InspectServiceClient::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip)
 }
 
 pub struct InspectService {
@@ -52,24 +104,145 @@ pub struct InspectService {
 
 impl InspectService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, "inspect", INSPECT_SERVICE, |channel| {
-            InspectServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        let service = Service::connect_for(connection, "inspect", INSPECT_SERVICE, client).await?;
 
         Ok(Self { service })
     }
 
     pub async fn inspect(&mut self) -> Result<InspectResponse, Error> {
-        let response = self
-            .service
+        self.service
             .unary("inspect", InspectRequest {}, async |client, request| {
                 client.inspect(request).await
             })
-            .await?;
+            .await
+    }
+}
 
-        Ok(response)
+/// Completion candidates for an `--agent` argument: the agents the instance
+/// currently reports.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn agent_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(Cmd::command, client, async move |mut client| {
+        let response = client.inspect(InspectRequest {}).await?.into_inner();
+
+        let mut names: Vec<String> = response
+            .instance_info
+            .into_iter()
+            .flat_map(|info| info.agents)
+            .map(|agent| agent.name)
+            .collect();
+        names.sort();
+        names.dedup();
+
+        Ok(names)
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use ynpb::pb::{AgentInfo, DeviceInfo, InstanceInfo, PipelineInfo};
+
+    use super::*;
+
+    /// Returns an instance carrying the named agents alongside one device and
+    /// one pipeline, so that dropping one section leaves the others
+    /// observable.
+    fn response(agents: &[&str]) -> InspectResponse {
+        InspectResponse {
+            instance_info: Some(InstanceInfo {
+                instance_idx: 0,
+                numa_idx: 0,
+                dp_modules: Vec::new(),
+                cp_configs: Vec::new(),
+                functions: Vec::new(),
+                pipelines: vec![PipelineInfo {
+                    name: "forward".to_owned(),
+                    functions: Vec::new(),
+                }],
+                agents: agents
+                    .iter()
+                    .map(|name| AgentInfo {
+                        name: (*name).to_owned(),
+                        instances: Vec::new(),
+                    })
+                    .collect(),
+                devices: vec![DeviceInfo {
+                    r#type: "plain".to_owned(),
+                    name: "port0".to_owned(),
+                    input_pipelines: Vec::new(),
+                    output_pipelines: Vec::new(),
+                    index: 0,
+                }],
+            }),
+        }
+    }
+
+    /// Returns the agent names left in an inspection response.
+    fn agent_names(response: &InspectResponse) -> Vec<&str> {
+        response
+            .instance_info
+            .iter()
+            .flat_map(|info| &info.agents)
+            .map(|agent| agent.name.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn test_select_without_selectors_keeps_everything() {
+        let mut response = response(&["route", "acl"]);
+
+        select(&mut response, &View::new(Vec::new(), false, None), None);
+
+        let info = response.instance_info.as_ref().unwrap();
+        assert_eq!(vec!["route", "acl"], agent_names(&response));
+        assert_eq!(1, info.devices.len());
+        assert_eq!(1, info.pipelines.len());
+    }
+
+    #[test]
+    fn test_select_keeps_only_the_named_agent() {
+        let mut response = response(&["route", "acl"]);
+
+        select(&mut response, &View::new(Vec::new(), false, None), Some("acl"));
+
+        assert_eq!(vec!["acl"], agent_names(&response));
+    }
+
+    #[test]
+    fn test_select_unknown_agent_leaves_no_agents() {
+        let mut response = response(&["route"]);
+
+        select(&mut response, &View::new(Vec::new(), false, None), Some("missing"));
+
+        assert!(agent_names(&response).is_empty());
+    }
+
+    #[test]
+    fn test_select_drops_unselected_sections() {
+        let mut response = response(&["route"]);
+
+        select(&mut response, &View::new(vec![Section::Memory], false, None), None);
+
+        let info = response.instance_info.as_ref().unwrap();
+        assert_eq!(vec!["route"], agent_names(&response));
+        assert!(info.devices.is_empty());
+        assert!(info.pipelines.is_empty());
+    }
+
+    #[test]
+    fn test_select_keeps_every_named_section() {
+        let mut response = response(&["route"]);
+
+        select(
+            &mut response,
+            &View::new(vec![Section::Device, Section::Pipeline], false, None),
+            None,
+        );
+
+        let info = response.instance_info.as_ref().unwrap();
+        assert!(agent_names(&response).is_empty());
+        assert_eq!(1, info.devices.len());
+        assert_eq!(1, info.pipelines.len());
     }
 }

--- a/cli/modules/inspect/src/report.rs
+++ b/cli/modules/inspect/src/report.rs
@@ -1,12 +1,61 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use bytesize::ByteSize;
+use clap::ValueEnum;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 use ync::{display, output};
 use ynpb::pb::{DevicePipelineInfo, InspectResponse, InstanceInfo, MemoryNode};
 
 use crate::memory::{MemoryTree, node_live};
+
+/// One block of the report, selectable on the command line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Section {
+    Memory,
+    Device,
+    Pipeline,
+    Function,
+    Module,
+}
+
+/// How much of the instance the report shows: which blocks, whether each
+/// agent's memory contexts are expanded, and how many levels of the context
+/// tree are printed.
+#[derive(Debug, Clone)]
+pub struct View {
+    sections: Vec<Section>,
+    memory: bool,
+    depth: Option<usize>,
+}
+
+impl View {
+    pub fn new(sections: Vec<Section>, memory: bool, depth: Option<usize>) -> Self {
+        Self { sections, memory, depth }
+    }
+
+    /// Reports whether a block belongs to the report; selecting none selects
+    /// them all.
+    pub fn shows(&self, section: Section) -> bool {
+        self.sections.is_empty() || self.sections.contains(&section)
+    }
+
+    /// Reports whether memory contexts are expanded under each agent.
+    ///
+    /// Asking for a depth is asking for the tree the depth applies to.
+    fn expands_memory(&self) -> bool {
+        self.memory || self.depth.is_some()
+    }
+
+    /// Returns how many levels of the context tree are printed.
+    ///
+    /// The levels are counted from the topmost printed context, and the
+    /// subtree totals stay those of the whole tree, so a cut branch still
+    /// accounts for everything below it.
+    fn levels(&self) -> usize {
+        self.depth.unwrap_or(usize::MAX)
+    }
+}
 
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 enum Style {
@@ -94,20 +143,29 @@ impl Record {
     }
 }
 
-pub fn render(response: &InspectResponse, memory: bool) {
+pub fn render(response: &InspectResponse, view: &View) {
     let Some(info) = &response.instance_info else {
         output::empty(format_args!("No instance information found."));
         return;
     };
 
     let colored = output::stdout_is_terminal() && output::is_colored();
-    let groups = vec![
-        memory_records(info, memory, colored),
-        device_records(info),
-        pipeline_records(info),
-        function_records(info),
-        module_records(info),
-    ];
+    let mut groups = Vec::new();
+    if view.shows(Section::Memory) {
+        groups.push(memory_records(info, view, colored));
+    }
+    if view.shows(Section::Device) {
+        groups.push(device_records(info));
+    }
+    if view.shows(Section::Pipeline) {
+        groups.push(pipeline_records(info));
+    }
+    if view.shows(Section::Function) {
+        groups.push(function_records(info));
+    }
+    if view.shows(Section::Module) {
+        groups.push(module_records(info));
+    }
 
     let width = display::terminal_width().filter(|&width| width > 0);
     let header = format!("YANET  instance {}  NUMA {}", info.instance_idx, info.numa_idx);
@@ -150,7 +208,8 @@ fn nonempty(records: Vec<Record>, kind: &'static str) -> Vec<Record> {
     }
 }
 
-fn memory_records(info: &InstanceInfo, details: bool, unicode: bool) -> Vec<Record> {
+fn memory_records(info: &InstanceInfo, view: &View, unicode: bool) -> Vec<Record> {
+    let details = view.expands_memory();
     let mut agents: Vec<_> = info.agents.iter().collect();
     agents.sort_by_key(|agent| &agent.name);
     let mut rows = Vec::new();
@@ -193,7 +252,13 @@ fn memory_records(info: &InstanceInfo, details: bool, unicode: bool) -> Vec<Reco
                 ],
             );
             if details {
-                rows.extend(memory_tree_records(row, &agent.name, &instance.memory_tree, unicode));
+                rows.extend(memory_tree_records(
+                    row,
+                    &agent.name,
+                    &instance.memory_tree,
+                    unicode,
+                    view.levels(),
+                ));
             } else {
                 rows.push(row);
             }
@@ -342,7 +407,13 @@ fn memory_fields(total: String, own: String, branch: bool) -> Vec<Field> {
     vec![total, Field::new("own", own)]
 }
 
-fn memory_tree_records(mut root: Record, agent_name: &str, nodes: &[MemoryNode], unicode: bool) -> Vec<Record> {
+fn memory_tree_records(
+    mut root: Record,
+    agent_name: &str,
+    nodes: &[MemoryNode],
+    unicode: bool,
+    levels: usize,
+) -> Vec<Record> {
     let tree = MemoryTree::new(nodes);
     let folded_root = match tree.roots.as_slice() {
         &[idx] if nodes[idx].parent_idx == u32::MAX && nodes[idx].name == agent_name => Some(idx),
@@ -368,12 +439,10 @@ fn memory_tree_records(mut root: Record, agent_name: &str, nodes: &[MemoryNode],
     let mut rows = vec![root];
 
     let roots = folded_root.map(|idx| &tree.children[idx]).unwrap_or(&tree.roots);
-    let mut pending: Vec<_> = roots
-        .iter()
-        .enumerate()
-        .rev()
-        .map(|(pos, &idx)| (idx, 0, pos + 1 == roots.len()))
-        .collect();
+    let mut pending: Vec<(usize, usize, bool)> = Vec::new();
+    if levels > 0 {
+        pending.extend(sibling_level(roots, 0));
+    }
     let mut continuation = Vec::new();
     while let Some((idx, depth, last)) = pending.pop() {
         continuation.truncate(depth);
@@ -404,15 +473,21 @@ fn memory_tree_records(mut root: Record, agent_name: &str, nodes: &[MemoryNode],
         });
         rows.push(row);
         continuation.push(!last);
-        pending.extend(
-            children
-                .iter()
-                .enumerate()
-                .rev()
-                .map(|(pos, &child)| (child, depth + 1, pos + 1 == children.len())),
-        );
+        if depth + 1 < levels {
+            pending.extend(sibling_level(children, depth + 1));
+        }
     }
     rows
+}
+
+/// Returns one level of the traversal stack: each sibling with its depth and
+/// whether it closes the level, ordered so that popping visits them in turn.
+fn sibling_level(siblings: &[usize], depth: usize) -> impl Iterator<Item = (usize, usize, bool)> + '_ {
+    siblings
+        .iter()
+        .enumerate()
+        .rev()
+        .map(move |(pos, &idx)| (idx, depth, pos + 1 == siblings.len()))
 }
 
 fn format_report(header: &str, groups: &[Vec<Record>], width: Option<usize>, colored: bool) -> String {
@@ -615,5 +690,98 @@ fn append_lines(out: &mut String, lines: Vec<Vec<Span>>, colored: bool) {
             out.push_str(&span.style.paint(&span.text, colored));
         }
         out.push('\n');
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Returns a memory context that allocated and never freed, so its live
+    /// bytes are exactly what it was given.
+    fn node(name: &str, parent_idx: u32, balloc_size: u64) -> MemoryNode {
+        MemoryNode {
+            name: name.to_string(),
+            parent_idx,
+            balloc_count: 0,
+            bfree_count: 0,
+            balloc_size,
+            bfree_size: 0,
+        }
+    }
+
+    /// Returns a chain of contexts under an agent's own root, one context per
+    /// level, so a depth cut is visible as a shorter chain.
+    fn chain() -> Vec<MemoryNode> {
+        vec![
+            node("agent", u32::MAX, 1),
+            node("filter", 0, 100),
+            node("lpm", 1, 20),
+            node("values", 2, 3),
+        ]
+    }
+
+    /// Returns the names printed for an agent's tree, the agent's own row
+    /// first.
+    fn printed(levels: usize) -> Vec<String> {
+        let root = Record::new("memory", "agent", Vec::new());
+
+        memory_tree_records(root, "agent", &chain(), true, levels)
+            .into_iter()
+            .map(|row| row.name)
+            .collect()
+    }
+
+    #[test]
+    fn test_memory_tree_records_prints_every_level_by_default() {
+        assert_eq!(vec!["agent", "filter", "lpm", "values"], printed(usize::MAX));
+    }
+
+    #[test]
+    fn test_memory_tree_records_depth_caps_printed_levels() {
+        assert_eq!(vec!["agent", "filter"], printed(1));
+        assert_eq!(vec!["agent", "filter", "lpm"], printed(2));
+    }
+
+    #[test]
+    fn test_memory_tree_records_zero_depth_prints_no_contexts() {
+        assert_eq!(vec!["agent"], printed(0));
+    }
+
+    #[test]
+    fn test_memory_tree_records_cut_branch_keeps_its_whole_subtree_total() {
+        let root = Record::new("memory", "agent", Vec::new());
+        let rows = memory_tree_records(root, "agent", &chain(), true, 1);
+
+        let values: Vec<String> = rows[1].fields.iter().map(|field| field.value.clone()).collect();
+
+        assert_eq!(vec![bytes(100 + 20 + 3), bytes(100)], values);
+    }
+
+    #[test]
+    fn test_view_without_selection_shows_every_section() {
+        let view = View::new(Vec::new(), false, None);
+
+        assert!(view.shows(Section::Memory));
+        assert!(view.shows(Section::Device));
+        assert!(view.shows(Section::Pipeline));
+        assert!(view.shows(Section::Function));
+        assert!(view.shows(Section::Module));
+    }
+
+    #[test]
+    fn test_view_shows_only_the_selected_sections() {
+        let view = View::new(vec![Section::Memory, Section::Module], false, None);
+
+        assert!(view.shows(Section::Memory));
+        assert!(view.shows(Section::Module));
+        assert!(!view.shows(Section::Device));
+    }
+
+    #[test]
+    fn test_view_depth_expands_memory_contexts() {
+        assert!(!View::new(Vec::new(), false, None).expands_memory());
+        assert!(View::new(Vec::new(), true, None).expands_memory());
+        assert!(View::new(Vec::new(), false, Some(1)).expands_memory());
     }
 }


### PR DESCRIPTION
- `gateway list` settles the order of its own table instead of inheriting whatever the registry contract leaves open — nothing on the wire promises an order — so the same registry renders the same way on every run.
- `gateway list` takes `--kind` and `--suffix`, narrowing the table and the JSON payload alike; `--suffix` matches the trailing dot-separated segment, the same rule discovery already uses to recognise a service family, and completes from the segments the gateway currently serves.
- `gateway list` reports staleness beside the age, so an external backend that stopped registering is named as such instead of leaving the operator to know the registration lifetime. `--stale-after` moves that line, defaulting to the gateway's own registration lifetime; a kind that is not known to re-register keeps its age but is never judged, so a gateway too old to classify its backends does not turn every built-in stale.
- The JSON payload keeps the wire record and gains one `stale` field beside it.
- `inspect` takes `--only` to pick report sections and `--agent` to pick one agent's memory, both narrowing the JSON payload too; `--agent` completes from the agents the instance reports.
- `inspect` takes `--depth` to cap the printed memory context tree, which it expands without `--memory`. Subtree totals stay those of the whole tree, so a cut branch still accounts for everything below it.
- `ync` gains the raw age behind its age formatter, now kept to subsecond precision so a fractional threshold is judged on the real age, and exposes the service-name suffix helpers, so neither CLI copies them.

Closes #2367.
