### PR TITLE
ci(rust): fail the checks when the lock file is stale

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -66,7 +66,8 @@ jobs:
         timeout-minutes: 10
         with:
           packages: cmake protobuf-compiler
-      - run: cargo test --workspace
+      # --locked: a manifest change passes only with its regenerated Cargo.lock.
+      - run: cargo test --workspace --locked
 
   # Clippy runs the full compiler front end over the workspace, so a type
   # error fails it exactly as a dedicated cargo check job would, which is
@@ -88,4 +89,4 @@ jobs:
         timeout-minutes: 10
         with:
           packages: cmake protobuf-compiler
-      - run: cargo clippy --workspace -- -D warnings
+      - run: cargo clippy --workspace --locked -- -D warnings


### PR DESCRIPTION
- Runs the rust-check test and clippy jobs in cargo's locked mode, so a manifest change committed without its lock file update fails CI instead of resolving a fresh lock silently.
- Records the decision for #1749: adopt the flag. It only gates dependency resolution, which runs before any build script, so the protoc-driven build and the pinned toolchains are unaffected.
- Verified against the current lock: resolution passes in locked mode on 1.88.0, 1.97.1 and nightly-2026-08-28, a manifest with one extra dependency fails it, and the full clippy job command passes on 1.97.1 against a warm build cache.
- Assumption: the fmt job stays as it is, since cargo fmt does not resolve dependencies.
- Assumption: the release build (`make cli`, debian) is outside the issue and keeps running without the flag.
- Closes #1749.
