### PR TITLE
refactor(cli): share the bracketed mark and hanging indent rendering

### DIFF
--- a/cli/core/src/display.rs
+++ b/cli/core/src/display.rs
@@ -248,6 +248,73 @@ fn apply_style(table: &mut Table) {
     }
 }
 
+/// A bracketed mark with a Unicode and an ASCII face and the colour it
+/// wears on a coloured render.
+#[derive(Debug, Clone, Copy)]
+pub struct Mark {
+    pub unicode: &'static str,
+    pub ascii: &'static str,
+    pub color: fn(&str) -> String,
+}
+
+impl Mark {
+    /// The bare face of a `colored` or plain render.
+    pub fn text(&self, colored: bool) -> &'static str {
+        if colored { self.unicode } else { self.ascii }
+    }
+
+    /// The face of a `colored` or plain render, painted when coloured.
+    pub fn styled(&self, colored: bool) -> String {
+        self.paint(self.text(colored), colored)
+    }
+
+    /// Paints `text` in the mark's colour, or returns it as is on a plain
+    /// render.
+    pub fn paint(&self, text: &str, colored: bool) -> String {
+        if colored { (self.color)(text) } else { text.to_owned() }
+    }
+}
+
+/// Collapses every run of whitespace, embedded newlines included, into
+/// one space.
+///
+/// Meant for the non-wrapping path, where a message that arrived with
+/// embedded newlines still has to print as one grep-friendly line.
+pub fn normalize_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Prints `texts` after a prefix `indent` columns wide already on the
+/// line, later lines hanging under it, each line through `paint`.
+///
+/// Every text wraps to `wrap_width` when given, otherwise it prints as one
+/// whitespace-normalised line. The line is ended even when `texts` is
+/// empty, so a caller never ends it itself.
+pub fn print_hanging<I, P>(indent: usize, wrap_width: Option<usize>, texts: I, paint: P)
+where
+    I: IntoIterator<Item = String>,
+    P: Fn(&str) -> String,
+{
+    let mut first = true;
+
+    for text in texts {
+        let lines = match wrap_width {
+            Some(width) if width > indent => wrap_words(&text, width - indent),
+            _ => vec![normalize_whitespace(&text)],
+        };
+
+        for line in lines {
+            if !first {
+                print!("\n{:indent$}", "");
+            }
+            print!("{}", paint(&line));
+            first = false;
+        }
+    }
+
+    println!();
+}
+
 /// Returns the bar length for a histogram bucket, scaled to `BAR_MAX`.
 ///
 /// Returns `0` when `max_count` is `0`. Non-zero counts that round to `0`
@@ -271,7 +338,32 @@ pub fn bar_len(count: u64, max_count: u64) -> usize {
 
 #[cfg(test)]
 mod test {
-    use super::{KeyValue, bar_len, escape_wire_text, sorted_names, wrap_words};
+    use super::{KeyValue, Mark, bar_len, escape_wire_text, normalize_whitespace, sorted_names, wrap_words};
+
+    #[test]
+    fn test_mark_faces_and_paint_follow_the_color_flag() {
+        let mark = Mark {
+            unicode: "[✓]",
+            ascii: "[ok]",
+            color: |text| format!("<{text}>"),
+        };
+
+        assert_eq!("[✓]", mark.text(true));
+        assert_eq!("[ok]", mark.text(false));
+        assert_eq!("<[✓]>", mark.styled(true));
+        assert_eq!("[ok]", mark.styled(false));
+        assert_eq!("<ready>", mark.paint("ready", true));
+        assert_eq!("ready", mark.paint("ready", false));
+    }
+
+    #[test]
+    fn test_normalize_whitespace_collapses_runs_and_newlines() {
+        assert_eq!(
+            "rpc error: connection refused extra detail",
+            normalize_whitespace("rpc error:  connection refused\nextra detail")
+        );
+        assert_eq!("", normalize_whitespace(""));
+    }
 
     #[test]
     fn test_key_value_escapes_every_cell_and_marks_an_empty_list() {

--- a/cli/core/src/main.rs
+++ b/cli/core/src/main.rs
@@ -14,6 +14,7 @@ use yanet_cli::{
     client::{ConnectionArgs, Service},
     config::{self, Origin, Settings},
     dispatcher::{self, Dispatch, Namespace},
+    display::Mark,
     errors::Error,
     init, output,
 };
@@ -280,16 +281,20 @@ const DETAIL_WIDTH: usize = 13;
 /// details indented under the name.
 fn print_principal(endpoint: &str, principal: &Principal) {
     let colored = output::is_colored();
-    let (unicode_mark, ascii_mark, color): (&str, &str, fn(&str) -> String) = if principal.is_anonymous {
-        ("[~]", "[!!]", |s| s.yellow().to_string())
+    let mark = if principal.is_anonymous {
+        Mark {
+            unicode: "[~]",
+            ascii: "[!!]",
+            color: output::paint_warning,
+        }
     } else {
-        ("[✓]", "[ok]", |s| s.green().to_string())
+        Mark {
+            unicode: "[✓]",
+            ascii: "[ok]",
+            color: output::paint_ok,
+        }
     };
-    let mark = if colored {
-        color(unicode_mark)
-    } else {
-        ascii_mark.to_owned()
-    };
+    let mark = mark.styled(colored);
     let indent = " ".repeat(if colored { 4 } else { 5 });
     let user = if colored {
         principal.user.bold().to_string()

--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -493,6 +493,11 @@ pub fn paint_warning(text: &str) -> String {
     text.yellow().to_string()
 }
 
+/// Paints `text` in the green reserved for a healthy or accepted state.
+pub fn paint_ok(text: &str) -> String {
+    text.green().to_string()
+}
+
 /// Paints red text after the caller has checked terminal colour support.
 pub fn paint_error(text: &str) -> String {
     text.red().to_string()

--- a/cli/modules/ready/src/fixtures.rs
+++ b/cli/modules/ready/src/fixtures.rs
@@ -1,0 +1,46 @@
+//! The scopes and reports the crate's tests build their cases from.
+
+use readinesspb::pb::{Reason, Scope, State};
+
+use crate::ServiceReport;
+
+/// A reason-less scope in `state`.
+pub fn scope(name: &str, state: State) -> Scope {
+    Scope {
+        name: name.to_owned(),
+        state: state as i32,
+        reasons: Vec::new(),
+        observed_at: None,
+        last_transition_time: None,
+        expected_observation_interval: None,
+    }
+}
+
+/// A scope in `state` carrying one message-less reason with `code`.
+pub fn scope_with_reason(name: &str, state: State, code: &str) -> Scope {
+    Scope {
+        reasons: vec![Reason {
+            code: code.to_owned(),
+            message: String::new(),
+        }],
+        ..scope(name, state)
+    }
+}
+
+/// A probed service's report with `scopes`.
+pub fn report(service: &str, scopes: Vec<Scope>) -> ServiceReport {
+    ServiceReport {
+        service: service.to_owned(),
+        scopes,
+        error: None,
+    }
+}
+
+/// The report of a service whose probe failed.
+pub fn failed_report(service: &str) -> ServiceReport {
+    ServiceReport {
+        service: service.to_owned(),
+        scopes: Vec::new(),
+        error: Some("unknown service".to_owned()),
+    }
+}

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -15,6 +15,8 @@ use ync::{
     output,
 };
 
+#[cfg(test)]
+mod fixtures;
 mod render;
 mod watch;
 
@@ -389,33 +391,7 @@ fn service_candidates() -> Vec<CompletionCandidate> {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    fn scope(name: &str, state: State) -> Scope {
-        Scope {
-            name: name.to_owned(),
-            state: state as i32,
-            reasons: Vec::new(),
-            observed_at: None,
-            last_transition_time: None,
-            expected_observation_interval: None,
-        }
-    }
-
-    fn report(service: &str, scopes: Vec<Scope>) -> ServiceReport {
-        ServiceReport {
-            service: service.to_owned(),
-            scopes,
-            error: None,
-        }
-    }
-
-    fn failed_report(service: &str) -> ServiceReport {
-        ServiceReport {
-            service: service.to_owned(),
-            scopes: Vec::new(),
-            error: Some("unknown service".to_owned()),
-        }
-    }
+    use crate::fixtures::{failed_report, report, scope};
 
     #[test]
     fn all_ready_when_every_scope_of_every_service_is_ready() {

--- a/cli/modules/ready/src/render/layout.rs
+++ b/cli/modules/ready/src/render/layout.rs
@@ -1,6 +1,5 @@
-//! Text-layout helpers: the scope-name column width and whitespace
-//! normalization. Word wrapping itself lives in `ync::display::wrap_words`,
-//! shared with the core CLI's own output helpers.
+//! The scope-name column width. Word wrapping and whitespace
+//! normalization live in ync's display helpers, shared with every CLI.
 
 const MIN_NAME_WIDTH: usize = 12;
 const MAX_NAME_WIDTH: usize = 40;
@@ -17,16 +16,6 @@ pub fn name_width<'a>(names: impl IntoIterator<Item = &'a str>) -> usize {
         .max()
         .unwrap_or(MIN_NAME_WIDTH)
         .clamp(MIN_NAME_WIDTH, MAX_NAME_WIDTH)
-}
-
-/// Collapses every run of whitespace in `text` — including embedded
-/// newlines — into a single ASCII space.
-///
-/// Used on the non-wrapping (non-TTY) render path, where reason text is
-/// printed as one grep-friendly line; the source message (a Go
-/// `err.Error()`) may otherwise carry embedded newlines.
-pub fn normalize_whitespace(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 #[cfg(test)]
@@ -52,23 +41,5 @@ mod test {
     #[test]
     fn name_width_empty_defaults_to_minimum() {
         assert_eq!(MIN_NAME_WIDTH, name_width(core::iter::empty()));
-    }
-
-    #[test]
-    fn normalize_whitespace_collapses_embedded_newlines() {
-        assert_eq!(
-            "rpc error: connection refused extra detail",
-            normalize_whitespace("rpc error: connection refused\nextra detail")
-        );
-    }
-
-    #[test]
-    fn normalize_whitespace_collapses_runs_of_spaces() {
-        assert_eq!("a b", normalize_whitespace("a    b"));
-    }
-
-    #[test]
-    fn normalize_whitespace_empty_text_returns_empty() {
-        assert_eq!("", normalize_whitespace(""));
     }
 }

--- a/cli/modules/ready/src/render/mod.rs
+++ b/cli/modules/ready/src/render/mod.rs
@@ -13,9 +13,12 @@ use std::time::SystemTime;
 
 use colored::Colorize;
 use readinesspb::pb::{Reason, Scope, State};
-use ync::{display, humanfmt, output};
+use ync::{
+    display::{self, Mark},
+    humanfmt, output,
+};
 
-use self::{age::is_stale, layout::normalize_whitespace};
+use self::age::is_stale;
 pub use self::{
     layout::name_width,
     watch::{
@@ -49,8 +52,8 @@ fn reason_indent(colored: bool) -> usize {
 /// arrow, the header/summary dash, the summary separator, and the
 /// watching-suffix ellipsis.
 ///
-/// Chosen once from the same `colored` flag as [`StateStyle`] so every
-/// symbol in the render degrades to plain ASCII together — no glyph can
+/// Chosen once from the same `colored` flag the marks are painted with, so
+/// every symbol in the render degrades to plain ASCII together — no glyph can
 /// drift out of sync with the marks in a non-UTF-8 locale or piped run.
 struct Symbols {
     arrow: &'static str,
@@ -150,13 +153,17 @@ pub fn print_watching_line() {
 
 /// Builds the green all-ready banner's text.
 ///
-/// Reuses [`StateStyle`] for `State::Ready` rather than a bespoke mark, so
+/// Reuses [`state_mark`] for `State::Ready` rather than a bespoke mark, so
 /// this line's glyph and color can never drift from the `READY` marks used
 /// everywhere else in the render.
 fn all_ready_line(colored: bool) -> String {
-    let style = StateStyle::new(State::Ready, colored);
+    let mark = state_mark(State::Ready);
 
-    format!("{} {}", style.styled_mark(), style.paint("all subsystems are ready"))
+    format!(
+        "{} {}",
+        mark.styled(colored),
+        mark.paint("all subsystems are ready", colored)
+    )
 }
 
 /// Prints the distinct banner aggregate `--watch` shows each time the whole
@@ -215,41 +222,30 @@ fn print_scope_row(
 /// This is the single place the state → (mark, color) map lives. Both the
 /// snapshot block and the `--watch` transition log build their cells from
 /// here, so a state can never be green in one render and yellow in the
-/// other. `colored` is supplied by the caller — the global color gate is
-/// read once at the top of a render, never here.
-struct StateStyle {
-    mark: &'static str,
-    color: fn(&str) -> String,
-    colored: bool,
-}
-
-impl StateStyle {
-    fn new(state: State, colored: bool) -> Self {
-        let (unicode_mark, ascii_mark, color): (&str, &str, fn(&str) -> String) = match state {
-            State::Ready => ("[✓]", "[ok]", |s| s.green().to_string()),
-            State::Degraded => ("[~]", "[!!]", |s| s.yellow().to_string()),
-            State::NotReady => ("[✗]", "[xx]", |s| s.red().to_string()),
-            State::Unknown | State::Unspecified => ("[?]", "[??]", output::paint_dim),
-        };
-
-        let mark = if colored { unicode_mark } else { ascii_mark };
-
-        Self { mark, color, colored }
-    }
-
-    /// Returns the mark glyph in the state's color.
-    fn styled_mark(&self) -> String {
-        self.paint(self.mark)
-    }
-
-    /// Paints `text` in the state's color, or returns it as-is when the
-    /// render is not colored.
-    fn paint(&self, text: &str) -> String {
-        if self.colored {
-            (self.color)(text)
-        } else {
-            text.to_string()
-        }
+/// other. `colored` is supplied by the caller at every use — the global
+/// color gate is read once at the top of a render, never here.
+fn state_mark(state: State) -> Mark {
+    match state {
+        State::Ready => Mark {
+            unicode: "[✓]",
+            ascii: "[ok]",
+            color: output::paint_ok,
+        },
+        State::Degraded => Mark {
+            unicode: "[~]",
+            ascii: "[!!]",
+            color: output::paint_warning,
+        },
+        State::NotReady => Mark {
+            unicode: "[✗]",
+            ascii: "[xx]",
+            color: output::paint_error,
+        },
+        State::Unknown | State::Unspecified => Mark {
+            unicode: "[?]",
+            ascii: "[??]",
+            color: output::paint_dim,
+        },
     }
 }
 
@@ -260,10 +256,10 @@ impl StateStyle {
 /// for colored Unicode marks, 4 chars / 9+ chars for the ASCII fallback) so
 /// a double-width glyph can never shift a column.
 fn state_cells(state: State, colored: bool) -> (String, String) {
-    let style = StateStyle::new(state, colored);
+    let mark = state_mark(state);
     let label_cell = format!("{:<width$}", label(state), width = STATE_WIDTH);
 
-    (style.styled_mark(), style.paint(&label_cell))
+    (mark.styled(colored), mark.paint(&label_cell, colored))
 }
 
 /// Paints `text` in the grey reserved for secondary text.
@@ -315,20 +311,11 @@ fn format_reason(reason: &Reason) -> String {
 /// hanging indent when `wrap_width` is `Some` (stdout is a TTY); otherwise
 /// it prints as one long, grep-friendly line.
 fn print_reason_lines(reasons: &[Reason], colored: bool, wrap_width: Option<usize>) {
-    let reason_indent = reason_indent(colored);
-    let indent = " ".repeat(reason_indent);
+    let indent = reason_indent(colored);
 
     for reason in reasons {
-        let text = format_reason(reason);
-
-        let lines = match wrap_width {
-            Some(width) if width > reason_indent => display::wrap_words(&text, width - reason_indent),
-            _ => vec![normalize_whitespace(&text)],
-        };
-
-        for line in lines {
-            println!("{indent}{}", dim(&line, colored));
-        }
+        print!("{:indent$}", "");
+        display::print_hanging(indent, wrap_width, [format_reason(reason)], |line| dim(line, colored));
     }
 }
 

--- a/cli/modules/ready/src/render/watch.rs
+++ b/cli/modules/ready/src/render/watch.rs
@@ -7,11 +7,13 @@ use core::time::Duration;
 use std::collections::BTreeMap;
 
 use chrono::Local;
-use colored::Colorize;
 use readinesspb::pb::{Scope, State};
-use ync::{display, output};
+use ync::{
+    display::{self, Mark},
+    output,
+};
 
-use super::{StateStyle, Symbols, dim, layout::normalize_whitespace};
+use super::{Symbols, dim, state_mark};
 
 /// Gap between the transition line's prefix and the reason text that follows
 /// it on the same line.
@@ -120,7 +122,7 @@ struct Prefix {
 ///
 /// `name` must already be padded to the scope-name column width. Every part
 /// is rendered twice from the same text: once bare for [`Prefix::plain`] and
-/// once through [`StateStyle`] for [`Prefix::styled`], so the two can never
+/// once through [`state_mark`] for [`Prefix::styled`], so the two can never
 /// disagree on the visible width. The mark and both state labels are colored
 /// by their own state — the previous label keeps its old state's color — and
 /// the timestamp, service cell, and arrow stay grey or uncolored.
@@ -136,22 +138,21 @@ fn transition_prefix(
     colored: bool,
 ) -> Prefix {
     let symbols = Symbols::new(colored);
-    let style = StateStyle::new(state, colored);
+    let mark = state_mark(state);
     let label = super::label(state);
     let service = service.cell();
 
     let (change, styled_change) = match transition {
         Transition::StateChanged { previous } => {
-            let previous_style = StateStyle::new(previous, colored);
             let previous_label = super::label(previous);
 
             (
                 format!("{previous_label} {} {label}", symbols.arrow),
                 format!(
                     "{} {} {}",
-                    previous_style.paint(previous_label),
+                    state_mark(previous).paint(previous_label, colored),
                     dim(symbols.arrow, colored),
-                    style.paint(label)
+                    mark.paint(label, colored)
                 ),
             )
         }
@@ -162,16 +163,16 @@ fn transition_prefix(
             // cannot share that column anyway, so it is left unpadded.
             let label = format!("{label:<width$}", width = super::STATE_WIDTH);
 
-            (label.clone(), style.paint(&label))
+            (label.clone(), mark.paint(&label, colored))
         }
     };
 
     Prefix {
-        plain: format!("{timestamp}  {} {service}{name} {change}", style.mark),
+        plain: format!("{timestamp}  {} {service}{name} {change}", mark.text(colored)),
         styled: format!(
             "{}  {} {service}{name} {styled_change}",
             dim(timestamp, colored),
-            style.styled_mark()
+            mark.styled(colored)
         ),
     }
 }
@@ -212,28 +213,16 @@ pub fn print_transition_line(service: ServiceColumn, scope: &Scope, name_width: 
         print!("{:width$}{tag}", "", width = REASON_GAP);
     }
 
-    let mut is_first_line = true;
-    for reason in &scope.reasons {
-        let reason_text = super::format_reason(reason);
-
-        let lines = match wrap_width {
-            Some(width) if width > indent => display::wrap_words(&reason_text, width - indent),
-            _ => vec![normalize_whitespace(&reason_text)],
-        };
-
-        for line in &lines {
-            let styled = dim(line, colored);
-
-            if is_first_line {
-                print!("{:width$}{styled}", "", width = REASON_GAP);
-                is_first_line = false;
-            } else {
-                print!("\n{:indent$}{styled}", "");
-            }
-        }
+    if !scope.reasons.is_empty() {
+        print!("{:width$}", "", width = REASON_GAP);
     }
 
-    println!();
+    display::print_hanging(
+        indent,
+        wrap_width,
+        scope.reasons.iter().map(super::format_reason),
+        |line| dim(line, colored),
+    );
 }
 
 /// Prints one dim lifecycle line for `--watch` reconnect chatter that is
@@ -243,7 +232,7 @@ pub fn print_transition_line(service: ServiceColumn, scope: &Scope, name_width: 
 /// Callers compose `message` themselves — [`print_lost_line`] shows how a
 /// lost stream's cause and retry delay become one such message.
 /// `HH:MM:SS  [!] alias message`, the whole line dim — this is transport
-/// chatter, not a readiness state, and must never borrow a [`StateStyle`]
+/// chatter, not a readiness state, and must never borrow a state mark's
 /// colour or [`print_membership_line`]'s colored mark. Long messages wrap
 /// with a hanging indent, the same way a transition line's reason text
 /// does.
@@ -258,20 +247,7 @@ pub fn print_lifecycle_line(alias: &str, alias_width: usize, message: &str) {
     let indent = prefix.chars().count();
 
     print!("{}", dim(&prefix, colored));
-
-    let lines = match wrap_width {
-        Some(width) if width > indent => display::wrap_words(message, width - indent),
-        _ => vec![normalize_whitespace(message)],
-    };
-
-    for (idx, line) in lines.iter().enumerate() {
-        if idx > 0 {
-            print!("\n{:indent$}", "");
-        }
-        print!("{}", dim(line, colored));
-    }
-
-    println!();
+    display::print_hanging(indent, wrap_width, [message.to_owned()], |line| dim(line, colored));
 }
 
 /// Prints one lifecycle line for a `--watch` supervisor losing its stream,
@@ -317,38 +293,24 @@ impl Membership {
     }
 }
 
-/// [`Membership`]'s mark and color, resolved once per call from the same
-/// `colored` gate every other glyph in this render uses.
+/// [`Membership`]'s mark and color.
 ///
-/// Mirrors [`StateStyle`]'s shape: the glyph itself changes between the
+/// Mirrors [`state_mark`]'s shape: the glyph itself changes between the
 /// Unicode and ASCII forms, not just its color, chosen so neither
 /// direction is ever confused with a readiness-state mark or with
 /// [`print_lifecycle_line`]'s own `[!]` / `[--]` transport marks.
-struct MembershipStyle {
-    mark: &'static str,
-    color: fn(&str) -> String,
-    colored: bool,
-}
-
-impl MembershipStyle {
-    fn new(membership: Membership, colored: bool) -> Self {
-        let (unicode_mark, ascii_mark, color): (&str, &str, fn(&str) -> String) = match membership {
-            Membership::Discovered => ("[▲]", "[^^]", |s| s.green().to_string()),
-            Membership::Gone => ("[▼]", "[vv]", |s| s.red().to_string()),
-        };
-
-        let mark = if colored { unicode_mark } else { ascii_mark };
-
-        Self { mark, color, colored }
-    }
-
-    /// Returns the mark glyph in this direction's color.
-    fn styled_mark(&self) -> String {
-        if self.colored {
-            (self.color)(self.mark)
-        } else {
-            self.mark.to_string()
-        }
+fn membership_mark(membership: Membership) -> Mark {
+    match membership {
+        Membership::Discovered => Mark {
+            unicode: "[▲]",
+            ascii: "[^^]",
+            color: output::paint_ok,
+        },
+        Membership::Gone => Mark {
+            unicode: "[▼]",
+            ascii: "[vv]",
+            color: output::paint_error,
+        },
     }
 }
 
@@ -360,7 +322,7 @@ impl MembershipStyle {
 /// but the mark keeps `membership`'s own color instead of [`dim`]'s grey: a
 /// backend joining or leaving the registry is a state-level event, not
 /// transport chatter, so the mark stays as prominent as a readiness
-/// [`StateStyle`] mark. The alias prints at full weight and only the
+/// state mark. The alias prints at full weight and only the
 /// descriptive message is dimmed, the same split a transition line makes
 /// between its state labels and its dim reason text. `membership` alone
 /// selects the mark, its color, and the message text, so the joined and
@@ -369,56 +331,21 @@ pub fn print_membership_line(alias: &str, alias_width: usize, membership: Member
     let colored = output::is_colored();
     let wrap_width = display::terminal_width();
     let timestamp = Local::now().format("%H:%M:%S").to_string();
-    let style = MembershipStyle::new(membership, colored);
+    let mark = membership_mark(membership);
     let message = membership.message();
     let name = format!("{alias:<alias_width$}");
 
-    let plain_prefix = format!("{timestamp}  {} {name} ", style.mark);
+    let plain_prefix = format!("{timestamp}  {} {name} ", mark.text(colored));
     let indent = plain_prefix.chars().count();
 
-    print!("{}  {} {name} ", dim(&timestamp, colored), style.styled_mark());
-
-    let lines = match wrap_width {
-        Some(width) if width > indent => display::wrap_words(message, width - indent),
-        _ => vec![normalize_whitespace(message)],
-    };
-
-    for (idx, line) in lines.iter().enumerate() {
-        if idx > 0 {
-            print!("\n{:indent$}", "");
-        }
-        print!("{}", dim(line, colored));
-    }
-
-    println!();
+    print!("{}  {} {name} ", dim(&timestamp, colored), mark.styled(colored));
+    display::print_hanging(indent, wrap_width, [message.to_owned()], |line| dim(line, colored));
 }
 
 #[cfg(test)]
 mod test {
-    use readinesspb::pb::Reason;
-
     use super::*;
-
-    fn scope(name: &str, state: State) -> Scope {
-        Scope {
-            name: name.to_string(),
-            state: state as i32,
-            reasons: Vec::new(),
-            observed_at: None,
-            last_transition_time: None,
-            expected_observation_interval: None,
-        }
-    }
-
-    fn scope_with_reason(name: &str, state: State, code: &str) -> Scope {
-        Scope {
-            reasons: vec![Reason {
-                code: code.to_owned(),
-                message: String::new(),
-            }],
-            ..scope(name, state)
-        }
-    }
+    use crate::fixtures::{scope, scope_with_reason};
 
     /// Drops every ANSI SGR escape (`ESC [ … m`) from `text`, leaving the
     /// characters a terminal would actually show.
@@ -491,7 +418,7 @@ mod test {
         );
 
         assert_eq!(prefix.plain, strip_ansi(&prefix.styled));
-        assert!(prefix.plain.contains(StateStyle::new(State::Degraded, true).mark));
+        assert!(prefix.plain.contains(state_mark(State::Degraded).text(true)));
         assert!(prefix.plain.contains("rib"));
         assert!(!prefix.plain.contains(Symbols::new(true).arrow));
     }
@@ -523,12 +450,11 @@ mod test {
     }
 
     #[test]
-    fn membership_style_uncolored_mark_is_ascii_for_both_directions() {
+    fn membership_mark_uncolored_is_ascii_for_both_directions() {
         for membership in [Membership::Discovered, Membership::Gone] {
-            let style = MembershipStyle::new(membership, false);
+            let mark = membership_mark(membership);
 
-            assert!(style.mark.is_ascii());
-            assert_eq!(style.mark, style.styled_mark());
+            assert!(mark.text(false).is_ascii());
             assert!(membership.message().is_ascii());
         }
     }

--- a/cli/modules/ready/src/watch.rs
+++ b/cli/modules/ready/src/watch.rs
@@ -917,33 +917,7 @@ mod test {
     use readinesspb::pb::State;
 
     use super::*;
-
-    fn scope(name: &str, state: State) -> Scope {
-        Scope {
-            name: name.to_owned(),
-            state: state as i32,
-            reasons: Vec::new(),
-            observed_at: None,
-            last_transition_time: None,
-            expected_observation_interval: None,
-        }
-    }
-
-    fn report(service: &str, scopes: Vec<Scope>) -> ServiceReport {
-        ServiceReport {
-            service: service.to_owned(),
-            scopes,
-            error: None,
-        }
-    }
-
-    fn failed_report(service: &str) -> ServiceReport {
-        ServiceReport {
-            service: service.to_owned(),
-            scopes: Vec::new(),
-            error: Some("unknown service".to_owned()),
-        }
-    }
+    use crate::fixtures::{failed_report, report, scope};
 
     #[test]
     fn grow_widths_widens_alias_width_from_a_service_event_and_never_shrinks_it() {


### PR DESCRIPTION
- `display::Mark` carries a mark's Unicode and ASCII faces with its colour, replacing ready's two style structs and the dispatcher's principal mark tuple.
- `display::print_hanging` prints wrapped text under a prefix with a hanging indent, replacing the four loops in ready, and `normalize_whitespace` moves to ync with it.
- Ready's tests build their scopes and reports from one fixtures module instead of three copies.