### PR TITLE
docs(cli): name every shared renderer in the code-cli skill

### DIFF
--- a/.agents/skills/code-cli/SKILL.md
+++ b/.agents/skills/code-cli/SKILL.md
@@ -85,8 +85,14 @@ has the manifest, `build.rs`, skeleton and registration steps for a new binary.
   <path>`) or a filter pattern (`counters [PATTERN]…`); everything else
   is a flag. A file never has a flag. A YAML file positional loads with
   `ync::yaml::load::<T>(&path)`, its error already naming the path, mapped
-  with `service.invalid("<verb>", err.to_string())`; no private `load`
-  that opens and parses on its own.
+  with `service.invalid("<verb>", err.to_string())`. A wire-shaped request
+  file loads before the connection with `yaml::load_document::<T>(&path)`
+  plus `yaml::bind_name(&mut request.name, &cmd.name)`, both mapped with
+  `Error::invalid_argument("<verb>", label, …)` over a
+  `client::resolve_label` label; such a request type derives `Deserialize`
+  with `#[serde(default, deny_unknown_fields)]` from `build.rs`, so a sparse
+  file loads and a misspelled key is refused. No private `load` that opens
+  and parses on its own.
 - Flags: `--name/-n` names the object the binary manages (a config, a map,
   a sessions state) and nothing else; `-4/-6` family filters, mutually
   exclusive (nat64's address pair excepted); `--endpoint` and `--auth`
@@ -131,9 +137,20 @@ no `--yes`, no `--dry-run`.
   Tabled for <wire type>` (`LENGTH`, `fields` with `Cow::Borrowed` for `&str`
   and `Cow::Owned` for computed cells, `headers`). A local row struct only
   where the orphan rule blocks that (a type from a shared proto crate) or for
-  a document schema that also parses a file. A single object is a key/value
-  block, nested lists as sub-tables. Never a pretty-printed JSON, YAML or tree
-  dump in human mode.
+  a document schema that also parses a file. A table whose columns are only
+  known at run time is built as a `tabled::Table` and handed to
+  `display::print_table`, which styles and fits it the same way. A list of
+  bare names (a config
+  CLI's `list`) is `display::print_names(&names, empty)` or
+  `print_names_with_hint(&names, empty, hint)`, sorted and escaped. A single
+  object is a `display::KeyValue` block (`row`, `rows` for a list one item
+  per line, `print`). Never a pretty-printed JSON, YAML or tree dump in
+  human mode, except a config updated from a wire-shaped file, whose `show`
+  prints that YAML document so a redirected `show` feeds `update`.
+- A server stream or a paged dump leaves through `output::rows(header,
+  render)`: `push` per row, `finish(empty)` at the end; under `--format json`
+  every row is one JSON line. Wrapped text under a prefix with a hanging
+  indent is `display::print_hanging`, a histogram is `display::print_bars`.
 - Empty results: inside the render closure, `output::empty(…)` or
   `output::empty_with_hint(…, "create one with '<full command>'")` and an
   early return; never bare printing or a call-site guard. The primitive owns
@@ -142,14 +159,24 @@ no `--yes`, no `--dry-run`.
   sentence `<Verb-ed> <kind> '<name>'.` (name quoted, `config` for a module
   CLI's kind).
 - Colour and glyphs only via `output::is_colored()`, `output::dim`,
-  `output::paint_dim`; no `colored` dependency in a CLI crate (#2377).
+  `output::paint_dim` / `paint_bold` / `paint_ok` / `paint_warning` /
+  `paint_error`, and a
+  bracketed status mark with a Unicode and an ASCII face is a
+  `display::Mark`; no `colored` dependency in a CLI crate (#2377).
   `ync::init`, called by `entrypoint`, decides colour once for the process; a
   crate never calls `colored::control` outside its tests.
 - An unusable derived JSON shape (an enum as a number) is fixed on the wire
-  type: `field_attribute` in `build.rs` adds `#[serde(serialize_with = "…")]`,
-  the function lives in `main.rs`, the exception is owner-approved.
-- Ages, durations, sizes: `ync::humanfmt`; metrics: `ync::metrics`, its
-  `format_number` the one thousands-separator formatter.
+  type: `field_attribute` in `build.rs` adds `#[serde(serialize_with =
+  "commonpb::serde_with::timestamp")]` (or `duration`) for an instant,
+  `#[serde(deserialize_with = "filterpb::null_as_default")]` for a nullable
+  field, and for an enum field a `serialize_with` / `deserialize_with` pair
+  of functions in `main.rs` delegating to `commonpb::serde_with::declared_name`
+  and `from_declared_name` (`lowercase_name` renders an output-only field);
+  the exception is owner-approved.
+- Ages and instants: `ync::humanfmt` (`format_age`, `age_since`,
+  `format_timestamp`); a duration: `humantime::format_duration`; sizes:
+  `bytesize::ByteSize`; metrics: `ync::metrics`,
+  its `format_number` the one thousands-separator formatter.
 
 ## Errors and exit codes
 

--- a/.agents/skills/code-cli/references/new-crate.md
+++ b/.agents/skills/code-cli/references/new-crate.md
@@ -32,30 +32,27 @@ workspace = true
 
 [dependencies]
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
+# Only when the proto imports common/filterpb.
+filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 netip = "0.3"
 prost = "0.14"
 serde = { version = "1", features = ["derive"] }
-tabled = { version = "0.21", default-features = false, features = ["ansi", "derive"] }
 tonic = { version = "0.14", features = ["gzip"] }
 tonic-prost = "0.14"
 
 [build-dependencies]
-tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
+ync-build = { path = "../../../cli/ync-build", version = "0.1", package = "yanet-cli-build" }
 ```
 
-Add a dependency only when the code uses it; `netip` and `tabled` are
-listed because almost every binary parses an address or prints a table.
-`tabled` keeps its default features off, since the default `assert`
-feature links `testing_table` into the binary, and lists `derive` only
-when a row type derives `Tabled`.
-
-`tonic-prost-build` keeps its default features off: the default
-`cleanup-markdown` re-renders proto doc comments and fails clippy's
-`doc_lazy_continuation` on the generated code, while `transport` keeps the
-generated `connect` constructors that tonic-build 0.13 always emitted.
+Add a dependency only when the code uses it; `netip` is listed because
+almost every binary parses an address. A binary that prints a table adds
+`tabled = { version = "0.21", default-features = false, features = ["ansi",
+"derive"] }`: default features off, since the default `assert` feature
+links `testing_table` into the binary, and `derive` only when a row type
+derives `Tabled`.
 
 ## build.rs
 
@@ -63,53 +60,47 @@ generated `connect` constructors that tonic-build 0.13 always emitted.
 use core::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let root = "../../..";
     // modules, devices and objects; an operator's protos live under
     // operators/<x>/operatorpb/v1/ instead, with file names of their
     // own (route.proto, operator.proto, …) — check the tree.
-    let proto = "<owner>/<x>/controlplane/<x>pb/v1/<x>.proto";
-    println!("cargo:rerun-if-changed={root}/{proto}");
-
-    tonic_prost_build::configure()
-        .emit_rerun_if_changed(false)
-        .build_server(false)
-        .message_attribute(".", "#[derive(serde::Serialize)]")
-        // One line per enum field that must render by its proto name.
-        .field_attribute(".<package>.<Message>.<field>", "#[serde(serialize_with = \"crate::serialize_<field>\")]")
-        .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .compile_protos(&[format!("{root}/{proto}")], &[root])?;
-
-    Ok(())
+    ync_build::client("../../..", &["<owner>/<x>/controlplane/<x>pb/v1/<x>.proto"])
+        .serialize()
+        // One call per enum field that must render by its proto name.
+        .with(|builder| {
+            builder.field_attribute(
+                ".<package>.<Message>.<field>",
+                "#[serde(serialize_with = \"crate::serialize_<field>\")]",
+            )
+        })
+        .compile()
 }
 ```
 
-Shared packages (`common.commonpb.v1`, `common.filterpb.v1`) are always
-`extern_path`ed to their crate; never compile them twice.
+`ync_build::client` builds a client-only crate, `extern_path`s the shared
+packages (`common.commonpb.v1`, `common.filterpb.v1`) to their crates and
+watches the listed protos; a proto they import is not watched.
 
 ## src/main.rs
 
 ```rust
 //! CLI for YANET <x>.
 
-use std::borrow::Cow;
-
 use clap::{CommandFactory, Parser};
 use clap_complete::{
     engine::{ArgValueCandidates, CompletionCandidate},
 };
-use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     GlobalArgs,
     client::{LayeredChannel, Service},
     completion,
-    display::print_table_from_entries,
+    display,
     errors::Error,
     output,
 };
 
 use crate::<x>pb::{
-    Config, DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
+    DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     <x>_service_client::<X>ServiceClient,
 };
 
@@ -213,17 +204,11 @@ async fn list_configs(service: &mut <X>Service) -> Result<(), Error> {
     output::data(
         || &response.configs,
         || {
-            if response.configs.is_empty() {
-                output::empty_with_hint(
-                    format_args!("No configs found."),
-                    format_args!("create one with 'yanet-cli-<suffix> update --name <name> …'"),
-                );
-                return;
-            }
-
-            let mut entries: Vec<&Config> = response.configs.iter().collect();
-            entries.sort_by(|a, b| a.name.cmp(&b.name));
-            print_table_from_entries(entries);
+            display::print_names_with_hint(
+                &response.configs,
+                format_args!("No configs found."),
+                format_args!("create one with 'yanet-cli-<suffix> update --name <name> …'"),
+            )
         },
     );
 
@@ -245,8 +230,10 @@ async fn show_config(service: &mut <X>Service, cmd: ShowCmd) -> Result<(), Error
     output::data(
         || &response,
         || {
-            println!("name:     {}", response.name);
-            println!("prefixes: {}", response.prefixes.len());
+            display::KeyValue::new()
+                .row("name", &response.name)
+                .row("prefixes", response.prefixes.len())
+                .print();
         },
     );
 
@@ -285,34 +272,12 @@ async fn delete_config(service: &mut <X>Service, cmd: DeleteCmd) -> Result<(), E
     Ok(())
 }
 
-impl Tabled for Config {
-    const LENGTH: usize = 2;
-
-    fn fields(&self) -> Vec<Cow<'_, str>> {
-        vec![
-            Cow::Borrowed(self.name.as_str()),
-            Cow::Owned(self.prefixes.len().to_string()),
-        ]
-    }
-
-    fn headers() -> Vec<Cow<'static, str>> {
-        vec![Cow::Borrowed("NAME"), Cow::Borrowed("PREFIXES")]
-    }
-}
-
 fn config_candidates() -> Vec<CompletionCandidate> {
     completion::candidates(
         Cmd::command,
         client,
         async move |mut client| {
-            Ok(client
-                .list_configs(ListConfigsRequest {})
-                .await?
-                .into_inner()
-                .configs
-                .into_iter()
-                .map(|config| config.name)
-                .collect())
+            Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs)
         },
     )
 }

--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -508,9 +508,9 @@ impl<C> Service<C> {
 
     /// The endpoint this client reached.
     ///
-    /// Exposed for the few call sites that build errors through a helper
-    /// other than [`status`](Service::status) / [`invalid`](Service::invalid)
-    /// (for example a [`NotFoundMapper`](crate::errors::NotFoundMapper)).
+    /// Read it only for a payload or an error label built without
+    /// [`status`](Service::status), [`invalid`](Service::invalid) or
+    /// [`not_found`](Service::not_found).
     pub fn endpoint(&self) -> &str {
         &self.endpoint
     }


### PR DESCRIPTION
- The skill's output section points at `display::print_names`, `KeyValue`, `output::rows`, `print_hanging`, `print_bars`, `Mark`, the `paint_*` family and `humanfmt::format_timestamp`, so a new crate reaches for them instead of a private copy.
- The skeleton's show renders through `KeyValue`, and the `Service::endpoint` doc cites `not_found` instead of the mapper it no longer needs.