### PR TITLE
fix(dataplane,vlan,nat64): keep header prepends clear of the packet descriptor

### DIFF
--- a/devices/vlan/dataplane/dataplane.c
+++ b/devices/vlan/dataplane/dataplane.c
@@ -116,8 +116,12 @@ vlan_output_handle(
 		}
 
 		// Inject new vlan header
-		// FIXME: check error
-		rte_pktmbuf_prepend(mbuf, sizeof(struct rte_vlan_hdr));
+		if (packet_headroom_prepend(
+			    mbuf, sizeof(struct rte_vlan_hdr)
+		    ) == NULL) {
+			packet_front_drop(packet_front, packet);
+			goto next;
+		}
 		packet_refresh_data_len(packet);
 		memmove(rte_pktmbuf_mtod(mbuf, char *),
 			rte_pktmbuf_mtod_offset(

--- a/lib/dataplane/packet/data.h
+++ b/lib/dataplane/packet/data.h
@@ -33,6 +33,22 @@ packet_data_offset(struct packet *packet) {
 	return packet_to_mbuf(packet)->data_off;
 }
 
+// Grows the frame upwards and returns NULL once the room above the packet
+// descriptor sharing the headroom is spent.
+static inline char *
+packet_headroom_prepend(struct rte_mbuf *mbuf, uint16_t len) {
+	if (rte_pktmbuf_headroom(mbuf) < sizeof(struct packet) + len) {
+		return NULL;
+	}
+	return rte_pktmbuf_prepend(mbuf, len);
+}
+
+// A headroom too small for the descriptor would refuse every prepend.
+_Static_assert(
+	RTE_PKTMBUF_HEADROOM > sizeof(struct packet),
+	"the packet descriptor must fit inside the mbuf headroom"
+);
+
 // Refresh the cached first-segment length after the mbuf was resized.
 //
 // Call this only while the packet is not linked in a counted packet_front

--- a/lib/dataplane/packet/encap.c
+++ b/lib/dataplane/packet/encap.c
@@ -16,7 +16,7 @@ int
 packet_prepend(struct packet *packet, const void *header, const size_t size) {
 	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
 
-	if (rte_pktmbuf_prepend(mbuf, size) == NULL) {
+	if (packet_headroom_prepend(mbuf, size) == NULL) {
 		return -1;
 	}
 	memcpy(rte_pktmbuf_mtod(mbuf, char *), header, size);
@@ -37,7 +37,7 @@ packet_network_prepend(
 ) {
 	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
 
-	if (rte_pktmbuf_prepend(mbuf, size) == NULL) {
+	if (packet_headroom_prepend(mbuf, size) == NULL) {
 		return -1;
 	}
 	memmove(rte_pktmbuf_mtod(mbuf, char *),

--- a/lib/dataplane/packet/mss.c
+++ b/lib/dataplane/packet/mss.c
@@ -182,7 +182,9 @@ clamp_mss_option(
  */
 static enum packet_set_mss_result
 insert_mss_gap(struct rte_mbuf *mbuf, uint16_t prefix_len) {
-	if (unlikely(rte_pktmbuf_prepend(mbuf, TCP_OPTION_MSS_LEN) == NULL)) {
+	if (unlikely(
+		    packet_headroom_prepend(mbuf, TCP_OPTION_MSS_LEN) == NULL
+	    )) {
 		return packet_set_mss_no_headroom;
 	}
 	memmove(rte_pktmbuf_mtod(mbuf, char *),

--- a/lib/dataplane/packet/mss.h
+++ b/lib/dataplane/packet/mss.h
@@ -13,7 +13,7 @@ enum packet_set_mss_result {
 	 * data_off field. The packet is left untouched.
 	 */
 	packet_set_mss_malformed,
-	/* mbuf has no headroom at the front to prepend the new option. */
+	// No room above the packet descriptor to prepend the new option.
 	packet_set_mss_no_headroom,
 };
 

--- a/modules/nat64/dataplane/nat64dp.c
+++ b/modules/nat64/dataplane/nat64dp.c
@@ -3030,7 +3030,7 @@ nat64_handle_v4(
 
 	char *nmbuf = NULL;
 	if (delta >= 0) {
-		nmbuf = rte_pktmbuf_prepend(mbuf, delta);
+		nmbuf = packet_headroom_prepend(mbuf, delta);
 	} else {
 		// RFC7915 1.2 ( -> .. -> RFC2765 1.1) does not translate any
 		// IPv4 options.

--- a/modules/route-mpls/tests/functional/route_mpls_test.go
+++ b/modules/route-mpls/tests/functional/route_mpls_test.go
@@ -429,6 +429,18 @@ func catchAllForwardRules(device string) []cforward.ForwardRule {
 	}
 }
 
+// loopForwardRules returns one forward rule that sends every IPv4 packet back
+// into the device's input stage, so the chain runs on it again.
+func loopForwardRules(device string) []cforward.ForwardRule {
+	return []cforward.ForwardRule{{
+		Target:  device,
+		Mode:    cforward.ModeIn,
+		Counter: "loop4",
+		Src4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+		Dst4s:   []xnetip.Contiguous[xnetip.Network4]{filter.UnspecifiedIPv4},
+	}}
+}
+
 // deployRules builds a one-device harness with route-mpls and forward loaded,
 // publishes rules as the route-mpls config and wires the ingress topology.
 //
@@ -438,13 +450,35 @@ func catchAllForwardRules(device string) []cforward.ForwardRule {
 func deployRules(t *testing.T, rules []croutempls.Rule) *dataplaneut.Harness {
 	t.Helper()
 
+	return deployChain(t, rules, catchAllForwardRules(mplsDevice), 0)
+}
+
+// deployLoop is deployRules with the forward stage sending every IPv4 packet
+// back into the ingress device under the given redirect limit.
+func deployLoop(t *testing.T, rules []croutempls.Rule, recircLimit uint16) *dataplaneut.Harness {
+	t.Helper()
+
+	return deployChain(t, rules, loopForwardRules(mplsDevice), recircLimit)
+}
+
+// deployChain builds the harness behind deployRules and deployLoop with the
+// given forward rules as the chain's second stage.
+func deployChain(
+	t *testing.T,
+	rules []croutempls.Rule,
+	sinkRules []cforward.ForwardRule,
+	recircLimit uint16,
+) *dataplaneut.Harness {
+	t.Helper()
+
 	config := dataplaneut.Config{
-		CPMemory:      uint64(mplsCPSize),
-		DPMemory:      uint64(mplsDPSize),
-		WorkerCount:   1,
-		Devices:       []string{mplsDevice},
-		Modules:       []string{"route_mpls", "forward"},
-		DevicesToLoad: []string{"plain"},
+		CPMemory:          uint64(mplsCPSize),
+		DPMemory:          uint64(mplsDPSize),
+		WorkerCount:       1,
+		PacketRecircLimit: recircLimit,
+		Devices:           []string{mplsDevice},
+		Modules:           []string{"route_mpls", "forward"},
+		DevicesToLoad:     []string{"plain"},
 	}
 	harness, err := dataplaneut.NewHarness(config)
 	require.NoError(t, err)
@@ -459,7 +493,7 @@ func deployRules(t *testing.T, rules []croutempls.Rule) *dataplaneut.Harness {
 	t.Cleanup(func() { _ = handle.Free() })
 
 	sinkName := mplsConfigName + "-sink"
-	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, catchAllForwardRules(mplsDevice))
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, sinkRules)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sinkHandle.Free() })
 
@@ -517,6 +551,42 @@ func requireNexthopCounter(
 	t.Helper()
 
 	dataplaneut.RequireRuleCounter(t, harness, counterPath(), name, wantPackets, wantBytes)
+}
+
+// Test_RouteMPLS_EncapLoop_StopsBeforeThePacketDescriptor verifies that a
+// packet re-encapsulated on every loop pass is dropped once the headroom
+// above the packet descriptor is spent.
+//
+// Each IPv4 tunnel pass prepends 32 bytes into the 256-byte headroom whose
+// first 56 bytes hold the descriptor, so the seventh pass is refused.
+// Without the guard the eighth pass overwrites the descriptor's list and
+// mbuf pointers.
+func Test_RouteMPLS_EncapLoop_StopsBeforeThePacketDescriptor(t *testing.T) {
+	const (
+		tunnelHeaderSize = 4 + 20 + 8
+		refusedPass      = 7
+		// Well above the refused pass, so the redirect budget never ends
+		// the loop first.
+		recircLimit = 12
+	)
+
+	frame := ip4Frame(t, "10.1.1.5")
+	// The tunnel destination sits inside the matched prefix, so the
+	// encapsulated packet matches again on the next pass.
+	harness := deployLoop(t, []croutempls.Rule{rule4("10.0.0.0/8", tunnel4.nexthop(1))}, recircLimit)
+
+	result, err := harness.HandlePackets(frame.packet)
+	require.NoError(t, err)
+	require.Empty(t, result.Output, "a packet out of headroom must not leave the chain")
+	require.Len(t, result.Drop, 1, "the refused encapsulation must drop the packet")
+
+	// Every pass accounts the frame before encapsulating it, carrying the
+	// tunnel headers of the passes before.
+	bytes := uint64(0)
+	for pass := range refusedPass {
+		bytes += frame.size() + uint64(pass*tunnelHeaderSize)
+	}
+	requireNexthopCounter(t, harness, tunnel4.counter, refusedPass, bytes)
 }
 
 // Test_RouteMPLS_Encap verifies that a packet matching a tunnel nexthop is


### PR DESCRIPTION
- The packet descriptor shares the mbuf headroom with the frame, yet every header prepend was guarded against the full headroom only, so a lineage encapsulated a few times over wrote its new header across the descriptor's list and mbuf pointers.
- Every prepend in the tree now goes through one helper that refuses once the room above the descriptor is spent, callers drop the packet as before on a refused prepend, and the vlan output stops writing through an unchecked prepend.
- A route-mpls functional test loops a packet through re-encapsulation and pins the refusal at the seventh 32-byte pass, which on unchanged code silently ran nine passes.
