### PR TITLE
feat(operators,cli): neighbour cli file input, filters and readable ages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ dependencies = [
  "netip",
  "prost",
  "serde",
- "serde_json",
+ "serde_yaml",
  "tabled",
  "tonic",
  "tonic-prost",

--- a/common/go/operator/server.go
+++ b/common/go/operator/server.go
@@ -11,6 +11,17 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/xgrpc"
 )
 
+// Largest gRPC request an operator accepts.
+//
+// A bulk configuration push carries a whole table in one request, so the
+// four mebibytes gRPC defaults to would bound a legitimate update; the
+// gateway standing in front of the operators allows the same ceiling. Only
+// the request direction is capped: a reply repeats a table back with
+// everything the operator stamps on each entry, so it outgrows the request
+// that produced it and keeps the far larger ceiling gRPC gives it. A reply
+// travelling through the gateway is still bounded by the gateway.
+const maxRequestSize = 1024 * 1024 * 256
+
 type grpcServerOptions struct {
 	Log *zap.Logger
 }
@@ -49,7 +60,7 @@ func NewGRPCServer(
 		o(opts)
 	}
 
-	server := grpc.NewServer()
+	server := grpc.NewServer(grpc.MaxRecvMsgSize(maxRequestSize))
 	serviceNames := make([]string, len(services))
 	for idx, register := range services {
 		serviceNames[idx] = register(server)

--- a/common/go/operator/server_test.go
+++ b/common/go/operator/server_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +34,74 @@ func (m *blockingReadinessServer) Watch(
 
 	<-stream.Context().Done()
 	return stream.Context().Err()
+}
+
+// countingReadinessServer is a fake ReadinessServiceServer that reports
+// how many scopes the request carried, so a caller can tell an accepted
+// large request from a refused one.
+type countingReadinessServer struct {
+	ynpb.UnimplementedReadinessServiceServer
+}
+
+func (m *countingReadinessServer) Ready(
+	ctx context.Context,
+	req *readinesspb.ReadyRequest,
+) (*readinesspb.ReadyResponse, error) {
+	scopes := make([]*readinesspb.Scope, 0, len(req.GetScopes()))
+	for _, scope := range req.GetScopes() {
+		scopes = append(scopes, &readinesspb.Scope{Name: scope})
+	}
+
+	return &readinesspb.ReadyResponse{Scopes: scopes[:min(len(scopes), 1)]}, nil
+}
+
+// Test_GRPCServer_Ready_AcceptsARequestPastTheGRPCDefault verifies that a
+// request larger than the four mebibytes gRPC accepts by default reaches
+// the handler, so a bulk configuration push is not refused as exhausted.
+func Test_GRPCServer_Ready_AcceptsARequestPastTheGRPCDefault(t *testing.T) {
+	t.Parallel()
+
+	registrar := func(server *grpc.Server) string {
+		ynpb.RegisterReadinessServiceServer(server, &countingReadinessServer{})
+		return ynpb.ReadinessService_ServiceDesc.ServiceName
+	}
+
+	server, _ := NewGRPCServer(GRPCServerConfig{}, []ServiceRegistrar{registrar}, WithGRPCLog(zap.NewNop()))
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var group errgroup.Group
+	group.Go(func() error {
+		return server.Run(ctx, listener)
+	})
+
+	conn, err := grpc.NewClient(listener.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(maxRequestSize)),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Just past the four mebibytes gRPC would otherwise refuse.
+	const scopeCount = 5 * 1024
+	const scopeSize = 1024
+
+	scopes := make([]string, scopeCount)
+	for idx := range scopes {
+		scopes[idx] = strings.Repeat("s", scopeSize)
+	}
+
+	response, err := ynpb.NewReadinessServiceClient(conn).Ready(ctx, &readinesspb.ReadyRequest{Scopes: scopes})
+
+	require.NoError(t, err)
+	require.Len(t, response.GetScopes(), 1)
+
+	cancel()
+	require.NoError(t, group.Wait())
 }
 
 // TestGRPCServer_Run_ShutsDownWithOpenStream verifies that GRPCServer.Run

--- a/common/go/rcucache/cache.go
+++ b/common/go/rcucache/cache.go
@@ -32,12 +32,17 @@ func (m *Cache[K, V]) View() CacheView[K, V] {
 
 	// Just copy the pointer here.
 	//
-	// The returned type provides only read-only access, while this structure
-	// only allows to atomically swap the entire table.
+	// The view reads the table without taking a lock, so it stays sound
+	// only while nothing writes into that table in place; swapping a
+	// rebuilt table in leaves the view reading the one it was given.
 	return CacheView[K, V]{cache: m.cache}
 }
 
 // Swap atomically swaps the entire cache.
+//
+// The supplied table becomes the published one, so a caller that keeps a
+// reference and writes through it later corrupts a reader already walking
+// it: hand over a table nothing else holds.
 func (m *Cache[K, V]) Swap(cache map[K]V) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -46,6 +51,11 @@ func (m *Cache[K, V]) Swap(cache map[K]V) {
 }
 
 // Set inserts or updates a single entry in the cache.
+//
+// The entry lands in the table every outstanding view is already reading,
+// and a reader walking that table at the same time aborts the process.
+// Use this only before the cache is reachable by a reader; afterwards
+// swap a rebuilt table in instead.
 func (m *Cache[K, V]) Set(key K, value V) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -54,6 +64,9 @@ func (m *Cache[K, V]) Set(key K, value V) {
 }
 
 // Delete removes a single entry from the cache.
+//
+// Carries the same hazard as Set: it writes into the table outstanding
+// views are reading.
 func (m *Cache[K, V]) Delete(key K) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/operators/route/cli/neighbour/Cargo.toml
+++ b/operators/route/cli/neighbour/Cargo.toml
@@ -22,7 +22,7 @@ tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 
 [dev-dependencies]
-serde_json = "1"
+serde_yaml = "0.9"
 
 [build-dependencies]
 ync-build = { path = "../../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -5,9 +5,9 @@
 //! has propagated) and drives the operator-owned neighbour tables.
 
 use core::net::IpAddr;
-use std::{borrow::Cow, time::SystemTime};
+use std::{borrow::Cow, path::PathBuf, time::SystemTime};
 
-use clap::{CommandFactory, Parser};
+use clap::{CommandFactory, Parser, ValueEnum};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::{
     pb::{IpAddress, MacAddress},
@@ -18,11 +18,11 @@ use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{LayeredChannel, Service},
+    client::{self, LayeredChannel, Service},
     completion,
     display::print_table_from_entries,
     errors::Error,
-    humanfmt, output,
+    humanfmt, output, yaml,
 };
 
 use crate::operatorpb::{
@@ -40,8 +40,42 @@ pub mod operatorpb {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "operators.route.operatorpb.v1.NeighbourService";
 
+/// Largest request this client sends.
+///
+/// A whole table travels in one message, so the four mebibytes tonic
+/// defaults to would bound a legitimate load; this is the ceiling the
+/// operator and the gateway accept.
+const MAX_REQUEST_SIZE: usize = 256 * 1024 * 1024;
+
+/// Largest reply this client accepts.
+///
+/// A listing repeats every entry back with the state, the age and the
+/// origin the operator stamps on it, so the reply describing a table
+/// pushed at the request ceiling outgrows the request that made it. The
+/// room is reachable on a direct connection; a gateway in the path bounds
+/// the reply at its own ceiling.
+const MAX_REPLY_SIZE: usize = 4 * MAX_REQUEST_SIZE;
+
+/// The table a mutation addresses when the caller names none.
+///
+/// The operator applies the same default, so an unnamed table must resolve
+/// to the same one on both sides for a success message to be truthful.
+const DEFAULT_TABLE: &str = "static";
+
+/// Resolves the table name a command carries, treating an empty name as no
+/// name at all.
+///
+/// An empty name reaches the operator as no name, so collapsing the two
+/// here keeps the table that is reported and the table that changes the
+/// same one.
+fn named_table(table: Option<&String>) -> Option<&str> {
+    table.map(String::as_str).filter(|name| !name.is_empty())
+}
+
 fn client(channel: LayeredChannel) -> NeighbourServiceClient<LayeredChannel> {
     NeighbourServiceClient::new(channel)
+        .max_decoding_message_size(MAX_REPLY_SIZE)
+        .max_encoding_message_size(MAX_REQUEST_SIZE)
         .send_compressed(CompressionEncoding::Gzip)
         .accept_compressed(CompressionEncoding::Gzip)
 }
@@ -61,8 +95,24 @@ pub struct Cmd {
 pub enum ModeCmd {
     /// Show current neighbours.
     Show(ShowCmd),
-    /// Add one or more static neighbour entries.
+    /// Add a static neighbour entry.
+    ///
+    /// The operator records the entry as permanent, so it never ages out
+    /// and only an explicit removal drops it. An entry already present
+    /// under the same next hop is overwritten.
     Add(AddCmd),
+    /// Add the static neighbours listed in a YAML file.
+    ///
+    /// The file holds a "neighbours" list, naming the same keys the
+    /// operator's own seed configuration names: "next_hop", "link_addr"
+    /// for the neighbour's own MAC, "hardware_addr" for the MAC of the
+    /// local interface, and optionally "device" and "priority". The table
+    /// is named by the flag rather than in the file.
+    ///
+    /// The whole file reaches the operator in a single request, and every
+    /// neighbour in it is recorded as permanent, exactly as a single add.
+    /// Neighbours the file does not mention are left untouched.
+    Update(UpdateCmd),
     /// Remove one or more neighbour entries.
     Remove(RemoveCmd),
     /// Manage neighbour tables.
@@ -74,6 +124,7 @@ impl ModeCmd {
         match self {
             Self::Show(..) => "show",
             Self::Add(..) => "add",
+            Self::Update(..) => "update",
             Self::Remove(..) => "remove",
             Self::Table(cmd) => match &cmd.action {
                 TableAction::Show => "list tables",
@@ -109,6 +160,68 @@ pub struct ShowCmd {
     /// merged view.
     #[arg(long, add = ArgValueCandidates::new(table_candidates))]
     pub table: Option<String>,
+    /// Show only the entries in this state.
+    #[arg(long)]
+    pub state: Option<StateFilter>,
+    /// Show only the entries reachable over this network interface. An
+    /// empty name selects the entries that name no interface.
+    #[arg(long, short = 'd')]
+    pub device: Option<String>,
+}
+
+impl ShowCmd {
+    /// Reports whether an entry survives the requested filters.
+    ///
+    /// A filter left unset admits everything, so an unfiltered command
+    /// keeps the whole listing.
+    fn matches(&self, entry: &ProtoNeighbourEntry) -> bool {
+        let state = self
+            .state
+            .is_none_or(|state| reported_state(entry.state) == NeighbourState::from(state));
+        let device = self.device.as_ref().is_none_or(|device| entry.device == *device);
+
+        state && device
+    }
+
+    /// Reports whether the command narrows the listing beyond its table.
+    fn filtered(&self) -> bool {
+        self.state.is_some() || self.device.is_some()
+    }
+}
+
+/// The neighbour states a listing can be narrowed to.
+///
+/// The set mirrors the kernel's neighbour states, which the operator
+/// reports unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum StateFilter {
+    None,
+    Incomplete,
+    Reachable,
+    Stale,
+    Delay,
+    Probe,
+    Failed,
+    Noarp,
+    Permanent,
+    Unknown,
+}
+
+impl From<StateFilter> for NeighbourState {
+    fn from(filter: StateFilter) -> Self {
+        match filter {
+            StateFilter::None => Self::NudNone,
+            StateFilter::Incomplete => Self::NudIncomplete,
+            StateFilter::Reachable => Self::NudReachable,
+            StateFilter::Stale => Self::NudStale,
+            StateFilter::Delay => Self::NudDelay,
+            StateFilter::Probe => Self::NudProbe,
+            StateFilter::Failed => Self::NudFailed,
+            StateFilter::Noarp => Self::NudNoarp,
+            StateFilter::Permanent => Self::NudPermanent,
+            StateFilter::Unknown => Self::NudUnknown,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -131,6 +244,62 @@ pub struct AddCmd {
     /// default priority.
     #[arg(long)]
     pub priority: Option<u32>,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct UpdateCmd {
+    /// YAML file listing the neighbours to add.
+    pub file: PathBuf,
+    /// Neighbour table name. Defaults to "static".
+    #[arg(long, add = ArgValueCandidates::new(table_candidates))]
+    pub table: Option<String>,
+}
+
+/// A file of static neighbours, as the caller writes it.
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NeighbourFile {
+    #[serde(default)]
+    neighbours: Vec<FileNeighbour>,
+}
+
+/// One static neighbour, as the caller writes it.
+///
+/// The state a neighbour is in, when it last changed and where it came
+/// from all belong to the operator, so a file cannot set them; refusing
+/// an unrecognised key reports such an attempt instead of discarding it
+/// in silence.
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileNeighbour {
+    next_hop: IpAddress,
+    link_addr: MacAddress,
+    hardware_addr: MacAddress,
+    #[serde(default)]
+    priority: u32,
+    #[serde(default)]
+    device: String,
+}
+
+impl From<FileNeighbour> for ProtoNeighbourEntry {
+    fn from(neighbour: FileNeighbour) -> Self {
+        let FileNeighbour {
+            next_hop,
+            link_addr,
+            hardware_addr,
+            priority,
+            device,
+        } = neighbour;
+
+        Self {
+            next_hop: Some(next_hop),
+            link_addr: Some(link_addr),
+            hardware_addr: Some(hardware_addr),
+            priority,
+            device,
+            ..Default::default()
+        }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -175,11 +344,33 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
+
+    // The file is read before the connection, so a missing or malformed
+    // one fails the same way whether or not the operator can be reached.
+    let entries = match &cmd.mode {
+        ModeCmd::Update(update) => {
+            let endpoint = client::resolve_label(&cmd.globals.connection, action)?;
+            let file: NeighbourFile = yaml::load_document(&update.file)
+                .map_err(|err| Error::invalid_argument(action, endpoint.clone(), err.to_string()))?;
+            if file.neighbours.is_empty() {
+                return Err(Error::invalid_argument(
+                    action,
+                    endpoint,
+                    format!("{} names no neighbours", update.file.display()),
+                ));
+            }
+
+            file.neighbours.into_iter().map(Into::into).collect()
+        }
+        _ => Vec::new(),
+    };
+
     let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
         ModeCmd::Show(args) => show_neighbours(&mut service, args).await,
         ModeCmd::Add(args) => update_neighbour(&mut service, args).await,
+        ModeCmd::Update(args) => update_neighbours(&mut service, args, entries).await,
         ModeCmd::Remove(args) => remove_neighbours(&mut service, args).await,
         ModeCmd::Table(cmd) => match cmd.action {
             TableAction::Show => list_tables(&mut service).await,
@@ -193,10 +384,11 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 type NeighbourService = Service<NeighbourServiceClient<LayeredChannel>>;
 
 async fn show_neighbours(service: &mut NeighbourService, cmd: ShowCmd) -> Result<(), Error> {
+    let table = named_table(cmd.table.as_ref());
     let request = ListNeighboursRequest {
-        table: cmd.table.clone().unwrap_or_default(),
+        table: table.unwrap_or_default().to_owned(),
     };
-    let resource = cmd.table.as_ref().map(|table| format!("table '{table}'"));
+    let resource = table.map(|table| format!("table '{table}'"));
 
     let response = service
         .unary_with(
@@ -207,19 +399,30 @@ async fn show_neighbours(service: &mut NeighbourService, cmd: ShowCmd) -> Result
         )
         .await?;
 
+    let neighbours: Vec<ProtoNeighbourEntry> = response
+        .neighbours
+        .into_iter()
+        .filter(|entry| cmd.matches(entry))
+        .collect();
+
     output::data(
-        || &response.neighbours,
+        || &neighbours,
         || {
-            if response.neighbours.is_empty() {
-                match &cmd.table {
-                    Some(table) => output::empty(format_args!("No neighbours found for table '{table}'.")),
-                    None => output::empty(format_args!("No neighbours found.")),
+            if neighbours.is_empty() {
+                let scope = match table {
+                    Some(table) => format!(" for table '{table}'"),
+                    None => String::new(),
+                };
+                if cmd.filtered() {
+                    output::empty(format_args!("No neighbours match the filters{scope}."));
+                } else {
+                    output::empty(format_args!("No neighbours found{scope}."));
                 }
                 return;
             }
 
-            let mut entries: Vec<&ProtoNeighbourEntry> = response.neighbours.iter().collect();
-            entries.sort_by_key(|entry| {
+            let mut entries: Vec<&ProtoNeighbourEntry> = neighbours.iter().collect();
+            entries.sort_by_cached_key(|entry| {
                 let next_hop = entry
                     .next_hop
                     .as_ref()
@@ -235,10 +438,10 @@ async fn show_neighbours(service: &mut NeighbourService, cmd: ShowCmd) -> Result
 }
 
 async fn update_neighbour(service: &mut NeighbourService, cmd: AddCmd) -> Result<(), Error> {
-    let table = cmd.table.clone().unwrap_or_else(|| "static".to_owned());
+    let table = named_table(cmd.table.as_ref()).unwrap_or(DEFAULT_TABLE);
 
     let request = UpdateNeighboursRequest {
-        table: cmd.table.clone().unwrap_or_default(),
+        table: table.to_owned(),
         entries: vec![ProtoNeighbourEntry {
             next_hop: Some(IpAddress::from(cmd.next_hop)),
             link_addr: Some(MacAddress::from(cmd.link_addr)),
@@ -266,11 +469,33 @@ async fn update_neighbour(service: &mut NeighbourService, cmd: AddCmd) -> Result
     Ok(())
 }
 
+async fn update_neighbours(
+    service: &mut NeighbourService,
+    cmd: UpdateCmd,
+    entries: Vec<ProtoNeighbourEntry>,
+) -> Result<(), Error> {
+    let table = named_table(cmd.table.as_ref()).unwrap_or(DEFAULT_TABLE);
+    let count = entries.len();
+
+    let request = UpdateNeighboursRequest { table: table.to_owned(), entries };
+
+    service
+        .unary("update", request, async |client, request| {
+            client.update_neighbours(request).await
+        })
+        .await?;
+
+    let noun = if count == 1 { "entry" } else { "entries" };
+    output::success("update", format_args!("Applied {count} {noun} to table '{table}'."));
+
+    Ok(())
+}
+
 async fn remove_neighbours(service: &mut NeighbourService, cmd: RemoveCmd) -> Result<(), Error> {
-    let table = cmd.table.clone().unwrap_or_else(|| "static".to_owned());
+    let table = named_table(cmd.table.as_ref()).unwrap_or(DEFAULT_TABLE);
 
     let request = RemoveNeighboursRequest {
-        table: cmd.table.clone().unwrap_or_default(),
+        table: table.to_owned(),
         next_hops: cmd.next_hops.iter().copied().map(IpAddress::from).collect(),
     };
 
@@ -376,14 +601,19 @@ async fn remove_table(service: &mut NeighbourService, cmd: RemoveTableCmd) -> Re
     Ok(())
 }
 
+/// Resolves a reported state, standing in the unknown one for a value the
+/// wire contract does not define.
+///
+/// Every reader of a reported state goes through here, so a listing and a
+/// filter agree on what an undefined value is.
+fn reported_state(value: i32) -> NeighbourState {
+    NeighbourState::try_from(value).unwrap_or(NeighbourState::NudUnknown)
+}
+
 /// Returns the proto-defined name for a `NeighbourState` discriminant,
 /// stripped of its `NUD_` prefix (e.g. `"REACHABLE"`).
-///
-/// An unrecognized discriminant falls back to `NeighbourState::NudUnknown`.
 fn state_name(value: i32) -> &'static str {
-    let state = NeighbourState::try_from(value).unwrap_or(NeighbourState::NudUnknown);
-
-    serde_with::short_name(state.as_str_name(), "NUD_")
+    serde_with::short_name(reported_state(value).as_str_name(), "NUD_")
 }
 
 /// Serializes the `state` field of `NeighbourEntry` as its proto-defined
@@ -395,7 +625,16 @@ where
     serializer.serialize_str(state_name(*value))
 }
 
+/// Renders how long ago an entry last changed.
+///
+/// A dash stands in for an entry the operator has never stamped. Such an
+/// entry carries the far side's zero instant, which lies well before the
+/// epoch rather than on it.
 fn age(updated_at: i64) -> String {
+    if updated_at <= 0 {
+        return "-".to_owned();
+    }
+
     humanfmt::age_since(updated_at, SystemTime::now())
 }
 
@@ -468,25 +707,230 @@ fn table_candidates() -> Vec<CompletionCandidate> {
 mod test {
     use super::*;
 
-    /// Pins the JSON shape of a serialized `NeighbourEntry`.
-    ///
-    /// `next_hop`/`link_addr` need no `serialize_with` override, since
-    /// commonpb's own `Serialize` impl already renders them as plain address
-    /// strings. `state` does need one, via `serialize_neighbour_state`.
-    #[test]
-    fn neighbour_entry_serializes_addresses_as_strings_and_state_as_its_name() {
-        let entry = ProtoNeighbourEntry {
-            next_hop: Some(IpAddress::from(IpAddr::V4(core::net::Ipv4Addr::new(192, 0, 2, 1)))),
-            link_addr: Some("aa:bb:cc:dd:ee:ff".parse::<MacAddress>().unwrap()),
-            state: NeighbourState::NudReachable as i32,
+    /// Builds an entry carrying only the fields a listing filter reads.
+    fn entry(state: NeighbourState, device: &str) -> ProtoNeighbourEntry {
+        ProtoNeighbourEntry {
+            state: state as i32,
+            device: device.to_owned(),
             ..Default::default()
-        };
+        }
+    }
 
-        let json = serde_json::to_string(&entry).unwrap();
+    /// Builds a listing command over the merged view with the given
+    /// filters.
+    fn show(state: Option<StateFilter>, device: Option<&str>) -> ShowCmd {
+        ShowCmd {
+            table: None,
+            state,
+            device: device.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn test_show_filters_unset_keep_every_entry() {
+        let cmd = show(None, None);
+
+        assert!(cmd.matches(&entry(NeighbourState::NudStale, "eth0")));
+        assert!(!cmd.filtered());
+    }
+
+    #[test]
+    fn test_show_filters_state_drops_every_other_state() {
+        let cmd = show(Some(StateFilter::Reachable), None);
+
+        assert!(cmd.matches(&entry(NeighbourState::NudReachable, "eth0")));
+        assert!(!cmd.matches(&entry(NeighbourState::NudStale, "eth0")));
+    }
+
+    #[test]
+    fn test_show_filters_device_drops_every_other_device() {
+        let cmd = show(None, Some("eth0"));
+
+        assert!(cmd.matches(&entry(NeighbourState::NudStale, "eth0")));
+        assert!(!cmd.matches(&entry(NeighbourState::NudStale, "eth1")));
+    }
+
+    #[test]
+    fn test_show_filters_state_and_device_both_have_to_hold() {
+        let cmd = show(Some(StateFilter::Permanent), Some("eth0"));
+
+        assert!(cmd.matches(&entry(NeighbourState::NudPermanent, "eth0")));
+        assert!(!cmd.matches(&entry(NeighbourState::NudPermanent, "eth1")));
+        assert!(!cmd.matches(&entry(NeighbourState::NudStale, "eth0")));
+    }
+
+    #[test]
+    fn test_show_filters_device_drops_an_entry_with_no_device() {
+        let cmd = show(None, Some("eth0"));
+
+        assert!(!cmd.matches(&entry(NeighbourState::NudStale, "")));
+    }
+
+    /// Verifies that an entry the listing shows as unknown is selected by
+    /// the filter of that name, not dropped for carrying an undefined
+    /// discriminant.
+    #[test]
+    fn test_show_filters_state_unknown_keeps_an_undefined_state() {
+        let cmd = show(Some(StateFilter::Unknown), None);
+        let undefined = ProtoNeighbourEntry { state: 3, ..Default::default() };
+
+        assert_eq!("UNKNOWN", state_name(undefined.state));
+        assert!(cmd.matches(&undefined));
+    }
+
+    #[test]
+    fn test_named_table_reads_an_empty_name_as_no_name() {
+        assert_eq!(None, named_table(Some(&String::new())));
+        assert_eq!(None, named_table(None));
+    }
+
+    #[test]
+    fn test_named_table_keeps_a_spelled_name() {
+        assert_eq!(Some("custom"), named_table(Some(&"custom".to_owned())));
+    }
+
+    /// Verifies that a state a listing can report always has a filter
+    /// spelling that selects it.
+    #[test]
+    fn test_state_filter_covers_every_reported_state() {
+        for value in 0..=i32::from(u8::MAX) {
+            let Ok(state) = NeighbourState::try_from(value) else {
+                continue;
+            };
+
+            assert!(
+                StateFilter::value_variants()
+                    .iter()
+                    .any(|filter| NeighbourState::from(*filter) == state),
+                "{state:?} has no filter spelling"
+            );
+        }
+    }
+
+    /// Verifies that a filter is spelled exactly as the state column
+    /// renders the state it selects, in lower case.
+    #[test]
+    fn test_state_filter_spelling_matches_the_rendered_state() {
+        for filter in StateFilter::value_variants() {
+            let rendered = state_name(NeighbourState::from(*filter) as i32).to_lowercase();
+            let spelling = filter.to_possible_value().expect("every filter is selectable");
+
+            assert_eq!(rendered, spelling.get_name());
+        }
+    }
+
+    #[test]
+    fn test_neighbour_file_maps_every_entry_onto_the_wire() {
+        let document = "
+neighbours:
+  - next_hop: 192.0.2.1
+    link_addr: aa:bb:cc:dd:ee:ff
+    hardware_addr: 11:22:33:44:55:66
+    priority: 7
+    device: eth0
+  - next_hop: 2001:db8::1
+    link_addr: aa:bb:cc:dd:ee:01
+    hardware_addr: 11:22:33:44:55:02
+";
+
+        let file: NeighbourFile = serde_yaml::from_str(document).unwrap();
+        let entries: Vec<ProtoNeighbourEntry> = file.neighbours.into_iter().map(Into::into).collect();
 
         assert_eq!(
-            r#"{"next_hop":"192.0.2.1","link_addr":"aa:bb:cc:dd:ee:ff","hardware_addr":null,"state":"REACHABLE","updated_at":0,"source":"","priority":0,"device":""}"#,
-            json
+            vec![
+                ProtoNeighbourEntry {
+                    next_hop: Some("192.0.2.1".parse::<IpAddress>().unwrap()),
+                    link_addr: Some("aa:bb:cc:dd:ee:ff".parse::<MacAddress>().unwrap()),
+                    hardware_addr: Some("11:22:33:44:55:66".parse::<MacAddress>().unwrap()),
+                    priority: 7,
+                    device: "eth0".to_owned(),
+                    ..Default::default()
+                },
+                ProtoNeighbourEntry {
+                    next_hop: Some("2001:db8::1".parse::<IpAddress>().unwrap()),
+                    link_addr: Some("aa:bb:cc:dd:ee:01".parse::<MacAddress>().unwrap()),
+                    hardware_addr: Some("11:22:33:44:55:02".parse::<MacAddress>().unwrap()),
+                    ..Default::default()
+                },
+            ],
+            entries
         );
+    }
+
+    #[test]
+    fn test_neighbour_file_without_entries_parses_as_empty() {
+        let file: NeighbourFile = serde_yaml::from_str("{}").unwrap();
+
+        assert!(file.neighbours.is_empty());
+    }
+
+    /// Verifies that a neighbour factored out of an earlier one carries
+    /// the keys it inherits, so a repetitive file can be written once.
+    #[test]
+    fn test_neighbour_file_expands_a_merge_key() {
+        let document = "
+neighbours:
+  - &first
+    next_hop: 192.0.2.1
+    link_addr: aa:bb:cc:dd:ee:ff
+    hardware_addr: 11:22:33:44:55:66
+    device: eth0
+  - <<: *first
+    next_hop: 192.0.2.2
+";
+
+        let mut value: serde_yaml::Value = serde_yaml::from_str(document).unwrap();
+        value.apply_merge().unwrap();
+        let file: NeighbourFile = serde_yaml::from_value(value).unwrap();
+
+        assert_eq!("eth0", file.neighbours[1].device);
+        assert_eq!("192.0.2.2", file.neighbours[1].next_hop.to_string());
+    }
+
+    #[test]
+    fn test_neighbour_file_rejects_an_operator_owned_key() {
+        let document = "
+neighbours:
+  - next_hop: 192.0.2.1
+    link_addr: aa:bb:cc:dd:ee:ff
+    hardware_addr: 11:22:33:44:55:66
+    state: REACHABLE
+";
+
+        assert!(serde_yaml::from_str::<NeighbourFile>(document).is_err());
+    }
+
+    #[test]
+    fn test_neighbour_file_rejects_a_missing_hardware_address() {
+        let document = "
+neighbours:
+  - next_hop: 192.0.2.1
+    link_addr: aa:bb:cc:dd:ee:ff
+";
+
+        assert!(serde_yaml::from_str::<NeighbourFile>(document).is_err());
+    }
+
+    #[test]
+    fn test_neighbour_file_rejects_a_malformed_address() {
+        let document = "
+neighbours:
+  - next_hop: 192.0.2.300
+    link_addr: aa:bb:cc:dd:ee:ff
+    hardware_addr: 11:22:33:44:55:66
+";
+
+        assert!(serde_yaml::from_str::<NeighbourFile>(document).is_err());
+    }
+
+    /// Verifies that both spellings of "never stamped" render as a dash:
+    /// the epoch itself, and the zero instant the operator's own clock
+    /// encodes, which lies far before it.
+    #[test]
+    fn test_age_of_an_unstamped_entry_is_a_dash() {
+        const ZERO_INSTANT: i64 = -62_135_596_800;
+
+        assert_eq!("-", age(0));
+        assert_eq!("-", age(ZERO_INSTANT));
     }
 }

--- a/operators/route/internal/discovery/neigh/table.go
+++ b/operators/route/internal/discovery/neigh/table.go
@@ -2,6 +2,7 @@ package neigh
 
 import (
 	"fmt"
+	"maps"
 	"net/netip"
 	"sync"
 
@@ -155,8 +156,23 @@ func (m *NeighTable) Source(name string) (*NeighSource, bool) {
 	return src, ok
 }
 
+// copySourceEntries copies a source's entries into a fresh map sized for a
+// pending change.
+//
+// A view hands out the entry map itself and walks it without holding a
+// lock, so a change has to land as one whole new map; writing into the map
+// a reader may be walking crashes the process.
+func copySourceEntries(cache *NexthopCache, pendingCount int) map[netip.Addr]NeighbourEntry {
+	all, count := cache.View().All()
+
+	next := make(map[netip.Addr]NeighbourEntry, count+pendingCount)
+	maps.Insert(next, all)
+
+	return next
+}
+
 // Add inserts or updates entries in the specified source table and
-// triggers a single re-merge.
+// triggers a single re-merge; a reader sees the batch whole or not at all.
 func (m *NeighTable) Add(table string, entries []NeighbourEntry) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -166,19 +182,21 @@ func (m *NeighTable) Add(table string, entries []NeighbourEntry) error {
 		return fmt.Errorf("source %q not found", table)
 	}
 
+	next := copySourceEntries(src.Cache, len(entries))
 	for _, entry := range entries {
 		if entry.Priority == 0 {
 			entry.Priority = src.DefaultPriority
 		}
-		src.Cache.Set(entry.NextHop, entry)
+		next[entry.NextHop] = entry
 	}
+	src.Cache.Swap(next)
 
 	m.rebuildMergedCacheLocked()
 	return nil
 }
 
 // Remove deletes entries from the specified source table and triggers
-// a single re-merge.
+// a single re-merge; a reader sees the batch whole or not at all.
 func (m *NeighTable) Remove(table string, addrs []netip.Addr) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -188,9 +206,11 @@ func (m *NeighTable) Remove(table string, addrs []netip.Addr) error {
 		return fmt.Errorf("source %q not found", table)
 	}
 
+	next := copySourceEntries(src.Cache, 0)
 	for _, addr := range addrs {
-		src.Cache.Delete(addr)
+		delete(next, addr)
 	}
+	src.Cache.Swap(next)
 
 	m.rebuildMergedCacheLocked()
 	return nil
@@ -199,7 +219,10 @@ func (m *NeighTable) Remove(table string, addrs []netip.Addr) error {
 // SwapSource atomically replaces all entries in the named source and triggers
 // a re-merge.
 //
-// Entries with zero priority inherit the source's default priority.
+// Entries with zero priority inherit the source's default priority. The
+// supplied map becomes the published one, so a caller that keeps a
+// reference and writes through it later corrupts a listing already walking
+// it: hand over a map nothing else holds.
 func (m *NeighTable) SwapSource(name string, entries map[netip.Addr]NeighbourEntry) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/operators/route/internal/discovery/neigh/table_test.go
+++ b/operators/route/internal/discovery/neigh/table_test.go
@@ -1,11 +1,13 @@
 package neigh
 
 import (
+	"fmt"
 	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 func makeEntry(ip string, mac [6]byte, priority uint32) NeighbourEntry {
@@ -268,6 +270,94 @@ func TestNeighTableBatchRemove(t *testing.T) {
 
 	_, ok := view.Lookup(netip.MustParseAddr("10.0.0.2"))
 	require.True(t, ok)
+}
+
+// Test_NeighTable_Add_ConcurrentWithSourceView verifies that a listing
+// walking a source table while batches land against it neither races the
+// writer nor aborts the process.
+//
+// The race detector is what gives this test its teeth, and the failure it
+// guards against is a runtime abort rather than a recoverable one, so a
+// regression takes the whole operator down rather than failing one call.
+func Test_NeighTable_Add_ConcurrentWithSourceView(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "static", 10, true)
+
+	const rounds = 200
+
+	var writers errgroup.Group
+	writers.Go(func() error {
+		for round := range rounds {
+			entry := makeEntry(fmt.Sprintf("10.0.%d.%d", round/256, round%256),
+				[6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 10)
+
+			if err := nt.Add("static", []NeighbourEntry{entry}); err != nil {
+				return err
+			}
+			if err := nt.Remove("static", []netip.Addr{entry.NextHop}); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	writers.Go(func() error {
+		for range rounds {
+			view, ok := nt.SourceView("static")
+			if !ok {
+				return fmt.Errorf("source not found")
+			}
+
+			entries, _ := view.Entries()
+			for range entries {
+			}
+		}
+
+		return nil
+	})
+
+	require.NoError(t, writers.Wait())
+}
+
+// Test_NeighTable_Add_LeavesAnEarlierViewUntouched verifies that a batch
+// applied after a view was taken lands in a map of its own, so a reader
+// still walking that view neither sees the batch nor races the writer.
+func Test_NeighTable_Add_LeavesAnEarlierViewUntouched(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "static", 10, true)
+	require.NoError(t, nt.Add("static", []NeighbourEntry{
+		makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 10),
+	}))
+
+	view, ok := nt.SourceView("static")
+	require.True(t, ok)
+
+	require.NoError(t, nt.Add("static", []NeighbourEntry{
+		makeEntry("10.0.0.2", [6]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}, 20),
+	}))
+
+	_, count := view.Entries()
+	require.Equal(t, 1, count)
+}
+
+// Test_NeighTable_Remove_LeavesAnEarlierViewUntouched verifies that a
+// removal applied after a view was taken lands in a map of its own, so a
+// reader still walking that view neither loses the entry nor races the
+// writer.
+func Test_NeighTable_Remove_LeavesAnEarlierViewUntouched(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "static", 10, true)
+	require.NoError(t, nt.Add("static", []NeighbourEntry{
+		makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 10),
+	}))
+
+	view, ok := nt.SourceView("static")
+	require.True(t, ok)
+
+	require.NoError(t, nt.Remove("static", []netip.Addr{netip.MustParseAddr("10.0.0.1")}))
+
+	_, count := view.Entries()
+	require.Equal(t, 1, count)
 }
 
 func TestNeighTableListSources(t *testing.T) {


### PR DESCRIPTION
- Add a bulk form that reads static neighbours from a YAML file and applies the whole file in one request, so seeding a table no longer costs one process per neighbour; the file is the command's positional, the table stays a flag.
- Name in the file the same keys the operator's own seed configuration names, and spell out in the help which address is the neighbour's and which is the local interface's, so a neighbour list can be moved between the two without being rewritten.
- Expand a merge key, so a repetitive file states a shared interface or hardware address once instead of per neighbour.
- Read the file before the connection is made, so a missing, malformed or empty one is reported with its path and line rather than hidden behind an unreachable endpoint.
- Refuse a file key the operator owns, so a state, a timestamp or a source written into a file is reported instead of being discarded in silence; an unrecognised key fails the load naming the file and listing what is accepted.
- Land a batch of neighbours as one replacement map instead of one write per entry. The cache hands a reader the table itself and that reader walks it without a lock, so the previous write-per-entry could abort the operator with a concurrent map iteration and write; a listing overlapping an update now sees the batch whole or not at all.
- Raise the request ceiling an operator accepts from the 4 MiB gRPC defaults to, to the 256 MiB the gateway standing in front of every operator already admits. This is a shared constructor, so it moves every operator; the gateway already passes a message that size through, so the operator behind it was the only hop refusing one. A reply keeps the far larger ceiling gRPC gives it by default, since a listing repeats a table back with everything the operator stamps on each entry.
- Narrow a listing by state and by device, in the human table and in the JSON payload alike, with the state spelled exactly as the state column renders it and an undefined discriminant resolved the same way on both sides.
- Read an empty table name as no name, so `--table=` from an unset shell variable no longer changes the default table while reporting one called `''`.
- Read an entry the far side never stamped as a dash. Its zero instant arrives as a second count well before the epoch, not as zero.
- State on the cache primitive that writing a single entry lands it in the table outstanding readers are walking; the comment there previously advertised a safety guarantee the type does not have, which is how the abort came to be written.
- State in the help that an added entry is permanent, never ages out, and is overwritten by a later add for the same next hop.
- Cover the file schema, the wire mapping, both filters, the batch atomicity and the raised ceiling with tests, including a race-detector test for a listing overlapping an update, and a guard that every state a listing can report has a filter spelling that selects it.

Closes #2362.
