### PR TITLE
refactor(cli): share the timestamp, age and bar rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2653,7 +2653,6 @@ dependencies = [
 name = "yanet-cli-balancer2"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "clap",
  "clap_complete",
  "log",

--- a/cli/core/src/display.rs
+++ b/cli/core/src/display.rs
@@ -315,6 +315,22 @@ where
     println!();
 }
 
+/// Prints one bar row per `(label, count)`: the label, the count
+/// right-aligned in brackets and a bar scaled to the largest count.
+pub fn print_bars<I>(rows: I)
+where
+    I: IntoIterator<Item = (String, u64)>,
+{
+    let rows: Vec<(String, u64)> = rows.into_iter().collect();
+    let max_count = rows.iter().map(|(_, count)| *count).max().unwrap_or(0);
+    let count_width = rows.iter().map(|(_, count)| count.to_string().len()).max().unwrap_or(0);
+
+    for (label, count) in rows {
+        let bars = "∎".repeat(bar_len(count, max_count));
+        println!("  {label} [ {count:>count_width$} ] {bars}");
+    }
+}
+
 /// Returns the bar length for a histogram bucket, scaled to `BAR_MAX`.
 ///
 /// Returns `0` when `max_count` is `0`. Non-zero counts that round to `0`

--- a/cli/core/src/humanfmt.rs
+++ b/cli/core/src/humanfmt.rs
@@ -1,4 +1,4 @@
-//! Human-readable age formatting shared across CLI crates.
+//! Human-readable age and timestamp formatting shared across CLI crates.
 
 use core::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -21,12 +21,41 @@ pub fn format_age(ts: Option<&Timestamp>, now: SystemTime) -> Option<String> {
         _ => return None,
     };
 
+    Some(age_since(ts.seconds, now))
+}
+
+/// Formats the time elapsed since the Unix second `seconds` relative to
+/// `now`, capped at two units like [`format_age`].
+///
+/// A negative second count reads as an age counted from the epoch.
+pub fn age_since(seconds: i64, now: SystemTime) -> String {
     let now_secs = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-    let ts_secs = ts.seconds.max(0) as u64;
+    let ts_secs = seconds.max(0) as u64;
     let age = now_secs.saturating_sub(ts_secs);
 
     let rendered = humantime::format_duration(Duration::from_secs(round_age(age))).to_string();
-    Some(rendered.split_whitespace().take(2).collect::<Vec<_>>().join(" "))
+    rendered.split_whitespace().take(2).collect::<Vec<_>>().join(" ")
+}
+
+/// The first second RFC 3339 cannot spell, midnight of the year 10000.
+const RFC3339_LIMIT: i64 = 253_402_300_800;
+
+/// Formats a `Timestamp` as an RFC 3339 instant in UTC, to the second.
+///
+/// Returns `None` when `ts` is absent, the zero sentinel, outside the
+/// years 1970 to 9999 or malformed in its nanoseconds, leaving the caller
+/// to decide what to render.
+pub fn format_timestamp(ts: Option<&Timestamp>) -> Option<String> {
+    let ts = match ts {
+        Some(ts) if ts.seconds != 0 || ts.nanos != 0 => ts,
+        _ => return None,
+    };
+    if !(0..RFC3339_LIMIT).contains(&ts.seconds) || !(0..1_000_000_000).contains(&ts.nanos) {
+        return None;
+    }
+    let instant = UNIX_EPOCH + Duration::from_secs(u64::try_from(ts.seconds).ok()?);
+
+    Some(humantime::format_rfc3339_seconds(instant).to_string())
 }
 
 /// Rounds an age in seconds down, dropping precision finer than the
@@ -73,6 +102,36 @@ mod test {
             round_age(3 * SECONDS_PER_DAY + 5 * SECONDS_PER_HOUR + 40 * SECONDS_PER_MINUTE)
         );
         assert_eq!(SECONDS_PER_DAY, round_age(SECONDS_PER_DAY));
+    }
+
+    #[test]
+    fn test_format_timestamp_renders_utc_to_the_second() {
+        let epoch_minute = Timestamp { seconds: 60, nanos: 5 };
+
+        assert_eq!(
+            Some("1970-01-01T00:01:00Z".to_owned()),
+            format_timestamp(Some(&epoch_minute))
+        );
+    }
+
+    #[test]
+    fn test_format_timestamp_none_for_absent_sentinel_and_unspellable() {
+        for seconds in [-1, RFC3339_LIMIT, i64::MAX] {
+            assert_eq!(
+                None,
+                format_timestamp(Some(&Timestamp { seconds, nanos: 0 })),
+                "{seconds}"
+            );
+        }
+        for nanos in [-1, 1_000_000_000] {
+            assert_eq!(
+                None,
+                format_timestamp(Some(&Timestamp { seconds: 60, nanos })),
+                "{nanos}"
+            );
+        }
+        assert_eq!(None, format_timestamp(Some(&Timestamp { seconds: 0, nanos: 0 })));
+        assert_eq!(None, format_timestamp(None));
     }
 
     #[test]

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -7,6 +7,7 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
     client::{LayeredChannel, Service},
+    display,
     errors::Error,
     metrics, output,
 };
@@ -304,7 +305,7 @@ fn format_worker_counters(response: &WorkerCountersResponse) {
     }
 
     let rows: Vec<WorkerRow> = response.workers.iter().map(WorkerRow::from).collect();
-    ync::display::print_table_from_entries(rows);
+    display::print_table_from_entries(rows);
 
     for worker in &response.workers {
         print_worker_histogram(worker);
@@ -320,14 +321,14 @@ fn print_worker_histogram(worker: &WorkerCounter) {
 
     println!("worker {} rx bursts", worker.worker_idx);
 
-    let max_count = bursts.iter().copied().max().unwrap_or(0);
     let wl = bursts.len().saturating_sub(1).to_string().len().max("0".len());
-    let wc = bursts.iter().map(|c| c.to_string().len()).max().unwrap_or(0);
 
-    for (idx, &count) in bursts.iter().enumerate() {
-        let bars = "∎".repeat(ync::display::bar_len(count, max_count));
-        println!("  {idx:>wl$} [ {count:>wc$} ] {bars}");
-    }
+    display::print_bars(
+        bursts
+            .iter()
+            .enumerate()
+            .map(|(idx, &count)| (format!("{idx:>wl$}"), count)),
+    );
 
     println!();
 }

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -8,6 +8,7 @@ use ync::{
     GlobalArgs,
     client::{self, Connection},
     discovery::Family,
+    display,
     errors::Error,
     output,
 };
@@ -151,7 +152,7 @@ async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>) ->
 
             if !scalars.is_empty() {
                 let rows: Vec<MetricRow> = scalars.iter().map(|m| MetricRow::from(*m)).collect();
-                ync::display::print_table_from_entries(rows);
+                display::print_table_from_entries(rows);
             }
 
             if !histograms.is_empty() {
@@ -262,8 +263,6 @@ fn print_histogram(name: &str, labels: &[Label], histogram: &Histogram) {
         return;
     }
 
-    let max_count = buckets.iter().map(|b| b.count).max().unwrap_or(0);
-
     let bounds: Vec<(String, String)> = buckets
         .iter()
         .enumerate()
@@ -275,13 +274,13 @@ fn print_histogram(name: &str, labels: &[Label], histogram: &Histogram) {
 
     let wl = bounds.iter().map(|(l, _)| l.len()).max().unwrap_or(0);
     let wu = bounds.iter().map(|(_, u)| u.len()).max().unwrap_or(0);
-    let wc = buckets.iter().map(|b| b.count.to_string().len()).max().unwrap_or(0);
 
-    for (bucket, (lower, upper)) in buckets.iter().zip(bounds.iter()) {
-        let bars = "∎".repeat(ync::display::bar_len(bucket.count, max_count));
-        let count = bucket.count;
-        println!("  {lower:>wl$} .. {upper:>wu$} [ {count:>wc$} ] {bars}");
-    }
+    display::print_bars(
+        buckets
+            .iter()
+            .zip(&bounds)
+            .map(|(bucket, (lower, upper))| (format!("{lower:>wl$} .. {upper:>wu$}"), bucket.count)),
+    );
 
     println!("  count = {}", histogram.total_count);
     println!();

--- a/modules/balancer2/cli/Cargo.toml
+++ b/modules/balancer2/cli/Cargo.toml
@@ -24,7 +24,6 @@ serde_json = "1"
 serde_yaml = "0.9"
 tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 log = "0.4"
-chrono = "0.4"
 netip = "0.3"
 
 [build-dependencies]

--- a/modules/balancer2/cli/src/display.rs
+++ b/modules/balancer2/cli/src/display.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use commonpb::ip_from_octets;
 use tabled::Tabled;
-use ync::display::print_table_from_entries;
+use ync::{display::print_table_from_entries, humanfmt};
 
 use crate::{balancerpb, format_ip_port};
 
@@ -104,10 +104,7 @@ fn print_table_view_state(state: &balancerpb::BalancerState, opts: &ShowOptions)
         println!("Active Sessions: {}", state.active_sessions);
         println!(
             "Last Packet: {}",
-            state
-                .last_packet_timestamp
-                .as_ref()
-                .map_or_else(|| "N/A".to_string(), format_timestamp),
+            humanfmt::format_timestamp(state.last_packet_timestamp.as_ref()).unwrap_or_else(|| "N/A".to_string()),
         );
         println!();
     }
@@ -144,7 +141,10 @@ fn print_table_view_vs(vs: &balancerpb::VsState, opts: &ShowOptions) {
     if opts.stats {
         println!("  Active Sessions: {}", vs.active_sessions);
         if let Some(ts) = &vs.last_packet_timestamp {
-            println!("  Last Packet: {}", format_timestamp(ts));
+            println!(
+                "  Last Packet: {}",
+                humanfmt::format_timestamp(Some(ts)).unwrap_or_else(|| "N/A".to_string())
+            );
         }
         if let Some(stats) = &vs.stats {
             print_vs_stats(stats);
@@ -221,10 +221,7 @@ fn real_stats_row(real: &balancerpb::RealState) -> Option<RealStatsRow> {
         bytes: rs.map_or(0, |s| s.bytes),
         active_sessions: real.active_sessions,
         created_sessions: rs.map_or(0, |s| s.created_sessions),
-        last_packet: real
-            .last_packet_timestamp
-            .as_ref()
-            .map_or_else(|| "-".to_string(), format_timestamp),
+        last_packet: humanfmt::format_timestamp(real.last_packet_timestamp.as_ref()).unwrap_or_else(|| "-".to_string()),
         disabled_pkts: rs.map_or(0, |s| s.packets_real_disabled),
         icmp_pkts: rs.map_or(0, |s| s.error_icmp_packets),
     })
@@ -520,17 +517,6 @@ fn print_ref_inline(r: &balancerpb::PacketHandlerRef) {
     }
     if !parts.is_empty() {
         println!("{}", parts.join(" | "));
-    }
-}
-
-fn format_timestamp(ts: &prost_types::Timestamp) -> String {
-    if ts.seconds == 0 && ts.nanos == 0 {
-        return "N/A".to_string();
-    }
-    let ndt = chrono::DateTime::from_timestamp(ts.seconds, ts.nanos as u32);
-    match ndt {
-        Some(dt) => dt.format("%Y-%m-%d %H:%M:%S").to_string(),
-        None => "-".to_string(),
     }
 }
 

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -4,11 +4,8 @@
 //! (the operator process directly, or the gateway once registration
 //! has propagated) and drives the operator-owned neighbour tables.
 
-use core::{net::IpAddr, time::Duration};
-use std::{
-    borrow::Cow,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use core::net::IpAddr;
+use std::{borrow::Cow, time::SystemTime};
 
 use clap::{CommandFactory, Parser};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
@@ -25,7 +22,7 @@ use ync::{
     completion,
     display::print_table_from_entries,
     errors::Error,
-    output,
+    humanfmt, output,
 };
 
 use crate::operatorpb::{
@@ -398,13 +395,8 @@ where
     serializer.serialize_str(state_name(*value))
 }
 
-/// Formats the time elapsed since a neighbour entry's `updated_at` Unix
-/// timestamp, clamping a negative timestamp to the epoch to avoid an
-/// overflow panic.
 fn age(updated_at: i64) -> String {
-    let updated_at = UNIX_EPOCH + Duration::from_secs(updated_at.max(0) as u64);
-    let elapsed = SystemTime::now().duration_since(updated_at).unwrap_or_default();
-    format!("{elapsed:.2?}")
+    humanfmt::age_since(updated_at, SystemTime::now())
 }
 
 impl Tabled for ProtoNeighbourEntry {


### PR DESCRIPTION
- `humanfmt` gains `format_timestamp` and `age_since`, used by balancer2 in place of its chrono formatter and by the neighbour CLI in place of a Debug duration.
- `display::print_bars` draws the histogram rows of the metrics and counters CLIs.
- A balancer2 timestamp now reads as an RFC 3339 instant in UTC and a neighbour age as at most two units, like every other age.
- In the balancer2 reals table an unset last-packet time reads `-` like an absent one.