### PR TITLE
build(cli): share one proto build script helper across the cli crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,8 +2643,8 @@ dependencies = [
  "tabled",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
  "yanet-filterpb",
 ]
@@ -2666,8 +2666,8 @@ dependencies = [
  "tabled",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
  "yanet-filterpb",
 ]
@@ -2682,8 +2682,15 @@ dependencies = [
  "serde",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
+]
+
+[[package]]
+name = "yanet-cli-build"
+version = "0.1.0"
+dependencies = [
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -2723,8 +2730,8 @@ dependencies = [
  "serde",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
 ]
 
@@ -2761,8 +2768,8 @@ dependencies = [
  "tabled",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
  "yanet-ynpb",
 ]
@@ -2777,8 +2784,8 @@ dependencies = [
  "serde",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
 ]
 
@@ -2793,8 +2800,8 @@ dependencies = [
  "tabled",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
  "yanet-ynpb",
 ]
@@ -2810,8 +2817,8 @@ dependencies = [
  "serde",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
 ]
 
@@ -2826,8 +2833,8 @@ dependencies = [
  "serde_yaml",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
  "yanet-filterpb",
 ]
@@ -2857,8 +2864,8 @@ dependencies = [
  "serde",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
 ]
 
@@ -2874,8 +2881,8 @@ dependencies = [
  "serde_json",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
 ]
 
@@ -2926,8 +2933,8 @@ dependencies = [
  "serde_yaml",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
  "yanet-filterpb",
 ]
@@ -2943,8 +2950,8 @@ dependencies = [
  "serde",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
 ]
 
@@ -2961,8 +2968,8 @@ dependencies = [
  "tabled",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
 ]
 
@@ -2988,8 +2995,8 @@ dependencies = [
  "tabled",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
 ]
 
@@ -3010,8 +3017,8 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
 ]
 
 [[package]]
@@ -3058,8 +3065,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
 ]
 
@@ -3075,8 +3082,8 @@ dependencies = [
  "serde_yaml",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
 ]
 
@@ -3091,8 +3098,8 @@ dependencies = [
  "serde_yaml",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "yanet-cli",
+ "yanet-cli-build",
  "yanet-commonpb",
  "yanet-filterpb",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "common/rust/filterpb",
     "common/rust/readinesspb",
     "common/rust/ynpb",
+    "cli/ync-build",
     "cli/core",
     "cli/modules/common",
     "cli/modules/inspect",

--- a/cli/ync-build/Cargo.toml
+++ b/cli/ync-build/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "yanet-cli-build"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+rust-version = "1.88"
+
+[lints]
+workspace = true
+
+[dependencies]
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }

--- a/cli/ync-build/src/lib.rs
+++ b/cli/ync-build/src/lib.rs
@@ -1,0 +1,59 @@
+//! Build-script helper for the yanet CLI crates: one client-only tonic
+//! build with the settings every crate shares.
+
+use core::error::Error;
+use std::path::{Path, PathBuf};
+
+pub use tonic_prost_build::Builder;
+
+/// A pending client build of `protos`, paths relative to `root`, the
+/// repository root as seen from the crate.
+pub struct Build {
+    root: PathBuf,
+    protos: Vec<PathBuf>,
+    builder: Builder,
+}
+
+/// Starts a client-only build with the shared packages mapped to their
+/// crates and no rerun-if-changed noise.
+pub fn client(root: impl AsRef<Path>, protos: &[&str]) -> Build {
+    let builder = tonic_prost_build::configure()
+        .emit_rerun_if_changed(false)
+        .build_server(false)
+        .extern_path(".common.commonpb.v1", "::commonpb::pb")
+        .extern_path(".common.filterpb.v1", "::filterpb::pb");
+
+    Build {
+        root: root.as_ref().to_path_buf(),
+        protos: protos.iter().map(PathBuf::from).collect(),
+        builder,
+    }
+}
+
+impl Build {
+    /// Derives `serde::Serialize` on every message.
+    pub fn serialize(self) -> Self {
+        self.with(|builder| builder.message_attribute(".", "#[derive(serde::Serialize)]"))
+    }
+
+    /// Applies the crate's own settings to the underlying tonic builder.
+    pub fn with(mut self, configure: impl FnOnce(Builder) -> Builder) -> Self {
+        self.builder = configure(self.builder);
+
+        self
+    }
+
+    /// Compiles the protos, rerunning the build script when one of them
+    /// changes. A proto they import is not watched.
+    pub fn compile(self) -> Result<(), Box<dyn Error>> {
+        let protos: Vec<PathBuf> = self.protos.iter().map(|proto| self.root.join(proto)).collect();
+
+        for proto in &protos {
+            println!("cargo:rerun-if-changed={}", proto.display());
+        }
+
+        self.builder.compile_protos(&protos, &[self.root])?;
+
+        Ok(())
+    }
+}

--- a/devices/plain/cli/Cargo.toml
+++ b/devices/plain/cli/Cargo.toml
@@ -22,4 +22,4 @@ tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/devices/plain/cli/build.rs
+++ b/devices/plain/cli/build.rs
@@ -1,14 +1,7 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/plainpb/v1/plain.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["plainpb/v1/plain.proto"], &["../../..", "../controlplane"])?;
-
-    Ok(())
+    ync_build::client("../../..", &["devices/plain/controlplane/plainpb/v1/plain.proto"])
+        .serialize()
+        .compile()
 }

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -19,8 +19,6 @@ use ynpb::pb::{ListDevicesRequest, device_service_client::DeviceServiceClient};
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod plainpb {
-    use serde::Serialize;
-
     tonic::include_proto!("devices.plain.controlplane.plainpb.v1");
 }
 

--- a/devices/trafgen/cli/Cargo.toml
+++ b/devices/trafgen/cli/Cargo.toml
@@ -20,4 +20,4 @@ tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/devices/trafgen/cli/build.rs
+++ b/devices/trafgen/cli/build.rs
@@ -1,14 +1,7 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/trafgenpb/v1/trafgen.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["trafgenpb/v1/trafgen.proto"], &["../../..", "../controlplane"])?;
-
-    Ok(())
+    ync_build::client("../../..", &["devices/trafgen/controlplane/trafgenpb/v1/trafgen.proto"])
+        .serialize()
+        .compile()
 }

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -18,8 +18,6 @@ use ync::{
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod trafgenpb {
-    use serde::Serialize;
-
     tonic::include_proto!("devices.trafgen.controlplane.trafgenpb.v1");
 }
 

--- a/devices/vlan/cli/Cargo.toml
+++ b/devices/vlan/cli/Cargo.toml
@@ -22,4 +22,4 @@ tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/devices/vlan/cli/build.rs
+++ b/devices/vlan/cli/build.rs
@@ -1,14 +1,7 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/vlanpb/v1/vlan.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["vlanpb/v1/vlan.proto"], &["../../..", "../controlplane"])?;
-
-    Ok(())
+    ync_build::client("../../..", &["devices/vlan/controlplane/vlanpb/v1/vlan.proto"])
+        .serialize()
+        .compile()
 }

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -17,8 +17,6 @@ use ynpb::pb::{ListDevicesRequest, device_service_client::DeviceServiceClient};
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod vlanpb {
-    use serde::Serialize;
-
     tonic::include_proto!("devices.vlan.controlplane.vlanpb.v1");
 }
 

--- a/modules/acl/cli/Cargo.toml
+++ b/modules/acl/cli/Cargo.toml
@@ -23,4 +23,4 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/acl/cli/build.rs
+++ b/modules/acl/cli/build.rs
@@ -1,56 +1,51 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/aclpb/v1/acl.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .extern_path(".common.filterpb.v1", "::filterpb::pb")
-        .message_attribute(
-            ".modules.acl.controlplane.aclpb.v1.Rule",
-            "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default)]",
-        )
-        .message_attribute(
-            ".modules.acl.controlplane.aclpb.v1.Action",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .message_attribute(
-            ".modules.acl.controlplane.aclpb.v1.ShowConfigResponse",
-            "#[derive(serde::Serialize)]",
-        )
-        .message_attribute(
-            ".modules.acl.controlplane.aclpb.v1.RuleCounter",
-            "#[derive(serde::Serialize)]",
-        )
-        .message_attribute(
-            ".modules.acl.controlplane.aclpb.v1.SyncConfig",
-            "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default)]",
-        )
-        .field_attribute(
-            ".modules.acl.controlplane.aclpb.v1.Action.kind",
-            "#[serde(with = \"crate::action_kind\")]",
-        )
-        // The typed network lists stay out of the YAML output while empty,
-        // so show rendering of a legacy-schema config is unchanged.
-        .field_attribute(
-            ".modules.acl.controlplane.aclpb.v1.Rule.sources4",
-            "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
-        )
-        .field_attribute(
-            ".modules.acl.controlplane.aclpb.v1.Rule.sources6",
-            "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
-        )
-        .field_attribute(
-            ".modules.acl.controlplane.aclpb.v1.Rule.destinations4",
-            "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
-        )
-        .field_attribute(
-            ".modules.acl.controlplane.aclpb.v1.Rule.destinations6",
-            "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
-        )
-        .compile_protos(&["aclpb/v1/acl.proto"], &["../../..", "../controlplane"])?;
-
-    Ok(())
+    ync_build::client("../../..", &["modules/acl/controlplane/aclpb/v1/acl.proto"])
+        .with(|builder| {
+            builder
+                .message_attribute(
+                    ".modules.acl.controlplane.aclpb.v1.Rule",
+                    "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default)]",
+                )
+                .message_attribute(
+                    ".modules.acl.controlplane.aclpb.v1.Action",
+                    "#[derive(serde::Serialize, serde::Deserialize)]",
+                )
+                .message_attribute(
+                    ".modules.acl.controlplane.aclpb.v1.ShowConfigResponse",
+                    "#[derive(serde::Serialize)]",
+                )
+                .message_attribute(
+                    ".modules.acl.controlplane.aclpb.v1.RuleCounter",
+                    "#[derive(serde::Serialize)]",
+                )
+                .message_attribute(
+                    ".modules.acl.controlplane.aclpb.v1.SyncConfig",
+                    "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default)]",
+                )
+                .field_attribute(
+                    ".modules.acl.controlplane.aclpb.v1.Action.kind",
+                    "#[serde(with = \"crate::action_kind\")]",
+                )
+                // The typed network lists stay out of the YAML output while empty,
+                // so show rendering of a legacy-schema config is unchanged.
+                .field_attribute(
+                    ".modules.acl.controlplane.aclpb.v1.Rule.sources4",
+                    "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
+                )
+                .field_attribute(
+                    ".modules.acl.controlplane.aclpb.v1.Rule.sources6",
+                    "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
+                )
+                .field_attribute(
+                    ".modules.acl.controlplane.aclpb.v1.Rule.destinations4",
+                    "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
+                )
+                .field_attribute(
+                    ".modules.acl.controlplane.aclpb.v1.Rule.destinations6",
+                    "#[serde(skip_serializing_if = \"Vec::is_empty\")]",
+                )
+        })
+        .compile()
 }

--- a/modules/balancer2/cli/Cargo.toml
+++ b/modules/balancer2/cli/Cargo.toml
@@ -28,4 +28,4 @@ chrono = "0.4"
 netip = "0.3"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/balancer2/cli/build.rs
+++ b/modules/balancer2/cli/build.rs
@@ -1,56 +1,48 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/balancerpb/v1/balancer.proto");
-    println!("cargo:rerun-if-changed=../controlplane/balancerpb/v1/config.proto");
-    println!("cargo:rerun-if-changed=../controlplane/balancerpb/v1/state.proto");
-    println!("cargo:rerun-if-changed=../controlplane/balancerpb/v1/filter.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .protoc_arg("--experimental_allow_proto3_optional")
-        .extern_path(".common.filterpb.v1", "::filterpb::pb")
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .message_attribute(".", "#[derive(serde::Serialize)]")
-        .enum_attribute(".", "#[derive(serde::Serialize)]")
-        .field_attribute(
-            "modules.balancer2.controlplane.balancerpb.v1.WlcConfig.refresh_period",
-            "#[serde(skip)]",
-        )
-        .field_attribute(
-            "modules.balancer2.controlplane.balancerpb.v1.BalancerState.last_packet_timestamp",
-            "#[serde(skip)]",
-        )
-        .field_attribute(
-            "modules.balancer2.controlplane.balancerpb.v1.VsState.last_packet_timestamp",
-            "#[serde(skip)]",
-        )
-        .field_attribute(
-            "modules.balancer2.controlplane.balancerpb.v1.RealState.last_packet_timestamp",
-            "#[serde(skip)]",
-        )
-        .field_attribute(
-            "modules.balancer2.controlplane.balancerpb.v1.Session.last_packet_timestamp",
-            "#[serde(skip)]",
-        )
-        .field_attribute(
-            "modules.balancer2.controlplane.balancerpb.v1.Session.create_timestamp",
-            "#[serde(skip)]",
-        )
-        .field_attribute(
-            "modules.balancer2.controlplane.balancerpb.v1.Session.timeout",
-            "#[serde(skip)]",
-        )
-        .compile_protos(
-            &[
-                "modules/balancer2/controlplane/balancerpb/v1/balancer.proto",
-                "modules/balancer2/controlplane/balancerpb/v1/config.proto",
-                "modules/balancer2/controlplane/balancerpb/v1/state.proto",
-                "modules/balancer2/controlplane/balancerpb/v1/filter.proto",
-            ],
-            &["../../.."],
-        )?;
-
-    Ok(())
+    ync_build::client(
+        "../../..",
+        &[
+            "modules/balancer2/controlplane/balancerpb/v1/balancer.proto",
+            "modules/balancer2/controlplane/balancerpb/v1/config.proto",
+            "modules/balancer2/controlplane/balancerpb/v1/state.proto",
+            "modules/balancer2/controlplane/balancerpb/v1/filter.proto",
+        ],
+    )
+    .serialize()
+    .with(|builder| {
+        builder
+            .protoc_arg("--experimental_allow_proto3_optional")
+            .enum_attribute(".", "#[derive(serde::Serialize)]")
+            .field_attribute(
+                "modules.balancer2.controlplane.balancerpb.v1.WlcConfig.refresh_period",
+                "#[serde(skip)]",
+            )
+            .field_attribute(
+                "modules.balancer2.controlplane.balancerpb.v1.BalancerState.last_packet_timestamp",
+                "#[serde(skip)]",
+            )
+            .field_attribute(
+                "modules.balancer2.controlplane.balancerpb.v1.VsState.last_packet_timestamp",
+                "#[serde(skip)]",
+            )
+            .field_attribute(
+                "modules.balancer2.controlplane.balancerpb.v1.RealState.last_packet_timestamp",
+                "#[serde(skip)]",
+            )
+            .field_attribute(
+                "modules.balancer2.controlplane.balancerpb.v1.Session.last_packet_timestamp",
+                "#[serde(skip)]",
+            )
+            .field_attribute(
+                "modules.balancer2.controlplane.balancerpb.v1.Session.create_timestamp",
+                "#[serde(skip)]",
+            )
+            .field_attribute(
+                "modules.balancer2.controlplane.balancerpb.v1.Session.timeout",
+                "#[serde(skip)]",
+            )
+    })
+    .compile()
 }

--- a/modules/blackhole/cli/Cargo.toml
+++ b/modules/blackhole/cli/Cargo.toml
@@ -19,4 +19,4 @@ tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/blackhole/cli/build.rs
+++ b/modules/blackhole/cli/build.rs
@@ -1,13 +1,10 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/blackholepb/v1/blackhole.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["blackholepb/v1/blackhole.proto"], &["../controlplane"])?;
-
-    Ok(())
+    ync_build::client(
+        "../../..",
+        &["modules/blackhole/controlplane/blackholepb/v1/blackhole.proto"],
+    )
+    .serialize()
+    .compile()
 }

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -15,8 +15,6 @@ use ync::{
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod blackholepb {
-    use serde::Serialize;
-
     tonic::include_proto!("modules.blackhole.controlplane.blackholepb.v1");
 }
 

--- a/modules/decap/cli/Cargo.toml
+++ b/modules/decap/cli/Cargo.toml
@@ -21,4 +21,4 @@ tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/decap/cli/build.rs
+++ b/modules/decap/cli/build.rs
@@ -1,14 +1,7 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/decappb/v1/decap.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["decappb/v1/decap.proto"], &["../controlplane", "../../.."])?;
-
-    Ok(())
+    ync_build::client("../../..", &["modules/decap/controlplane/decappb/v1/decap.proto"])
+        .serialize()
+        .compile()
 }

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -17,8 +17,6 @@ use ync::{
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod decappb {
-    use serde::Serialize;
-
     tonic::include_proto!("modules.decap.controlplane.decappb.v1");
 }
 

--- a/modules/dscp/cli/Cargo.toml
+++ b/modules/dscp/cli/Cargo.toml
@@ -21,4 +21,4 @@ tonic-prost = "0.14"
 prost = "0.14"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/dscp/cli/build.rs
+++ b/modules/dscp/cli/build.rs
@@ -1,14 +1,7 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/dscppb/v1/dscp.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["dscppb/v1/dscp.proto"], &["../controlplane", "../../.."])?;
-
-    Ok(())
+    ync_build::client("../../..", &["modules/dscp/controlplane/dscppb/v1/dscp.proto"])
+        .serialize()
+        .compile()
 }

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -19,8 +19,6 @@ use crate::dscppb::ListConfigsRequest;
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod dscppb {
-    use serde::Serialize;
-
     tonic::include_proto!("modules.dscp.controlplane.dscppb.v1");
 }
 

--- a/modules/forward/cli/Cargo.toml
+++ b/modules/forward/cli/Cargo.toml
@@ -22,4 +22,4 @@ tonic-prost = "0.14"
 serde_yaml = "0.9"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/forward/cli/build.rs
+++ b/modules/forward/cli/build.rs
@@ -1,36 +1,31 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/forwardpb/v1/forward.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .extern_path(".common.filterpb.v1", "::filterpb::pb")
-        .message_attribute(".", "#[derive(Serialize, Deserialize)]")
-        .message_attribute(".", "#[serde(default, deny_unknown_fields)]")
-        .field_attribute(
-            ".modules.forward.controlplane.forwardpb.v1.Action.mode",
-            "#[serde(serialize_with = \"crate::serialize_forward_mode\", deserialize_with = \"crate::deserialize_forward_mode\")]",
-        )
-        .field_attribute(
-            ".modules.forward.controlplane.forwardpb.v1.Action.target",
-            "#[serde(deserialize_with = \"crate::null_as_default\")]",
-        )
-        .field_attribute(
-            ".modules.forward.controlplane.forwardpb.v1.Action.counter",
-            "#[serde(deserialize_with = \"crate::null_as_default\")]",
-        )
-        .field_attribute(
-            ".modules.forward.controlplane.forwardpb.v1.Rule",
-            "#[serde(deserialize_with = \"crate::null_as_default\")]",
-        )
-        .field_attribute(
-            ".modules.forward.controlplane.forwardpb.v1.UpdateConfigRequest",
-            "#[serde(deserialize_with = \"crate::null_as_default\")]",
-        )
-        .compile_protos(&["forwardpb/v1/forward.proto"], &["../../..", "../controlplane"])?;
-
-    Ok(())
+    ync_build::client("../../..", &["modules/forward/controlplane/forwardpb/v1/forward.proto"])
+        .with(|builder| {
+            builder
+                .message_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
+                .message_attribute(".", "#[serde(default, deny_unknown_fields)]")
+                .field_attribute(
+                    ".modules.forward.controlplane.forwardpb.v1.Action.mode",
+                    "#[serde(serialize_with = \"crate::serialize_forward_mode\", deserialize_with = \"crate::deserialize_forward_mode\")]",
+                )
+                .field_attribute(
+                    ".modules.forward.controlplane.forwardpb.v1.Action.target",
+                    "#[serde(deserialize_with = \"crate::null_as_default\")]",
+                )
+                .field_attribute(
+                    ".modules.forward.controlplane.forwardpb.v1.Action.counter",
+                    "#[serde(deserialize_with = \"crate::null_as_default\")]",
+                )
+                .field_attribute(
+                    ".modules.forward.controlplane.forwardpb.v1.Rule",
+                    "#[serde(deserialize_with = \"crate::null_as_default\")]",
+                )
+                .field_attribute(
+                    ".modules.forward.controlplane.forwardpb.v1.UpdateConfigRequest",
+                    "#[serde(deserialize_with = \"crate::null_as_default\")]",
+                )
+        })
+        .compile()
 }

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -18,8 +18,6 @@ use ync::{
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod forwardpb {
-    use serde::{Deserialize, Serialize};
-
     tonic::include_proto!("modules.forward.controlplane.forwardpb.v1");
 }
 

--- a/modules/fwstate/cli/Cargo.toml
+++ b/modules/fwstate/cli/Cargo.toml
@@ -22,4 +22,4 @@ serde = { version = "1", features = ["derive"] }
 humantime = "2"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/fwstate/cli/build.rs
+++ b/modules/fwstate/cli/build.rs
@@ -1,17 +1,7 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/fwstatepb/v1/fwstate.proto");
-    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/ipaddr.proto");
-    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/macaddr.proto");
-    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/metric.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["fwstatepb/v1/fwstate.proto"], &["../controlplane", "../../.."])?;
-
-    Ok(())
+    ync_build::client("../../..", &["modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto"])
+        .serialize()
+        .compile()
 }

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -21,8 +21,6 @@ mod args;
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod fwstatepb {
-    use serde::Serialize;
-
     tonic::include_proto!("modules.fwstate.controlplane.fwstatepb.v1");
 }
 

--- a/modules/mirror/cli/Cargo.toml
+++ b/modules/mirror/cli/Cargo.toml
@@ -22,4 +22,4 @@ tonic-prost = "0.14"
 serde_yaml = "0.9"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/mirror/cli/build.rs
+++ b/modules/mirror/cli/build.rs
@@ -1,15 +1,7 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/mirrorpb/v1/mirror.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .extern_path(".common.filterpb.v1", "::filterpb::pb")
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["mirrorpb/v1/mirror.proto"], &["../../..", "../controlplane"])?;
-
-    Ok(())
+    ync_build::client("../../..", &["modules/mirror/controlplane/mirrorpb/v1/mirror.proto"])
+        .serialize()
+        .compile()
 }

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -20,8 +20,6 @@ use ync::{
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod mirrorpb {
-    use serde::Serialize;
-
     tonic::include_proto!("modules.mirror.controlplane.mirrorpb.v1");
 }
 

--- a/modules/nat64/cli/Cargo.toml
+++ b/modules/nat64/cli/Cargo.toml
@@ -21,4 +21,4 @@ tonic-prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/nat64/cli/build.rs
+++ b/modules/nat64/cli/build.rs
@@ -1,14 +1,7 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/nat64pb/v1/nat64.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["nat64pb/v1/nat64.proto"], &["../controlplane", "../../.."])?;
-
-    Ok(())
+    ync_build::client("../../..", &["modules/nat64/controlplane/nat64pb/v1/nat64.proto"])
+        .serialize()
+        .compile()
 }

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -19,7 +19,6 @@ use ync::{
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod nat64pb {
-    use serde::Serialize;
     tonic::include_proto!("modules.nat64.controlplane.nat64pb.v1");
 }
 

--- a/modules/pdump/cli/Cargo.toml
+++ b/modules/pdump/cli/Cargo.toml
@@ -27,5 +27,5 @@ tokio-util = "0.7"
 pnet_packet = "0.35"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }
 bindgen = "0.72"

--- a/modules/pdump/cli/build.rs
+++ b/modules/pdump/cli/build.rs
@@ -2,13 +2,9 @@ use core::error::Error;
 use std::{env, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/pdumppb/v1/pdump.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["pdumppb/v1/pdump.proto"], &["../controlplane"])?;
+    ync_build::client("../../..", &["modules/pdump/controlplane/pdumppb/v1/pdump.proto"])
+        .serialize()
+        .compile()?;
 
     let bindings = bindgen::Builder::default()
         .header("../dataplane/mode.h")

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -28,8 +28,6 @@ mod writer;
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod pdumppb {
-    use serde::Serialize;
-
     tonic::include_proto!("modules.pdump.controlplane.pdumppb.v1");
 }
 

--- a/modules/route-mpls/cli/Cargo.toml
+++ b/modules/route-mpls/cli/Cargo.toml
@@ -22,4 +22,4 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/route-mpls/cli/build.rs
+++ b/modules/route-mpls/cli/build.rs
@@ -1,17 +1,11 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/ipprefix.proto");
-    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/ipaddr.proto");
-    println!("cargo:rerun-if-changed=../controlplane/routemplspb/v1/routempls.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .message_attribute(".", "#[derive(Serialize)]")
-        .enum_attribute(".", "#[derive(serde::Serialize)]")
-        .compile_protos(&["routemplspb/v1/routempls.proto"], &["../../..", "../controlplane"])?;
-
-    Ok(())
+    ync_build::client(
+        "../../..",
+        &["modules/route-mpls/controlplane/routemplspb/v1/routempls.proto"],
+    )
+    .serialize()
+    .with(|builder| builder.enum_attribute(".", "#[derive(serde::Serialize)]"))
+    .compile()
 }

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -4,8 +4,6 @@ use core::net::IpAddr;
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod routemplspb {
-    use serde::Serialize;
-
     tonic::include_proto!("modules.route_mpls.controlplane.routemplspb.v1");
 }
 

--- a/modules/route/cli/Cargo.toml
+++ b/modules/route/cli/Cargo.toml
@@ -27,4 +27,4 @@ netip = "0.3"
 tokio = { version = "1", features = ["macros", "net", "rt", "time"] }
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/route/cli/build.rs
+++ b/modules/route/cli/build.rs
@@ -17,36 +17,35 @@ const SERDE_MESSAGES: &[&str] = &[
 ];
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/routepb/v1/route.proto");
-
-    let mut config = tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        // Lets a YAML entry that carries no nexthops omit `nexthops`
-        // entirely instead of spelling out `nexthops: []` -- see
-        // `UpdateFIBRequest`'s proto doc comment: such an entry is skipped
-        // entirely rather than clearing anything, but that omission is
-        // still a legitimate, deliberate shape to write.
-        .field_attribute(
-            ".modules.route.controlplane.routepb.v1.FIBEntry.nexthops",
-            "#[serde(default)]",
-        )
-        // `counter` is a plain `String`, so prost's derived `Deserialize`
-        // has no `Option` to default on its own. Empty is the normal
-        // uncounted state, so `skip_serializing_if` drops the key on write
-        // and `default` restores it on read, instead of a dead
-        // `"counter":""` on every uncounted row.
-        .field_attribute(
-            ".modules.route.controlplane.routepb.v1.FIBNexthop.counter",
-            "#[serde(default, skip_serializing_if = \"String::is_empty\")]",
-        );
+    let mut build =
+        ync_build::client("../../..", &["modules/route/controlplane/routepb/v1/route.proto"]).with(|builder| {
+            builder
+                // Lets a YAML entry that carries no nexthops omit `nexthops`
+                // entirely instead of spelling out `nexthops: []` -- see
+                // `UpdateFIBRequest`'s proto doc comment: such an entry is skipped
+                // entirely rather than clearing anything, but that omission is
+                // still a legitimate, deliberate shape to write.
+                .field_attribute(
+                    ".modules.route.controlplane.routepb.v1.FIBEntry.nexthops",
+                    "#[serde(default)]",
+                )
+                // `counter` is a plain `String`, so prost's derived `Deserialize`
+                // has no `Option` to default on its own. Empty is the normal
+                // uncounted state, so `skip_serializing_if` drops the key on write
+                // and `default` restores it on read, instead of a dead
+                // `"counter":""` on every uncounted row.
+                .field_attribute(
+                    ".modules.route.controlplane.routepb.v1.FIBNexthop.counter",
+                    "#[serde(default, skip_serializing_if = \"String::is_empty\")]",
+                )
+        });
     for message in SERDE_MESSAGES {
-        config = config
-            .message_attribute(message, "#[derive(serde::Serialize, serde::Deserialize)]")
-            .message_attribute(message, "#[serde(deny_unknown_fields)]");
+        build = build.with(|builder| {
+            builder
+                .message_attribute(message, "#[derive(serde::Serialize, serde::Deserialize)]")
+                .message_attribute(message, "#[serde(deny_unknown_fields)]")
+        });
     }
-    config.compile_protos(&["modules/route/controlplane/routepb/v1/route.proto"], &["../../../"])?;
 
-    Ok(())
+    build.compile()
 }

--- a/modules/unrdup/cli/Cargo.toml
+++ b/modules/unrdup/cli/Cargo.toml
@@ -22,4 +22,4 @@ tonic-prost = "0.14"
 prost = "0.14"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/unrdup/cli/build.rs
+++ b/modules/unrdup/cli/build.rs
@@ -1,15 +1,7 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/unrduppb/v1/unrdup.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .message_attribute(".", "#[derive(Serialize)]")
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .extern_path(".common.filterpb.v1", "::filterpb::pb")
-        .compile_protos(&["unrduppb/v1/unrdup.proto"], &["../controlplane", "../../.."])?;
-
-    Ok(())
+    ync_build::client("../../..", &["modules/unrdup/controlplane/unrduppb/v1/unrdup.proto"])
+        .serialize()
+        .compile()
 }

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -21,8 +21,6 @@ use ync::{
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod unrduppb {
-    use serde::Serialize;
-
     tonic::include_proto!("modules.unrdup.controlplane.unrduppb.v1");
 }
 

--- a/objects/fwstate/cli/Cargo.toml
+++ b/objects/fwstate/cli/Cargo.toml
@@ -22,4 +22,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/objects/fwstate/cli/build.rs
+++ b/objects/fwstate/cli/build.rs
@@ -1,15 +1,10 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/fwstatemappb/v1/fwstatemap.proto");
-    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/ipaddr.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["fwstatemappb/v1/fwstatemap.proto"], &["../controlplane", "../../.."])?;
-
-    Ok(())
+    ync_build::client(
+        "../../..",
+        &["objects/fwstate/controlplane/fwstatemappb/v1/fwstatemap.proto"],
+    )
+    .serialize()
+    .compile()
 }

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -22,8 +22,6 @@ mod args;
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod fwstatemappb {
-    use serde::Serialize;
-
     tonic::include_proto!("objects.fwstate.controlplane.fwstatemappb.v1");
 }
 

--- a/operators/route/cli/neighbour/Cargo.toml
+++ b/operators/route/cli/neighbour/Cargo.toml
@@ -25,4 +25,4 @@ tonic-prost = "0.14"
 serde_json = "1"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/operators/route/cli/neighbour/build.rs
+++ b/operators/route/cli/neighbour/build.rs
@@ -1,20 +1,13 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../../operatorpb/v1/neighbour.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .message_attribute(".", "#[derive(serde::Serialize)]")
-        .field_attribute(
-            ".operators.route.operatorpb.v1.NeighbourEntry.state",
-            "#[serde(serialize_with = \"crate::serialize_neighbour_state\")]",
-        )
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .compile_protos(
-            &["../../../../operators/route/operatorpb/v1/neighbour.proto"],
-            &["../../../../"],
-        )
-        .map_err(Into::into)
+    ync_build::client("../../../..", &["operators/route/operatorpb/v1/neighbour.proto"])
+        .serialize()
+        .with(|builder| {
+            builder.field_attribute(
+                ".operators.route.operatorpb.v1.NeighbourEntry.state",
+                "#[serde(serialize_with = \"crate::serialize_neighbour_state\")]",
+            )
+        })
+        .compile()
 }

--- a/operators/route/cli/route/Cargo.toml
+++ b/operators/route/cli/route/Cargo.toml
@@ -26,4 +26,4 @@ tonic-prost = "0.14"
 serde_json = "1"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/operators/route/cli/route/build.rs
+++ b/operators/route/cli/route/build.rs
@@ -1,20 +1,13 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../../operatorpb/v1/route.proto");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .message_attribute(".", "#[derive(serde::Serialize)]")
-        .field_attribute(
-            ".operators.route.operatorpb.v1.Route.source",
-            "#[serde(serialize_with = \"crate::serialize_route_source\")]",
-        )
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .compile_protos(
-            &["../../../../operators/route/operatorpb/v1/route.proto"],
-            &["../../../../"],
-        )
-        .map_err(Into::into)
+    ync_build::client("../../../..", &["operators/route/operatorpb/v1/route.proto"])
+        .serialize()
+        .with(|builder| {
+            builder.field_attribute(
+                ".operators.route.operatorpb.v1.Route.source",
+                "#[serde(serialize_with = \"crate::serialize_route_source\")]",
+            )
+        })
+        .compile()
 }


### PR DESCRIPTION
- Adds the yanet-cli-build crate (ync-build), a client-only tonic build with the shared packages mapped to their crates, the blanket Serialize derive, a per-crate hook for further attributes and one rerun-if-changed per proto.
- Every module, device, object and operator CLI build script uses it instead of repeating the tonic configuration, and drops the serde import inside its proto module because the derive is now qualified.
- Generated code is unchanged apart from the qualified derive path.