### PR TITLE
test(cli): drop the tests that only exercised clap

### DIFF
--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -291,20 +291,6 @@ mod test {
     use super::*;
 
     #[test]
-    fn no_arguments_leaves_the_service_unset() {
-        let cmd = Cmd::try_parse_from(["yanet-cli-metrics"]).expect("no arguments must parse");
-
-        assert!(cmd.name.is_none());
-    }
-
-    #[test]
-    fn naming_a_service_sets_the_service() {
-        let cmd = Cmd::try_parse_from(["yanet-cli-metrics", "route"]).expect("a service name must parse");
-
-        assert_eq!(Some("route".to_owned()), cmd.name);
-    }
-
-    #[test]
     fn a_tag_entry_splits_on_the_first_equals() {
         let tag = parse_tag("config=my-acl").expect("a well-formed tag must parse");
 

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -424,46 +424,4 @@ mod test {
     fn not_ready_without_any_discovered_service() {
         assert!(!all_ready(&[]));
     }
-
-    #[test]
-    fn aggregate_mode_is_the_default() {
-        let cmd = Cmd::try_parse_from(["yanet-cli-ready"]).expect("no arguments must parse");
-
-        assert!(cmd.is_aggregate());
-    }
-
-    #[test]
-    fn naming_a_service_leaves_aggregate_mode() {
-        let cmd = Cmd::try_parse_from(["yanet-cli-ready", "route"]).expect("a service name must parse");
-
-        assert!(!cmd.is_aggregate());
-    }
-
-    #[test]
-    fn all_flag_conflicts_with_a_named_service() {
-        assert!(Cmd::try_parse_from(["yanet-cli-ready", "--all", "route"]).is_err());
-    }
-
-    #[test]
-    fn test_cmd_stale_multiple_defaults_to_three() {
-        let cmd = Cmd::try_parse_from(["yanet-cli-ready"]).expect("default command must parse");
-
-        assert_eq!(3, cmd.stale_multiple);
-    }
-
-    #[test]
-    fn test_cmd_stale_multiple_accepts_override() {
-        let cmd =
-            Cmd::try_parse_from(["yanet-cli-ready", "--stale-multiple", "7"]).expect("staleness multiplier must parse");
-
-        assert_eq!(7, cmd.stale_multiple);
-    }
-
-    #[test]
-    fn test_cmd_stale_multiple_accepts_zero() {
-        let cmd = Cmd::try_parse_from(["yanet-cli-ready", "--stale-multiple", "0"])
-            .expect("zero staleness multiplier must parse");
-
-        assert_eq!(0, cmd.stale_multiple);
-    }
 }

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -230,42 +230,7 @@ fn device_client(channel: LayeredChannel) -> DeviceServiceClient<LayeredChannel>
 
 #[cfg(test)]
 mod test {
-    use clap::{CommandFactory, error::ErrorKind};
-
     use super::*;
-
-    #[test]
-    fn test_cmd_is_valid() {
-        Cmd::command().debug_assert();
-    }
-
-    /// Verifies that the verbosity flag still counts after the subcommand,
-    /// where a short form of the vlan flag used to shadow it.
-    #[test]
-    fn test_update_verbosity_after_subcommand_counts() {
-        let cmd = Cmd::try_parse_from(["yanet-cli-device-vlan", "update", "-n", "x", "--vlan", "5", "-vv"]).unwrap();
-
-        assert_eq!(2, cmd.globals.verbose);
-    }
-
-    #[test]
-    fn test_update_vlan_accepts_range_boundaries() {
-        for (arg, expected) in [("0", 0), ("4094", 4094)] {
-            let cmd = Cmd::try_parse_from(["yanet-cli-device-vlan", "update", "-n", "x", "--vlan", arg]).unwrap();
-            let ModeCmd::Update(update) = cmd.mode else {
-                panic!("expected ModeCmd::Update");
-            };
-
-            assert_eq!(expected, update.vlan);
-        }
-    }
-
-    #[test]
-    fn test_update_vlan_rejects_id_above_range() {
-        let err = Cmd::try_parse_from(["yanet-cli-device-vlan", "update", "-n", "x", "--vlan", "4095"]).unwrap_err();
-
-        assert_eq!(ErrorKind::ValueValidation, err.kind());
-    }
 
     #[test]
     fn test_binding_rows_sorts_by_direction_then_pipeline() {

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -414,13 +414,8 @@ rules:
 
     #[test]
     fn test_unknown_null_valued_keys_are_still_refused() {
-        let yaml = "rulez: null\n";
-        let path = std::env::temp_dir().join(format!("fwd-nullkey-{}.yaml", std::process::id()));
-        std::fs::write(&path, yaml).expect("the fixture must be written");
-
-        let refused = yaml::load_document::<UpdateConfigRequest>(&path)
+        let refused = serde_yaml::from_str::<UpdateConfigRequest>("rulez: null\n")
             .expect_err("a misspelled null-valued key must be refused");
-        std::fs::remove_file(&path).ok();
 
         assert!(refused.to_string().contains("rulez"));
     }
@@ -428,11 +423,8 @@ rules:
     #[test]
     fn test_null_fields_read_as_zero_values() {
         let yaml = "name: forward0\nrules:\n  - action:\n      target: t\n      mode: OUT\n      counter: c\n    devices: null\n    sources4: null\n";
-        let path = std::env::temp_dir().join(format!("fwd-null-{}.yaml", std::process::id()));
-        std::fs::write(&path, yaml).expect("the fixture must be written");
 
-        let request = yaml::load_document::<UpdateConfigRequest>(&path).expect("null fields must load");
-        std::fs::remove_file(&path).ok();
+        let request: UpdateConfigRequest = serde_yaml::from_str(yaml).expect("null fields must load");
 
         assert_eq!("forward0", request.name);
         assert!(request.rules[0].devices.is_empty());

--- a/modules/route/cli/src/main.rs
+++ b/modules/route/cli/src/main.rs
@@ -323,11 +323,6 @@ mod test {
 
     use super::*;
 
-    #[test]
-    fn cmd_is_valid() {
-        Cmd::command().debug_assert();
-    }
-
     fn ip_range(start: &str, end: &str) -> IpRange {
         IpRange::from((start.parse::<IpAddr>().unwrap(), end.parse::<IpAddr>().unwrap()))
     }

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -398,11 +398,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cmd_is_valid() {
-        Cmd::command().debug_assert();
-    }
-
-    #[test]
     fn format_endpoint_brackets_ipv6_only() {
         let v4: IpAddress = "192.0.2.10".parse().unwrap();
         let v6: IpAddress = "2001:db8::2".parse().unwrap();

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -616,80 +616,6 @@ mod test {
         );
     }
 
-    /// `--via ADDR PREFIX` must not consume the positional prefix as a second
-    /// nexthop.
-    #[test]
-    fn insert_via_does_not_consume_prefix() {
-        let cmd = Cmd::try_parse_from([
-            "yanet-cli-operator-route",
-            "insert",
-            "--via",
-            "192.0.2.1",
-            "10.0.0.0/8",
-            "-n",
-            "cfg",
-        ])
-        .expect("parse must succeed");
-
-        let ModeCmd::Insert(insert) = cmd.mode else {
-            panic!("expected Insert variant");
-        };
-
-        assert_eq!("10.0.0.0/8", insert.prefix.to_string());
-        assert_eq!(1, insert.nexthop_addrs.len());
-        assert_eq!("192.0.2.1", insert.nexthop_addrs[0].to_string());
-    }
-
-    /// Repeating `--via` accumulates nexthops for ECMP routes.
-    #[test]
-    fn insert_via_repeated_accumulates_nexthops() {
-        let cmd = Cmd::try_parse_from([
-            "yanet-cli-operator-route",
-            "insert",
-            "--via",
-            "192.0.2.1",
-            "--via",
-            "192.0.2.2",
-            "10.0.0.0/8",
-            "-n",
-            "cfg",
-        ])
-        .expect("parse must succeed");
-
-        let ModeCmd::Insert(insert) = cmd.mode else {
-            panic!("expected Insert variant");
-        };
-
-        assert_eq!("10.0.0.0/8", insert.prefix.to_string());
-        assert_eq!(2, insert.nexthop_addrs.len());
-        assert_eq!("192.0.2.1", insert.nexthop_addrs[0].to_string());
-        assert_eq!("192.0.2.2", insert.nexthop_addrs[1].to_string());
-    }
-
-    /// `--via ADDR PREFIX` in remove must not consume the positional prefix as
-    /// a second nexthop.
-    #[test]
-    fn remove_via_does_not_consume_prefix() {
-        let cmd = Cmd::try_parse_from([
-            "yanet-cli-operator-route",
-            "remove",
-            "--via",
-            "192.0.2.1",
-            "10.0.0.0/8",
-            "-n",
-            "cfg",
-        ])
-        .expect("parse must succeed");
-
-        let ModeCmd::Remove(remove) = cmd.mode else {
-            panic!("expected Remove variant");
-        };
-
-        assert_eq!("10.0.0.0/8", remove.prefix.to_string());
-        assert_eq!(1, remove.nexthop_addrs.len());
-        assert_eq!("192.0.2.1", remove.nexthop_addrs[0].to_string());
-    }
-
     fn entry_with(prefix: PrefixValue, source: &str, is_best: bool) -> RouteEntry {
         RouteEntry {
             prefix: Prefix(prefix, is_best, 1),
@@ -845,10 +771,5 @@ mod test {
         assert_eq!(2, entries[0].prefix.2);
         assert_eq!(1, entries[1].prefix.2);
         assert_eq!(2, entries[2].prefix.2);
-    }
-
-    #[test]
-    fn cmd_is_valid() {
-        Cmd::command().debug_assert();
     }
 }


### PR DESCRIPTION
- The `debug_assert` and `try_parse_from` tests of ready, metrics, device-vlan, fwstate-map, route and the route operator go, per the CLI test policy: defaults, ranges, conflicts and flag placement are clap's contract, not the crate's logic.
- Forward's two null-field tests parse a string instead of writing a scratch file.