### PR TITLE
refactor(ffi,modules,devices): classify a typed free once in the shared-memory wrappers

### DIFF
--- a/bindings/go/cerrors/cgo.go
+++ b/bindings/go/cerrors/cgo.go
@@ -98,3 +98,12 @@ func FromC(cErr unsafe.Pointer) error {
 		kind: Kind(C.yanet_error_kind(err)),
 	}
 }
+
+// Free releases a C error without reading it, for an outcome the caller
+// classifies from the return code alone.
+func Free(cErr unsafe.Pointer) {
+	if cErr == nil {
+		return
+	}
+	C.yanet_error_free((*C.yanet_error)(cErr))
+}

--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -21,8 +21,10 @@ package ffi
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+	"syscall"
 	"unsafe"
 
 	"github.com/c2h5oh/datasize"
@@ -55,6 +57,36 @@ func (m ModuleConfig) AsRawPtr() unsafe.Pointer {
 	return unsafe.Pointer(m.ptr)
 }
 
+// Free destroys the module config through the typed free the module
+// supplies and forgets the pointer once it is gone.
+//
+// The typed free succeeds only once no live generation references the
+// config. A refused attempt reports ErrStillReferenced, releases the error
+// chain it allocated and leaves the handle usable, so the owner can retry
+// once the generations holding it drain. Repeated calls after a success
+// are no-ops reporting nil. The handle to free is the binding's own, not
+// a copy handed out for publishing, which would keep the original live
+// after the object is gone.
+func (m *ModuleConfig) Free(
+	free func(ptr unsafe.Pointer) (rc int, cErr unsafe.Pointer, errno error),
+) error {
+	if m.ptr == nil {
+		return nil
+	}
+
+	rc, cErr, errno := free(unsafe.Pointer(m.ptr))
+	if rc == 0 {
+		m.ptr = nil
+		return nil
+	}
+	if errors.Is(errno, syscall.EAGAIN) {
+		cerrors.Free(cErr)
+		return ErrStillReferenced
+	}
+
+	return fmt.Errorf("failed to free module config: %w", freeFailure(cErr, errno))
+}
+
 // ShmDeviceConfig is a Go wrapper around a C cp_device pointer, representing
 // a device's shared memory configuration.
 //
@@ -79,6 +111,39 @@ func NewShmDeviceConfig(ptr unsafe.Pointer) ShmDeviceConfig {
 // across CGo package boundaries.
 func (m ShmDeviceConfig) AsRawPtr() unsafe.Pointer {
 	return unsafe.Pointer(m.ptr)
+}
+
+// Free destroys the device config through the typed free the device
+// supplies and forgets the pointer once it is gone.
+//
+// The refusal contract is the one of a module config's free.
+func (m *ShmDeviceConfig) Free(
+	free func(ptr unsafe.Pointer) (rc int, cErr unsafe.Pointer, errno error),
+) error {
+	if m.ptr == nil {
+		return nil
+	}
+
+	rc, cErr, errno := free(unsafe.Pointer(m.ptr))
+	if rc == 0 {
+		m.ptr = nil
+		return nil
+	}
+	if errors.Is(errno, syscall.EAGAIN) {
+		cerrors.Free(cErr)
+		return ErrStillReferenced
+	}
+
+	return fmt.Errorf("failed to free device config: %w", freeFailure(cErr, errno))
+}
+
+// freeFailure reads the C error of a failed free, falling back to the
+// errno when the free reported none.
+func freeFailure(cErr unsafe.Pointer, errno error) error {
+	if err := cerrors.FromC(cErr); err != nil {
+		return err
+	}
+	return errno
 }
 
 // MaxDeviceNameLen is the size of the C-side device name buffer, including

--- a/controlplane/ffi/free_test.go
+++ b/controlplane/ffi/free_test.go
@@ -1,0 +1,93 @@
+package ffi_test
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+var errInjectedFree = errors.New("injected free failure")
+
+// fakeObject returns a pointer the wrappers may cast to their C config
+// types without the race detector's pointer checks objecting, since the
+// fake free never dereferences it.
+func fakeObject() unsafe.Pointer {
+	block := make([]byte, 1<<16)
+	return unsafe.Pointer(&block[0])
+}
+
+// freeOutcome scripts what the typed free reports and counts the calls
+// that reached it.
+//
+// It never hands back a C error chain, which only a cgo package can
+// allocate, so the path that reads and releases one is not pinned here.
+type freeOutcome struct {
+	rc    int
+	errno error
+	calls int
+}
+
+func (m *freeOutcome) free(unsafe.Pointer) (int, unsafe.Pointer, error) {
+	m.calls++
+	return m.rc, nil, m.errno
+}
+
+// Test_ModuleConfig_Free_SuccessForgetsPointer verifies that a successful
+// free clears the handle, so a repeated free is a no-op that never reaches
+// the typed free again.
+func Test_ModuleConfig_Free_SuccessForgetsPointer(t *testing.T) {
+	handle := ffi.NewModuleConfig(fakeObject())
+	outcome := &freeOutcome{}
+
+	require.NoError(t, handle.Free(outcome.free))
+	require.Nil(t, handle.AsRawPtr())
+
+	require.NoError(t, handle.Free(outcome.free))
+	require.Equal(t, 1, outcome.calls)
+}
+
+// Test_ModuleConfig_Free_RefusedKeepsHandle verifies that a refused free
+// reports still-referenced and keeps the handle, so a retry reaches the
+// typed free again.
+func Test_ModuleConfig_Free_RefusedKeepsHandle(t *testing.T) {
+	handle := ffi.NewModuleConfig(fakeObject())
+	outcome := &freeOutcome{rc: -1, errno: syscall.EAGAIN}
+
+	require.ErrorIs(t, handle.Free(outcome.free), ffi.ErrStillReferenced)
+	require.NotNil(t, handle.AsRawPtr())
+
+	outcome.rc, outcome.errno = 0, nil
+	require.NoError(t, handle.Free(outcome.free))
+	require.Equal(t, 2, outcome.calls)
+}
+
+// Test_ModuleConfig_Free_FailureKeepsHandle verifies that any other
+// failure is reported with its cause and keeps the handle.
+func Test_ModuleConfig_Free_FailureKeepsHandle(t *testing.T) {
+	handle := ffi.NewModuleConfig(fakeObject())
+	outcome := &freeOutcome{rc: -1, errno: errInjectedFree}
+
+	err := handle.Free(outcome.free)
+	require.ErrorIs(t, err, errInjectedFree)
+	require.NotErrorIs(t, err, ffi.ErrStillReferenced)
+	require.NotNil(t, handle.AsRawPtr())
+}
+
+// Test_ShmDeviceConfig_Free_RefusedKeepsHandle verifies that a device
+// handle follows the same refusal contract as a module handle.
+func Test_ShmDeviceConfig_Free_RefusedKeepsHandle(t *testing.T) {
+	handle := ffi.NewShmDeviceConfig(fakeObject())
+	outcome := &freeOutcome{rc: -1, errno: syscall.EAGAIN}
+
+	require.ErrorIs(t, handle.Free(outcome.free), ffi.ErrStillReferenced)
+	require.NotNil(t, handle.AsRawPtr())
+
+	outcome.rc, outcome.errno = 0, nil
+	require.NoError(t, handle.Free(outcome.free))
+	require.Nil(t, handle.AsRawPtr())
+}

--- a/devices/plain/controlplane/ffi.go
+++ b/devices/plain/controlplane/ffi.go
@@ -10,9 +10,7 @@ package plain
 import "C"
 
 import (
-	"errors"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -83,39 +81,19 @@ func NewDeviceConfig(
 	}, nil
 }
 
-func (m *DeviceConfig) asRawPtr() *C.struct_cp_device {
-	return (*C.struct_cp_device)(m.ptr.AsRawPtr())
-}
-
 // AsFFIDevice returns the module configuration as an FFI module
 func (m *DeviceConfig) AsFFIDevice() ffi.ShmDeviceConfig {
 	return m.ptr
 }
 
-// Free destroys the plain device when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the device, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *DeviceConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.cp_device_plain_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ShmDeviceConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free plain device: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.cp_device_plain_free((*C.struct_cp_device)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }
 
 // UpdateDevices creates one plain device per configuration and

--- a/devices/trafgen/bindings/go/ctrafgen/cgo.go
+++ b/devices/trafgen/bindings/go/ctrafgen/cgo.go
@@ -9,9 +9,7 @@ package ctrafgen
 import "C"
 
 import (
-	"errors"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -121,30 +119,14 @@ func (m *DeviceConfig) AsFFIDevice() ffi.ShmDeviceConfig {
 	return m.ptr
 }
 
-// Free destroys the trafgen device when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the device, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *DeviceConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.cp_device_trafgen_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ShmDeviceConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free trafgen device: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.cp_device_trafgen_free((*C.struct_cp_device)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }
 
 // setRate sets the target aggregate packet rate in packets per second.

--- a/devices/vlan/controlplane/ffi.go
+++ b/devices/vlan/controlplane/ffi.go
@@ -10,9 +10,7 @@ package vlan
 import "C"
 
 import (
-	"errors"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -106,37 +104,17 @@ func LookupVlan(agent *ffi.Agent, name string) (uint16, error) {
 	return uint16(cVlan), nil
 }
 
-func (m *DeviceConfig) asRawPtr() *C.struct_cp_device {
-	return (*C.struct_cp_device)(m.ptr.AsRawPtr())
-}
-
 // AsFFIDevice returns the module configuration as an FFI module
 func (m *DeviceConfig) AsFFIDevice() ffi.ShmDeviceConfig {
 	return m.ptr
 }
 
-// Free destroys the vlan device when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the device, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *DeviceConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.cp_device_vlan_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ShmDeviceConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free vlan device: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.cp_device_vlan_free((*C.struct_cp_device)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }

--- a/modules/acl/bindings/go/cacl/cgo.go
+++ b/modules/acl/bindings/go/cacl/cgo.go
@@ -11,10 +11,8 @@ package cacl
 import "C"
 
 import (
-	"errors"
 	"fmt"
 	"runtime"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -98,28 +96,12 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free destroys the module config when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.acl_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.acl_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }

--- a/modules/blackhole/bindings/go/cblackhole/bindings.go
+++ b/modules/blackhole/bindings/go/cblackhole/bindings.go
@@ -9,9 +9,7 @@ package cblackhole
 import "C"
 
 import (
-	"errors"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -43,37 +41,17 @@ func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 	}, nil
 }
 
-func (m *ModuleConfig) asRawPtr() *C.struct_cp_module {
-	return (*C.struct_cp_module)(m.ptr.AsRawPtr())
-}
-
 // AsFFIModule returns the underlying common module config handle.
 func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free destroys the module config when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.blackhole_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.blackhole_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }

--- a/modules/decap/bindings/go/cdecap/cgo.go
+++ b/modules/decap/bindings/go/cdecap/cgo.go
@@ -8,9 +8,7 @@ package cdecap
 import "C"
 
 import (
-	"errors"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -48,30 +46,14 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free destroys the module config when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.decap_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.decap_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }
 
 // addPrefixV4 maps 1:1 to decap_module_config_add_prefix_v4.

--- a/modules/dscp/bindings/go/cdscp/cgo.go
+++ b/modules/dscp/bindings/go/cdscp/cgo.go
@@ -8,9 +8,7 @@ package cdscp
 import "C"
 
 import (
-	"errors"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -44,30 +42,14 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free destroys the module config when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.dscp_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.dscp_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }
 
 func (m *ModuleConfig) prefixAdd4(addrStart [4]byte, addrEnd [4]byte) error {

--- a/modules/forward/bindings/go/cforward/cgo.go
+++ b/modules/forward/bindings/go/cforward/cgo.go
@@ -9,9 +9,7 @@ package cforward
 import "C"
 
 import (
-	"errors"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -49,30 +47,14 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free destroys the module config when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.forward_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.forward_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }
 
 // update maps 1:1 to forward_module_config_update.

--- a/modules/fwstate/bindings/go/cfwstate/cgo.go
+++ b/modules/fwstate/bindings/go/cfwstate/cgo.go
@@ -17,9 +17,7 @@ package cfwstate
 import "C"
 
 import (
-	"errors"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -108,28 +106,12 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free destroys the module config when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.fwstate_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.fwstate_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }

--- a/modules/mirror/bindings/go/cmirror/cgo.go
+++ b/modules/mirror/bindings/go/cmirror/cgo.go
@@ -9,9 +9,7 @@ package cmirror
 import "C"
 
 import (
-	"errors"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -49,30 +47,14 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free destroys the module config when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.mirror_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.mirror_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }
 
 // update maps 1:1 to mirror_module_config_update.

--- a/modules/nat64/bindings/go/cnat64/cgo.go
+++ b/modules/nat64/bindings/go/cnat64/cgo.go
@@ -9,9 +9,7 @@ package cnat64
 import "C"
 
 import (
-	"errors"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -52,30 +50,14 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free destroys the module config when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.nat64_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.nat64_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }
 
 // addMapping maps 1:1 to nat64_module_config_add_mapping.

--- a/modules/pdump/controlplane/ffi.go
+++ b/modules/pdump/controlplane/ffi.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"runtime/cgo"
 	"strings"
-	"syscall"
 	"unsafe"
 
 	"go.uber.org/zap"
@@ -156,30 +155,14 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free destroys the module config when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.pdump_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.pdump_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }
 
 func (m *ModuleConfig) SetFilter(filter string) error {

--- a/modules/route-mpls/bindings/go/croutempls/cgo.go
+++ b/modules/route-mpls/bindings/go/croutempls/cgo.go
@@ -23,10 +23,8 @@ package croutempls
 import "C"
 
 import (
-	"errors"
 	"fmt"
 	"runtime"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -65,30 +63,14 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free destroys the module config when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.route_mpls_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.route_mpls_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }
 
 // Update marshals rules into C structs and calls route_mpls_module_config_update.

--- a/modules/route/bindings/go/croute/cgo.go
+++ b/modules/route/bindings/go/croute/cgo.go
@@ -9,11 +9,9 @@ package croute
 import "C"
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"net/netip"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -55,30 +53,14 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free destroys the module config when it is dangling — referenced by no live
-// configuration generation — and reports nil. While a live generation
-// still references it the free is refused with ffi.ErrStillReferenced
-// and the handle stays usable: the caller must remember it and free it
-// again once the generations holding it drain. Safe to call multiple
-// times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-	var cErr *C.yanet_error
-	rc, errno := C.route_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		// The refused attempt allocated an error chain; release it
-		// rather than leaking one per attempt. The object is intact.
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-	return fmt.Errorf("failed to free module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.route_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }
 
 // addRoute maps 1:1 to route_module_config_add_route.

--- a/modules/unrdup/bindings/go/cunrdup/cgo.go
+++ b/modules/unrdup/bindings/go/cunrdup/cgo.go
@@ -9,9 +9,7 @@ package cunrdup
 import "C"
 
 import (
-	"errors"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -45,32 +43,14 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free releases the module config unless the dataplane still references it.
-//
-// A refused attempt reports ErrStillReferenced and leaves the object intact,
-// so it can be retried once the generations holding it drain. Safe to call
-// multiple times: subsequent calls are no-ops reporting nil.
+// Free destroys the module config, or reports ffi.ErrStillReferenced while a
+// live generation still holds it. Safe to call multiple times.
 func (m *ModuleConfig) Free() error {
-	ptr := m.asRawPtr()
-	if ptr == nil {
-		return nil
-	}
-
-	var cErr *C.yanet_error
-	rc, errno := C.unrdup_module_config_free(ptr, &cErr)
-	if rc == 0 {
-		m.ptr = ffi.ModuleConfig{}
-		return nil
-	}
-	if errors.Is(errno, syscall.EAGAIN) {
-		C.yanet_error_free(cErr)
-		return ffi.ErrStillReferenced
-	}
-
-	return fmt.Errorf(
-		"failed to free module config: %w",
-		cerrors.FromC(unsafe.Pointer(cErr)),
-	)
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.unrdup_module_config_free((*C.struct_cp_module)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
 }
 
 func (m *ModuleConfig) setSource(family C.enum_ip_family, addr *C.uint8_t, mask *C.uint8_t) error {


### PR DESCRIPTION
- Let the ffi module and device wrappers run the typed free of their owner through a callback and classify the outcome, so the refusal contract lives in one place.
- Reduce every module and device binding's free to its own C call, which also drops the device type from a failed device free's message.
- Leave the fwstate map object handle as is, since it wraps a shared object rather than a module or device config.
