### PR TITLE
refactor(controlplane,modules,devices): share the shared-memory attach config and helper

### DIFF
--- a/common/go/xcfg/load.go
+++ b/common/go/xcfg/load.go
@@ -244,10 +244,14 @@ func validate(v reflect.Value, path string) error {
 				continue
 			}
 
-			name := yamlFieldName(f)
-			fieldPath := name
-			if path != "" {
-				fieldPath = path + "." + name
+			// An inline struct's fields live at the parent's level in
+			// the document, so its errors carry the parent's path.
+			fieldPath := path
+			if !isInlineTag(f.Tag.Get("yaml")) {
+				fieldPath = yamlFieldName(f)
+				if path != "" {
+					fieldPath = path + "." + fieldPath
+				}
 			}
 
 			if err := validate(v.Field(i), fieldPath); err != nil {

--- a/common/go/xcfg/load_test.go
+++ b/common/go/xcfg/load_test.go
@@ -88,6 +88,28 @@ func Test_Load_RejectsNestedNull(t *testing.T) {
 	require.Equal(t, "inner.addr", pathErr.Path)
 }
 
+// Test_Load_InlineStructErrorsAtParentPath verifies that a field of an
+// inline struct reports its error at the parent's level, where the
+// document places the key.
+func Test_Load_InlineStructErrorsAtParentPath(t *testing.T) {
+	type Shared struct {
+		Addr NonEmptyString `yaml:"addr"`
+	}
+	type Inner struct {
+		Shared `yaml:",inline"`
+	}
+	type Outer struct {
+		Inner Inner `yaml:"inner"`
+	}
+
+	var cfg Outer
+	err := Decode([]byte("inner:\n  addr:"), &cfg)
+
+	var pathErr *PathError
+	require.ErrorAs(t, err, &pathErr)
+	require.Equal(t, "inner.addr", pathErr.Path)
+}
+
 func Test_Load_SkipsNilPointer(t *testing.T) {
 	type Inner struct {
 		Path NonEmptyString `yaml:"path"`

--- a/controlplane/bundle/cfg_test.go
+++ b/controlplane/bundle/cfg_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 	"github.com/yanet-platform/yanet2/controlplane/bundle"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	decap "github.com/yanet-platform/yanet2/modules/decap/controlplane"
 )
 
@@ -75,10 +76,12 @@ func Test_NewBundle_EmptyConfig_NoServicesNoAgents(t *testing.T) {
 func Test_NewBundle_ConfiguredModuleWithBadPath_FailsNamingModule(t *testing.T) {
 	cfg := bundle.ModulesConfig{
 		Decap: xcfg.NewOptional(decap.Config{
-			InstanceID:         xcfg.NewRequired(uint32(0)),
-			MemoryPath:         xcfg.MustNonEmptyString("/nonexistent/path/for/bundle/cfg/test"),
-			MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-			Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+			AttachConfig: ffi.AttachConfig{
+				InstanceID:         xcfg.NewRequired(uint32(0)),
+				MemoryPath:         xcfg.MustNonEmptyString("/nonexistent/path/for/bundle/cfg/test"),
+				MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+			},
+			Endpoint: xcfg.MustNonEmptyString("[::1]:0"),
 		}),
 	}
 

--- a/controlplane/ffi/attach.go
+++ b/controlplane/ffi/attach.go
@@ -1,0 +1,80 @@
+package ffi
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/c2h5oh/datasize"
+	"go.uber.org/zap"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+)
+
+// AttachConfig names the dataplane instance an agent serves and the shared
+// memory it attaches to.
+//
+// A module or device control plane embeds it inline in its own config, so
+// the keys sit at the top level of that config's document.
+type AttachConfig struct {
+	// InstanceID specifies which dataplane instance the agent serves.
+	//
+	// Required: a listed module or device must set it explicitly, even
+	// to 0.
+	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
+	// MemoryPath is the path to the shared-memory file that is used to
+	// communicate with the dataplane.
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
+	// MemoryRequirements is the size of the agent's arena in shared
+	// memory.
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+}
+
+// DefaultAttachConfig returns the shared-memory defaults with the given
+// arena size and no instance, which every listed agent must set itself.
+func DefaultAttachConfig(memory datasize.ByteSize) AttachConfig {
+	return AttachConfig{
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(memory),
+	}
+}
+
+// Attachment is an agent attached to a dataplane instance together with
+// the shared-memory mapping it lives in.
+type Attachment struct {
+	Agent *Agent
+
+	shm *SharedMemory
+}
+
+// Attach maps the shared memory the config names and attaches the named
+// agent to its dataplane instance.
+//
+// A failed agent attach unmaps the memory again, so an error leaves
+// nothing behind for the caller to release.
+func Attach(cfg AttachConfig, name string, log *zap.Logger) (*Attachment, error) {
+	shm, err := AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debug("mapping shared memory",
+		zap.String("agent", name),
+		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
+		zap.Stringer("size", cfg.MemoryRequirements),
+	)
+
+	agent, err := shm.AgentAttach(name, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("failed to attach agent to shared memory: %w", err),
+			shm.Detach(),
+		)
+	}
+
+	return &Attachment{Agent: agent, shm: shm}, nil
+}
+
+// Close releases the agent and unmaps the shared memory.
+func (m *Attachment) Close() error {
+	return errors.Join(m.Agent.Close(), m.shm.Detach())
+}

--- a/controlplane/ffi/attach_test.go
+++ b/controlplane/ffi/attach_test.go
@@ -1,0 +1,55 @@
+package ffi_test
+
+import (
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+// moduleConfig mirrors how a module config embeds the attach config: the
+// attach keys sit at the document's top level beside the module's own.
+type moduleConfig struct {
+	ffi.AttachConfig `yaml:",inline"`
+
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+}
+
+// Test_AttachConfig_InlineDecode verifies that the attach keys decode from
+// the top level of an embedding config and that the embedding config's own
+// keys still decode beside them.
+func Test_AttachConfig_InlineDecode(t *testing.T) {
+	cfg := moduleConfig{AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB)}
+	err := xcfg.Decode([]byte(
+		"instance_id: 2\nmemory_path: /dev/hugepages/test\nendpoint: '[::1]:9000'\n",
+	), &cfg, xcfg.WithKnownFields())
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(2), cfg.InstanceID.Unwrap())
+	require.Equal(t, "/dev/hugepages/test", cfg.MemoryPath.Unwrap())
+	require.Equal(t, 16*datasize.MB, cfg.MemoryRequirements.Unwrap())
+	require.Equal(t, "[::1]:9000", cfg.Endpoint.Unwrap())
+}
+
+// Test_AttachConfig_UnknownKeyRejected verifies that an unknown top-level
+// key is still rejected when the attach keys are merged in by inlining.
+func Test_AttachConfig_UnknownKeyRejected(t *testing.T) {
+	cfg := moduleConfig{AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB)}
+	err := xcfg.Decode([]byte("instance_id: 0\nmemory_size: 1\n"), &cfg, xcfg.WithKnownFields())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "memory_size")
+}
+
+// Test_DefaultAttachConfig_LeavesInstanceUnset verifies that the defaults
+// carry the memory path and the given arena size but no instance, so a
+// listed agent that omits it still fails validation.
+func Test_DefaultAttachConfig_LeavesInstanceUnset(t *testing.T) {
+	cfg := ffi.DefaultAttachConfig(64 * datasize.MB)
+
+	require.Equal(t, "/dev/hugepages/yanet", cfg.MemoryPath.Unwrap())
+	require.Equal(t, 64*datasize.MB, cfg.MemoryRequirements.Unwrap())
+	require.Error(t, cfg.InstanceID.Validate())
+}

--- a/devices/plain/controlplane/cfg.go
+++ b/devices/plain/controlplane/cfg.go
@@ -3,20 +3,12 @@ package plain
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 // Config represents plain device configuration
 type Config struct {
-	// InstanceID specifies which dataplane instance this device serves.
-	//
-	// Required: a listed device must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-
-	// MemoryPath is the path to the shared memory file
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-
-	// MemoryRequirements specifies memory requirements for the module
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	// Endpoint is the gRPC endpoint address
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
@@ -25,9 +17,8 @@ type Config struct {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/devices/plain/controlplane/mod.go
+++ b/devices/plain/controlplane/mod.go
@@ -1,9 +1,6 @@
 package plain
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -33,10 +30,9 @@ func WithLog(log *zap.Logger) Option {
 
 // DevicePlainDevice is a control-plane component responsible for plain devices
 type DevicePlainDevice struct {
-	cfg     *Config
-	shm     *ffi.SharedMemory
-	agent   *ffi.Agent
-	service *DevicePlainService
+	cfg        *Config
+	attachment *ffi.Attachment
+	service    *DevicePlainService
 }
 
 // NewDevicePlainDevice creates a new DevicePlain device instance
@@ -48,31 +44,18 @@ func NewDevicePlainDevice(cfg *Config, options ...Option) (*DevicePlainDevice, e
 
 	log := opts.Log.With(zap.String("module", "devices.plain.controlplane.plainpb.v1.DevicePlainService"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := ffi.Attach(cfg.AttachConfig, "plain", log)
 	if err != nil {
 		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach("plain", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	plainService := NewDevicePlainService(agent)
 
 	return &DevicePlainDevice{
-		cfg:     cfg,
-		shm:     shm,
-		agent:   agent,
-		service: plainService,
+		cfg:        cfg,
+		attachment: attachment,
+		service:    plainService,
 	}, nil
 }
 
@@ -94,5 +77,5 @@ func (m *DevicePlainDevice) RegisterService(server *grpc.Server) {
 
 // Close closes the device and releases all resources
 func (m *DevicePlainDevice) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/devices/trafgen/controlplane/cfg.go
+++ b/devices/trafgen/controlplane/cfg.go
@@ -3,29 +3,20 @@ package trafgen
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 // Config represents trafgen device configuration.
 type Config struct {
-	// InstanceID specifies which dataplane instance this device serves.
-	//
-	// Required: a listed device must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-	// MemoryPath is the path to the shared-memory file that is used to
-	// communicate with dataplane.
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements is the amount of memory that is required for a single
-	// transaction.
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/devices/trafgen/controlplane/mod.go
+++ b/devices/trafgen/controlplane/mod.go
@@ -2,9 +2,6 @@
 package trafgen
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -40,10 +37,9 @@ func WithLog(log *zap.Logger) Option {
 
 // TrafgenDevice is the control-plane component of the traffic generator device.
 type TrafgenDevice struct {
-	cfg     *Config
-	shm     *ffi.SharedMemory
-	agent   *ffi.Agent
-	service *TrafgenService
+	cfg        *Config
+	attachment *ffi.Attachment
+	service    *TrafgenService
 }
 
 // NewTrafgenDevice creates a new TrafgenDevice.
@@ -55,31 +51,18 @@ func NewTrafgenDevice(cfg *Config, options ...Option) (*TrafgenDevice, error) {
 
 	log := opts.Log.With(zap.String("device", deviceName))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := ffi.Attach(cfg.AttachConfig, agentName, log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach shared memory: %w", err)
+		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	service := NewTrafgenService(NewBackend(agent))
 
 	return &TrafgenDevice{
-		cfg:     cfg,
-		shm:     shm,
-		agent:   agent,
-		service: service,
+		cfg:        cfg,
+		attachment: attachment,
+		service:    service,
 	}, nil
 }
 
@@ -105,5 +88,5 @@ func (m *TrafgenDevice) RegisterService(server *grpc.Server) {
 
 // Close releases shared memory resources held by the device.
 func (m *TrafgenDevice) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/devices/vlan/controlplane/cfg.go
+++ b/devices/vlan/controlplane/cfg.go
@@ -3,20 +3,12 @@ package vlan
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 // Config represents VLAN device configuration
 type Config struct {
-	// InstanceID specifies which dataplane instance this device serves.
-	//
-	// Required: a listed device must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-
-	// MemoryPath is the path to the shared memory file
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-
-	// MemoryRequirements specifies memory requirements for the module
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	// Endpoint is the gRPC endpoint address
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
@@ -25,9 +17,8 @@ type Config struct {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/devices/vlan/controlplane/mod.go
+++ b/devices/vlan/controlplane/mod.go
@@ -1,9 +1,6 @@
 package vlan
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -33,10 +30,9 @@ func WithLog(log *zap.Logger) Option {
 
 // DeviceVlanDevice is a control-plane component responsible for vlan devices
 type DeviceVlanDevice struct {
-	cfg     *Config
-	shm     *ffi.SharedMemory
-	agent   *ffi.Agent
-	service *DeviceVlanService
+	cfg        *Config
+	attachment *ffi.Attachment
+	service    *DeviceVlanService
 }
 
 // NewDeviceVlanDevice creates a new DeviceVlan device instance
@@ -48,31 +44,18 @@ func NewDeviceVlanDevice(cfg *Config, options ...Option) (*DeviceVlanDevice, err
 
 	log := opts.Log.With(zap.String("module", "devices.vlan.controlplane.vlanpb.v1.DeviceVlanService"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := ffi.Attach(cfg.AttachConfig, "vlan", log)
 	if err != nil {
 		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach("vlan", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	vlanService := NewDeviceVlanService(agent)
 
 	return &DeviceVlanDevice{
-		cfg:     cfg,
-		shm:     shm,
-		agent:   agent,
-		service: vlanService,
+		cfg:        cfg,
+		attachment: attachment,
+		service:    vlanService,
 	}, nil
 }
 
@@ -94,5 +77,5 @@ func (m *DeviceVlanDevice) RegisterService(server *grpc.Server) {
 
 // Close closes the device and releases all resources
 func (m *DeviceVlanDevice) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/acl/controlplane/cfg.go
+++ b/modules/acl/controlplane/cfg.go
@@ -3,18 +3,13 @@ package acl
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 // Config represents ACL module configuration
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	//
-	// Required: a listed module must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-	// MemoryPath is the path to the shared memory file
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements specifies memory requirements for the module
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
+
 	// Endpoint is the gRPC endpoint address
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
@@ -22,9 +17,8 @@ type Config struct {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(64 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(64 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -1,9 +1,6 @@
 package acl
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -42,8 +39,7 @@ func WithModuleLog(log *zap.Logger) ModuleOption {
 // module.
 type ACLModule struct {
 	cfg            *Config
-	shm            *ffi.SharedMemory
-	agent          *ffi.Agent
+	attachment     *ffi.Attachment
 	aclService     *ACLService
 	metricsService *MetricsService
 }
@@ -57,23 +53,11 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 
 	log := opts.Log.With(zap.String("module", serviceName))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := ffi.Attach(cfg.AttachConfig, agentName, log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach shared memory: %w", err)
+		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	aclService := NewACLService(
 		NewBackend(agent),
@@ -87,8 +71,7 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 
 	return &ACLModule{
 		cfg:            cfg,
-		shm:            shm,
-		agent:          agent,
+		attachment:     attachment,
 		aclService:     aclService,
 		metricsService: metricsService,
 	}, nil
@@ -127,5 +110,5 @@ func (m *ACLModule) Close() error {
 	// In-flight metric collections read the shared memory outside the
 	// drained request handlers; wait for them before releasing it.
 	m.aclService.DrainMetricsReads()
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/blackhole/controlplane/cfg.go
+++ b/modules/blackhole/controlplane/cfg.go
@@ -3,19 +3,12 @@ package blackhole
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 // Config represents Blackhole module configuration.
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	//
-	// Required: a listed module must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-	// MemoryPath is the path to the shared memory file.
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements is the amount of memory required for a single
-	// transaction.
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	// Endpoint is the gRPC address the module listens on.
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
@@ -24,9 +17,8 @@ type Config struct {
 // DefaultConfig returns default configuration.
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(4 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(4 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/modules/blackhole/controlplane/mod.go
+++ b/modules/blackhole/controlplane/mod.go
@@ -2,9 +2,6 @@
 package blackhole
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	blackholepb "github.com/yanet-platform/yanet2/modules/blackhole/controlplane/blackholepb/v1"
 	"go.uber.org/zap"
@@ -40,8 +37,7 @@ func WithLog(log *zap.Logger) Option {
 // BlackholeModule is a controlplane component for blackhole module.
 type BlackholeModule struct {
 	cfg              *Config
-	shm              *ffi.SharedMemory
-	agent            *ffi.Agent
+	attachment       *ffi.Attachment
 	blackholeService *BlackholeService
 }
 
@@ -54,30 +50,17 @@ func NewBlackholeModule(cfg *Config, options ...Option) (*BlackholeModule, error
 
 	log := opts.Log.With(zap.String("module", serviceName))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := ffi.Attach(cfg.AttachConfig, agentName, log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach shared memory: %w", err)
+		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	blackholeService := NewBlackholeService(NewBackend(agent))
 
 	return &BlackholeModule{
 		cfg:              cfg,
-		shm:              shm,
-		agent:            agent,
+		attachment:       attachment,
 		blackholeService: blackholeService,
 	}, nil
 }
@@ -104,5 +87,5 @@ func (m *BlackholeModule) RegisterService(server *grpc.Server) {
 
 // Close releases shared memory resources held by the module.
 func (m *BlackholeModule) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/decap/controlplane/cfg.go
+++ b/modules/decap/controlplane/cfg.go
@@ -3,28 +3,19 @@ package decap
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	//
-	// Required: a listed module must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-	// MemoryPath is the path to the shared-memory file that is used to
-	// communicate with dataplane.
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements is the amount of memory that is required for a single
-	// transaction.
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/modules/decap/controlplane/mod.go
+++ b/modules/decap/controlplane/mod.go
@@ -1,9 +1,6 @@
 package decap
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -35,8 +32,7 @@ func WithLog(log *zap.Logger) Option {
 // decapsulating various kinds of tunnels.
 type DecapModule struct {
 	cfg          *Config
-	shm          *ffi.SharedMemory
-	agent        *ffi.Agent
+	attachment   *ffi.Attachment
 	decapService *DecapService
 }
 
@@ -48,30 +44,17 @@ func NewDecapModule(cfg *Config, options ...Option) (*DecapModule, error) {
 
 	log := opts.Log.With(zap.String("module", "modules.decap.controlplane.decappb.v1.DecapService"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := ffi.Attach(cfg.AttachConfig, "decap", log)
 	if err != nil {
 		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach("decap", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	decapService := NewDecapService(NewBackend(agent))
 
 	return &DecapModule{
 		cfg:          cfg,
-		shm:          shm,
-		agent:        agent,
+		attachment:   attachment,
 		decapService: decapService,
 	}, nil
 }
@@ -94,5 +77,5 @@ func (m *DecapModule) RegisterService(server *grpc.Server) {
 
 // Close closes the module.
 func (m *DecapModule) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/dscp/controlplane/cfg.go
+++ b/modules/dscp/controlplane/cfg.go
@@ -3,28 +3,19 @@ package dscp
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	//
-	// Required: a listed module must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-	// MemoryPath is the path to the shared-memory file that is used to
-	// communicate with dataplane.
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements is the amount of memory that is required for a single
-	// transaction.
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/modules/dscp/controlplane/mod.go
+++ b/modules/dscp/controlplane/mod.go
@@ -1,9 +1,6 @@
 package dscp
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -35,8 +32,7 @@ func WithLog(log *zap.Logger) Option {
 // DSCP marking of packets.
 type DscpModule struct {
 	cfg         *Config
-	shm         *ffi.SharedMemory
-	agent       *ffi.Agent
+	attachment  *ffi.Attachment
 	dscpService *DscpService
 }
 
@@ -48,31 +44,17 @@ func NewDSCPModule(cfg *Config, options ...Option) (*DscpModule, error) {
 
 	log := opts.Log.With(zap.String("module", "dscp"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := ffi.Attach(cfg.AttachConfig, "dscp", log)
 	if err != nil {
 		return nil, err
 	}
-
-	log.Debug(
-		"mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach("dscp", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	dscpService := NewDscpService(newBackend(agent))
 
 	return &DscpModule{
 		cfg:         cfg,
-		shm:         shm,
-		agent:       agent,
+		attachment:  attachment,
 		dscpService: dscpService,
 	}, nil
 }
@@ -95,5 +77,5 @@ func (m *DscpModule) RegisterService(server *grpc.Server) {
 
 // Close closes the module.
 func (m *DscpModule) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/forward/controlplane/cfg.go
+++ b/modules/forward/controlplane/cfg.go
@@ -3,28 +3,19 @@ package forward
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	//
-	// Required: a listed module must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-	// MemoryPath is the path to the shared-memory file that is used to
-	// communicate with dataplane.
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements is the amount of memory that is required for a single
-	// transaction.
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/modules/forward/controlplane/mod.go
+++ b/modules/forward/controlplane/mod.go
@@ -1,9 +1,6 @@
 package forward
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -41,8 +38,7 @@ func WithLog(log *zap.Logger) Option {
 // forwarding traffic between devices.
 type ForwardModule struct {
 	cfg            *Config
-	shm            *cpffi.SharedMemory
-	agent          *cpffi.Agent
+	attachment     *cpffi.Attachment
 	forwardService *ForwardService
 	metricsService *MetricsService
 }
@@ -55,31 +51,18 @@ func NewForwardModule(cfg *Config, options ...Option) (*ForwardModule, error) {
 
 	log := opts.Log.With(zap.String("module", serviceName))
 
-	shm, err := cpffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := cpffi.Attach(cfg.AttachConfig, agentName, log)
 	if err != nil {
 		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	forwardService := NewForwardService(NewBackend(agent))
 	metricsService := NewMetricsService(forwardService)
 
 	return &ForwardModule{
 		cfg:            cfg,
-		shm:            shm,
-		agent:          agent,
+		attachment:     attachment,
 		forwardService: forwardService,
 		metricsService: metricsService,
 	}, nil
@@ -104,5 +87,5 @@ func (m *ForwardModule) RegisterService(server *grpc.Server) {
 
 // Close closes the module.
 func (m *ForwardModule) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/fwstate/controlplane/cfg.go
+++ b/modules/fwstate/controlplane/cfg.go
@@ -6,21 +6,13 @@ import (
 	"github.com/c2h5oh/datasize"
 
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	fwstatemap "github.com/yanet-platform/yanet2/objects/fwstate/controlplane"
 )
 
 // Config represents FWState module configuration
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	//
-	// Required: a listed module must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-
-	// MemoryPath is the path to the shared memory file
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-
-	// MemoryRequirements specifies memory requirements for the module
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	// Endpoint is the gRPC endpoint address
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
@@ -32,14 +24,13 @@ type Config struct {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath: xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		// The fwstate-map objects linked by acl and fwstate configs
 		// allocate in this module's agent zone, so the default must
 		// hold at least the default map dimensions: a zero-sizing
 		// CreateMap picks a 1,048,576-entry index, and one such layer
 		// across both families needs well over 100 MB before module
 		// configs and allocator overhead.
-		MemoryRequirements:      xcfg.MustNonZero(1024 * datasize.MB),
+		AttachConfig:            ffi.DefaultAttachConfig(1024 * datasize.MB),
 		Endpoint:                xcfg.MustNonEmptyString("[::1]:0"),
 		StaleLayerSweepInterval: fwstatemap.DefaultStaleLayerSweepInterval,
 	}

--- a/modules/fwstate/controlplane/mod.go
+++ b/modules/fwstate/controlplane/mod.go
@@ -2,8 +2,6 @@ package fwstate
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -23,8 +21,7 @@ const agentName = moduleType
 // generation, where module configs of any agent resolve them by name.
 type FWStateModule struct {
 	cfg                   *Config
-	shm                   *ffi.SharedMemory
-	agent                 *ffi.Agent
+	attachment            *ffi.Attachment
 	fwstateService        *FWStateService
 	fwstateMetricsService *MetricsService
 	mapService            *fwstatemap.FWStateMapService
@@ -39,23 +36,11 @@ func NewFWStateModule(cfg *Config, options ...Option) (*FWStateModule, error) {
 
 	log := opts.Log.With(zap.String("module", moduleType))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := ffi.Attach(cfg.AttachConfig, agentName, log)
 	if err != nil {
 		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	// The map service owns the fwstate-map objects both this module's
 	// configs and ACL configs link by name; a published object resolves
@@ -79,8 +64,7 @@ func NewFWStateModule(cfg *Config, options ...Option) (*FWStateModule, error) {
 
 	return &FWStateModule{
 		cfg:                   cfg,
-		shm:                   shm,
-		agent:                 agent,
+		attachment:            attachment,
 		fwstateService:        fwstateService,
 		fwstateMetricsService: fwstateMetricsService,
 		mapService:            mapService,
@@ -134,5 +118,5 @@ func (m *FWStateModule) Run(ctx context.Context) error {
 
 // Close closes the module.
 func (m *FWStateModule) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/mirror/controlplane/cfg.go
+++ b/modules/mirror/controlplane/cfg.go
@@ -3,28 +3,19 @@ package mirror
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	//
-	// Required: a listed module must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-	// MemoryPath is the path to the shared-memory file that is used to
-	// communicate with dataplane.
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements is the amount of memory that is required for a single
-	// transaction.
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/modules/mirror/controlplane/mod.go
+++ b/modules/mirror/controlplane/mod.go
@@ -1,9 +1,6 @@
 package mirror
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -40,8 +37,7 @@ func WithLog(log *zap.Logger) Option {
 // mirroring traffic between devices.
 type MirrorModule struct {
 	cfg           *Config
-	shm           *cpffi.SharedMemory
-	agent         *cpffi.Agent
+	attachment    *cpffi.Attachment
 	mirrorService *MirrorService
 }
 
@@ -53,30 +49,17 @@ func NewMirrorModule(cfg *Config, options ...Option) (*MirrorModule, error) {
 
 	log := opts.Log.With(zap.String("module", "modules.mirror.controlplane.mirrorpb.v1.MirrorService"))
 
-	shm, err := cpffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := cpffi.Attach(cfg.AttachConfig, agentName, log)
 	if err != nil {
 		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	mirrorService := NewMirrorService(NewBackend(agent))
 
 	return &MirrorModule{
 		cfg:           cfg,
-		shm:           shm,
-		agent:         agent,
+		attachment:    attachment,
 		mirrorService: mirrorService,
 	}, nil
 }
@@ -99,5 +82,5 @@ func (m *MirrorModule) RegisterService(server *grpc.Server) {
 
 // Close closes the module.
 func (m *MirrorModule) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/nat64/controlplane/cfg.go
+++ b/modules/nat64/controlplane/cfg.go
@@ -3,20 +3,12 @@ package nat64
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 // Config represents NAT64 module configuration
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	//
-	// Required: a listed module must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-
-	// MemoryPath is the path to the shared memory file
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-
-	// MemoryRequirements specifies memory requirements for the module
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	// Endpoint is the gRPC endpoint address
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
@@ -25,9 +17,8 @@ type Config struct {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/modules/nat64/controlplane/mod.go
+++ b/modules/nat64/controlplane/mod.go
@@ -1,9 +1,6 @@
 package nat64
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -34,8 +31,7 @@ func WithLog(log *zap.Logger) Option {
 // NAT64Module is a control-plane component responsible for NAT64 translation
 type NAT64Module struct {
 	cfg          *Config
-	shm          *ffi.SharedMemory
-	agent        *ffi.Agent
+	attachment   *ffi.Attachment
 	nat64Service *NAT64Service
 }
 
@@ -48,30 +44,17 @@ func NewNAT64Module(cfg *Config, options ...Option) (*NAT64Module, error) {
 
 	log := opts.Log.With(zap.String("module", "modules.nat64.controlplane.nat64pb.v1.NAT64Service"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := ffi.Attach(cfg.AttachConfig, "nat64", log)
 	if err != nil {
 		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach("nat64", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	nat64Service := NewNAT64Service(NewBackend(agent), WithNAT64ServiceLog(log))
 
 	return &NAT64Module{
 		cfg:          cfg,
-		shm:          shm,
-		agent:        agent,
+		attachment:   attachment,
 		nat64Service: nat64Service,
 	}, nil
 }
@@ -94,5 +77,5 @@ func (m *NAT64Module) RegisterService(server *grpc.Server) {
 
 // Close closes the module and releases all resources
 func (m *NAT64Module) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/pdump/controlplane/cfg.go
+++ b/modules/pdump/controlplane/cfg.go
@@ -3,19 +3,11 @@ package pdump
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	//
-	// Required: a listed module must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-	// MemoryPath is the path to the shared-memory file that is used to
-	// communicate with dataplane.
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements is the amount of memory that is required for a single
-	// transaction.
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	Endpoint  xcfg.NonEmptyString `yaml:"endpoint"`
 	DebugEBPF bool                `yaml:"debug_ebpf"`
@@ -23,10 +15,9 @@ type Config struct {
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		DebugEBPF:          false,
+		AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
+		DebugEBPF:    false,
 	}
 }
 

--- a/modules/pdump/controlplane/mod.go
+++ b/modules/pdump/controlplane/mod.go
@@ -2,8 +2,6 @@ package pdump
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -35,11 +33,10 @@ func WithLog(log *zap.Logger) Option {
 
 // PdumpModule is a control-plane component of a packet dump module.
 type PdumpModule struct {
-	cfg     *Config
-	shm     *ffi.SharedMemory
-	agent   *ffi.Agent
-	service *PdumpService
-	log     *zap.Logger
+	cfg        *Config
+	attachment *ffi.Attachment
+	service    *PdumpService
+	log        *zap.Logger
 }
 
 func NewPdumpModule(cfg *Config, options ...Option) (*PdumpModule, error) {
@@ -57,32 +54,19 @@ func NewPdumpModule(cfg *Config, options ...Option) (*PdumpModule, error) {
 	)
 	debugEBPF = cfg.DebugEBPF
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := ffi.Attach(cfg.AttachConfig, moduleType, log)
 	if err != nil {
 		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach(moduleType, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	service := NewPdumpService(agent, WithPdumpServiceLog(log))
 
 	return &PdumpModule{
-		cfg:     cfg,
-		shm:     shm,
-		agent:   agent,
-		service: service,
-		log:     log,
+		cfg:        cfg,
+		attachment: attachment,
+		service:    service,
+		log:        log,
 	}, nil
 }
 
@@ -113,5 +97,5 @@ func (m *PdumpModule) Run(ctx context.Context) error {
 
 // Close closes the module.
 func (m *PdumpModule) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/route-mpls/controlplane/cfg.go
+++ b/modules/route-mpls/controlplane/cfg.go
@@ -3,20 +3,13 @@ package route_mpls
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 // Config holds the configuration for the route-mpls control-plane module.
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	//
-	// Required: a listed module must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-	// MemoryPath is the path to the shared-memory file used to communicate
-	// with the dataplane.
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements is the amount of shared memory required for a single
-	// transaction.
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
+
 	// Endpoint is the gRPC listen address for this module.
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
@@ -24,9 +17,8 @@ type Config struct {
 // DefaultConfig returns a Config populated with sensible defaults.
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/modules/route-mpls/controlplane/mod.go
+++ b/modules/route-mpls/controlplane/mod.go
@@ -1,9 +1,6 @@
 package route_mpls
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -39,10 +36,9 @@ func WithLog(log *zap.Logger) Option {
 // RouteMPLSModule is the controlplane part of the route-mpls module that owns
 // shared memory and exposes the routemplspb.RouteMPLSService gRPC surface.
 type RouteMPLSModule struct {
-	cfg     *Config
-	shm     *cpffi.SharedMemory
-	agent   *cpffi.Agent
-	service *RouteMPLSService
+	cfg        *Config
+	attachment *cpffi.Attachment
+	service    *RouteMPLSService
 }
 
 // NewRouteMPLSModule creates a new RouteMPLSModule.
@@ -54,31 +50,18 @@ func NewRouteMPLSModule(cfg *Config, options ...Option) (*RouteMPLSModule, error
 
 	log := opts.Log.With(zap.String("module", "modules.route_mpls.controlplane.routemplspb.v1.RouteMPLSService"))
 
-	shm, err := cpffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := cpffi.Attach(cfg.AttachConfig, agentName, log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach to shared memory %q: %w", cfg.MemoryPath, err)
+		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	service := NewRouteMPLSService(NewBackend(agent), WithRouteMPLSServiceLog(log))
 
 	return &RouteMPLSModule{
-		cfg:     cfg,
-		shm:     shm,
-		agent:   agent,
-		service: service,
+		cfg:        cfg,
+		attachment: attachment,
+		service:    service,
 	}, nil
 }
 
@@ -106,5 +89,5 @@ func (m *RouteMPLSModule) RegisterService(server *grpc.Server) {
 
 // Close closes the module.
 func (m *RouteMPLSModule) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/route/controlplane/cfg.go
+++ b/modules/route/controlplane/cfg.go
@@ -3,20 +3,13 @@ package route
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 // Config is the route module shim configuration.
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	//
-	// Required: a listed module must set it explicitly, even to 0.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-	// MemoryPath is the path to the shared-memory file that is used to
-	// communicate with dataplane.
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements is the amount of memory that is required for a
-	// single transaction.
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
+
 	// Endpoint is the gRPC endpoint of the route module shim.
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 	// DisableNexthopCounters turns off the per-nexthop dataplane counters.
@@ -30,9 +23,8 @@ type Config struct {
 // DefaultConfig returns a Config populated with sensible defaults.
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(16 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -1,9 +1,6 @@
 package route
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -45,8 +42,7 @@ func WithLog(log *zap.Logger) Option {
 // UpdateFIB.
 type RouteModule struct {
 	cfg            *Config
-	shm            *cpffi.SharedMemory
-	agent          *cpffi.Agent
+	attachment     *cpffi.Attachment
 	service        *RouteService
 	metricsService *MetricsService
 }
@@ -60,23 +56,11 @@ func NewRouteModule(cfg *Config, options ...Option) (*RouteModule, error) {
 
 	log := opts.Log.With(zap.String("module", "modules.route.controlplane.routepb.v1.RouteService"))
 
-	shm, err := cpffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := cpffi.Attach(cfg.AttachConfig, agentName, log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach to shared memory %q: %w", cfg.MemoryPath, err)
+		return nil, err
 	}
-
-	log.Debug("mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	serviceOptions := []RouteServiceOption{
 		WithMetrics(grpcmetrics.NewFactory(
@@ -93,8 +77,7 @@ func NewRouteModule(cfg *Config, options ...Option) (*RouteModule, error) {
 
 	return &RouteModule{
 		cfg:            cfg,
-		shm:            shm,
-		agent:          agent,
+		attachment:     attachment,
 		service:        service,
 		metricsService: metricsService,
 	}, nil
@@ -137,5 +120,5 @@ func (m *RouteModule) UnaryServerInterceptors() []grpc.UnaryServerInterceptor {
 
 // Close closes the module.
 func (m *RouteModule) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }

--- a/modules/unrdup/controlplane/cfg.go
+++ b/modules/unrdup/controlplane/cfg.go
@@ -3,24 +3,19 @@ package unrdup
 import (
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 type Config struct {
-	// InstanceID specifies which dataplane instance this module serves.
-	InstanceID xcfg.Required[uint32] `yaml:"instance_id"`
-	// MemoryPath is the shared-memory file used to talk to the dataplane.
-	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements is the memory needed for a single transaction.
-	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	ffi.AttachConfig `yaml:",inline"`
 
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
-		MemoryRequirements: xcfg.MustNonZero(32 * datasize.MB),
-		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		AttachConfig: ffi.DefaultAttachConfig(32 * datasize.MB),
+		Endpoint:     xcfg.MustNonEmptyString("[::1]:0"),
 	}
 }
 

--- a/modules/unrdup/controlplane/mod.go
+++ b/modules/unrdup/controlplane/mod.go
@@ -1,9 +1,6 @@
 package unrdup
 
 import (
-	"errors"
-	"fmt"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -34,8 +31,7 @@ func WithLog(log *zap.Logger) Option {
 // UnrdupModule is the control-plane component of the unrdup module.
 type UnrdupModule struct {
 	cfg           *Config
-	shm           *ffi.SharedMemory
-	agent         *ffi.Agent
+	attachment    *ffi.Attachment
 	unrdupService *UnrdupService
 }
 
@@ -47,29 +43,15 @@ func NewUnrdupModule(cfg *Config, options ...Option) (*UnrdupModule, error) {
 
 	log := opts.Log.With(zap.String("module", "unrdup"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	attachment, err := ffi.Attach(cfg.AttachConfig, "unrdup", log)
 	if err != nil {
 		return nil, err
 	}
-
-	log.Debug(
-		"mapping shared memory",
-		zap.Uint32("instance_id", cfg.InstanceID.Unwrap()),
-		zap.Stringer("size", cfg.MemoryRequirements),
-	)
-
-	agent, err := shm.AgentAttach("unrdup", cfg.InstanceID.Unwrap(), cfg.MemoryRequirements.Unwrap())
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to attach agent to shared memory: %w", err),
-			shm.Detach(),
-		)
-	}
+	agent := attachment.Agent
 
 	return &UnrdupModule{
 		cfg:           cfg,
-		shm:           shm,
-		agent:         agent,
+		attachment:    attachment,
 		unrdupService: NewUnrdupService(newBackend(agent)),
 	}, nil
 }
@@ -92,5 +74,5 @@ func (m *UnrdupModule) RegisterService(server *grpc.Server) {
 
 // Close closes the module.
 func (m *UnrdupModule) Close() error {
-	return errors.Join(m.agent.Close(), m.shm.Detach())
+	return m.attachment.Close()
 }


### PR DESCRIPTION
- Add an attach config that every module and device config embeds inline, together with one attach helper that maps the shared memory, attaches the agent and releases both.
- Rewrite the module and device constructors and configs onto them, keeping each one's arena size, extra fields and YAML keys.
- Report validation errors of inline config fields at the parent's path.
