### PR TITLE
refactor(cli): render show commands as a key/value block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,18 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,12 +16,6 @@ checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -118,12 +100,6 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
-name = "arraydeque"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
@@ -228,12 +204,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -275,9 +245,6 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "block-buffer"
@@ -466,58 +433,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
-dependencies = [
- "async-trait",
- "convert_case",
- "json5",
- "nom",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde",
- "serde_json",
- "toml",
- "yaml-rust2",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "core-foundation"
@@ -552,12 +471,6 @@ checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -621,36 +534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,15 +576,6 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -752,12 +626,6 @@ name = "find-msvc-tools"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -904,16 +772,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -926,15 +784,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hashlink"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "heck"
@@ -1161,23 +1010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
-]
-
-[[package]]
-name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,15 +1039,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1308,7 +1131,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "lazy_static 1.5.0",
+ "lazy_static",
  "libm",
  "num-integer",
  "num-iter",
@@ -1381,31 +1204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,12 +1255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
 name = "pcap-file"
 version = "3.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,7 +1263,7 @@ dependencies = [
  "byteorder_slice",
  "derive-into-owned",
  "once_cell",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -1490,64 +1282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
-dependencies = [
- "pest",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset 0.4.2",
- "indexmap",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset 0.5.7",
+ "fixedbitset",
  "hashbrown 0.15.5",
  "indexmap",
 ]
@@ -1732,7 +1472,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph 0.8.3",
+ "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
@@ -1761,21 +1501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
-]
-
-[[package]]
-name = "ptree"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289cfd20ebec0e7ff2572e370dd7a1c9973ba666d3c38c5e747de0a4ada21f17"
-dependencies = [
- "anstyle",
- "config",
- "directories",
- "petgraph 0.6.5",
- "serde",
- "serde-value",
- "tint",
 ]
 
 [[package]]
@@ -1820,17 +1545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1887,18 +1601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
-dependencies = [
- "base64 0.21.7",
- "bitflags",
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,16 +1619,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
 ]
 
 [[package]]
@@ -2065,16 +1757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,15 +1787,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2381,31 +2054,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.20",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2449,24 +2102,6 @@ checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tint"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af24570664a3074673dbbf69a65bdae0ae0b72f2949b1adfbacb736ee4d6896"
-dependencies = [
- "lazy_static 0.2.11",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -2531,47 +2166,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -2736,12 +2330,6 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -2927,20 +2515,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2954,40 +2533,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2997,21 +2555,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3027,21 +2573,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3051,47 +2585,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "yaml-rust2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
-dependencies = [
- "arraydeque",
- "encoding_rs",
- "hashlink",
-]
 
 [[package]]
 name = "yanet-cli"
@@ -3117,7 +2619,7 @@ dependencies = [
  "ssh-key",
  "tabled",
  "terminal_size",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -3218,7 +2720,6 @@ dependencies = [
  "clap_complete",
  "netip",
  "prost",
- "ptree",
  "serde",
  "tonic",
  "tonic-prost",
@@ -3306,7 +2807,6 @@ dependencies = [
  "clap_complete",
  "netip",
  "prost",
- "ptree",
  "serde",
  "tonic",
  "tonic-prost",
@@ -3355,7 +2855,6 @@ dependencies = [
  "netip",
  "prost",
  "serde",
- "tabled",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -3441,7 +2940,6 @@ dependencies = [
  "clap_complete",
  "netip",
  "prost",
- "ptree",
  "serde",
  "tonic",
  "tonic-prost",
@@ -3507,7 +3005,6 @@ dependencies = [
  "pcap-file",
  "pnet_packet",
  "prost",
- "ptree",
  "serde",
  "tokio",
  "tokio-util",

--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -9,7 +9,7 @@ use ync::{
     GlobalArgs,
     client::{ConnectionArgs, LayeredChannel, Service},
     completion,
-    display::print_table_from_entries,
+    display::{self, print_table_from_entries},
     errors::Error,
     output,
 };
@@ -172,7 +172,11 @@ async fn run_logging(connection: &ConnectionArgs, mode: LoggingCmd) -> Result<()
 
             output::data(
                 || &response,
-                || println!("level: {}", ynpb::log_level_name(response.level)),
+                || {
+                    display::KeyValue::new()
+                        .row("level", ynpb::log_level_name(response.level))
+                        .print()
+                },
             );
         }
     }

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -177,9 +177,11 @@ impl TrafgenService {
         output::data(
             || &response,
             || {
-                println!("rate (pps):  {}", response.rate_pps);
-                println!("frame count: {}", response.frame_count);
-                println!("total bytes: {}", response.total_bytes);
+                display::KeyValue::new()
+                    .row("rate (pps)", response.rate_pps)
+                    .row("frame count", response.frame_count)
+                    .row("total bytes", response.total_bytes)
+                    .print()
             },
         );
 

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -147,9 +147,7 @@ impl BlackholeService {
 
         output::data(
             || &response,
-            || {
-                println!("name: {}", response.name);
-            },
+            || display::KeyValue::new().row("name", &response.name).print(),
         );
 
         Ok(())

--- a/modules/decap/cli/Cargo.toml
+++ b/modules/decap/cli/Cargo.toml
@@ -19,7 +19,6 @@ prost = "0.14"
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
-ptree = "0.5"
 
 [build-dependencies]
 tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -6,7 +6,6 @@ use decappb::{
     decap_service_client::DecapServiceClient,
 };
 use netip::{Contiguous, IpNetwork};
-use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
@@ -162,7 +161,7 @@ impl DecapService {
                     return;
                 }
 
-                print_tree(&response);
+                config_block(&response).print();
             },
         );
 
@@ -205,19 +204,14 @@ impl DecapService {
     }
 }
 
-fn print_tree(resp: &ShowConfigResponse) {
-    let mut tree = TreeBuilder::new("Decap Prefixes".to_string());
-
-    let prefixes = resp
+fn config_block(response: &ShowConfigResponse) -> display::KeyValue {
+    let prefixes = response
         .prefixes4
         .iter()
         .map(ToString::to_string)
-        .chain(resp.prefixes6.iter().map(ToString::to_string));
-    for (idx, prefix) in prefixes.enumerate() {
-        tree.add_empty_child(format!("{idx}: {prefix}"));
-    }
+        .chain(response.prefixes6.iter().map(ToString::to_string));
 
-    let _ = ptree::print_tree(&tree.build());
+    display::KeyValue::new().rows("prefixes", prefixes)
 }
 
 /// Completion candidates for a `--name` argument: the decap configs the

--- a/modules/dscp/cli/Cargo.toml
+++ b/modules/dscp/cli/Cargo.toml
@@ -19,7 +19,6 @@ serde = { version = "1", features = ["derive"] }
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 prost = "0.14"
-ptree = "0.5"
 
 [build-dependencies]
 tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -2,11 +2,10 @@ use clap::{CommandFactory, Parser, ValueEnum, value_parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use commonpb::partition_prefixes;
 use dscppb::{
-    AddPrefixesRequest, DeleteConfigRequest, DscpConfig, RemovePrefixesRequest, SetDscpMarkingRequest,
-    ShowConfigRequest, ShowConfigResponse, dscp_service_client::DscpServiceClient,
+    AddPrefixesRequest, Config, DeleteConfigRequest, DscpConfig, RemovePrefixesRequest, SetDscpMarkingRequest,
+    ShowConfigRequest, dscp_service_client::DscpServiceClient,
 };
 use netip::{Contiguous, IpNetwork};
-use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
@@ -208,15 +207,15 @@ impl DscpService {
         output::data(
             || &response,
             || {
-                if response.config.is_none() {
+                let Some(config) = &response.config else {
                     output::empty_with_hint(
                         format_args!("No DSCP configuration found for '{}'.", cmd.config_name),
                         format_args!("create one with 'yanet-cli-dscp prefix-add --name <name> --prefix <cidr>'"),
                     );
                     return;
-                }
+                };
 
-                print_tree(&response);
+                config_block(config).print();
             },
         );
 
@@ -309,34 +308,22 @@ impl DscpService {
     }
 }
 
-fn print_tree(response: &ShowConfigResponse) {
-    let mut tree = TreeBuilder::new("View DSCP Config".to_string());
+fn config_block(config: &Config) -> display::KeyValue {
+    let mut block = display::KeyValue::new();
 
-    if let Some(config) = &response.config {
-        if let Some(dscp_config) = config.dscp_config {
-            tree.begin_child("DSCP Marking".to_string());
-            tree.add_empty_child(format!("Flag: {}", flag_to_string(dscp_config.flag)));
-            tree.add_empty_child(format!("Mark: {} (0x{:02x})", dscp_config.mark, dscp_config.mark));
-            tree.end_child();
-        }
-
-        tree.begin_child("Prefixes".to_string());
-        if config.prefixes4.is_empty() && config.prefixes6.is_empty() {
-            tree.add_empty_child("(none)".to_owned());
-        }
-
-        let prefixes = config
-            .prefixes4
-            .iter()
-            .map(ToString::to_string)
-            .chain(config.prefixes6.iter().map(ToString::to_string));
-        for (idx, prefix) in prefixes.enumerate() {
-            tree.add_empty_child(format!("{idx}: {prefix}"));
-        }
-        tree.end_child();
+    if let Some(marking) = config.dscp_config {
+        block = block
+            .row("flag", flag_to_string(marking.flag))
+            .row("mark", format!("{} (0x{:02x})", marking.mark, marking.mark));
     }
 
-    let _ = ptree::print_tree(&tree.build());
+    let prefixes = config
+        .prefixes4
+        .iter()
+        .map(ToString::to_string)
+        .chain(config.prefixes6.iter().map(ToString::to_string));
+
+    block.rows("prefixes", prefixes)
 }
 
 fn flag_to_string(flag: u32) -> String {

--- a/modules/fwstate/cli/Cargo.toml
+++ b/modules/fwstate/cli/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
-tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 netip = "0.3"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -8,7 +8,6 @@ use fwstatepb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, ShowConfigResponse, SyncConfig, UpdateConfigRequest,
     fw_state_service_client::FwStateServiceClient,
 };
-use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
@@ -64,54 +63,29 @@ fn format_timeout_millis(nanos: u64) -> String {
     format!("{millis}.{}", fraction.trim_end_matches('0'))
 }
 
-#[derive(Tabled)]
-struct SettingRow {
-    #[tabled(rename = "Setting")]
-    setting: String,
-    #[tabled(rename = "Value")]
-    value: String,
-}
-
-impl SettingRow {
-    fn new(setting: &str, value: String) -> Self {
-        Self { setting: setting.to_string(), value }
-    }
-}
-
 /// Lays out one stored configuration for a human reader.
-fn config_rows(response: &ShowConfigResponse) -> Vec<SettingRow> {
-    let mut rows = vec![
-        SettingRow::new("name", display::escape_wire_text(&response.name)),
-        SettingRow::new("map name v4", display::escape_wire_text(&response.map_name_v4)),
-        SettingRow::new("map name v6", display::escape_wire_text(&response.map_name_v6)),
-    ];
+fn config_block(response: &ShowConfigResponse) -> display::KeyValue {
+    let mut block = display::KeyValue::new()
+        .row("name", &response.name)
+        .row("map name v4", &response.map_name_v4)
+        .row("map name v6", &response.map_name_v6);
 
     let Some(sync_config) = response.sync_config.as_ref() else {
-        return rows;
+        return block;
     };
 
     let address = |addr: Option<&IpAddress>| addr.map_or_else(|| "-".to_string(), ToString::to_string);
-    rows.push(SettingRow::new("src addr", address(sync_config.src_addr.as_ref())));
-    rows.push(SettingRow::new(
-        "dst ether",
-        sync_config
-            .dst_ether
-            .as_ref()
-            .map_or_else(|| "-".to_string(), ToString::to_string),
-    ));
-    rows.push(SettingRow::new(
-        "dst addr multicast",
-        address(sync_config.dst_addr_multicast.as_ref()),
-    ));
-    rows.push(SettingRow::new(
-        "port multicast",
-        sync_config.port_multicast.to_string(),
-    ));
-    rows.push(SettingRow::new(
-        "dst addr unicast",
-        address(sync_config.dst_addr_unicast.as_ref()),
-    ));
-    rows.push(SettingRow::new("port unicast", sync_config.port_unicast.to_string()));
+    let dst_ether = sync_config
+        .dst_ether
+        .as_ref()
+        .map_or_else(|| "-".to_string(), ToString::to_string);
+    block = block
+        .row("src addr", address(sync_config.src_addr.as_ref()))
+        .row("dst ether", dst_ether)
+        .row("dst addr multicast", address(sync_config.dst_addr_multicast.as_ref()))
+        .row("port multicast", sync_config.port_multicast)
+        .row("dst addr unicast", address(sync_config.dst_addr_unicast.as_ref()))
+        .row("port unicast", sync_config.port_unicast);
 
     for (setting, nanos) in [
         ("tcp syn-ack timeout", sync_config.tcp_syn_ack),
@@ -122,10 +96,10 @@ fn config_rows(response: &ShowConfigResponse) -> Vec<SettingRow> {
         ("default timeout", sync_config.default),
         ("sync suppress timeout", sync_config.sync_suppress_timeout),
     ] {
-        rows.push(SettingRow::new(setting, format!("{} ms", format_timeout_millis(nanos))));
+        block = block.row(setting, format!("{} ms", format_timeout_millis(nanos)));
     }
 
-    rows
+    block
 }
 
 /// Builds a partial update from explicitly supplied flags only.
@@ -297,10 +271,7 @@ impl FWStateService {
             )
             .await?;
 
-        output::data(
-            || &response,
-            || display::print_table_from_entries(config_rows(&response)),
-        );
+        output::data(|| &response, || config_block(&response).print());
 
         Ok(())
     }
@@ -428,7 +399,7 @@ mod tests {
     }
 
     #[test]
-    fn test_config_rows_carry_endpoints_and_converted_timeouts() {
+    fn test_config_block_carries_endpoints_and_converted_timeouts() {
         let response = ShowConfigResponse {
             name: "fwstate0".to_string(),
             sync_config: Some(fwstatepb::SyncConfig {
@@ -445,10 +416,8 @@ mod tests {
             ..Default::default()
         };
 
-        let rows: Vec<(String, String)> = config_rows(&response)
-            .into_iter()
-            .map(|row| (row.setting, row.value))
-            .collect();
+        let block = config_block(&response);
+        let rows = block.entries();
         for expected in [
             ("src addr", "::1"),
             ("dst ether", "33:33:00:00:00:01"),
@@ -460,29 +429,32 @@ mod tests {
             ("sync suppress timeout", "0 ms"),
         ] {
             assert!(
-                rows.iter().any(|row| row.0 == expected.0 && row.1 == expected.1),
+                rows.iter()
+                    .any(|(key, lines)| key == expected.0 && *lines == [expected.1]),
                 "missing {expected:?} in {rows:?}"
             );
         }
         assert!(
-            !rows.iter().any(|row| row.1.contains("60000000000")),
+            !rows.iter().any(|(_, lines)| lines[0].contains("60000000000")),
             "no row may carry the stored nanoseconds: {rows:?}"
         );
     }
 
     #[test]
-    fn test_config_rows_without_sync_config_omit_timeouts() {
+    fn test_config_block_without_sync_config_omits_timeouts() {
         let response = show_response("fwstate0", "map4", "map6");
 
-        let settings: Vec<String> = config_rows(&response).into_iter().map(|row| row.setting).collect();
+        let block = config_block(&response);
+        let settings: Vec<&str> = block.entries().iter().map(|(key, _)| key.as_str()).collect();
         assert_eq!(vec!["name", "map name v4", "map name v6"], settings);
     }
 
     #[test]
-    fn test_config_rows_escape_names() {
+    fn test_config_block_escapes_names() {
         let response = show_response("fw\nstate0", "map\u{1b}4", "map6");
 
-        let values: Vec<String> = config_rows(&response).into_iter().map(|row| row.value).collect();
+        let block = config_block(&response);
+        let values: Vec<&str> = block.entries().iter().map(|(_, lines)| lines[0].as_str()).collect();
         assert_eq!(vec!["fw\\nstate0", "map\\u{1b}4", "map6"], values);
     }
 

--- a/modules/nat64/cli/Cargo.toml
+++ b/modules/nat64/cli/Cargo.toml
@@ -19,7 +19,6 @@ prost = "0.14"
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
-ptree = "0.5"
 
 [build-dependencies]
 tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -3,12 +3,11 @@ use core::net::{Ipv4Addr, Ipv6Addr};
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use nat64pb::{
-    AddMappingRequest, AddPrefixRequest, DeleteConfigRequest, ListConfigsRequest, RemoveMappingRequest,
-    RemovePrefixRequest, SetDropUnknownRequest, SetMtuRequest, ShowConfigRequest, ShowConfigResponse,
+    AddMappingRequest, AddPrefixRequest, Config, DeleteConfigRequest, ListConfigsRequest, RemoveMappingRequest,
+    RemovePrefixRequest, SetDropUnknownRequest, SetMtuRequest, ShowConfigRequest,
     nat64_service_client::Nat64ServiceClient,
 };
 use netip::{Contiguous, Ipv6Network};
-use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
@@ -260,15 +259,15 @@ impl NAT64Service {
         output::data(
             || &response,
             || {
-                if response.config.is_none() {
+                let Some(config) = &response.config else {
                     output::empty_with_hint(
                         format_args!("No NAT64 configuration found for '{}'.", cmd.config_name),
                         format_args!("create one with 'yanet-cli-nat64 prefix add --name <name> --prefix <cidr>'"),
                     );
                     return;
-                }
+                };
 
-                print_tree(&response);
+                config_block(config).print();
             },
         );
 
@@ -422,48 +421,30 @@ impl NAT64Service {
     }
 }
 
-fn print_tree(resp: &ShowConfigResponse) {
-    let mut tree = TreeBuilder::new("NAT64 Config".to_owned());
+fn config_block(config: &Config) -> display::KeyValue {
+    let prefixes = config
+        .prefixes
+        .iter()
+        .enumerate()
+        .map(|(idx, prefix)| format!("{idx}: {prefix}"));
+    let mappings = config.mappings.iter().map(|mapping| {
+        let ipv4 = mapping.ipv4.as_ref().map(|a| a.to_string()).unwrap_or_default();
+        let ipv6 = mapping.ipv6.as_ref().map(|a| a.to_string()).unwrap_or_default();
 
-    if let Some(config) = &resp.config {
-        tree.begin_child("Prefixes".to_owned());
-        if config.prefixes.is_empty() {
-            tree.add_empty_child("(none)".to_owned());
-        }
+        format!("{ipv4} -> {ipv6} (prefix {})", mapping.prefix_index)
+    });
 
-        for (idx, prefix) in config.prefixes.iter().enumerate() {
-            tree.add_empty_child(format!("{}: {}", idx, prefix));
-        }
-        tree.end_child();
+    let mut block = display::KeyValue::new()
+        .rows("prefixes", prefixes)
+        .rows("mappings", mappings);
 
-        tree.begin_child("Mappings".to_owned());
-        if config.mappings.is_empty() {
-            tree.add_empty_child("(none)".to_owned());
-        }
-
-        for mapping in &config.mappings {
-            let ipv4 = mapping.ipv4.as_ref().map(|a| a.to_string()).unwrap_or_default();
-            let ipv6 = mapping.ipv6.as_ref().map(|a| a.to_string()).unwrap_or_default();
-
-            tree.add_empty_child(format!(
-                "IPv4: {} -> IPv6: {} (prefix: {})",
-                ipv4, ipv6, mapping.prefix_index
-            ));
-        }
-        tree.end_child();
-
-        if let Some(mtu) = &config.mtu {
-            tree.begin_child("MTU".to_owned());
-            tree.add_empty_child(format!("IPv4: {}", mtu.ipv4_mtu));
-            tree.add_empty_child(format!("IPv6: {}", mtu.ipv6_mtu));
-            tree.end_child();
-        }
-
-        tree.add_empty_child(format!("DropUnknownPrefix: {}", config.drop_unknown_prefix));
-        tree.add_empty_child(format!("DropUnknownMapping: {}", config.drop_unknown_mapping));
+    if let Some(mtu) = &config.mtu {
+        block = block.row("mtu ipv4", mtu.ipv4_mtu).row("mtu ipv6", mtu.ipv6_mtu);
     }
 
-    let _ = ptree::print_tree(&tree.build());
+    block
+        .row("drop unknown prefix", config.drop_unknown_prefix)
+        .row("drop unknown mapping", config.drop_unknown_mapping)
 }
 
 fn parse_prefix(value: &str) -> Result<Contiguous<Ipv6Network>, String> {

--- a/modules/pdump/cli/Cargo.toml
+++ b/modules/pdump/cli/Cargo.toml
@@ -18,7 +18,6 @@ tokio = { version = "1", features = ["rt", "macros", "signal"] }
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 prost = "0.14"
-ptree = "0.5"
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 bytesize = "2"
 # Pinned exactly: semver sorts rc.2 below rc1, so a caret requirement

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -5,7 +5,6 @@ use pdumppb::{
     DeleteConfigRequest, ListConfigsRequest, ReadDumpRequest, ShowConfigRequest, ShowConfigResponse,
     pdump_service_client::PdumpServiceClient,
 };
-use ptree::TreeBuilder;
 use tokio::{
     signal::{unix, unix::SignalKind},
     task::JoinSet,
@@ -118,15 +117,15 @@ impl PdumpService {
         output::data(
             || &response,
             || {
-                if response.config.is_none() {
+                let Some(config) = &response.config else {
                     output::empty_with_hint(
                         format_args!("No pdump configuration found for '{}'.", cmd.config_name),
                         format_args!("create one with 'yanet-cli-pdump set --name <name>'"),
                     );
                     return;
-                }
+                };
 
-                print_tree(&response);
+                config_block(config).print();
             },
         );
 
@@ -290,17 +289,12 @@ impl PdumpService {
     }
 }
 
-fn print_tree(resp: &ShowConfigResponse) {
-    let mut tree = TreeBuilder::new("Pdump Config".to_owned());
-
-    if let Some(config) = &resp.config {
-        tree.add_empty_child(format!("Filter: {}", config.filter));
-        tree.add_empty_child(format!("Mode: {}", dump_mode::to_str(config.mode)));
-        tree.add_empty_child(format!("Snaplen: {}", config.snaplen));
-        tree.add_empty_child(format!("PerWorkerRingSize: {}", config.ring_size));
-    }
-
-    let _ = ptree::print_tree(&tree.build());
+fn config_block(config: &pdumppb::Config) -> display::KeyValue {
+    display::KeyValue::new()
+        .row("filter", &config.filter)
+        .row("mode", dump_mode::to_str(config.mode))
+        .row("snaplen", config.snaplen)
+        .row("ring size", config.ring_size)
 }
 
 fn main() -> std::process::ExitCode {


### PR DESCRIPTION
- decap, dscp, nat64, pdump, blackhole, trafgen, fwstate and the logging show print their object through display::KeyValue instead of a ptree tree, a two-column table or bare println lines.
- decap, dscp, nat64 and pdump drop their ptree dependency, fwstate drops tabled.
- The JSON payloads are unchanged.