### PR TITLE
refactor(cli): read wire-shaped yaml files through ync

### DIFF
--- a/cli/core/src/yaml.rs
+++ b/cli/core/src/yaml.rs
@@ -3,11 +3,12 @@
 
 use core::error::Error as StdError;
 use std::{
-    fs::File,
+    fs::{self, File},
     path::{Path, PathBuf},
 };
 
-use serde::de::DeserializeOwned;
+use serde::{Deserialize, de::DeserializeOwned};
+use serde_yaml::Value;
 
 /// The underlying `std::io::Error` or `serde_yaml::Error`, type-erased so
 /// both failure modes fit one struct.
@@ -22,6 +23,49 @@ pub fn load<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T, Error> {
     let file = File::open(path).map_err(|source| at_path(Box::new(source)))?;
 
     serde_yaml::from_reader(file).map_err(|source| at_path(Box::new(source)))
+}
+
+/// Loads the one document at `path` as `T` the way the operators read a
+/// file: merge keys expand and an empty document is the default value.
+///
+/// A file holding more than one document is refused.
+pub fn load_document<T: DeserializeOwned + Default>(path: impl AsRef<Path>) -> Result<T, Error> {
+    let path = path.as_ref();
+
+    let at_path = |source: Source| Error { path: path.to_owned(), source };
+
+    let content = fs::read_to_string(path).map_err(|source| at_path(Box::new(source)))?;
+    let mut documents = Vec::new();
+    for document in serde_yaml::Deserializer::from_str(&content) {
+        let value = Value::deserialize(document).map_err(|source| at_path(Box::new(source)))?;
+        if !value.is_null() {
+            documents.push(value);
+        }
+    }
+
+    let mut value = match documents.pop() {
+        None => return Ok(T::default()),
+        Some(_) if !documents.is_empty() => return Err(at_path("the file holds more than one document".into())),
+        Some(value) => value,
+    };
+    value.apply_merge().map_err(|source| at_path(Box::new(source)))?;
+
+    serde_yaml::from_value(value).map_err(|source| at_path(Box::new(source)))
+}
+
+/// Binds the name given on the command line into a file's name field:
+/// fills an empty one, accepts an equal one and refuses another.
+pub fn bind_name(field: &mut String, name: &str) -> Result<(), String> {
+    if field.is_empty() {
+        *field = name.to_owned();
+        return Ok(());
+    }
+
+    if field != name {
+        return Err(format!("the file names config {field:?}, but --name is {name:?}"));
+    }
+
+    Ok(())
 }
 
 /// A YAML file that failed to open or to parse, naming the offending path.
@@ -44,6 +88,31 @@ mod test {
     #[derive(Debug, Deserialize)]
     struct Doc {
         name: String,
+    }
+
+    #[derive(Debug, Default, PartialEq, Deserialize)]
+    #[serde(default, deny_unknown_fields)]
+    struct Config {
+        name: String,
+        rules: Vec<Rule>,
+    }
+
+    #[derive(Debug, Default, PartialEq, Deserialize)]
+    #[serde(default, deny_unknown_fields)]
+    struct Rule {
+        target: String,
+        weight: u32,
+    }
+
+    /// Loads `content` as a config through a scratch file.
+    fn load_config(case: &str, content: &str) -> Result<Config, Error> {
+        let path = scratch_path(case);
+        fs::write(&path, content).unwrap();
+
+        let loaded = load_document(&path);
+        fs::remove_file(&path).unwrap();
+
+        loaded
     }
 
     /// Builds a scratch path under the process id so parallel test runs
@@ -70,6 +139,64 @@ mod test {
         fs::remove_file(&path).unwrap();
 
         assert!(err.to_string().starts_with(&path.display().to_string()), "{err}");
+    }
+
+    #[test]
+    fn test_load_document_empty_and_comment_only_files_are_the_default() {
+        for (case, content) in [("empty", ""), ("comment", "# nothing yet\n")] {
+            assert_eq!(Config::default(), load_config(case, content).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_load_document_refuses_an_unknown_null_valued_key() {
+        let err = load_config("nullkey", "rulez: null\n").expect_err("a misspelled null-valued key must be refused");
+
+        assert!(err.to_string().contains("rulez"), "{err}");
+    }
+
+    #[test]
+    fn test_load_document_tolerates_a_trailing_separator_and_refuses_a_second_document() {
+        let tolerated = load_config("separator", "name: c0\n---\n").unwrap();
+        let refused = load_config("two", "name: c0\n---\nname: c1\n").expect_err("a second document must be refused");
+
+        assert_eq!("c0", tolerated.name);
+        assert!(refused.to_string().contains("more than one document"), "{refused}");
+    }
+
+    #[test]
+    fn test_load_document_expands_merge_keys() {
+        let content = "rules:\n  - &base\n    target: base\n    weight: 10\n  - <<: *base\n    target: other\n";
+
+        let config = load_config("merge", content).unwrap();
+
+        assert_eq!(
+            vec![
+                Rule {
+                    target: "base".to_owned(),
+                    weight: 10
+                },
+                Rule {
+                    target: "other".to_owned(),
+                    weight: 10
+                },
+            ],
+            config.rules
+        );
+    }
+
+    #[test]
+    fn test_bind_name_fills_checks_and_refuses() {
+        let mut empty = String::new();
+        bind_name(&mut empty, "c0").expect("an empty name must bind");
+        assert_eq!("c0", empty);
+
+        let mut matching = "c0".to_owned();
+        bind_name(&mut matching, "c0").expect("a matching name must pass");
+
+        let mut other = "c1".to_owned();
+        let err = bind_name(&mut other, "c0").expect_err("a mismatch must be refused");
+        assert!(err.contains("c1") && err.contains("c0"), "{err}");
     }
 
     #[test]

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -172,3 +172,11 @@ balancer2, `-c` in `sessions update`, `-t` in counters, `-f` and `-s` in
 pdump) and the spellings `--config` on `acl metrics-rules` and
 `--prefixes` on `decap update` keep working as hidden aliases for one
 release.
+
+## Mirror rule files spell the wire request
+
+`yanet-cli-mirror update` reads the shape the generic operator pushes and
+`show` prints, exactly like forward: a rule carries an `action` object
+(`target`, `mode`, `counter`) and its `devices` as named objects. The
+previous flat rule form is refused, and `--format json` prints the wire
+message.

--- a/modules/acl/cli/build.rs
+++ b/modules/acl/cli/build.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 )
                 .field_attribute(
                     ".modules.acl.controlplane.aclpb.v1.Action.kind",
-                    "#[serde(with = \"crate::action_kind\")]",
+                    "#[serde(serialize_with = \"crate::serialize_action_kind\", deserialize_with = \"crate::deserialize_action_kind\")]",
                 )
                 // The typed network lists stay out of the YAML output while empty,
                 // so show rendering of a legacy-schema config is unchanged.

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -7,7 +7,7 @@ use aclpb::{
 use args::{DeleteCmd, MetricsRulesCmd, ModeCmd, RuleCountersCmd, ShowCmd, UpdateCmd};
 use clap::{CommandFactory, Parser};
 use clap_complete::engine::CompletionCandidate;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
@@ -20,30 +20,27 @@ use ync::{
 
 mod args;
 
-use ::commonpb::pb as commonpb;
+use ::commonpb::{pb as commonpb, serde_with};
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod aclpb {
     tonic::include_proto!("modules.acl.controlplane.aclpb.v1");
 }
 
-pub(crate) mod action_kind {
-    use serde::{Deserialize, Deserializer, Serializer, de};
+/// Serializes an action kind as its declared name, an undeclared number as
+/// the number itself, so one unknown kind cannot hide the rest of a ruleset.
+fn serialize_action_kind<S: Serializer>(kind: &i32, serializer: S) -> Result<S::Ok, S::Error> {
+    serde_with::declared_name(kind, serializer, aclpb::ActionKind::as_str_name)
+}
 
-    use super::aclpb;
+/// Deserializes an action kind from its declared name only: a null or a
+/// number is refused, because the zero kind would silently read as PASS.
+fn deserialize_action_kind<'de, D: Deserializer<'de>>(deserializer: D) -> Result<i32, D::Error> {
+    let name = String::deserialize(deserializer)?;
+    let kind = aclpb::ActionKind::from_str_name(&name)
+        .ok_or_else(|| de::Error::custom(format!("unknown ActionKind name `{name}`")))?;
 
-    pub fn serialize<S: Serializer>(kind: &i32, s: S) -> Result<S::Ok, S::Error> {
-        let action_kind = aclpb::ActionKind::try_from(*kind)
-            .map_err(|_| serde::ser::Error::custom(format!("unknown ActionKind value {kind}")))?;
-        s.serialize_str(action_kind.as_str_name())
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<i32, D::Error> {
-        let s = String::deserialize(d)?;
-        let action_kind = aclpb::ActionKind::from_str_name(&s)
-            .ok_or_else(|| de::Error::custom(format!("unknown ActionKind name `{s}`")))?;
-        Ok(action_kind as i32)
-    }
+    Ok(kind as i32)
 }
 
 #[derive(Tabled)]

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -1,19 +1,20 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
+use commonpb::serde_with;
 use forwardpb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     forward_service_client::ForwardServiceClient,
 };
-use serde::{Deserialize, Deserializer, Serializer};
+use serde::{Deserializer, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
     client::{self, ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output,
+    output, yaml,
 };
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
@@ -91,10 +92,7 @@ pub struct UpdateCmd {
 /// the number itself, so one rule from a newer module cannot hide the rest
 /// of a configuration.
 fn serialize_forward_mode<S: Serializer>(mode: &i32, serializer: S) -> Result<S::Ok, S::Error> {
-    match forwardpb::ForwardMode::try_from(*mode) {
-        Ok(mode) => serializer.serialize_str(mode.as_str_name()),
-        Err(_) => serializer.serialize_i32(*mode),
-    }
+    serde_with::declared_name(mode, serializer, forwardpb::ForwardMode::as_str_name)
 }
 
 /// Deserializes a forward mode from its declared name or number, a null
@@ -103,67 +101,7 @@ fn serialize_forward_mode<S: Serializer>(mode: &i32, serializer: S) -> Result<S:
 /// An undeclared value is refused here, because the service would
 /// silently coerce it to NONE rather than reject it.
 fn deserialize_forward_mode<'de, D: Deserializer<'de>>(deserializer: D) -> Result<i32, D::Error> {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum NameOrNumber {
-        Number(i32),
-        Name(String),
-    }
-
-    match Option::<NameOrNumber>::deserialize(deserializer)? {
-        None => Ok(forwardpb::ForwardMode::None as i32),
-        Some(NameOrNumber::Number(mode)) => forwardpb::ForwardMode::try_from(mode)
-            .map(|mode| mode as i32)
-            .map_err(|_| serde::de::Error::custom(format!("unknown forward mode {mode}"))),
-        Some(NameOrNumber::Name(name)) => forwardpb::ForwardMode::from_str_name(&name)
-            .map(|mode| mode as i32)
-            .ok_or_else(|| serde::de::Error::custom(format!("unknown forward mode {name:?}"))),
-    }
-}
-
-/// Loads the update request from its YAML file.
-///
-/// The reading matches the generic operator's: merge keys expand, a null
-/// field takes its zero value, an empty document is the zero request and
-/// a bare document separator is tolerated.
-fn load_request<P>(path: P) -> Result<UpdateConfigRequest, Box<dyn core::error::Error>>
-where
-    P: AsRef<Path>,
-{
-    let content = std::fs::read_to_string(path)?;
-    let mut documents = Vec::new();
-    for document in serde_yaml::Deserializer::from_str(&content) {
-        let value = serde_yaml::Value::deserialize(document)?;
-        if !value.is_null() {
-            documents.push(value);
-        }
-    }
-
-    let mut value = match documents.pop() {
-        None => return Ok(UpdateConfigRequest::default()),
-        Some(_) if !documents.is_empty() => {
-            return Err("the file holds more than one document".into());
-        }
-        Some(value) => value,
-    };
-    value.apply_merge()?;
-    Ok(serde_yaml::from_value(value)?)
-}
-
-/// Binds the config name into a loaded request, refusing a file that names
-/// another config.
-fn bind_request_name(request: &mut UpdateConfigRequest, name: &str) -> Result<(), String> {
-    if request.name.is_empty() {
-        request.name = name.to_string();
-        return Ok(());
-    }
-    if request.name != name {
-        return Err(format!(
-            "the file names config {:?}, but --name is {:?}",
-            request.name, name
-        ));
-    }
-    Ok(())
+    serde_with::from_declared_name(deserializer, forwardpb::ForwardMode::from_str_name)
 }
 
 /// The fully-qualified gRPC service name used in error messages.
@@ -281,10 +219,10 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     let update = match &cmd.mode {
         ModeCmd::Update(update) => {
             let endpoint = client::resolve_label(&cmd.globals.connection, action)?;
-            let mut request = load_request(&update.file)
-                .map_err(|e| Error::invalid_argument("update", endpoint.clone(), e.to_string()))?;
-            bind_request_name(&mut request, &update.config)
-                .map_err(|e| Error::invalid_argument("update", endpoint, e))?;
+            let mut request: UpdateConfigRequest = yaml::load_document(&update.file)
+                .map_err(|err| Error::invalid_argument("update", endpoint.clone(), err.to_string()))?;
+            yaml::bind_name(&mut request.name, &update.config)
+                .map_err(|err| Error::invalid_argument("update", endpoint, err))?;
             Some(request)
         }
         _ => None,
@@ -468,19 +406,6 @@ rules:
     }
 
     #[test]
-    fn test_empty_and_comment_only_files_are_the_zero_request() {
-        for content in ["", "# nothing yet\n"] {
-            let path = std::env::temp_dir().join(format!("fwd-empty-{}-{}.yaml", std::process::id(), content.len()));
-            std::fs::write(&path, content).expect("the fixture must be written");
-
-            let request = load_request(&path).expect("an empty document must load");
-            std::fs::remove_file(&path).ok();
-
-            assert_eq!(UpdateConfigRequest::default(), request);
-        }
-    }
-
-    #[test]
     fn test_extern_messages_default_and_refuse_unknown_keys() {
         let sparse: forwardpb::Rule =
             serde_yaml::from_str("vlan_ranges:\n  - {}\n").expect("an empty vlan range must default");
@@ -501,7 +426,8 @@ rules:
         let path = std::env::temp_dir().join(format!("fwd-nullkey-{}.yaml", std::process::id()));
         std::fs::write(&path, yaml).expect("the fixture must be written");
 
-        let refused = load_request(&path).expect_err("a misspelled null-valued key must be refused");
+        let refused = yaml::load_document::<UpdateConfigRequest>(&path)
+            .expect_err("a misspelled null-valued key must be refused");
         std::fs::remove_file(&path).ok();
 
         assert!(refused.to_string().contains("rulez"));
@@ -513,95 +439,10 @@ rules:
         let path = std::env::temp_dir().join(format!("fwd-null-{}.yaml", std::process::id()));
         std::fs::write(&path, yaml).expect("the fixture must be written");
 
-        let request = load_request(&path).expect("null fields must load");
+        let request = yaml::load_document::<UpdateConfigRequest>(&path).expect("null fields must load");
         std::fs::remove_file(&path).ok();
 
         assert_eq!("forward0", request.name);
         assert!(request.rules[0].devices.is_empty());
-    }
-
-    #[test]
-    fn test_trailing_separator_is_tolerated_but_a_second_document_is_not() {
-        let trailing = "name: forward0\n---\n";
-        let second = "name: forward0\n---\nname: forward1\n";
-        let dir = std::env::temp_dir();
-        let trailing_path = dir.join(format!("fwd-sep-{}.yaml", std::process::id()));
-        let second_path = dir.join(format!("fwd-two-{}.yaml", std::process::id()));
-        std::fs::write(&trailing_path, trailing).expect("the fixture must be written");
-        std::fs::write(&second_path, second).expect("the fixture must be written");
-
-        let tolerated = load_request(&trailing_path).expect("a bare separator must be tolerated");
-        let refused = load_request(&second_path).expect_err("a second document must be refused");
-        std::fs::remove_file(&trailing_path).ok();
-        std::fs::remove_file(&second_path).ok();
-
-        assert_eq!("forward0", tolerated.name);
-        assert!(refused.to_string().contains("more than one document"));
-    }
-
-    #[test]
-    fn test_file_rejects_duplicate_keys() {
-        let yaml = "rules:\n  - action:\n      target: t\n      mode: OUT\n      mode: NONE\n";
-
-        let parsed: Result<serde_yaml::Value, _> = serde_yaml::from_str(yaml);
-
-        assert!(
-            parsed
-                .expect_err("a duplicate mapping key must be refused")
-                .to_string()
-                .contains("duplicate")
-        );
-    }
-
-    #[test]
-    fn test_file_expands_merge_keys() {
-        let yaml = r#"
-rules:
-  - &base
-    action:
-      target: base
-      mode: OUT
-      counter: base
-    vlan_ranges:
-      - from: 0
-        to: 100
-  - <<: *base
-    devices:
-      - name: eth0
-"#;
-        let path = std::env::temp_dir().join(format!("fwd-merge-{}.yaml", std::process::id()));
-        std::fs::write(&path, yaml).expect("the fixture must be written");
-
-        let request = load_request(&path).expect("a merged document must load");
-        std::fs::remove_file(&path).ok();
-
-        assert_eq!(2, request.rules.len());
-        assert_eq!("base", request.rules[1].action.as_ref().expect("merged action").target);
-        assert_eq!(
-            vec![filterpb::pb::Device { name: "eth0".to_string() }],
-            request.rules[1].devices
-        );
-        assert_eq!(request.rules[0].vlan_ranges, request.rules[1].vlan_ranges);
-    }
-
-    #[test]
-    fn test_bind_request_name_fills_checks_and_refuses() {
-        let mut nameless = UpdateConfigRequest::default();
-        bind_request_name(&mut nameless, "forward0").expect("an empty name must bind");
-        assert_eq!("forward0", nameless.name);
-
-        let mut matching = UpdateConfigRequest {
-            name: "forward0".to_string(),
-            ..Default::default()
-        };
-        bind_request_name(&mut matching, "forward0").expect("a matching name must pass");
-
-        let mut mismatched = UpdateConfigRequest {
-            name: "other".to_string(),
-            ..Default::default()
-        };
-        let err = bind_request_name(&mut mismatched, "forward0").expect_err("a mismatch must be refused");
-        assert!(err.contains("other"));
-        assert!(err.contains("forward0"));
     }
 }

--- a/modules/mirror/cli/build.rs
+++ b/modules/mirror/cli/build.rs
@@ -2,6 +2,30 @@ use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     ync_build::client("../../..", &["modules/mirror/controlplane/mirrorpb/v1/mirror.proto"])
-        .serialize()
+        .with(|builder| {
+            builder
+                .message_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
+                .message_attribute(".", "#[serde(default, deny_unknown_fields)]")
+                .field_attribute(
+                    ".modules.mirror.controlplane.mirrorpb.v1.Action.mode",
+                    "#[serde(serialize_with = \"crate::serialize_mirror_mode\", deserialize_with = \"crate::deserialize_mirror_mode\")]",
+                )
+                .field_attribute(
+                    ".modules.mirror.controlplane.mirrorpb.v1.Action.target",
+                    "#[serde(deserialize_with = \"filterpb::null_as_default\")]",
+                )
+                .field_attribute(
+                    ".modules.mirror.controlplane.mirrorpb.v1.Action.counter",
+                    "#[serde(deserialize_with = \"filterpb::null_as_default\")]",
+                )
+                .field_attribute(
+                    ".modules.mirror.controlplane.mirrorpb.v1.Rule",
+                    "#[serde(deserialize_with = \"filterpb::null_as_default\")]",
+                )
+                .field_attribute(
+                    ".modules.mirror.controlplane.mirrorpb.v1.UpdateConfigRequest",
+                    "#[serde(deserialize_with = \"filterpb::null_as_default\")]",
+                )
+        })
         .compile()
 }

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -1,18 +1,17 @@
-use core::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
-use commonpb::pb::{IPv4Network, IPv6Network};
+use commonpb::serde_with;
 use mirrorpb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     mirror_service_client::MirrorServiceClient,
 };
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserializer, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{self, ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
     output, yaml,
@@ -76,157 +75,32 @@ pub struct UpdateCmd {
     /// The name of the module config to operate on.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config: String,
-    /// Path to the ruleset YAML file.
+    /// Path to the module config file: the update request in YAML.
+    ///
+    /// The file spells the wire request, exactly what the generic operator
+    /// pushes and what `show` prints: rules with an `action`, `devices` as
+    /// named objects, family-typed `sources4/6` and `destinations4/6`
+    /// networks, a mode by its declared name in any case or by its number.
+    /// An undeclared mode number, which `show` still prints raw, is
+    /// refused. The `name` may be omitted, it is then taken from `--name`,
+    /// and a file naming another config is refused.
     #[arg(value_name = "PATH")]
     pub file: PathBuf,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct VlanRange {
-    from: u32,
-    to: u32,
+/// Serializes a mirror mode as its declared name, an undeclared number as
+/// the number itself, so one unknown mode cannot hide the rest of a config.
+fn serialize_mirror_mode<S: Serializer>(mode: &i32, serializer: S) -> Result<S::Ok, S::Error> {
+    serde_with::declared_name(mode, serializer, mirrorpb::MirrorMode::as_str_name)
 }
 
-impl From<VlanRange> for filterpb::pb::VlanRange {
-    fn from(r: VlanRange) -> Self {
-        Self { from: r.from, to: r.to }
-    }
-}
-
-impl From<filterpb::pb::VlanRange> for VlanRange {
-    fn from(r: filterpb::pb::VlanRange) -> Self {
-        Self { from: r.from, to: r.to }
-    }
-}
-
-/// Mirroring direction for a rule's action.
+/// Deserializes a mirror mode from its declared name or number, a null
+/// as NONE.
 ///
-/// The uppercase spelling is canonical, matching `MirrorMode`'s proto enum
-/// names. The PascalCase spellings are accepted because the schema used them
-/// previously.
-#[derive(Debug, Deserialize)]
-enum ModeKind {
-    #[serde(rename = "NONE", alias = "None")]
-    None,
-    #[serde(rename = "IN", alias = "In")]
-    In,
-    #[serde(rename = "OUT", alias = "Out")]
-    Out,
-    /// An unrecognised proto enum value.
-    ///
-    /// `show` renders the raw number so one rule from a newer module cannot
-    /// hide the rest of a configuration. `update` rejects it.
-    #[serde(skip)]
-    Unknown(i32),
-}
-
-impl Display for ModeKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            Self::None => write!(f, "NONE"),
-            Self::In => write!(f, "IN"),
-            Self::Out => write!(f, "OUT"),
-            Self::Unknown(mode) => write!(f, "{mode}"),
-        }
-    }
-}
-
-impl Serialize for ModeKind {
-    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        s.collect_str(self)
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct MirrorRule {
-    target: String,
-    mode: ModeKind,
-    counter: String,
-    devices: Vec<String>,
-    vlan_ranges: Vec<VlanRange>,
-    sources4: Vec<IPv4Network>,
-    sources6: Vec<IPv6Network>,
-    destinations4: Vec<IPv4Network>,
-    destinations6: Vec<IPv6Network>,
-}
-
-impl TryFrom<MirrorRule> for mirrorpb::Rule {
-    type Error = Box<dyn core::error::Error>;
-
-    fn try_from(mirror_rule: MirrorRule) -> Result<Self, Self::Error> {
-        let mode: i32 = match mirror_rule.mode {
-            ModeKind::None => mirrorpb::MirrorMode::None.into(),
-            ModeKind::In => mirrorpb::MirrorMode::In.into(),
-            ModeKind::Out => mirrorpb::MirrorMode::Out.into(),
-            ModeKind::Unknown(mode) => return Err(format!("unknown mirror mode {mode}").into()),
-        };
-
-        Ok(Self {
-            action: Some(mirrorpb::Action {
-                target: mirror_rule.target,
-                mode,
-                counter: mirror_rule.counter,
-            }),
-            devices: mirror_rule.devices.into_iter().map(|m| m.into()).collect(),
-            vlan_ranges: mirror_rule.vlan_ranges.into_iter().map(Into::into).collect(),
-            sources4: mirror_rule.sources4,
-            sources6: mirror_rule.sources6,
-            destinations4: mirror_rule.destinations4,
-            destinations6: mirror_rule.destinations6,
-        })
-    }
-}
-
-impl TryFrom<mirrorpb::Rule> for MirrorRule {
-    type Error = Box<dyn core::error::Error>;
-
-    fn try_from(rule: mirrorpb::Rule) -> Result<Self, Self::Error> {
-        let action = rule.action.ok_or("mirror rule is missing its action")?;
-        let mode = match mirrorpb::MirrorMode::try_from(action.mode) {
-            Ok(mirrorpb::MirrorMode::None) => ModeKind::None,
-            Ok(mirrorpb::MirrorMode::In) => ModeKind::In,
-            Ok(mirrorpb::MirrorMode::Out) => ModeKind::Out,
-            Err(_) => ModeKind::Unknown(action.mode),
-        };
-
-        Ok(Self {
-            target: action.target,
-            mode,
-            counter: action.counter,
-            devices: rule.devices.into_iter().map(|d| d.name).collect(),
-            vlan_ranges: rule.vlan_ranges.into_iter().map(VlanRange::from).collect(),
-            sources4: rule.sources4,
-            sources6: rule.sources6,
-            destinations4: rule.destinations4,
-            destinations6: rule.destinations6,
-        })
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MirrorConfig {
-    rules: Vec<MirrorRule>,
-}
-
-impl TryFrom<MirrorConfig> for Vec<mirrorpb::Rule> {
-    type Error = Box<dyn core::error::Error>;
-
-    fn try_from(config: MirrorConfig) -> Result<Self, Self::Error> {
-        config.rules.into_iter().map(mirrorpb::Rule::try_from).collect()
-    }
-}
-
-impl TryFrom<Vec<mirrorpb::Rule>> for MirrorConfig {
-    type Error = Box<dyn core::error::Error>;
-
-    fn try_from(rules: Vec<mirrorpb::Rule>) -> Result<Self, Self::Error> {
-        Ok(Self {
-            rules: rules
-                .into_iter()
-                .map(MirrorRule::try_from)
-                .collect::<Result<Vec<_>, _>>()?,
-        })
-    }
+/// An undeclared value is refused here, because the service would
+/// silently coerce it to NONE rather than reject it.
+fn deserialize_mirror_mode<'de, D: Deserializer<'de>>(deserializer: D) -> Result<i32, D::Error> {
+    serde_with::from_declared_name(deserializer, mirrorpb::MirrorMode::from_str_name)
 }
 
 /// The fully-qualified gRPC service name used in error messages.
@@ -261,18 +135,18 @@ impl MirrorService {
             )
             .await?;
 
-        let config = MirrorConfig::try_from(response.rules)
-            .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("show", e.to_string()))?;
-
         output::data(
-            || &config,
+            || &response,
             || {
+                // The document is printed even without rules, so a
+                // redirected show yields a file update accepts, an
+                // undeclared mode number excepted.
                 print!(
                     "{}",
-                    serde_yaml::to_string(&config).expect("mirror config YAML serialization must not fail")
+                    serde_yaml::to_string(&response).expect("mirror config YAML serialization must not fail")
                 );
 
-                if config.rules.is_empty() {
+                if response.rules.is_empty() {
                     output::empty_with_hint(
                         format_args!("No mirror rules found for '{}'.", cmd.config_name),
                         format_args!("create one with 'yanet-cli-mirror update --name <name> <path>'"),
@@ -322,12 +196,7 @@ impl MirrorService {
         Ok(())
     }
 
-    pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let config: MirrorConfig = yaml::load(&cmd.file).map_err(|e| self.service.invalid("update", e.to_string()))?;
-        let rules: Vec<mirrorpb::Rule> = config
-            .try_into()
-            .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("update", e.to_string()))?;
-        let request = UpdateConfigRequest { name: cmd.config.clone(), rules };
+    pub async fn update_config(&mut self, cmd: UpdateCmd, request: UpdateConfigRequest) -> Result<(), Error> {
         self.service
             .unary("update", request, async |client, request| {
                 client.update_config(request).await
@@ -342,11 +211,30 @@ impl MirrorService {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
+
+    // The update file is read and bound before the connection, so bad
+    // local input fails deterministically with or without a reachable
+    // gateway.
+    let update = match &cmd.mode {
+        ModeCmd::Update(update) => {
+            let endpoint = client::resolve_label(&cmd.globals.connection, action)?;
+            let mut request: UpdateConfigRequest = yaml::load_document(&update.file)
+                .map_err(|err| Error::invalid_argument("update", endpoint.clone(), err.to_string()))?;
+            yaml::bind_name(&mut request.name, &update.config)
+                .map_err(|err| Error::invalid_argument("update", endpoint, err))?;
+            Some(request)
+        }
+        _ => None,
+    };
+
     let mut service = MirrorService::new(&cmd.globals.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
-        ModeCmd::Update(cmd) => service.update_config(cmd).await,
+        ModeCmd::Update(cmd) => {
+            let request = update.expect("prepared for the update mode");
+            service.update_config(cmd, request).await
+        }
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
         ModeCmd::List => service.list_configs().await,
     }
@@ -368,195 +256,69 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 
 #[cfg(test)]
 mod test {
+    use commonpb::pb::{IPv4Network, IPv6Network};
+
     use super::*;
 
-    fn v4_net(net: &str) -> IPv4Network {
-        net.parse().expect("valid IPv4 network in test fixture")
-    }
-
-    fn v6_net(net: &str) -> IPv6Network {
-        net.parse().expect("valid IPv6 network in test fixture")
-    }
-
-    fn sample_rules() -> Vec<mirrorpb::Rule> {
-        vec![
-            mirrorpb::Rule {
-                action: Some(mirrorpb::Action {
-                    target: "target-none".to_string(),
-                    mode: mirrorpb::MirrorMode::None as i32,
-                    counter: "counter-none".to_string(),
-                }),
-                devices: vec![
-                    filterpb::pb::Device { name: "eth0".to_string() },
-                    filterpb::pb::Device { name: "eth1".to_string() },
-                ],
-                vlan_ranges: vec![
-                    filterpb::pb::VlanRange { from: 0, to: 100 },
-                    filterpb::pb::VlanRange { from: 200, to: 300 },
-                ],
-                sources4: vec![v4_net("192.0.2.0/24")],
-                sources6: vec![v6_net("2001:db8::/32")],
-                destinations4: vec![v4_net("203.0.113.0/24")],
-                destinations6: vec![v6_net("2001:db8:1::/48")],
-            },
-            mirrorpb::Rule {
-                action: Some(mirrorpb::Action {
-                    target: "target-in".to_string(),
-                    mode: mirrorpb::MirrorMode::In as i32,
-                    counter: String::new(),
-                }),
-                devices: vec![],
-                vlan_ranges: vec![],
-                sources4: vec![],
-                sources6: vec![],
-                destinations4: vec![],
-                destinations6: vec![],
-            },
-            mirrorpb::Rule {
+    #[test]
+    fn test_shown_config_round_trips_into_the_update_request() {
+        let shown = mirrorpb::ShowConfigResponse {
+            name: "mirror0".to_string(),
+            rules: vec![mirrorpb::Rule {
                 action: Some(mirrorpb::Action {
                     target: "target-out".to_string(),
                     mode: mirrorpb::MirrorMode::Out as i32,
                     counter: "counter-out".to_string(),
                 }),
-                devices: vec![filterpb::pb::Device { name: "eth2".to_string() }],
+                devices: vec![filterpb::pb::Device { name: "eth0".to_string() }],
                 vlan_ranges: vec![filterpb::pb::VlanRange { from: 10, to: 20 }],
-                sources4: vec![v4_net("10.0.0.0/8")],
-                sources6: vec![],
-                destinations4: vec![v4_net("10.1.0.0/16")],
+                sources4: vec!["10.0.0.0/8".parse::<IPv4Network>().unwrap()],
+                // The mask hole sits exactly at the /64 boundary, which the
+                // filter compiler accepts.
+                sources6: vec!["2001:db8::/ffff:ffff:ffff:0:ffff::".parse::<IPv6Network>().unwrap()],
+                destinations4: vec![],
                 destinations6: vec![],
-            },
-        ]
-    }
-
-    #[test]
-    fn a_shown_config_round_trips_through_yaml_back_into_the_original_rules() {
-        let rules = sample_rules();
-
-        let config = MirrorConfig::try_from(rules.clone()).expect("pb rules must convert into a mirror config");
-        let yaml = serde_yaml::to_string(&config).expect("mirror config must serialize");
-        let parsed: MirrorConfig = serde_yaml::from_str(&yaml).expect("mirror config must deserialize");
-        let reconstructed: Vec<mirrorpb::Rule> = parsed.try_into().expect("mirror config must convert back");
-
-        assert_eq!(rules, reconstructed);
-    }
-
-    #[test]
-    fn a_rule_file_accepts_the_full_mode_vocabulary() {
-        let uppercase = r#"
-rules:
-  - target: "t1"
-    mode: "NONE"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    sources4: []
-    sources6: []
-    destinations4: []
-    destinations6: []
-  - target: "t2"
-    mode: "IN"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    sources4: []
-    sources6: []
-    destinations4: []
-    destinations6: []
-  - target: "t3"
-    mode: "OUT"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    sources4: []
-    sources6: []
-    destinations4: []
-    destinations6: []
-"#;
-        let legacy = r#"
-rules:
-  - target: "t1"
-    mode: "None"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    sources4: []
-    sources6: []
-    destinations4: []
-    destinations6: []
-  - target: "t2"
-    mode: "In"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    sources4: []
-    sources6: []
-    destinations4: []
-    destinations6: []
-  - target: "t3"
-    mode: "Out"
-    counter: ""
-    devices: []
-    vlan_ranges: []
-    sources4: []
-    sources6: []
-    destinations4: []
-    destinations6: []
-"#;
-
-        for yaml in [uppercase, legacy] {
-            let config: MirrorConfig = serde_yaml::from_str(yaml).expect("mode spellings must parse");
-            assert!(matches!(config.rules[0].mode, ModeKind::None));
-            assert!(matches!(config.rules[1].mode, ModeKind::In));
-            assert!(matches!(config.rules[2].mode, ModeKind::Out));
-        }
-    }
-
-    #[test]
-    fn a_bi_contiguous_v6_mask_round_trips_through_the_rule_file() {
-        let rule = mirrorpb::Rule {
-            action: Some(mirrorpb::Action {
-                target: "t".to_string(),
-                mode: mirrorpb::MirrorMode::None as i32,
-                counter: "c".to_string(),
-            }),
-            devices: vec![],
-            vlan_ranges: vec![],
-            sources4: vec![],
-            // The mask hole sits exactly at the /64 boundary, which the
-            // filter compiler accepts.
-            sources6: vec![v6_net("2001:db8::/ffff:ffff:ffff:0:ffff::")],
-            destinations4: vec![],
-            destinations6: vec![],
+            }],
         };
 
-        let config = MirrorConfig::try_from(vec![rule.clone()]).expect("a bi-contiguous v6 network must render");
-        let yaml = serde_yaml::to_string(&config).expect("mirror config must serialize");
-        let parsed: MirrorConfig = serde_yaml::from_str(&yaml).expect("mirror config must deserialize");
-        let rebuilt: Vec<mirrorpb::Rule> = parsed.try_into().expect("mirror config must convert back");
+        let yaml = serde_yaml::to_string(&shown).expect("shown config must serialize");
+        let parsed: UpdateConfigRequest = serde_yaml::from_str(&yaml).expect("shown config must parse back");
 
-        assert_eq!(vec![rule], rebuilt);
+        assert_eq!(shown.name, parsed.name);
+        assert_eq!(shown.rules, parsed.rules);
     }
 
     #[test]
-    fn an_unrecognised_mode_number_is_shown_but_rejected_by_update() {
-        let rule = mirrorpb::Rule {
-            action: Some(mirrorpb::Action {
-                target: "t".to_string(),
-                mode: 99,
-                counter: String::new(),
-            }),
-            devices: vec![],
-            vlan_ranges: vec![],
-            sources4: vec![],
-            sources6: vec![],
-            destinations4: vec![],
-            destinations6: vec![],
+    fn test_null_fields_read_as_zero_values() {
+        let yaml = "name: mirror0\nrules:\n  - action:\n      target: t\n      mode: OUT\n      counter: c\n    devices: null\n    sources4: null\n";
+
+        let request: UpdateConfigRequest = serde_yaml::from_str(yaml).expect("null fields must load");
+
+        assert_eq!(1, request.rules.len());
+        assert!(request.rules[0].devices.is_empty());
+        assert!(request.rules[0].sources4.is_empty());
+    }
+
+    #[test]
+    fn test_mode_accepts_the_legacy_pascal_case_spelling() {
+        let action: mirrorpb::Action = serde_yaml::from_str("mode: Out\n").expect("a legacy spelling must parse");
+
+        assert_eq!(mirrorpb::MirrorMode::Out as i32, action.mode);
+    }
+
+    #[test]
+    fn test_an_undeclared_mode_is_shown_but_refused_by_update() {
+        let action = mirrorpb::Action {
+            target: "t".to_string(),
+            mode: 99,
+            counter: String::new(),
         };
 
-        let config = MirrorConfig::try_from(vec![rule]).expect("an unrecognised mode must not blank the show");
-        assert!(serde_yaml::to_string(&config).is_ok());
-
-        let rebuilt: Result<Vec<mirrorpb::Rule>, _> = config.try_into();
-        assert!(rebuilt.is_err());
+        assert!(
+            serde_yaml::to_string(&action)
+                .expect("must serialize")
+                .contains("mode: 99")
+        );
+        assert!(serde_yaml::from_str::<mirrorpb::Action>("mode: 99\n").is_err());
     }
 }


### PR DESCRIPTION
- Adds `ync::yaml::load_document`, reading one document the way the operators do, and `bind_name`, both moved from the forward CLI with their tests.
- Forward, mirror and acl print their enum fields through `commonpb::serde_with`, so an undeclared value shows as its number instead of aborting a show, and forward and mirror read them through it as well.
- Mirror reads and shows the wire request the way forward does, dropping its private rule schema.
- Notes the mirror rule file change in the upgrade guide.