### PR TITLE
docs(cli): drop the repeated brief on the completion candidate functions

### DIFF
--- a/.agents/skills/code-cli/references/new-crate.md
+++ b/.agents/skills/code-cli/references/new-crate.md
@@ -300,10 +300,6 @@ impl Tabled for Config {
     }
 }
 
-/// Completion candidates for a config-name argument: the configs the
-/// service currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(
         Cmd::command,

--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -277,10 +277,6 @@ impl From<&ArenaInfo> for ArenaRow {
     }
 }
 
-/// Completion candidates for the agent argument: the agents that can be
-/// grown, leaving out the retired generations.
-///
-/// Strictly best-effort — an unreachable service offers no candidates.
 fn agent_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, memory_client, async move |mut client| {
         let mut names: Vec<String> = client

--- a/cli/modules/device-delete/src/main.rs
+++ b/cli/modules/device-delete/src/main.rs
@@ -56,10 +56,6 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     Ok(())
 }
 
-/// Completion candidates for the device-name argument: the devices the
-/// service currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn device_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -218,10 +218,6 @@ async fn delete_function(service: &mut FunctionService, cmd: DeleteCmd) -> Resul
     Ok(())
 }
 
-/// Completion candidates for a `--name` argument: the functions the module
-/// currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn function_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -174,8 +174,6 @@ async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>) ->
     Ok(())
 }
 
-/// Completion candidates for the service positional: the metrics services
-/// the gateway currently knows.
 fn service_candidates() -> Vec<CompletionCandidate> {
     METRICS.candidates(Cmd::command)
 }

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -218,10 +218,6 @@ async fn delete_pipeline(service: &mut PipelineService, action: &'static str, cm
     Ok(())
 }
 
-/// Completion candidates for a `--name` argument: the pipelines the module
-/// currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn pipeline_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -382,8 +382,6 @@ fn print_missing(missing: &[&str]) {
     }
 }
 
-/// Completion candidates for the service positional: the readiness services
-/// the gateway currently knows.
 fn service_candidates() -> Vec<CompletionCandidate> {
     READINESS.candidates(Cmd::command)
 }

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -196,10 +196,6 @@ fn binding_rows(device: &Device) -> Vec<BindingRow> {
     rows
 }
 
-/// Completion candidates for the device-name argument: the plain devices
-/// the device service currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn device_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, device_client, async move |mut client| {
         Ok(client

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -227,10 +227,6 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
-/// Completion candidates for a `--name` argument: the generator device
-/// configs the module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -204,10 +204,6 @@ fn binding_rows(device: &Device) -> Vec<BindingRow> {
     rows
 }
 
-/// Completion candidates for the device-name argument: the vlan devices the
-/// device service currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn device_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, device_client, async move |mut client| {
         Ok(client

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -475,10 +475,6 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
-/// Completion candidates for a `--name` argument: the ACL configs the
-/// module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -297,10 +297,6 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
-/// Completion candidates for a `--name` argument: the balancer configs the
-/// module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client
@@ -311,10 +307,6 @@ fn config_candidates() -> Vec<CompletionCandidate> {
     })
 }
 
-/// Completion candidates for a sessions-state name argument: the sessions
-/// states the module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn sessions_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -169,10 +169,6 @@ async fn delete_config(service: &mut BlackholeService, cmd: DeleteConfigCmd) -> 
     Ok(())
 }
 
-/// Completion candidates for a `--name` argument: the blackhole configs the
-/// module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -199,10 +199,6 @@ fn config_block(response: &ShowConfigResponse) -> display::KeyValue {
     display::KeyValue::new().rows("prefixes", prefixes)
 }
 
-/// Completion candidates for a `--name` argument: the decap configs the
-/// module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -320,10 +320,6 @@ fn flag_to_string(flag: u32) -> String {
     }
 }
 
-/// Completion candidates for a `--name` argument: the dscp configs the
-/// module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -237,10 +237,6 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
-/// Completion candidates for a `--name` argument: the forward configs the
-/// module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, forward_client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -308,10 +308,6 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
-/// Completion candidates for a `--name` argument: the fwstate configs the
-/// module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -232,10 +232,6 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
-/// Completion candidates for a `--name` argument: the mirror configs the
-/// module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -445,10 +445,6 @@ fn parse_prefix(value: &str) -> Result<Contiguous<Ipv6Network>, String> {
     Ok(prefix)
 }
 
-/// Completion candidates for a `--name` argument: the nat64 configs the
-/// module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -284,10 +284,6 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
-/// Completion candidates for a `--name` argument: the pdump configs the
-/// module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -138,10 +138,6 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
-/// Completion candidates for a `--name` argument: the route-mpls configs
-/// the module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/modules/route/cli/src/main.rs
+++ b/modules/route/cli/src/main.rs
@@ -199,10 +199,6 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
-/// Completion candidates for a `--name` argument: the route configs the
-/// module currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)

--- a/objects/fwstate/cli/src/main.rs
+++ b/objects/fwstate/cli/src/main.rs
@@ -383,10 +383,6 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
-/// Completion candidates for a `--name` argument: the fwstate-map objects
-/// the map service currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn map_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_maps(ListMapsRequest {}).await?.into_inner().maps)

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -451,10 +451,6 @@ impl Tabled for NeighbourTableInfo {
     }
 }
 
-/// Completion candidates for a table-name argument: the neighbour tables
-/// the operator currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn table_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -171,10 +171,6 @@ fn main() -> std::process::ExitCode {
     ync::entrypoint(|cmd: &Cmd| cmd.globals.options(), run)
 }
 
-/// Completion candidates for a `--name` argument: the route operator
-/// configs the operator currently knows.
-///
-/// Strictly best-effort — see [`completion::candidates`].
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(Cmd::command, client, async move |mut client| {
         Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)


### PR DESCRIPTION
- The 26 repeated "Completion candidates for a name argument" briefs go, the best-effort contract lives on `completion::candidates` and `Family::candidates`, which every one of them calls.
- The new-crate skeleton in the code-cli skill follows.