### PR TITLE
fix(route): refuse a fib with more than 1024 distinct nexthops

### DIFF
--- a/common/go/bitset/bitset.go
+++ b/common/go/bitset/bitset.go
@@ -9,6 +9,9 @@ import (
 // MaxBitsetWords specifies the number of 64-bit words in the bitset.
 const MaxBitsetWords = 16
 
+// MaxBits is the number of distinct indexes a TinyBitset can hold.
+const MaxBits = 64 * MaxBitsetWords
+
 // TinyBitset implements constant-length bitset.
 //
 // This structure is designed to be used as a comparable key in maps.
@@ -28,8 +31,8 @@ func (m *TinyBitset) Count() uint {
 
 // Insert inserts the given index into the bitset.
 func (m *TinyBitset) Insert(idx uint32) {
-	if idx >= 64*MaxBitsetWords {
-		panic(fmt.Sprintf("index %d is too big: must be less than %d", idx, 64*MaxBitsetWords))
+	if idx >= MaxBits {
+		panic(fmt.Sprintf("index %d is too big: must be less than %d", idx, MaxBits))
 	}
 
 	m.words[idx/64] |= 1 << (idx % 64)

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -1,6 +1,7 @@
 package route
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/yanet-platform/yanet2/common/go/bitset"
@@ -65,6 +66,10 @@ type Backend interface {
 	RuntimeModuleCounters(name string, counterNames []string) []CounterView
 }
 
+// ErrTooManyNexthops reports a FIB that resolves to more distinct hardware
+// nexthops than one route config can index.
+var ErrTooManyNexthops = errors.New("too many distinct nexthops")
+
 // backend is the real Backend implementation backed by shared memory.
 type backend struct {
 	agent *ffi.Agent
@@ -117,6 +122,12 @@ func (m *backend) UpdateModule(name string, entries []*routepb.FIBEntry) (Module
 
 			idx, ok := hardwareIndex[hardwareRoute]
 			if !ok {
+				if len(hardwareIndex) >= bitset.MaxBits {
+					if err := module.Free(); err != nil {
+						return nil, fmt.Errorf("failed to free abandoned config: %w", err)
+					}
+					return nil, fmt.Errorf("%w: a route config indexes at most %d", ErrTooManyNexthops, bitset.MaxBits)
+				}
 				// Read from nh, not hardwareRoute: RouteService already
 				// rejects two different counter names for one identity, so
 				// the first nexthop seen carries the name every later one

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -414,7 +414,11 @@ func (m *RouteService) UpdateFIB(
 
 	module, err := m.backend.UpdateModule(name, entries)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to apply FIB for %q: %v", name, err)
+		code := codes.Internal
+		if errors.Is(err, ErrTooManyNexthops) {
+			code = codes.InvalidArgument
+		}
+		return nil, status.Errorf(code, "failed to apply FIB for %q: %v", name, err)
 	}
 
 	// The exported set is the reachable one, read back off the handle

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -2,6 +2,7 @@ package route_test
 
 import (
 	"errors"
+	"fmt"
 	"net/netip"
 	"sort"
 	"strings"
@@ -75,6 +76,8 @@ type fakeBackend struct {
 	// updateCalls records the range entries passed to UpdateModule on
 	// every call, in call order.
 	updateCalls [][]*routepb.FIBEntry
+	// updateErr, when set, is returned by UpdateModule instead of a handle.
+	updateErr error
 }
 
 func newFakeBackend() *fakeBackend {
@@ -90,6 +93,9 @@ func (m *fakeBackend) UpdateModule(name string, entries []*routepb.FIBEntry) (ro
 	defer m.mu.Unlock()
 
 	m.updateCalls = append(m.updateCalls, entries)
+	if m.updateErr != nil {
+		return nil, m.updateErr
+	}
 
 	names := map[string]struct{}{}
 	for _, entry := range entries {
@@ -560,6 +566,23 @@ func TestUpdateFIBDisabledRejectsExplicitCounter(t *testing.T) {
 	})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+}
+
+// Test_RouteService_UpdateFIB_TooManyNexthopsIsInvalidArgument verifies that
+// a FIB the backend refuses with ErrTooManyNexthops is reported as a request
+// error, not as an internal failure.
+func Test_RouteService_UpdateFIB_TooManyNexthopsIsInvalidArgument(t *testing.T) {
+	backend := newFakeBackend()
+	backend.updateErr = fmt.Errorf("wrapped: %w", route.ErrTooManyNexthops)
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 // TestUpdateFIBDisabledAllowsEmptyCounter verifies that a nexthop leaving

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yanet-platform/xnetip"
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/bitset"
 	"github.com/yanet-platform/yanet2/common/go/xerror"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -1145,6 +1146,40 @@ func TestRoute_ECMPDistinctSourceMACRemainsSeparate(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, fib, 1)
 	require.Len(t, fib[0].Nexthops, 2, "nexthops differing only in src_mac must remain distinct routes")
+}
+
+// Test_UpdateFIB_MoreThan1024DistinctNexthops verifies that a FIB with more
+// distinct nexthops than one config can index is refused, not panicked on.
+//
+// Thirty refusals in a row on the 2 MB agent arena prove every refused
+// config is freed, since a leaked one would exhaust the arena. The fake
+// backend never builds the route-list key, so this runs on the real one.
+func Test_UpdateFIB_MoreThan1024DistinctNexthops(t *testing.T) {
+	const nexthopCount = bitset.MaxBits + 1
+
+	_, _, backend := setupRouteHarness(t, "port0")
+
+	entries := make([]FIBEntry, 0, nexthopCount)
+	for idx := range nexthopCount {
+		entries = append(entries, FIBEntry{
+			Prefix: netip.PrefixFrom(netip.AddrFrom4([4]byte{10, 0, byte(idx >> 8), byte(idx)}), 32),
+			Nexthops: []FIBNexthop{{
+				DstMAC: net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, byte(idx >> 8), byte(idx)},
+				SrcMAC: routeNextHop.SrcMAC,
+				Device: "port0",
+			}},
+		})
+	}
+
+	for range 30 {
+		_, err := backend.UpdateModule("cfg", toFIBEntries(t, entries))
+		require.ErrorIs(t, err, route.ErrTooManyNexthops)
+	}
+
+	handle := applyFIB(t, backend, "cfg", entries[:bitset.MaxBits])
+	fib, err := handle.DumpFIB()
+	require.NoError(t, err)
+	require.Len(t, fib, bitset.MaxBits)
 }
 
 // TestUpdateFIB_EmptyNexthopEntryDoesNotDisplaceEarlierEntry verifies the


### PR DESCRIPTION
- The FIB update keyed ECMP route lists with a 1024-bit set and panicked inside the gRPC handler on the 1025th distinct hardware nexthop, taking the whole director down under the shared-memory lock.
- Such a FIB is now refused with `InvalidArgument` and the abandoned config is freed, so the previously published FIB stays live and the operator gets a request error instead of a crash loop.
- A functional test against shared memory pins both the refusal and the reclamation (thirty refusals on a 2 MB arena), and a service test pins the error code.
