### PR TITLE
refactor(cli): turn the service wrappers into handler functions

### DIFF
--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -30,8 +30,11 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   `ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)`. The scaffold
   owns completion before Tokio, parsing, output initialisation, the
   current-thread runtime, error rendering and the process status.
-- `run(cmd)` determines the action, builds the service object once and matches
-  `cmd.mode`; every handler returns `Result<(), Error>`.
+- `run(cmd)` determines the action, connects the service once and matches
+  `cmd.mode` onto the handlers: free functions taking `&mut <X>Service`,
+  where `type <X>Service = Service<<X>ServiceClient<LayeredChannel>>`, each
+  returning `Result<(), Error>`. A crate talking to several services keeps
+  a local struct holding them.
 - `const SERVICE_NAME: &str = "<proto package>.<Service>";` with the doc
   `/// The fully-qualified gRPC service name used in error messages.`. A crate
   that builds its client at a single site keeps the builder inline:
@@ -50,11 +53,11 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   `cmd.globals.connection.endpoint` itself. A pre-connect error label comes from
   `client::resolve_label`, a post-connect one from `Service::endpoint()` /
   `Connection::endpoint()`.
-- Every unary RPC of a command handler: `self.service.unary("<verb>",
+- Every unary RPC of a command handler: `service.unary("<verb>",
   request, async |client, request| client.<rpc>(request).await).await?`; a
   mapper other than `status` goes through `unary_with("<verb>", request,
-  mapper, call)`. A streaming RPC keeps `self.service.client().<rpc>(request)
-  .await.map_err(self.service.status("<verb>"))?.into_inner()`, and a
+  mapper, call)`. A streaming RPC keeps `service.client().<rpc>(request)
+  .await.map_err(service.status("<verb>"))?.into_inner()`, and a
   completion lookup calls the raw client it is handed.
 - Generated code: `#[allow(clippy::std_instead_of_core, non_snake_case)]
   pub mod <x>pb { tonic::include_proto!("…"); }`; shared protos come
@@ -82,7 +85,7 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   <path>`) or a filter pattern (`counters [PATTERN]…`); everything else
   is a flag. A file never has a flag. A YAML file positional loads with
   `ync::yaml::load::<T>(&path)`, its error already naming the path, mapped
-  with `self.service.invalid("<verb>", err.to_string())`; no private `load`
+  with `service.invalid("<verb>", err.to_string())`; no private `load`
   that opens and parses on its own.
 - Flags: `--name/-n` names the object the binary manages (a config, a map,
   a sessions state) and nothing else; `-4/-6` family filters, mutually
@@ -154,9 +157,9 @@ no `--yes`, no `--dry-run`.
   or RPC error, 2 usage (clap), 3 not found or service not registered, 4
   connection or unavailable. No command invents a code (`ready`'s 2 for
   "not ready" is legacy until #2354).
-- A local rejection is `self.service.invalid("<verb>", message)` or
+- A local rejection is `service.invalid("<verb>", message)` or
   `Error::invalid_argument(verb, endpoint, message)`; a command addressing an
-  existing object passes `self.service.not_found("<verb>", "<resource>")` as
+  existing object passes `service.not_found("<verb>", "<resource>")` as
   the mapper of `unary_with`, so a missing object reads `<resource> not found`
   and exits 3. Hints via `.with_hint(…)`.
 

--- a/.agents/skills/code-cli/references/new-crate.md
+++ b/.agents/skills/code-cli/references/new-crate.md
@@ -101,7 +101,7 @@ use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion,
     display::print_table_from_entries,
     errors::Error,
@@ -191,110 +191,98 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = <X>Service::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Show(args) => service.show_config(args).await,
-        ModeCmd::Update(args) => service.update_config(args).await,
-        ModeCmd::Delete(args) => service.delete_config(args).await,
+        ModeCmd::List => list_configs(&mut service).await,
+        ModeCmd::Show(args) => show_config(&mut service, args).await,
+        ModeCmd::Update(args) => update_config(&mut service, args).await,
+        ModeCmd::Delete(args) => delete_config(&mut service, args).await,
     }
 }
 
-pub struct <X>Service {
-    service: Service<<X>ServiceClient<LayeredChannel>>,
+type <X>Service = Service<<X>ServiceClient<LayeredChannel>>;
+
+async fn list_configs(service: &mut <X>Service) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
+
+    output::data(
+        || &response.configs,
+        || {
+            if response.configs.is_empty() {
+                output::empty_with_hint(
+                    format_args!("No configs found."),
+                    format_args!("create one with 'yanet-cli-<suffix> update --name <name> …'"),
+                );
+                return;
+            }
+
+            let mut entries: Vec<&Config> = response.configs.iter().collect();
+            entries.sort_by(|a, b| a.name.cmp(&b.name));
+            print_table_from_entries(entries);
+        },
+    );
+
+    Ok(())
 }
 
-impl <X>Service {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn show_config(service: &mut <X>Service, cmd: ShowCmd) -> Result<(), Error> {
+    let request = ShowConfigRequest { name: cmd.config_name.clone() };
 
-        Ok(Self { service })
-    }
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.show_config(request).await,
+        )
+        .await?;
 
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
+    output::data(
+        || &response,
+        || {
+            println!("name:     {}", response.name);
+            println!("prefixes: {}", response.prefixes.len());
+        },
+    );
 
-        output::data(
-            || &response.configs,
-            || {
-                if response.configs.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No configs found."),
-                        format_args!("create one with 'yanet-cli-<suffix> update --name <name> …'"),
-                    );
-                    return;
-                }
+    Ok(())
+}
 
-                let mut entries: Vec<&Config> = response.configs.iter().collect();
-                entries.sort_by(|a, b| a.name.cmp(&b.name));
-                print_table_from_entries(entries);
-            },
-        );
+async fn update_config(service: &mut <X>Service, cmd: UpdateCmd) -> Result<(), Error> {
+    let request = UpdateConfigRequest {
+        name: cmd.config_name.clone(),
+        prefixes: cmd.prefixes.iter().map(|prefix| prefix.clone().into()).collect(),
+    };
 
-        Ok(())
-    }
+    service
+        .unary("update", request, async |client, request| client.update_config(request).await)
+        .await?;
 
-    pub async fn show_config(&mut self, cmd: ShowCmd) -> Result<(), Error> {
-        let request = ShowConfigRequest { name: cmd.config_name.clone() };
+    output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.show_config(request).await,
-            )
-            .await?;
+    Ok(())
+}
 
-        output::data(
-            || &response,
-            || {
-                println!("name:     {}", response.name);
-                println!("prefixes: {}", response.prefixes.len());
-            },
-        );
+async fn delete_config(service: &mut <X>Service, cmd: DeleteCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config_name.clone() };
 
-        Ok(())
-    }
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
 
-    pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let request = UpdateConfigRequest {
-            name: cmd.config_name.clone(),
-            prefixes: cmd.prefixes.iter().map(|prefix| prefix.clone().into()).collect(),
-        };
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
-        self.service
-            .unary("update", request, async |client, request| client.update_config(request).await)
-            .await?;
-
-        output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
-
-    pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service.not_found("delete", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.delete_config(request).await,
-            )
-            .await?;
-
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 impl Tabled for Config {
@@ -336,8 +324,8 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 
 Several services behind one binary:
 `Connection::connect_for(connection, action).await?` once, then
-`Service::new(&connection, NAME, build)` for each client, all kept in the
-service struct.
+`Service::new(&connection, NAME, build)` for each client, all kept in a
+local struct the handlers take instead of the alias.
 
 ## Registration
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,7 +3062,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tabled",
- "tokio",
  "tonic",
  "tonic-prost",
  "yanet-cli",

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -6,7 +6,7 @@ use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     errors::Error,
     metrics, output,
 };
@@ -119,11 +119,18 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.as_ref().map_or("show counters", ModeCmd::action);
-    let mut service = CountersService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, COUNTERS_SERVICE, |channel| {
+        CountersServiceClient::new(channel)
+            .max_decoding_message_size(256 * 1024 * 1024)
+            .max_encoding_message_size(256 * 1024 * 1024)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip)
+    })
+    .await?;
 
     match cmd.mode {
         Some(ModeCmd::Workers) => {
-            let response = service.workers().await?;
+            let response = workers(&mut service, action).await?;
             output::data(
                 || &response,
                 || {
@@ -132,7 +139,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
             );
         }
         Some(ModeCmd::Ports) => {
-            let response = service.ports().await?;
+            let response = ports(&mut service, action).await?;
             output::data(
                 || &response,
                 || {
@@ -148,7 +155,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
             );
         }
         None => {
-            let response = service.by_tags(cmd.by_tags.into()).await?;
+            let response = by_tags(&mut service, action, cmd.by_tags.into()).await?;
             output::data(
                 || &response,
                 || {
@@ -168,48 +175,32 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     Ok(())
 }
 
-pub struct CountersService {
-    service: Service<CountersServiceClient<LayeredChannel>>,
+type CountersService = Service<CountersServiceClient<LayeredChannel>>;
+
+async fn by_tags(
+    service: &mut CountersService,
     action: &'static str,
+    request: CountersByTagsRequest,
+) -> Result<CountersByTagsResponse, Error> {
+    service
+        .unary(action, request, async |client, request| client.by_tags(request).await)
+        .await
 }
 
-impl CountersService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, COUNTERS_SERVICE, |channel| {
-            CountersServiceClient::new(channel)
-                .max_decoding_message_size(256 * 1024 * 1024)
-                .max_encoding_message_size(256 * 1024 * 1024)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
+async fn workers(service: &mut CountersService, action: &'static str) -> Result<WorkerCountersResponse, Error> {
+    service
+        .unary(action, WorkerCountersRequest {}, async |client, request| {
+            client.workers(request).await
         })
-        .await?;
+        .await
+}
 
-        Ok(Self { service, action })
-    }
-
-    pub async fn by_tags(&mut self, request: CountersByTagsRequest) -> Result<CountersByTagsResponse, Error> {
-        self.service
-            .unary(self.action, request, async |client, request| {
-                client.by_tags(request).await
-            })
-            .await
-    }
-
-    pub async fn workers(&mut self) -> Result<WorkerCountersResponse, Error> {
-        self.service
-            .unary(self.action, WorkerCountersRequest {}, async |client, request| {
-                client.workers(request).await
-            })
-            .await
-    }
-
-    pub async fn ports(&mut self) -> Result<PortCountersResponse, Error> {
-        self.service
-            .unary(self.action, PortCountersRequest {}, async |client, request| {
-                client.ports(request).await
-            })
-            .await
-    }
+async fn ports(service: &mut CountersService, action: &'static str) -> Result<PortCountersResponse, Error> {
+    service
+        .unary(action, PortCountersRequest {}, async |client, request| {
+            client.ports(request).await
+        })
+        .await
 }
 
 /// A displayable summary row for one worker in the workers table.

--- a/cli/modules/device/src/main.rs
+++ b/cli/modules/device/src/main.rs
@@ -9,7 +9,7 @@ use colored::Colorize;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     errors::Error,
     output,
 };
@@ -31,40 +31,29 @@ fn main() -> std::process::ExitCode {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = DeviceService::new(&cmd.globals.connection).await?;
-    let response = service.list().await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, "device-list", DEVICE_SERVICE, |channel| {
+        DeviceServiceClient::new(channel)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip)
+    })
+    .await?;
+    let response = list(&mut service).await?;
 
     output::data(|| &response, || render(&response));
 
     Ok(())
 }
 
-pub struct DeviceService {
-    service: Service<DeviceServiceClient<LayeredChannel>>,
-}
+type DeviceService = Service<DeviceServiceClient<LayeredChannel>>;
 
-impl DeviceService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, "device-list", DEVICE_SERVICE, |channel| {
-            DeviceServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
+async fn list(service: &mut DeviceService) -> Result<ListDevicesResponse, Error> {
+    let response = service
+        .unary("device-list", ListDevicesRequest {}, async |client, request| {
+            client.list(request).await
         })
         .await?;
 
-        Ok(Self { service })
-    }
-
-    pub async fn list(&mut self) -> Result<ListDevicesResponse, Error> {
-        let response = self
-            .service
-            .unary("device-list", ListDevicesRequest {}, async |client, request| {
-                client.list(request).await
-            })
-            .await?;
-
-        Ok(response)
-    }
+    Ok(response)
 }
 
 fn render(response: &ListDevicesResponse) {

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -6,7 +6,7 @@ use commonpb::pb::FunctionId;
 use tonic::{Status, codec::CompressionEncoding};
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -91,11 +91,11 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = FunctionService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, FUNCTION_SERVICE, client).await?;
 
     match cmd.mode {
         ModeCmd::List => {
-            let ids = service.list_functions().await?;
+            let ids = list_functions(&mut service).await?;
             let names: Vec<String> = ids.iter().map(|id| id.name.clone()).collect();
             output::data(
                 || &ids,
@@ -103,7 +103,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
             );
         }
         ModeCmd::Show(show) => {
-            let function = service.get_function(&show.name).await?;
+            let function = get_function(&mut service, &show.name).await?;
             output::data(
                 || &function,
                 || {
@@ -125,12 +125,12 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         }
         ModeCmd::Update(update) => {
             let name = update.name.clone();
-            service.update_function(update).await?;
+            update_function(&mut service, update).await?;
             output::success("update function", format_args!("Updated function '{name}'."));
         }
         ModeCmd::Delete(delete) => {
             let name = delete.name.clone();
-            service.delete_function(delete).await?;
+            delete_function(&mut service, delete).await?;
             output::success("delete function", format_args!("Deleted function '{name}'."));
         }
     }
@@ -138,96 +138,84 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     Ok(())
 }
 
-pub struct FunctionService {
-    service: Service<FunctionServiceClient<LayeredChannel>>,
+type FunctionService = Service<FunctionServiceClient<LayeredChannel>>;
+
+async fn list_functions(service: &mut FunctionService) -> Result<Vec<FunctionId>, Error> {
+    let response = service
+        .unary_with(
+            "list functions",
+            ListFunctionsRequest {},
+            service.not_found("list functions", "requested function"),
+            async |client, request| client.list(request).await,
+        )
+        .await?;
+
+    Ok(response.ids)
 }
 
-impl FunctionService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, FUNCTION_SERVICE, client).await?;
+async fn get_function(service: &mut FunctionService, name: &str) -> Result<Function, Error> {
+    let request = GetFunctionRequest {
+        id: Some(FunctionId { name: name.to_string() }),
+    };
 
-        Ok(Self { service })
-    }
+    let response = service
+        .unary_with(
+            "show function",
+            request,
+            service.not_found("show function", &format!("function '{name}'")),
+            async |client, request| client.get(request).await,
+        )
+        .await?;
 
-    pub async fn list_functions(&mut self) -> Result<Vec<FunctionId>, Error> {
-        let response = self
-            .service
-            .unary_with(
-                "list functions",
-                ListFunctionsRequest {},
-                self.service.not_found("list functions", "requested function"),
-                async |client, request| client.list(request).await,
-            )
-            .await?;
+    let function = response.function.ok_or_else(|| {
+        Error::from_status(
+            Status::not_found(format!("function '{name}' not found")),
+            "show function",
+            service.endpoint(),
+            FUNCTION_SERVICE,
+        )
+    })?;
 
-        Ok(response.ids)
-    }
+    Ok(function)
+}
 
-    pub async fn get_function(&mut self, name: &str) -> Result<Function, Error> {
-        let request = GetFunctionRequest {
-            id: Some(FunctionId { name: name.to_string() }),
-        };
+async fn update_function(service: &mut FunctionService, cmd: UpdateCmd) -> Result<(), Error> {
+    let request = UpdateFunctionRequest {
+        function: Some(Function {
+            id: Some(FunctionId { name: cmd.name.clone() }),
+            chains: cmd.chains,
+        }),
+    };
 
-        let response = self
-            .service
-            .unary_with(
-                "show function",
-                request,
-                self.service.not_found("show function", &format!("function '{name}'")),
-                async |client, request| client.get(request).await,
-            )
-            .await?;
+    // Update is an upsert, so a chain module the live configuration cannot
+    // resolve is a failed precondition, never a missing function.
+    //
+    // The backend message is kept verbatim.
+    service
+        .unary("update function", request, async |client, request| {
+            client.update(request).await
+        })
+        .await?;
 
-        let function = response.function.ok_or_else(|| {
-            Error::from_status(
-                Status::not_found(format!("function '{name}' not found")),
-                "show function",
-                self.service.endpoint(),
-                FUNCTION_SERVICE,
-            )
-        })?;
+    Ok(())
+}
 
-        Ok(function)
-    }
+async fn delete_function(service: &mut FunctionService, cmd: DeleteCmd) -> Result<(), Error> {
+    let name = cmd.name;
 
-    pub async fn update_function(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let request = UpdateFunctionRequest {
-            function: Some(Function {
-                id: Some(FunctionId { name: cmd.name.clone() }),
-                chains: cmd.chains,
-            }),
-        };
+    let request = DeleteFunctionRequest {
+        id: Some(FunctionId { name: name.clone() }),
+    };
+    service
+        .unary_with(
+            "delete function",
+            request,
+            service.not_found("delete function", &format!("function '{name}'")),
+            async |client, request| client.delete(request).await,
+        )
+        .await?;
 
-        // Update is an upsert, so a chain module the live configuration cannot
-        // resolve is a failed precondition, never a missing function.
-        //
-        // The backend message is kept verbatim.
-        self.service
-            .unary("update function", request, async |client, request| {
-                client.update(request).await
-            })
-            .await?;
-
-        Ok(())
-    }
-
-    pub async fn delete_function(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
-        let name = cmd.name;
-
-        let request = DeleteFunctionRequest {
-            id: Some(FunctionId { name: name.clone() }),
-        };
-        self.service
-            .unary_with(
-                "delete function",
-                request,
-                self.service.not_found("delete function", &format!("function '{name}'")),
-                async |client, request| client.delete(request).await,
-            )
-            .await?;
-
-        Ok(())
-    }
+    Ok(())
 }
 
 /// Completion candidates for a `--name` argument: the functions the module

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -7,7 +7,7 @@ use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     errors::Error,
     humanfmt, output,
 };
@@ -37,53 +37,42 @@ fn main() -> std::process::ExitCode {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = GatewayService::new(&cmd.globals.connection).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, "gateway", GATEWAY_SERVICE, |channel| {
+        GatewayClient::new(channel)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip)
+    })
+    .await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_services().await,
+        ModeCmd::List => list_services(&mut service).await,
     }
 }
 
-pub struct GatewayService {
-    service: Service<GatewayClient<LayeredChannel>>,
-}
+type GatewayService = Service<GatewayClient<LayeredChannel>>;
 
-impl GatewayService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, "gateway", GATEWAY_SERVICE, |channel| {
-            GatewayClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
+async fn list_services(service: &mut GatewayService) -> Result<(), Error> {
+    let response = service
+        .unary("gateway", ListServicesRequest {}, async |client, request| {
+            client.list_services(request).await
         })
         .await?;
 
-        Ok(Self { service })
-    }
+    output::data(
+        || &response.services,
+        || {
+            let rows: Vec<ServiceRow> = response.services.iter().map(ServiceRow::from).collect();
 
-    pub async fn list_services(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("gateway", ListServicesRequest {}, async |client, request| {
-                client.list_services(request).await
-            })
-            .await?;
+            if rows.is_empty() {
+                output::empty(format_args!("No services registered."));
+                return;
+            }
 
-        output::data(
-            || &response.services,
-            || {
-                let rows: Vec<ServiceRow> = response.services.iter().map(ServiceRow::from).collect();
+            ync::display::print_table_from_entries(&rows);
+        },
+    );
 
-                if rows.is_empty() {
-                    output::empty(format_args!("No services registered."));
-                    return;
-                }
-
-                ync::display::print_table_from_entries(&rows);
-            },
-        );
-
-        Ok(())
-    }
+    Ok(())
 }
 
 /// A displayable row for the gateway services table.

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     errors::Error,
     output,
 };
@@ -33,38 +33,27 @@ fn main() -> std::process::ExitCode {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let mut service = InspectService::new(&cmd.globals.connection).await?;
-    let response = service.inspect().await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, "inspect", INSPECT_SERVICE, |channel| {
+        InspectServiceClient::new(channel)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip)
+    })
+    .await?;
+    let response = inspect(&mut service).await?;
 
     output::data(|| &response, || report::render(&response, cmd.memory));
 
     Ok(())
 }
 
-pub struct InspectService {
-    service: Service<InspectServiceClient<LayeredChannel>>,
-}
+type InspectService = Service<InspectServiceClient<LayeredChannel>>;
 
-impl InspectService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, "inspect", INSPECT_SERVICE, |channel| {
-            InspectServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
+async fn inspect(service: &mut InspectService) -> Result<InspectResponse, Error> {
+    let response = service
+        .unary("inspect", InspectRequest {}, async |client, request| {
+            client.inspect(request).await
         })
         .await?;
 
-        Ok(Self { service })
-    }
-
-    pub async fn inspect(&mut self) -> Result<InspectResponse, Error> {
-        let response = self
-            .service
-            .unary("inspect", InspectRequest {}, async |client, request| {
-                client.inspect(request).await
-            })
-            .await?;
-
-        Ok(response)
-    }
+    Ok(response)
 }

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -6,7 +6,7 @@ use commonpb::pb::{FunctionId, PipelineId};
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -89,11 +89,11 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = PipelineService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, PIPELINE_SERVICE, client).await?;
 
     match cmd.mode {
         ModeCmd::List => {
-            let ids = service.list_pipelines().await?;
+            let ids = list_pipelines(&mut service, action).await?;
             let names: Vec<String> = ids.iter().map(|id| id.name.clone()).collect();
             output::data(
                 || &ids,
@@ -101,7 +101,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
             );
         }
         ModeCmd::Show(show) => {
-            let pipeline = service.get_pipeline(&show.name).await?;
+            let pipeline = get_pipeline(&mut service, action, &show.name).await?;
             output::data(
                 || &pipeline,
                 || {
@@ -123,12 +123,12 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         }
         ModeCmd::Update(update) => {
             let name = update.name.clone();
-            service.update_pipeline(update).await?;
+            update_pipeline(&mut service, action, update).await?;
             output::success(action, format_args!("Updated pipeline '{name}'."));
         }
         ModeCmd::Delete(delete) => {
             let name = delete.name.clone();
-            service.delete_pipeline(delete).await?;
+            delete_pipeline(&mut service, action, delete).await?;
             output::success(action, format_args!("Deleted pipeline '{name}'."));
         }
     }
@@ -136,101 +136,86 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     Ok(())
 }
 
-pub struct PipelineService {
-    service: Service<PipelineServiceClient<LayeredChannel>>,
-    action: &'static str,
+type PipelineService = Service<PipelineServiceClient<LayeredChannel>>;
+
+async fn list_pipelines(service: &mut PipelineService, action: &'static str) -> Result<Vec<PipelineId>, Error> {
+    let response = service
+        .unary_with(
+            action,
+            ListPipelinesRequest {},
+            service.not_found(action, "pipeline service"),
+            async |client, request| client.list(request).await,
+        )
+        .await?;
+
+    Ok(response.ids)
 }
 
-impl PipelineService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, PIPELINE_SERVICE, client).await?;
+async fn get_pipeline(service: &mut PipelineService, action: &'static str, name: &str) -> Result<Pipeline, Error> {
+    let request = GetPipelineRequest {
+        id: Some(PipelineId { name: name.to_string() }),
+    };
+    let response = service
+        .unary_with(
+            action,
+            request,
+            service.not_found(action, &format!("pipeline '{name}'")),
+            async |client, request| client.get(request).await,
+        )
+        .await?;
 
-        Ok(Self { service, action })
-    }
+    let pipeline = response.pipeline.ok_or_else(|| {
+        Error::from_status(
+            tonic::Status::not_found(format!("pipeline {name} not found")),
+            action,
+            service.endpoint(),
+            PIPELINE_SERVICE,
+        )
+    })?;
 
-    pub async fn list_pipelines(&mut self) -> Result<Vec<PipelineId>, Error> {
-        let response = self
-            .service
-            .unary_with(
-                self.action,
-                ListPipelinesRequest {},
-                self.service.not_found(self.action, "pipeline service"),
-                async |client, request| client.list(request).await,
-            )
-            .await?;
+    Ok(pipeline)
+}
 
-        Ok(response.ids)
-    }
+async fn update_pipeline(service: &mut PipelineService, action: &'static str, cmd: UpdateCmd) -> Result<(), Error> {
+    let pipeline_name = cmd.name;
+    let request = UpdatePipelineRequest {
+        pipeline: Some(Pipeline {
+            id: Some(PipelineId { name: pipeline_name.clone() }),
+            functions: cmd
+                .functions
+                .into_iter()
+                .map(|m| FunctionId { name: m.to_string() })
+                .collect(),
+        }),
+    };
 
-    pub async fn get_pipeline(&mut self, name: &str) -> Result<Pipeline, Error> {
-        let request = GetPipelineRequest {
-            id: Some(PipelineId { name: name.to_string() }),
-        };
-        let response = self
-            .service
-            .unary_with(
-                self.action,
-                request,
-                self.service.not_found(self.action, &format!("pipeline '{name}'")),
-                async |client, request| client.get(request).await,
-            )
-            .await?;
+    // Update is an upsert, so a referenced function the live configuration
+    // cannot resolve is a failed precondition, never a missing pipeline.
+    //
+    // The backend message is kept verbatim.
+    service
+        .unary(action, request, async |client, request| client.update(request).await)
+        .await?;
 
-        let pipeline = response.pipeline.ok_or_else(|| {
-            Error::from_status(
-                tonic::Status::not_found(format!("pipeline {name} not found")),
-                self.action,
-                self.service.endpoint(),
-                PIPELINE_SERVICE,
-            )
-        })?;
+    Ok(())
+}
 
-        Ok(pipeline)
-    }
+async fn delete_pipeline(service: &mut PipelineService, action: &'static str, cmd: DeleteCmd) -> Result<(), Error> {
+    let request = DeletePipelineRequest {
+        id: Some(PipelineId { name: cmd.name }),
+    };
 
-    pub async fn update_pipeline(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let pipeline_name = cmd.name;
-        let request = UpdatePipelineRequest {
-            pipeline: Some(Pipeline {
-                id: Some(PipelineId { name: pipeline_name.clone() }),
-                functions: cmd
-                    .functions
-                    .into_iter()
-                    .map(|m| FunctionId { name: m.to_string() })
-                    .collect(),
-            }),
-        };
+    let name = request.id.as_ref().expect("pipeline id").name.clone();
+    service
+        .unary_with(
+            action,
+            request,
+            service.not_found(action, &format!("pipeline '{name}'")),
+            async |client, request| client.delete(request).await,
+        )
+        .await?;
 
-        // Update is an upsert, so a referenced function the live configuration
-        // cannot resolve is a failed precondition, never a missing pipeline.
-        //
-        // The backend message is kept verbatim.
-        self.service
-            .unary(self.action, request, async |client, request| {
-                client.update(request).await
-            })
-            .await?;
-
-        Ok(())
-    }
-
-    pub async fn delete_pipeline(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
-        let request = DeletePipelineRequest {
-            id: Some(PipelineId { name: cmd.name }),
-        };
-
-        let name = request.id.as_ref().expect("pipeline id").name.clone();
-        self.service
-            .unary_with(
-                self.action,
-                request,
-                self.service.not_found(self.action, &format!("pipeline '{name}'")),
-                async |client, request| client.delete(request).await,
-            )
-            .await?;
-
-        Ok(())
-    }
+    Ok(())
 }
 
 /// Completion candidates for a `--name` argument: the pipelines the module

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -10,7 +10,7 @@ use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -73,83 +73,72 @@ pub struct UpdateCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "devices.plain.controlplane.plainpb.v1.DevicePlainService";
 
-pub struct DevicePlainService {
-    service: Service<DevicePlainServiceClient<LayeredChannel>>,
+type DevicePlainService = Service<DevicePlainServiceClient<LayeredChannel>>;
+
+async fn show_device(service: &mut DevicePlainService, cmd: ShowCmd) -> Result<(), Error> {
+    let name = cmd.name;
+    let request = ShowDevicePlainRequest { name: name.clone() };
+
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("plain device '{name}'")),
+            async |client, request| client.show_device(request).await,
+        )
+        .await?;
+
+    output::data(
+        || &response,
+        || {
+            let rows = response.device.as_ref().map(binding_rows).unwrap_or_default();
+
+            if rows.is_empty() {
+                output::empty_with_hint(
+                    format_args!("No pipeline bindings found for '{name}'."),
+                    format_args!(
+                        "bind one with 'yanet-cli device plain update -n <name> -i <pipeline:weight> -o <pipeline:weight>'"
+                    ),
+                );
+                return;
+            }
+
+            display::print_table_from_entries(rows);
+        },
+    );
+
+    Ok(())
 }
 
-impl DevicePlainService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            DevicePlainServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
+async fn update_config(service: &mut DevicePlainService, cmd: UpdateCmd) -> Result<(), Error> {
+    let request = UpdateDevicePlainRequest {
+        name: cmd.name.clone(),
+        device: Some(Device { input: cmd.input, output: cmd.output }),
+    };
+
+    service
+        .unary("update", request, async |client, request| {
+            client.update_device(request).await
         })
         .await?;
 
-        Ok(Self { service })
-    }
+    output::success("update", format_args!("Updated device '{}'.", cmd.name));
 
-    pub async fn show_device(&mut self, cmd: ShowCmd) -> Result<(), Error> {
-        let name = cmd.name;
-        let request = ShowDevicePlainRequest { name: name.clone() };
-
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("plain device '{name}'")),
-                async |client, request| client.show_device(request).await,
-            )
-            .await?;
-
-        output::data(
-            || &response,
-            || {
-                let rows = response.device.as_ref().map(binding_rows).unwrap_or_default();
-
-                if rows.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No pipeline bindings found for '{name}'."),
-                        format_args!(
-                            "bind one with 'yanet-cli device plain update -n <name> -i <pipeline:weight> -o <pipeline:weight>'"
-                        ),
-                    );
-                    return;
-                }
-
-                display::print_table_from_entries(rows);
-            },
-        );
-
-        Ok(())
-    }
-
-    pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let request = UpdateDevicePlainRequest {
-            name: cmd.name.clone(),
-            device: Some(Device { input: cmd.input, output: cmd.output }),
-        };
-
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_device(request).await
-            })
-            .await?;
-
-        output::success("update", format_args!("Updated device '{}'.", cmd.name));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = DevicePlainService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, |channel| {
+        DevicePlainServiceClient::new(channel)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip)
+    })
+    .await?;
 
     match cmd.mode {
-        ModeCmd::Show(cmd) => service.show_device(cmd).await,
-        ModeCmd::Update(cmd) => service.update_config(cmd).await,
+        ModeCmd::Show(cmd) => show_device(&mut service, cmd).await,
+        ModeCmd::Update(cmd) => update_config(&mut service, cmd).await,
     }
 }
 

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -10,7 +10,7 @@ use trafgenpb::{
 };
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -109,131 +109,117 @@ fn client(channel: LayeredChannel) -> TrafgenServiceClient<LayeredChannel> {
         .accept_compressed(CompressionEncoding::Gzip)
 }
 
-pub struct TrafgenService {
-    service: Service<TrafgenServiceClient<LayeredChannel>>,
+type TrafgenService = Service<TrafgenServiceClient<LayeredChannel>>;
+
+async fn update_device(service: &mut TrafgenService, cmd: UpdateCmd) -> Result<(), Error> {
+    let request = UpdateDeviceRequest {
+        name: cmd.config_name.clone(),
+        device: Some(Device { input: cmd.input, output: cmd.output }),
+    };
+    service
+        .unary("update", request, async |client, request| {
+            client.update_device(request).await
+        })
+        .await?;
+
+    output::success("update", format_args!("Updated device '{}'.", cmd.config_name));
+
+    Ok(())
 }
 
-impl TrafgenService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn list_configs(service: &mut TrafgenService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
 
-        Ok(Self { service })
-    }
-
-    pub async fn update_device(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let request = UpdateDeviceRequest {
-            name: cmd.config_name.clone(),
-            device: Some(Device { input: cmd.input, output: cmd.output }),
-        };
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_device(request).await
-            })
-            .await?;
-
-        output::success("update", format_args!("Updated device '{}'.", cmd.config_name));
-
-        Ok(())
-    }
-
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
-
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No trafgen configurations found."),
-                    format_args!(
-                        "create one with 'yanet-cli-device-trafgen update --name <name> --input <pipeline:weight> --output <pipeline:weight>'"
-                    ),
-                )
-            },
-        );
-
-        Ok(())
-    }
-
-    pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
-        let request = ShowConfigRequest { name: cmd.config_name.clone() };
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("device '{}'", cmd.config_name)),
-                async |client, request| client.show_config(request).await,
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No trafgen configurations found."),
+                format_args!(
+                    "create one with 'yanet-cli-device-trafgen update --name <name> --input <pipeline:weight> --output <pipeline:weight>'"
+                ),
             )
-            .await?;
+        },
+    );
 
-        output::data(
-            || &response,
-            || {
-                display::KeyValue::new()
-                    .row("rate (pps)", response.rate_pps)
-                    .row("frame count", response.frame_count)
-                    .row("total bytes", response.total_bytes)
-                    .print()
-            },
-        );
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn show_config(service: &mut TrafgenService, cmd: ShowConfigCmd) -> Result<(), Error> {
+    let request = ShowConfigRequest { name: cmd.config_name.clone() };
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("device '{}'", cmd.config_name)),
+            async |client, request| client.show_config(request).await,
+        )
+        .await?;
 
-    pub async fn upload_pcap(&mut self, cmd: UploadPcapCmd) -> Result<(), Error> {
-        let pcap = std::fs::read(&cmd.pcap).map_err(|err| {
-            self.service
-                .invalid("upload", format!("failed to read pcap {}: {err}", cmd.pcap.display()))
-        })?;
+    output::data(
+        || &response,
+        || {
+            display::KeyValue::new()
+                .row("rate (pps)", response.rate_pps)
+                .row("frame count", response.frame_count)
+                .row("total bytes", response.total_bytes)
+                .print()
+        },
+    );
 
-        // The capture itself must never reach the log, so the upload
-        // bypasses the logged call path.
-        let request = UploadPcapRequest { name: cmd.config_name.clone(), pcap };
-        self.service
-            .client()
-            .upload_pcap(request)
-            .await
-            .map_err(self.service.status("upload"))?;
+    Ok(())
+}
 
-        output::success("upload", format_args!("Uploaded pcap to device '{}'.", cmd.config_name));
+async fn upload_pcap(service: &mut TrafgenService, cmd: UploadPcapCmd) -> Result<(), Error> {
+    let pcap = std::fs::read(&cmd.pcap)
+        .map_err(|err| service.invalid("upload", format!("failed to read pcap {}: {err}", cmd.pcap.display())))?;
 
-        Ok(())
-    }
+    // The capture itself must never reach the log, so the upload
+    // bypasses the logged call path.
+    let request = UploadPcapRequest { name: cmd.config_name.clone(), pcap };
+    service
+        .client()
+        .upload_pcap(request)
+        .await
+        .map_err(service.status("upload"))?;
 
-    pub async fn set_rate(&mut self, cmd: SetRateCmd) -> Result<(), Error> {
-        let request = SetRateRequest {
-            name: cmd.config_name.clone(),
-            rate_pps: cmd.rate,
-        };
-        self.service
-            .unary("rate", request, async |client, request| client.set_rate(request).await)
-            .await?;
+    output::success("upload", format_args!("Uploaded pcap to device '{}'.", cmd.config_name));
 
-        output::success(
-            "rate",
-            format_args!("Set rate on device '{}' to {} pps.", cmd.config_name, cmd.rate),
-        );
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn set_rate(service: &mut TrafgenService, cmd: SetRateCmd) -> Result<(), Error> {
+    let request = SetRateRequest {
+        name: cmd.config_name.clone(),
+        rate_pps: cmd.rate,
+    };
+    service
+        .unary("rate", request, async |client, request| client.set_rate(request).await)
+        .await?;
+
+    output::success(
+        "rate",
+        format_args!("Set rate on device '{}' to {} pps.", cmd.config_name, cmd.rate),
+    );
+
+    Ok(())
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = TrafgenService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::Update(cmd) => service.update_device(cmd).await,
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::Upload(cmd) => service.upload_pcap(cmd).await,
-        ModeCmd::Rate(cmd) => service.set_rate(cmd).await,
+        ModeCmd::Update(cmd) => update_device(&mut service, cmd).await,
+        ModeCmd::List => list_configs(&mut service).await,
+        ModeCmd::Show(cmd) => show_config(&mut service, cmd).await,
+        ModeCmd::Upload(cmd) => upload_pcap(&mut service, cmd).await,
+        ModeCmd::Rate(cmd) => set_rate(&mut service, cmd).await,
     }
 }
 

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -8,7 +8,7 @@ use tonic::codec::CompressionEncoding;
 use vlanpb::{ShowDeviceVlanRequest, UpdateDeviceVlanRequest, device_vlan_service_client::DeviceVlanServiceClient};
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -74,90 +74,79 @@ pub struct UpdateCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "devices.vlan.controlplane.vlanpb.v1.DeviceVlanService";
 
-pub struct DeviceVlanService {
-    service: Service<DeviceVlanServiceClient<LayeredChannel>>,
+type DeviceVlanService = Service<DeviceVlanServiceClient<LayeredChannel>>;
+
+async fn show_device(service: &mut DeviceVlanService, cmd: ShowCmd) -> Result<(), Error> {
+    let name = cmd.name;
+    let request = ShowDeviceVlanRequest { name: name.clone() };
+
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("vlan device '{name}'")),
+            async |client, request| client.show_device(request).await,
+        )
+        .await?;
+
+    output::data(
+        || &response,
+        || {
+            let rows = response.device.as_ref().map(binding_rows).unwrap_or_default();
+
+            if output::is_colored() {
+                println!("{}: {}", output::paint_bold("VLAN"), response.vlan);
+            } else {
+                println!("VLAN: {}", response.vlan);
+            }
+
+            if rows.is_empty() {
+                output::empty_with_hint(
+                    format_args!("No pipeline bindings found for '{name}'."),
+                    format_args!(
+                        "bind one with 'yanet-cli device vlan update -n <name> -i <pipeline:weight> -o <pipeline:weight> --vlan <id>'"
+                    ),
+                );
+                return;
+            }
+
+            display::print_table_from_entries(rows);
+        },
+    );
+
+    Ok(())
 }
 
-impl DeviceVlanService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, |channel| {
-            DeviceVlanServiceClient::new(channel)
-                .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip)
+async fn update_config(service: &mut DeviceVlanService, cmd: UpdateCmd) -> Result<(), Error> {
+    let request = UpdateDeviceVlanRequest {
+        name: cmd.name.clone(),
+        device: Some(Device { input: cmd.input, output: cmd.output }),
+        vlan: cmd.vlan as u32,
+    };
+
+    service
+        .unary("update", request, async |client, request| {
+            client.update_device(request).await
         })
         .await?;
 
-        Ok(Self { service })
-    }
+    output::success("update", format_args!("Updated device '{}'.", cmd.name));
 
-    pub async fn show_device(&mut self, cmd: ShowCmd) -> Result<(), Error> {
-        let name = cmd.name;
-        let request = ShowDeviceVlanRequest { name: name.clone() };
-
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("vlan device '{name}'")),
-                async |client, request| client.show_device(request).await,
-            )
-            .await?;
-
-        output::data(
-            || &response,
-            || {
-                let rows = response.device.as_ref().map(binding_rows).unwrap_or_default();
-
-                if output::is_colored() {
-                    println!("{}: {}", output::paint_bold("VLAN"), response.vlan);
-                } else {
-                    println!("VLAN: {}", response.vlan);
-                }
-
-                if rows.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No pipeline bindings found for '{name}'."),
-                        format_args!(
-                            "bind one with 'yanet-cli device vlan update -n <name> -i <pipeline:weight> -o <pipeline:weight> --vlan <id>'"
-                        ),
-                    );
-                    return;
-                }
-
-                display::print_table_from_entries(rows);
-            },
-        );
-
-        Ok(())
-    }
-
-    pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let request = UpdateDeviceVlanRequest {
-            name: cmd.name.clone(),
-            device: Some(Device { input: cmd.input, output: cmd.output }),
-            vlan: cmd.vlan as u32,
-        };
-
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_device(request).await
-            })
-            .await?;
-
-        output::success("update", format_args!("Updated device '{}'.", cmd.name));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = DeviceVlanService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, |channel| {
+        DeviceVlanServiceClient::new(channel)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip)
+    })
+    .await?;
 
     match cmd.mode {
-        ModeCmd::Show(cmd) => service.show_device(cmd).await,
-        ModeCmd::Update(cmd) => service.update_config(cmd).await,
+        ModeCmd::Show(cmd) => show_device(&mut service, cmd).await,
+        ModeCmd::Update(cmd) => update_config(&mut service, cmd).await,
     }
 }
 

--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -13,9 +13,9 @@ use std::path::PathBuf;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
-use ync::{GlobalArgs, completion, errors::Error};
+use ync::{GlobalArgs, client::Service, completion, errors::Error};
 
-use crate::service::{Balancer2Service, client};
+use crate::service::{SERVICE_NAME, client, handle};
 
 #[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod balancerpb {
@@ -316,8 +316,9 @@ impl FilterFlags {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = Balancer2Service::connect(&cmd.globals.connection, action).await?;
-    service.handle(cmd.mode).await
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
+
+    handle(&mut service, cmd.mode).await
 }
 
 fn main() -> std::process::ExitCode {

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -4,7 +4,7 @@ use std::time;
 use commonpb::pb::GetMetricsRequest;
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     display::print_names_with_hint,
     errors::Error,
     output, yaml,
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// The fully-qualified gRPC service name used in error messages.
-const SERVICE_NAME: &str = "modules.balancer2.controlplane.balancerpb.v1.Balancer";
+pub const SERVICE_NAME: &str = "modules.balancer2.controlplane.balancerpb.v1.Balancer";
 
 pub fn client(channel: LayeredChannel) -> BalancerClient<LayeredChannel> {
     BalancerClient::new(channel)
@@ -32,293 +32,275 @@ pub fn client(channel: LayeredChannel) -> BalancerClient<LayeredChannel> {
         .accept_compressed(CompressionEncoding::Gzip)
 }
 
-pub struct Balancer2Service {
-    service: Service<BalancerClient<LayeredChannel>>,
+pub type Balancer2Service = Service<BalancerClient<LayeredChannel>>;
+
+pub async fn handle(service: &mut Balancer2Service, mode: ModeCmd) -> Result<(), Error> {
+    match mode {
+        ModeCmd::Update(cmd) => update(service, cmd).await,
+        ModeCmd::List => list(service).await,
+        ModeCmd::Config(cmd) => config(service, cmd).await,
+        ModeCmd::Show(cmd) => show(service, cmd).await,
+        ModeCmd::Sessions(cmd) => match cmd.mode {
+            SessionsMode::List => sessions_list(service).await,
+            SessionsMode::Show(cmd) => sessions_show(service, cmd).await,
+            SessionsMode::Update(cmd) => sessions_update(service, cmd).await,
+        },
+        ModeCmd::Metrics(cmd) => metrics(service, cmd).await,
+        ModeCmd::Reals(cmd) => match cmd.mode {
+            RealsMode::Enable(cmd) => enable_real(service, cmd).await,
+            RealsMode::Disable(cmd) => disable_real(service, cmd).await,
+        },
+    }
 }
 
-impl Balancer2Service {
-    pub async fn connect(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn update(service: &mut Balancer2Service, cmd: UpdateCmd) -> Result<(), Error> {
+    let yaml_config: BalancerConfig =
+        yaml::load(&cmd.file).map_err(|err| service.invalid("update", err.to_string()))?;
+    let parts: ConfigParts = yaml_config
+        .try_into()
+        .map_err(|err: Box<dyn core::error::Error>| service.invalid("update", err.to_string()))?;
 
-        Ok(Self { service })
-    }
+    let request = UpdateConfigRequest {
+        config_name: cmd.name.clone(),
+        sessions_state_name: cmd.sessions,
+        vs: parts.vs,
+        timeouts: parts.timeouts,
+        addr: parts.addr,
+        wlc: parts.wlc,
+    };
+    service
+        .unary("update", request, async |client, request| {
+            client.update_config(request).await
+        })
+        .await?;
 
-    pub async fn handle(&mut self, mode: ModeCmd) -> Result<(), Error> {
-        match mode {
-            ModeCmd::Update(cmd) => self.update(cmd).await,
-            ModeCmd::List => self.list().await,
-            ModeCmd::Config(cmd) => self.config(cmd).await,
-            ModeCmd::Show(cmd) => self.show(cmd).await,
-            ModeCmd::Sessions(cmd) => match cmd.mode {
-                SessionsMode::List => self.sessions_list().await,
-                SessionsMode::Show(cmd) => self.sessions_show(cmd).await,
-                SessionsMode::Update(cmd) => self.sessions_update(cmd).await,
-            },
-            ModeCmd::Metrics(cmd) => self.metrics(cmd).await,
-            ModeCmd::Reals(cmd) => match cmd.mode {
-                RealsMode::Enable(cmd) => self.enable_real(cmd).await,
-                RealsMode::Disable(cmd) => self.disable_real(cmd).await,
-            },
-        }
-    }
+    output::success("update", format_args!("Updated config '{}'.", cmd.name));
 
-    async fn update(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let yaml_config: BalancerConfig =
-            yaml::load(&cmd.file).map_err(|err| self.service.invalid("update", err.to_string()))?;
-        let parts: ConfigParts = yaml_config
-            .try_into()
-            .map_err(|err: Box<dyn core::error::Error>| self.service.invalid("update", err.to_string()))?;
+    Ok(())
+}
 
-        let request = UpdateConfigRequest {
-            config_name: cmd.name.clone(),
-            sessions_state_name: cmd.sessions,
-            vs: parts.vs,
-            timeouts: parts.timeouts,
-            addr: parts.addr,
-            wlc: parts.wlc,
-        };
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_config(request).await
-            })
-            .await?;
+async fn list(service: &mut Balancer2Service) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
 
-        output::success("update", format_args!("Updated config '{}'.", cmd.name));
-
-        Ok(())
-    }
-
-    async fn list(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
-
-        output::data(
-            || &response.names,
-            || {
-                print_names_with_hint(
-                    &response.names,
-                    format_args!("No balancer configurations found."),
-                    format_args!(
-                        "create one with 'yanet-cli-balancer2 update --name <name> --sessions <sessions-name> <path>'"
-                    ),
-                )
-            },
-        );
-
-        Ok(())
-    }
-
-    async fn config(&mut self, cmd: ConfigCmd) -> Result<(), Error> {
-        let request = GetConfigRequest { config_name: cmd.name.clone() };
-        let response = self
-            .service
-            .unary_with(
-                "config",
-                request,
-                self.service.not_found("config", &format!("config '{}'", cmd.name)),
-                async |client, request| client.get_config(request).await,
+    output::data(
+        || &response.names,
+        || {
+            print_names_with_hint(
+                &response.names,
+                format_args!("No balancer configurations found."),
+                format_args!(
+                    "create one with 'yanet-cli-balancer2 update --name <name> --sessions <sessions-name> <path>'"
+                ),
             )
-            .await?;
+        },
+    );
 
-        output::data(
-            || &response,
-            || {
-                let mut json_value =
-                    serde_json::to_value(&response).expect("balancer config JSON conversion must not fail");
-                display::prettify_json(&mut json_value);
-                let yaml =
-                    serde_yaml::to_string(&json_value).expect("balancer config YAML serialization must not fail");
-                print!("{yaml}");
-            },
-        );
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn config(service: &mut Balancer2Service, cmd: ConfigCmd) -> Result<(), Error> {
+    let request = GetConfigRequest { config_name: cmd.name.clone() };
+    let response = service
+        .unary_with(
+            "config",
+            request,
+            service.not_found("config", &format!("config '{}'", cmd.name)),
+            async |client, request| client.get_config(request).await,
+        )
+        .await?;
 
-    async fn show(&mut self, cmd: ShowCmd) -> Result<(), Error> {
-        let opts = display::ShowOptions {
-            stats: cmd.stats || cmd.detail,
-            acl: cmd.acl || cmd.detail,
-            peers: cmd.peers || cmd.detail,
-            decap: cmd.decap || cmd.detail,
+    output::data(
+        || &response,
+        || {
+            let mut json_value =
+                serde_json::to_value(&response).expect("balancer config JSON conversion must not fail");
+            display::prettify_json(&mut json_value);
+            let yaml = serde_yaml::to_string(&json_value).expect("balancer config YAML serialization must not fail");
+            print!("{yaml}");
+        },
+    );
+
+    Ok(())
+}
+
+async fn show(service: &mut Balancer2Service, cmd: ShowCmd) -> Result<(), Error> {
+    let opts = display::ShowOptions {
+        stats: cmd.stats || cmd.detail,
+        acl: cmd.acl || cmd.detail,
+        peers: cmd.peers || cmd.detail,
+        decap: cmd.decap || cmd.detail,
+    };
+
+    let packet_handler_ref =
+        if cmd.device.is_some() || cmd.pipeline.is_some() || cmd.function.is_some() || cmd.chain.is_some() {
+            Some(PacketHandlerRef {
+                device: cmd.device,
+                pipeline: cmd.pipeline,
+                function: cmd.function,
+                chain: cmd.chain,
+            })
+        } else {
+            None
         };
 
-        let packet_handler_ref =
-            if cmd.device.is_some() || cmd.pipeline.is_some() || cmd.function.is_some() || cmd.chain.is_some() {
-                Some(PacketHandlerRef {
-                    device: cmd.device,
-                    pipeline: cmd.pipeline,
-                    function: cmd.function,
-                    chain: cmd.chain,
-                })
-            } else {
-                None
-            };
+    let name = cmd.name.clone();
+    let filter = cmd.filter.to_proto();
+    let request = GetStateRequest {
+        config_name: cmd.name,
+        packet_handler_ref,
+        filter,
+    };
+    let response = service
+        .unary("show", request, async |client, request| client.get_state(request).await)
+        .await?;
 
-        let name = cmd.name.clone();
-        let filter = cmd.filter.to_proto();
-        let request = GetStateRequest {
-            config_name: cmd.name,
-            packet_handler_ref,
-            filter,
-        };
-        let response = self
-            .service
-            .unary("show", request, async |client, request| client.get_state(request).await)
-            .await?;
+    output::data(
+        || &response.states,
+        || {
+            if response.states.is_empty() {
+                output::empty(format_args!("No balancer state found for '{name}'."));
+                return;
+            }
 
-        output::data(
-            || &response.states,
-            || {
-                if response.states.is_empty() {
-                    output::empty(format_args!("No balancer state found for '{name}'."));
-                    return;
-                }
+            display::print_table_view(&response.states, &opts);
+        },
+    );
 
-                display::print_table_view(&response.states, &opts);
-            },
-        );
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn sessions_list(service: &mut Balancer2Service) -> Result<(), Error> {
+    let response = service
+        .unary(
+            "sessions list",
+            ListSessionsStatesRequest {},
+            async |client, request| client.list_sessions_states(request).await,
+        )
+        .await?;
 
-    async fn sessions_list(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary(
-                "sessions list",
-                ListSessionsStatesRequest {},
-                async |client, request| client.list_sessions_states(request).await,
+    output::data(
+        || &response.names,
+        || {
+            print_names_with_hint(
+                &response.names,
+                format_args!("No session states found."),
+                format_args!("create one with 'yanet-cli-balancer2 sessions update --name <name> --capacity <n>'"),
             )
-            .await?;
+        },
+    );
 
-        output::data(
-            || &response.names,
-            || {
-                print_names_with_hint(
-                    &response.names,
-                    format_args!("No session states found."),
-                    format_args!("create one with 'yanet-cli-balancer2 sessions update --name <name> --capacity <n>'"),
-                )
-            },
-        );
+    Ok(())
+}
 
-        Ok(())
+async fn sessions_show(service: &mut Balancer2Service, cmd: SessionsShowCmd) -> Result<(), Error> {
+    let name = cmd.name.clone();
+    let request = ListSessionsRequest {
+        sessions_state_name: cmd.name,
+        filter: cmd.filter.to_proto(),
+    };
+    log::trace!("list sessions request: {request:?}");
+
+    let mut stream = service
+        .client()
+        .list_sessions(request)
+        .await
+        .map_err(service.status("sessions show"))?
+        .into_inner();
+
+    let now = time::SystemTime::now()
+        .duration_since(time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_secs() as i64;
+    let mut rows = output::rows(display::print_sessions_header, |session| {
+        display::print_session(session, now)
+    });
+
+    while let Some(session) = stream.message().await.map_err(service.status("sessions show"))? {
+        rows.push(&session);
     }
 
-    async fn sessions_show(&mut self, cmd: SessionsShowCmd) -> Result<(), Error> {
-        let name = cmd.name.clone();
-        let request = ListSessionsRequest {
-            sessions_state_name: cmd.name,
-            filter: cmd.filter.to_proto(),
-        };
-        log::trace!("list sessions request: {request:?}");
+    rows.finish(format_args!("No sessions found for '{name}'."));
 
-        let mut stream = self
-            .service
-            .client()
-            .list_sessions(request)
-            .await
-            .map_err(self.service.status("sessions show"))?
-            .into_inner();
+    Ok(())
+}
 
-        let now = time::SystemTime::now()
-            .duration_since(time::UNIX_EPOCH)
-            .expect("system clock before UNIX epoch")
-            .as_secs() as i64;
-        let mut rows = output::rows(display::print_sessions_header, |session| {
-            display::print_session(session, now)
-        });
+async fn sessions_update(service: &mut Balancer2Service, cmd: SessionsUpdateCmd) -> Result<(), Error> {
+    let request = UpdateSessionsStateRequest {
+        sessions_state_name: cmd.name.clone(),
+        capacity: cmd.capacity,
+    };
+    service
+        .unary("sessions update", request, async |client, request| {
+            client.update_sessions_state(request).await
+        })
+        .await?;
 
-        while let Some(session) = stream.message().await.map_err(self.service.status("sessions show"))? {
-            rows.push(&session);
-        }
+    output::success(
+        "sessions update",
+        format_args!("Updated sessions state '{}' (capacity: {}).", cmd.name, cmd.capacity),
+    );
 
-        rows.finish(format_args!("No sessions found for '{name}'."));
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn metrics(service: &mut Balancer2Service, _cmd: MetricsCmd) -> Result<(), Error> {
+    let response = service
+        .unary("metrics", GetMetricsRequest::default(), async |client, request| {
+            client.get_metrics(request).await
+        })
+        .await?;
 
-    async fn sessions_update(&mut self, cmd: SessionsUpdateCmd) -> Result<(), Error> {
-        let request = UpdateSessionsStateRequest {
-            sessions_state_name: cmd.name.clone(),
-            capacity: cmd.capacity,
-        };
-        self.service
-            .unary("sessions update", request, async |client, request| {
-                client.update_sessions_state(request).await
-            })
-            .await?;
+    output::data(
+        || &response,
+        || {
+            let mut json_value =
+                serde_json::to_value(&response).expect("balancer metrics JSON conversion must not fail");
+            display::prettify_json(&mut json_value);
+            let json = serde_json::to_string(&json_value).expect("balancer metrics JSON serialization must not fail");
+            println!("{json}");
 
-        output::success(
-            "sessions update",
-            format_args!("Updated sessions state '{}' (capacity: {}).", cmd.name, cmd.capacity),
-        );
+            if response.metrics.is_empty() {
+                output::empty(format_args!("No balancer metrics found."));
+            }
+        },
+    );
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    async fn metrics(&mut self, _cmd: MetricsCmd) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("metrics", GetMetricsRequest::default(), async |client, request| {
-                client.get_metrics(request).await
-            })
-            .await?;
+async fn enable_real(service: &mut Balancer2Service, cmd: EnableRealCmd) -> Result<(), Error> {
+    let updates = build_real_updates(&cmd.vs, &cmd.reals, Some(true), cmd.weight);
+    send_real_updates(service, "enable", cmd.name, updates).await
+}
 
-        output::data(
-            || &response,
-            || {
-                let mut json_value =
-                    serde_json::to_value(&response).expect("balancer metrics JSON conversion must not fail");
-                display::prettify_json(&mut json_value);
-                let json =
-                    serde_json::to_string(&json_value).expect("balancer metrics JSON serialization must not fail");
-                println!("{json}");
+async fn disable_real(service: &mut Balancer2Service, cmd: DisableRealCmd) -> Result<(), Error> {
+    let updates = build_real_updates(&cmd.vs, &cmd.reals, Some(false), None);
+    send_real_updates(service, "disable", cmd.name, updates).await
+}
 
-                if response.metrics.is_empty() {
-                    output::empty(format_args!("No balancer metrics found."));
-                }
-            },
-        );
+async fn send_real_updates(
+    service: &mut Balancer2Service,
+    action: &'static str,
+    config_name: String,
+    updates: Vec<RealUpdate>,
+) -> Result<(), Error> {
+    let request = UpdateRealsRequest {
+        config_name: config_name.clone(),
+        updates,
+    };
+    service
+        .unary(action, request, async |client, request| {
+            client.update_reals(request).await
+        })
+        .await?;
 
-        Ok(())
-    }
+    output::success(action, format_args!("Updated reals of config '{config_name}'."));
 
-    async fn enable_real(&mut self, cmd: EnableRealCmd) -> Result<(), Error> {
-        let updates = build_real_updates(&cmd.vs, &cmd.reals, Some(true), cmd.weight);
-        self.send_real_updates("enable", cmd.name, updates).await
-    }
-
-    async fn disable_real(&mut self, cmd: DisableRealCmd) -> Result<(), Error> {
-        let updates = build_real_updates(&cmd.vs, &cmd.reals, Some(false), None);
-        self.send_real_updates("disable", cmd.name, updates).await
-    }
-
-    async fn send_real_updates(
-        &mut self,
-        action: &'static str,
-        config_name: String,
-        updates: Vec<RealUpdate>,
-    ) -> Result<(), Error> {
-        let request = UpdateRealsRequest {
-            config_name: config_name.clone(),
-            updates,
-        };
-        self.service
-            .unary(action, request, async |client, request| {
-                client.update_reals(request).await
-            })
-            .await?;
-
-        output::success(action, format_args!("Updated reals of config '{config_name}'."));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 fn build_real_updates(vs: &VsId, reals: &[IpAddr], enable: Option<bool>, weight: Option<u32>) -> Vec<RealUpdate> {

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -7,7 +7,7 @@ use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -88,98 +88,85 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = BlackholeService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::Update(cmd) => service.update_config(cmd).await,
-        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
+        ModeCmd::List => list_configs(&mut service).await,
+        ModeCmd::Show(cmd) => show_config(&mut service, cmd).await,
+        ModeCmd::Update(cmd) => update_config(&mut service, cmd).await,
+        ModeCmd::Delete(cmd) => delete_config(&mut service, cmd).await,
     }
 }
 
-pub struct BlackholeService {
-    service: Service<BlackholeServiceClient<LayeredChannel>>,
+type BlackholeService = Service<BlackholeServiceClient<LayeredChannel>>;
+
+async fn list_configs(service: &mut BlackholeService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
+
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No blackhole configurations found."),
+                format_args!("create one with 'yanet-cli-blackhole update --name <name>'"),
+            )
+        },
+    );
+
+    Ok(())
 }
 
-impl BlackholeService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn show_config(service: &mut BlackholeService, cmd: ShowConfigCmd) -> Result<(), Error> {
+    let request = ShowConfigRequest { name: cmd.config_name.clone() };
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.show_config(request).await,
+        )
+        .await?;
 
-        Ok(Self { service })
-    }
+    output::data(
+        || &response,
+        || display::KeyValue::new().row("name", &response.name).print(),
+    );
 
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
+    Ok(())
+}
 
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No blackhole configurations found."),
-                    format_args!("create one with 'yanet-cli-blackhole update --name <name>'"),
-                )
-            },
-        );
+async fn update_config(service: &mut BlackholeService, cmd: UpdateConfigCmd) -> Result<(), Error> {
+    let request = UpdateConfigRequest { name: cmd.config_name.clone() };
+    service
+        .unary("update", request, async |client, request| {
+            client.update_config(request).await
+        })
+        .await?;
 
-        Ok(())
-    }
+    output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
-    pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
-        let request = ShowConfigRequest { name: cmd.config_name.clone() };
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.show_config(request).await,
-            )
-            .await?;
+    Ok(())
+}
 
-        output::data(
-            || &response,
-            || display::KeyValue::new().row("name", &response.name).print(),
-        );
+async fn delete_config(service: &mut BlackholeService, cmd: DeleteConfigCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
 
-        Ok(())
-    }
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
-    pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Error> {
-        let request = UpdateConfigRequest { name: cmd.config_name.clone() };
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_config(request).await
-            })
-            .await?;
-
-        output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
-
-    pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service
-                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.delete_config(request).await,
-            )
-            .await?;
-
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 /// Completion candidates for a `--name` argument: the blackhole configs the

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -9,7 +9,7 @@ use netip::{Contiguous, IpNetwork};
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -93,113 +93,100 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = DecapService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::Update(cmd) => service.update_config(cmd).await,
-        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
+        ModeCmd::List => list_configs(&mut service).await,
+        ModeCmd::Show(cmd) => show_config(&mut service, cmd).await,
+        ModeCmd::Update(cmd) => update_config(&mut service, cmd).await,
+        ModeCmd::Delete(cmd) => delete_config(&mut service, cmd).await,
     }
 }
 
-pub struct DecapService {
-    service: Service<DecapServiceClient<LayeredChannel>>,
+type DecapService = Service<DecapServiceClient<LayeredChannel>>;
+
+async fn list_configs(service: &mut DecapService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
+
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No decap configurations found."),
+                format_args!("create one with 'yanet-cli-decap update --name <name> --prefix <cidr>'"),
+            )
+        },
+    );
+
+    Ok(())
 }
 
-impl DecapService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn show_config(service: &mut DecapService, cmd: ShowConfigCmd) -> Result<(), Error> {
+    let request = ShowConfigRequest { name: cmd.config_name.to_owned() };
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.show_config(request).await,
+        )
+        .await?;
 
-        Ok(Self { service })
-    }
-
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
-
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No decap configurations found."),
+    output::data(
+        || &response,
+        || {
+            if response.prefixes4.is_empty() && response.prefixes6.is_empty() {
+                output::empty_with_hint(
+                    format_args!("No decap prefixes found for '{}'.", cmd.config_name),
                     format_args!("create one with 'yanet-cli-decap update --name <name> --prefix <cidr>'"),
-                )
-            },
-        );
+                );
+                return;
+            }
 
-        Ok(())
-    }
+            config_block(&response).print();
+        },
+    );
 
-    pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
-        let request = ShowConfigRequest { name: cmd.config_name.to_owned() };
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.show_config(request).await,
-            )
-            .await?;
+    Ok(())
+}
 
-        output::data(
-            || &response,
-            || {
-                if response.prefixes4.is_empty() && response.prefixes6.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No decap prefixes found for '{}'.", cmd.config_name),
-                        format_args!("create one with 'yanet-cli-decap update --name <name> --prefix <cidr>'"),
-                    );
-                    return;
-                }
+async fn update_config(service: &mut DecapService, cmd: UpdateConfigCmd) -> Result<(), Error> {
+    let (prefixes4, prefixes6) = partition_prefixes(cmd.prefixes);
+    let request = UpdateConfigRequest {
+        name: cmd.config_name.clone(),
+        prefixes4,
+        prefixes6,
+    };
+    service
+        .unary("update", request, async |client, request| {
+            client.update_config(request).await
+        })
+        .await?;
 
-                config_block(&response).print();
-            },
-        );
+    output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Error> {
-        let (prefixes4, prefixes6) = partition_prefixes(cmd.prefixes);
-        let request = UpdateConfigRequest {
-            name: cmd.config_name.clone(),
-            prefixes4,
-            prefixes6,
-        };
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_config(request).await
-            })
-            .await?;
+async fn delete_config(service: &mut DecapService, cmd: DeleteConfigCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
 
-        output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
-        Ok(())
-    }
-
-    pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service
-                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.delete_config(request).await,
-            )
-            .await?;
-
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 fn config_block(response: &ShowConfigResponse) -> display::KeyValue {

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -9,7 +9,7 @@ use netip::{Contiguous, IpNetwork};
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -145,165 +145,152 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = DscpService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::PrefixAdd(cmd) => service.add_prefixes(cmd).await,
-        ModeCmd::PrefixRemove(cmd) => service.remove_prefixes(cmd).await,
-        ModeCmd::SetMarking(cmd) => service.set_dscp_marking(cmd).await,
-        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
+        ModeCmd::List => list_configs(&mut service).await,
+        ModeCmd::Show(cmd) => show_config(&mut service, cmd).await,
+        ModeCmd::PrefixAdd(cmd) => add_prefixes(&mut service, cmd).await,
+        ModeCmd::PrefixRemove(cmd) => remove_prefixes(&mut service, cmd).await,
+        ModeCmd::SetMarking(cmd) => set_dscp_marking(&mut service, cmd).await,
+        ModeCmd::Delete(cmd) => delete_config(&mut service, cmd).await,
     }
 }
 
-pub struct DscpService {
-    service: Service<DscpServiceClient<LayeredChannel>>,
+type DscpService = Service<DscpServiceClient<LayeredChannel>>;
+
+async fn list_configs(service: &mut DscpService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
+
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No DSCP configurations found."),
+                format_args!("create one with 'yanet-cli-dscp prefix-add --name <name> --prefix <cidr>'"),
+            )
+        },
+    );
+
+    Ok(())
 }
 
-impl DscpService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn show_config(service: &mut DscpService, cmd: ShowConfigCmd) -> Result<(), Error> {
+    let request = ShowConfigRequest { name: cmd.config_name.to_owned() };
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.show_config(request).await,
+        )
+        .await?;
 
-        Ok(Self { service })
-    }
-
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
-
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No DSCP configurations found."),
+    output::data(
+        || &response,
+        || {
+            let Some(config) = &response.config else {
+                output::empty_with_hint(
+                    format_args!("No DSCP configuration found for '{}'.", cmd.config_name),
                     format_args!("create one with 'yanet-cli-dscp prefix-add --name <name> --prefix <cidr>'"),
-                )
-            },
-        );
+                );
+                return;
+            };
 
-        Ok(())
-    }
+            config_block(config).print();
+        },
+    );
 
-    pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
-        let request = ShowConfigRequest { name: cmd.config_name.to_owned() };
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.show_config(request).await,
-            )
-            .await?;
+    Ok(())
+}
 
-        output::data(
-            || &response,
-            || {
-                let Some(config) = &response.config else {
-                    output::empty_with_hint(
-                        format_args!("No DSCP configuration found for '{}'.", cmd.config_name),
-                        format_args!("create one with 'yanet-cli-dscp prefix-add --name <name> --prefix <cidr>'"),
-                    );
-                    return;
-                };
+async fn add_prefixes(service: &mut DscpService, cmd: AddPrefixesCmd) -> Result<(), Error> {
+    let (prefixes4, prefixes6) = partition_prefixes(cmd.prefix.iter().copied());
+    let request = AddPrefixesRequest {
+        name: cmd.config_name.clone(),
+        prefixes4,
+        prefixes6,
+    };
+    service
+        .unary("prefix-add", request, async |client, request| {
+            client.add_prefixes(request).await
+        })
+        .await?;
 
-                config_block(config).print();
-            },
-        );
+    output::success(
+        "prefix-add",
+        format_args!("Added {} prefix(es) to config '{}'.", cmd.prefix.len(), cmd.config_name),
+    );
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn add_prefixes(&mut self, cmd: AddPrefixesCmd) -> Result<(), Error> {
-        let (prefixes4, prefixes6) = partition_prefixes(cmd.prefix.iter().copied());
-        let request = AddPrefixesRequest {
-            name: cmd.config_name.clone(),
-            prefixes4,
-            prefixes6,
-        };
-        self.service
-            .unary("prefix-add", request, async |client, request| {
-                client.add_prefixes(request).await
-            })
-            .await?;
+async fn remove_prefixes(service: &mut DscpService, cmd: RemovePrefixesCmd) -> Result<(), Error> {
+    let (prefixes4, prefixes6) = partition_prefixes(cmd.prefix.iter().copied());
+    let request = RemovePrefixesRequest {
+        name: cmd.config_name.clone(),
+        prefixes4,
+        prefixes6,
+    };
+    service
+        .unary("prefix-remove", request, async |client, request| {
+            client.remove_prefixes(request).await
+        })
+        .await?;
 
-        output::success(
-            "prefix-add",
-            format_args!("Added {} prefix(es) to config '{}'.", cmd.prefix.len(), cmd.config_name),
-        );
+    output::success(
+        "prefix-remove",
+        format_args!(
+            "Removed {} prefix(es) from config '{}'.",
+            cmd.prefix.len(),
+            cmd.config_name
+        ),
+    );
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn remove_prefixes(&mut self, cmd: RemovePrefixesCmd) -> Result<(), Error> {
-        let (prefixes4, prefixes6) = partition_prefixes(cmd.prefix.iter().copied());
-        let request = RemovePrefixesRequest {
-            name: cmd.config_name.clone(),
-            prefixes4,
-            prefixes6,
-        };
-        self.service
-            .unary("prefix-remove", request, async |client, request| {
-                client.remove_prefixes(request).await
-            })
-            .await?;
+async fn set_dscp_marking(service: &mut DscpService, cmd: SetDscpMarkingCmd) -> Result<(), Error> {
+    let request = SetDscpMarkingRequest {
+        name: cmd.config_name.clone(),
+        dscp_config: Some(DscpConfig {
+            flag: cmd.flag.into(),
+            mark: cmd.mark,
+        }),
+    };
+    service
+        .unary("set-marking", request, async |client, request| {
+            client.set_dscp_marking(request).await
+        })
+        .await?;
 
-        output::success(
-            "prefix-remove",
-            format_args!(
-                "Removed {} prefix(es) from config '{}'.",
-                cmd.prefix.len(),
-                cmd.config_name
-            ),
-        );
+    output::success(
+        "set-marking",
+        format_args!("Set marking on config '{}'.", cmd.config_name),
+    );
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn set_dscp_marking(&mut self, cmd: SetDscpMarkingCmd) -> Result<(), Error> {
-        let request = SetDscpMarkingRequest {
-            name: cmd.config_name.clone(),
-            dscp_config: Some(DscpConfig {
-                flag: cmd.flag.into(),
-                mark: cmd.mark,
-            }),
-        };
-        self.service
-            .unary("set-marking", request, async |client, request| {
-                client.set_dscp_marking(request).await
-            })
-            .await?;
+async fn delete_config(service: &mut DscpService, cmd: DeleteConfigCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
 
-        output::success(
-            "set-marking",
-            format_args!("Set marking on config '{}'.", cmd.config_name),
-        );
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
-        Ok(())
-    }
-
-    pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service
-                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.delete_config(request).await,
-            )
-            .await?;
-
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 fn config_block(config: &Config) -> display::KeyValue {

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -11,7 +11,7 @@ use serde::{Deserializer, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{self, ConnectionArgs, LayeredChannel, Service},
+    client::{self, LayeredChannel, Service},
     completion, display,
     errors::Error,
     output, yaml,
@@ -113,101 +113,93 @@ fn forward_client(channel: LayeredChannel) -> ForwardServiceClient<LayeredChanne
         .accept_compressed(CompressionEncoding::Gzip)
 }
 
-pub struct ForwardService {
-    service: Service<ForwardServiceClient<LayeredChannel>>,
+type ForwardService = Service<ForwardServiceClient<LayeredChannel>>;
+
+async fn show_config(service: &mut ForwardService, cmd: ShowCmd) -> Result<(), Error> {
+    let request = ShowConfigRequest { name: cmd.config_name.clone() };
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.show_config(request).await,
+        )
+        .await?;
+
+    output::data(
+        || &response,
+        || {
+            // The document is printed even without rules, so a
+            // redirected show yields a file update accepts, an
+            // undeclared mode number excepted.
+            print!(
+                "{}",
+                serde_yaml::to_string(&response).expect("forward config YAML serialization must not fail")
+            );
+
+            if response.rules.is_empty() {
+                output::empty_with_hint(
+                    format_args!("No forward rules found for '{}'.", cmd.config_name),
+                    format_args!("create one with 'yanet-cli-forward update --name <name> <path>'"),
+                );
+            }
+        },
+    );
+
+    Ok(())
 }
 
-impl ForwardService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, forward_client).await?;
+async fn list_configs(service: &mut ForwardService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
 
-        Ok(Self { service })
-    }
-
-    pub async fn show_config(&mut self, cmd: ShowCmd) -> Result<(), Error> {
-        let request = ShowConfigRequest { name: cmd.config_name.clone() };
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.show_config(request).await,
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No forward configurations found."),
+                format_args!("create one with 'yanet-cli-forward update --name <name> <path>'"),
             )
-            .await?;
+        },
+    );
 
-        output::data(
-            || &response,
-            || {
-                // The document is printed even without rules, so a
-                // redirected show yields a file update accepts, an
-                // undeclared mode number excepted.
-                print!(
-                    "{}",
-                    serde_yaml::to_string(&response).expect("forward config YAML serialization must not fail")
-                );
+    Ok(())
+}
 
-                if response.rules.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No forward rules found for '{}'.", cmd.config_name),
-                        format_args!("create one with 'yanet-cli-forward update --name <name> <path>'"),
-                    );
-                }
-            },
-        );
+async fn delete_config(service: &mut ForwardService, cmd: DeleteCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config.clone() };
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
 
-        Ok(())
-    }
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config));
 
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
+    Ok(())
+}
 
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No forward configurations found."),
-                    format_args!("create one with 'yanet-cli-forward update --name <name> <path>'"),
-                )
-            },
-        );
+async fn update_config(
+    service: &mut ForwardService,
+    cmd: UpdateCmd,
+    request: UpdateConfigRequest,
+) -> Result<(), Error> {
+    service
+        .unary("update", request, async |client, request| {
+            client.update_config(request).await
+        })
+        .await?;
 
-        Ok(())
-    }
+    output::success("update", format_args!("Updated config '{}'.", cmd.config));
 
-    pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config.clone() };
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service.not_found("delete", &format!("config '{}'", cmd.config)),
-                async |client, request| client.delete_config(request).await,
-            )
-            .await?;
-
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config));
-
-        Ok(())
-    }
-
-    pub async fn update_config(&mut self, cmd: UpdateCmd, request: UpdateConfigRequest) -> Result<(), Error> {
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_config(request).await
-            })
-            .await?;
-
-        output::success("update", format_args!("Updated config '{}'.", cmd.config));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
@@ -228,16 +220,16 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         _ => None,
     };
 
-    let mut service = ForwardService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, forward_client).await?;
 
     match cmd.mode {
-        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
+        ModeCmd::Delete(cmd) => delete_config(&mut service, cmd).await,
         ModeCmd::Update(cmd) => {
             let request = update.expect("prepared for the update mode");
-            service.update_config(cmd, request).await
+            update_config(&mut service, cmd, request).await
         }
-        ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::List => service.list_configs().await,
+        ModeCmd::Show(cmd) => show_config(&mut service, cmd).await,
+        ModeCmd::List => list_configs(&mut service).await,
     }
 }
 

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -11,7 +11,7 @@ use fwstatepb::{
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{Connection, ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -219,101 +219,88 @@ fn update_sync_endpoints(sync_config: &mut SyncConfig, cmd: &UpdateCmd) -> Resul
     Ok(())
 }
 
-pub struct FWStateService {
-    service: Service<FwStateServiceClient<LayeredChannel>>,
+type FWStateService = Service<FwStateServiceClient<LayeredChannel>>;
+
+async fn list_configs(service: &mut FWStateService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
+
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No FWState configurations found."),
+                format_args!(
+                    "provision maps with 'yanet-cli-fwstatemap create --name <map> --kind <v4|v6>', then create a config with 'yanet-cli-fwstate update --name <name> --map-name-v4 <map> --map-name-v6 <map>'"
+                ),
+            )
+        },
+    );
+
+    Ok(())
 }
 
-impl FWStateService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let conn = Connection::connect_for(connection, action).await?;
-        let service = Service::new(&conn, SERVICE_NAME, client);
-        Ok(Self { service })
-    }
+async fn show_config(service: &mut FWStateService, cmd: ShowCmd) -> Result<(), Error> {
+    let request = ShowConfigRequest {
+        name: cmd.config_name.clone(),
+        ok_if_not_found: false,
+    };
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.show_config(request).await,
+        )
+        .await?;
 
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
+    output::data(|| &response, || config_block(&response).print());
 
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No FWState configurations found."),
-                    format_args!(
-                        "provision maps with 'yanet-cli-fwstatemap create --name <map> --kind <v4|v6>', then create a config with 'yanet-cli-fwstate update --name <name> --map-name-v4 <map> --map-name-v6 <map>'"
-                    ),
-                )
-            },
-        );
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn delete_config(service: &mut FWStateService, cmd: DeleteCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
 
-    pub async fn show_config(&mut self, cmd: ShowCmd) -> Result<(), Error> {
-        let request = ShowConfigRequest {
-            name: cmd.config_name.clone(),
-            ok_if_not_found: false,
-        };
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.show_config(request).await,
-            )
-            .await?;
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
-        output::data(|| &response, || config_block(&response).print());
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn update_config(service: &mut FWStateService, cmd: UpdateCmd) -> Result<(), Error> {
+    let request = update_request(&cmd).map_err(|err| service.invalid("update", err))?;
+    service
+        .unary("update", request, async |client, request| {
+            client.update_config(request).await
+        })
+        .await?;
 
-    pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service
-                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.delete_config(request).await,
-            )
-            .await?;
+    output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
-
-    pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
-        let request = update_request(&cmd).map_err(|err| self.service.invalid("update", err))?;
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_config(request).await
-            })
-            .await?;
-
-        output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = FWStateService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
-        ModeCmd::Update(cmd) => service.update_config(cmd).await,
-        ModeCmd::Show(cmd) => service.show_config(cmd).await,
+        ModeCmd::List => list_configs(&mut service).await,
+        ModeCmd::Delete(cmd) => delete_config(&mut service, cmd).await,
+        ModeCmd::Update(cmd) => update_config(&mut service, cmd).await,
+        ModeCmd::Show(cmd) => show_config(&mut service, cmd).await,
     }
 }
 

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -11,7 +11,7 @@ use serde::{Deserializer, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{self, ConnectionArgs, LayeredChannel, Service},
+    client::{self, LayeredChannel, Service},
     completion, display,
     errors::Error,
     output, yaml,
@@ -112,101 +112,89 @@ fn client(channel: LayeredChannel) -> MirrorServiceClient<LayeredChannel> {
         .accept_compressed(CompressionEncoding::Gzip)
 }
 
-pub struct MirrorService {
-    service: Service<MirrorServiceClient<LayeredChannel>>,
+type MirrorService = Service<MirrorServiceClient<LayeredChannel>>;
+
+async fn show_config(service: &mut MirrorService, cmd: ShowCmd) -> Result<(), Error> {
+    let request = ShowConfigRequest { name: cmd.config_name.clone() };
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.show_config(request).await,
+        )
+        .await?;
+
+    output::data(
+        || &response,
+        || {
+            // The document is printed even without rules, so a
+            // redirected show yields a file update accepts, an
+            // undeclared mode number excepted.
+            print!(
+                "{}",
+                serde_yaml::to_string(&response).expect("mirror config YAML serialization must not fail")
+            );
+
+            if response.rules.is_empty() {
+                output::empty_with_hint(
+                    format_args!("No mirror rules found for '{}'.", cmd.config_name),
+                    format_args!("create one with 'yanet-cli-mirror update --name <name> <path>'"),
+                );
+            }
+        },
+    );
+
+    Ok(())
 }
 
-impl MirrorService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn list_configs(service: &mut MirrorService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
 
-        Ok(Self { service })
-    }
-
-    pub async fn show_config(&mut self, cmd: ShowCmd) -> Result<(), Error> {
-        let request = ShowConfigRequest { name: cmd.config_name.clone() };
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.show_config(request).await,
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No mirror configurations found."),
+                format_args!("create one with 'yanet-cli-mirror update --name <name> <path>'"),
             )
-            .await?;
+        },
+    );
 
-        output::data(
-            || &response,
-            || {
-                // The document is printed even without rules, so a
-                // redirected show yields a file update accepts, an
-                // undeclared mode number excepted.
-                print!(
-                    "{}",
-                    serde_yaml::to_string(&response).expect("mirror config YAML serialization must not fail")
-                );
+    Ok(())
+}
 
-                if response.rules.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No mirror rules found for '{}'.", cmd.config_name),
-                        format_args!("create one with 'yanet-cli-mirror update --name <name> <path>'"),
-                    );
-                }
-            },
-        );
+async fn delete_config(service: &mut MirrorService, cmd: DeleteCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config.clone() };
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
 
-        Ok(())
-    }
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config));
 
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
+    Ok(())
+}
 
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No mirror configurations found."),
-                    format_args!("create one with 'yanet-cli-mirror update --name <name> <path>'"),
-                )
-            },
-        );
+async fn update_config(service: &mut MirrorService, cmd: UpdateCmd, request: UpdateConfigRequest) -> Result<(), Error> {
+    service
+        .unary("update", request, async |client, request| {
+            client.update_config(request).await
+        })
+        .await?;
 
-        Ok(())
-    }
+    output::success("update", format_args!("Updated config '{}'.", cmd.config));
 
-    pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config.clone() };
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service.not_found("delete", &format!("config '{}'", cmd.config)),
-                async |client, request| client.delete_config(request).await,
-            )
-            .await?;
-
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config));
-
-        Ok(())
-    }
-
-    pub async fn update_config(&mut self, cmd: UpdateCmd, request: UpdateConfigRequest) -> Result<(), Error> {
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_config(request).await
-            })
-            .await?;
-
-        output::success("update", format_args!("Updated config '{}'.", cmd.config));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
@@ -227,16 +215,16 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         _ => None,
     };
 
-    let mut service = MirrorService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
+        ModeCmd::Delete(cmd) => delete_config(&mut service, cmd).await,
         ModeCmd::Update(cmd) => {
             let request = update.expect("prepared for the update mode");
-            service.update_config(cmd, request).await
+            update_config(&mut service, cmd, request).await
         }
-        ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::List => service.list_configs().await,
+        ModeCmd::Show(cmd) => show_config(&mut service, cmd).await,
+        ModeCmd::List => list_configs(&mut service).await,
     }
 }
 

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -11,7 +11,7 @@ use netip::{Contiguous, Ipv6Network};
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -191,233 +191,220 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = NAT64Service::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
+        ModeCmd::List => list_configs(&mut service).await,
+        ModeCmd::Show(cmd) => show_config(&mut service, cmd).await,
+        ModeCmd::Delete(cmd) => delete_config(&mut service, cmd).await,
         ModeCmd::Prefix { cmd } => match cmd {
-            PrefixCmd::Add(cmd) => service.add_prefix(cmd).await,
-            PrefixCmd::Remove(cmd) => service.remove_prefix(cmd).await,
+            PrefixCmd::Add(cmd) => add_prefix(&mut service, cmd).await,
+            PrefixCmd::Remove(cmd) => remove_prefix(&mut service, cmd).await,
         },
         ModeCmd::Mapping { cmd } => match cmd {
-            MappingCmd::Add(cmd) => service.add_mapping(cmd).await,
-            MappingCmd::Remove(cmd) => service.remove_mapping(cmd).await,
+            MappingCmd::Add(cmd) => add_mapping(&mut service, cmd).await,
+            MappingCmd::Remove(cmd) => remove_mapping(&mut service, cmd).await,
         },
-        ModeCmd::Mtu(cmd) => service.set_mtu(cmd).await,
-        ModeCmd::Drop(cmd) => service.set_drop_unknown(cmd).await,
+        ModeCmd::Mtu(cmd) => set_mtu(&mut service, cmd).await,
+        ModeCmd::Drop(cmd) => set_drop_unknown(&mut service, cmd).await,
     }
 }
 
-pub struct NAT64Service {
-    service: Service<Nat64ServiceClient<LayeredChannel>>,
+type NAT64Service = Service<Nat64ServiceClient<LayeredChannel>>;
+
+async fn list_configs(service: &mut NAT64Service) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
+
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No NAT64 configurations found."),
+                format_args!("create one with 'yanet-cli-nat64 prefix add --name <name> --prefix <cidr>'"),
+            )
+        },
+    );
+
+    Ok(())
 }
 
-impl NAT64Service {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn show_config(service: &mut NAT64Service, cmd: ShowConfigCmd) -> Result<(), Error> {
+    let request = ShowConfigRequest { name: cmd.config_name.clone() };
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.show_config(request).await,
+        )
+        .await?;
 
-        Ok(Self { service })
-    }
-
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
-
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No NAT64 configurations found."),
+    output::data(
+        || &response,
+        || {
+            let Some(config) = &response.config else {
+                output::empty_with_hint(
+                    format_args!("No NAT64 configuration found for '{}'.", cmd.config_name),
                     format_args!("create one with 'yanet-cli-nat64 prefix add --name <name> --prefix <cidr>'"),
-                )
-            },
-        );
+                );
+                return;
+            };
 
-        Ok(())
-    }
+            config_block(config).print();
+        },
+    );
 
-    pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
-        let request = ShowConfigRequest { name: cmd.config_name.clone() };
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.show_config(request).await,
-            )
-            .await?;
+    Ok(())
+}
 
-        output::data(
-            || &response,
-            || {
-                let Some(config) = &response.config else {
-                    output::empty_with_hint(
-                        format_args!("No NAT64 configuration found for '{}'.", cmd.config_name),
-                        format_args!("create one with 'yanet-cli-nat64 prefix add --name <name> --prefix <cidr>'"),
-                    );
-                    return;
-                };
+async fn delete_config(service: &mut NAT64Service, cmd: DeleteConfigCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
 
-                config_block(config).print();
-            },
-        );
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service
-                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.delete_config(request).await,
-            )
-            .await?;
+async fn add_prefix(service: &mut NAT64Service, cmd: AddPrefixCmd) -> Result<(), Error> {
+    let request = AddPrefixRequest {
+        name: cmd.config_name.clone(),
+        prefix: Some(cmd.prefix.into()),
+    };
+    service
+        .unary("add prefix", request, async |client, request| {
+            client.add_prefix(request).await
+        })
+        .await?;
 
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
+    output::success(
+        "add prefix",
+        format_args!("Added prefix {} to config '{}'.", cmd.prefix, cmd.config_name),
+    );
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn add_prefix(&mut self, cmd: AddPrefixCmd) -> Result<(), Error> {
-        let request = AddPrefixRequest {
-            name: cmd.config_name.clone(),
-            prefix: Some(cmd.prefix.into()),
-        };
-        self.service
-            .unary("add prefix", request, async |client, request| {
-                client.add_prefix(request).await
-            })
-            .await?;
+async fn remove_prefix(service: &mut NAT64Service, cmd: RemovePrefixCmd) -> Result<(), Error> {
+    let request = RemovePrefixRequest {
+        name: cmd.config_name.clone(),
+        prefix: Some(cmd.prefix.into()),
+    };
+    service
+        .unary("remove prefix", request, async |client, request| {
+            client.remove_prefix(request).await
+        })
+        .await?;
 
-        output::success(
-            "add prefix",
-            format_args!("Added prefix {} to config '{}'.", cmd.prefix, cmd.config_name),
-        );
+    output::success(
+        "remove prefix",
+        format_args!("Removed prefix {} from config '{}'.", cmd.prefix, cmd.config_name),
+    );
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn remove_prefix(&mut self, cmd: RemovePrefixCmd) -> Result<(), Error> {
-        let request = RemovePrefixRequest {
-            name: cmd.config_name.clone(),
-            prefix: Some(cmd.prefix.into()),
-        };
-        self.service
-            .unary("remove prefix", request, async |client, request| {
-                client.remove_prefix(request).await
-            })
-            .await?;
+async fn add_mapping(service: &mut NAT64Service, cmd: AddMappingCmd) -> Result<(), Error> {
+    let request = AddMappingRequest {
+        name: cmd.config_name.clone(),
+        ipv4: Some(cmd.ipv4.into()),
+        ipv6: Some(cmd.ipv6.into()),
+        prefix_index: cmd.prefix_index,
+    };
+    service
+        .unary("add mapping", request, async |client, request| {
+            client.add_mapping(request).await
+        })
+        .await?;
 
-        output::success(
-            "remove prefix",
-            format_args!("Removed prefix {} from config '{}'.", cmd.prefix, cmd.config_name),
-        );
+    output::success(
+        "add mapping",
+        format_args!(
+            "Added mapping {} -> {} (prefix {}) to config '{}'.",
+            cmd.ipv4, cmd.ipv6, cmd.prefix_index, cmd.config_name
+        ),
+    );
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn add_mapping(&mut self, cmd: AddMappingCmd) -> Result<(), Error> {
-        let request = AddMappingRequest {
-            name: cmd.config_name.clone(),
-            ipv4: Some(cmd.ipv4.into()),
-            ipv6: Some(cmd.ipv6.into()),
-            prefix_index: cmd.prefix_index,
-        };
-        self.service
-            .unary("add mapping", request, async |client, request| {
-                client.add_mapping(request).await
-            })
-            .await?;
+async fn remove_mapping(service: &mut NAT64Service, cmd: RemoveMappingCmd) -> Result<(), Error> {
+    let request = RemoveMappingRequest {
+        name: cmd.config_name.clone(),
+        ipv4: Some(cmd.ipv4.into()),
+    };
+    service
+        .unary("remove mapping", request, async |client, request| {
+            client.remove_mapping(request).await
+        })
+        .await?;
 
-        output::success(
-            "add mapping",
-            format_args!(
-                "Added mapping {} -> {} (prefix {}) to config '{}'.",
-                cmd.ipv4, cmd.ipv6, cmd.prefix_index, cmd.config_name
-            ),
-        );
+    output::success(
+        "remove mapping",
+        format_args!("Removed mapping for {} from config '{}'.", cmd.ipv4, cmd.config_name),
+    );
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn remove_mapping(&mut self, cmd: RemoveMappingCmd) -> Result<(), Error> {
-        let request = RemoveMappingRequest {
-            name: cmd.config_name.clone(),
-            ipv4: Some(cmd.ipv4.into()),
-        };
-        self.service
-            .unary("remove mapping", request, async |client, request| {
-                client.remove_mapping(request).await
-            })
-            .await?;
+async fn set_mtu(service: &mut NAT64Service, cmd: MtuCmd) -> Result<(), Error> {
+    let request = SetMtuRequest {
+        name: cmd.config_name.clone(),
+        mtu: Some(nat64pb::MtuConfig {
+            ipv4_mtu: cmd.ipv4_mtu,
+            ipv6_mtu: cmd.ipv6_mtu,
+        }),
+    };
+    service
+        .unary("set mtu", request, async |client, request| {
+            client.set_mtu(request).await
+        })
+        .await?;
 
-        output::success(
-            "remove mapping",
-            format_args!("Removed mapping for {} from config '{}'.", cmd.ipv4, cmd.config_name),
-        );
+    output::success(
+        "set mtu",
+        format_args!(
+            "Set MTU on config '{}' (IPv4: {}, IPv6: {}).",
+            cmd.config_name, cmd.ipv4_mtu, cmd.ipv6_mtu
+        ),
+    );
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn set_mtu(&mut self, cmd: MtuCmd) -> Result<(), Error> {
-        let request = SetMtuRequest {
-            name: cmd.config_name.clone(),
-            mtu: Some(nat64pb::MtuConfig {
-                ipv4_mtu: cmd.ipv4_mtu,
-                ipv6_mtu: cmd.ipv6_mtu,
-            }),
-        };
-        self.service
-            .unary("set mtu", request, async |client, request| {
-                client.set_mtu(request).await
-            })
-            .await?;
+async fn set_drop_unknown(service: &mut NAT64Service, cmd: DropCmd) -> Result<(), Error> {
+    let request = SetDropUnknownRequest {
+        name: cmd.config_name.clone(),
+        drop_unknown_prefix: cmd.drop_unknown_prefix,
+        drop_unknown_mapping: cmd.drop_unknown_mapping,
+    };
+    service
+        .unary("set drop", request, async |client, request| {
+            client.set_drop_unknown(request).await
+        })
+        .await?;
 
-        output::success(
-            "set mtu",
-            format_args!(
-                "Set MTU on config '{}' (IPv4: {}, IPv6: {}).",
-                cmd.config_name, cmd.ipv4_mtu, cmd.ipv6_mtu
-            ),
-        );
+    output::success(
+        "set drop",
+        format_args!(
+            "Set drop flags on config '{}' (unknown prefix: {}, unknown mapping: {}).",
+            cmd.config_name, cmd.drop_unknown_prefix, cmd.drop_unknown_mapping
+        ),
+    );
 
-        Ok(())
-    }
-
-    pub async fn set_drop_unknown(&mut self, cmd: DropCmd) -> Result<(), Error> {
-        let request = SetDropUnknownRequest {
-            name: cmd.config_name.clone(),
-            drop_unknown_prefix: cmd.drop_unknown_prefix,
-            drop_unknown_mapping: cmd.drop_unknown_mapping,
-        };
-        self.service
-            .unary("set drop", request, async |client, request| {
-                client.set_drop_unknown(request).await
-            })
-            .await?;
-
-        output::success(
-            "set drop",
-            format_args!(
-                "Set drop flags on config '{}' (unknown prefix: {}, unknown mapping: {}).",
-                cmd.config_name, cmd.drop_unknown_prefix, cmd.drop_unknown_mapping
-            ),
-        );
-
-        Ok(())
-    }
+    Ok(())
 }
 
 fn config_block(config: &Config) -> display::KeyValue {

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 use tonic::{Status, codec::CompressionEncoding};
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::{Error, ErrorKind},
     output,
@@ -44,14 +44,14 @@ pub struct Cmd {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = PdumpService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::Set(cmd) => service.set_config(cmd).await,
-        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
-        ModeCmd::Read(cmd) => service.read_dump(cmd).await,
+        ModeCmd::List => list_configs(&mut service).await,
+        ModeCmd::Show(cmd) => show_config(&mut service, cmd).await,
+        ModeCmd::Set(cmd) => set_config(&mut service, cmd).await,
+        ModeCmd::Delete(cmd) => delete_config(&mut service, cmd).await,
+        ModeCmd::Read(cmd) => read_dump(&mut service, cmd).await,
     }
 }
 
@@ -64,227 +64,212 @@ fn client(channel: LayeredChannel) -> PdumpServiceClient<LayeredChannel> {
         .accept_compressed(CompressionEncoding::Gzip)
 }
 
-pub struct PdumpService {
-    service: Service<PdumpServiceClient<LayeredChannel>>,
+type PdumpService = Service<PdumpServiceClient<LayeredChannel>>;
+
+async fn get_config(service: &mut PdumpService, name: &str, action: &'static str) -> Result<ShowConfigResponse, Error> {
+    let request = ShowConfigRequest { name: name.to_owned() };
+    service
+        .unary_with(
+            action,
+            request,
+            service.not_found(action, &format!("config '{name}'")),
+            async |client, request| client.show_config(request).await,
+        )
+        .await
 }
 
-impl PdumpService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn list_configs(service: &mut PdumpService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
 
-        Ok(Self { service })
-    }
-
-    async fn get_config(&mut self, name: &str, action: &'static str) -> Result<ShowConfigResponse, Error> {
-        let request = ShowConfigRequest { name: name.to_owned() };
-        self.service
-            .unary_with(
-                action,
-                request,
-                self.service.not_found(action, &format!("config '{name}'")),
-                async |client, request| client.show_config(request).await,
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No pdump configurations found."),
+                format_args!("create one with 'yanet-cli-pdump set --name <name>'"),
             )
-            .await
-    }
+        },
+    );
 
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
+    Ok(())
+}
 
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No pdump configurations found."),
+async fn show_config(service: &mut PdumpService, cmd: ShowConfigCmd) -> Result<(), Error> {
+    let response = get_config(service, &cmd.config_name, "show").await?;
+
+    output::data(
+        || &response,
+        || {
+            let Some(config) = &response.config else {
+                output::empty_with_hint(
+                    format_args!("No pdump configuration found for '{}'.", cmd.config_name),
                     format_args!("create one with 'yanet-cli-pdump set --name <name>'"),
-                )
-            },
-        );
-
-        Ok(())
-    }
-
-    pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
-        let response = self.get_config(&cmd.config_name, "show").await?;
-
-        output::data(
-            || &response,
-            || {
-                let Some(config) = &response.config else {
-                    output::empty_with_hint(
-                        format_args!("No pdump configuration found for '{}'.", cmd.config_name),
-                        format_args!("create one with 'yanet-cli-pdump set --name <name>'"),
-                    );
-                    return;
-                };
-
-                config_block(config).print();
-            },
-        );
-
-        Ok(())
-    }
-
-    pub async fn set_config(&mut self, cmd: SetConfigCmd) -> Result<(), Error> {
-        let mut request = SetConfigRequest {
-            name: cmd.config_name.clone(),
-            ..Default::default()
-        };
-        let mut cfg = request.config.unwrap_or_default();
-        let mut mask = request.update_mask.unwrap_or_default();
-
-        if let Some(filter) = &cmd.filter {
-            cfg.filter = filter.to_string();
-            mask.paths.push("filter".to_string());
-        }
-
-        if let Some(mode) = cmd.mode {
-            cfg.mode = mode.into();
-            mask.paths.push("mode".to_string());
-        }
-
-        if let Some(snaplen) = cmd.snaplen {
-            cfg.snaplen = snaplen;
-            mask.paths.push("snaplen".to_string());
-        }
-
-        if let Some(ring_size) = cmd.ring_size {
-            cfg.ring_size = ring_size.get();
-            mask.paths.push("ring_size".to_string());
-        }
-
-        request.config = Some(cfg);
-        request.update_mask = Some(mask);
-        self.service
-            .unary("set", request, async |client, request| client.set_config(request).await)
-            .await?;
-
-        output::success("set", format_args!("Updated config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
-
-    pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service
-                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.delete_config(request).await,
-            )
-            .await?;
-
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
-
-    pub async fn read_dump(&mut self, cmd: ReadCmd) -> Result<(), Error> {
-        let cancellation_token = CancellationToken::new();
-        let done = cancellation_token.clone();
-
-        let mut reader_set = JoinSet::new();
-        let (tx, rx) = tokio::sync::mpsc::channel::<pdumppb::Record>(16);
-
-        log::debug!("request current pdump configuration");
-        let config = self.get_config(&cmd.config_name, "read").await?;
-        let Some(config) = config.config else {
-            return Err(Error::from_status(
-                Status::not_found(format!("config '{}' not found", cmd.config_name)),
-                "read",
-                self.service.endpoint(),
-                SERVICE_NAME,
-            ));
-        };
-
-        let request = ReadDumpRequest { name: cmd.config_name.clone() };
-        log::trace!("read_data request: {request:?}");
-        let stream = self
-            .service
-            .client()
-            .read_dump(request)
-            .await
-            .map_err(self.service.status("read"))?
-            .into_inner();
-        log::debug!("read_data successfully acquired data stream for {}", cmd.config_name,);
-
-        // Register before the first byte is written, so that a closed output
-        // reaches the writer instead of the default SIGPIPE disposition.
-        let mut sig_pipe = unix::signal(SignalKind::pipe()).expect("failed to register SIGPIPE handler");
-
-        // Opened once the capture is granted, so that a rejected request
-        // leaves an existing file alone.
-        let output = cmd.output.clone().unwrap_or_else(|| "-".to_owned());
-        let dump_writer = PdumpWriter::new(cmd.dump_format, &output, config.snaplen).map_err(|err| {
-            self.service
-                .invalid("read", format!("cannot write to '{output}': {err}"))
-        })?;
-
-        reader_set.spawn(writer::pdump_stream_reader(stream, tx.clone(), done.clone()));
-        drop(tx);
-
-        // Spawn outside the reader_set to get unpinable join handler.
-        let mut write_jh = tokio::task::spawn_blocking(move || writer::pdump_write(dump_writer, rx, cmd.num));
-
-        let mut finished = None;
-        tokio::select! {
-            _ = sig_pipe.recv() => {
-                log::debug!("the output pipe is closed, stopping the capture");
-                cancellation_token.cancel();
-            }
-            _ = tokio::signal::ctrl_c() => {
-                log::debug!("interrupted, stopping the capture");
-                cancellation_token.cancel();
-            }
-            res = &mut write_jh => {
-                log::debug!("the writer finished, stopping the capture");
-                cancellation_token.cancel();
-                finished = Some(res);
-            }
-        }
-
-        // A capture stopped by a signal leaves the writer running, so wait for
-        // it to drain the channel and flush before reporting anything.
-        let written = match finished {
-            Some(res) => res,
-            None => (&mut write_jh).await,
-        };
-
-        let mut result = match written {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(err)) => Err(self.write_failed(err.to_string())),
-            Err(err) => Err(self.write_failed(format!("the writer task failed: {err}"))),
-        };
-
-        while let Some(res) = reader_set.join_next().await {
-            let failure = match res {
-                Ok(Ok(())) => continue,
-                Ok(Err(status)) => (self.service.status("read"))(status),
-                Err(err) => self.write_failed(format!("the reader task failed: {err}")),
+                );
+                return;
             };
 
-            if result.is_ok() {
-                result = Err(failure);
-            } else {
-                log::debug!("the capture also failed to read the stream: {}", failure.message());
-            }
+            config_block(config).print();
+        },
+    );
+
+    Ok(())
+}
+
+async fn set_config(service: &mut PdumpService, cmd: SetConfigCmd) -> Result<(), Error> {
+    let mut request = SetConfigRequest {
+        name: cmd.config_name.clone(),
+        ..Default::default()
+    };
+    let mut cfg = request.config.unwrap_or_default();
+    let mut mask = request.update_mask.unwrap_or_default();
+
+    if let Some(filter) = &cmd.filter {
+        cfg.filter = filter.to_string();
+        mask.paths.push("filter".to_string());
+    }
+
+    if let Some(mode) = cmd.mode {
+        cfg.mode = mode.into();
+        mask.paths.push("mode".to_string());
+    }
+
+    if let Some(snaplen) = cmd.snaplen {
+        cfg.snaplen = snaplen;
+        mask.paths.push("snaplen".to_string());
+    }
+
+    if let Some(ring_size) = cmd.ring_size {
+        cfg.ring_size = ring_size.get();
+        mask.paths.push("ring_size".to_string());
+    }
+
+    request.config = Some(cfg);
+    request.update_mask = Some(mask);
+    service
+        .unary("set", request, async |client, request| client.set_config(request).await)
+        .await?;
+
+    output::success("set", format_args!("Updated config '{}'.", cmd.config_name));
+
+    Ok(())
+}
+
+async fn delete_config(service: &mut PdumpService, cmd: DeleteCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
+
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
+
+    Ok(())
+}
+
+async fn read_dump(service: &mut PdumpService, cmd: ReadCmd) -> Result<(), Error> {
+    let cancellation_token = CancellationToken::new();
+    let done = cancellation_token.clone();
+
+    let mut reader_set = JoinSet::new();
+    let (tx, rx) = tokio::sync::mpsc::channel::<pdumppb::Record>(16);
+
+    log::debug!("request current pdump configuration");
+    let config = get_config(service, &cmd.config_name, "read").await?;
+    let Some(config) = config.config else {
+        return Err(Error::from_status(
+            Status::not_found(format!("config '{}' not found", cmd.config_name)),
+            "read",
+            service.endpoint(),
+            SERVICE_NAME,
+        ));
+    };
+
+    let request = ReadDumpRequest { name: cmd.config_name.clone() };
+    log::trace!("read_data request: {request:?}");
+    let stream = service
+        .client()
+        .read_dump(request)
+        .await
+        .map_err(service.status("read"))?
+        .into_inner();
+    log::debug!("read_data successfully acquired data stream for {}", cmd.config_name,);
+
+    // Register before the first byte is written, so that a closed output
+    // reaches the writer instead of the default SIGPIPE disposition.
+    let mut sig_pipe = unix::signal(SignalKind::pipe()).expect("failed to register SIGPIPE handler");
+
+    // Opened once the capture is granted, so that a rejected request
+    // leaves an existing file alone.
+    let output = cmd.output.clone().unwrap_or_else(|| "-".to_owned());
+    let dump_writer = PdumpWriter::new(cmd.dump_format, &output, config.snaplen)
+        .map_err(|err| service.invalid("read", format!("cannot write to '{output}': {err}")))?;
+
+    reader_set.spawn(writer::pdump_stream_reader(stream, tx.clone(), done.clone()));
+    drop(tx);
+
+    // Spawn outside the reader_set to get unpinable join handler.
+    let mut write_jh = tokio::task::spawn_blocking(move || writer::pdump_write(dump_writer, rx, cmd.num));
+
+    let mut finished = None;
+    tokio::select! {
+        _ = sig_pipe.recv() => {
+            log::debug!("the output pipe is closed, stopping the capture");
+            cancellation_token.cancel();
         }
-
-        result
+        _ = tokio::signal::ctrl_c() => {
+            log::debug!("interrupted, stopping the capture");
+            cancellation_token.cancel();
+        }
+        res = &mut write_jh => {
+            log::debug!("the writer finished, stopping the capture");
+            cancellation_token.cancel();
+            finished = Some(res);
+        }
     }
 
-    /// Reports a failure of the local capture pipeline, which has no gRPC
-    /// status of its own.
-    fn write_failed(&self, message: String) -> Error {
-        Error::new(ErrorKind::Rpc, "read", self.service.endpoint(), message)
+    // A capture stopped by a signal leaves the writer running, so wait for
+    // it to drain the channel and flush before reporting anything.
+    let written = match finished {
+        Some(res) => res,
+        None => (&mut write_jh).await,
+    };
+
+    let mut result = match written {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(err)) => Err(write_failed(service, err.to_string())),
+        Err(err) => Err(write_failed(service, format!("the writer task failed: {err}"))),
+    };
+
+    while let Some(res) = reader_set.join_next().await {
+        let failure = match res {
+            Ok(Ok(())) => continue,
+            Ok(Err(status)) => (service.status("read"))(status),
+            Err(err) => write_failed(service, format!("the reader task failed: {err}")),
+        };
+
+        if result.is_ok() {
+            result = Err(failure);
+        } else {
+            log::debug!("the capture also failed to read the stream: {}", failure.message());
+        }
     }
+
+    result
+}
+
+/// Reports a failure of the local capture pipeline, which has no gRPC
+/// status of its own.
+fn write_failed(service: &PdumpService, message: String) -> Error {
+    Error::new(ErrorKind::Rpc, "read", service.endpoint(), message)
 }
 
 fn config_block(config: &pdumppb::Config) -> display::KeyValue {

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -17,7 +17,7 @@ use routemplspb::{
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -150,174 +150,161 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = RouteMplsService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::Create(cmd) => service.create_config(cmd).await,
-        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
-        ModeCmd::Update(cmd) => service.update_route(cmd).await,
-        ModeCmd::Withdraw(cmd) => service.withdraw_route(cmd).await,
+        ModeCmd::List => list_configs(&mut service).await,
+        ModeCmd::Show(cmd) => show_config(&mut service, cmd).await,
+        ModeCmd::Create(cmd) => create_config(&mut service, cmd).await,
+        ModeCmd::Delete(cmd) => delete_config(&mut service, cmd).await,
+        ModeCmd::Update(cmd) => update_route(&mut service, cmd).await,
+        ModeCmd::Withdraw(cmd) => withdraw_route(&mut service, cmd).await,
     }
 }
 
-pub struct RouteMplsService {
-    service: Service<RouteMplsServiceClient<LayeredChannel>>,
-}
+type RouteMplsService = Service<RouteMplsServiceClient<LayeredChannel>>;
 
-impl RouteMplsService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn list_configs(service: &mut RouteMplsService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
 
-        Ok(Self { service })
-    }
-
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
-
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No route-mpls configurations found."),
-                    format_args!("create one with 'yanet-cli-route-mpls create --name <name>'"),
-                )
-            },
-        );
-
-        Ok(())
-    }
-
-    pub async fn show_config(&mut self, cmd: RouteShowCmd) -> Result<(), Error> {
-        let request = ShowConfigRequest { name: cmd.config_name.clone() };
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.show_config(request).await,
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No route-mpls configurations found."),
+                format_args!("create one with 'yanet-cli-route-mpls create --name <name>'"),
             )
-            .await?;
+        },
+    );
 
-        output::data(
-            || &response,
-            || {
-                print!(
-                    "{}",
-                    serde_yaml::to_string(&response).expect("route-mpls config YAML serialization must not fail")
+    Ok(())
+}
+
+async fn show_config(service: &mut RouteMplsService, cmd: RouteShowCmd) -> Result<(), Error> {
+    let request = ShowConfigRequest { name: cmd.config_name.clone() };
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.show_config(request).await,
+        )
+        .await?;
+
+    output::data(
+        || &response,
+        || {
+            print!(
+                "{}",
+                serde_yaml::to_string(&response).expect("route-mpls config YAML serialization must not fail")
+            );
+
+            if response.rules.is_empty() {
+                output::empty_with_hint(
+                    format_args!("No route-mpls rules found for '{}'.", cmd.config_name),
+                    format_args!(
+                        "create one with 'yanet-cli-route-mpls update --name <name> --prefix <cidr> --dst <addr> --label <n> --src <addr> --weight <n> --counter <counter-name>'"
+                    ),
                 );
+            }
+        },
+    );
 
-                if response.rules.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No route-mpls rules found for '{}'.", cmd.config_name),
-                        format_args!(
-                            "create one with 'yanet-cli-route-mpls update --name <name> --prefix <cidr> --dst <addr> --label <n> --src <addr> --weight <n> --counter <counter-name>'"
-                        ),
-                    );
-                }
-            },
-        );
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn create_config(service: &mut RouteMplsService, cmd: RouteCreateCmd) -> Result<(), Error> {
+    let request = CreateConfigRequest {
+        name: cmd.config_name.clone(),
+        rules: Vec::<Rule>::new(),
+    };
+    service
+        .unary("create", request, async |client, request| {
+            client.create_config(request).await
+        })
+        .await?;
 
-    pub async fn create_config(&mut self, cmd: RouteCreateCmd) -> Result<(), Error> {
-        let request = CreateConfigRequest {
-            name: cmd.config_name.clone(),
-            rules: Vec::<Rule>::new(),
-        };
-        self.service
-            .unary("create", request, async |client, request| {
-                client.create_config(request).await
-            })
-            .await?;
+    output::success("create", format_args!("Created config '{}'.", cmd.config_name));
 
-        output::success("create", format_args!("Created config '{}'.", cmd.config_name));
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn delete_config(service: &mut RouteMplsService, cmd: RouteDeleteCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
 
-    pub async fn delete_config(&mut self, cmd: RouteDeleteCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service
-                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.delete_config(request).await,
-            )
-            .await?;
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn update_route(service: &mut RouteMplsService, cmd: RouteUpdateCmd) -> Result<(), Error> {
+    let request = UpdateConfigRequest {
+        name: cmd.config_name.clone(),
+        updates: vec![UpdateEvent {
+            event: Some(Event::Update(Rule {
+                prefix: Some(cmd.prefix.into()),
+                nexthop: Some(NextHop {
+                    kind: routemplspb::ActionKind::Tunnel.into(),
+                    label: cmd.mpls_label,
+                    source_ip: Some(cmd.src_addr.into()),
+                    destination_ip: Some(cmd.dst_addr.into()),
+                    weight: cmd.weight,
+                    counter: cmd.counter,
+                }),
+            })),
+        }],
+    };
+    service
+        .unary("update", request, async |client, request| {
+            client.update_config(request).await
+        })
+        .await?;
 
-    pub async fn update_route(&mut self, cmd: RouteUpdateCmd) -> Result<(), Error> {
-        let request = UpdateConfigRequest {
-            name: cmd.config_name.clone(),
-            updates: vec![UpdateEvent {
-                event: Some(Event::Update(Rule {
-                    prefix: Some(cmd.prefix.into()),
-                    nexthop: Some(NextHop {
-                        kind: routemplspb::ActionKind::Tunnel.into(),
-                        label: cmd.mpls_label,
-                        source_ip: Some(cmd.src_addr.into()),
-                        destination_ip: Some(cmd.dst_addr.into()),
-                        weight: cmd.weight,
-                        counter: cmd.counter,
-                    }),
-                })),
-            }],
-        };
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_config(request).await
-            })
-            .await?;
+    output::success("update", format_args!("Updated route in config '{}'.", cmd.config_name));
 
-        output::success("update", format_args!("Updated route in config '{}'.", cmd.config_name));
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn withdraw_route(service: &mut RouteMplsService, cmd: RouteWithdrawCmd) -> Result<(), Error> {
+    let request = UpdateConfigRequest {
+        name: cmd.config_name.clone(),
+        updates: vec![UpdateEvent {
+            event: Some(Event::Withdraw(Rule {
+                prefix: Some(cmd.prefix.into()),
+                nexthop: Some(NextHop {
+                    kind: routemplspb::ActionKind::Tunnel.into(),
+                    label: cmd.mpls_label,
+                    source_ip: None,
+                    destination_ip: Some(cmd.dst_addr.into()),
+                    weight: 0,
+                    counter: "".to_string(),
+                }),
+            })),
+        }],
+    };
+    service
+        .unary("withdraw", request, async |client, request| {
+            client.update_config(request).await
+        })
+        .await?;
 
-    pub async fn withdraw_route(&mut self, cmd: RouteWithdrawCmd) -> Result<(), Error> {
-        let request = UpdateConfigRequest {
-            name: cmd.config_name.clone(),
-            updates: vec![UpdateEvent {
-                event: Some(Event::Withdraw(Rule {
-                    prefix: Some(cmd.prefix.into()),
-                    nexthop: Some(NextHop {
-                        kind: routemplspb::ActionKind::Tunnel.into(),
-                        label: cmd.mpls_label,
-                        source_ip: None,
-                        destination_ip: Some(cmd.dst_addr.into()),
-                        weight: 0,
-                        counter: "".to_string(),
-                    }),
-                })),
-            }],
-        };
-        self.service
-            .unary("withdraw", request, async |client, request| {
-                client.update_config(request).await
-            })
-            .await?;
+    output::success(
+        "withdraw",
+        format_args!("Withdrew route from config '{}'.", cmd.config_name),
+    );
 
-        output::success(
-            "withdraw",
-            format_args!("Withdrew route from config '{}'.", cmd.config_name),
-        );
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/modules/route/cli/Cargo.toml
+++ b/modules/route/cli/Cargo.toml
@@ -24,7 +24,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 netip = "0.3"
-tokio = { version = "1", features = ["macros", "net", "rt", "time"] }
 
 [build-dependencies]
 ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }

--- a/modules/route/cli/src/main.rs
+++ b/modules/route/cli/src/main.rs
@@ -10,7 +10,7 @@ use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output, yaml,
@@ -211,133 +211,115 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = RouteService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
         ModeCmd::Fib(cmd) => match cmd.action {
-            FibAction::List => service.list_fibs().await,
-            FibAction::Show(cmd) => service.show_fib(cmd).await,
-            FibAction::Update(cmd) => service.update_fib(cmd).await,
-            FibAction::Delete(cmd) => service.delete_fib(cmd).await,
+            FibAction::List => list_fibs(&mut service).await,
+            FibAction::Show(cmd) => show_fib(&mut service, cmd).await,
+            FibAction::Update(cmd) => update_fib(&mut service, cmd).await,
+            FibAction::Delete(cmd) => delete_fib(&mut service, cmd).await,
         },
     }
 }
 
-pub struct RouteService {
-    service: Service<RouteServiceClient<LayeredChannel>>,
+type RouteService = Service<RouteServiceClient<LayeredChannel>>;
+
+async fn update_fib(service: &mut RouteService, cmd: FibUpdateCmd) -> Result<(), Error> {
+    let config = FibConfig::load(&cmd.file).map_err(|err| service.invalid("update", err.to_string()))?;
+    let entry_count = config.entries.len();
+    let request = UpdateFibRequest {
+        module_name: cmd.config_name.clone(),
+        entries: config.entries,
+    };
+    service
+        .unary("update", request, async |client, request| {
+            client.update_fib(request).await
+        })
+        .await?;
+
+    output::success(
+        "update",
+        format_args!("Updated config '{}' ({} entries).", cmd.config_name, entry_count),
+    );
+    Ok(())
 }
 
-impl RouteService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn delete_fib(service: &mut RouteService, cmd: FibDeleteCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config_name.clone() };
 
-        Ok(Self { service })
-    }
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
 
-    pub async fn update_fib(&mut self, cmd: FibUpdateCmd) -> Result<(), Error> {
-        let config = FibConfig::load(&cmd.file).map_err(|err| self.service.invalid("update", err.to_string()))?;
-        let entry_count = config.entries.len();
-        let request = UpdateFibRequest {
-            module_name: cmd.config_name.clone(),
-            entries: config.entries,
-        };
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_fib(request).await
-            })
-            .await?;
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
+    Ok(())
+}
 
-        output::success(
-            "update",
-            format_args!("Updated config '{}' ({} entries).", cmd.config_name, entry_count),
-        );
-        Ok(())
-    }
+async fn list_fibs(service: &mut RouteService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
 
-    pub async fn delete_fib(&mut self, cmd: FibDeleteCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service
-                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.delete_config(request).await,
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No FIB configurations found."),
+                format_args!("create one with 'yanet-cli-route fib update --name <name> <path>'"),
             )
-            .await?;
+        },
+    );
+    Ok(())
+}
 
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
-        Ok(())
-    }
+async fn show_fib(service: &mut RouteService, cmd: FibShowCmd) -> Result<(), Error> {
+    let request = ShowFibRequest {
+        name: cmd.config_name.clone(),
+        ipv4_only: cmd.ipv4,
+        ipv6_only: cmd.ipv6,
+    };
 
-    pub async fn list_fibs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.show_fib(request).await,
+        )
+        .await?;
+    let entries = response.entries;
 
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No FIB configurations found."),
-                    format_args!("create one with 'yanet-cli-route fib update --name <name> <path>'"),
-                )
-            },
-        );
-        Ok(())
-    }
+    output::data(
+        || &entries,
+        || {
+            if entries.is_empty() {
+                output::empty(format_args!("No FIB entries found for '{}'.", cmd.config_name));
+                return;
+            }
 
-    pub async fn show_fib(&mut self, cmd: FibShowCmd) -> Result<(), Error> {
-        let request = ShowFibRequest {
-            name: cmd.config_name.clone(),
-            ipv4_only: cmd.ipv4,
-            ipv6_only: cmd.ipv6,
-        };
+            print_fib(&entries);
+        },
+    );
 
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.show_fib(request).await,
-            )
-            .await?;
-        let entries = response.entries;
-
-        output::data(
-            || &entries,
-            || {
-                if entries.is_empty() {
-                    output::empty(format_args!("No FIB entries found for '{}'.", cmd.config_name));
-                    return;
-                }
-
-                print_fib(&entries);
-            },
-        );
-
-        Ok(())
-    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod test {
     use core::net::IpAddr;
-    use std::{env, fs, net::TcpListener};
+    use std::{env, fs};
 
     use commonpb::pb::{IpRange, MacAddress};
     use netip::MacAddr;
-    use ync::{
-        auth::{AuthArgs, AuthMethod},
-        client::TlsArgs,
-        errors::ErrorKind,
-    };
 
     use super::*;
 
@@ -735,28 +717,5 @@ entries:
         fs::remove_file(&path).unwrap();
 
         assert_eq!(format!("{}: entry 0: missing range", path.display()), err.to_string());
-    }
-
-    /// Verifies that a refused connection is reported through the shared
-    /// error contract as a connection failure, exit code 4.
-    #[tokio::test]
-    async fn test_route_service_new_connection_refused_reports_connection_error() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
-        let connection = ConnectionArgs {
-            endpoint: Some(format!("grpc://127.0.0.1:{port}")),
-            auth: AuthArgs {
-                auth: Some(AuthMethod::None),
-                cert_tag: None,
-            },
-            tls: TlsArgs::default(),
-            timeout: None,
-        };
-
-        let err = RouteService::new(&connection, "list").await.err().unwrap();
-
-        assert_eq!(ErrorKind::Connection, err.kind());
-        assert_eq!(4, err.exit_code());
     }
 }

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -13,7 +13,7 @@ use unrduppb::{
 };
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service as GrpcService},
+    client::{LayeredChannel, Service as GrpcService},
     completion, display,
     errors::Error,
     output, yaml,
@@ -232,116 +232,101 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = UnrdupService::new(&cmd.globals.connection, action).await?;
+    let mut service = GrpcService::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::Update(cmd) => service.update_config(cmd).await,
-        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
+        ModeCmd::List => list_configs(&mut service).await,
+        ModeCmd::Show(cmd) => show_config(&mut service, cmd).await,
+        ModeCmd::Update(cmd) => update_config(&mut service, cmd).await,
+        ModeCmd::Delete(cmd) => delete_config(&mut service, cmd).await,
     }
 }
 
-pub struct UnrdupService {
-    service: GrpcService<UnrdupServiceClient<LayeredChannel>>,
+type UnrdupService = GrpcService<UnrdupServiceClient<LayeredChannel>>;
+
+async fn list_configs(service: &mut UnrdupService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
+
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No unrdup configurations found."),
+                format_args!("create one with 'yanet-cli-unrdup update --name <name> <path>'"),
+            )
+        },
+    );
+
+    Ok(())
 }
 
-impl UnrdupService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = GrpcService::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn show_config(service: &mut UnrdupService, cmd: ShowConfigCmd) -> Result<(), Error> {
+    let request = ShowConfigRequest { name: cmd.config_name.clone() };
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.show_config(request).await,
+        )
+        .await?;
 
-        Ok(Self { service })
-    }
+    let config = response
+        .config
+        .ok_or_else(|| service.invalid("show", "response carries no config"))?;
 
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
+    let rendered = UnrdupConfig::try_from(config.clone()).map_err(|err| service.invalid("show", err.to_string()))?;
 
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No unrdup configurations found."),
-                    format_args!("create one with 'yanet-cli-unrdup update --name <name> <path>'"),
-                )
-            },
-        );
+    output::data(
+        || &config,
+        || {
+            println!(
+                "{}",
+                serde_yaml::to_string(&rendered).expect("unrdup config YAML serialization must not fail")
+            );
+        },
+    );
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
-        let request = ShowConfigRequest { name: cmd.config_name.clone() };
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.show_config(request).await,
-            )
-            .await?;
+async fn update_config(service: &mut UnrdupService, cmd: UpdateConfigCmd) -> Result<(), Error> {
+    let config: UnrdupConfig = yaml::load(&cmd.file).map_err(|err| service.invalid("update", err.to_string()))?;
 
-        let config = response
-            .config
-            .ok_or_else(|| self.service.invalid("show", "response carries no config"))?;
+    let request = UpdateConfigRequest {
+        name: cmd.config_name.clone(),
+        config: Some(Config::from(config)),
+    };
+    service
+        .unary("update", request, async |client, request| {
+            client.update_config(request).await
+        })
+        .await?;
 
-        let rendered =
-            UnrdupConfig::try_from(config.clone()).map_err(|err| self.service.invalid("show", err.to_string()))?;
+    output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
 
-        output::data(
-            || &config,
-            || {
-                println!(
-                    "{}",
-                    serde_yaml::to_string(&rendered).expect("unrdup config YAML serialization must not fail")
-                );
-            },
-        );
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn delete_config(service: &mut UnrdupService, cmd: DeleteConfigCmd) -> Result<(), Error> {
+    let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("config '{}'", cmd.config_name)),
+            async |client, request| client.delete_config(request).await,
+        )
+        .await?;
 
-    pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Error> {
-        let config: UnrdupConfig =
-            yaml::load(&cmd.file).map_err(|err| self.service.invalid("update", err.to_string()))?;
+    output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
 
-        let request = UpdateConfigRequest {
-            name: cmd.config_name.clone(),
-            config: Some(Config::from(config)),
-        };
-        self.service
-            .unary("update", request, async |client, request| {
-                client.update_config(request).await
-            })
-            .await?;
-
-        output::success("update", format_args!("Updated config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
-
-    pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
-        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
-        self.service
-            .unary_with(
-                "delete",
-                request,
-                self.service
-                    .not_found("delete", &format!("config '{}'", cmd.config_name)),
-                async |client, request| client.delete_config(request).await,
-            )
-            .await?;
-
-        output::success("delete", format_args!("Deleted config '{}'.", cmd.config_name));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 fn config_candidates() -> Vec<CompletionCandidate> {

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{Connection, ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -45,9 +45,7 @@ pub struct Cmd {
     pub globals: GlobalArgs,
 }
 
-pub struct FWStateMapService {
-    service: Service<FwStateMapServiceClient<LayeredChannel>>,
-}
+type FWStateMapService = Service<FwStateMapServiceClient<LayeredChannel>>;
 
 /// Warns when a response reports a different generation than the one
 /// before it, `seen` carrying the last one across the batches.
@@ -66,206 +64,193 @@ fn note_generation(seen: &mut Option<u64>, generation: u64) {
     }
 }
 
-impl FWStateMapService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let conn = Connection::connect_for(connection, action).await?;
-        let service = Service::new(&conn, SERVICE_NAME, client);
+async fn map_create(service: &mut FWStateMapService, cmd: CreateCmd) -> Result<(), Error> {
+    let request = CreateMapRequest {
+        name: cmd.map_name.clone(),
+        kind: match cmd.kind {
+            args::MapKind::V4 => fwstatemappb::Kind::V4.into(),
+            args::MapKind::V6 => fwstatemappb::Kind::V6.into(),
+        },
+        index_size: cmd.index_size.unwrap_or(0),
+        extra_bucket_count: cmd.extra_bucket_count.unwrap_or(0),
+        worker_count: cmd.worker_count.unwrap_or(0),
+    };
+    service
+        .unary("create", request, async |client, request| {
+            client.create_map(request).await
+        })
+        .await?;
 
-        Ok(Self { service })
+    output::success("create", format_args!("Created map '{}'.", cmd.map_name));
+
+    Ok(())
+}
+
+async fn map_delete(service: &mut FWStateMapService, cmd: DeleteCmd) -> Result<(), Error> {
+    let request = DeleteMapRequest { name: cmd.map_name.clone() };
+    service
+        .unary_with(
+            "delete",
+            request,
+            service.not_found("delete", &format!("map '{}'", cmd.map_name)),
+            async |client, request| client.delete_map(request).await,
+        )
+        .await?;
+
+    output::success("delete", format_args!("Deleted map '{}'.", cmd.map_name));
+
+    Ok(())
+}
+
+async fn map_list(service: &mut FWStateMapService, _cmd: ListCmd) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListMapsRequest {}, async |client, request| {
+            client.list_maps(request).await
+        })
+        .await?;
+
+    // The wire response's kinds map has no defined iteration order and
+    // HashMap serialization is keyed by name only, so a stable payload
+    // pairs each name with its family in the listing's own order. A
+    // kind the enum does not know (a server ahead of this CLI) reads
+    // as "unknown" rather than silently pretending to be a family.
+    #[derive(Serialize)]
+    struct ListedMap<'a> {
+        name: &'a str,
+        kind: &'a str,
     }
-
-    pub async fn map_create(&mut self, cmd: CreateCmd) -> Result<(), Error> {
-        let request = CreateMapRequest {
-            name: cmd.map_name.clone(),
-            kind: match cmd.kind {
-                args::MapKind::V4 => fwstatemappb::Kind::V4.into(),
-                args::MapKind::V6 => fwstatemappb::Kind::V6.into(),
+    let listed: Vec<ListedMap> = response
+        .maps
+        .iter()
+        .map(|name| ListedMap {
+            name,
+            kind: match response.kinds.get(name).and_then(|raw| Kind::try_from(*raw).ok()) {
+                Some(Kind::V4) => "v4",
+                Some(Kind::V6) => "v6",
+                // Absent from the map or a discriminant this CLI's
+                // enum does not know (a server ahead of it).
+                None => "unknown",
             },
-            index_size: cmd.index_size.unwrap_or(0),
-            extra_bucket_count: cmd.extra_bucket_count.unwrap_or(0),
-            worker_count: cmd.worker_count.unwrap_or(0),
+        })
+        .collect();
+
+    output::data(
+        || &listed,
+        || {
+            display::print_names_with_hint(
+                &response.maps,
+                format_args!("No fwstate-map objects found."),
+                format_args!("create one with 'yanet-cli-fwstatemap create --name <name> --kind <v4|v6>'"),
+            )
+        },
+    );
+
+    Ok(())
+}
+
+async fn map_stats(service: &mut FWStateMapService, cmd: StatsCmd) -> Result<(), Error> {
+    let request = GetMapStatsRequest { name: cmd.map_name.clone() };
+    let response = service
+        .unary_with(
+            "stats",
+            request,
+            service.not_found("stats", &format!("map '{}'", cmd.map_name)),
+            async |client, request| client.get_map_stats(request).await,
+        )
+        .await?;
+
+    output::data(
+        || &response,
+        || {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&response).expect("fwstate-map stats JSON serialization must not fail")
+            );
+        },
+    );
+
+    Ok(())
+}
+
+async fn map_insert_layer(service: &mut FWStateMapService, cmd: InsertLayerCmd) -> Result<(), Error> {
+    // The map object carries its own address family; the request's kind
+    // field is redundant with it, so it is left at the default.
+    let request = InsertLayerRequest {
+        name: cmd.map_name.clone(),
+        index_size: cmd.index_size.unwrap_or(0),
+        extra_bucket_count: cmd.extra_bucket_count.unwrap_or(0),
+        worker_count: cmd.worker_count.unwrap_or(0),
+        ..Default::default()
+    };
+    service
+        .unary("insert-layer", request, async |client, request| {
+            client.insert_layer(request).await
+        })
+        .await?;
+
+    output::success(
+        "insert-layer",
+        format_args!("Inserted layer into map '{}'.", cmd.map_name),
+    );
+
+    Ok(())
+}
+
+async fn map_entries(service: &mut FWStateMapService, cmd: EntriesCmd) -> Result<(), Error> {
+    let direction = match cmd.direction {
+        DirectionArg::Forward => Direction::Forward,
+        DirectionArg::Backward => Direction::Backward,
+    };
+
+    let limit = usize::try_from(cmd.count).expect("a count fits usize");
+    let mut generation = None;
+    let mut rows = output::rows(print_entries_header, print_entry);
+
+    // Plain cursor pagination: each request carries the full cursor
+    // and the response's index feeds the next call until has_more is
+    // false, so a failed page is one failed call rather than a torn
+    // stream.
+    let mut index = cmd.index as i64;
+    loop {
+        let request = ListEntriesRequest {
+            map_name: cmd.map_name.clone(),
+            layer_index: cmd.layer,
+            include_expired: cmd.include_expired,
+            direction: direction as i32,
+            batch_size: cmd.batch,
+            index,
         };
-        self.service
-            .unary("create", request, async |client, request| {
-                client.create_map(request).await
-            })
-            .await?;
-
-        output::success("create", format_args!("Created map '{}'.", cmd.map_name));
-
-        Ok(())
-    }
-
-    pub async fn map_delete(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
-        let request = DeleteMapRequest { name: cmd.map_name.clone() };
-        self.service
+        let resp = service
             .unary_with(
-                "delete",
+                "entries",
                 request,
-                self.service.not_found("delete", &format!("map '{}'", cmd.map_name)),
-                async |client, request| client.delete_map(request).await,
+                service.not_found("entries", &format!("map '{}'", cmd.map_name)),
+                async |client, request| client.list_entries(request).await,
             )
             .await?;
 
-        output::success("delete", format_args!("Deleted map '{}'.", cmd.map_name));
+        note_generation(&mut generation, resp.generation);
 
-        Ok(())
-    }
-
-    pub async fn map_list(&mut self, _cmd: ListCmd) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListMapsRequest {}, async |client, request| {
-                client.list_maps(request).await
-            })
-            .await?;
-
-        // The wire response's kinds map has no defined iteration order and
-        // HashMap serialization is keyed by name only, so a stable payload
-        // pairs each name with its family in the listing's own order. A
-        // kind the enum does not know (a server ahead of this CLI) reads
-        // as "unknown" rather than silently pretending to be a family.
-        #[derive(Serialize)]
-        struct ListedMap<'a> {
-            name: &'a str,
-            kind: &'a str,
-        }
-        let listed: Vec<ListedMap> = response
-            .maps
-            .iter()
-            .map(|name| ListedMap {
-                name,
-                kind: match response.kinds.get(name).and_then(|raw| Kind::try_from(*raw).ok()) {
-                    Some(Kind::V4) => "v4",
-                    Some(Kind::V6) => "v6",
-                    // Absent from the map or a discriminant this CLI's
-                    // enum does not know (a server ahead of it).
-                    None => "unknown",
-                },
-            })
-            .collect();
-
-        output::data(
-            || &listed,
-            || {
-                display::print_names_with_hint(
-                    &response.maps,
-                    format_args!("No fwstate-map objects found."),
-                    format_args!("create one with 'yanet-cli-fwstatemap create --name <name> --kind <v4|v6>'"),
-                )
-            },
-        );
-
-        Ok(())
-    }
-
-    pub async fn map_stats(&mut self, cmd: StatsCmd) -> Result<(), Error> {
-        let request = GetMapStatsRequest { name: cmd.map_name.clone() };
-        let response = self
-            .service
-            .unary_with(
-                "stats",
-                request,
-                self.service.not_found("stats", &format!("map '{}'", cmd.map_name)),
-                async |client, request| client.get_map_stats(request).await,
-            )
-            .await?;
-
-        output::data(
-            || &response,
-            || {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&response)
-                        .expect("fwstate-map stats JSON serialization must not fail")
-                );
-            },
-        );
-
-        Ok(())
-    }
-
-    pub async fn map_insert_layer(&mut self, cmd: InsertLayerCmd) -> Result<(), Error> {
-        // The map object carries its own address family; the request's kind
-        // field is redundant with it, so it is left at the default.
-        let request = InsertLayerRequest {
-            name: cmd.map_name.clone(),
-            index_size: cmd.index_size.unwrap_or(0),
-            extra_bucket_count: cmd.extra_bucket_count.unwrap_or(0),
-            worker_count: cmd.worker_count.unwrap_or(0),
-            ..Default::default()
-        };
-        self.service
-            .unary("insert-layer", request, async |client, request| {
-                client.insert_layer(request).await
-            })
-            .await?;
-
-        output::success(
-            "insert-layer",
-            format_args!("Inserted layer into map '{}'.", cmd.map_name),
-        );
-
-        Ok(())
-    }
-
-    pub async fn map_entries(&mut self, cmd: EntriesCmd) -> Result<(), Error> {
-        let direction = match cmd.direction {
-            DirectionArg::Forward => Direction::Forward,
-            DirectionArg::Backward => Direction::Backward,
-        };
-
-        let limit = usize::try_from(cmd.count).expect("a count fits usize");
-        let mut generation = None;
-        let mut rows = output::rows(print_entries_header, print_entry);
-
-        // Plain cursor pagination: each request carries the full cursor
-        // and the response's index feeds the next call until has_more is
-        // false, so a failed page is one failed call rather than a torn
-        // stream.
-        let mut index = cmd.index as i64;
-        loop {
-            let request = ListEntriesRequest {
-                map_name: cmd.map_name.clone(),
-                layer_index: cmd.layer,
-                include_expired: cmd.include_expired,
-                direction: direction as i32,
-                batch_size: cmd.batch,
-                index,
-            };
-            let resp = self
-                .service
-                .unary_with(
-                    "entries",
-                    request,
-                    self.service.not_found("entries", &format!("map '{}'", cmd.map_name)),
-                    async |client, request| client.list_entries(request).await,
-                )
-                .await?;
-
-            note_generation(&mut generation, resp.generation);
-
-            for entry in &resp.entries {
-                if limit > 0 && rows.printed() >= limit {
-                    break;
-                }
-
-                rows.push(entry);
-            }
-
-            if (limit > 0 && rows.printed() >= limit) || !resp.has_more {
+        for entry in &resp.entries {
+            if limit > 0 && rows.printed() >= limit {
                 break;
             }
-            index = resp.index;
+
+            rows.push(entry);
         }
 
-        rows.finish(format_args!(
-            "No firewall state entries found for map '{}'.",
-            cmd.map_name
-        ));
-
-        Ok(())
+        if (limit > 0 && rows.printed() >= limit) || !resp.has_more {
+            break;
+        }
+        index = resp.index;
     }
+
+    rows.finish(format_args!(
+        "No firewall state entries found for map '{}'.",
+        cmd.map_name
+    ));
+
+    Ok(())
 }
 
 /// Formats an address and port as an endpoint, bracketing IPv6.
@@ -385,15 +370,15 @@ fn print_entry(entry: &fwstatemappb::FwStateEntry) {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = FWStateMapService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.map_list(args::ListCmd).await,
-        ModeCmd::Create(cmd) => service.map_create(cmd).await,
-        ModeCmd::Delete(cmd) => service.map_delete(cmd).await,
-        ModeCmd::Stats(cmd) => service.map_stats(cmd).await,
-        ModeCmd::Entries(cmd) => service.map_entries(cmd).await,
-        ModeCmd::InsertLayer(cmd) => service.map_insert_layer(cmd).await,
+        ModeCmd::List => map_list(&mut service, args::ListCmd).await,
+        ModeCmd::Create(cmd) => map_create(&mut service, cmd).await,
+        ModeCmd::Delete(cmd) => map_delete(&mut service, cmd).await,
+        ModeCmd::Stats(cmd) => map_stats(&mut service, cmd).await,
+        ModeCmd::Entries(cmd) => map_entries(&mut service, cmd).await,
+        ModeCmd::InsertLayer(cmd) => map_insert_layer(&mut service, cmd).await,
     }
 }
 

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -21,7 +21,7 @@ use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion,
     display::print_table_from_entries,
     errors::Error,
@@ -178,218 +178,205 @@ fn main() -> std::process::ExitCode {
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = NeighbourService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::Show(args) => service.show_neighbours(args).await,
-        ModeCmd::Add(args) => service.update_neighbour(args).await,
-        ModeCmd::Remove(args) => service.remove_neighbours(args).await,
+        ModeCmd::Show(args) => show_neighbours(&mut service, args).await,
+        ModeCmd::Add(args) => update_neighbour(&mut service, args).await,
+        ModeCmd::Remove(args) => remove_neighbours(&mut service, args).await,
         ModeCmd::Table(cmd) => match cmd.action {
-            TableAction::Show => service.list_tables().await,
-            TableAction::Create(args) => service.create_table(args).await,
-            TableAction::Update(args) => service.update_table(args).await,
-            TableAction::Remove(args) => service.remove_table(args).await,
+            TableAction::Show => list_tables(&mut service).await,
+            TableAction::Create(args) => create_table(&mut service, args).await,
+            TableAction::Update(args) => update_table(&mut service, args).await,
+            TableAction::Remove(args) => remove_table(&mut service, args).await,
         },
     }
 }
 
-pub struct NeighbourService {
-    service: Service<NeighbourServiceClient<LayeredChannel>>,
+type NeighbourService = Service<NeighbourServiceClient<LayeredChannel>>;
+
+async fn show_neighbours(service: &mut NeighbourService, cmd: ShowCmd) -> Result<(), Error> {
+    let request = ListNeighboursRequest {
+        table: cmd.table.clone().unwrap_or_default(),
+    };
+    let resource = cmd.table.as_ref().map(|table| format!("table '{table}'"));
+
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", resource.as_deref().unwrap_or("requested table")),
+            async |client, request| client.list(request).await,
+        )
+        .await?;
+
+    output::data(
+        || &response.neighbours,
+        || {
+            if response.neighbours.is_empty() {
+                match &cmd.table {
+                    Some(table) => output::empty(format_args!("No neighbours found for table '{table}'.")),
+                    None => output::empty(format_args!("No neighbours found.")),
+                }
+                return;
+            }
+
+            let mut entries: Vec<&ProtoNeighbourEntry> = response.neighbours.iter().collect();
+            entries.sort_by_key(|entry| {
+                let next_hop = entry
+                    .next_hop
+                    .as_ref()
+                    .and_then(|addr| IpAddr::try_from(addr).ok())
+                    .map(|addr| addr.to_canonical());
+                (entry.state, next_hop)
+            });
+            print_table_from_entries(entries);
+        },
+    );
+
+    Ok(())
 }
 
-impl NeighbourService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let service = Service::connect_for(connection, action, SERVICE_NAME, client).await?;
+async fn update_neighbour(service: &mut NeighbourService, cmd: AddCmd) -> Result<(), Error> {
+    let table = cmd.table.clone().unwrap_or_else(|| "static".to_owned());
 
-        Ok(Self { service })
-    }
+    let request = UpdateNeighboursRequest {
+        table: cmd.table.clone().unwrap_or_default(),
+        entries: vec![ProtoNeighbourEntry {
+            next_hop: Some(IpAddress::from(cmd.next_hop)),
+            link_addr: Some(MacAddress::from(cmd.link_addr)),
+            hardware_addr: Some(MacAddress::from(cmd.hardware_addr)),
+            priority: cmd.priority.unwrap_or_default(),
+            device: cmd.device.clone().unwrap_or_default(),
+            ..Default::default()
+        }],
+    };
 
-    pub async fn show_neighbours(&mut self, cmd: ShowCmd) -> Result<(), Error> {
-        let request = ListNeighboursRequest {
-            table: cmd.table.clone().unwrap_or_default(),
-        };
-        let resource = cmd.table.as_ref().map(|table| format!("table '{table}'"));
+    service
+        .unary("add", request, async |client, request| {
+            client.update_neighbours(request).await
+        })
+        .await?;
 
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service
-                    .not_found("show", resource.as_deref().unwrap_or("requested table")),
-                async |client, request| client.list(request).await,
-            )
-            .await?;
+    output::success(
+        "add",
+        format_args!(
+            "Added neighbour {} ({}) to table '{}'.",
+            cmd.next_hop, cmd.link_addr, table
+        ),
+    );
 
-        output::data(
-            || &response.neighbours,
-            || {
-                if response.neighbours.is_empty() {
-                    match &cmd.table {
-                        Some(table) => output::empty(format_args!("No neighbours found for table '{table}'.")),
-                        None => output::empty(format_args!("No neighbours found.")),
-                    }
-                    return;
-                }
+    Ok(())
+}
 
-                let mut entries: Vec<&ProtoNeighbourEntry> = response.neighbours.iter().collect();
-                entries.sort_by_key(|entry| {
-                    let next_hop = entry
-                        .next_hop
-                        .as_ref()
-                        .and_then(|addr| IpAddr::try_from(addr).ok())
-                        .map(|addr| addr.to_canonical());
-                    (entry.state, next_hop)
-                });
-                print_table_from_entries(entries);
-            },
-        );
+async fn remove_neighbours(service: &mut NeighbourService, cmd: RemoveCmd) -> Result<(), Error> {
+    let table = cmd.table.clone().unwrap_or_else(|| "static".to_owned());
 
-        Ok(())
-    }
+    let request = RemoveNeighboursRequest {
+        table: cmd.table.clone().unwrap_or_default(),
+        next_hops: cmd.next_hops.iter().copied().map(IpAddress::from).collect(),
+    };
 
-    pub async fn update_neighbour(&mut self, cmd: AddCmd) -> Result<(), Error> {
-        let table = cmd.table.clone().unwrap_or_else(|| "static".to_owned());
+    service
+        .unary("remove", request, async |client, request| {
+            client.remove_neighbours(request).await
+        })
+        .await?;
 
-        let request = UpdateNeighboursRequest {
-            table: cmd.table.clone().unwrap_or_default(),
-            entries: vec![ProtoNeighbourEntry {
-                next_hop: Some(IpAddress::from(cmd.next_hop)),
-                link_addr: Some(MacAddress::from(cmd.link_addr)),
-                hardware_addr: Some(MacAddress::from(cmd.hardware_addr)),
-                priority: cmd.priority.unwrap_or_default(),
-                device: cmd.device.clone().unwrap_or_default(),
-                ..Default::default()
-            }],
-        };
+    let next_hops = cmd
+        .next_hops
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    output::success("remove", format_args!("Removed {next_hops} from table '{table}'."));
 
-        self.service
-            .unary("add", request, async |client, request| {
-                client.update_neighbours(request).await
-            })
-            .await?;
+    Ok(())
+}
 
-        output::success(
-            "add",
-            format_args!(
-                "Added neighbour {} ({}) to table '{}'.",
-                cmd.next_hop, cmd.link_addr, table
-            ),
-        );
+async fn list_tables(service: &mut NeighbourService) -> Result<(), Error> {
+    let response = service
+        .unary("list tables", ListNeighbourTablesRequest {}, async |client, request| {
+            client.list_tables(request).await
+        })
+        .await?;
 
-        Ok(())
-    }
+    output::data(
+        || &response.tables,
+        || {
+            if response.tables.is_empty() {
+                output::empty_with_hint(
+                    format_args!("No neighbour tables found."),
+                    format_args!(
+                        "create one with 'yanet-cli-operator-neighbour table create <name> --default-priority <n>'"
+                    ),
+                );
+                return;
+            }
 
-    pub async fn remove_neighbours(&mut self, cmd: RemoveCmd) -> Result<(), Error> {
-        let table = cmd.table.clone().unwrap_or_else(|| "static".to_owned());
+            let entries: Vec<&NeighbourTableInfo> = response.tables.iter().collect();
+            print_table_from_entries(entries);
+        },
+    );
 
-        let request = RemoveNeighboursRequest {
-            table: cmd.table.clone().unwrap_or_default(),
-            next_hops: cmd.next_hops.iter().copied().map(IpAddress::from).collect(),
-        };
+    Ok(())
+}
 
-        self.service
-            .unary("remove", request, async |client, request| {
-                client.remove_neighbours(request).await
-            })
-            .await?;
+async fn create_table(service: &mut NeighbourService, cmd: CreateTableCmd) -> Result<(), Error> {
+    let request = CreateNeighbourTableRequest {
+        name: cmd.name.clone(),
+        default_priority: cmd.default_priority,
+    };
 
-        let next_hops = cmd
-            .next_hops
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join(", ");
-        output::success("remove", format_args!("Removed {next_hops} from table '{table}'."));
+    service
+        .unary("create table", request, async |client, request| {
+            client.create_table(request).await
+        })
+        .await?;
 
-        Ok(())
-    }
+    output::success("create table", format_args!("Created table '{}'.", cmd.name));
 
-    pub async fn list_tables(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list tables", ListNeighbourTablesRequest {}, async |client, request| {
-                client.list_tables(request).await
-            })
-            .await?;
+    Ok(())
+}
 
-        output::data(
-            || &response.tables,
-            || {
-                if response.tables.is_empty() {
-                    output::empty_with_hint(
-                        format_args!("No neighbour tables found."),
-                        format_args!(
-                            "create one with 'yanet-cli-operator-neighbour table create <name> --default-priority <n>'"
-                        ),
-                    );
-                    return;
-                }
+async fn update_table(service: &mut NeighbourService, cmd: UpdateTableCmd) -> Result<(), Error> {
+    let request = UpdateNeighbourTableRequest {
+        name: cmd.name.clone(),
+        default_priority: cmd.default_priority,
+    };
 
-                let entries: Vec<&NeighbourTableInfo> = response.tables.iter().collect();
-                print_table_from_entries(entries);
-            },
-        );
+    service
+        .unary("update table", request, async |client, request| {
+            client.update_table(request).await
+        })
+        .await?;
 
-        Ok(())
-    }
+    output::success(
+        "update table",
+        format_args!(
+            "Updated table '{}' (default priority {}).",
+            cmd.name, cmd.default_priority
+        ),
+    );
 
-    pub async fn create_table(&mut self, cmd: CreateTableCmd) -> Result<(), Error> {
-        let request = CreateNeighbourTableRequest {
-            name: cmd.name.clone(),
-            default_priority: cmd.default_priority,
-        };
+    Ok(())
+}
 
-        self.service
-            .unary("create table", request, async |client, request| {
-                client.create_table(request).await
-            })
-            .await?;
+async fn remove_table(service: &mut NeighbourService, cmd: RemoveTableCmd) -> Result<(), Error> {
+    let request = RemoveNeighbourTableRequest { name: cmd.name.clone() };
 
-        output::success("create table", format_args!("Created table '{}'.", cmd.name));
+    service
+        .unary_with(
+            "remove table",
+            request,
+            service.not_found("remove table", &format!("table '{}'", cmd.name)),
+            async |client, request| client.remove_table(request).await,
+        )
+        .await?;
 
-        Ok(())
-    }
+    output::success("remove table", format_args!("Removed table '{}'.", cmd.name));
 
-    pub async fn update_table(&mut self, cmd: UpdateTableCmd) -> Result<(), Error> {
-        let request = UpdateNeighbourTableRequest {
-            name: cmd.name.clone(),
-            default_priority: cmd.default_priority,
-        };
-
-        self.service
-            .unary("update table", request, async |client, request| {
-                client.update_table(request).await
-            })
-            .await?;
-
-        output::success(
-            "update table",
-            format_args!(
-                "Updated table '{}' (default priority {}).",
-                cmd.name, cmd.default_priority
-            ),
-        );
-
-        Ok(())
-    }
-
-    pub async fn remove_table(&mut self, cmd: RemoveTableCmd) -> Result<(), Error> {
-        let request = RemoveNeighbourTableRequest { name: cmd.name.clone() };
-
-        self.service
-            .unary_with(
-                "remove table",
-                request,
-                self.service.not_found("remove table", &format!("table '{}'", cmd.name)),
-                async |client, request| client.remove_table(request).await,
-            )
-            .await?;
-
-        output::success("remove table", format_args!("Removed table '{}'.", cmd.name));
-
-        Ok(())
-    }
+    Ok(())
 }
 
 /// Returns the proto-defined name for a `NeighbourState` discriminant,

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -19,7 +19,7 @@ use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
-    client::{Connection, ConnectionArgs, LayeredChannel, Service},
+    client::{LayeredChannel, Service},
     completion, display,
     errors::Error,
     output,
@@ -187,208 +187,192 @@ fn config_candidates() -> Vec<CompletionCandidate> {
 /// failure.
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let action = cmd.mode.action();
-    let mut service = RouteService::new(&cmd.globals.connection, action).await?;
+    let mut service = Service::connect_for(&cmd.globals.connection, action, SERVICE_NAME, client).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Show(c) => service.show_routes(c).await,
-        ModeCmd::Lookup(c) => service.lookup_route(c).await,
-        ModeCmd::Insert(c) => service.insert_route(c).await,
-        ModeCmd::Remove(c) => service.remove_route(c).await,
-        ModeCmd::Flush(c) => service.flush_routes(c).await,
+        ModeCmd::List => list_configs(&mut service).await,
+        ModeCmd::Show(c) => show_routes(&mut service, c).await,
+        ModeCmd::Lookup(c) => lookup_route(&mut service, c).await,
+        ModeCmd::Insert(c) => insert_route(&mut service, c).await,
+        ModeCmd::Remove(c) => remove_route(&mut service, c).await,
+        ModeCmd::Flush(c) => flush_routes(&mut service, c).await,
     }
 }
 
-pub struct RouteService {
-    service: Service<RouteServiceClient<LayeredChannel>>,
-}
+type RouteService = Service<RouteServiceClient<LayeredChannel>>;
 
-impl RouteService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let conn = Connection::connect_for(connection, action).await?;
-        let service = Service::new(&conn, SERVICE_NAME, client);
+async fn list_configs(service: &mut RouteService) -> Result<(), Error> {
+    let response = service
+        .unary("list", ListConfigsRequest {}, async |client, request| {
+            client.list_configs(request).await
+        })
+        .await?;
 
-        Ok(Self { service })
-    }
-
-    pub async fn list_configs(&mut self) -> Result<(), Error> {
-        let response = self
-            .service
-            .unary("list", ListConfigsRequest {}, async |client, request| {
-                client.list_configs(request).await
-            })
-            .await?;
-
-        output::data(
-            || &response.configs,
-            || {
-                display::print_names_with_hint(
-                    &response.configs,
-                    format_args!("No route configurations found."),
-                    format_args!(
-                        "create one with 'yanet-cli-operator-route insert <prefix> --name <name> --via <addr>'"
-                    ),
-                )
-            },
-        );
-
-        Ok(())
-    }
-
-    pub async fn show_routes(&mut self, cmd: RouteShowCmd) -> Result<(), Error> {
-        let request = ShowRoutesRequest {
-            name: cmd.name.clone(),
-            ipv4_only: cmd.ipv4,
-            ipv6_only: cmd.ipv6,
-        };
-
-        let response = self
-            .service
-            .unary_with(
-                "show",
-                request,
-                self.service.not_found("show", &format!("config '{}'", cmd.name)),
-                async |client, request| client.show_routes(request).await,
+    output::data(
+        || &response.configs,
+        || {
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No route configurations found."),
+                format_args!("create one with 'yanet-cli-operator-route insert <prefix> --name <name> --via <addr>'"),
             )
-            .await?;
+        },
+    );
 
-        output::data(
-            || &response.routes,
-            || {
-                if response.routes.is_empty() {
-                    output::empty(format_args!("No routes found for '{}'.", cmd.name));
-                    return;
-                }
+    Ok(())
+}
 
-                let mut entries: Vec<RouteEntry> = response.routes.iter().cloned().map(RouteEntry::from).collect();
-                entries.sort_by(|a, b| a.prefix.0.cmp(&b.prefix.0));
-                annotate_ecmp_groups(&mut entries);
-                print_route_table(entries);
-            },
-        );
+async fn show_routes(service: &mut RouteService, cmd: RouteShowCmd) -> Result<(), Error> {
+    let request = ShowRoutesRequest {
+        name: cmd.name.clone(),
+        ipv4_only: cmd.ipv4,
+        ipv6_only: cmd.ipv6,
+    };
 
-        Ok(())
-    }
+    let response = service
+        .unary_with(
+            "show",
+            request,
+            service.not_found("show", &format!("config '{}'", cmd.name)),
+            async |client, request| client.show_routes(request).await,
+        )
+        .await?;
 
-    pub async fn lookup_route(&mut self, cmd: RouteLookupCmd) -> Result<(), Error> {
-        let request = LookupRouteRequest {
-            name: cmd.name.clone(),
-            ip_addr: Some(cmd.addr.into()),
-        };
+    output::data(
+        || &response.routes,
+        || {
+            if response.routes.is_empty() {
+                output::empty(format_args!("No routes found for '{}'.", cmd.name));
+                return;
+            }
 
-        let response = self
-            .service
-            .unary("lookup", request, async |client, request| {
-                client.lookup_route(request).await
-            })
-            .await?;
+            let mut entries: Vec<RouteEntry> = response.routes.iter().cloned().map(RouteEntry::from).collect();
+            entries.sort_by(|a, b| a.prefix.0.cmp(&b.prefix.0));
+            annotate_ecmp_groups(&mut entries);
+            print_route_table(entries);
+        },
+    );
 
-        output::data(
-            || &response.routes,
-            || {
-                if response.routes.is_empty() {
-                    output::empty(format_args!("No routes found for {}.", cmd.addr));
-                    return;
-                }
+    Ok(())
+}
 
-                let mut entries: Vec<RouteEntry> = response.routes.iter().cloned().map(RouteEntry::from).collect();
-                annotate_ecmp_groups(&mut entries);
-                print_route_table(entries);
-            },
-        );
+async fn lookup_route(service: &mut RouteService, cmd: RouteLookupCmd) -> Result<(), Error> {
+    let request = LookupRouteRequest {
+        name: cmd.name.clone(),
+        ip_addr: Some(cmd.addr.into()),
+    };
 
-        Ok(())
-    }
+    let response = service
+        .unary("lookup", request, async |client, request| {
+            client.lookup_route(request).await
+        })
+        .await?;
 
-    pub async fn insert_route(&mut self, cmd: RouteInsertCmd) -> Result<(), Error> {
-        let nexthop_addrs = cmd.nexthop_addrs.iter().copied().map(Into::into).collect();
+    output::data(
+        || &response.routes,
+        || {
+            if response.routes.is_empty() {
+                output::empty(format_args!("No routes found for {}.", cmd.addr));
+                return;
+            }
 
-        let request = InsertRouteRequest {
-            name: cmd.name.clone(),
-            prefix: Some(IpPrefix::from(cmd.prefix)),
-            nexthop_addrs,
-            do_flush: true,
-            source_id: cmd.source.to_proto().into(),
-        };
+            let mut entries: Vec<RouteEntry> = response.routes.iter().cloned().map(RouteEntry::from).collect();
+            annotate_ecmp_groups(&mut entries);
+            print_route_table(entries);
+        },
+    );
 
-        self.service
-            .unary("insert", request, async |client, request| {
-                client.insert_route(request).await
-            })
-            .await?;
+    Ok(())
+}
 
-        let via = cmd
-            .nexthop_addrs
-            .iter()
-            .map(|a| a.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
+async fn insert_route(service: &mut RouteService, cmd: RouteInsertCmd) -> Result<(), Error> {
+    let nexthop_addrs = cmd.nexthop_addrs.iter().copied().map(Into::into).collect();
 
-        output::success(
-            "insert",
-            format_args!(
-                "Inserted {} via {} in config '{}' (source: {}).",
-                cmd.prefix,
-                via,
-                cmd.name,
-                cmd.source.as_str()
-            ),
-        );
+    let request = InsertRouteRequest {
+        name: cmd.name.clone(),
+        prefix: Some(IpPrefix::from(cmd.prefix)),
+        nexthop_addrs,
+        do_flush: true,
+        source_id: cmd.source.to_proto().into(),
+    };
 
-        Ok(())
-    }
+    service
+        .unary("insert", request, async |client, request| {
+            client.insert_route(request).await
+        })
+        .await?;
 
-    pub async fn remove_route(&mut self, cmd: RouteRemoveCmd) -> Result<(), Error> {
-        let nexthop_addrs = cmd.nexthop_addrs.iter().copied().map(Into::into).collect();
+    let via = cmd
+        .nexthop_addrs
+        .iter()
+        .map(|a| a.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
 
-        let request = DeleteRouteRequest {
-            name: cmd.name.clone(),
-            prefix: Some(IpPrefix::from(cmd.prefix)),
-            nexthop_addrs,
-            do_flush: true,
-            source_id: cmd.source.to_proto().into(),
-        };
+    output::success(
+        "insert",
+        format_args!(
+            "Inserted {} via {} in config '{}' (source: {}).",
+            cmd.prefix,
+            via,
+            cmd.name,
+            cmd.source.as_str()
+        ),
+    );
 
-        self.service
-            .unary("remove", request, async |client, request| {
-                client.delete_route(request).await
-            })
-            .await?;
+    Ok(())
+}
 
-        let via = cmd
-            .nexthop_addrs
-            .iter()
-            .map(|a| a.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
+async fn remove_route(service: &mut RouteService, cmd: RouteRemoveCmd) -> Result<(), Error> {
+    let nexthop_addrs = cmd.nexthop_addrs.iter().copied().map(Into::into).collect();
 
-        output::success(
-            "remove",
-            format_args!(
-                "Removed {} via {} from config '{}' (source: {}).",
-                cmd.prefix,
-                via,
-                cmd.name,
-                cmd.source.as_str()
-            ),
-        );
+    let request = DeleteRouteRequest {
+        name: cmd.name.clone(),
+        prefix: Some(IpPrefix::from(cmd.prefix)),
+        nexthop_addrs,
+        do_flush: true,
+        source_id: cmd.source.to_proto().into(),
+    };
 
-        Ok(())
-    }
+    service
+        .unary("remove", request, async |client, request| {
+            client.delete_route(request).await
+        })
+        .await?;
 
-    pub async fn flush_routes(&mut self, cmd: RouteFlushCmd) -> Result<(), Error> {
-        let request = FlushRoutesRequest { name: cmd.name.clone() };
+    let via = cmd
+        .nexthop_addrs
+        .iter()
+        .map(|a| a.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
 
-        self.service
-            .unary("flush", request, async |client, request| {
-                client.flush_routes(request).await
-            })
-            .await?;
+    output::success(
+        "remove",
+        format_args!(
+            "Removed {} via {} from config '{}' (source: {}).",
+            cmd.prefix,
+            via,
+            cmd.name,
+            cmd.source.as_str()
+        ),
+    );
 
-        output::success("flush", format_args!("Flushed config '{}'.", cmd.name));
+    Ok(())
+}
 
-        Ok(())
-    }
+async fn flush_routes(service: &mut RouteService, cmd: RouteFlushCmd) -> Result<(), Error> {
+    let request = FlushRoutesRequest { name: cmd.name.clone() };
+
+    service
+        .unary("flush", request, async |client, request| {
+            client.flush_routes(request).await
+        })
+        .await?;
+
+    output::success("flush", format_args!("Flushed config '{}'.", cmd.name));
+
+    Ok(())
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
- Every CLI's `<X>Service` becomes a type alias of `ync::client::Service` and its methods free functions taking the connected service, so a crate no longer carries a struct and constructor that only forwarded to ync.
- `run` connects through `Service::connect_for` in place, the two-step connection of fwstate, fwstate-map and the route operator included.
- The code-cli skill skeleton follows the same shape, a crate talking to several services keeps its local struct.
- Drops the route CLI's connection-refused test, which only exercised ync's own error mapping.