### PR TITLE
refactor(blackhole,mirror,forward,route-mpls,unrdup): own published configs through the shared store

### DIFF
--- a/modules/blackhole/controlplane/service.go
+++ b/modules/blackhole/controlplane/service.go
@@ -1,16 +1,13 @@
 package blackhole
 
 import (
-	"errors"
-
-	"github.com/yanet-platform/yanet2/controlplane/ffi"
-
 	"context"
-	"sync"
+	"errors"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	blackholepb "github.com/yanet-platform/yanet2/modules/blackhole/controlplane/blackholepb/v1"
 )
 
@@ -48,22 +45,15 @@ func (m *config) Free() error {
 type BlackholeService struct {
 	blackholepb.UnimplementedBlackholeServiceServer
 
-	// deferred holds superseded module handles whose free was refused
-	// because a live configuration generation still referenced them.
-	// This service is their owner: it retries them on its next update,
-	// through ReclaimDeferred, and nothing else remembers them.
-	deferred []ModuleHandle
-
-	mu      sync.Mutex
 	backend Backend
-	configs map[string]*config
+	configs *configstore.Store[*config]
 }
 
 // NewBlackholeService constructs a BlackholeService backed by the given Backend.
 func NewBlackholeService(backend Backend) *BlackholeService {
 	return &BlackholeService{
 		backend: backend,
-		configs: map[string]*config{},
+		configs: configstore.NewStore[*config](),
 	}
 }
 
@@ -72,15 +62,7 @@ func (m *BlackholeService) ListConfigs(
 	ctx context.Context,
 	req *blackholepb.ListConfigsRequest,
 ) (*blackholepb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	names := make([]string, 0, len(m.configs))
-	for name := range m.configs {
-		names = append(names, name)
-	}
-
-	return &blackholepb.ListConfigsResponse{Configs: names}, nil
+	return &blackholepb.ListConfigsResponse{Configs: m.configs.Names()}, nil
 }
 
 // ShowConfig returns the named config when it exists.
@@ -93,10 +75,7 @@ func (m *BlackholeService) ShowConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if _, ok := m.configs[name]; !ok {
+	if _, ok := m.configs.Get(name); !ok {
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
 
@@ -114,10 +93,14 @@ func (m *BlackholeService) UpdateConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if err := m.updateConfig(name); err != nil {
+	err := m.configs.Update(name, func(*config, bool) (*config, error) {
+		module, err := m.backend.UpdateModule(name)
+		if err != nil {
+			return nil, err
+		}
+		return &config{Module: module}, nil
+	})
+	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to update module config %q: %v", name, err,
@@ -125,27 +108,6 @@ func (m *BlackholeService) UpdateConfig(
 	}
 
 	return &blackholepb.UpdateConfigResponse{}, nil
-}
-
-// updateConfig publishes a fresh config and, on success, frees the old module
-// handle and stores the new one.
-//
-// The caller must hold m.mu.
-func (m *BlackholeService) updateConfig(name string) error {
-	mod, err := m.backend.UpdateModule(name)
-	if err != nil {
-		return err
-	}
-
-	m.reclaimDeferred()
-
-	if old, ok := m.configs[name]; ok {
-		m.parkOrFree(old.Module)
-	}
-
-	m.configs[name] = &config{Module: mod}
-
-	return nil
 }
 
 // DeleteConfig removes the named config if it is not referenced by any
@@ -159,60 +121,27 @@ func (m *BlackholeService) DeleteConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	entry, ok := m.configs[name]
-	if !ok {
+	err := m.configs.Delete(name, func(*config) error {
+		return m.backend.DeleteModule(name)
+	})
+	if errors.Is(err, configstore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
-
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to delete module config %q: %v", name, err,
 		)
 	}
 
-	// The delete retired the generation holding the published module;
-	// retry the deferred ones, then retire this one.
-	m.reclaimDeferred()
-	m.parkOrFree(entry.Module)
-
-	delete(m.configs, name)
-
 	return &blackholepb.DeleteConfigResponse{}, nil
 }
 
-// parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.mu.
-func (m *BlackholeService) parkOrFree(handle ModuleHandle) {
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every deferred handle, dropping the ones whose
-// generations have drained and keeping the rest deferred. It is the
-// reclamation handler for this module's superseded configs; the service
-// itself runs it after each successful publish, and anything else may
-// call it at any time.
+// ReclaimDeferred retries every superseded config whose free was refused,
+// releasing the ones whose generations have drained.
+//
+// The service runs it after each successful publish, and anything else
+// may call it at any time.
 func (m *BlackholeService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *BlackholeService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
-		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
-		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+	m.configs.ReclaimDeferred()
 }

--- a/modules/forward/controlplane/metrics.go
+++ b/modules/forward/controlplane/metrics.go
@@ -56,11 +56,13 @@ func (m *ForwardService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metri
 // per-module counter such as "rx" — leaves that config with nothing to
 // read.
 func (m *ForwardService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*commonpb.Metric, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	result := make([]*commonpb.Metric, 0)
-	for configName, config := range m.configs {
+	for _, configName := range m.configs.Names() {
+		// A config deleted since the listing has no counters to read.
+		config, ok := m.configs.Get(configName)
+		if !ok {
+			continue
+		}
 		names, read := metrics.Query(tags, metrics.WithEntryCounters(ruleCounterNames(config.Rules)))
 		if !read {
 			continue

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"unicode/utf8"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	filterpbconv "github.com/yanet-platform/yanet2/bindings/go/filterpbconv/v1"
-	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
 	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
@@ -51,37 +50,22 @@ func (m *forwardConfig) Free() error {
 type ForwardService struct {
 	forwardpb.UnimplementedForwardServiceServer
 
-	mu sync.RWMutex
-
-	// deferred holds superseded module handles whose free was refused
-	// because a live configuration generation still referenced them.
-	// This service is their owner: it retries them on its next update,
-	// through ReclaimDeferred, and nothing else remembers them.
-	deferred []ModuleHandle
-	backend  Backend
-	configs  map[string]forwardConfig
+	backend Backend
+	configs *configstore.Store[*forwardConfig]
 }
 
 func NewForwardService(backend Backend) *ForwardService {
 	return &ForwardService{
 		backend: backend,
-		configs: map[string]forwardConfig{},
+		configs: configstore.NewStore[*forwardConfig](),
 	}
 }
 
 func (m *ForwardService) ListConfigs(
 	ctx context.Context, request *forwardpb.ListConfigsRequest,
 ) (*forwardpb.ListConfigsResponse, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	configs := make([]string, 0, len(m.configs))
-	for name := range m.configs {
-		configs = append(configs, name)
-	}
-
 	response := &forwardpb.ListConfigsResponse{
-		Configs: configs,
+		Configs: m.configs.Names(),
 	}
 
 	return response, nil
@@ -93,11 +77,7 @@ func (m *ForwardService) ShowConfig(ctx context.Context, req *forwardpb.ShowConf
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	config, ok := m.configs[req.Name]
-
+	config, ok := m.configs.Get(name)
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
@@ -205,23 +185,15 @@ func (m *ForwardService) UpdateConfig(ctx context.Context, req *forwardpb.Update
 		rules = append(rules, rule)
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	module, err := m.backend.UpdateModule(name, rules)
+	err := m.configs.Update(name, func(*forwardConfig, bool) (*forwardConfig, error) {
+		module, err := m.backend.UpdateModule(name, rules)
+		if err != nil {
+			return nil, err
+		}
+		return &forwardConfig{Rules: reqRules, Module: module}, nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update module config: %w", err)
-	}
-
-	m.reclaimDeferred()
-
-	if oldModule, ok := m.configs[name]; ok {
-		m.parkOrFree(oldModule.Module)
-	}
-
-	m.configs[name] = forwardConfig{
-		Rules:  reqRules,
-		Module: module,
 	}
 
 	return &forwardpb.UpdateConfigResponse{}, nil
@@ -233,58 +205,24 @@ func (m *ForwardService) DeleteConfig(ctx context.Context, req *forwardpb.Delete
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	config, ok := m.configs[name]
-	if !ok {
+	err := m.configs.Delete(name, func(*forwardConfig) error {
+		return m.backend.DeleteModule(name)
+	})
+	if errors.Is(err, configstore.ErrNotFound) {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
-
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("failed to delete module config %q: %w", name, err)
 	}
-
-	m.reclaimDeferred()
-	m.parkOrFree(config.Module)
-
-	delete(m.configs, name)
 
 	return &forwardpb.DeleteConfigResponse{}, nil
 }
 
-// parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.mu.
-func (m *ForwardService) parkOrFree(handle ModuleHandle) {
-	if handle == nil {
-		return
-	}
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every deferred handle, dropping the ones whose
-// generations have drained and keeping the rest deferred. It is the
-// reclamation handler for this module's superseded configs; the service
-// itself runs it after each successful publish, and anything else may
-// call it at any time.
+// ReclaimDeferred retries every superseded config whose free was refused,
+// releasing the ones whose generations have drained.
+//
+// The service runs it after each successful publish, and anything else
+// may call it at any time.
 func (m *ForwardService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *ForwardService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
-		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
-		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+	m.configs.ReclaimDeferred()
 }

--- a/modules/mirror/controlplane/service.go
+++ b/modules/mirror/controlplane/service.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	filterpbconv "github.com/yanet-platform/yanet2/bindings/go/filterpbconv/v1"
-	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	"github.com/yanet-platform/yanet2/modules/mirror/bindings/go/cmirror"
 	mirrorpb "github.com/yanet-platform/yanet2/modules/mirror/controlplane/mirrorpb/v1"
 )
@@ -47,37 +46,22 @@ func (m *mirrorConfig) Free() error {
 type MirrorService struct {
 	mirrorpb.UnimplementedMirrorServiceServer
 
-	mu sync.Mutex
-
-	// deferred holds superseded module handles whose free was refused
-	// because a live configuration generation still referenced them.
-	// This service is their owner: it retries them on its next update,
-	// through ReclaimDeferred, and nothing else remembers them.
-	deferred []ModuleHandle
-	backend  Backend
-	configs  map[string]mirrorConfig
+	backend Backend
+	configs *configstore.Store[*mirrorConfig]
 }
 
 func NewMirrorService(backend Backend) *MirrorService {
 	return &MirrorService{
 		backend: backend,
-		configs: map[string]mirrorConfig{},
+		configs: configstore.NewStore[*mirrorConfig](),
 	}
 }
 
 func (m *MirrorService) ListConfigs(
 	ctx context.Context, request *mirrorpb.ListConfigsRequest,
 ) (*mirrorpb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	configs := make([]string, 0, len(m.configs))
-	for name := range m.configs {
-		configs = append(configs, name)
-	}
-
 	response := &mirrorpb.ListConfigsResponse{
-		Configs: configs,
+		Configs: m.configs.Names(),
 	}
 
 	return response, nil
@@ -92,11 +76,7 @@ func (m *MirrorService) ShowConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	config, ok := m.configs[req.Name]
-
+	config, ok := m.configs.Get(name)
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
@@ -180,23 +160,15 @@ func (m *MirrorService) UpdateConfig(
 		rules = append(rules, rule)
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	module, err := m.backend.UpdateModule(name, rules)
+	err := m.configs.Update(name, func(*mirrorConfig, bool) (*mirrorConfig, error) {
+		module, err := m.backend.UpdateModule(name, rules)
+		if err != nil {
+			return nil, err
+		}
+		return &mirrorConfig{Rules: reqRules, Module: module}, nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update module config: %w", err)
-	}
-
-	m.reclaimDeferred()
-
-	if oldModule, ok := m.configs[name]; ok {
-		m.parkOrFree(oldModule.Module)
-	}
-
-	m.configs[name] = mirrorConfig{
-		Rules:  reqRules,
-		Module: module,
 	}
 
 	return &mirrorpb.UpdateConfigResponse{}, nil
@@ -211,58 +183,24 @@ func (m *MirrorService) DeleteConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	config, ok := m.configs[name]
-	if !ok {
+	err := m.configs.Delete(name, func(*mirrorConfig) error {
+		return m.backend.DeleteModule(name)
+	})
+	if errors.Is(err, configstore.ErrNotFound) {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
-
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("failed to delete module config %q: %w", name, err)
 	}
-
-	m.reclaimDeferred()
-	m.parkOrFree(config.Module)
-
-	delete(m.configs, name)
 
 	return &mirrorpb.DeleteConfigResponse{}, nil
 }
 
-// parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.mu.
-func (m *MirrorService) parkOrFree(handle ModuleHandle) {
-	if handle == nil {
-		return
-	}
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every deferred handle, dropping the ones whose
-// generations have drained and keeping the rest deferred. It is the
-// reclamation handler for this module's superseded configs; the service
-// itself runs it after each successful publish, and anything else may
-// call it at any time.
+// ReclaimDeferred retries every superseded config whose free was refused,
+// releasing the ones whose generations have drained.
+//
+// The service runs it after each successful publish, and anything else
+// may call it at any time.
 func (m *MirrorService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *MirrorService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
-		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
-		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+	m.configs.ReclaimDeferred()
 }

--- a/modules/route-mpls/controlplane/service.go
+++ b/modules/route-mpls/controlplane/service.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/netip"
 	"slices"
-	"sort"
-	"sync"
 
 	"go.uber.org/zap"
 
@@ -18,7 +16,7 @@ import (
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/maptrie"
-	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	"github.com/yanet-platform/yanet2/modules/route-mpls/bindings/go/croutempls"
 	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1"
 )
@@ -49,17 +47,7 @@ type RouteMPLSService struct {
 	routemplspb.UnimplementedRouteMPLSServiceServer
 
 	backend Backend
-
-	// deferred holds superseded module handles whose free was refused
-	// because a live configuration generation still referenced them.
-	// This service is their owner: it retries them on its next update,
-	// through ReclaimDeferred, and nothing else remembers them.
-	deferred []ModuleHandle
-
-	// shmLock serializes shared-memory mutations and protects the
-	// configs map.
-	shmLock sync.RWMutex
-	configs map[string]routeMPLSConfig
+	configs *configstore.Store[*routeMPLSConfig]
 
 	log *zap.Logger
 }
@@ -196,7 +184,7 @@ func NewRouteMPLSService(backend Backend, options ...RouteMPLSServiceOption) *Ro
 
 	return &RouteMPLSService{
 		backend: backend,
-		configs: map[string]routeMPLSConfig{},
+		configs: configstore.NewStore[*routeMPLSConfig](),
 		log:     opts.Log,
 	}
 }
@@ -207,17 +195,7 @@ func (m *RouteMPLSService) ListConfigs(
 	ctx context.Context,
 	request *routemplspb.ListConfigsRequest,
 ) (*routemplspb.ListConfigsResponse, error) {
-	m.shmLock.RLock()
-	defer m.shmLock.RUnlock()
-
-	response := &routemplspb.ListConfigsResponse{
-		Configs: make([]string, 0, len(m.configs)),
-	}
-	for name := range m.configs {
-		response.Configs = append(response.Configs, name)
-	}
-	sort.Strings(response.Configs)
-	return response, nil
+	return &routemplspb.ListConfigsResponse{Configs: m.configs.Names()}, nil
 }
 
 // ShowConfig returns the rules currently stored for the requested configuration.
@@ -230,10 +208,7 @@ func (m *RouteMPLSService) ShowConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.shmLock.RLock()
-	defer m.shmLock.RUnlock()
-
-	config, ok := m.configs[name]
+	config, ok := m.configs.Get(name)
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
@@ -277,21 +252,15 @@ func (m *RouteMPLSService) DeleteConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.shmLock.Lock()
-	defer m.shmLock.Unlock()
-
-	config, ok := m.configs[name]
-	if !ok {
+	err := m.configs.Delete(name, func(*routeMPLSConfig) error {
+		return m.backend.DeleteModule(name)
+	})
+	if errors.Is(err, configstore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "not found")
 	}
-
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
 	}
-
-	m.reclaimDeferred()
-	m.parkOrFree(config.Handle)
-	delete(m.configs, name)
 
 	return &routemplspb.DeleteConfigResponse{}, nil
 }
@@ -334,26 +303,21 @@ func (m *RouteMPLSService) CreateConfig(
 		)
 	}
 
-	config := routeMPLSConfig{
+	config := &routeMPLSConfig{
 		Prefixes: prefixes,
 	}
 
-	m.shmLock.Lock()
-	defer m.shmLock.Unlock()
-
-	handle, err := m.backend.UpdateModule(name, config.BuildRules())
+	err := m.configs.Update(name, func(*routeMPLSConfig, bool) (*routeMPLSConfig, error) {
+		handle, err := m.backend.UpdateModule(name, config.BuildRules())
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		}
+		config.Handle = handle
+		return config, nil
+	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		return nil, err
 	}
-
-	m.reclaimDeferred()
-
-	if old, ok := m.configs[name]; ok {
-		m.parkOrFree(old.Handle)
-	}
-
-	config.Handle = handle
-	m.configs[name] = config
 
 	return &routemplspb.CreateConfigResponse{}, nil
 }
@@ -369,79 +333,78 @@ func (m *RouteMPLSService) UpdateConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.shmLock.Lock()
-	defer m.shmLock.Unlock()
-
-	oldConfig, ok := m.configs[name]
-	if !ok {
-		oldConfig = routeMPLSConfig{
-			Prefixes: maptrie.NewMapTrie[netip.Prefix, netip.Addr, NextHopList](0),
+	err := m.configs.Update(name, func(current *routeMPLSConfig, ok bool) (*routeMPLSConfig, error) {
+		// Every mutation below copies the nexthop list it touches, since
+		// the trie clone shares the lists with the published config.
+		//
+		// Readers see the published config without a lock, and a failed
+		// publish keeps it live, so an in-place change would both race
+		// with them and corrupt what stays published.
+		prefixes := maptrie.NewMapTrie[netip.Prefix, netip.Addr, NextHopList](0)
+		if ok {
+			prefixes = current.Prefixes.Clone()
 		}
-	}
+		config := &routeMPLSConfig{Prefixes: prefixes}
 
-	config := routeMPLSConfig{
-		Prefixes: oldConfig.Prefixes.Clone(),
-	}
+		for _, update := range req.Updates {
+			if u := update.GetUpdate(); u != nil {
+				prefix, err := u.GetPrefix().ToPrefix()
+				if err != nil {
+					return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
+				}
 
-	for _, update := range req.Updates {
-		if u := update.GetUpdate(); u != nil {
-			prefix, err := u.GetPrefix().ToPrefix()
-			if err != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
+				nextHop, err := makeNextHop(u.Nexthop)
+				if err != nil {
+					return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop: %v", err)
+				}
+
+				config.Prefixes.InsertOrUpdate(
+					prefix,
+					func() NextHopList {
+						return NextHopList{
+							NextHops: append(make([]NextHop, 0, 1), nextHop),
+						}
+					},
+					func(list NextHopList) NextHopList {
+						list.NextHops = slices.Clone(list.NextHops)
+						list.Insert(nextHop)
+						return list
+					},
+				)
 			}
 
-			nextHop, err := makeNextHop(u.Nexthop)
-			if err != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop: %v", err)
-			}
+			if w := update.GetWithdraw(); w != nil {
+				prefix, err := w.GetPrefix().ToPrefix()
+				if err != nil {
+					return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
+				}
 
-			config.Prefixes.InsertOrUpdate(
-				prefix,
-				func() NextHopList {
-					return NextHopList{
-						NextHops: append(make([]NextHop, 0, 1), nextHop),
-					}
-				},
-				func(list NextHopList) NextHopList {
-					list.Insert(nextHop)
-					return list
-				},
-			)
+				nextHop, err := makeWithdrawNextHop(w.Nexthop)
+				if err != nil {
+					return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop: %v", err)
+				}
+
+				config.Prefixes.UpdateOrDelete(
+					prefix,
+					func(list NextHopList) (NextHopList, bool) {
+						list.NextHops = slices.Clone(list.NextHops)
+						list.Remove(nextHop)
+						return list, len(list.NextHops) == 0
+					},
+				)
+			}
 		}
 
-		if w := update.GetWithdraw(); w != nil {
-			prefix, err := w.GetPrefix().ToPrefix()
-			if err != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
-			}
-
-			nextHop, err := makeWithdrawNextHop(w.Nexthop)
-			if err != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop: %v", err)
-			}
-
-			config.Prefixes.UpdateOrDelete(
-				prefix,
-				func(list NextHopList) (NextHopList, bool) {
-					list.Remove(nextHop)
-					return list, len(list.NextHops) == 0
-				},
-			)
+		handle, err := m.backend.UpdateModule(name, config.BuildRules())
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 		}
-	}
-
-	handle, err := m.backend.UpdateModule(name, config.BuildRules())
+		config.Handle = handle
+		return config, nil
+	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		return nil, err
 	}
-
-	m.reclaimDeferred()
-	if ok {
-		m.parkOrFree(oldConfig.Handle)
-	}
-
-	config.Handle = handle
-	m.configs[name] = config
 
 	return &routemplspb.UpdateConfigResponse{}, nil
 }
@@ -498,35 +461,11 @@ func makeWithdrawNextHop(nexthop *routemplspb.NextHop) (NextHop, error) {
 	}, nil
 }
 
-// parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.shmLock.
-func (m *RouteMPLSService) parkOrFree(handle ModuleHandle) {
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every deferred handle, dropping the ones whose
-// generations have drained and keeping the rest deferred. It is the
-// reclamation handler for this module's superseded configs; the service
-// itself runs it after each successful publish, and anything else may
-// call it at any time.
+// ReclaimDeferred retries every superseded config whose free was refused,
+// releasing the ones whose generations have drained.
+//
+// The service runs it after each successful publish, and anything else
+// may call it at any time.
 func (m *RouteMPLSService) ReclaimDeferred() {
-	m.shmLock.Lock()
-	defer m.shmLock.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.shmLock.
-func (m *RouteMPLSService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
-		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
-		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+	m.configs.ReclaimDeferred()
 }

--- a/modules/route-mpls/controlplane/service_test.go
+++ b/modules/route-mpls/controlplane/service_test.go
@@ -433,6 +433,69 @@ func Test_RouteMPLSService_CreateConfig_BackendFailure(t *testing.T) {
 	assert.Len(t, show.Rules, 1)
 }
 
+// Test_RouteMPLSService_UpdateConfig_FailedPublishLeavesPreviousIntact
+// verifies that an incremental update whose publish fails leaves the
+// published config exactly as it was.
+//
+// The update must change a copy of the nexthop lists rather than the lists
+// readers see.
+func Test_RouteMPLSService_UpdateConfig_FailedPublishLeavesPreviousIntact(t *testing.T) {
+	readvertised := makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)
+	readvertised.Nexthop.Weight = 7
+
+	cases := []struct {
+		name  string
+		event *routemplspb.UpdateEvent
+	}{
+		{
+			name: "withdraw of one nexthop",
+			event: &routemplspb.UpdateEvent{Event: &routemplspb.UpdateEvent_Withdraw{
+				Withdraw: makeRule(t, "10.0.0.0/24", "203.0.113.1", 100),
+			}},
+		},
+		{
+			name: "re-advertise with a new weight",
+			event: &routemplspb.UpdateEvent{Event: &routemplspb.UpdateEvent_Update{
+				Update: readvertised,
+			}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewRouteMPLSService(&flakyBackend{})
+			ctx := t.Context()
+
+			_, err := svc.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
+				Name: "mpls0",
+				Rules: []*routemplspb.Rule{
+					makeRule(t, "10.0.0.0/24", "203.0.113.1", 100),
+					makeRule(t, "10.0.0.0/24", "203.0.113.2", 200),
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = svc.UpdateConfig(ctx, &routemplspb.UpdateConfigRequest{
+				Name:    "mpls0",
+				Updates: []*routemplspb.UpdateEvent{tc.event},
+			})
+			require.Equal(t, codes.Internal, status.Code(err))
+
+			show, err := svc.ShowConfig(ctx, &routemplspb.ShowConfigRequest{Name: "mpls0"})
+			require.NoError(t, err)
+			require.Len(t, show.Rules, 2)
+			for _, rule := range show.Rules {
+				assert.Equal(t, uint64(1), rule.GetNexthop().GetWeight())
+			}
+			labels := []uint32{
+				show.Rules[0].GetNexthop().GetLabel(),
+				show.Rules[1].GetNexthop().GetLabel(),
+			}
+			assert.ElementsMatch(t, []uint32{100, 200}, labels)
+		})
+	}
+}
+
 // Test_RouteMPLSService_ConcurrentAccess runs with -race to detect data races.
 func Test_RouteMPLSService_ConcurrentAccess(t *testing.T) {
 	svc := newTestService(t)

--- a/modules/unrdup/controlplane/service.go
+++ b/modules/unrdup/controlplane/service.go
@@ -3,15 +3,13 @@ package unrdup
 import (
 	"context"
 	"errors"
-	"slices"
 	"strings"
-	"sync"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/xnetip"
-	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	"github.com/yanet-platform/yanet2/modules/unrdup/bindings/go/cunrdup"
 	"github.com/yanet-platform/yanet2/modules/unrdup/controlplane/unrduppb/v1"
 )
@@ -62,39 +60,17 @@ type Backend interface {
 type UnrdupService struct {
 	unrduppb.UnimplementedUnrdupServiceServer
 
-	mu       sync.RWMutex
-	backend  Backend
-	configs  map[string]*config
-	deferred []ModuleHandle
+	backend Backend
+	configs *configstore.Store[*config]
 }
 
-// parkOrFree frees a superseded handle, keeping it for a later retry while a
-// live generation still references it. The caller must hold m.mu.
-func (m *UnrdupService) parkOrFree(handle ModuleHandle) {
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every parked handle, dropping the ones whose
-// generations have drained and keeping the rest parked.
+// ReclaimDeferred retries every superseded config whose free was refused,
+// releasing the ones whose generations have drained.
+//
+// The service runs it after each successful publish, and anything else
+// may call it at any time.
 func (m *UnrdupService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must hold
-// m.mu.
-func (m *UnrdupService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
-		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
-		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+	m.configs.ReclaimDeferred()
 }
 
 type config struct {
@@ -102,6 +78,16 @@ type config struct {
 	SourceV6 xnetip.Network
 	Services []cunrdup.Service
 	Module   ModuleHandle
+}
+
+// Free releases the module handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *config) Free() error {
+	if m.Module == nil {
+		return nil
+	}
+	return m.Module.Free()
 }
 
 func (m *config) Sources() []xnetip.Network {
@@ -119,7 +105,7 @@ func (m *config) Sources() []xnetip.Network {
 func NewUnrdupService(backend Backend) *UnrdupService {
 	return &UnrdupService{
 		backend: backend,
-		configs: map[string]*config{},
+		configs: configstore.NewStore[*config](),
 	}
 }
 
@@ -127,19 +113,7 @@ func (m *UnrdupService) ListConfigs(
 	ctx context.Context,
 	request *unrduppb.ListConfigsRequest,
 ) (*unrduppb.ListConfigsResponse, error) {
-	response := &unrduppb.ListConfigsResponse{
-		Configs: make([]string, 0),
-	}
-
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	for name := range m.configs {
-		response.Configs = append(response.Configs, name)
-	}
-	slices.Sort(response.Configs)
-
-	return response, nil
+	return &unrduppb.ListConfigsResponse{Configs: m.configs.Names()}, nil
 }
 
 func (m *UnrdupService) ShowConfig(
@@ -151,10 +125,7 @@ func (m *UnrdupService) ShowConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	current, ok := m.configs[name]
+	current, ok := m.configs.Get(name)
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "config %q is not found", name)
 	}
@@ -179,24 +150,19 @@ func (m *UnrdupService) UpdateConfig(
 		return nil, err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	module, err := m.backend.UpdateModule(name, updated.Sources(), updated.Services)
+	err = m.configs.Update(name, func(*config, bool) (*config, error) {
+		module, err := m.backend.UpdateModule(name, updated.Sources(), updated.Services)
+		if err != nil {
+			return nil, err
+		}
+		updated.Module = module
+		return updated, nil
+	})
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal, "failed to update config %q: %s", name, err,
 		)
 	}
-
-	m.reclaimDeferred()
-
-	if previous, ok := m.configs[name]; ok && previous.Module != nil {
-		m.parkOrFree(previous.Module)
-	}
-
-	updated.Module = module
-	m.configs[name] = updated
 
 	return &unrduppb.UpdateConfigResponse{}, nil
 }
@@ -212,26 +178,17 @@ func (m *UnrdupService) DeleteConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	current, ok := m.configs[name]
-	if !ok {
+	err := m.configs.Delete(name, func(*config) error {
+		return m.backend.DeleteModule(name)
+	})
+	if errors.Is(err, configstore.ErrNotFound) {
 		return nil, status.Errorf(codes.NotFound, "config %q is not found", name)
 	}
-
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal, "failed to delete config %q: %s", name, err,
 		)
 	}
-
-	// The delete retired the generation holding the published module.
-	// Retry the deferred ones, then retire this one.
-	m.reclaimDeferred()
-	m.parkOrFree(current.Module)
-
-	delete(m.configs, name)
 
 	return &unrduppb.DeleteConfigResponse{}, nil
 }


### PR DESCRIPTION
- Migrate the blackhole, mirror, forward, route-mpls and unrdup services onto the config store, so their reads no longer wait for a shared-memory publish.
- Collect forward rule counters without holding a service lock across the dataplane read.

Closes #2533, #2534, #2537.
