### PR TITLE
feat(dataplane): module and device commit handlers

### DIFF
--- a/devices/plain/dataplane/dataplane.c
+++ b/devices/plain/dataplane/dataplane.c
@@ -39,6 +39,12 @@ struct device_plain {
 	struct device device;
 };
 
+static void
+plain_device_commit(struct dp_config *dp_config, struct cp_device *cp_device) {
+	(void)dp_config;
+	(void)cp_device;
+}
+
 struct device *
 new_device_plain() {
 	struct device_plain *device_plain =
@@ -56,6 +62,7 @@ new_device_plain() {
 	);
 	device_plain->device.input_handler = plain_input_handle;
 	device_plain->device.output_handler = plain_output_handle;
+	device_plain->device.commit_handler = plain_device_commit;
 
 	return &device_plain->device;
 }

--- a/devices/trafgen/dataplane/dataplane.c
+++ b/devices/trafgen/dataplane/dataplane.c
@@ -166,6 +166,14 @@ trafgen_output_handle(
 	packet_front_pass(packet_front);
 }
 
+static void
+trafgen_device_commit(
+	struct dp_config *dp_config, struct cp_device *cp_device
+) {
+	(void)dp_config;
+	(void)cp_device;
+}
+
 struct device *
 new_device_trafgen() {
 	struct device_trafgen *device =
@@ -183,6 +191,7 @@ new_device_trafgen() {
 	);
 	device->device.input_handler = trafgen_input_handle;
 	device->device.output_handler = trafgen_output_handle;
+	device->device.commit_handler = trafgen_device_commit;
 
 	return &device->device;
 }

--- a/devices/vlan/dataplane/dataplane.c
+++ b/devices/vlan/dataplane/dataplane.c
@@ -152,6 +152,12 @@ struct device_vlan {
 	struct device device;
 };
 
+static void
+vlan_device_commit(struct dp_config *dp_config, struct cp_device *cp_device) {
+	(void)dp_config;
+	(void)cp_device;
+}
+
 struct device *
 new_device_vlan() {
 	struct device_vlan *device_vlan =
@@ -169,6 +175,7 @@ new_device_vlan() {
 	);
 	device_vlan->device.input_handler = vlan_input_handle;
 	device_vlan->device.output_handler = vlan_output_handle;
+	device_vlan->device.commit_handler = vlan_device_commit;
 
 	return &device_vlan->device;
 }

--- a/lib/dataplane/config/bootstrap.c
+++ b/lib/dataplane/config/bootstrap.c
@@ -35,6 +35,10 @@ dp_storage_init(
 
 	dp_config->config_lock = 0;
 
+	// Nothing is committed into a fresh zone; the record starts at
+	// none.
+	dp_config->committed_gen_seq = 0;
+
 	dp_config->dp_modules = NULL;
 	dp_config->module_count = 0;
 

--- a/lib/dataplane/config/module_loader.c
+++ b/lib/dataplane/config/module_loader.c
@@ -73,6 +73,7 @@ dp_load_module(
 
 	strtcpy(dp_module->name, module->name, sizeof(dp_module->name));
 	dp_module->handler = module->handler;
+	dp_module->commit_handler = module->commit_handler;
 
 	SET_OFFSET_OF(&dp_config->dp_modules, dp_modules);
 
@@ -115,6 +116,7 @@ dp_load_device(struct dp_config *dp_config, void *bin_hndl, const char *name) {
 	strtcpy(dp_device->name, device->name, sizeof(dp_device->name));
 	dp_device->input_handler = device->input_handler;
 	dp_device->output_handler = device->output_handler;
+	dp_device->commit_handler = device->commit_handler;
 
 	SET_OFFSET_OF(&dp_config->dp_devices, dp_devices);
 

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -20,11 +20,15 @@
 #include "lib/dataplane/pipeline/econtext.h"
 
 _Static_assert(
-	sizeof(struct module) == 88,
+	sizeof(struct module) == 96,
 	"struct module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct dp_config) == 1240,
+	sizeof(struct device) == 104,
+	"struct device size changed, bump YANET_MODULE_ABI_VERSION"
+);
+_Static_assert(
+	sizeof(struct dp_config) == 1248,
 	"struct dp_config size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/config/zone.c
+++ b/lib/dataplane/config/zone.c
@@ -4,8 +4,13 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "common/container_of.h"
+#include "lib/controlplane/config/cp_device.h"
+#include "lib/controlplane/config/cp_module.h"
+#include "lib/controlplane/config/registry.h"
 #include "lib/controlplane/config/zone.h"
 #include "lib/dataplane/pipeline/pipeline.h"
+#include "lib/logging/log.h"
 
 struct dp_config *
 dp_config_nextk(struct dp_config *current, uint32_t k) {
@@ -65,10 +70,123 @@ dp_config_wait_for_worker_ectx(
 	}
 }
 
+// Serializes commit passes within one dataplane process.
+//
+// Every assigner thread of the process contends here before reading the
+// commit bookkeeping, so exactly one thread runs the handlers for a
+// shared config and generation while the others observe the recorded
+// outcome and skip — the single-writer guarantee the handlers rely on.
+static pthread_mutex_t commit_lock = PTHREAD_MUTEX_INITIALIZER;
+
+// Runs the module commit handlers of a generation.
+//
+// Modules are visited in registry order; an item whose dataplane
+// slot index falls outside the loaded array is skipped with an error
+// logged. That path is unreachable in practice — the indices are
+// validated when the config is built — so the skip is purely
+// defensive.
+static void
+dp_config_commit_gen_modules(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+) {
+	struct cp_module_registry *module_registry =
+		&config_gen->module_registry;
+	struct dp_module *dp_modules = ADDR_OF(&dp_config->dp_modules);
+
+	for (uint64_t idx = 0; idx < module_registry->registry.capacity;
+	     ++idx) {
+		struct registry_item *item =
+			registry_get(&module_registry->registry, idx);
+		if (item == NULL) {
+			continue;
+		}
+		struct cp_module *cp_module =
+			container_of(item, struct cp_module, config_item);
+		if (cp_module->dp_module_idx >= dp_config->module_count) {
+			LOG(ERROR,
+			    "commit skipped for module '%s:%s': no dataplane "
+			    "module",
+			    cp_module->type,
+			    cp_module->name);
+			continue;
+		}
+		struct dp_module *dp_module =
+			dp_modules + cp_module->dp_module_idx;
+		if (dp_module->commit_handler != NULL) {
+			dp_module->commit_handler(dp_config, cp_module);
+		}
+	}
+}
+
+// Runs the device commit handlers of a generation, after every module
+// handler; devices are visited in registry order, with the same
+// defensive skip of an out-of-range slot index as the module pass.
+static void
+dp_config_commit_gen_devices(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+) {
+	struct cp_device_registry *device_registry =
+		&config_gen->device_registry;
+	struct dp_device *dp_devices = ADDR_OF(&dp_config->dp_devices);
+
+	for (uint64_t idx = 0; idx < device_registry->registry.capacity;
+	     ++idx) {
+		struct registry_item *item =
+			registry_get(&device_registry->registry, idx);
+		if (item == NULL) {
+			continue;
+		}
+		struct cp_device *cp_device =
+			container_of(item, struct cp_device, config_item);
+		if (cp_device->dp_device_idx >= dp_config->device_count) {
+			LOG(ERROR,
+			    "commit skipped for device '%s:%s': no dataplane "
+			    "device",
+			    cp_device->type,
+			    cp_device->name);
+			continue;
+		}
+		struct dp_device *dp_device =
+			dp_devices + cp_device->dp_device_idx;
+		if (dp_device->commit_handler != NULL) {
+			dp_device->commit_handler(dp_config, cp_device);
+		}
+	}
+}
+
+void
+dp_config_commit_gen(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+) {
+	if (config_gen == NULL) {
+		return;
+	}
+
+	// Generation sequence, encoded so zero still means "none".
+	const uint64_t gen_seq = config_gen->gen + 1;
+
+	pthread_mutex_lock(&commit_lock);
+	if (dp_config->committed_gen_seq == gen_seq) {
+		pthread_mutex_unlock(&commit_lock);
+		return;
+	}
+
+	dp_config_commit_gen_modules(dp_config, config_gen);
+	dp_config_commit_gen_devices(dp_config, config_gen);
+
+	// Plain store: the record is touched only under this lock, by
+	// this process's assigner threads or harness round driver; no
+	// reader in another process exists.
+	dp_config->committed_gen_seq = gen_seq;
+	pthread_mutex_unlock(&commit_lock);
+}
+
 void
 dp_config_assign_worker_ectxs(
 	struct dp_config *dp_config, struct cp_config_gen *config_gen
 ) {
+	dp_config_commit_gen(dp_config, config_gen);
+
 	// The loop bound and the array it indexes come from one observation.
 	struct dp_worker *const *workers = ADDR_OF(&dp_config->workers);
 	const uint64_t worker_count = dp_config->worker_count;

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -22,12 +22,14 @@ struct rte_mempool;
 struct dp_module {
 	char name[80];
 	module_handler handler;
+	module_commit_handler commit_handler;
 };
 
 struct dp_device {
 	char name[DEVICE_TYPE_LEN];
 	device_handler input_handler;
 	device_handler output_handler;
+	device_commit_handler commit_handler;
 };
 
 /*
@@ -171,6 +173,19 @@ struct dp_config {
 	uint64_t port_count;
 	struct dp_port_counters *port_counters;
 
+	// Commit-pass bookkeeping, mutated only under the process-wide
+	// commit lock shared by every commit pass.
+	//
+	// The record stores the encoded generation sequence: 0 means
+	// none, otherwise the generation number plus one. Generation
+	// numbers advance monotonically per zone — a superseded
+	// generation is freed only after every worker moved to its
+	// successor — so the record names exactly one generation: the
+	// last whose commit handlers ran. It is written and read only
+	// under the commit lock, by one process's assigner threads or
+	// harness round driver; no reader in another process exists.
+	uint64_t committed_gen_seq;
+
 	// Selects the synchronous generation hand-off used by in-process
 	// harnesses; production leaves it clear.
 	//
@@ -246,6 +261,18 @@ dp_config_lookup_object(
 // set.
 uint64_t
 dp_config_device_worker_count(struct dp_config *dp_config, uint32_t device_id);
+
+// Run the generation's commit handlers once.
+//
+// Runs inside the dataplane address space during config deliverance,
+// from exactly one thread per shared config: a process-wide lock plus
+// the per-zone record above make the pass single-writer, so two
+// assigner threads observing the same generation do not both run it.
+// An absent generation commits nothing.
+void
+dp_config_commit_gen(
+	struct dp_config *dp_config, struct cp_config_gen *config_gen
+);
 
 // Deliver each worker of dp_config the execution context built for it in
 // config_gen.

--- a/lib/dataplane/device/device.h
+++ b/lib/dataplane/device/device.h
@@ -5,6 +5,8 @@
 struct packet_front;
 struct device_ectx;
 struct dp_worker;
+struct dp_config;
+struct cp_device;
 
 typedef void (*device_handler)(
 	struct dp_worker *dp_worker,
@@ -12,10 +14,29 @@ typedef void (*device_handler)(
 	struct packet_front *packet_front
 );
 
+// Commit handler: a preparation hook, run exactly once per published
+// generation per shared device config.
+//
+// Runs inside the dataplane address space, from exactly one thread,
+// before the generation's contexts reach the workers. Only
+// generation-invariant derivation — from the item's own content
+// alone, like absolutizing its own internal pointers — may be
+// written; the item is shared with older generations whose workers
+// read it concurrently and observe the write. Controlplane-owned
+// relative fields stay authoritative, and anything per-worker or
+// referencing generation-owned memory belongs in the ectx layer
+// instead. The thread holds no control-plane lock in production and
+// is the installer holding the control-plane configuration lock in
+// the harness; taking that lock self-deadlocks.
+typedef void (*device_commit_handler)(
+	struct dp_config *dp_config, struct cp_device *cp_device
+);
+
 struct device {
 	char name[DEVICE_TYPE_LEN];
 	device_handler input_handler;
 	device_handler output_handler;
+	device_commit_handler commit_handler;
 };
 
 typedef struct device *(*device_load_handler)();

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 28
+#define YANET_MODULE_ABI_VERSION 29
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.
@@ -25,6 +25,8 @@
 struct packet_front;
 struct module_ectx;
 struct dp_worker;
+struct dp_config;
+struct cp_module;
 
 /*
  * Module handler called for a pipeline front.
@@ -39,9 +41,28 @@ typedef void (*module_handler)(
 	struct packet_front *packet_front
 );
 
+// Commit handler: a preparation hook, run exactly once per published
+// generation per shared module config.
+//
+// Runs inside the dataplane address space, from exactly one thread,
+// before the generation's contexts reach the workers. Only
+// generation-invariant derivation — from the item's own content
+// alone, like absolutizing its own internal pointers — may be
+// written; the item is shared with older generations whose workers
+// read it concurrently and observe the write. Controlplane-owned
+// relative fields stay authoritative, and anything per-worker or
+// referencing generation-owned memory belongs in the ectx layer
+// instead. The thread holds no control-plane lock in production and
+// is the installer holding the control-plane configuration lock in
+// the harness; taking that lock self-deadlocks.
+typedef void (*module_commit_handler)(
+	struct dp_config *dp_config, struct cp_module *cp_module
+);
+
 struct module {
 	char name[MODULE_TYPE_LEN];
 	module_handler handler;
+	module_commit_handler commit_handler;
 };
 
 typedef struct module *(*module_load_handler)();

--- a/lib/tests/dataplane/commit_test.c
+++ b/lib/tests/dataplane/commit_test.c
@@ -1,0 +1,525 @@
+// Generation commit pass: module and device commit handlers run
+// exactly once per published generation as a preparation hook.
+//
+// Pins the once-per-generation semantics (a repeated pass on an
+// already committed generation must not re-run handlers), the silent
+// skip of handlers never registered and of out-of-range slot indices,
+// that the harness deliverance path runs the handlers during its
+// in-place delivery, and that the delivery wait completes once a real
+// worker holds the delivered context.
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "common/exp_array.h"
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "common/test_assert.h"
+
+#include "lib/controlplane/config/cp_device.h"
+#include "lib/controlplane/config/cp_module.h"
+#include "lib/controlplane/config/registry.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/dataplane/pipeline/econtext.h"
+#include "lib/logging/log.h"
+#include "lib/tests/dataplane/fixture.h"
+
+// Registry capacity for the ownerless test registries; two entries per
+// generation is the most any scenario registers.
+#define COMMIT_TEST_REGISTRY_CAPACITY 4
+
+// Invocation counters shared by the counting handlers.
+static uint64_t commit_test_module_runs;
+static uint64_t commit_test_device_runs;
+
+static void
+commit_test_module_count(
+	struct dp_config *dp_config, struct cp_module *cp_module
+) {
+	(void)dp_config;
+	(void)cp_module;
+	commit_test_module_runs += 1;
+}
+
+static void
+commit_test_device_count(
+	struct dp_config *dp_config, struct cp_device *cp_device
+) {
+	(void)dp_config;
+	(void)cp_device;
+	commit_test_device_runs += 1;
+}
+
+// Builds an empty generation with ownerless module and device
+// registries on the fixture's memory context.
+static int
+commit_test_gen_init(
+	struct dp_config *cfg, struct cp_config_gen *gen, uint64_t gen_number
+) {
+	memset(gen, 0, sizeof(*gen));
+	gen->gen = gen_number;
+
+	if (registry_init(
+		    &cfg->memory_context,
+		    NULL,
+		    &gen->module_registry.registry,
+		    COMMIT_TEST_REGISTRY_CAPACITY
+	    )) {
+		return -1;
+	}
+	SET_OFFSET_OF(
+		&gen->module_registry.memory_context, &cfg->memory_context
+	);
+
+	if (registry_init(
+		    &cfg->memory_context,
+		    NULL,
+		    &gen->device_registry.registry,
+		    COMMIT_TEST_REGISTRY_CAPACITY
+	    )) {
+		return -1;
+	}
+	SET_OFFSET_OF(
+		&gen->device_registry.memory_context, &cfg->memory_context
+	);
+
+	return 0;
+}
+
+// Appends a dataplane module slot to the config and registers a
+// module config in the generation pointing at it, mirroring what
+// module loading and a generation upsert do together.
+static int
+commit_test_add_module(
+	struct dp_config *cfg,
+	struct cp_config_gen *gen,
+	struct cp_module *cp_module,
+	module_commit_handler commit_handler
+) {
+	struct dp_module *dp_modules = ADDR_OF(&cfg->dp_modules);
+	if (mem_array_expand_exp(
+		    &cfg->memory_context,
+		    (void **)&dp_modules,
+		    sizeof(*dp_modules),
+		    &cfg->module_count
+	    )) {
+		return -1;
+	}
+	SET_OFFSET_OF(&cfg->dp_modules, dp_modules);
+
+	memset(cp_module, 0, sizeof(*cp_module));
+	registry_item_init(&cp_module->config_item);
+	snprintf(cp_module->type, sizeof(cp_module->type), "%s", "test");
+	snprintf(cp_module->name, sizeof(cp_module->name), "%s", "m0");
+	cp_module->dp_module_idx = cfg->module_count - 1;
+
+	struct dp_module *dp_module =
+		ADDR_OF(&cfg->dp_modules) + cp_module->dp_module_idx;
+	dp_module->commit_handler = commit_handler;
+
+	return registry_insert(
+		&gen->module_registry.registry, &cp_module->config_item
+	);
+}
+
+// Appends a dataplane device slot to the config and registers a
+// device config in the generation pointing at it.
+static int
+commit_test_add_device(
+	struct dp_config *cfg,
+	struct cp_config_gen *gen,
+	struct cp_device *cp_device,
+	device_commit_handler commit_handler
+) {
+	struct dp_device *dp_devices = ADDR_OF(&cfg->dp_devices);
+	if (mem_array_expand_exp(
+		    &cfg->memory_context,
+		    (void **)&dp_devices,
+		    sizeof(*dp_devices),
+		    &cfg->device_count
+	    )) {
+		return -1;
+	}
+	SET_OFFSET_OF(&cfg->dp_devices, dp_devices);
+
+	memset(cp_device, 0, sizeof(*cp_device));
+	registry_item_init(&cp_device->config_item);
+	snprintf(cp_device->type, sizeof(cp_device->type), "%s", "test");
+	snprintf(cp_device->name, sizeof(cp_device->name), "%s", "d0");
+	cp_device->dp_device_idx = cfg->device_count - 1;
+
+	struct dp_device *dp_device =
+		ADDR_OF(&cfg->dp_devices) + cp_device->dp_device_idx;
+	dp_device->commit_handler = commit_handler;
+
+	return registry_insert(
+		&gen->device_registry.registry, &cp_device->config_item
+	);
+}
+
+// Wires a single worker into the config, standing in for the
+// per-instance worker array the assigner walks.
+static int
+commit_test_wire_worker(struct dp_config *cfg, struct dp_worker *worker) {
+	memset(worker, 0, sizeof(*worker));
+
+	struct dp_worker **workers = (struct dp_worker **)memory_balloc(
+		&cfg->memory_context, sizeof(struct dp_worker *)
+	);
+	TEST_ASSERT_NOT_NULL(workers, "worker array alloc failed");
+	SET_OFFSET_OF(workers, worker);
+	SET_OFFSET_OF(&cfg->workers, workers);
+	cfg->worker_count = 1;
+
+	return TEST_SUCCESS;
+}
+
+// Verifies that the commit pass runs each module and device handler
+// exactly once per generation: a second pass on the same generation
+// does not re-invoke, a bumped generation does.
+static int
+test_commit_runs_once_per_gen(void) {
+	struct dataplane_test_fixture fixture;
+	TEST_ASSERT_SUCCESS(
+		dataplane_test_fixture_init(&fixture, "commit_test", 1),
+		"fixture init failed"
+	);
+	struct dp_config *cfg = &fixture.dp_config;
+
+	struct cp_config_gen gen;
+	struct cp_module cp_module;
+	struct cp_device cp_device;
+	TEST_ASSERT_SUCCESS(
+		commit_test_gen_init(cfg, &gen, 7), "gen init failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		commit_test_add_module(
+			cfg, &gen, &cp_module, commit_test_module_count
+		),
+		"add module failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		commit_test_add_device(
+			cfg, &gen, &cp_device, commit_test_device_count
+		),
+		"add device failed"
+	);
+
+	commit_test_module_runs = 0;
+	commit_test_device_runs = 0;
+
+	dp_config_commit_gen(cfg, &gen);
+	TEST_ASSERT_EQUAL(
+		commit_test_module_runs,
+		1,
+		"module handler must run once on first commit"
+	);
+	TEST_ASSERT_EQUAL(
+		commit_test_device_runs,
+		1,
+		"device handler must run once on first commit"
+	);
+
+	dp_config_commit_gen(cfg, &gen);
+	TEST_ASSERT_EQUAL(
+		commit_test_module_runs,
+		1,
+		"a committed generation must not re-run the module handler"
+	);
+	TEST_ASSERT_EQUAL(
+		commit_test_device_runs,
+		1,
+		"a committed generation must not re-run the device handler"
+	);
+
+	gen.gen = 8;
+	dp_config_commit_gen(cfg, &gen);
+	TEST_ASSERT_EQUAL(
+		commit_test_module_runs,
+		2,
+		"a bumped generation must re-run the module handler"
+	);
+	TEST_ASSERT_EQUAL(
+		commit_test_device_runs,
+		2,
+		"a bumped generation must re-run the device handler"
+	);
+
+	dataplane_test_fixture_fini(&fixture);
+	return TEST_SUCCESS;
+}
+
+// Verifies that modules and devices which registered no commit handler
+// are skipped without disturbing the pass.
+static int
+test_null_handlers_skipped(void) {
+	struct dataplane_test_fixture fixture;
+	TEST_ASSERT_SUCCESS(
+		dataplane_test_fixture_init(&fixture, "commit_test", 1),
+		"fixture init failed"
+	);
+	struct dp_config *cfg = &fixture.dp_config;
+
+	struct cp_config_gen gen;
+	struct cp_module cp_module;
+	struct cp_device cp_device;
+	TEST_ASSERT_SUCCESS(
+		commit_test_gen_init(cfg, &gen, 1), "gen init failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		commit_test_add_module(cfg, &gen, &cp_module, NULL),
+		"add module failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		commit_test_add_device(cfg, &gen, &cp_device, NULL),
+		"add device failed"
+	);
+
+	dp_config_commit_gen(cfg, &gen);
+
+	dataplane_test_fixture_fini(&fixture);
+	return TEST_SUCCESS;
+}
+
+// Verifies that an item whose slot index points past the loaded array
+// is skipped defensively while the valid items' handlers still run,
+// and that the skipped generation commit does not re-run them.
+static int
+test_out_of_range_indices_skip(void) {
+	struct dataplane_test_fixture fixture;
+	TEST_ASSERT_SUCCESS(
+		dataplane_test_fixture_init(&fixture, "commit_test", 1),
+		"fixture init failed"
+	);
+	struct dp_config *cfg = &fixture.dp_config;
+
+	struct cp_config_gen gen;
+	struct cp_module cp_module;
+	struct cp_device cp_device;
+	TEST_ASSERT_SUCCESS(
+		commit_test_gen_init(cfg, &gen, 2), "gen init failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		commit_test_add_module(
+			cfg, &gen, &cp_module, commit_test_module_count
+		),
+		"add module failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		commit_test_add_device(
+			cfg, &gen, &cp_device, commit_test_device_count
+		),
+		"add device failed"
+	);
+	cp_module.dp_module_idx = cfg->module_count;
+	cp_device.dp_device_idx = cfg->device_count;
+
+	commit_test_module_runs = 0;
+	commit_test_device_runs = 0;
+
+	dp_config_commit_gen(cfg, &gen);
+	TEST_ASSERT_EQUAL(
+		commit_test_module_runs,
+		0,
+		"no handler may run for an out-of-range index"
+	);
+	TEST_ASSERT_EQUAL(
+		commit_test_device_runs,
+		0,
+		"no handler may run for an out-of-range index"
+	);
+
+	// The skip is defensive only: a corrected successor generation
+	// commits and runs the handlers.
+	cp_module.dp_module_idx = 0;
+	cp_device.dp_device_idx = 0;
+	gen.gen = 3;
+	dp_config_commit_gen(cfg, &gen);
+	TEST_ASSERT_EQUAL(
+		commit_test_module_runs,
+		1,
+		"the counting handler must run once for the successor"
+	);
+	TEST_ASSERT_EQUAL(
+		commit_test_device_runs,
+		1,
+		"the counting device handler must run once for the successor"
+	);
+
+	dataplane_test_fixture_fini(&fixture);
+	return TEST_SUCCESS;
+}
+
+// Verifies that an absent generation commits nothing.
+static int
+test_null_gen_commits_nothing(void) {
+	struct dataplane_test_fixture fixture;
+	TEST_ASSERT_SUCCESS(
+		dataplane_test_fixture_init(&fixture, "commit_test", 1),
+		"fixture init failed"
+	);
+	struct dp_config *cfg = &fixture.dp_config;
+
+	dp_config_commit_gen(cfg, NULL);
+
+	dataplane_test_fixture_fini(&fixture);
+	return TEST_SUCCESS;
+}
+
+// Verifies that the harness deliverance path runs the commit handlers
+// during its in-place delivery under the round lock, exactly once per
+// generation.
+static int
+test_external_round_delivery_runs_handlers(void) {
+	struct dataplane_test_fixture fixture;
+	TEST_ASSERT_SUCCESS(
+		dataplane_test_fixture_init(&fixture, "commit_test", 1),
+		"fixture init failed"
+	);
+	struct dp_config *cfg = &fixture.dp_config;
+
+	pthread_mutex_init(dp_config_external_round_lock(cfg), NULL);
+	cfg->external_worker_rounds = true;
+
+	struct cp_config_gen gen;
+	struct cp_module cp_module;
+	TEST_ASSERT_SUCCESS(
+		commit_test_gen_init(cfg, &gen, 11), "gen init failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		commit_test_add_module(
+			cfg, &gen, &cp_module, commit_test_module_count
+		),
+		"add module failed"
+	);
+
+	commit_test_module_runs = 0;
+
+	dp_config_wait_for_gen(cfg, &gen);
+	TEST_ASSERT_EQUAL(
+		commit_test_module_runs,
+		1,
+		"the commit pass must run inside the harness delivery"
+	);
+	dp_config_wait_for_gen(cfg, &gen);
+	TEST_ASSERT_EQUAL(
+		commit_test_module_runs,
+		1,
+		"the committed generation must not re-run the handler"
+	);
+
+	pthread_mutex_destroy(dp_config_external_round_lock(cfg));
+	dataplane_test_fixture_fini(&fixture);
+	return TEST_SUCCESS;
+}
+
+// Verifies that the delivery wait completes once a real worker holds
+// the generation's context and has acknowledged it — the observation
+// walks the worker array and the generation's own context array
+// rather than an empty loop.
+static int
+test_wait_completes_on_real_worker(void) {
+	struct dataplane_test_fixture fixture;
+	TEST_ASSERT_SUCCESS(
+		dataplane_test_fixture_init(&fixture, "commit_test", 1),
+		"fixture init failed"
+	);
+	struct dp_config *cfg = &fixture.dp_config;
+
+	struct cp_config_gen gen;
+	struct cp_module cp_module;
+	TEST_ASSERT_SUCCESS(
+		commit_test_gen_init(cfg, &gen, 9), "gen init failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		commit_test_add_module(
+			cfg, &gen, &cp_module, commit_test_module_count
+		),
+		"add module failed"
+	);
+	dp_config_commit_gen(cfg, &gen);
+
+	// Leave the worker in the state the assigner and the worker
+	// itself produce after a delivery: it holds the generation's
+	// context (released store, as the assigner writes it) and has
+	// acknowledged the generation.
+	struct dp_worker worker;
+	TEST_ASSERT_SUCCESS(
+		commit_test_wire_worker(cfg, &worker), "worker wiring failed"
+	);
+	struct config_gen_ectx *config_gen_ectx =
+		(struct config_gen_ectx *)memory_balloc(
+			&cfg->memory_context, sizeof(struct config_gen_ectx)
+		);
+	TEST_ASSERT_NOT_NULL(config_gen_ectx, "ectx alloc failed");
+	memset(config_gen_ectx, 0, sizeof(*config_gen_ectx));
+	struct config_gen_ectx **config_gen_ectxs =
+		(struct config_gen_ectx **)memory_balloc(
+			&cfg->memory_context, sizeof(struct config_gen_ectx *)
+		);
+	TEST_ASSERT_NOT_NULL(config_gen_ectxs, "ectx array alloc failed");
+	SET_OFFSET_OF(config_gen_ectxs, config_gen_ectx);
+	SET_OFFSET_OF(&gen.config_gen_ectxs, config_gen_ectxs);
+	gen.config_gen_ectx_count = 1;
+	ATOMIC_SET_OFFSET_OF(&worker.config_gen_ectx, config_gen_ectx);
+	worker.gen = gen.gen;
+
+	// Watchdog: a broken observation must fail the suite, not hang it.
+	alarm(10);
+	dp_config_wait_for_gen(cfg, &gen);
+	alarm(0);
+
+	dataplane_test_fixture_fini(&fixture);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	LOG(INFO, "=== Starting Commit Test Suite ===");
+
+	struct {
+		const char *name;
+		int (*fn)(void);
+	} tests[] = {
+		{"commit_runs_once_per_gen", test_commit_runs_once_per_gen},
+		{"null_handlers_skipped", test_null_handlers_skipped},
+		{"out_of_range_indices_skip", test_out_of_range_indices_skip},
+		{"null_gen_commits_nothing", test_null_gen_commits_nothing},
+		{"external_round_delivery_runs_handlers",
+		 test_external_round_delivery_runs_handlers},
+		{"wait_completes_on_real_worker",
+		 test_wait_completes_on_real_worker},
+	};
+
+	size_t total = sizeof(tests) / sizeof(tests[0]);
+	size_t failed = 0;
+
+	for (size_t idx = 0; idx < total; ++idx) {
+		LOG(INFO,
+		    "[%zu/%zu] running %s...",
+		    idx + 1,
+		    total,
+		    tests[idx].name);
+		if (tests[idx].fn() != TEST_SUCCESS) {
+			LOG(ERROR, "%s FAILED", tests[idx].name);
+			++failed;
+		} else {
+			LOG(INFO, "%s passed", tests[idx].name);
+		}
+	}
+
+	if (failed == 0) {
+		LOG(INFO, "=== All %zu commit tests passed! ===", total);
+	} else {
+		LOG(ERROR, "=== %zu/%zu commit tests failed ===", failed, total
+		);
+	}
+
+	return failed == 0 ? TEST_SUCCESS : TEST_FAILED;
+}

--- a/lib/tests/dataplane/meson.build
+++ b/lib/tests/dataplane/meson.build
@@ -106,6 +106,20 @@ zone_test = executable(
 )
 test('zone', zone_test, suite: 'lib_dataplane')
 
+commit_test = executable(
+  'commit_test',
+  'commit_test.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_config_dp_dep,
+    lib_config_cp_dep,
+    lib_logging_dep,
+  ],
+  include_directories: yanet_rootdir,
+)
+test('commit', commit_test, suite: 'lib_dataplane')
+
 worker_clone_test = executable(
   'worker_clone_test',
   'worker_clone_test.c',

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -654,6 +654,12 @@ acl_handle_packets(
 	}
 }
 
+static void
+acl_module_commit(struct dp_config *dp_config, struct cp_module *cp_module) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_acl() {
 	struct acl_module *module =
@@ -665,6 +671,7 @@ new_module_acl() {
 
 	snprintf(module->module.name, sizeof(module->module.name), "%s", "acl");
 	module->module.handler = acl_handle_packets;
+	module->module.commit_handler = acl_module_commit;
 
 	return &module->module;
 }

--- a/modules/blackhole/dataplane/dataplane.c
+++ b/modules/blackhole/dataplane/dataplane.c
@@ -21,6 +21,14 @@ blackhole_handle_packets(
 	}
 }
 
+static void
+blackhole_module_commit(
+	struct dp_config *dp_config, struct cp_module *cp_module
+) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_blackhole() {
 	struct module *module = (struct module *)malloc(sizeof(*module));
@@ -31,6 +39,7 @@ new_module_blackhole() {
 
 	snprintf(module->name, sizeof(module->name), "%s", "blackhole");
 	module->handler = blackhole_handle_packets;
+	module->commit_handler = blackhole_module_commit;
 
 	return module;
 }

--- a/modules/decap/dataplane/dataplane.c
+++ b/modules/decap/dataplane/dataplane.c
@@ -91,6 +91,12 @@ decap_handle_packets(
 	}
 }
 
+static void
+decap_module_commit(struct dp_config *dp_config, struct cp_module *cp_module) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_decap() {
 	struct decap_module *module =
@@ -104,6 +110,7 @@ new_module_decap() {
 		module->module.name, sizeof(module->module.name), "%s", "decap"
 	);
 	module->module.handler = decap_handle_packets;
+	module->module.commit_handler = decap_module_commit;
 
 	return &module->module;
 }

--- a/modules/dscp/dataplane/dataplane.c
+++ b/modules/dscp/dataplane/dataplane.c
@@ -85,6 +85,12 @@ struct dscp_module {
 	struct module module;
 };
 
+static void
+dscp_module_commit(struct dp_config *dp_config, struct cp_module *cp_module) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_dscp() {
 	struct dscp_module *module =
@@ -98,6 +104,7 @@ new_module_dscp() {
 		module->module.name, sizeof(module->module.name), "%s", "dscp"
 	);
 	module->module.handler = dscp_handle_packets;
+	module->module.commit_handler = dscp_module_commit;
 
 	return &module->module;
 }

--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -170,6 +170,14 @@ struct forward_module {
 	struct module module;
 };
 
+static void
+forward_module_commit(
+	struct dp_config *dp_config, struct cp_module *cp_module
+) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_forward() {
 	struct forward_module *module =
@@ -186,6 +194,7 @@ new_module_forward() {
 		"forward"
 	);
 	module->module.handler = forward_handle_packets;
+	module->module.commit_handler = forward_module_commit;
 
 	return &module->module;
 }

--- a/modules/fwstate/dataplane/dataplane.c
+++ b/modules/fwstate/dataplane/dataplane.c
@@ -683,6 +683,14 @@ struct fwstate_module {
 	struct module module;
 };
 
+static void
+fwstate_module_commit(
+	struct dp_config *dp_config, struct cp_module *cp_module
+) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_fwstate() {
 	struct fwstate_module *module =
@@ -699,6 +707,7 @@ new_module_fwstate() {
 		FWSTATE_MODULE_NAME
 	);
 	module->module.handler = fwstate_handle_packets;
+	module->module.commit_handler = fwstate_module_commit;
 
 	return &module->module;
 }

--- a/modules/mirror/dataplane/dataplane.c
+++ b/modules/mirror/dataplane/dataplane.c
@@ -185,6 +185,12 @@ struct mirror_module {
 	struct module module;
 };
 
+static void
+mirror_module_commit(struct dp_config *dp_config, struct cp_module *cp_module) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_mirror() {
 	struct mirror_module *module =
@@ -198,6 +204,7 @@ new_module_mirror() {
 		module->module.name, sizeof(module->module.name), "%s", "mirror"
 	);
 	module->module.handler = mirror_handle_packets;
+	module->module.commit_handler = mirror_module_commit;
 
 	return &module->module;
 }

--- a/modules/nat64/dataplane/nat64dp.c
+++ b/modules/nat64/dataplane/nat64dp.c
@@ -3241,6 +3241,12 @@ nat64_handle_packets(
 	}
 }
 
+static void
+nat64_module_commit(struct dp_config *dp_config, struct cp_module *cp_module) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_nat64() {
 
@@ -3259,6 +3265,7 @@ new_module_nat64() {
 		module->module.name, sizeof(module->module.name), "%s", "nat64"
 	);
 	module->module.handler = nat64_handle_packets;
+	module->module.commit_handler = nat64_module_commit;
 
 	return &module->module;
 }

--- a/modules/pdump/dataplane/dataplane.c
+++ b/modules/pdump/dataplane/dataplane.c
@@ -111,6 +111,12 @@ struct pdump_module {
 	struct module module;
 };
 
+static void
+pdump_module_commit(struct dp_config *dp_config, struct cp_module *cp_module) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_pdump() {
 	struct pdump_module *module =
@@ -124,6 +130,7 @@ new_module_pdump() {
 		module->module.name, sizeof(module->module.name), "%s", "pdump"
 	);
 	module->module.handler = pdump_handle_packets;
+	module->module.commit_handler = pdump_module_commit;
 
 	return &module->module;
 }

--- a/modules/route-mpls/dataplane/dataplane.c
+++ b/modules/route-mpls/dataplane/dataplane.c
@@ -187,6 +187,14 @@ route_mpls_handle_packets(
 	}
 }
 
+static void
+route_mpls_module_commit(
+	struct dp_config *dp_config, struct cp_module *cp_module
+) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_route_mpls() {
 	struct route_module *module =
@@ -203,6 +211,7 @@ new_module_route_mpls() {
 		"route-mpls"
 	);
 	module->module.handler = route_mpls_handle_packets;
+	module->module.commit_handler = route_mpls_module_commit;
 
 	return &module->module;
 }

--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -256,6 +256,12 @@ route_handle_packets(
 	}
 }
 
+static void
+route_module_commit(struct dp_config *dp_config, struct cp_module *cp_module) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_route() {
 	struct route_module *module =
@@ -269,6 +275,7 @@ new_module_route() {
 		module->module.name, sizeof(module->module.name), "%s", "route"
 	);
 	module->module.handler = route_handle_packets;
+	module->module.commit_handler = route_module_commit;
 
 	return &module->module;
 }

--- a/modules/unrdup/dataplane/dataplane.c
+++ b/modules/unrdup/dataplane/dataplane.c
@@ -835,6 +835,12 @@ unrdup_handle_packets(
 	}
 }
 
+static void
+unrdup_module_commit(struct dp_config *dp_config, struct cp_module *cp_module) {
+	(void)dp_config;
+	(void)cp_module;
+}
+
 struct module *
 new_module_unrdup() {
 	struct unrdup_module *module =
@@ -848,6 +854,7 @@ new_module_unrdup() {
 		module->module.name, sizeof(module->module.name), "%s", "unrdup"
 	);
 	module->module.handler = unrdup_handle_packets;
+	module->module.commit_handler = unrdup_module_commit;
 
 	return &module->module;
 }


### PR DESCRIPTION
- Deliverance-time commit handlers for modules and devices: a void preparation hook run exactly once per published generation, before worker delivery, single-writer under a process-wide lock with a per-zone once-per-generation record.
- Handlers cannot fail by design; validation stays on the agent side before publication, and out-of-range slot indices are skipped defensively with an error logged.
- Registers empty handlers across 12 modules and 3 devices as the integration point; bumps the module plugin ABI to 29 for the new handler slots.
- Adds a six-scenario commit test suite pinning once-per-generation semantics, the defensive skip, the harness in-place delivery path and delivery-wait completion on a real worker.

Closes #2578.