### PR TITLE
refactor(nat64,dscp,devices): own published configs through the shared store

### DIFF
--- a/devices/plain/controlplane/service.go
+++ b/devices/plain/controlplane/service.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
 )
@@ -18,20 +18,14 @@ import (
 type DevicePlainService struct {
 	plainpb.UnimplementedDevicePlainServiceServer
 
-	mu sync.Mutex
-	// deferred holds superseded devices whose free was refused because
-	// a live configuration generation still referenced them. This
-	// service is their owner: it retries them on its next update,
-	// through ReclaimDeferred, and nothing else remembers them.
-	deferred []DeviceConfig
-	agent    *ffi.Agent
-	configs  map[string]DeviceConfig
+	agent   *ffi.Agent
+	configs *configstore.Store[*DeviceConfig]
 }
 
 func NewDevicePlainService(agent *ffi.Agent) *DevicePlainService {
 	return &DevicePlainService{
 		agent:   agent,
-		configs: map[string]DeviceConfig{},
+		configs: configstore.NewStore[*DeviceConfig](),
 	}
 }
 
@@ -39,9 +33,6 @@ func (m *DevicePlainService) UpdateDevice(
 	ctx context.Context,
 	request *plainpb.UpdateDevicePlainRequest,
 ) (*plainpb.UpdateDevicePlainResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	name := request.GetName()
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
@@ -53,33 +44,30 @@ func (m *DevicePlainService) UpdateDevice(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	deviceConfig, err := NewDeviceConfig(m.agent, name, request.GetDevice())
+	err := m.configs.Update(name, func(*DeviceConfig, bool) (*DeviceConfig, error) {
+		deviceConfig, err := NewDeviceConfig(m.agent, name, request.GetDevice())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create device config: %w", err)
+		}
+
+		if err := m.agent.UpdateDevices([]ffi.ShmDeviceConfig{deviceConfig.AsFFIDevice()}); err != nil {
+			if freeErr := deviceConfig.Free(); freeErr != nil {
+				return nil, fmt.Errorf("failed to update device and free the unpublished replacement: %w (update error: %v)", freeErr, err)
+			}
+			code := codes.Internal
+			if errors.Is(err, ffi.ErrFailedPrecondition) {
+				// The device names an entity of the graph it runs that the
+				// configuration cannot resolve.
+				code = codes.FailedPrecondition
+			}
+			return nil, status.Errorf(code, "failed to update device: %v", err)
+		}
+
+		return deviceConfig, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create device config: %w", err)
+		return nil, err
 	}
-
-	if err := m.agent.UpdateDevices([]ffi.ShmDeviceConfig{deviceConfig.AsFFIDevice()}); err != nil {
-		if err := deviceConfig.Free(); err != nil {
-			return nil, fmt.Errorf("failed to update device and free the unpublished replacement: %w (update error: %v)", err, err)
-		}
-		code := codes.Internal
-		if errors.Is(err, ffi.ErrFailedPrecondition) {
-			// The device names an entity of the graph it runs that the
-			// configuration cannot resolve.
-			code = codes.FailedPrecondition
-		}
-		return nil, status.Errorf(code, "failed to update device: %v", err)
-	}
-
-	// The update retired the generations holding this service's deferred
-	// devices; retry them, then retire the displaced one: freed outright
-	// when dangling, parked while a pinned generation still references
-	// it.
-	m.reclaimDeferred()
-	if old, ok := m.configs[name]; ok {
-		m.parkOrFree(old)
-	}
-	m.configs[name] = *deviceConfig
 
 	return &plainpb.UpdateDevicePlainResponse{}, nil
 }
@@ -121,35 +109,11 @@ func deviceProto(info ffi.DeviceInfo) *commonpb.Device {
 	return device
 }
 
-// parkOrFree frees the device when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.mu.
-func (m *DevicePlainService) parkOrFree(handle DeviceConfig) {
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every deferred device, dropping the ones whose
-// generations have drained and keeping the rest deferred. It is the
-// reclamation handler for this service's superseded devices; the service
-// itself runs it after each successful publish, and anything else may
-// call it at any time.
+// ReclaimDeferred retries every superseded device whose free was refused,
+// releasing the ones whose generations have drained.
+//
+// The service runs it after each successful publish, and anything else
+// may call it at any time.
 func (m *DevicePlainService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *DevicePlainService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for idx := range m.deferred {
-		if err := m.deferred[idx].Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, m.deferred[idx])
-		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+	m.configs.ReclaimDeferred()
 }

--- a/devices/trafgen/controlplane/service.go
+++ b/devices/trafgen/controlplane/service.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sync"
 
 	"github.com/gopacket/gopacket/layers"
 	"github.com/gopacket/gopacket/pcapgo"
@@ -14,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/devices/trafgen/bindings/go/ctrafgen"
 	trafgenpb "github.com/yanet-platform/yanet2/devices/trafgen/controlplane/trafgenpb/v1"
@@ -53,25 +53,29 @@ type config struct {
 	Handle     *ctrafgen.DeviceConfig
 }
 
+// Free releases the device handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *config) Free() error {
+	if m.Handle == nil {
+		return nil
+	}
+	return m.Handle.Free()
+}
+
 // TrafgenService implements the TrafgenService gRPC server.
 type TrafgenService struct {
 	trafgenpb.UnimplementedTrafgenServiceServer
 
-	mu sync.Mutex
-	// deferred holds superseded devices whose free was refused because
-	// a live configuration generation still referenced them. This
-	// service is their owner: it retries them on its next update,
-	// through ReclaimDeferred, and nothing else remembers them.
-	deferred []*ctrafgen.DeviceConfig
-	backend  Backend
-	configs  map[string]*config
+	backend Backend
+	configs *configstore.Store[*config]
 }
 
 // NewTrafgenService constructs a TrafgenService backed by the given Backend.
 func NewTrafgenService(backend Backend) *TrafgenService {
 	return &TrafgenService{
 		backend: backend,
-		configs: map[string]*config{},
+		configs: configstore.NewStore[*config](),
 	}
 }
 
@@ -97,17 +101,15 @@ func (m *TrafgenService) UpdateDevice(
 	input := pipelinesFromProto(req.GetDevice().GetInput())
 	output := pipelinesFromProto(req.GetDevice().GetOutput())
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	var packets [][]byte
-	var ratePps uint64
-	if old, ok := m.configs[name]; ok {
-		packets = old.Packets
-		ratePps = old.RatePps
-	}
-
-	if err := m.apply(name, packets, ratePps, input, output); err != nil {
+	err := m.publish(name, func(current *config, ok bool) *config {
+		next := &config{Input: input, Output: output}
+		if ok {
+			next.Packets = current.Packets
+			next.RatePps = current.RatePps
+		}
+		return next
+	})
+	if err != nil {
 		code := codes.Internal
 		if errors.Is(err, ffi.ErrFailedPrecondition) {
 			// The device names an entity of the graph it runs that the
@@ -125,15 +127,7 @@ func (m *TrafgenService) ListConfigs(
 	ctx context.Context,
 	req *trafgenpb.ListConfigsRequest,
 ) (*trafgenpb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	names := make([]string, 0, len(m.configs))
-	for name := range m.configs {
-		names = append(names, name)
-	}
-
-	return &trafgenpb.ListConfigsResponse{Configs: names}, nil
+	return &trafgenpb.ListConfigsResponse{Configs: m.configs.Names()}, nil
 }
 
 // ShowConfig returns the loaded frame statistics and target rate for a config.
@@ -146,10 +140,7 @@ func (m *TrafgenService) ShowConfig(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	entry, ok := m.configs[name]
+	entry, ok := m.configs.Get(name)
 	if !ok {
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
@@ -171,10 +162,7 @@ func (m *TrafgenService) ShowPackets(
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	entry, ok := m.configs[name]
+	entry, ok := m.configs.Get(name)
 	if !ok {
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
@@ -207,18 +195,16 @@ func (m *TrafgenService) UploadPcap(
 		return nil, status.Error(codes.InvalidArgument, "pcap contains no packets")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	var ratePps uint64
-	var input, output []Pipeline
-	if old, ok := m.configs[name]; ok {
-		ratePps = old.RatePps
-		input = old.Input
-		output = old.Output
-	}
-
-	if err := m.apply(name, packets, ratePps, input, output); err != nil {
+	err = m.publish(name, func(current *config, ok bool) *config {
+		next := &config{Packets: packets}
+		if ok {
+			next.RatePps = current.RatePps
+			next.Input = current.Input
+			next.Output = current.Output
+		}
+		return next
+	})
+	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to update device config %q: %v", name, err,
@@ -242,18 +228,16 @@ func (m *TrafgenService) SetRate(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	var packets [][]byte
-	var input, output []Pipeline
-	if old, ok := m.configs[name]; ok {
-		packets = old.Packets
-		input = old.Input
-		output = old.Output
-	}
-
-	if err := m.apply(name, packets, req.GetRatePps(), input, output); err != nil {
+	err := m.publish(name, func(current *config, ok bool) *config {
+		next := &config{RatePps: req.GetRatePps()}
+		if ok {
+			next.Packets = current.Packets
+			next.Input = current.Input
+			next.Output = current.Output
+		}
+		return next
+	})
+	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to update device config %q: %v", name, err,
@@ -263,47 +247,27 @@ func (m *TrafgenService) SetRate(
 	return &trafgenpb.SetRateResponse{}, nil
 }
 
-// apply publishes the full device state through the backend and, on success,
-// stores the new config. The caller must hold m.mu.
+// publish builds the next device state from the current one and writes it
+// to the dataplane, attaching the published handle and frame statistics.
 //
-// The publish retired the generations holding this service's deferred
-// devices; they are retried here, and the superseded handle is retired
-// after: freed outright when dangling, parked while a pinned generation
-// still references it.
-func (m *TrafgenService) apply(
-	name string,
-	packets [][]byte,
-	ratePps uint64,
-	input, output []Pipeline,
-) error {
-	frames, lengths := flattenFrames(packets)
+// The caller's builder returns the packets, rate and pipelines of the new
+// state and may carry any of them over from the current config.
+func (m *TrafgenService) publish(name string, next func(current *config, ok bool) *config) error {
+	return m.configs.Update(name, func(current *config, ok bool) (*config, error) {
+		cfg := next(current, ok)
+		frames, lengths := flattenFrames(cfg.Packets)
 
-	handle, err := m.backend.UpdateDevice(name, input, output, frames, lengths, ratePps)
-	if err != nil {
-		return fmt.Errorf("failed to update device config %q: %w", name, err)
-	}
+		handle, err := m.backend.UpdateDevice(name, cfg.Input, cfg.Output, frames, lengths, cfg.RatePps)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update device config %q: %w", name, err)
+		}
 
-	var oldHandle *ctrafgen.DeviceConfig
-	if old, ok := m.configs[name]; ok {
-		oldHandle = old.Handle
-	}
+		cfg.FrameCount = uint32(len(cfg.Packets))
+		cfg.TotalBytes = uint64(len(frames))
+		cfg.Handle = handle
 
-	m.configs[name] = &config{
-		RatePps:    ratePps,
-		FrameCount: uint32(len(packets)),
-		TotalBytes: uint64(len(frames)),
-		Packets:    packets,
-		Input:      input,
-		Output:     output,
-		Handle:     handle,
-	}
-
-	m.reclaimDeferred()
-	if oldHandle != nil {
-		m.parkOrFree(oldHandle)
-	}
-
-	return nil
+		return cfg, nil
+	})
 }
 
 // pipelinesFromProto converts the wire pipeline assignments into the service
@@ -376,35 +340,11 @@ func parsePcap(pcap []byte) ([][]byte, error) {
 	return packets, nil
 }
 
-// parkOrFree frees the device when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.mu.
-func (m *TrafgenService) parkOrFree(handle *ctrafgen.DeviceConfig) {
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every deferred device, dropping the ones whose
-// generations have drained and keeping the rest deferred. It is the
-// reclamation handler for this service's superseded devices; the service
-// itself runs it after each successful publish, and anything else may
-// call it at any time.
+// ReclaimDeferred retries every superseded device whose free was refused,
+// releasing the ones whose generations have drained.
+//
+// The service runs it after each successful publish, and anything else
+// may call it at any time.
 func (m *TrafgenService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *TrafgenService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
-		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
-		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+	m.configs.ReclaimDeferred()
 }

--- a/devices/vlan/controlplane/service.go
+++ b/devices/vlan/controlplane/service.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )
@@ -25,20 +25,14 @@ const maxVlanID = 4094
 type DeviceVlanService struct {
 	vlanpb.UnimplementedDeviceVlanServiceServer
 
-	mu sync.Mutex
-	// deferred holds superseded devices whose free was refused because
-	// a live configuration generation still referenced them. This
-	// service is their owner: it retries them on its next update,
-	// through ReclaimDeferred, and nothing else remembers them.
-	deferred []DeviceConfig
-	agent    *ffi.Agent
-	configs  map[string]DeviceConfig
+	agent   *ffi.Agent
+	configs *configstore.Store[*DeviceConfig]
 }
 
 func NewDeviceVlanService(agent *ffi.Agent) *DeviceVlanService {
 	return &DeviceVlanService{
 		agent:   agent,
-		configs: map[string]DeviceConfig{},
+		configs: configstore.NewStore[*DeviceConfig](),
 	}
 }
 
@@ -46,9 +40,6 @@ func (m *DeviceVlanService) UpdateDevice(
 	ctx context.Context,
 	request *vlanpb.UpdateDeviceVlanRequest,
 ) (*vlanpb.UpdateDeviceVlanResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	name := request.GetName()
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
@@ -65,33 +56,30 @@ func (m *DeviceVlanService) UpdateDevice(
 		return nil, status.Errorf(codes.InvalidArgument, "vlan %d exceeds maximum allowed value %d", vlan, maxVlanID)
 	}
 
-	deviceConfig, err := NewDeviceConfig(m.agent, name, request.GetDevice(), uint16(vlan))
+	err := m.configs.Update(name, func(*DeviceConfig, bool) (*DeviceConfig, error) {
+		deviceConfig, err := NewDeviceConfig(m.agent, name, request.GetDevice(), uint16(vlan))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create device config: %w", err)
+		}
+
+		if err := m.agent.UpdateDevices([]ffi.ShmDeviceConfig{deviceConfig.AsFFIDevice()}); err != nil {
+			if freeErr := deviceConfig.Free(); freeErr != nil {
+				return nil, fmt.Errorf("failed to update device and free the unpublished replacement: %w (update error: %v)", freeErr, err)
+			}
+			code := codes.Internal
+			if errors.Is(err, ffi.ErrFailedPrecondition) {
+				// The device names an entity of the graph it runs that the
+				// configuration cannot resolve.
+				code = codes.FailedPrecondition
+			}
+			return nil, status.Errorf(code, "failed to update device: %v", err)
+		}
+
+		return deviceConfig, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create device config: %w", err)
+		return nil, err
 	}
-
-	if err := m.agent.UpdateDevices([]ffi.ShmDeviceConfig{deviceConfig.AsFFIDevice()}); err != nil {
-		if err := deviceConfig.Free(); err != nil {
-			return nil, fmt.Errorf("failed to update device and free the unpublished replacement: %w (update error: %v)", err, err)
-		}
-		code := codes.Internal
-		if errors.Is(err, ffi.ErrFailedPrecondition) {
-			// The device names an entity of the graph it runs that the
-			// configuration cannot resolve.
-			code = codes.FailedPrecondition
-		}
-		return nil, status.Errorf(code, "failed to update device: %v", err)
-	}
-
-	// The update retired the generations holding this service's deferred
-	// devices; retry them, then retire the displaced one: freed outright
-	// when dangling, parked while a pinned generation still references
-	// it.
-	m.reclaimDeferred()
-	if old, ok := m.configs[name]; ok {
-		m.parkOrFree(old)
-	}
-	m.configs[name] = *deviceConfig
 
 	return &vlanpb.UpdateDeviceVlanResponse{}, nil
 }
@@ -144,35 +132,11 @@ func deviceProto(info ffi.DeviceInfo) *commonpb.Device {
 	return device
 }
 
-// parkOrFree frees the device when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.mu.
-func (m *DeviceVlanService) parkOrFree(handle DeviceConfig) {
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every deferred device, dropping the ones whose
-// generations have drained and keeping the rest deferred. It is the
-// reclamation handler for this service's superseded devices; the service
-// itself runs it after each successful publish, and anything else may
-// call it at any time.
+// ReclaimDeferred retries every superseded device whose free was refused,
+// releasing the ones whose generations have drained.
+//
+// The service runs it after each successful publish, and anything else
+// may call it at any time.
 func (m *DeviceVlanService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *DeviceVlanService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for idx := range m.deferred {
-		if err := m.deferred[idx].Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, m.deferred[idx])
-		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+	m.configs.ReclaimDeferred()
 }

--- a/modules/dscp/controlplane/service.go
+++ b/modules/dscp/controlplane/service.go
@@ -6,13 +6,12 @@ import (
 	"errors"
 	"net/netip"
 	"slices"
-	"sync"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
-	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	"github.com/yanet-platform/yanet2/modules/dscp/controlplane/dscppb/v1"
 )
 
@@ -33,15 +32,8 @@ type Backend interface {
 type DscpService struct {
 	dscppb.UnimplementedDscpServiceServer
 
-	mu sync.RWMutex
-
-	// deferred holds superseded module handles whose free was refused
-	// because a live configuration generation still referenced them.
-	// This service is their owner: it retries them on its next update,
-	// through ReclaimDeferred, and nothing else remembers them.
-	deferred []ModuleHandle
-	backend  Backend
-	configs  map[string]*config
+	backend Backend
+	configs *configstore.Store[*config]
 }
 
 type config struct {
@@ -65,12 +57,13 @@ func (m *config) Free() error {
 	return m.Module.Free()
 }
 
+// Clone copies the prefix sets and marking but never the published handle,
+// so a copy never inherits ownership of the shared-memory config.
 func (m *config) Clone() *config {
 	return &config{
 		Prefixes4: slices.Clone(m.Prefixes4),
 		Prefixes6: slices.Clone(m.Prefixes6),
 		Config:    m.Config,
-		Module:    m.Module,
 	}
 }
 
@@ -82,7 +75,7 @@ type dscpConfig struct {
 func NewDscpService(backend Backend) *DscpService {
 	return &DscpService{
 		backend: backend,
-		configs: map[string]*config{},
+		configs: configstore.NewStore[*config](),
 	}
 }
 
@@ -90,18 +83,7 @@ func (m *DscpService) ListConfigs(
 	ctx context.Context,
 	request *dscppb.ListConfigsRequest,
 ) (*dscppb.ListConfigsResponse, error) {
-	response := &dscppb.ListConfigsResponse{
-		Configs: make([]string, 0),
-	}
-
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	for name := range m.configs {
-		response.Configs = append(response.Configs, name)
-	}
-
-	return response, nil
+	return &dscppb.ListConfigsResponse{Configs: m.configs.Names()}, nil
 }
 
 func (m *DscpService) ShowConfig(
@@ -115,10 +97,7 @@ func (m *DscpService) ShowConfig(
 	name := request.GetName()
 	response := &dscppb.ShowConfigResponse{}
 
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	config, ok := m.configs[name]
+	config, ok := m.configs.Get(name)
 	if !ok {
 		return nil, status.Error(codes.NotFound, "config not found")
 	}
@@ -162,18 +141,11 @@ func (m *DscpService) AddPrefixes(
 		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	cfg := &config{}
-	if currConfig, ok := m.configs[name]; ok {
-		cfg = currConfig.Clone()
-	}
-
-	cfg.Prefixes4 = mergePrefixes(cfg.Prefixes4, toAdd4)
-	cfg.Prefixes6 = mergePrefixes(cfg.Prefixes6, toAdd6)
-
-	if err := m.updateModuleConfig(name, cfg); err != nil {
+	err = m.publish(name, func(cfg *config) {
+		cfg.Prefixes4 = mergePrefixes(cfg.Prefixes4, toAdd4)
+		cfg.Prefixes6 = mergePrefixes(cfg.Prefixes6, toAdd6)
+	})
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
@@ -216,20 +188,11 @@ func (m *DscpService) RemovePrefixes(
 		return nil, status.Errorf(codes.InvalidArgument, "failed to convert prefixes: %v", err)
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Create a new config to-be-updated either from scratch or from the
-	// current config.
-	cfg := &config{}
-	if currConfig, ok := m.configs[name]; ok {
-		cfg = currConfig.Clone()
-	}
-
-	cfg.Prefixes4 = removePrefixes(cfg.Prefixes4, toRemove4)
-	cfg.Prefixes6 = removePrefixes(cfg.Prefixes6, toRemove6)
-
-	if err := m.updateModuleConfig(name, cfg); err != nil {
+	err = m.publish(name, func(cfg *config) {
+		cfg.Prefixes4 = removePrefixes(cfg.Prefixes4, toRemove4)
+		cfg.Prefixes6 = removePrefixes(cfg.Prefixes6, toRemove6)
+	})
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
@@ -258,19 +221,13 @@ func (m *DscpService) SetDscpMarking(
 	flag := uint8(request.GetDscpConfig().GetFlag())
 	mark := uint8(request.GetDscpConfig().GetMark())
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	cfg := &config{}
-	if currConfig, ok := m.configs[name]; ok {
-		cfg = currConfig.Clone()
-	}
-	cfg.Config = dscpConfig{
-		Flag: flag,
-		Mark: mark,
-	}
-
-	if err := m.updateModuleConfig(name, cfg); err != nil {
+	err := m.publish(name, func(cfg *config) {
+		cfg.Config = dscpConfig{
+			Flag: flag,
+			Mark: mark,
+		}
+	})
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config %q: %v", name, err)
 	}
 
@@ -289,87 +246,52 @@ func (m *DscpService) DeleteConfig(
 
 	name := request.GetName()
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	entry, ok := m.configs[name]
-	if !ok {
+	err := m.configs.Delete(name, func(*config) error {
+		return m.backend.DeleteModule(name)
+	})
+	if errors.Is(err, configstore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "config not found")
 	}
-
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to delete module config %q: %v", name, err,
 		)
 	}
 
-	// The delete retired the generation holding the published module.
-	// Retry the deferred ones, then retire this one.
-	m.reclaimDeferred()
-	m.parkOrFree(entry.Module)
-
-	delete(m.configs, name)
-
 	return &dscppb.DeleteConfigResponse{}, nil
 }
 
-func (m *DscpService) updateModuleConfig(name string, cfg *config) error {
-	module, err := m.backend.UpdateModule(
-		name,
-		slices.Concat(cfg.Prefixes4, cfg.Prefixes6),
-		cfg.Config.Flag,
-		cfg.Config.Mark,
-	)
-	if err != nil {
-		return err
-	}
-
-	m.reclaimDeferred()
-	m.parkOrFree(cfg.Module)
-
-	m.configs[name] = &config{
-		Prefixes4: cfg.Prefixes4,
-		Prefixes6: cfg.Prefixes6,
-		Config:    cfg.Config,
-		Module:    module,
-	}
-
-	return nil
-}
-
-// parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.mu.
-func (m *DscpService) parkOrFree(handle ModuleHandle) {
-	if handle == nil {
-		return
-	}
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every deferred handle, dropping the ones whose
-// generations have drained and keeping the rest deferred. It is the
-// reclamation handler for this module's superseded configs; the service
-// itself runs it after each successful publish, and anything else may
-// call it at any time.
-func (m *DscpService) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *DscpService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
-		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
+// publish applies a mutation to a copy of the named config, starting from
+// an empty one when the name is new, and publishes the result.
+func (m *DscpService) publish(name string, mutate func(cfg *config)) error {
+	return m.configs.Update(name, func(current *config, ok bool) (*config, error) {
+		cfg := &config{}
+		if ok {
+			cfg = current.Clone()
 		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+		mutate(cfg)
+
+		module, err := m.backend.UpdateModule(
+			name,
+			slices.Concat(cfg.Prefixes4, cfg.Prefixes6),
+			cfg.Config.Flag,
+			cfg.Config.Mark,
+		)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Module = module
+
+		return cfg, nil
+	})
+}
+
+// ReclaimDeferred retries every superseded config whose free was refused,
+// releasing the ones whose generations have drained.
+//
+// The service runs it after each successful publish, and anything else
+// may call it at any time.
+func (m *DscpService) ReclaimDeferred() {
+	m.configs.ReclaimDeferred()
 }

--- a/modules/dscp/controlplane/service_test.go
+++ b/modules/dscp/controlplane/service_test.go
@@ -456,7 +456,7 @@ func Test_DscpService_DeleteConfig_ParksThenReclaims(t *testing.T) {
 	response, err := service.DeleteConfig(ctx, &dscppb.DeleteConfigRequest{Name: "dscp0"})
 	require.NotNil(t, response)
 	require.NoError(t, err)
-	require.Len(t, service.deferred, 1)
+	assert.Equal(t, int64(1), backend.first.numCalls.Load())
 	assert.Equal(t, int64(0), backend.first.freed.Load())
 
 	// A later successful update reclaims deferred handles first.
@@ -465,7 +465,7 @@ func Test_DscpService_DeleteConfig_ParksThenReclaims(t *testing.T) {
 		Prefixes4: mustPrefixes4(t, "10.0.1.0/24"),
 	})
 	require.NoError(t, err)
-	assert.Empty(t, service.deferred)
+	assert.Equal(t, int64(2), backend.first.numCalls.Load())
 	assert.Equal(t, int64(1), backend.first.freed.Load())
 }
 

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -5,20 +5,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"math"
 	"net/netip"
 	"slices"
-	"sync"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
-	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	nat64pb "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb/v1"
 )
+
+// errUnchanged is reported by a mutation callback that found nothing to
+// publish, so the current config stays as it is.
+var errUnchanged = errors.New("config unchanged")
 
 // NAT64ServiceOption configures the NAT64Service constructor.
 type NAT64ServiceOption func(*nat64ServiceOptions)
@@ -44,16 +46,9 @@ func WithNAT64ServiceLog(log *zap.Logger) NAT64ServiceOption {
 type NAT64Service struct {
 	nat64pb.UnimplementedNAT64ServiceServer
 
-	mu sync.Mutex
-
-	// deferred holds superseded module handles whose free was refused
-	// because a live configuration generation still referenced them.
-	// This service is their owner: it retries them on its next update,
-	// through ReclaimDeferred, and nothing else remembers them.
-	deferred []ModuleHandle
-	backend  Backend
-	configs  map[string]config
-	log      *zap.Logger
+	backend Backend
+	configs *configstore.Store[*config]
+	log     *zap.Logger
 }
 
 type config struct {
@@ -69,13 +64,6 @@ func (m *config) Free() error {
 		return nil
 	}
 	return m.Module.Free()
-}
-
-func (m config) Clone() config {
-	return config{
-		Config: m.Config.Clone(),
-		Module: m.Module,
-	}
 }
 
 // NAT64Config represents the configuration for a NAT64 instance
@@ -140,16 +128,13 @@ func NewNAT64Service(backend Backend, options ...NAT64ServiceOption) *NAT64Servi
 	return &NAT64Service{
 		backend: backend,
 		log:     opts.Log,
-		configs: map[string]config{},
+		configs: configstore.NewStore[*config](),
 	}
 }
 
 func (m *NAT64Service) ListConfigs(ctx context.Context, req *nat64pb.ListConfigsRequest) (*nat64pb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	return &nat64pb.ListConfigsResponse{
-		Configs: slices.Sorted(maps.Keys(m.configs)),
+		Configs: m.configs.Names(),
 	}, nil
 }
 
@@ -161,10 +146,7 @@ func (m *NAT64Service) ShowConfig(ctx context.Context, req *nat64pb.ShowConfigRe
 
 	response := &nat64pb.ShowConfigResponse{}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	inst, ok := m.configs[name]
+	inst, ok := m.configs.Get(name)
 	if !ok {
 		return nil, status.Error(codes.NotFound, "config not found")
 	}
@@ -211,17 +193,17 @@ func (m *NAT64Service) AddPrefix(ctx context.Context, req *nat64pb.AddPrefixRequ
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	err = m.configs.Update(name, func(current *config, ok bool) (*config, error) {
+		next := nextConfig(current, ok)
+		if slices.ContainsFunc(next.Config.Prefixes, func(existing []byte) bool { return bytes.Equal(existing, prefix) }) {
+			return nil, errUnchanged
+		}
+		next.Config.Prefixes = append(next.Config.Prefixes, prefix)
 
-	inst := m.instanceFor(name).Clone()
-	if slices.ContainsFunc(inst.Config.Prefixes, func(existing []byte) bool { return bytes.Equal(existing, prefix) }) {
-		return &nat64pb.AddPrefixResponse{}, nil
-	}
-	inst.Config.Prefixes = append(inst.Config.Prefixes, prefix)
-
-	if err := m.updateModuleConfig(name, inst); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		return m.publish(name, next)
+	})
+	if err != nil && !errors.Is(err, errUnchanged) {
+		return nil, err
 	}
 
 	return &nat64pb.AddPrefixResponse{}, nil
@@ -238,31 +220,30 @@ func (m *NAT64Service) RemovePrefix(ctx context.Context, req *nat64pb.RemovePref
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	inst, ok := m.configs[name]
-	if !ok {
-		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
-	}
-	next := inst.Clone()
-
-	removeIdx := -1
-	for idx, storedPrefix := range next.Config.Prefixes {
-		if bytes.Equal(storedPrefix, prefix) {
-			removeIdx = idx
-			break
+	err = m.configs.Update(name, func(current *config, ok bool) (*config, error) {
+		if !ok {
+			return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 		}
-	}
-	if removeIdx == -1 {
-		return nil, status.Errorf(codes.NotFound, "prefix not found in config %q", name)
-	}
+		next := nextConfig(current, ok)
 
-	next.Config.Prefixes = slices.Delete(next.Config.Prefixes, removeIdx, removeIdx+1)
-	next.Config.Mappings = adjustMappingsAfterPrefixRemove(next.Config.Mappings, uint32(removeIdx))
+		removeIdx := -1
+		for idx, storedPrefix := range next.Config.Prefixes {
+			if bytes.Equal(storedPrefix, prefix) {
+				removeIdx = idx
+				break
+			}
+		}
+		if removeIdx == -1 {
+			return nil, status.Errorf(codes.NotFound, "prefix not found in config %q", name)
+		}
 
-	if err := m.updateModuleConfig(name, next); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		next.Config.Prefixes = slices.Delete(next.Config.Prefixes, removeIdx, removeIdx+1)
+		next.Config.Mappings = adjustMappingsAfterPrefixRemove(next.Config.Mappings, uint32(removeIdx))
+
+		return m.publish(name, next)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &nat64pb.RemovePrefixResponse{}, nil
@@ -286,27 +267,27 @@ func (m *NAT64Service) AddMapping(ctx context.Context, req *nat64pb.AddMappingRe
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	err := m.configs.Update(name, func(current *config, ok bool) (*config, error) {
+		next := nextConfig(current, ok)
+		if req.PrefixIndex >= uint32(len(next.Config.Prefixes)) {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"invalid prefix index: got %d, prefixes count %d",
+				req.PrefixIndex,
+				len(next.Config.Prefixes),
+			)
+		}
+		next.Config.Mappings = slices.DeleteFunc(next.Config.Mappings, func(existing Mapping) bool { return existing.IPv4 == ipv4 })
+		next.Config.Mappings = append(next.Config.Mappings, Mapping{
+			IPv4:        ipv4,
+			IPv6:        ipv6,
+			PrefixIndex: req.PrefixIndex,
+		})
 
-	inst := m.instanceFor(name).Clone()
-	if req.PrefixIndex >= uint32(len(inst.Config.Prefixes)) {
-		return nil, status.Errorf(
-			codes.InvalidArgument,
-			"invalid prefix index: got %d, prefixes count %d",
-			req.PrefixIndex,
-			len(inst.Config.Prefixes),
-		)
-	}
-	inst.Config.Mappings = slices.DeleteFunc(inst.Config.Mappings, func(existing Mapping) bool { return existing.IPv4 == ipv4 })
-	inst.Config.Mappings = append(inst.Config.Mappings, Mapping{
-		IPv4:        ipv4,
-		IPv6:        ipv6,
-		PrefixIndex: req.PrefixIndex,
+		return m.publish(name, next)
 	})
-
-	if err := m.updateModuleConfig(name, inst); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+	if err != nil {
+		return nil, err
 	}
 
 	return &nat64pb.AddMappingResponse{}, nil
@@ -323,24 +304,23 @@ func (m *NAT64Service) RemoveMapping(ctx context.Context, req *nat64pb.RemoveMap
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	err := m.configs.Update(name, func(current *config, ok bool) (*config, error) {
+		if !ok {
+			return nil, status.Errorf(codes.NotFound, "config %q not found", name)
+		}
+		next := nextConfig(current, ok)
 
-	inst, ok := m.configs[name]
-	if !ok {
-		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
-	}
-	next := inst.Clone()
+		next.Config.Mappings = slices.DeleteFunc(next.Config.Mappings, func(mapping Mapping) bool {
+			return mapping.IPv4 == ipv4
+		})
+		if len(next.Config.Mappings) == len(current.Config.Mappings) {
+			return nil, status.Errorf(codes.NotFound, "mapping for %s not found in config %q", ipv4, name)
+		}
 
-	next.Config.Mappings = slices.DeleteFunc(next.Config.Mappings, func(mapping Mapping) bool {
-		return mapping.IPv4 == ipv4
+		return m.publish(name, next)
 	})
-	if len(next.Config.Mappings) == len(inst.Config.Mappings) {
-		return nil, status.Errorf(codes.NotFound, "mapping for %s not found in config %q", ipv4, name)
-	}
-
-	if err := m.updateModuleConfig(name, next); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+	if err != nil {
+		return nil, err
 	}
 
 	return &nat64pb.RemoveMappingResponse{}, nil
@@ -362,17 +342,17 @@ func (m *NAT64Service) SetMTU(ctx context.Context, req *nat64pb.SetMTURequest) (
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	err := m.configs.Update(name, func(current *config, ok bool) (*config, error) {
+		next := nextConfig(current, ok)
+		next.Config.MTU = MTUConfig{
+			IPv4MTU: req.Mtu.Ipv4Mtu,
+			IPv6MTU: req.Mtu.Ipv6Mtu,
+		}
 
-	inst := m.instanceFor(name).Clone()
-	inst.Config.MTU = MTUConfig{
-		IPv4MTU: req.Mtu.Ipv4Mtu,
-		IPv6MTU: req.Mtu.Ipv6Mtu,
-	}
-
-	if err := m.updateModuleConfig(name, inst); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		return m.publish(name, next)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &nat64pb.SetMTUResponse{}, nil
@@ -384,15 +364,15 @@ func (m *NAT64Service) SetDropUnknown(ctx context.Context, req *nat64pb.SetDropU
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	err := m.configs.Update(name, func(current *config, ok bool) (*config, error) {
+		next := nextConfig(current, ok)
+		next.Config.DropUnknownPrefix = req.DropUnknownPrefix
+		next.Config.DropUnknownMapping = req.DropUnknownMapping
 
-	inst := m.instanceFor(name).Clone()
-	inst.Config.DropUnknownPrefix = req.DropUnknownPrefix
-	inst.Config.DropUnknownMapping = req.DropUnknownMapping
-
-	if err := m.updateModuleConfig(name, inst); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		return m.publish(name, next)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &nat64pb.SetDropUnknownResponse{}, nil
@@ -444,50 +424,38 @@ func (m *NAT64Service) DeleteConfig(ctx context.Context, req *nat64pb.DeleteConf
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	inst, ok := m.configs[name]
-	if !ok {
+	err := m.configs.Delete(name, func(*config) error {
+		return m.backend.DeleteModule(name)
+	})
+	if errors.Is(err, configstore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "config not found")
 	}
-
-	if err := m.backend.DeleteModule(name); err != nil {
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete module config: %v", err)
 	}
-
-	// The delete retired the generation holding the published module.
-	// Retry the deferred ones, then retire this one.
-	m.reclaimDeferred()
-	m.parkOrFree(inst.Module)
-
-	delete(m.configs, name)
 
 	return &nat64pb.DeleteConfigResponse{}, nil
 }
 
-func (m *NAT64Service) instanceFor(name string) config {
-	inst, ok := m.configs[name]
+// nextConfig returns the config a mutation starts from: a deep copy of the
+// current one, or the defaults when the name is new.
+func nextConfig(current *config, ok bool) *config {
 	if !ok {
-		return config{
-			Config: defaultNAT64Config(),
-		}
+		return &config{Config: defaultNAT64Config()}
 	}
-	return inst
+	return &config{Config: current.Config.Clone()}
 }
 
-func (m *NAT64Service) updateModuleConfig(name string, inst config) error {
-	module, err := m.backend.UpdateModule(name, &inst.Config)
+// publish writes the next config to the dataplane and attaches the
+// published handle to it.
+func (m *NAT64Service) publish(name string, next *config) (*config, error) {
+	module, err := m.backend.UpdateModule(name, &next.Config)
 	if err != nil {
-		return err
+		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
+	next.Module = module
 
-	m.reclaimDeferred()
-	m.parkOrFree(inst.Module)
-	inst.Module = module
-	m.configs[name] = inst
-
-	return nil
+	return next, nil
 }
 
 func adjustMappingsAfterPrefixRemove(mappings []Mapping, removed uint32) []Mapping {
@@ -504,38 +472,11 @@ func adjustMappingsAfterPrefixRemove(mappings []Mapping, removed uint32) []Mappi
 	return out
 }
 
-// parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.mu.
-func (m *NAT64Service) parkOrFree(handle ModuleHandle) {
-	if handle == nil {
-		return
-	}
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every deferred handle, dropping the ones whose
-// generations have drained and keeping the rest deferred. It is the
-// reclamation handler for this module's superseded configs; the service
-// itself runs it after each successful publish, and anything else may
-// call it at any time.
+// ReclaimDeferred retries every superseded config whose free was refused,
+// releasing the ones whose generations have drained.
+//
+// The service runs it after each successful publish, and anything else
+// may call it at any time.
 func (m *NAT64Service) ReclaimDeferred() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.mu.
-func (m *NAT64Service) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
-		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
-		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+	m.configs.ReclaimDeferred()
 }

--- a/modules/nat64/controlplane/service_test.go
+++ b/modules/nat64/controlplane/service_test.go
@@ -541,7 +541,7 @@ func Test_NAT64Service_DeleteConfig_ParksThenReclaims(t *testing.T) {
 	resp, err := service.DeleteConfig(ctx, &nat64pb.DeleteConfigRequest{Name: "nat64-0"})
 	require.NotNil(t, resp)
 	require.NoError(t, err)
-	require.Len(t, service.deferred, 1)
+	require.Equal(t, int64(1), backend.first.numCalls.Load())
 	require.Equal(t, int64(0), backend.first.freed.Load())
 
 	// A later successful update reclaims deferred handles first.
@@ -550,7 +550,7 @@ func Test_NAT64Service_DeleteConfig_ParksThenReclaims(t *testing.T) {
 		Prefix: mustIPv6Prefix(t, "64:ff9b::/96"),
 	})
 	require.NoError(t, err)
-	require.Empty(t, service.deferred)
+	require.Equal(t, int64(2), backend.first.numCalls.Load())
 	require.Equal(t, int64(1), backend.first.freed.Load())
 }
 


### PR DESCRIPTION
- Migrate the nat64 and dscp services onto the config store, rebuilding each incremental mutation from the current entry inside the store's callback.
- Migrate the plain, vlan and trafgen device services onto the config store.
- Report the update error, not the free error twice, when the plain and vlan devices fail to free an unpublished replacement.

Closes #2535, closes #2536.
