### PR TITLE
refactor(cli): stream rows through one ync sink

### DIFF
--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -268,6 +268,62 @@ where
     current().data(&payload, Box::new(render));
 }
 
+/// Opens a stream of rows, see [`Rows`].
+pub fn rows<'a, R, Header, Render>(header: Header, render: Render) -> Rows<'a, R>
+where
+    R: Serialize,
+    Header: FnOnce() + 'a,
+    Render: FnMut(&R) + 'a,
+{
+    Rows::new(current().serializes(), header, render)
+}
+
+/// Rows that leave one at a time: under a serializing backend each is one
+/// JSON line, otherwise a header goes out once before the first row.
+pub struct Rows<'a, R> {
+    serializes: bool,
+    printed: usize,
+    header: Option<Box<dyn FnOnce() + 'a>>,
+    render: Box<dyn FnMut(&R) + 'a>,
+}
+
+impl<'a, R: Serialize> Rows<'a, R> {
+    fn new(serializes: bool, header: impl FnOnce() + 'a, render: impl FnMut(&R) + 'a) -> Self {
+        Self {
+            serializes,
+            printed: 0,
+            header: Some(Box::new(header)),
+            render: Box::new(render),
+        }
+    }
+
+    pub fn push(&mut self, row: &R) {
+        if self.serializes {
+            let json = serde_json::to_string(row).expect("row serialization must not fail");
+            println!("{json}");
+        } else {
+            if let Some(header) = self.header.take() {
+                header();
+            }
+            (self.render)(row);
+        }
+
+        self.printed += 1;
+    }
+
+    /// Rows pushed so far.
+    pub fn printed(&self) -> usize {
+        self.printed
+    }
+
+    /// Closes the stream, reporting `message` when no row was pushed.
+    pub fn finish(self, message: Arguments) {
+        if self.printed == 0 {
+            empty(message);
+        }
+    }
+}
+
 /// Reports an empty result.
 ///
 /// Suppressed when the installed backend serializes — see
@@ -484,7 +540,42 @@ struct ErrorDetailJson<'a> {
 
 #[cfg(test)]
 mod test {
+    use core::cell::{Cell, RefCell};
+
     use super::*;
+
+    #[test]
+    fn test_rows_print_the_header_once_and_render_every_row_when_not_serializing() {
+        let headers = Cell::new(0);
+        let rendered = RefCell::new(Vec::new());
+        let mut rows = Rows::new(
+            false,
+            || headers.set(headers.get() + 1),
+            |row: &u8| rendered.borrow_mut().push(*row),
+        );
+
+        rows.push(&1);
+        rows.push(&2);
+
+        assert_eq!(2, rows.printed());
+        assert_eq!(1, headers.get());
+        assert_eq!(vec![1, 2], *rendered.borrow());
+    }
+
+    #[test]
+    fn test_rows_skip_the_header_and_the_renderer_when_serializing() {
+        let rendered = Cell::new(0);
+        let mut rows = Rows::new(
+            true,
+            || rendered.set(rendered.get() + 1),
+            |_: &u8| rendered.set(rendered.get() + 1),
+        );
+
+        rows.push(&1);
+
+        assert_eq!(1, rows.printed());
+        assert_eq!(0, rendered.get());
+    }
 
     /// Set on the re-invoked child process to select the direct-call branch
     /// below, instead of re-spawning itself again.

--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -317,7 +317,7 @@ impl FilterFlags {
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
     let mut service = Balancer2Service::connect(&cmd.globals.connection, action).await?;
-    service.handle(cmd.mode, cmd.globals.format).await
+    service.handle(cmd.mode).await
 }
 
 fn main() -> std::process::ExitCode {

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -7,8 +7,7 @@ use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     display::print_names_with_hint,
     errors::Error,
-    output::{self, CommonFormat},
-    yaml,
+    output, yaml,
 };
 
 use crate::{
@@ -44,7 +43,7 @@ impl Balancer2Service {
         Ok(Self { service })
     }
 
-    pub async fn handle(&mut self, mode: ModeCmd, format: CommonFormat) -> Result<(), Error> {
+    pub async fn handle(&mut self, mode: ModeCmd) -> Result<(), Error> {
         match mode {
             ModeCmd::Update(cmd) => self.update(cmd).await,
             ModeCmd::List => self.list().await,
@@ -52,7 +51,7 @@ impl Balancer2Service {
             ModeCmd::Show(cmd) => self.show(cmd).await,
             ModeCmd::Sessions(cmd) => match cmd.mode {
                 SessionsMode::List => self.sessions_list().await,
-                SessionsMode::Show(cmd) => self.sessions_show(cmd, format).await,
+                SessionsMode::Show(cmd) => self.sessions_show(cmd).await,
                 SessionsMode::Update(cmd) => self.sessions_update(cmd).await,
             },
             ModeCmd::Metrics(cmd) => self.metrics(cmd).await,
@@ -211,7 +210,7 @@ impl Balancer2Service {
         Ok(())
     }
 
-    async fn sessions_show(&mut self, cmd: SessionsShowCmd, format: CommonFormat) -> Result<(), Error> {
+    async fn sessions_show(&mut self, cmd: SessionsShowCmd) -> Result<(), Error> {
         let name = cmd.name.clone();
         let request = ListSessionsRequest {
             sessions_state_name: cmd.name,
@@ -231,32 +230,15 @@ impl Balancer2Service {
             .duration_since(time::UNIX_EPOCH)
             .expect("system clock before UNIX epoch")
             .as_secs() as i64;
-        let mut printed = 0usize;
-        // Deferred until the first session actually arrives, so a zero-session
-        // result does not print a header row over an empty table.
-        let mut header_printed = false;
+        let mut rows = output::rows(display::print_sessions_header, |session| {
+            display::print_session(session, now)
+        });
 
         while let Some(session) = stream.message().await.map_err(self.service.status("sessions show"))? {
-            match format {
-                CommonFormat::Human => {
-                    if !header_printed {
-                        display::print_sessions_header();
-                        header_printed = true;
-                    }
-
-                    display::print_session(&session, now);
-                }
-                CommonFormat::Json => println!(
-                    "{}",
-                    serde_json::to_string(&session).expect("balancer session JSON serialization must not fail")
-                ),
-            }
-            printed += 1;
+            rows.push(&session);
         }
 
-        if printed == 0 {
-            output::empty(format_args!("No sessions found for '{name}'."));
-        }
+        rows.finish(format_args!("No sessions found for '{name}'."));
 
         Ok(())
     }

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -15,7 +15,7 @@ use ync::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
     completion, display,
     errors::Error,
-    output::{self, CommonFormat},
+    output,
 };
 
 mod args;
@@ -49,41 +49,20 @@ pub struct FWStateMapService {
     service: Service<FwStateMapServiceClient<LayeredChannel>>,
 }
 
-/// State an `entries` dump carries across its batches.
-struct DumpState {
-    /// Entries printed so far, which `--count` limits.
-    printed: u32,
-    /// Whether the human-readable header row is already out. Deferred until
-    /// the first entry arrives, so a zero-entry result prints no header.
-    header_printed: bool,
-    /// Map generation the last response reported.
-    generation: Option<u64>,
-}
-
-impl DumpState {
-    fn new() -> Self {
-        Self {
-            printed: 0,
-            header_printed: false,
-            generation: None,
-        }
-    }
-
-    /// Warns when a response reports a different generation than the one
-    /// before it.
-    ///
-    /// A bump means layers were relinked, so the cursor and `--layer` stop
-    /// denoting what they did when the dump began, and the remaining
-    /// entries can repeat or be missed. Rows already printed were accurate
-    /// when read, so the dump goes on and only warns.
-    fn note_generation(&mut self, generation: u64) {
-        match self.generation.replace(generation) {
-            Some(previous) if previous != generation => log::warn!(
-                "fwstate-map changed mid-dump (generation {previous} -> {generation}): \
-                 entries may repeat or be missed"
-            ),
-            _ => {}
-        }
+/// Warns when a response reports a different generation than the one
+/// before it, `seen` carrying the last one across the batches.
+///
+/// A bump means layers were relinked, so the cursor and `--layer` stop
+/// denoting what they did when the dump began, and the remaining
+/// entries can repeat or be missed. Rows already printed were accurate
+/// when read, so the dump goes on and only warns.
+fn note_generation(seen: &mut Option<u64>, generation: u64) {
+    match seen.replace(generation) {
+        Some(previous) if previous != generation => log::warn!(
+            "fwstate-map changed mid-dump (generation {previous} -> {generation}): \
+             entries may repeat or be missed"
+        ),
+        _ => {}
     }
 }
 
@@ -230,14 +209,15 @@ impl FWStateMapService {
         Ok(())
     }
 
-    pub async fn map_entries(&mut self, cmd: EntriesCmd, format: CommonFormat) -> Result<(), Error> {
+    pub async fn map_entries(&mut self, cmd: EntriesCmd) -> Result<(), Error> {
         let direction = match cmd.direction {
             DirectionArg::Forward => Direction::Forward,
             DirectionArg::Backward => Direction::Backward,
         };
 
-        let limit = cmd.count;
-        let mut state = DumpState::new();
+        let limit = usize::try_from(cmd.count).expect("a count fits usize");
+        let mut generation = None;
+        let mut rows = output::rows(print_entries_header, print_entry);
 
         // Plain cursor pagination: each request carries the full cursor
         // and the response's index feeds the next call until has_more is
@@ -263,48 +243,26 @@ impl FWStateMapService {
                 )
                 .await?;
 
-            state.note_generation(resp.generation);
+            note_generation(&mut generation, resp.generation);
 
             for entry in &resp.entries {
-                if limit > 0 && state.printed >= limit {
+                if limit > 0 && rows.printed() >= limit {
                     break;
                 }
 
-                match format {
-                    CommonFormat::Human => {
-                        if !state.header_printed {
-                            println!(
-                                "{:<6} {:<48} {:<48} {:<8} {:<9} {:<7}",
-                                "IDX", "SRC", "DST", "PROTO", "FLAGS S|D", "EXPRD"
-                            );
-                            state.header_printed = true;
-                        }
-
-                        print_entry(entry);
-                    }
-                    CommonFormat::Json => {
-                        println!(
-                            "{}",
-                            serde_json::to_string(entry).expect("fwstate-map entry JSON serialization must not fail")
-                        );
-                    }
-                }
-
-                state.printed += 1;
+                rows.push(entry);
             }
 
-            if (limit > 0 && state.printed >= limit) || !resp.has_more {
+            if (limit > 0 && rows.printed() >= limit) || !resp.has_more {
                 break;
             }
             index = resp.index;
         }
 
-        if state.printed == 0 {
-            output::empty(format_args!(
-                "No firewall state entries found for map '{}'.",
-                cmd.map_name
-            ));
-        }
+        rows.finish(format_args!(
+            "No firewall state entries found for map '{}'.",
+            cmd.map_name
+        ));
 
         Ok(())
     }
@@ -395,6 +353,13 @@ impl fmt::Display for FwStateFlags {
     }
 }
 
+fn print_entries_header() {
+    println!(
+        "{:<6} {:<48} {:<48} {:<8} {:<9} {:<7}",
+        "IDX", "SRC", "DST", "PROTO", "FLAGS S|D", "EXPRD"
+    );
+}
+
 fn print_entry(entry: &fwstatemappb::FwStateEntry) {
     let (src, dst, proto) = match &entry.key {
         Some(key) => (
@@ -421,14 +386,13 @@ fn print_entry(entry: &fwstatemappb::FwStateEntry) {
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
     let mut service = FWStateMapService::new(&cmd.globals.connection, action).await?;
-    let format = cmd.globals.format;
 
     match cmd.mode {
         ModeCmd::List => service.map_list(args::ListCmd).await,
         ModeCmd::Create(cmd) => service.map_create(cmd).await,
         ModeCmd::Delete(cmd) => service.map_delete(cmd).await,
         ModeCmd::Stats(cmd) => service.map_stats(cmd).await,
-        ModeCmd::Entries(cmd) => service.map_entries(cmd, format).await,
+        ModeCmd::Entries(cmd) => service.map_entries(cmd).await,
         ModeCmd::InsertLayer(cmd) => service.map_insert_layer(cmd).await,
     }
 }


### PR DESCRIPTION
- Adds `output::rows`, which prints each row as one JSON line under `--format json` and otherwise a header once before the first row, reporting an empty result at the end.
- Balancer2 session listing and fwstate-map entry dumps use it instead of their own per-row format switches, so neither command threads the output format through its handlers any more.