### PR TITLE
fix(cli): report a missing object the same way on every show and delete

### DIFF
--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -166,9 +166,12 @@ impl TrafgenService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .unary("show", request, async |client, request| {
-                client.show_config(request).await
-            })
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("device '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
             .await?;
 
         output::data(

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -282,9 +282,12 @@ impl ACLService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .unary("show", request, async |client, request| {
-                client.show_config(request).await
-            })
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
             .await?;
 
         output::data(
@@ -323,9 +326,13 @@ impl ACLService {
     pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
         self.service
-            .unary("delete", request, async |client, request| {
-                client.delete_config(request).await
-            })
+            .unary_with(
+                "delete",
+                request,
+                self.service
+                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.delete_config(request).await,
+            )
             .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -114,12 +114,15 @@ impl Balancer2Service {
     }
 
     async fn config(&mut self, cmd: ConfigCmd) -> Result<(), Error> {
-        let request = GetConfigRequest { config_name: cmd.name };
+        let request = GetConfigRequest { config_name: cmd.name.clone() };
         let response = self
             .service
-            .unary("config", request, async |client, request| {
-                client.get_config(request).await
-            })
+            .unary_with(
+                "config",
+                request,
+                self.service.not_found("config", &format!("config '{}'", cmd.name)),
+                async |client, request| client.get_config(request).await,
+            )
             .await?;
 
         output::data(

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -137,9 +137,12 @@ impl BlackholeService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .unary("show", request, async |client, request| {
-                client.show_config(request).await
-            })
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
             .await?;
 
         output::data(
@@ -168,9 +171,13 @@ impl BlackholeService {
     pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
         self.service
-            .unary("delete", request, async |client, request| {
-                client.delete_config(request).await
-            })
+            .unary_with(
+                "delete",
+                request,
+                self.service
+                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.delete_config(request).await,
+            )
             .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -143,9 +143,12 @@ impl DecapService {
         let request = ShowConfigRequest { name: cmd.config_name.to_owned() };
         let response = self
             .service
-            .unary("show", request, async |client, request| {
-                client.show_config(request).await
-            })
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
             .await?;
 
         output::data(

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -197,9 +197,12 @@ impl DscpService {
         let request = ShowConfigRequest { name: cmd.config_name.to_owned() };
         let response = self
             .service
-            .unary("show", request, async |client, request| {
-                client.show_config(request).await
-            })
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
             .await?;
 
         output::data(

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -202,9 +202,12 @@ impl ForwardService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .unary("show", request, async |client, request| {
-                client.show_config(request).await
-            })
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
             .await?;
 
         output::data(
@@ -255,9 +258,12 @@ impl ForwardService {
     pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config.clone() };
         self.service
-            .unary("delete", request, async |client, request| {
-                client.delete_config(request).await
-            })
+            .unary_with(
+                "delete",
+                request,
+                self.service.not_found("delete", &format!("config '{}'", cmd.config)),
+                async |client, request| client.delete_config(request).await,
+            )
             .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config));

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -289,9 +289,12 @@ impl FWStateService {
         };
         let response = self
             .service
-            .unary("show", request, async |client, request| {
-                client.show_config(request).await
-            })
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
             .await?;
 
         output::data(
@@ -305,9 +308,13 @@ impl FWStateService {
     pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
         self.service
-            .unary("delete", request, async |client, request| {
-                client.delete_config(request).await
-            })
+            .unary_with(
+                "delete",
+                request,
+                self.service
+                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.delete_config(request).await,
+            )
             .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -255,9 +255,12 @@ impl MirrorService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .unary("show", request, async |client, request| {
-                client.show_config(request).await
-            })
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
             .await?;
 
         let config = MirrorConfig::try_from(response.rules)
@@ -308,9 +311,12 @@ impl MirrorService {
     pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config.clone() };
         self.service
-            .unary("delete", request, async |client, request| {
-                client.delete_config(request).await
-            })
+            .unary_with(
+                "delete",
+                request,
+                self.service.not_found("delete", &format!("config '{}'", cmd.config)),
+                async |client, request| client.delete_config(request).await,
+            )
             .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config));

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -81,9 +81,12 @@ impl PdumpService {
     async fn get_config(&mut self, name: &str, action: &'static str) -> Result<ShowConfigResponse, Error> {
         let request = ShowConfigRequest { name: name.to_owned() };
         self.service
-            .unary(action, request, async |client, request| {
-                client.show_config(request).await
-            })
+            .unary_with(
+                action,
+                request,
+                self.service.not_found(action, &format!("config '{name}'")),
+                async |client, request| client.show_config(request).await,
+            )
             .await
     }
 
@@ -172,9 +175,13 @@ impl PdumpService {
     pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
         self.service
-            .unary("delete", request, async |client, request| {
-                client.delete_config(request).await
-            })
+            .unary_with(
+                "delete",
+                request,
+                self.service
+                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.delete_config(request).await,
+            )
             .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -201,9 +201,12 @@ impl RouteMplsService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .unary("show", request, async |client, request| {
-                client.show_config(request).await
-            })
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
             .await?;
 
         output::data(
@@ -247,9 +250,13 @@ impl RouteMplsService {
     pub async fn delete_config(&mut self, cmd: RouteDeleteCmd) -> Result<(), Error> {
         let request = DeleteConfigRequest { name: cmd.config_name.clone() };
         self.service
-            .unary("delete", request, async |client, request| {
-                client.delete_config(request).await
-            })
+            .unary_with(
+                "delete",
+                request,
+                self.service
+                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.delete_config(request).await,
+            )
             .await?;
 
         output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));

--- a/modules/route/cli/src/main.rs
+++ b/modules/route/cli/src/main.rs
@@ -301,7 +301,12 @@ impl RouteService {
 
         let response = self
             .service
-            .unary("show", request, async |client, request| client.show_fib(request).await)
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_fib(request).await,
+            )
             .await?;
         let entries = response.entries;
 

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -281,9 +281,12 @@ impl UnrdupService {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
             .service
-            .unary("show", request, async |client, request| {
-                client.show_config(request).await
-            })
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
+                async |client, request| client.show_config(request).await,
+            )
             .await?;
 
         let config = response

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -122,9 +122,12 @@ impl FWStateMapService {
     pub async fn map_delete(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteMapRequest { name: cmd.map_name.clone() };
         self.service
-            .unary("delete", request, async |client, request| {
-                client.delete_map(request).await
-            })
+            .unary_with(
+                "delete",
+                request,
+                self.service.not_found("delete", &format!("map '{}'", cmd.map_name)),
+                async |client, request| client.delete_map(request).await,
+            )
             .await?;
 
         output::success("delete", format_args!("Deleted map '{}'.", cmd.map_name));
@@ -183,9 +186,12 @@ impl FWStateMapService {
         let request = GetMapStatsRequest { name: cmd.map_name.clone() };
         let response = self
             .service
-            .unary("stats", request, async |client, request| {
-                client.get_map_stats(request).await
-            })
+            .unary_with(
+                "stats",
+                request,
+                self.service.not_found("stats", &format!("map '{}'", cmd.map_name)),
+                async |client, request| client.get_map_stats(request).await,
+            )
             .await?;
 
         output::data(
@@ -251,9 +257,12 @@ impl FWStateMapService {
             };
             let resp = self
                 .service
-                .unary("entries", request, async |client, request| {
-                    client.list_entries(request).await
-                })
+                .unary_with(
+                    "entries",
+                    request,
+                    self.service.not_found("entries", &format!("map '{}'", cmd.map_name)),
+                    async |client, request| client.list_entries(request).await,
+                )
                 .await?;
 
             state.note_generation(resp.generation);

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -375,9 +375,12 @@ impl NeighbourService {
         let request = RemoveNeighbourTableRequest { name: cmd.name.clone() };
 
         self.service
-            .unary("remove table", request, async |client, request| {
-                client.remove_table(request).await
-            })
+            .unary_with(
+                "remove table",
+                request,
+                self.service.not_found("remove table", &format!("table '{}'", cmd.name)),
+                async |client, request| client.remove_table(request).await,
+            )
             .await?;
 
         output::success("remove table", format_args!("Removed table '{}'.", cmd.name));

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -244,9 +244,12 @@ impl RouteService {
 
         let response = self
             .service
-            .unary("show", request, async |client, request| {
-                client.show_routes(request).await
-            })
+            .unary_with(
+                "show",
+                request,
+                self.service.not_found("show", &format!("config '{}'", cmd.name)),
+                async |client, request| client.show_routes(request).await,
+            )
             .await?;
 
         output::data(


### PR DESCRIPTION
- Every command that shows, deletes or removes a whole named object maps a genuine NotFound to "<kind> '<name>' not found" with exit code 3, as decap, dscp, unrdup, nat64, route, function, pipeline and device delete already did.
- Covers blackhole, forward, mirror, acl, fwstate, route-mpls, pdump, fwstate-map (delete, stats and entries), trafgen, balancer2 config, the route operator and the neighbour tables.
- A service that is not registered with the gateway still reports as such.