### PR TITLE
refactor(cli): share the address octet and enum name conversions

### DIFF
--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -29,13 +29,46 @@ impl FromStr for pb::DevicePipeline {
     }
 }
 
+/// The wire octets of an address: four for IPv4, sixteen for IPv6.
+pub fn ip_octets(addr: IpAddr) -> Vec<u8> {
+    match addr {
+        IpAddr::V4(v4) => v4.octets().to_vec(),
+        IpAddr::V6(v6) => v6.octets().to_vec(),
+    }
+}
+
+/// Reads an address back from its wire octets, any other count being
+/// malformed.
+pub fn ip_from_octets(octets: &[u8]) -> Result<IpAddr, InvalidIpLength> {
+    if let Ok(octets) = <[u8; 4]>::try_from(octets) {
+        return Ok(Ipv4Addr::from(octets).into());
+    }
+    if let Ok(octets) = <[u8; 16]>::try_from(octets) {
+        return Ok(Ipv6Addr::from(octets).into());
+    }
+
+    Err(InvalidIpLength(octets.len()))
+}
+
+/// An address that arrived with neither four nor sixteen octets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidIpLength(pub usize);
+
+impl Display for InvalidIpLength {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "invalid IP address length {}: expected 4 (IPv4) or 16 (IPv6)",
+            self.0
+        )
+    }
+}
+
+impl Error for InvalidIpLength {}
+
 impl From<IpAddr> for pb::IpAddress {
     fn from(addr: IpAddr) -> Self {
-        let bytes = match addr {
-            IpAddr::V4(v4) => v4.octets().to_vec(),
-            IpAddr::V6(v6) => v6.octets().to_vec(),
-        };
-        pb::IpAddress { addr: bytes }
+        pb::IpAddress { addr: ip_octets(addr) }
     }
 }
 
@@ -110,17 +143,7 @@ impl TryFrom<&pb::IpAddress> for IpAddr {
     type Error = Box<dyn Error>;
 
     fn try_from(ip: &pb::IpAddress) -> Result<Self, Self::Error> {
-        match ip.addr.len() {
-            4 => {
-                let octets: [u8; 4] = ip.addr[..].try_into().unwrap();
-                Ok(IpAddr::V4(Ipv4Addr::from(octets)))
-            }
-            16 => {
-                let octets: [u8; 16] = ip.addr[..].try_into().unwrap();
-                Ok(IpAddr::V6(Ipv6Addr::from(octets)))
-            }
-            n => Err(format!("invalid IP address length {n}: expected 4 (IPv4) or 16 (IPv6)").into()),
-        }
+        Ok(ip_from_octets(&ip.addr)?)
     }
 }
 
@@ -868,6 +891,20 @@ mod test {
         assert_eq!(16, ip.addr.len());
         let got = IpAddr::try_from(&ip).unwrap();
         assert_eq!(addr, got);
+    }
+
+    #[test]
+    fn test_ip_octets_round_trip_both_families() {
+        for text in ["10.0.0.1", "2001:db8::1"] {
+            let addr: IpAddr = text.parse().unwrap();
+
+            assert_eq!(Ok(addr), ip_from_octets(&ip_octets(addr)));
+        }
+    }
+
+    #[test]
+    fn test_ip_from_octets_refuses_another_count() {
+        assert_eq!(Err(InvalidIpLength(5)), ip_from_octets(&[0; 5]));
     }
 
     #[test]

--- a/modules/balancer2/cli/src/config.rs
+++ b/modules/balancer2/cli/src/config.rs
@@ -5,11 +5,12 @@ use core::{
     str::FromStr,
 };
 
+use commonpb::ip_octets;
 use filterpb::pb::PortRange;
 use netip::IpNetwork;
 use serde::{Deserialize, Deserializer};
 
-use crate::{balancerpb, ip_to_bytes};
+use crate::{Proto, balancerpb};
 
 fn deserialize_from_str<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
@@ -69,15 +70,6 @@ pub enum Scheduler {
     Wrr,
     Wlc,
     Op,
-}
-
-// Mirrors main::Proto for YAML config; the two cannot share a type because of
-// orphan-rule + derive constraints.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Proto {
-    Tcp,
-    Udp,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -175,9 +167,9 @@ fn build_addr_config(v4: Option<Ipv4Addr>, v6: Option<Ipv6Addr>, decaps: &[IpAdd
         return None;
     }
     Some(balancerpb::AddrConfig {
-        source_ip4: v4.map(|a| ip_to_bytes(IpAddr::V4(a))).unwrap_or_default(),
-        source_ip6: v6.map(|a| ip_to_bytes(IpAddr::V6(a))).unwrap_or_default(),
-        decaps: decaps.iter().copied().map(ip_to_bytes).collect(),
+        source_ip4: v4.map(|a| ip_octets(IpAddr::V4(a))).unwrap_or_default(),
+        source_ip6: v6.map(|a| ip_octets(IpAddr::V6(a))).unwrap_or_default(),
+        decaps: decaps.iter().copied().map(ip_octets).collect(),
     })
 }
 
@@ -185,10 +177,7 @@ impl TryFrom<VirtualService> for balancerpb::VsConfig {
     type Error = Box<dyn Error>;
 
     fn try_from(vs: VirtualService) -> Result<Self, Self::Error> {
-        let proto = match vs.proto {
-            Proto::Tcp => balancerpb::TransportProto::Tcp,
-            Proto::Udp => balancerpb::TransportProto::Udp,
-        };
+        let proto = balancerpb::TransportProto::from(vs.proto);
         let scheduler = match vs.scheduler {
             Scheduler::Sh => balancerpb::VsScheduler::Sh,
             Scheduler::Wrr => balancerpb::VsScheduler::Wrr,
@@ -205,7 +194,7 @@ impl TryFrom<VirtualService> for balancerpb::VsConfig {
 
         Ok(Self {
             id: Some(balancerpb::VsIdentifier {
-                addr: ip_to_bytes(vs.addr),
+                addr: ip_octets(vs.addr),
                 port: u32::from(vs.port),
                 proto: proto as i32,
             }),
@@ -213,7 +202,7 @@ impl TryFrom<VirtualService> for balancerpb::VsConfig {
             allowed_sources,
             reals,
             flags: Some(vs.flags.into()),
-            peers: vs.peers.into_iter().map(ip_to_bytes).collect(),
+            peers: vs.peers.into_iter().map(ip_octets).collect(),
         })
     }
 }
@@ -247,7 +236,7 @@ impl From<Real> for balancerpb::RealConfig {
     fn from(real: Real) -> Self {
         Self {
             id: Some(balancerpb::RelativeRealIdentifier {
-                ip: ip_to_bytes(real.ip),
+                ip: ip_octets(real.ip),
                 port: u32::from(real.port),
             }),
             weight: real.weight,

--- a/modules/balancer2/cli/src/display.rs
+++ b/modules/balancer2/cli/src/display.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
+use commonpb::ip_from_octets;
 use tabled::Tabled;
 use ync::display::print_table_from_entries;
 
-use crate::{balancerpb, bytes_to_ip, format_ip_port};
+use crate::{balancerpb, format_ip_port};
 
 fn print_module_stats(state: &balancerpb::BalancerState) {
     println!("Module:");
@@ -130,8 +131,8 @@ fn print_table_view_vs(vs: &balancerpb::VsState, opts: &ShowOptions) {
     let Some(addr_port) = fmt_addr_port(&id.addr, id.port) else {
         return;
     };
-    let proto = proto_str(id.proto).unwrap_or("???");
-    let scheduler = scheduler_str(cfg.scheduler).unwrap_or("???");
+    let proto = proto_name(id.proto).unwrap_or_else(|| "???".to_owned());
+    let scheduler = scheduler_name(cfg.scheduler).unwrap_or_else(|| "???".to_owned());
     let flags = flags_str(cfg.flags.as_ref());
 
     println!("VS {}/{}:", addr_port, proto);
@@ -181,7 +182,7 @@ fn real_display_addr(real: &balancerpb::RealState) -> Option<(String, &balancerp
         log::warn!("dropped real row: missing real id");
         return None;
     };
-    let rip = match bytes_to_ip(&rid.ip) {
+    let rip = match ip_from_octets(&rid.ip) {
         Ok(ip) => ip,
         Err(e) => {
             log::warn!("dropped real row: invalid ip bytes: {e}");
@@ -288,7 +289,7 @@ fn print_vs_peers(cfg: &balancerpb::VsConfig) {
     }
     println!("  Peers:");
     for peer in &cfg.peers {
-        if let Ok(ip) = bytes_to_ip(peer) {
+        if let Ok(ip) = ip_from_octets(peer) {
             println!("    {}", ip);
         }
     }
@@ -299,19 +300,19 @@ fn print_decap(state: &balancerpb::BalancerState) {
         return;
     };
     if !addr.source_ip4.is_empty()
-        && let Ok(ip) = bytes_to_ip(&addr.source_ip4)
+        && let Ok(ip) = ip_from_octets(&addr.source_ip4)
     {
         println!("Source IPv4: {}", ip);
     }
     if !addr.source_ip6.is_empty()
-        && let Ok(ip) = bytes_to_ip(&addr.source_ip6)
+        && let Ok(ip) = ip_from_octets(&addr.source_ip6)
     {
         println!("Source IPv6: {}", ip);
     }
     if !addr.decaps.is_empty() {
         println!("Decap Addresses:");
         for a in &addr.decaps {
-            if let Ok(ip) = bytes_to_ip(a) {
+            if let Ok(ip) = ip_from_octets(a) {
                 println!("  {}", ip);
             }
         }
@@ -343,7 +344,7 @@ pub fn print_sessions_header() {
 /// Format a wire-format addr+port pair. Returns None on bad address bytes
 /// or u16 overflow; port 0 is omitted from the output.
 fn fmt_addr_port(addr: &[u8], port: u32) -> Option<String> {
-    let ip = bytes_to_ip(addr).ok()?;
+    let ip = ip_from_octets(addr).ok()?;
     let port = u16::try_from(port).ok()?;
     Some(format_ip_port(ip, port))
 }
@@ -356,7 +357,7 @@ pub fn print_session(session: &balancerpb::Session, now: i64) {
             Some(format!(
                 "{}/{}",
                 fmt_addr_port(&id.addr, id.port)?,
-                proto_str(id.proto).unwrap_or("???")
+                proto_name(id.proto).unwrap_or_else(|| "???".to_owned())
             ))
         })
         .unwrap_or_else(|| "-".to_string());
@@ -443,8 +444,8 @@ pub fn prettify_json(value: &mut serde_json::Value) {
             }
         }
         serde_json::Value::Object(map) => {
-            prettify_enum(map, "scheduler", scheduler_str);
-            prettify_enum(map, "proto", proto_str);
+            prettify_enum(map, "scheduler", scheduler_name);
+            prettify_enum(map, "proto", proto_name);
             for (_, v) in map.iter_mut() {
                 prettify_json(v);
             }
@@ -453,15 +454,11 @@ pub fn prettify_json(value: &mut serde_json::Value) {
     }
 }
 
-fn prettify_enum(
-    map: &mut serde_json::Map<String, serde_json::Value>,
-    key: &str,
-    to_str: fn(i32) -> Option<&'static str>,
-) {
+fn prettify_enum(map: &mut serde_json::Map<String, serde_json::Value>, key: &str, to_name: fn(i32) -> Option<String>) {
     if let Some(val) = map.get(key).and_then(|v| v.as_i64())
-        && let Some(name) = to_str(val as i32)
+        && let Some(name) = to_name(val as i32)
     {
-        map.insert(key.to_string(), serde_json::Value::String(name.to_string()));
+        map.insert(key.to_string(), serde_json::Value::String(name));
     }
 }
 
@@ -473,23 +470,21 @@ fn bytes_array_to_ip_string(arr: &[serde_json::Value]) -> Option<String> {
         .iter()
         .map(|v| v.as_u64().and_then(|n| u8::try_from(n).ok()))
         .collect::<Option<Vec<_>>>()?;
-    Some(crate::bytes_to_ip(&bytes).ok()?.to_string())
+    Some(ip_from_octets(&bytes).ok()?.to_string())
 }
 
-fn proto_str(proto: i32) -> Option<&'static str> {
-    match balancerpb::TransportProto::try_from(proto).ok()? {
-        balancerpb::TransportProto::Tcp => Some("tcp"),
-        balancerpb::TransportProto::Udp => Some("udp"),
-    }
+/// The lowercase name of a declared transport protocol.
+fn proto_name(proto: i32) -> Option<String> {
+    let proto = balancerpb::TransportProto::try_from(proto).ok()?;
+
+    Some(proto.as_str_name().to_lowercase())
 }
 
-fn scheduler_str(scheduler: i32) -> Option<&'static str> {
-    match balancerpb::VsScheduler::try_from(scheduler).ok()? {
-        balancerpb::VsScheduler::Sh => Some("sh"),
-        balancerpb::VsScheduler::Wrr => Some("wrr"),
-        balancerpb::VsScheduler::Wlc => Some("wlc"),
-        balancerpb::VsScheduler::Op => Some("op"),
-    }
+/// The lowercase name of a declared scheduler.
+fn scheduler_name(scheduler: i32) -> Option<String> {
+    let scheduler = balancerpb::VsScheduler::try_from(scheduler).ok()?;
+
+    Some(scheduler.as_str_name().to_lowercase())
 }
 
 fn flags_str(flags: Option<&balancerpb::VsFlags>) -> String {
@@ -536,5 +531,23 @@ fn format_timestamp(ts: &prost_types::Timestamp) -> String {
     match ndt {
         Some(dt) => dt.format("%Y-%m-%d %H:%M:%S").to_string(),
         None => "-".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_enum_names_are_the_lowercase_declared_spellings() {
+        assert_eq!(
+            Some("tcp".to_owned()),
+            proto_name(balancerpb::TransportProto::Tcp as i32)
+        );
+        assert_eq!(
+            Some("wrr".to_owned()),
+            scheduler_name(balancerpb::VsScheduler::Wrr as i32)
+        );
+        assert_eq!(None, proto_name(99));
     }
 }

--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -6,13 +6,15 @@ mod sessions;
 
 use core::{
     fmt::{self, Display, Formatter},
-    net::{AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::{AddrParseError, IpAddr, SocketAddr},
     str::FromStr,
 };
 use std::path::PathBuf;
 
-use clap::{CommandFactory, Parser};
+use clap::{CommandFactory, Parser, ValueEnum};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
+use commonpb::ip_octets;
+use serde::Deserialize;
 use ync::{GlobalArgs, client::Service, completion, errors::Error};
 
 use crate::service::{SERVICE_NAME, client, handle};
@@ -159,12 +161,21 @@ pub struct FilterFlags {
     pub real_port: Option<u16>,
 }
 
-// Mirrors config::Proto for CLI filter flags; the two cannot share a type
-// because of orphan-rule + derive constraints.
-#[derive(Debug, Clone, clap::ValueEnum)]
+/// A transport protocol as a flag value or a config file field.
+#[derive(Debug, Clone, Copy, ValueEnum, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Proto {
     Tcp,
     Udp,
+}
+
+impl From<Proto> for balancerpb::TransportProto {
+    fn from(proto: Proto) -> Self {
+        match proto {
+            Proto::Tcp => Self::Tcp,
+            Proto::Udp => Self::Udp,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -237,46 +248,10 @@ impl Display for VsId {
 impl From<&VsId> for balancerpb::VsIdentifier {
     fn from(vs: &VsId) -> Self {
         Self {
-            addr: ip_to_bytes(vs.addr),
+            addr: ip_octets(vs.addr),
             port: u32::from(vs.port),
             proto: vs.proto as i32,
         }
-    }
-}
-
-pub fn ip_to_bytes(ip: IpAddr) -> Vec<u8> {
-    match ip {
-        IpAddr::V4(v4) => v4.octets().to_vec(),
-        IpAddr::V6(v6) => v6.octets().to_vec(),
-    }
-}
-
-#[derive(Debug)]
-pub enum BytesToIpError {
-    InvalidLength(usize),
-}
-
-impl Display for BytesToIpError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            Self::InvalidLength(n) => write!(f, "invalid IP address length: {n}"),
-        }
-    }
-}
-
-impl core::error::Error for BytesToIpError {}
-
-pub fn bytes_to_ip(bytes: &[u8]) -> Result<IpAddr, BytesToIpError> {
-    match bytes.len() {
-        4 => {
-            let arr = <[u8; 4]>::try_from(bytes).expect("length already checked");
-            Ok(Ipv4Addr::from(arr).into())
-        }
-        16 => {
-            let arr = <[u8; 16]>::try_from(bytes).expect("length already checked");
-            Ok(Ipv6Addr::from(arr).into())
-        }
-        n => Err(BytesToIpError::InvalidLength(n)),
     }
 }
 
@@ -302,13 +277,10 @@ impl FilterFlags {
         }
 
         Some(balancerpb::Filter {
-            vip: self.vip.map(ip_to_bytes),
+            vip: self.vip.map(ip_octets),
             vs_port: self.vs_port.map(u32::from),
-            proto: self.proto.as_ref().map(|p| match p {
-                Proto::Tcp => balancerpb::TransportProto::Tcp as i32,
-                Proto::Udp => balancerpb::TransportProto::Udp as i32,
-            }),
-            real_ip: self.real_ip.map(ip_to_bytes),
+            proto: self.proto.map(|proto| balancerpb::TransportProto::from(proto) as i32),
+            real_ip: self.real_ip.map(ip_octets),
             real_port: self.real_port.map(u32::from),
         })
     }

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -1,7 +1,7 @@
 use core::net::IpAddr;
 use std::time;
 
-use commonpb::pb::GetMetricsRequest;
+use commonpb::{ip_octets, pb::GetMetricsRequest};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{LayeredChannel, Service},
@@ -18,7 +18,7 @@ use crate::{
         balancer_client::BalancerClient,
     },
     config::{BalancerConfig, ConfigParts},
-    display, ip_to_bytes,
+    display,
     reals::{DisableRealCmd, EnableRealCmd, RealsMode},
     sessions::{SessionsMode, SessionsShowCmd, SessionsUpdateCmd},
 };
@@ -311,7 +311,7 @@ fn build_real_updates(vs: &VsId, reals: &[IpAddr], enable: Option<bool>, weight:
         .map(|real_ip| RealUpdate {
             real_id: Some(balancerpb::RealIdentifier {
                 vs: Some(vs_id.clone()),
-                real: Some(balancerpb::RelativeRealIdentifier { ip: ip_to_bytes(*real_ip), port: 0 }),
+                real: Some(balancerpb::RelativeRealIdentifier { ip: ip_octets(*real_ip), port: 0 }),
             }),
             enable,
             weight,

--- a/modules/unrdup/cli/src/main.rs
+++ b/modules/unrdup/cli/src/main.rs
@@ -136,8 +136,8 @@ impl From<UnrdupConfig> for Config {
 impl From<ServiceConfig> for Service {
     fn from(value: ServiceConfig) -> Self {
         Self {
-            vip: Some(addr_to_proto(value.vip)),
-            peers: value.peers.into_iter().map(addr_to_proto).collect(),
+            vip: Some(IpAddress::from(value.vip)),
+            peers: value.peers.into_iter().map(IpAddress::from).collect(),
             endpoints: value.endpoints.into_iter().map(Endpoint::from).collect(),
         }
     }
@@ -207,15 +207,6 @@ impl TryFrom<Protocol> for TransportProto {
             Protocol::Unspecified => Err("endpoint protocol is unspecified".into()),
         }
     }
-}
-
-fn addr_to_proto(addr: IpAddr) -> IpAddress {
-    let bytes = match addr {
-        IpAddr::V4(addr) => addr.octets().to_vec(),
-        IpAddr::V6(addr) => addr.octets().to_vec(),
-    };
-
-    IpAddress { addr: bytes }
 }
 
 const SERVICE_NAME: &str = "modules.unrdup.controlplane.unrduppb.v1.UnrdupService";

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -264,12 +264,9 @@ fn format_endpoint(addr: Option<&IpAddress>, port: u32) -> String {
         return format!("?:{port}");
     };
 
-    match IpAddr::try_from(addr) {
+    match IpAddr::try_from(addr).map(|addr| addr.to_canonical()) {
         Ok(IpAddr::V4(v4)) => format!("{v4}:{port}"),
-        Ok(IpAddr::V6(v6)) => match v6.to_ipv4_mapped() {
-            Some(v4) => format!("{v4}:{port}"),
-            None => format!("[{v6}]:{port}"),
-        },
+        Ok(IpAddr::V6(v6)) => format!("[{v6}]:{port}"),
         Err(..) => format!("invalid:{port}"),
     }
 }


### PR DESCRIPTION
- `commonpb` exposes `ip_octets` and `ip_from_octets`, the conversions its `IpAddress` already did, so balancer2 drops its private copies and error type and unrdup its `IpAddress` builder.
- Balancer2 keeps one `Proto` enum for the flag and the config file, and names its protocol and scheduler through the generated enums.
- The fwstate-map endpoint formatter unmaps IPv4-mapped addresses through `to_canonical`.