### PR TITLE
refactor(commonpb): share the timestamp, duration and enum name serializers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,6 +3110,7 @@ version = "0.1.0"
 dependencies = [
  "netip",
  "prost",
+ "prost-types",
  "serde",
  "serde_json",
  "tonic",
@@ -3138,6 +3139,7 @@ dependencies = [
  "serde_json",
  "tonic",
  "tonic-prost-build",
+ "yanet-commonpb",
 ]
 
 [[package]]

--- a/common/rust/commonpb/Cargo.toml
+++ b/common/rust/commonpb/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 netip = "0.3"
 prost = "0.14"
+prost-types = "0.14"
 serde = { version = "1", features = ["derive"] }
 tonic = { version = "0.14", features = ["gzip"] }
 

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -8,6 +8,8 @@ use core::{
 use netip::{Contiguous, IpNetwork, Ipv4Network, Ipv6Network, MacAddr, ipv4_range_to_networks, ipv6_range_to_networks};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
+pub mod serde_with;
+
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod pb {
     tonic::include_proto!("common.commonpb.v1");

--- a/common/rust/commonpb/src/serde_with.rs
+++ b/common/rust/commonpb/src/serde_with.rs
@@ -1,0 +1,190 @@
+//! Serializers a proto crate attaches to its generated messages with
+//! `serialize_with`.
+
+use prost_types::{Duration, Timestamp};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+#[derive(Serialize)]
+struct SecondsNanos {
+    seconds: i64,
+    nanos: i32,
+}
+
+/// Serializes an optional timestamp as `{"seconds": i64, "nanos": i32}`,
+/// or null when absent.
+pub fn timestamp<S: Serializer>(value: &Option<Timestamp>, serializer: S) -> Result<S::Ok, S::Error> {
+    match value {
+        Some(ts) => SecondsNanos { seconds: ts.seconds, nanos: ts.nanos }.serialize(serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
+/// Serializes an optional duration as `{"seconds": i64, "nanos": i32}`, or
+/// null when absent.
+pub fn duration<S: Serializer>(value: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error> {
+    match value {
+        Some(duration) => SecondsNanos {
+            seconds: duration.seconds,
+            nanos: duration.nanos,
+        }
+        .serialize(serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
+/// The short name of a proto enum discriminant: `name` with `prefix`
+/// stripped, the whole name when it carries no such prefix.
+pub fn short_name<'a>(name: &'a str, prefix: &str) -> &'a str {
+    name.strip_prefix(prefix).unwrap_or(name)
+}
+
+/// Serializes a discriminant as its lowercase short name, see
+/// [`short_name`].
+pub fn lowercase_name<S: Serializer>(name: &str, prefix: &str, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&short_name(name, prefix).to_lowercase())
+}
+
+/// Serializes a discriminant by the name `as_str_name` gives it, an
+/// undeclared value as the number itself.
+pub fn declared_name<S, E>(value: &i32, serializer: S, as_str_name: fn(&E) -> &'static str) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    E: TryFrom<i32>,
+{
+    match E::try_from(*value) {
+        Ok(variant) => serializer.serialize_str(as_str_name(&variant)),
+        Err(_) => serializer.serialize_i32(*value),
+    }
+}
+
+/// Deserializes a discriminant from its declared name in any case or from
+/// its number, null as the default, refusing an undeclared value.
+pub fn from_declared_name<'de, D, E>(deserializer: D, from_str_name: fn(&str) -> Option<E>) -> Result<i32, D::Error>
+where
+    D: Deserializer<'de>,
+    E: TryFrom<i32> + Into<i32> + Default,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum NameOrNumber {
+        Number(i32),
+        Name(String),
+    }
+
+    match Option::<NameOrNumber>::deserialize(deserializer)? {
+        None => Ok(E::default().into()),
+        Some(NameOrNumber::Number(number)) => E::try_from(number)
+            .map(Into::into)
+            .map_err(|_| de::Error::custom(format!("unknown value {number}"))),
+        Some(NameOrNumber::Name(name)) => from_str_name(&name.to_uppercase())
+            .map(Into::into)
+            .ok_or_else(|| de::Error::custom(format!("unknown name {name:?}"))),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(Clone, Copy, Default, PartialEq, Eq)]
+    enum Mode {
+        #[default]
+        None,
+        Out,
+    }
+
+    impl TryFrom<i32> for Mode {
+        type Error = ();
+
+        fn try_from(value: i32) -> Result<Self, ()> {
+            match value {
+                0 => Ok(Self::None),
+                1 => Ok(Self::Out),
+                _ => Err(()),
+            }
+        }
+    }
+
+    impl From<Mode> for i32 {
+        fn from(mode: Mode) -> Self {
+            mode as i32
+        }
+    }
+
+    impl Mode {
+        fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::None => "MODE_NONE",
+                Self::Out => "MODE_OUT",
+            }
+        }
+
+        fn from_str_name(name: &str) -> Option<Self> {
+            match name {
+                "MODE_NONE" => Some(Self::None),
+                "MODE_OUT" => Some(Self::Out),
+                _ => None,
+            }
+        }
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct Action {
+        #[serde(serialize_with = "serialize_mode", deserialize_with = "deserialize_mode")]
+        mode: i32,
+    }
+
+    fn serialize_mode<S: Serializer>(mode: &i32, serializer: S) -> Result<S::Ok, S::Error> {
+        declared_name(mode, serializer, Mode::as_str_name)
+    }
+
+    fn deserialize_mode<'de, D: Deserializer<'de>>(deserializer: D) -> Result<i32, D::Error> {
+        from_declared_name(deserializer, Mode::from_str_name)
+    }
+
+    #[test]
+    fn test_declared_name_serializes_by_name_and_an_undeclared_value_as_is() {
+        assert_eq!(
+            r#"{"mode":"MODE_OUT"}"#,
+            serde_json::to_string(&Action { mode: 1 }).unwrap()
+        );
+        assert_eq!(r#"{"mode":99}"#, serde_json::to_string(&Action { mode: 99 }).unwrap());
+    }
+
+    #[test]
+    fn test_from_declared_name_accepts_a_name_in_any_case_a_number_and_null() {
+        let mode = |json: &str| serde_json::from_str::<Action>(json).map(|action| action.mode);
+
+        assert_eq!(1, mode(r#"{"mode":"MODE_OUT"}"#).unwrap());
+        assert_eq!(1, mode(r#"{"mode":"mode_out"}"#).unwrap());
+        assert_eq!(1, mode(r#"{"mode":1}"#).unwrap());
+        assert_eq!(0, mode(r#"{"mode":null}"#).unwrap());
+        assert!(mode(r#"{"mode":"BOGUS"}"#).unwrap_err().to_string().contains("BOGUS"));
+        assert!(mode(r#"{"mode":99}"#).unwrap_err().to_string().contains("99"));
+    }
+
+    #[test]
+    fn test_short_name_strips_the_prefix_or_keeps_the_name() {
+        assert_eq!("READY", short_name("STATE_READY", "STATE_"));
+        assert_eq!("READY", short_name("READY", "STATE_"));
+    }
+
+    #[test]
+    fn test_timestamp_and_duration_serialize_seconds_and_nanos_or_null() {
+        #[derive(Serialize)]
+        struct Stamped {
+            #[serde(serialize_with = "timestamp")]
+            at: Option<Timestamp>,
+            #[serde(serialize_with = "duration")]
+            every: Option<Duration>,
+        }
+
+        let json = serde_json::to_string(&Stamped {
+            at: Some(Timestamp { seconds: 30, nanos: 5 }),
+            every: None,
+        })
+        .unwrap();
+
+        assert_eq!(r#"{"at":{"seconds":30,"nanos":5},"every":null}"#, json);
+    }
+}

--- a/common/rust/readinesspb/Cargo.toml
+++ b/common/rust/readinesspb/Cargo.toml
@@ -14,6 +14,7 @@ prost = "0.14"
 prost-types = "0.14"
 serde = { version = "1", features = ["derive"] }
 tonic = { version = "0.14", features = ["gzip"] }
+commonpb = { path = "../commonpb", version = "0.1", package = "yanet-commonpb" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/common/rust/readinesspb/build.rs
+++ b/common/rust/readinesspb/build.rs
@@ -1,7 +1,7 @@
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=common/readinesspb/v1/readiness.proto");
+    println!("cargo:rerun-if-changed=../../../common/readinesspb/v1/readiness.proto");
 
     tonic_prost_build::configure()
         .emit_rerun_if_changed(false)
@@ -16,15 +16,15 @@ fn main() -> Result<(), Box<dyn Error>> {
         )
         .field_attribute(
             "common.readinesspb.v1.Scope.observed_at",
-            "#[serde(serialize_with = \"crate::serialize_timestamp\")]",
+            "#[serde(serialize_with = \"commonpb::serde_with::timestamp\")]",
         )
         .field_attribute(
             "common.readinesspb.v1.Scope.last_transition_time",
-            "#[serde(serialize_with = \"crate::serialize_timestamp\")]",
+            "#[serde(serialize_with = \"commonpb::serde_with::timestamp\")]",
         )
         .field_attribute(
             "common.readinesspb.v1.Scope.expected_observation_interval",
-            "#[serde(serialize_with = \"crate::serialize_duration\")]",
+            "#[serde(serialize_with = \"commonpb::serde_with::duration\")]",
         )
         .enum_attribute(".", "#[derive(serde::Serialize)]")
         .compile_protos(&["common/readinesspb/v1/readiness.proto"], &["../../.."])

--- a/common/rust/readinesspb/src/lib.rs
+++ b/common/rust/readinesspb/src/lib.rs
@@ -15,62 +15,9 @@ pub fn serialize_state<S>(value: &i32, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    let name = pb::State::try_from(*value)
-        .unwrap_or_default()
-        .as_str_name()
-        .strip_prefix("STATE_")
-        .unwrap_or("unspecified")
-        .to_lowercase();
+    let state = pb::State::try_from(*value).unwrap_or_default();
 
-    serializer.serialize_str(&name)
-}
-
-/// Serializes an `Option<prost_types::Timestamp>` as `{"seconds": i64, "nanos":
-/// i32}` or `null` when absent.
-pub fn serialize_timestamp<S>(value: &Option<prost_types::Timestamp>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    use serde::Serialize;
-
-    match value {
-        Some(ts) => {
-            #[derive(serde::Serialize)]
-            struct Ts {
-                seconds: i64,
-                nanos: i32,
-            }
-            Ts { seconds: ts.seconds, nanos: ts.nanos }.serialize(serializer)
-        }
-        None => serializer.serialize_none(),
-    }
-}
-
-/// Preserves nanoseconds when serializing an optional duration.
-///
-/// The output is an object with integer seconds and nanoseconds, or null when
-/// no duration is present.
-pub fn serialize_duration<S>(value: &Option<prost_types::Duration>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    use serde::Serialize;
-
-    match value {
-        Some(duration) => {
-            #[derive(serde::Serialize)]
-            struct Dur {
-                seconds: i64,
-                nanos: i32,
-            }
-            Dur {
-                seconds: duration.seconds,
-                nanos: duration.nanos,
-            }
-            .serialize(serializer)
-        }
-        None => serializer.serialize_none(),
-    }
+    commonpb::serde_with::lowercase_name(state.as_str_name(), "STATE_", serializer)
 }
 
 #[cfg(test)]

--- a/common/rust/ynpb/build.rs
+++ b/common/rust/ynpb/build.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .message_attribute(".", "#[derive(serde::Serialize)]")
         .field_attribute(
             ".controlplane.ynpb.v1.RegisteredBackend.last_seen_at",
-            "#[serde(serialize_with = \"crate::serialize_timestamp\")]",
+            "#[serde(serialize_with = \"commonpb::serde_with::timestamp\")]",
         )
         .field_attribute(
             ".controlplane.ynpb.v1.RegisteredBackend.kind",

--- a/common/rust/ynpb/src/lib.rs
+++ b/common/rust/ynpb/src/lib.rs
@@ -11,14 +11,9 @@ pub fn serialize_backend_kind<S>(value: &i32, serializer: S) -> Result<S::Ok, S:
 where
     S: serde::Serializer,
 {
-    let name = pb::BackendKind::try_from(*value)
-        .unwrap_or_default()
-        .as_str_name()
-        .strip_prefix("BACKEND_KIND_")
-        .unwrap_or("UNSPECIFIED")
-        .to_lowercase();
+    let kind = pb::BackendKind::try_from(*value).unwrap_or_default();
 
-    serializer.serialize_str(&name)
+    commonpb::serde_with::lowercase_name(kind.as_str_name(), "BACKEND_KIND_", serializer)
 }
 
 /// Returns the lowercase name of a logging-level wire value (e.g. `debug`,
@@ -37,27 +32,6 @@ where
     S: serde::Serializer,
 {
     serializer.serialize_str(&log_level_name(*value))
-}
-
-/// Serializes an `Option<prost_types::Timestamp>` as `{"seconds": i64, "nanos":
-/// i32}` or `null` when absent.
-pub fn serialize_timestamp<S>(value: &Option<prost_types::Timestamp>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    use serde::Serialize;
-
-    match value {
-        Some(ts) => {
-            #[derive(serde::Serialize)]
-            struct Ts {
-                seconds: i64,
-                nanos: i32,
-            }
-            Ts { seconds: ts.seconds, nanos: ts.nanos }.serialize(serializer)
-        }
-        None => serializer.serialize_none(),
-    }
 }
 
 #[cfg(test)]

--- a/modules/forward/cli/build.rs
+++ b/modules/forward/cli/build.rs
@@ -12,19 +12,19 @@ fn main() -> Result<(), Box<dyn Error>> {
                 )
                 .field_attribute(
                     ".modules.forward.controlplane.forwardpb.v1.Action.target",
-                    "#[serde(deserialize_with = \"crate::null_as_default\")]",
+                    "#[serde(deserialize_with = \"filterpb::null_as_default\")]",
                 )
                 .field_attribute(
                     ".modules.forward.controlplane.forwardpb.v1.Action.counter",
-                    "#[serde(deserialize_with = \"crate::null_as_default\")]",
+                    "#[serde(deserialize_with = \"filterpb::null_as_default\")]",
                 )
                 .field_attribute(
                     ".modules.forward.controlplane.forwardpb.v1.Rule",
-                    "#[serde(deserialize_with = \"crate::null_as_default\")]",
+                    "#[serde(deserialize_with = \"filterpb::null_as_default\")]",
                 )
                 .field_attribute(
                     ".modules.forward.controlplane.forwardpb.v1.UpdateConfigRequest",
-                    "#[serde(deserialize_with = \"crate::null_as_default\")]",
+                    "#[serde(deserialize_with = \"filterpb::null_as_default\")]",
                 )
         })
         .compile()

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -121,16 +121,6 @@ fn deserialize_forward_mode<'de, D: Deserializer<'de>>(deserializer: D) -> Resul
     }
 }
 
-/// Deserializes a null as the field's zero value, as the operator's YAML
-/// decoder reads it.
-fn null_as_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
-where
-    T: Default + Deserialize<'de>,
-    D: Deserializer<'de>,
-{
-    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
-}
-
 /// Loads the update request from its YAML file.
 ///
 /// The reading matches the generic operator's: merge keys expand, a null

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -12,7 +12,10 @@ use std::{
 
 use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
-use commonpb::pb::{IpAddress, MacAddress};
+use commonpb::{
+    pb::{IpAddress, MacAddress},
+    serde_with,
+};
 use netip::MacAddr;
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
@@ -394,10 +397,9 @@ impl NeighbourService {
 ///
 /// An unrecognized discriminant falls back to `NeighbourState::NudUnknown`.
 fn state_name(value: i32) -> &'static str {
-    let name = NeighbourState::try_from(value)
-        .unwrap_or(NeighbourState::NudUnknown)
-        .as_str_name();
-    name.strip_prefix("NUD_").unwrap_or(name)
+    let state = NeighbourState::try_from(value).unwrap_or(NeighbourState::NudUnknown);
+
+    serde_with::short_name(state.as_str_name(), "NUD_")
 }
 
 /// Serializes the `state` field of `NeighbourEntry` as its proto-defined

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use colored::Colorize;
-use commonpb::pb::IpPrefix;
+use commonpb::{pb::IpPrefix, serde_with};
 use netip::{Contiguous, IpNetwork};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
@@ -588,12 +588,9 @@ fn print_route_table(entries: Vec<RouteEntry>) {
 /// Converts a raw `i32` source value to its lowercase string name by calling
 /// `as_str_name` on the corresponding `RouteSourceId` variant.
 fn route_source_name(value: i32) -> String {
-    RouteSourceId::try_from(value)
-        .unwrap_or_default()
-        .as_str_name()
-        .strip_prefix("ROUTE_SOURCE_ID_")
-        .unwrap_or_default()
-        .to_lowercase()
+    let source = RouteSourceId::try_from(value).unwrap_or_default();
+
+    serde_with::short_name(source.as_str_name(), "ROUTE_SOURCE_ID_").to_lowercase()
 }
 
 /// Serializes the `source` field of `Route` as a lowercase string name


### PR DESCRIPTION
- Adds commonpb::serde_with with the timestamp and duration serializers readinesspb and ynpb each carried, the short and lowercase enum name helpers behind serialize_state, serialize_backend_kind, the route source and neighbour state names, and declared_name/from_declared_name for an enum field written by its proto name.
- forward reuses filterpb::null_as_default instead of its own copy.
- readinesspb's rerun-if-changed path now points at the proto it names.