### PR TITLE
feat(route,dataplane): add the fib as a shared object

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -595,7 +595,7 @@ dataplane_init(
 		}
 
 		static const char *objects[] = {
-			"fwstate_map_v4", "fwstate_map_v6"
+			"fwstate_map_v4", "fwstate_map_v6", "route_fib"
 		};
 		for (size_t i = 0; i < sizeof(objects) / sizeof(objects[0]);
 		     ++i) {

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -1,24 +1,18 @@
 #include "controlplane.h"
 
 #include "config.h"
+#include "fib.h"
+
+#include <stdlib.h>
+#include <string.h>
 
 #include "common/container_of.h"
-#include "common/exp_array.h"
-#include "common/lpm.h"
 
 #include "lib/controlplane/agent/agent.h"
 
-enum fib_iter_phase {
-	fib_iter_phase_start = 0,
-	fib_iter_phase_ipv4 = 4,
-	fib_iter_phase_ipv6 = 6,
-	fib_iter_phase_done = 0xff,
-};
-
 struct fib_iter {
 	struct route_module_config *config;
-	struct lpm_iter lpm_it;
-	enum fib_iter_phase phase;
+	struct route_fib_iter it;
 };
 
 int
@@ -146,54 +140,12 @@ route_module_config_data_init(
 	struct route_module_config *config,
 	struct memory_context *memory_context
 ) {
-	if (lpm_init(&config->lpm_v4, memory_context, "lpm_v4")) {
-		return -1;
-	}
-	if (lpm_init(&config->lpm_v6, memory_context, "lpm_v6")) {
-		lpm_free(&config->lpm_v4);
-		return -1;
-	}
-
-	config->route_count = 0;
-	config->routes = NULL;
-
-	config->route_list_count = 0;
-	config->route_lists = NULL;
-
-	config->route_index_count = 0;
-	config->route_indexes = NULL;
-
-	return 0;
+	return route_fib_init(&config->fib, memory_context);
 }
 
 void
 route_module_config_data_fini(struct route_module_config *config) {
-	struct route *routes = ADDR_OF(&config->routes);
-	mem_array_free_exp(
-		&config->cp_module.memory_context,
-		routes,
-		sizeof(*routes),
-		config->route_count
-	);
-
-	struct route_list *route_lists = ADDR_OF(&config->route_lists);
-	mem_array_free_exp(
-		&config->cp_module.memory_context,
-		route_lists,
-		sizeof(*route_lists),
-		config->route_list_count
-	);
-
-	uint64_t *route_indexes = ADDR_OF(&config->route_indexes);
-	mem_array_free_exp(
-		&config->cp_module.memory_context,
-		route_indexes,
-		sizeof(*route_indexes),
-		config->route_index_count
-	);
-
-	lpm_free(&config->lpm_v6);
-	lpm_free(&config->lpm_v4);
+	route_fib_fini(&config->fib, &config->cp_module.memory_context);
 }
 
 static void
@@ -235,7 +187,6 @@ route_module_config_add_route(
 ) {
 	struct route_module_config *config =
 		container_of(cp_module, struct route_module_config, cp_module);
-	struct route *routes = ADDR_OF(&config->routes);
 
 	uint64_t device_index;
 	if (cp_module_link_device(cp_module, device_name, &device_index, err)) {
@@ -271,24 +222,14 @@ route_module_config_add_route(
 		}
 	}
 
-	if (mem_array_expand_exp(
-		    &config->cp_module.memory_context,
-		    (void **)&routes,
-		    sizeof(*routes),
-		    &config->route_count
-	    )) {
-		return -1;
-	}
-
-	routes[config->route_count - 1] = (struct route){
-		.dst_addr = dst_addr,
-		.src_addr = src_addr,
-		.device_id = device_index,
-		.counter_id = counter_id,
-	};
-	SET_OFFSET_OF(&config->routes, routes);
-
-	return config->route_count - 1;
+	return route_fib_add_route(
+		&config->fib,
+		&config->cp_module.memory_context,
+		dst_addr,
+		src_addr,
+		device_index,
+		counter_id
+	);
 }
 
 int
@@ -297,53 +238,9 @@ route_module_config_add_route_list(
 ) {
 	struct route_module_config *config =
 		container_of(cp_module, struct route_module_config, cp_module);
-
-	uint64_t start = config->route_index_count;
-
-	uint64_t *route_indexes = ADDR_OF(&config->route_indexes);
-
-	for (size_t idx = 0; idx < count; ++idx) {
-		/*
-		 * FIXME: if there are huge loads of route indexes then
-		 * the loop may be inefficient. However, I do not expect
-		 * more than 10 route indexes typically - so I let it
-		 * out of scope now.
-		 */
-		if (mem_array_expand_exp(
-			    &config->cp_module.memory_context,
-			    (void **)&route_indexes,
-			    sizeof(*route_indexes),
-			    &config->route_index_count
-		    )) {
-			return -1;
-		}
-		route_indexes[config->route_index_count - 1] = indexes[idx];
-
-		/*
-		 * route_indexes may be relocated so save the new value
-		 * as I do no want to have the config be completelly
-		 * broken.
-		 */
-		SET_OFFSET_OF(&config->route_indexes, route_indexes);
-	}
-
-	struct route_list *route_lists = ADDR_OF(&config->route_lists);
-	if (mem_array_expand_exp(
-		    &config->cp_module.memory_context,
-		    (void **)&route_lists,
-		    sizeof(*route_lists),
-		    &config->route_list_count
-	    )) {
-		return -1;
-	}
-	route_lists[config->route_list_count - 1] = (struct route_list){
-		.start = start,
-		.count = count,
-	};
-
-	SET_OFFSET_OF(&config->route_lists, route_lists);
-
-	return config->route_list_count - 1;
+	return route_fib_add_route_list(
+		&config->fib, &config->cp_module.memory_context, count, indexes
+	);
 }
 
 int
@@ -355,7 +252,9 @@ route_module_config_add_prefix_v4(
 ) {
 	struct route_module_config *config =
 		container_of(cp_module, struct route_module_config, cp_module);
-	return lpm_insert(&config->lpm_v4, 4, from, to, route_list_index);
+	return route_fib_add_prefix_v4(
+		&config->fib, from, to, route_list_index
+	);
 }
 
 int
@@ -367,47 +266,30 @@ route_module_config_add_prefix_v6(
 ) {
 	struct route_module_config *config =
 		container_of(cp_module, struct route_module_config, cp_module);
-	return lpm_insert(&config->lpm_v6, 16, from, to, route_list_index);
-}
-
-// Counts the LPM ranges over the whole key space of the given tree.
-static uint64_t
-route_lpm_range_count(const struct lpm *lpm, uint8_t key_size) {
-	uint8_t from[LPM_KEY_SIZE_MAX];
-	uint8_t to[LPM_KEY_SIZE_MAX];
-	memset(from, 0x00, key_size);
-	memset(to, 0xff, key_size);
-
-	struct lpm_iter it;
-	lpm_iter_init(&it, lpm, key_size, from, to);
-
-	uint64_t count = 0;
-	while (lpm_iter_next(&it)) {
-		++count;
-	}
-
-	return count;
+	return route_fib_add_prefix_v6(
+		&config->fib, from, to, route_list_index
+	);
 }
 
 uint64_t
 route_module_config_route_count(struct cp_module *cp_module) {
 	struct route_module_config *config =
 		container_of(cp_module, struct route_module_config, cp_module);
-	return config->route_count;
+	return config->fib.route_count;
 }
 
 uint64_t
 route_module_config_fib_range_count_v4(struct cp_module *cp_module) {
 	struct route_module_config *config =
 		container_of(cp_module, struct route_module_config, cp_module);
-	return route_lpm_range_count(&config->lpm_v4, 4);
+	return route_fib_range_count_v4(&config->fib);
 }
 
 uint64_t
 route_module_config_fib_range_count_v6(struct cp_module *cp_module) {
 	struct route_module_config *config =
 		container_of(cp_module, struct route_module_config, cp_module);
-	return route_lpm_range_count(&config->lpm_v6, 16);
+	return route_fib_range_count_v6(&config->fib);
 }
 
 struct fib_iter *
@@ -418,6 +300,7 @@ fib_iter_new(struct cp_module *cp_module) {
 	}
 	it->config =
 		container_of(cp_module, struct route_module_config, cp_module);
+	route_fib_iter_init(&it->it, &it->config->fib);
 	return it;
 }
 
@@ -428,92 +311,39 @@ fib_iter_free(struct fib_iter *it) {
 
 bool
 fib_iter_next(struct fib_iter *it) {
-	if (it->phase == fib_iter_phase_done) {
-		return false;
-	}
-
-	// Start or continue IPv4 walk.
-	if (it->phase == fib_iter_phase_start) {
-		uint8_t from[4] = {0, 0, 0, 0};
-		uint8_t to[4] = {0xff, 0xff, 0xff, 0xff};
-		lpm_iter_init(&it->lpm_it, &it->config->lpm_v4, 4, from, to);
-		it->phase = fib_iter_phase_ipv4;
-	}
-
-	if (it->phase == fib_iter_phase_ipv4) {
-		if (lpm_iter_next(&it->lpm_it)) {
-			return true;
-		}
-
-		// IPv4 exhausted, start IPv6.
-		uint8_t from[16];
-		uint8_t to[16];
-		memset(from, 0x00, 16);
-		memset(to, 0xff, 16);
-		lpm_iter_init(&it->lpm_it, &it->config->lpm_v6, 16, from, to);
-		it->phase = fib_iter_phase_ipv6;
-	}
-
-	if (it->phase == fib_iter_phase_ipv6) {
-		if (lpm_iter_next(&it->lpm_it)) {
-			return true;
-		}
-
-		it->phase = fib_iter_phase_done;
-	}
-
-	return false;
+	return route_fib_iter_next(&it->it);
 }
 
 uint8_t
 fib_iter_address_family(const struct fib_iter *it) {
-	return it->phase;
+	return route_fib_iter_address_family(&it->it);
 }
 
 const uint8_t *
 fib_iter_prefix_from(const struct fib_iter *it) {
-	return it->lpm_it.cur_from;
+	return route_fib_iter_prefix_from(&it->it);
 }
 
 const uint8_t *
 fib_iter_prefix_to(const struct fib_iter *it) {
-	return it->lpm_it.cur_to;
+	return route_fib_iter_prefix_to(&it->it);
 }
 
 uint64_t
 fib_iter_nexthop_count(const struct fib_iter *it) {
-	uint32_t rli = it->lpm_it.cur_value;
-	struct route_module_config *config = it->config;
-	if (rli >= config->route_list_count) {
-		return 0;
-	}
-	struct route_list *rls = ADDR_OF(&config->route_lists);
-	return rls[rli].count;
+	return route_fib_nexthop_count(
+		&it->config->fib, route_fib_iter_route_list_id(&it->it)
+	);
 }
 
 // Resolves the route for the i-th nexthop of the current entry.
 static const struct route *
 fib_iter_resolve_route(const struct fib_iter *it, uint64_t nexthop_idx) {
-	uint32_t rli = it->lpm_it.cur_value;
-	struct route_module_config *config = it->config;
-	if (rli >= config->route_list_count) {
-		return NULL;
-	}
-
-	struct route_list *rls = ADDR_OF(&config->route_lists);
-	struct route_list *rl = &rls[rli];
-	if (nexthop_idx >= rl->count) {
-		return NULL;
-	}
-
-	uint64_t *route_indexes = ADDR_OF(&config->route_indexes);
-	uint64_t route_idx = route_indexes[rl->start + nexthop_idx];
-	if (route_idx >= config->route_count) {
-		return NULL;
-	}
-
-	struct route *routes = ADDR_OF(&config->routes);
-	return &routes[route_idx];
+	return route_fib_resolve_route(
+		&it->config->fib,
+		route_fib_iter_route_list_id(&it->it),
+		nexthop_idx
+	);
 }
 
 void

--- a/modules/route/api/controlplane.h
+++ b/modules/route/api/controlplane.h
@@ -40,6 +40,10 @@ route_module_config_data_init(
 	struct memory_context *memory_context
 );
 
+// Releases the table set up by route_module_config_data_init.
+void
+route_module_config_data_fini(struct route_module_config *config);
+
 // Registers the module-level counters and records their ids in the config.
 //
 // The counter registry must already be initialized. Callers that build a

--- a/modules/route/api/fib.c
+++ b/modules/route/api/fib.c
@@ -1,0 +1,282 @@
+#include "fib.h"
+
+#include <string.h>
+
+#include "common/exp_array.h"
+#include "common/memory_address.h"
+
+int
+route_fib_init(struct route_fib *fib, struct memory_context *memory_context) {
+	if (lpm_init(&fib->lpm_v4, memory_context, "lpm_v4")) {
+		return -1;
+	}
+	if (lpm_init(&fib->lpm_v6, memory_context, "lpm_v6")) {
+		lpm_free(&fib->lpm_v4);
+		return -1;
+	}
+
+	fib->route_count = 0;
+	fib->routes = NULL;
+
+	fib->route_list_count = 0;
+	fib->route_lists = NULL;
+
+	fib->route_index_count = 0;
+	fib->route_indexes = NULL;
+
+	return 0;
+}
+
+void
+route_fib_fini(struct route_fib *fib, struct memory_context *memory_context) {
+	struct route *routes = ADDR_OF(&fib->routes);
+	mem_array_free_exp(
+		memory_context, routes, sizeof(*routes), fib->route_count
+	);
+
+	struct route_list *route_lists = ADDR_OF(&fib->route_lists);
+	mem_array_free_exp(
+		memory_context,
+		route_lists,
+		sizeof(*route_lists),
+		fib->route_list_count
+	);
+
+	uint64_t *route_indexes = ADDR_OF(&fib->route_indexes);
+	mem_array_free_exp(
+		memory_context,
+		route_indexes,
+		sizeof(*route_indexes),
+		fib->route_index_count
+	);
+
+	lpm_free(&fib->lpm_v6);
+	lpm_free(&fib->lpm_v4);
+}
+
+int
+route_fib_add_route(
+	struct route_fib *fib,
+	struct memory_context *memory_context,
+	struct ether_addr dst_addr,
+	struct ether_addr src_addr,
+	uint64_t device_index,
+	uint64_t counter_id
+) {
+	struct route *routes = ADDR_OF(&fib->routes);
+
+	if (mem_array_expand_exp(
+		    memory_context,
+		    (void **)&routes,
+		    sizeof(*routes),
+		    &fib->route_count
+	    )) {
+		return -1;
+	}
+
+	routes[fib->route_count - 1] = (struct route){
+		.dst_addr = dst_addr,
+		.src_addr = src_addr,
+		.device_id = device_index,
+		.counter_id = counter_id,
+	};
+	SET_OFFSET_OF(&fib->routes, routes);
+
+	return fib->route_count - 1;
+}
+
+int
+route_fib_add_route_list(
+	struct route_fib *fib,
+	struct memory_context *memory_context,
+	size_t count,
+	const uint32_t *indexes
+) {
+	uint64_t start = fib->route_index_count;
+
+	uint64_t *route_indexes = ADDR_OF(&fib->route_indexes);
+
+	// Grows the index array one slot per nexthop. Lists hold a handful of
+	// nexthops, so the per-slot growth has not been worth batching.
+	for (size_t idx = 0; idx < count; ++idx) {
+		if (mem_array_expand_exp(
+			    memory_context,
+			    (void **)&route_indexes,
+			    sizeof(*route_indexes),
+			    &fib->route_index_count
+		    )) {
+			return -1;
+		}
+		route_indexes[fib->route_index_count - 1] = indexes[idx];
+
+		// The array may have moved, so the table must not be left
+		// pointing at the old block even if a later step fails.
+		SET_OFFSET_OF(&fib->route_indexes, route_indexes);
+	}
+
+	struct route_list *route_lists = ADDR_OF(&fib->route_lists);
+	if (mem_array_expand_exp(
+		    memory_context,
+		    (void **)&route_lists,
+		    sizeof(*route_lists),
+		    &fib->route_list_count
+	    )) {
+		return -1;
+	}
+	route_lists[fib->route_list_count - 1] = (struct route_list){
+		.start = start,
+		.count = count,
+	};
+	SET_OFFSET_OF(&fib->route_lists, route_lists);
+
+	return fib->route_list_count - 1;
+}
+
+int
+route_fib_add_prefix_v4(
+	struct route_fib *fib,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t route_list_index
+) {
+	return lpm_insert(&fib->lpm_v4, 4, from, to, route_list_index);
+}
+
+int
+route_fib_add_prefix_v6(
+	struct route_fib *fib,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t route_list_index
+) {
+	return lpm_insert(&fib->lpm_v6, 16, from, to, route_list_index);
+}
+
+// Counts the LPM ranges over the whole key space of the given tree.
+static uint64_t
+route_lpm_range_count(const struct lpm *lpm, uint8_t key_size) {
+	uint8_t from[LPM_KEY_SIZE_MAX];
+	uint8_t to[LPM_KEY_SIZE_MAX];
+	memset(from, 0x00, key_size);
+	memset(to, 0xff, key_size);
+
+	struct lpm_iter it;
+	lpm_iter_init(&it, lpm, key_size, from, to);
+
+	uint64_t count = 0;
+	while (lpm_iter_next(&it)) {
+		++count;
+	}
+
+	return count;
+}
+
+uint64_t
+route_fib_range_count_v4(const struct route_fib *fib) {
+	return route_lpm_range_count(&fib->lpm_v4, 4);
+}
+
+uint64_t
+route_fib_range_count_v6(const struct route_fib *fib) {
+	return route_lpm_range_count(&fib->lpm_v6, 16);
+}
+
+uint64_t
+route_fib_nexthop_count(const struct route_fib *fib, uint32_t route_list_id) {
+	if (route_list_id >= fib->route_list_count) {
+		return 0;
+	}
+	struct route_list *route_lists = ADDR_OF(&fib->route_lists);
+	return route_lists[route_list_id].count;
+}
+
+const struct route *
+route_fib_resolve_route(
+	const struct route_fib *fib,
+	uint32_t route_list_id,
+	uint64_t nexthop_idx
+) {
+	if (route_list_id >= fib->route_list_count) {
+		return NULL;
+	}
+
+	struct route_list *route_lists = ADDR_OF(&fib->route_lists);
+	struct route_list *route_list = &route_lists[route_list_id];
+	if (nexthop_idx >= route_list->count) {
+		return NULL;
+	}
+
+	uint64_t *route_indexes = ADDR_OF(&fib->route_indexes);
+	uint64_t route_idx = route_indexes[route_list->start + nexthop_idx];
+	if (route_idx >= fib->route_count) {
+		return NULL;
+	}
+
+	struct route *routes = ADDR_OF(&fib->routes);
+	return &routes[route_idx];
+}
+
+void
+route_fib_iter_init(struct route_fib_iter *it, const struct route_fib *fib) {
+	memset(it, 0, sizeof(*it));
+	it->fib = fib;
+	it->phase = route_fib_iter_phase_start;
+}
+
+bool
+route_fib_iter_next(struct route_fib_iter *it) {
+	if (it->phase == route_fib_iter_phase_done) {
+		return false;
+	}
+
+	if (it->phase == route_fib_iter_phase_start) {
+		uint8_t from[4] = {0, 0, 0, 0};
+		uint8_t to[4] = {0xff, 0xff, 0xff, 0xff};
+		lpm_iter_init(&it->lpm_it, &it->fib->lpm_v4, 4, from, to);
+		it->phase = route_fib_iter_phase_ipv4;
+	}
+
+	if (it->phase == route_fib_iter_phase_ipv4) {
+		if (lpm_iter_next(&it->lpm_it)) {
+			return true;
+		}
+
+		// IPv4 exhausted, start IPv6.
+		uint8_t from[16];
+		uint8_t to[16];
+		memset(from, 0x00, 16);
+		memset(to, 0xff, 16);
+		lpm_iter_init(&it->lpm_it, &it->fib->lpm_v6, 16, from, to);
+		it->phase = route_fib_iter_phase_ipv6;
+	}
+
+	if (it->phase == route_fib_iter_phase_ipv6) {
+		if (lpm_iter_next(&it->lpm_it)) {
+			return true;
+		}
+
+		it->phase = route_fib_iter_phase_done;
+	}
+
+	return false;
+}
+
+uint8_t
+route_fib_iter_address_family(const struct route_fib_iter *it) {
+	return it->phase;
+}
+
+const uint8_t *
+route_fib_iter_prefix_from(const struct route_fib_iter *it) {
+	return it->lpm_it.cur_from;
+}
+
+const uint8_t *
+route_fib_iter_prefix_to(const struct route_fib_iter *it) {
+	return it->lpm_it.cur_to;
+}
+
+uint32_t
+route_fib_iter_route_list_id(const struct route_fib_iter *it) {
+	return it->lpm_it.cur_value;
+}

--- a/modules/route/api/fib.h
+++ b/modules/route/api/fib.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/lpm.h"
+#include "common/network.h"
+
+#include "modules/route/dataplane/fib.h"
+
+struct memory_context;
+
+// Initialize an empty table whose trees and arrays allocate from the given
+// context. On failure nothing is left allocated.
+int
+route_fib_init(struct route_fib *fib, struct memory_context *memory_context);
+
+// Release everything the table allocated from the given context.
+void
+route_fib_fini(struct route_fib *fib, struct memory_context *memory_context);
+
+// Append a nexthop and return its index, or -1 when the array cannot grow.
+//
+// The device index and counter id are stored as given: resolving a device
+// name to an index and registering a counter belong to the owner, whose
+// link table and counter registry the table does not know.
+int
+route_fib_add_route(
+	struct route_fib *fib,
+	struct memory_context *memory_context,
+	struct ether_addr dst_addr,
+	struct ether_addr src_addr,
+	uint64_t device_index,
+	uint64_t counter_id
+);
+
+// Append a route list selecting among the given nexthop indexes and return
+// its index, or -1 when an array cannot grow.
+int
+route_fib_add_route_list(
+	struct route_fib *fib,
+	struct memory_context *memory_context,
+	size_t count,
+	const uint32_t *indexes
+);
+
+// Map an inclusive IPv4 address range to a route list. Returns -1 when the
+// tree cannot grow.
+int
+route_fib_add_prefix_v4(
+	struct route_fib *fib,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t route_list_index
+);
+
+// Map an inclusive IPv6 address range to a route list. Returns -1 when the
+// tree cannot grow.
+int
+route_fib_add_prefix_v6(
+	struct route_fib *fib,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t route_list_index
+);
+
+// Count the IPv4 ranges a walk of the table would yield, without
+// materializing them.
+uint64_t
+route_fib_range_count_v4(const struct route_fib *fib);
+
+// Count the IPv6 ranges a walk of the table would yield, without
+// materializing them.
+uint64_t
+route_fib_range_count_v6(const struct route_fib *fib);
+
+// Return the number of nexthops of a route list, or 0 for an index the
+// table does not hold.
+uint64_t
+route_fib_nexthop_count(const struct route_fib *fib, uint32_t route_list_id);
+
+// Return the i-th nexthop of a route list, or NULL when either index is out
+// of range.
+const struct route *
+route_fib_resolve_route(
+	const struct route_fib *fib,
+	uint32_t route_list_id,
+	uint64_t nexthop_idx
+);
+
+enum route_fib_iter_phase {
+	route_fib_iter_phase_start = 0,
+	route_fib_iter_phase_ipv4 = 4,
+	route_fib_iter_phase_ipv6 = 6,
+	route_fib_iter_phase_done = 0xff,
+};
+
+// Zero-copy walk over the ranges of both trees, IPv4 first, reading them
+// in place from shared memory.
+struct route_fib_iter {
+	const struct route_fib *fib;
+	struct lpm_iter lpm_it;
+	enum route_fib_iter_phase phase;
+};
+
+void
+route_fib_iter_init(struct route_fib_iter *it, const struct route_fib *fib);
+
+// Advance to the next range. Returns false once both trees are exhausted.
+bool
+route_fib_iter_next(struct route_fib_iter *it);
+
+// Address family of the current range: 4 or 6.
+uint8_t
+route_fib_iter_address_family(const struct route_fib_iter *it);
+
+// Start of the current range, 4 or 16 bytes.
+const uint8_t *
+route_fib_iter_prefix_from(const struct route_fib_iter *it);
+
+// End of the current range, 4 or 16 bytes.
+const uint8_t *
+route_fib_iter_prefix_to(const struct route_fib_iter *it);
+
+uint32_t
+route_fib_iter_route_list_id(const struct route_fib_iter *it);

--- a/modules/route/api/fib_object.c
+++ b/modules/route/api/fib_object.c
@@ -1,0 +1,177 @@
+#include "fib_object.h"
+
+#include "fib.h"
+
+#include "common/container_of.h"
+#include "common/memory_address.h"
+
+#include "lib/controlplane/agent/agent.h"
+#include "lib/counters/counters.h"
+
+static struct route_fib_object *
+route_fib_object_of(struct cp_object *cp_object) {
+	return container_of(cp_object, struct route_fib_object, cp_object);
+}
+
+static void
+route_fib_object_destroy(struct cp_object *cp_object) {
+	struct route_fib_object *self = route_fib_object_of(cp_object);
+	struct agent *agent = ADDR_OF(&cp_object->agent);
+
+	route_fib_fini(&self->fib, &cp_object->memory_context);
+	cp_object_fini(cp_object);
+
+	memory_bfree(
+		&agent->memory_context, self, sizeof(struct route_fib_object)
+	);
+}
+
+struct cp_object *
+route_fib_object_new(struct agent *agent, const char *name, yanet_error **err) {
+	struct route_fib_object *self =
+		(struct route_fib_object *)memory_balloc(
+			&agent->memory_context, sizeof(struct route_fib_object)
+		);
+	if (self == NULL) {
+		yanet_error_add(err, "failed to allocate route fib object");
+		return NULL;
+	}
+
+	if (cp_object_init(
+		    &self->cp_object, agent, ROUTE_FIB_OBJECT_TYPE, name, err
+	    )) {
+		yanet_error_add(err, "failed to init route fib object");
+		memory_bfree(
+			&agent->memory_context,
+			self,
+			sizeof(struct route_fib_object)
+		);
+		return NULL;
+	}
+
+	if (route_fib_init(&self->fib, &self->cp_object.memory_context)) {
+		yanet_error_add(err, "failed to init route fib object data");
+		// A failed table setup never reaches a state its own teardown
+		// could walk, and nothing has observed the object yet, so the
+		// block is released directly.
+		cp_object_fini(&self->cp_object);
+		memory_bfree(
+			&agent->memory_context,
+			self,
+			sizeof(struct route_fib_object)
+		);
+		return NULL;
+	}
+
+	return &self->cp_object;
+}
+
+int
+route_fib_object_free(struct cp_object *cp_object, yanet_error **err) {
+	if (cp_object_try_destroy(cp_object, err)) {
+		return -1;
+	}
+
+	route_fib_object_destroy(cp_object);
+	return 0;
+}
+
+int
+route_fib_object_add_route(
+	struct cp_object *cp_object,
+	struct ether_addr dst_addr,
+	struct ether_addr src_addr,
+	uint64_t device_index,
+	const char *counter_name,
+	yanet_error **err
+) {
+	struct route_fib_object *self = route_fib_object_of(cp_object);
+
+	// The counter registers before the append, so a failed call leaves
+	// the table unchanged and at most a counter name nothing references.
+	uint64_t counter_id = COUNTER_INVALID;
+	if (counter_name != NULL && counter_name[0] != '\0') {
+		counter_id = counter_registry_register(
+			&cp_object->link_counter_registry, counter_name, 2, err
+		);
+		if (counter_id == COUNTER_INVALID) {
+			yanet_error_add(
+				err,
+				"failed to register counter '%s'",
+				counter_name
+			);
+			return -1;
+		}
+	}
+
+	int route_idx = route_fib_add_route(
+		&self->fib,
+		&cp_object->memory_context,
+		dst_addr,
+		src_addr,
+		device_index,
+		counter_id
+	);
+	if (route_idx == -1) {
+		yanet_error_add(
+			err,
+			"failed to grow the nexthop table of object '%s'",
+			cp_object->name
+		);
+		return -1;
+	}
+
+	return route_idx;
+}
+
+int
+route_fib_object_add_route_list(
+	struct cp_object *cp_object, size_t count, const uint32_t *indexes
+) {
+	struct route_fib_object *self = route_fib_object_of(cp_object);
+	return route_fib_add_route_list(
+		&self->fib, &cp_object->memory_context, count, indexes
+	);
+}
+
+int
+route_fib_object_add_prefix_v4(
+	struct cp_object *cp_object,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t route_list_index
+) {
+	struct route_fib_object *self = route_fib_object_of(cp_object);
+	return route_fib_add_prefix_v4(&self->fib, from, to, route_list_index);
+}
+
+int
+route_fib_object_add_prefix_v6(
+	struct cp_object *cp_object,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t route_list_index
+) {
+	struct route_fib_object *self = route_fib_object_of(cp_object);
+	return route_fib_add_prefix_v6(&self->fib, from, to, route_list_index);
+}
+
+const struct route_fib *
+route_fib_object_fib(const struct cp_object *cp_object) {
+	const struct route_fib_object *self = container_of(
+		cp_object, const struct route_fib_object, cp_object
+	);
+	return &self->fib;
+}
+
+const char *
+route_fib_object_counter_name(
+	const struct cp_object *cp_object, uint64_t counter_id
+) {
+	const struct counter_registry *registry =
+		&cp_object->link_counter_registry;
+	if (counter_id == COUNTER_INVALID || counter_id >= registry->count) {
+		return "";
+	}
+	return ADDR_OF(&registry->names)[counter_id].name;
+}

--- a/modules/route/api/fib_object.h
+++ b/modules/route/api/fib_object.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/network.h"
+
+#include "lib/errors/errors.h"
+
+#include "modules/route/dataplane/fib.h"
+
+struct agent;
+struct cp_object;
+
+// Allocate an empty FIB object registered under the FIB type and the given
+// name once published. The object starts dangling, owned by the caller.
+struct cp_object *
+route_fib_object_new(struct agent *agent, const char *name, yanet_error **err);
+
+// Destroy the object when it is dangling, per cp_object_try_destroy.
+//
+// Returns -1 with errno EAGAIN while a live generation still references
+// the object; the caller must keep its handle and retry later.
+int
+route_fib_object_free(struct cp_object *cp_object, yanet_error **err);
+
+// Append a nexthop and return its index, or -1 on failure.
+//
+// The device index is stored as given and resolves through the device
+// links of the module that runs the table, so keeping it within that
+// module's link table is the caller's contract. A NULL or empty counter
+// name leaves the nexthop uncounted, otherwise it names a packet/byte
+// counter registered in the object's link counter registry, so each
+// linking module counts through its own per-worker storage.
+int
+route_fib_object_add_route(
+	struct cp_object *cp_object,
+	struct ether_addr dst_addr,
+	struct ether_addr src_addr,
+	uint64_t device_index,
+	const char *counter_name,
+	yanet_error **err
+);
+
+int
+route_fib_object_add_route_list(
+	struct cp_object *cp_object, size_t count, const uint32_t *indexes
+);
+
+int
+route_fib_object_add_prefix_v4(
+	struct cp_object *cp_object,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t route_list_index
+);
+
+int
+route_fib_object_add_prefix_v6(
+	struct cp_object *cp_object,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t route_list_index
+);
+
+// The table behind the object, for walks and lookups.
+const struct route_fib *
+route_fib_object_fib(const struct cp_object *cp_object);
+
+// Name of a nexthop counter registered on the object, or an empty string
+// for an uncounted nexthop or an id the registry does not hold.
+const char *
+route_fib_object_counter_name(
+	const struct cp_object *cp_object, uint64_t counter_id
+);

--- a/modules/route/api/meson.build
+++ b/modules/route/api/meson.build
@@ -9,6 +9,8 @@ includes = include_directories('../dataplane')
 
 sources = files(
   'controlplane.c',
+  'fib.c',
+  'fib_object.c',
 )
 
 lib_route_cp = static_library(

--- a/modules/route/dataplane/config.h
+++ b/modules/route/dataplane/config.h
@@ -1,28 +1,8 @@
 #pragma once
 
-#include "common/lpm.h"
-#include "common/network.h"
-
 #include "lib/controlplane/config/zone.h"
 
-struct route {
-	/*
-	 * Assuming this is only about directly routed networks there
-	 * is nothing to handle except the neighbour ethernet address.
-	 */
-	struct ether_addr dst_addr;
-	struct ether_addr src_addr;
-	uint64_t device_id;
-
-	// Per-nexthop packet/byte counter, or COUNTER_INVALID if this
-	// nexthop is not individually counted.
-	uint64_t counter_id;
-};
-
-struct route_list {
-	uint64_t start;
-	uint64_t count;
-};
+#include "fib.h"
 
 // Counter ids of a single address family.
 //
@@ -47,20 +27,7 @@ struct route_family_counter_ids {
 struct route_module_config {
 	struct cp_module cp_module;
 
-	struct lpm lpm_v6;
-	struct lpm lpm_v4;
-
-	// All known good routes
-	uint64_t route_count;
-	struct route *routes;
-
-	// List of route indexes applicable for some destination
-	uint64_t route_list_count;
-	struct route_list *route_lists;
-
-	// Route indexes storage
-	uint64_t route_index_count;
-	uint64_t *route_indexes;
+	struct route_fib fib;
 
 	// Module-level counters, registered by route_module_config_new
 	struct route_family_counter_ids counters_v4;

--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -13,6 +13,7 @@
 
 #include "lib/dataplane/module/module.h"
 #include "lib/dataplane/module/packet_front.h"
+#include "lib/dataplane/object/object.h"
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/packet/packet.h"
 #include "lib/dataplane/pipeline/econtext.h"
@@ -72,7 +73,7 @@ route_handle_v4(
 
 	// Past the TTL check a miss is the only remaining way to fail.
 	*drop_reason = ROUTE_DROP_NO_ROUTE;
-	return lpm_lookup(&config->lpm_v4, 4, (uint8_t *)&header->dst_addr);
+	return lpm_lookup(&config->fib.lpm_v4, 4, (uint8_t *)&header->dst_addr);
 }
 
 static uint32_t
@@ -94,7 +95,7 @@ route_handle_v6(
 
 	// Past the hop limit check a miss is the only remaining way to fail.
 	*drop_reason = ROUTE_DROP_NO_ROUTE;
-	return lpm_lookup(&config->lpm_v6, 16, header->dst_addr);
+	return lpm_lookup(&config->fib.lpm_v6, 16, header->dst_addr);
 }
 
 static void
@@ -209,7 +210,7 @@ route_handle_packets(
 		}
 
 		struct route_list *route_list =
-			ADDR_OF(&route_config->route_lists) + route_list_id;
+			ADDR_OF(&route_config->fib.route_lists) + route_list_id;
 		if (route_list->count == 0) {
 			route_count_packet(
 				counter_storage,
@@ -222,11 +223,11 @@ route_handle_packets(
 
 		// TODO: Route selection should be based on hash/NUMA/dp
 		// instance/etc
-		uint64_t route_index = ADDR_OF(&route_config->route_indexes
+		uint64_t route_index = ADDR_OF(&route_config->fib.route_indexes
 		)[route_list->start + packet->hash % route_list->count];
 
 		struct route *route =
-			ADDR_OF(&route_config->routes) + route_index;
+			ADDR_OF(&route_config->fib.routes) + route_index;
 
 		uint16_t device_id = module_ectx_encode_device(
 			module_ectx, route->device_id
@@ -260,6 +261,25 @@ static void
 route_module_commit(struct dp_config *dp_config, struct cp_module *cp_module) {
 	(void)dp_config;
 	(void)cp_module;
+}
+
+// The object factory shares the module factory's translation unit.
+//
+// An executable that loads the module links only its dataplane library
+// and pulls this unit for the module factory, so the object factory rides
+// along instead of needing a dependency of its own.
+struct object *
+new_object_route_fib() {
+	struct object *object = (struct object *)malloc(sizeof(struct object));
+	if (object == NULL) {
+		return NULL;
+	}
+
+	snprintf(
+		object->name, sizeof(object->name), "%s", ROUTE_FIB_OBJECT_TYPE
+	);
+
+	return object;
 }
 
 struct module *

--- a/modules/route/dataplane/fib.h
+++ b/modules/route/dataplane/fib.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "common/lpm.h"
+#include "common/network.h"
+
+#include "lib/controlplane/config/cp_object.h"
+
+// Object type under which a FIB is registered in a configuration
+// generation and linked by a route module config.
+#define ROUTE_FIB_OBJECT_TYPE "route_fib"
+
+struct route {
+	/*
+	 * Assuming this is only about directly routed networks there
+	 * is nothing to handle except the neighbour ethernet address.
+	 */
+	struct ether_addr dst_addr;
+	struct ether_addr src_addr;
+	// Index into the device links of the module that runs the FIB.
+	uint64_t device_id;
+
+	// Per-nexthop packet/byte counter, or COUNTER_INVALID if this
+	// nexthop is not individually counted.
+	uint64_t counter_id;
+};
+
+struct route_list {
+	uint64_t start;
+	uint64_t count;
+};
+
+// A forwarding table: two LPM trees mapping a destination to a route list,
+// and the nexthops the lists select from by packet hash.
+//
+// The table is plain data. A route names its device by an index into the
+// device links of the module that runs the table and its counter by an id
+// in the registry the owner chose, so the same layout serves both a module
+// config holding its own table and a shared object linked by name.
+struct route_fib {
+	struct lpm lpm_v6;
+	struct lpm lpm_v4;
+
+	// All known good routes
+	uint64_t route_count;
+	struct route *routes;
+
+	// List of route indexes applicable for some destination
+	uint64_t route_list_count;
+	struct route_list *route_lists;
+
+	// Route indexes storage
+	uint64_t route_index_count;
+	uint64_t *route_indexes;
+};
+
+// A FIB published as a shared object, registered under its type and name
+// and reachable from a linking module's execution context.
+//
+// Per-nexthop counters register in the object's link counter registry,
+// so every linking module counts through its own per-worker storage.
+struct route_fib_object {
+	struct cp_object cp_object;
+
+	struct route_fib fib;
+};

--- a/modules/route/dataplane/meson.build
+++ b/modules/route/dataplane/meson.build
@@ -24,5 +24,8 @@ lib_route_dp_dep = declare_dependency(
     '-Wl,--defsym',
     '-Wl,new_module_route=new_module_route',
     '-Wl,--export-dynamic-symbol=new_module_route',
+    '-Wl,--defsym',
+    '-Wl,new_object_route_fib=new_object_route_fib',
+    '-Wl,--export-dynamic-symbol=new_object_route_fib',
   ],
 )

--- a/modules/route/fuzzing/route.c
+++ b/modules/route/fuzzing/route.c
@@ -43,25 +43,14 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 		    &config->cp_module.memory_context,
 		    0
 	    )) {
-		goto error_lpm_v4;
+		goto error_config;
 	}
 
 	struct memory_context *memory_context =
 		&config->cp_module.memory_context;
-	if (lpm_init(&config->lpm_v4, memory_context, "lpm_v4")) {
-		goto error_lpm_v4;
+	if (route_module_config_data_init(config, memory_context)) {
+		goto error_config;
 	}
-	if (lpm_init(&config->lpm_v6, memory_context, "lpm_v6")) {
-		goto error_lpm_v6;
-	}
-	config->route_count = 0;
-	config->routes = NULL;
-
-	config->route_list_count = 0;
-	config->route_lists = NULL;
-
-	config->route_index_count = 0;
-	config->route_indexes = NULL;
 
 	struct cp_module *rmc = &config->cp_module;
 
@@ -78,14 +67,14 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 		err
 	);
 	if (route_idx == -1) {
-		goto error_lpm_v6;
+		goto error_table;
 	}
 
 	int route_list_idx = route_module_config_add_route_list(
 		rmc, 1, (uint32_t[]){route_idx}
 	);
 	if (route_list_idx == -1) {
-		goto error_lpm_v6;
+		goto error_table;
 	}
 
 	// 127.0.0.0/24
@@ -96,7 +85,7 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 		route_list_idx
 	);
 	if (rc != 0) {
-		goto error_lpm_v6;
+		goto error_table;
 	}
 	// fe80::0/96
 	rc = route_module_config_add_prefix_v6(
@@ -108,26 +97,26 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 		route_list_idx
 	);
 	if (rc != 0) {
-		goto error_lpm_v6;
+		goto error_table;
 	}
 
 	// Set up counter storage, because route_handle_packets accesses
 	// counters on every outcome.
 	if (route_module_config_register_counters(config, err)) {
-		goto error_lpm_v6;
+		goto error_table;
 	}
 
 	if (counter_registry_link(
 		    &config->cp_module.counter_registry, NULL, err
 	    )) {
-		goto error_lpm_v6;
+		goto error_table;
 	}
 
 	struct counter_storage *cs = counter_storage_spawn(
 		&fuzz_params.mctx, NULL, &config->cp_module.counter_registry
 	);
 	if (cs == NULL) {
-		goto error_lpm_v6;
+		goto error_table;
 	}
 	SET_OFFSET_OF(&fuzz_params.module_ectx.counter_storage, cs);
 	fuzz_params.module_ectx.abs_counter_storage = cs;
@@ -135,10 +124,10 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 	*cp_module = (struct cp_module *)config;
 	return 0;
 
-error_lpm_v6:
-	lpm_free(&config->lpm_v4);
+error_table:
+	route_module_config_data_fini(config);
 
-error_lpm_v4:
+error_config:
 	memory_bfree(
 		&fuzz_params.mctx, config, sizeof(struct route_module_config)
 	);

--- a/modules/route/tests/meson.build
+++ b/modules/route/tests/meson.build
@@ -23,3 +23,27 @@ route_api_test = executable(
 )
 
 test('route_api_test', route_api_test, suite: 'route')
+
+route_fib_object_test = executable(
+  'route_fib_object_test',
+  ['route_fib_object_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_module_route',
+    '-Wl,--export-dynamic-symbol=new_module_route',
+    '-Wl,--undefined=new_device_plain',
+    '-Wl,--export-dynamic-symbol=new_device_plain',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_route_cp_dep,
+    libdpdk_dep,
+  ],
+  link_with: [lib_route_dp, lib_dev_plain_dp],
+  include_directories: includes,
+)
+
+test('route_fib_object_test', route_fib_object_test, suite: 'route')

--- a/modules/route/tests/route_fib_object_test.c
+++ b/modules/route/tests/route_fib_object_test.c
@@ -1,0 +1,336 @@
+// Pins the FIB object's table and lifecycle.
+//
+// A table built through the object walks back the ranges and nexthops it
+// was given with the device index and counter name intact, the object is
+// refused destruction while a generation references it and destroyed once
+// the generation drops it, and nothing of it stays in the arena afterwards.
+
+#include "api/agent.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+#include "lib/controlplane/agent/agent.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
+#include "modules/route/api/fib.h"
+#include "modules/route/api/fib_object.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ROUTE_FIB_OBJECT_TEST_MEMORY_LIMIT (4u * 1024u * 1024u)
+
+static const struct ether_addr dst_a = {
+	.addr = {0x02, 0x00, 0x00, 0x00, 0x00, 0x0a}
+};
+static const struct ether_addr dst_b = {
+	.addr = {0x02, 0x00, 0x00, 0x00, 0x00, 0x0b}
+};
+static const struct ether_addr src = {
+	.addr = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01}
+};
+
+static int
+run_table_walk_test(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm, 0, "fib-walk", ROUTE_FIB_OBJECT_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	size_t baseline = block_allocator_free_size(&agent->block_allocator);
+
+	struct cp_object *obj = route_fib_object_new(agent, "fib0", &err);
+	TEST_ASSERT_NOT_NULL(
+		obj,
+		"route_fib_object_new failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	TEST_ASSERT(
+		!strcmp(obj->type, ROUTE_FIB_OBJECT_TYPE),
+		"object type must be the FIB type, got '%s'",
+		obj->type
+	);
+
+	int route_a = route_fib_object_add_route(
+		obj, dst_a, src, 1, "nexthop_a", &err
+	);
+	TEST_ASSERT(route_a == 0, "first nexthop must take index 0");
+	int route_b =
+		route_fib_object_add_route(obj, dst_b, src, 2, NULL, &err);
+	TEST_ASSERT(route_b == 1, "second nexthop must take index 1");
+
+	uint32_t both[] = {(uint32_t)route_a, (uint32_t)route_b};
+	int ecmp = route_fib_object_add_route_list(obj, 2, both);
+	TEST_ASSERT(ecmp == 0, "first route list must take index 0");
+	uint32_t only_b[] = {(uint32_t)route_b};
+	int single = route_fib_object_add_route_list(obj, 1, only_b);
+	TEST_ASSERT(single == 1, "second route list must take index 1");
+
+	TEST_ASSERT_SUCCESS(
+		route_fib_object_add_prefix_v4(
+			obj,
+			(uint8_t[4]){10, 0, 0, 0},
+			(uint8_t[4]){10, 0, 0, 255},
+			(uint32_t)ecmp
+		),
+		"add_prefix_v4 failed"
+	);
+	TEST_ASSERT_SUCCESS(
+		route_fib_object_add_prefix_v6(
+			obj,
+			(uint8_t[16]){0xfd, 0x00, [15] = 0},
+			(uint8_t[16]){0xfd, 0x00, [2 ... 15] = 0xff},
+			(uint32_t)single
+		),
+		"add_prefix_v6 failed"
+	);
+
+	const struct route_fib *fib = route_fib_object_fib(obj);
+	TEST_ASSERT_EQUAL(
+		(long)route_fib_range_count_v4(fib),
+		1L,
+		"one IPv4 range was inserted"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)route_fib_range_count_v6(fib),
+		1L,
+		"one IPv6 range was inserted"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)fib->route_count, 2L, "two nexthops were added"
+	);
+
+	// The walk yields the IPv4 range first, resolving to the ECMP list,
+	// then the IPv6 range resolving to the single nexthop.
+	struct route_fib_iter it;
+	route_fib_iter_init(&it, fib);
+
+	TEST_ASSERT(route_fib_iter_next(&it), "walk must yield the IPv4 range");
+	TEST_ASSERT_EQUAL(
+		(long)route_fib_iter_address_family(&it),
+		4L,
+		"first range must be IPv4"
+	);
+	TEST_ASSERT(
+		!memcmp(route_fib_iter_prefix_from(&it),
+			(uint8_t[4]){10, 0, 0, 0},
+			4),
+		"IPv4 range start must be the inserted one"
+	);
+	uint32_t list_id = route_fib_iter_route_list_id(&it);
+	TEST_ASSERT_EQUAL(
+		(long)route_fib_nexthop_count(fib, list_id),
+		2L,
+		"IPv4 range must select the ECMP list"
+	);
+	const struct route *first = route_fib_resolve_route(fib, list_id, 0);
+	TEST_ASSERT_NOT_NULL(first, "first nexthop must resolve");
+	TEST_ASSERT(
+		!memcmp(&first->dst_addr, &dst_a, sizeof(dst_a)),
+		"first nexthop must carry its destination MAC"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)first->device_id,
+		1L,
+		"first nexthop must keep the device index it was given"
+	);
+	TEST_ASSERT(
+		!strcmp(route_fib_object_counter_name(obj, first->counter_id),
+			"nexthop_a"),
+		"first nexthop must resolve its counter name"
+	);
+	const struct route *second = route_fib_resolve_route(fib, list_id, 1);
+	TEST_ASSERT_NOT_NULL(second, "second nexthop must resolve");
+	TEST_ASSERT(
+		second->counter_id == COUNTER_INVALID,
+		"an uncounted nexthop must carry no counter"
+	);
+	TEST_ASSERT(
+		!strcmp(route_fib_object_counter_name(obj, second->counter_id),
+			""),
+		"an uncounted nexthop must render an empty counter name"
+	);
+	TEST_ASSERT_NULL(
+		route_fib_resolve_route(fib, list_id, 2),
+		"a nexthop index past the list must not resolve"
+	);
+	TEST_ASSERT_NULL(
+		route_fib_resolve_route(fib, 7, 0),
+		"a route list the table does not hold must not resolve"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)route_fib_nexthop_count(fib, 7),
+		0L,
+		"a route list the table does not hold must count no nexthops"
+	);
+	TEST_ASSERT(
+		!strcmp(route_fib_object_counter_name(obj, 5), ""),
+		"a counter id past the registry must render an empty name"
+	);
+
+	TEST_ASSERT(route_fib_iter_next(&it), "walk must yield the IPv6 range");
+	TEST_ASSERT_EQUAL(
+		(long)route_fib_iter_address_family(&it),
+		6L,
+		"second range must be IPv6"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)route_fib_nexthop_count(
+			fib, route_fib_iter_route_list_id(&it)
+		),
+		1L,
+		"IPv6 range must select the single nexthop"
+	);
+	TEST_ASSERT(
+		!route_fib_iter_next(&it), "walk must end after both trees"
+	);
+
+	// The counter registered for the nexthop lives in the link registry,
+	// so each linking module gets its own per-worker storage for it.
+	TEST_ASSERT_EQUAL(
+		(long)obj->link_counter_registry.count,
+		1L,
+		"the nexthop counter must register in the link registry"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)obj->counter_registry.count,
+		0L,
+		"the object's own registry must stay empty"
+	);
+
+	TEST_ASSERT_SUCCESS(
+		route_fib_object_free(obj, &err),
+		"free of a dangling object failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	size_t after = block_allocator_free_size(&agent->block_allocator);
+	TEST_ASSERT_EQUAL(
+		(long)after,
+		(long)baseline,
+		"arena did not return to baseline: baseline=%zu after=%zu",
+		baseline,
+		after
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+static int
+run_publish_lifecycle_test(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm, 0, "fib-publish", ROUTE_FIB_OBJECT_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	size_t baseline = block_allocator_free_size(&agent->block_allocator);
+
+	struct cp_object *obj = route_fib_object_new(agent, "fib0", &err);
+	TEST_ASSERT_NOT_NULL(obj, "route_fib_object_new failed");
+
+	struct cp_object *objects[] = {obj};
+	TEST_ASSERT_SUCCESS(
+		agent_update_objects(agent, 1, objects, &err),
+		"agent_update_objects failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+	struct cp_config_gen *gen = ADDR_OF(&cp_config->cp_config_gen);
+	uint64_t idx;
+	TEST_ASSERT_SUCCESS(
+		cp_config_gen_lookup_object_index(
+			gen, ROUTE_FIB_OBJECT_TYPE, "fib0", &idx
+		),
+		"the published object must be found by type and name"
+	);
+	TEST_ASSERT(
+		cp_config_gen_get_object(gen, idx) == obj,
+		"the generation must hold the published object"
+	);
+
+	// The live generation references the object, so the free is refused
+	// and the object stays intact for a later retry.
+	errno = 0;
+	TEST_ASSERT(
+		route_fib_object_free(obj, &err) == -1 && errno == EAGAIN,
+		"free must be refused while a generation references the object"
+	);
+	yanet_error_reset(&err);
+
+	TEST_ASSERT_SUCCESS(
+		agent_delete_object(agent, ROUTE_FIB_OBJECT_TYPE, "fib0", &err),
+		"agent_delete_object failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	TEST_ASSERT_SUCCESS(
+		route_fib_object_free(obj, &err),
+		"free after the generation dropped the object failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	size_t after = block_allocator_free_size(&agent->block_allocator);
+	TEST_ASSERT_EQUAL(
+		(long)after,
+		(long)baseline,
+		"arena did not return to baseline: baseline=%zu after=%zu",
+		baseline,
+		after
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	const char *port_names[] = {"01:00.0"};
+	const char *modules[] = {"route"};
+	const char *devs_to_load[] = {"plain"};
+	const char *objs_to_load[] = {ROUTE_FIB_OBJECT_TYPE};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 25,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = modules,
+		.module_count = 1,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+		.objects_to_load = objs_to_load,
+		.objects_to_load_count = 1,
+	};
+
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	if (ut == NULL) {
+		fprintf(stderr, "dataplane_ut_new failed\n");
+		return 1;
+	}
+
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	if (shm == NULL) {
+		fprintf(stderr, "dataplane_ut_shm returned NULL\n");
+		dataplane_ut_free(ut);
+		return 1;
+	}
+
+	int res = run_table_walk_test(shm);
+	if (res == TEST_SUCCESS) {
+		res = run_publish_lifecycle_test(shm);
+	}
+	dataplane_ut_free(ut);
+
+	return (res == TEST_SUCCESS) ? 0 : 1;
+}


### PR DESCRIPTION
- Introduce the route_fib object type: a forwarding table published on its own, whose lifetime is counted by configuration generations and whose per-nexthop counters live in the object's link counter registry.
- Extract the table core (trees, nexthops, route lists, iterator) into a library shared by the module config and the object, with the shared-memory layout and the FFI surface of the module config unchanged.
- Register the object type in the dataplane load list and export its factory next to the module one.
- Cover the object with a walk, publish, pin, refused-free and arena-baseline test and move the route fuzzer onto the shared core.
- Additive step of the route FIB object design, the module link, handler switch and Go service follow separately.