### PR TITLE
feat(route,ffi): run the forwarding table from the shared object

### DIFF
--- a/controlplane/ffi/counter.go
+++ b/controlplane/ffi/counter.go
@@ -219,6 +219,44 @@ func (m *DPConfig) ModuleRuntimeCounters(
 	return counters, nil
 }
 
+// ModuleObjectLinkCounters returns the counters an object's link counter
+// registry spawns for one module link, e.g. the route module's per-nexthop
+// counters, optionally filtered by name.
+//
+// If counterQuery is nil or empty, returns all of the link's counters.
+func (m *DPConfig) ModuleObjectLinkCounters(
+	deviceName string,
+	pipelineName string,
+	functionName string,
+	chainName string,
+	moduleType string,
+	moduleName string,
+	objectType string,
+	objectName string,
+	counterQuery []string,
+) ([]CounterInfo, error) {
+	groups, err := m.CountersByTags([]CounterTag{
+		{Key: "device", Value: deviceName},
+		{Key: "pipeline", Value: pipelineName},
+		{Key: "function", Value: functionName},
+		{Key: "chain", Value: chainName},
+		{Key: "module_type", Value: moduleType},
+		{Key: "module_name", Value: moduleName},
+		{Key: "object_type", Value: objectType},
+		{Key: "object_name", Value: objectName},
+		{Key: "kind", Value: "module_object_link"},
+	}, counterQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	counters := make([]CounterInfo, 0)
+	for _, group := range groups {
+		counters = append(counters, group.Counters...)
+	}
+	return counters, nil
+}
+
 // ObjectCounters returns the counters of an object identified by its
 // type and name, or nil when the read fails.
 func (m *DPConfig) ObjectCounters(

--- a/controlplane/ffi/free_test.go
+++ b/controlplane/ffi/free_test.go
@@ -91,3 +91,44 @@ func Test_ShmDeviceConfig_Free_RefusedKeepsHandle(t *testing.T) {
 	require.NoError(t, handle.Free(outcome.free))
 	require.Nil(t, handle.AsRawPtr())
 }
+
+// Test_ObjectConfig_Free_SuccessForgetsPointer verifies that a successful
+// free clears the handle, so a repeated free is a no-op that never reaches
+// the typed free again.
+func Test_ObjectConfig_Free_SuccessForgetsPointer(t *testing.T) {
+	handle := ffi.NewObjectConfig(fakeObject())
+	outcome := &freeOutcome{}
+
+	require.NoError(t, handle.Free(outcome.free))
+	require.Nil(t, handle.AsRawPtr())
+
+	require.NoError(t, handle.Free(outcome.free))
+	require.Equal(t, 1, outcome.calls)
+}
+
+// Test_ObjectConfig_Free_RefusedKeepsHandle verifies that a refused free
+// reports still-referenced and keeps the handle, so a retry reaches the
+// typed free again.
+func Test_ObjectConfig_Free_RefusedKeepsHandle(t *testing.T) {
+	handle := ffi.NewObjectConfig(fakeObject())
+	outcome := &freeOutcome{rc: -1, errno: syscall.EAGAIN}
+
+	require.ErrorIs(t, handle.Free(outcome.free), ffi.ErrStillReferenced)
+	require.NotNil(t, handle.AsRawPtr())
+
+	outcome.rc, outcome.errno = 0, nil
+	require.NoError(t, handle.Free(outcome.free))
+	require.Equal(t, 2, outcome.calls)
+}
+
+// Test_ObjectConfig_Free_FailureKeepsHandle verifies that any other
+// failure is reported with its cause and keeps the handle.
+func Test_ObjectConfig_Free_FailureKeepsHandle(t *testing.T) {
+	handle := ffi.NewObjectConfig(fakeObject())
+	outcome := &freeOutcome{rc: -1, errno: errInjectedFree}
+
+	err := handle.Free(outcome.free)
+	require.ErrorIs(t, err, errInjectedFree)
+	require.NotErrorIs(t, err, ffi.ErrStillReferenced)
+	require.NotNil(t, handle.AsRawPtr())
+}

--- a/controlplane/ffi/object.go
+++ b/controlplane/ffi/object.go
@@ -1,0 +1,123 @@
+package ffi
+
+//#cgo CFLAGS: -I../../
+//#cgo LDFLAGS: -L../../build/lib/controlplane/agent -lagent
+//#include "api/agent.h"
+//#include "lib/controlplane/agent/agent.h"
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
+)
+
+// ObjectConfig is a Go wrapper around a C cp_object pointer, representing
+// a shared object's configuration, such as a route module's FIB.
+//
+// Each object owner wraps it in its own typed handle, using
+// unsafe.Pointer as a bridge between CGo contexts of different
+// packages.
+type ObjectConfig struct {
+	ptr *C.struct_cp_object
+}
+
+// NewObjectConfig wraps a raw C pointer into an ObjectConfig.
+//
+// The pointer must originate from an object-specific C constructor that
+// returns a valid cp_object pointer.
+// The caller is responsible for ensuring the pointer's validity and lifetime.
+func NewObjectConfig(ptr unsafe.Pointer) ObjectConfig {
+	return ObjectConfig{
+		ptr: (*C.struct_cp_object)(ptr),
+	}
+}
+
+// AsRawPtr returns the underlying C pointer as unsafe.Pointer for passing
+// across CGo package boundaries.
+func (m ObjectConfig) AsRawPtr() unsafe.Pointer {
+	return unsafe.Pointer(m.ptr)
+}
+
+// Free destroys the object config through the typed free the object
+// supplies and forgets the pointer once it is gone.
+//
+// The refusal contract is the one of a module config's free.
+func (m *ObjectConfig) Free(
+	free func(ptr unsafe.Pointer) (rc int, cErr unsafe.Pointer, errno error),
+) error {
+	if m.ptr == nil {
+		return nil
+	}
+
+	rc, cErr, errno := free(unsafe.Pointer(m.ptr))
+	if rc == 0 {
+		m.ptr = nil
+		return nil
+	}
+	if errors.Is(errno, syscall.EAGAIN) {
+		cerrors.Free(cErr)
+		return ErrStillReferenced
+	}
+
+	return fmt.Errorf("failed to free object config: %w", freeFailure(cErr, errno))
+}
+
+// UpdateObjects upserts the given objects into the active configuration
+// generation.
+func (m *Agent) UpdateObjects(objects []ObjectConfig) error {
+	if len(objects) == 0 {
+		return fmt.Errorf("no objects provided")
+	}
+
+	configs := make([]*C.struct_cp_object, len(objects))
+	for idx, object := range objects {
+		if object.ptr == nil {
+			return fmt.Errorf("object config at index %d is nil", idx)
+		}
+		configs[idx] = (*C.struct_cp_object)(object.AsRawPtr())
+	}
+
+	var cErr *C.yanet_error
+	rc := C.agent_update_objects(
+		(*C.struct_agent)(m.AsRawPtr()),
+		C.uint64_t(len(objects)),
+		&configs[0],
+		&cErr,
+	)
+	if rc != 0 {
+		return fmt.Errorf("failed to update objects: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	}
+
+	return nil
+}
+
+// DeleteObject removes the named shared object.
+func (m *Agent) DeleteObject(objectType, objectName string) error {
+	cType := C.CString(objectType)
+	defer C.free(unsafe.Pointer(cType))
+
+	cName := C.CString(objectName)
+	defer C.free(unsafe.Pointer(cName))
+
+	var cErr *C.yanet_error
+	rc := C.agent_delete_object(
+		(*C.struct_agent)(m.AsRawPtr()),
+		cType,
+		cName,
+		&cErr,
+	)
+	if rc != 0 {
+		return fmt.Errorf(
+			"failed to delete object type %q name %q: %w",
+			objectType,
+			objectName,
+			cerrors.FromC(unsafe.Pointer(cErr)),
+		)
+	}
+
+	return nil
+}

--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -90,7 +90,6 @@ loopindex:modules/pdump/controlplane/ring_test.go:TestRingBufferRunReaders:i:2  
 loopindex:modules/pdump/controlplane/ring_test.go:TestWorkerAreaHasMore:i:1  # legacy: rename to idx
 loopindex:modules/pdump/controlplane/ring_test.go:TestWorkerAreaRead:i:1  # legacy: rename to idx
 loopindex:modules/pdump/controlplane/ring_test.go:createTestRingBuffer:i:1  # legacy: rename to idx
-loopindex:modules/route/bindings/go/croute/cgo.go:ModuleConfig.addRouteList:i:1  # legacy: rename to idx
 maplit:controlplane/ffi/shm.go:DPConfig.AllModulePositions:map[string][]Chain:1  # legacy: use T{} instead of make(map...)
 maplit:controlplane/ffi/shm.go:DPConfig.AllModulePositions:map[string][]string:1  # legacy: use T{} instead of make(map...)
 maplit:modules/acl/controlplane/metrics.go:ACLService.collectDataplaneMetrics:map[string]struct{}:1  # legacy: use T{} instead of make(map...)

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -227,6 +227,30 @@ route_snapshot_has_fib(const struct route_snapshot *snapshot) {
 }
 
 uint64_t
+route_snapshot_route_count(const struct route_snapshot *snapshot) {
+	if (snapshot->object == NULL) {
+		return 0;
+	}
+	return route_fib_object_route_count(snapshot->object);
+}
+
+uint64_t
+route_snapshot_range_count_v4(const struct route_snapshot *snapshot) {
+	if (snapshot->object == NULL) {
+		return 0;
+	}
+	return route_fib_object_range_count_v4(snapshot->object);
+}
+
+uint64_t
+route_snapshot_range_count_v6(const struct route_snapshot *snapshot) {
+	if (snapshot->object == NULL) {
+		return 0;
+	}
+	return route_fib_object_range_count_v6(snapshot->object);
+}
+
+uint64_t
 route_snapshot_device_count(const struct route_snapshot *snapshot) {
 	return snapshot->module->device_count;
 }

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -227,30 +227,6 @@ route_snapshot_has_fib(const struct route_snapshot *snapshot) {
 }
 
 uint64_t
-route_snapshot_route_count(const struct route_snapshot *snapshot) {
-	if (snapshot->object == NULL) {
-		return 0;
-	}
-	return route_fib_object_route_count(snapshot->object);
-}
-
-uint64_t
-route_snapshot_range_count_v4(const struct route_snapshot *snapshot) {
-	if (snapshot->object == NULL) {
-		return 0;
-	}
-	return route_fib_object_range_count_v4(snapshot->object);
-}
-
-uint64_t
-route_snapshot_range_count_v6(const struct route_snapshot *snapshot) {
-	if (snapshot->object == NULL) {
-		return 0;
-	}
-	return route_fib_object_range_count_v6(snapshot->object);
-}
-
-uint64_t
 route_snapshot_device_count(const struct route_snapshot *snapshot) {
 	return snapshot->module->device_count;
 }

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "fib.h"
+#include "fib_object.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -9,11 +10,6 @@
 #include "common/container_of.h"
 
 #include "lib/controlplane/agent/agent.h"
-
-struct fib_iter {
-	struct route_module_config *config;
-	struct route_fib_iter it;
-};
 
 int
 route_module_config_register_counters(
@@ -73,7 +69,20 @@ route_module_config_register_counters(
 }
 
 static void
-route_module_config_destroy(struct cp_module *cp_module);
+route_module_config_destroy(struct cp_module *cp_module) {
+	struct route_module_config *config =
+		container_of(cp_module, struct route_module_config, cp_module);
+
+	struct agent *agent = ADDR_OF(&cp_module->agent);
+
+	cp_module_fini(cp_module);
+
+	memory_bfree(
+		&agent->memory_context,
+		config,
+		sizeof(struct route_module_config)
+	);
+}
 
 struct cp_module *
 route_module_config_new(
@@ -99,71 +108,27 @@ route_module_config_new(
 		return NULL;
 	}
 
-	if (route_module_config_data_init(
-		    config, &config->cp_module.memory_context
+	// From here on the module is dangling with nothing but its own
+	// resources, so the type destructor is the right teardown for every
+	// later failure.
+	if (cp_module_link_object(
+		    &config->cp_module,
+		    ROUTE_FIB_OBJECT_TYPE,
+		    name,
+		    &config->fib_link_idx,
+		    err
 	    )) {
-		yanet_error_add(err, "failed to init config data");
-		// Frees directly instead of going through the type destructor.
-		//
-		// A failed configuration-data setup never reaches a state its
-		// own teardown could safely walk. No reference beyond the
-		// caller's own has been taken, and no registry has observed
-		// the module yet, so nothing is lost by freeing the block
-		// here.
-		cp_module_fini(&config->cp_module);
-		memory_bfree(
-			&agent->memory_context,
-			config,
-			sizeof(struct route_module_config)
-		);
+		yanet_error_add(err, "failed to link the fib object");
+		route_module_config_destroy(&config->cp_module);
 		return NULL;
 	}
 
 	if (route_module_config_register_counters(config, err)) {
-		// Frees directly instead of going through the public free.
-		//
-		// Registering counters is the last construction step, so
-		// configuration data is already fully set up and the type's
-		// own destructor can safely walk it. No reference beyond the
-		// caller's own has been taken and no registry has observed
-		// the module yet, so it is dangling and either path
-		// destroys it identically.
 		route_module_config_destroy(&config->cp_module);
 		return NULL;
 	}
 
 	return &config->cp_module;
-}
-
-int
-route_module_config_data_init(
-	struct route_module_config *config,
-	struct memory_context *memory_context
-) {
-	return route_fib_init(&config->fib, memory_context);
-}
-
-void
-route_module_config_data_fini(struct route_module_config *config) {
-	route_fib_fini(&config->fib, &config->cp_module.memory_context);
-}
-
-static void
-route_module_config_destroy(struct cp_module *cp_module) {
-	struct route_module_config *config =
-		container_of(cp_module, struct route_module_config, cp_module);
-
-	route_module_config_data_fini(config);
-
-	struct agent *agent = ADDR_OF(&cp_module->agent);
-
-	cp_module_fini(cp_module);
-
-	memory_bfree(
-		&agent->memory_context,
-		config,
-		sizeof(struct route_module_config)
-	);
 }
 
 int
@@ -177,130 +142,145 @@ route_module_config_free(struct cp_module *cp_module, yanet_error **err) {
 }
 
 int
-route_module_config_add_route(
+route_module_config_link_device(
 	struct cp_module *cp_module,
-	struct ether_addr dst_addr,
-	struct ether_addr src_addr,
 	const char *device_name,
-	const char *counter_name,
+	uint32_t *index,
 	yanet_error **err
 ) {
-	struct route_module_config *config =
-		container_of(cp_module, struct route_module_config, cp_module);
-
 	uint64_t device_index;
 	if (cp_module_link_device(cp_module, device_name, &device_index, err)) {
 		return -1;
 	}
-
-	uint64_t counter_id = COUNTER_INVALID;
-	if (counter_name != NULL && counter_name[0] != '\0') {
-		// Per-route counters live in a dedicated "routes" registry so
-		// they are separated from the module's predefined counters in
-		// the per-worker storages and the counter storage registry.
-		struct counter_registry *routes_registry =
-			cp_module_counter_registry(
-				cp_module,
-				"routes",
-				&config->routes_registry_idx,
-				err
-			);
-		if (routes_registry == NULL) {
-			return -1;
-		}
-
-		counter_id = counter_registry_register(
-			routes_registry, counter_name, 2, err
+	if (device_index > UINT32_MAX) {
+		yanet_error_add(
+			err,
+			"device table of module '%s' is full",
+			cp_module->name
 		);
-		if (counter_id == COUNTER_INVALID) {
-			yanet_error_add(
-				err,
-				"failed to register counter '%s'",
-				counter_name
-			);
-			return -1;
-		}
+		return -1;
+	}
+	*index = (uint32_t)device_index;
+	return 0;
+}
+
+struct route_snapshot {
+	struct cp_config *cp_config;
+	struct cp_config_gen *config_gen;
+	const struct cp_module *module;
+	// The table object, NULL while the generation holds none.
+	const struct cp_object *object;
+};
+
+struct route_snapshot *
+route_snapshot_open(struct agent *agent, const char *name, yanet_error **err) {
+	struct route_snapshot *snapshot = calloc(1, sizeof(*snapshot));
+	if (snapshot == NULL) {
+		yanet_error_add(err, "failed to allocate the snapshot");
+		return NULL;
 	}
 
-	return route_fib_add_route(
-		&config->fib,
-		&config->cp_module.memory_context,
-		dst_addr,
-		src_addr,
-		device_index,
-		counter_id
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+	cp_config_lock(cp_config);
+	struct cp_config_gen *config_gen = cp_config_gen_acquire(cp_config);
+	cp_config_unlock(cp_config);
+
+	struct cp_module *cp_module =
+		cp_config_gen_lookup_module(config_gen, "route", name);
+	if (cp_module == NULL) {
+		cp_config_lock(cp_config);
+		cp_config_gen_release(cp_config, config_gen);
+		cp_config_unlock(cp_config);
+		free(snapshot);
+		yanet_error_add_kind(
+			err,
+			YANET_ERROR_NOT_FOUND,
+			"route config '%s' is not snapshot",
+			name
+		);
+		return NULL;
+	}
+
+	snapshot->cp_config = cp_config;
+	snapshot->config_gen = config_gen;
+	snapshot->module = cp_module;
+	snapshot->object = cp_config_gen_lookup_object(
+		config_gen, ROUTE_FIB_OBJECT_TYPE, name
 	);
+	return snapshot;
 }
 
-int
-route_module_config_add_route_list(
-	struct cp_module *cp_module, size_t count, const uint32_t *indexes
-) {
-	struct route_module_config *config =
-		container_of(cp_module, struct route_module_config, cp_module);
-	return route_fib_add_route_list(
-		&config->fib, &config->cp_module.memory_context, count, indexes
-	);
+void
+route_snapshot_close(struct route_snapshot *snapshot) {
+	if (snapshot == NULL) {
+		return;
+	}
+	cp_config_lock(snapshot->cp_config);
+	cp_config_gen_release(snapshot->cp_config, snapshot->config_gen);
+	cp_config_unlock(snapshot->cp_config);
+	free(snapshot);
 }
 
-int
-route_module_config_add_prefix_v4(
-	struct cp_module *cp_module,
-	const uint8_t *from,
-	const uint8_t *to,
-	uint32_t route_list_index
-) {
-	struct route_module_config *config =
-		container_of(cp_module, struct route_module_config, cp_module);
-	return route_fib_add_prefix_v4(
-		&config->fib, from, to, route_list_index
-	);
-}
-
-int
-route_module_config_add_prefix_v6(
-	struct cp_module *cp_module,
-	const uint8_t *from,
-	const uint8_t *to,
-	uint32_t route_list_index
-) {
-	struct route_module_config *config =
-		container_of(cp_module, struct route_module_config, cp_module);
-	return route_fib_add_prefix_v6(
-		&config->fib, from, to, route_list_index
-	);
+bool
+route_snapshot_has_fib(const struct route_snapshot *snapshot) {
+	return snapshot->object != NULL;
 }
 
 uint64_t
-route_module_config_route_count(struct cp_module *cp_module) {
-	struct route_module_config *config =
-		container_of(cp_module, struct route_module_config, cp_module);
-	return config->fib.route_count;
+route_snapshot_device_count(const struct route_snapshot *snapshot) {
+	return snapshot->module->device_count;
 }
 
-uint64_t
-route_module_config_fib_range_count_v4(struct cp_module *cp_module) {
-	struct route_module_config *config =
-		container_of(cp_module, struct route_module_config, cp_module);
-	return route_fib_range_count_v4(&config->fib);
+const char *
+route_snapshot_device_name(
+	const struct route_snapshot *snapshot, uint64_t index
+) {
+	if (index >= snapshot->module->device_count) {
+		return "";
+	}
+	const struct cp_module_device *devices =
+		ADDR_OF(&snapshot->module->devices);
+	return devices[index].name;
 }
 
-uint64_t
-route_module_config_fib_range_count_v6(struct cp_module *cp_module) {
-	struct route_module_config *config =
-		container_of(cp_module, struct route_module_config, cp_module);
-	return route_fib_range_count_v6(&config->fib);
+struct fib_iter {
+	const struct cp_object *object;
+	// The module that resolves device names, NULL when unknown.
+	const struct cp_module *module;
+	struct route_fib_iter it;
+};
+
+struct fib_iter *
+route_snapshot_fib_iter(struct route_snapshot *snapshot, yanet_error **err) {
+	if (snapshot->object == NULL) {
+		yanet_error_add_kind(
+			err,
+			YANET_ERROR_NOT_FOUND,
+			"route config '%s' has no table snapshot",
+			snapshot->module->name
+		);
+		return NULL;
+	}
+
+	struct fib_iter *it = calloc(1, sizeof(*it));
+	if (it == NULL) {
+		yanet_error_add(err, "failed to allocate the table walk");
+		return NULL;
+	}
+	it->object = snapshot->object;
+	it->module = snapshot->module;
+	route_fib_iter_init(&it->it, route_fib_object_fib(snapshot->object));
+	return it;
 }
 
 struct fib_iter *
-fib_iter_new(struct cp_module *cp_module) {
+fib_iter_new(struct cp_object *cp_object) {
 	struct fib_iter *it = calloc(1, sizeof(*it));
 	if (it == NULL) {
 		return NULL;
 	}
-	it->config =
-		container_of(cp_module, struct route_module_config, cp_module);
-	route_fib_iter_init(&it->it, &it->config->fib);
+	it->object = cp_object;
+	route_fib_iter_init(&it->it, route_fib_object_fib(cp_object));
 	return it;
 }
 
@@ -332,7 +312,7 @@ fib_iter_prefix_to(const struct fib_iter *it) {
 uint64_t
 fib_iter_nexthop_count(const struct fib_iter *it) {
 	return route_fib_nexthop_count(
-		&it->config->fib, route_fib_iter_route_list_id(&it->it)
+		it->it.fib, route_fib_iter_route_list_id(&it->it)
 	);
 }
 
@@ -340,9 +320,7 @@ fib_iter_nexthop_count(const struct fib_iter *it) {
 static const struct route *
 fib_iter_resolve_route(const struct fib_iter *it, uint64_t nexthop_idx) {
 	return route_fib_resolve_route(
-		&it->config->fib,
-		route_fib_iter_route_list_id(&it->it),
-		nexthop_idx
+		it->it.fib, route_fib_iter_route_list_id(&it->it), nexthop_idx
 	);
 }
 
@@ -373,37 +351,19 @@ fib_iter_nexthop_src_mac(
 const char *
 fib_iter_nexthop_device_name(const struct fib_iter *it, uint64_t nexthop_idx) {
 	const struct route *r = fib_iter_resolve_route(it, nexthop_idx);
-	if (r == NULL) {
+	if (r == NULL || it->module == NULL ||
+	    r->device_id >= it->module->device_count) {
 		return "";
 	}
-
-	struct route_module_config *config = it->config;
-	struct cp_module_device *devices = ADDR_OF(&config->cp_module.devices);
-	if (r->device_id < config->cp_module.device_count) {
-		return devices[r->device_id].name;
-	}
-	return "";
+	const struct cp_module_device *devices = ADDR_OF(&it->module->devices);
+	return devices[r->device_id].name;
 }
 
 const char *
 fib_iter_nexthop_counter_name(const struct fib_iter *it, uint64_t nexthop_idx) {
 	const struct route *r = fib_iter_resolve_route(it, nexthop_idx);
-	if (r == NULL || r->counter_id == COUNTER_INVALID) {
+	if (r == NULL) {
 		return "";
 	}
-
-	struct route_module_config *config = it->config;
-	if (config->routes_registry_idx >=
-	    config->cp_module.runtime_counter_registry_count) {
-		return "";
-	}
-	struct cp_module_counter_registry **registries =
-		ADDR_OF(&config->cp_module.runtime_counter_registries);
-	struct cp_module_counter_registry *entry =
-		ADDR_OF(registries + config->routes_registry_idx);
-	struct counter_registry *registry = &entry->registry;
-	if (r->counter_id < registry->count) {
-		return ADDR_OF(&registry->names)[r->counter_id].name;
-	}
-	return "";
+	return route_fib_object_counter_name(it->object, r->counter_id);
 }

--- a/modules/route/api/controlplane.h
+++ b/modules/route/api/controlplane.h
@@ -6,22 +6,22 @@
 
 #include "common/network.h"
 
+#include "lib/controlplane/config/defines.h"
+#include "lib/counters/counters.h"
 #include "lib/errors/errors.h"
+
+#include "modules/route/dataplane/fib.h"
 
 struct agent;
 struct cp_module;
-struct memory_context;
+struct cp_object;
 struct route_module_config;
 
-// Zero-copy FIB iterator.
+// Allocate a module config linked to the table object published under the
+// same name.
 //
-// Walks IPv4 and IPv6 LPM trees sequentially. Each call to
-// fib_iter_next() advances to the next LPM range.
-//
-// Nexthop data (MAC addresses, device names) is resolved on demand directly
-// from shared memory without heap allocation.
-struct fib_iter;
-
+// A generation wiring the module into a chain installs only when the
+// object is published, so the object goes out first.
 struct cp_module *
 route_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
@@ -34,16 +34,6 @@ route_module_config_new(
 int
 route_module_config_free(struct cp_module *cp_module, yanet_error **err);
 
-int
-route_module_config_data_init(
-	struct route_module_config *config,
-	struct memory_context *memory_context
-);
-
-// Releases the table set up by route_module_config_data_init.
-void
-route_module_config_data_fini(struct route_module_config *config);
-
 // Registers the module-level counters and records their ids in the config.
 //
 // The counter registry must already be initialized. Callers that build a
@@ -54,66 +44,66 @@ route_module_config_register_counters(
 	struct route_module_config *config, yanet_error **err
 );
 
-// Appends a nexthop route to the config.
+// Link a device by name and return its index in the module's device table.
 //
-// A NULL or empty counter_name leaves the nexthop uncounted — otherwise it
-// names a per-nexthop packet/byte counter to register.
+// A name already linked keeps its index, so the table only ever grows and
+// a table object built against it stays valid across relinks.
 int
-route_module_config_add_route(
+route_module_config_link_device(
 	struct cp_module *cp_module,
-	struct ether_addr dst_addr,
-	struct ether_addr src_addr,
 	const char *device_name,
-	const char *counter_name,
+	uint32_t *index,
 	yanet_error **err
 );
 
-int
-route_module_config_add_route_list(
-	struct cp_module *cp_module, size_t count, const uint32_t *indexes
+// A route config as one generation holds it: the module config and, when
+// published, its table object, pinned for reading.
+struct route_snapshot;
+
+// Pin the generation publishing the named config.
+//
+// The pin keeps the module config and its table object alive until
+// route_snapshot_close. Fails with the not-found kind when no module
+// config of that name is published.
+struct route_snapshot *
+route_snapshot_open(struct agent *agent, const char *name, yanet_error **err);
+
+// Release the pin. Walks taken from the handle must be freed first.
+void
+route_snapshot_close(struct route_snapshot *published);
+
+// Whether the generation holds a table object for the config.
+bool
+route_snapshot_has_fib(const struct route_snapshot *published);
+
+// Size of the module's device table.
+uint64_t
+route_snapshot_device_count(const struct route_snapshot *published);
+
+// Name at the given index of the module's device table, or an empty
+// string past its end.
+const char *
+route_snapshot_device_name(
+	const struct route_snapshot *published, uint64_t index
 );
 
-int
-route_module_config_add_prefix_v4(
-	struct cp_module *cp_module,
-	const uint8_t *from,
-	const uint8_t *to,
-	uint32_t route_list_index
-);
+// Zero-copy walk over a table, reading shared memory in place.
+struct fib_iter;
 
-int
-route_module_config_add_prefix_v6(
-	struct cp_module *cp_module,
-	const uint8_t *from,
-	const uint8_t *to,
-	uint32_t route_list_index
-);
-
-// Returns the number of distinct hardware routes held by the config.
-uint64_t
-route_module_config_route_count(struct cp_module *cp_module);
-
-// Returns the number of IPv4 FIB ranges.
+// Open a walk over the published table, borrowing the handle's pin.
 //
-// Counts the same ranges a FIB iterator would yield for the IPv4 LPM, without
-// materializing any of them.
-uint64_t
-route_module_config_fib_range_count_v4(struct cp_module *cp_module);
-
-// Returns the number of IPv6 FIB ranges.
-//
-// Counts the same ranges a FIB iterator would yield for the IPv6 LPM, without
-// materializing any of them.
-uint64_t
-route_module_config_fib_range_count_v6(struct cp_module *cp_module);
-
-// Create a FIB iterator for the given module config.
-//
-// Returns NULL on allocation failure.
+// Fails with the not-found kind when the generation holds no table
+// object for the config.
 struct fib_iter *
-fib_iter_new(struct cp_module *cp_module);
+route_snapshot_fib_iter(struct route_snapshot *published, yanet_error **err);
 
-// Free a FIB iterator created by fib_iter_new.
+// Open a walk over an owned object, or NULL on allocation failure.
+//
+// Device names stay empty: they resolve through the module that runs the
+// table, which an owned object does not know.
+struct fib_iter *
+fib_iter_new(struct cp_object *cp_object);
+
 void
 fib_iter_free(struct fib_iter *it);
 

--- a/modules/route/api/controlplane.h
+++ b/modules/route/api/controlplane.h
@@ -70,21 +70,35 @@ route_snapshot_open(struct agent *agent, const char *name, yanet_error **err);
 
 // Release the pin. Walks taken from the handle must be freed first.
 void
-route_snapshot_close(struct route_snapshot *published);
+route_snapshot_close(struct route_snapshot *snapshot);
 
 // Whether the generation holds a table object for the config.
 bool
-route_snapshot_has_fib(const struct route_snapshot *published);
+route_snapshot_has_fib(const struct route_snapshot *snapshot);
+
+// Nexthops the published table holds, 0 without a table object.
+uint64_t
+route_snapshot_route_count(const struct route_snapshot *snapshot);
+
+// IPv4 ranges a walk of the published table would yield, 0 without a
+// table object.
+uint64_t
+route_snapshot_range_count_v4(const struct route_snapshot *snapshot);
+
+// IPv6 ranges a walk of the published table would yield, 0 without a
+// table object.
+uint64_t
+route_snapshot_range_count_v6(const struct route_snapshot *snapshot);
 
 // Size of the module's device table.
 uint64_t
-route_snapshot_device_count(const struct route_snapshot *published);
+route_snapshot_device_count(const struct route_snapshot *snapshot);
 
 // Name at the given index of the module's device table, or an empty
 // string past its end.
 const char *
 route_snapshot_device_name(
-	const struct route_snapshot *published, uint64_t index
+	const struct route_snapshot *snapshot, uint64_t index
 );
 
 // Zero-copy walk over a table, reading shared memory in place.
@@ -95,7 +109,7 @@ struct fib_iter;
 // Fails with the not-found kind when the generation holds no table
 // object for the config.
 struct fib_iter *
-route_snapshot_fib_iter(struct route_snapshot *published, yanet_error **err);
+route_snapshot_fib_iter(struct route_snapshot *snapshot, yanet_error **err);
 
 // Open a walk over an owned object, or NULL on allocation failure.
 //

--- a/modules/route/api/controlplane.h
+++ b/modules/route/api/controlplane.h
@@ -76,20 +76,6 @@ route_snapshot_close(struct route_snapshot *snapshot);
 bool
 route_snapshot_has_fib(const struct route_snapshot *snapshot);
 
-// Nexthops the published table holds, 0 without a table object.
-uint64_t
-route_snapshot_route_count(const struct route_snapshot *snapshot);
-
-// IPv4 ranges a walk of the published table would yield, 0 without a
-// table object.
-uint64_t
-route_snapshot_range_count_v4(const struct route_snapshot *snapshot);
-
-// IPv6 ranges a walk of the published table would yield, 0 without a
-// table object.
-uint64_t
-route_snapshot_range_count_v6(const struct route_snapshot *snapshot);
-
 // Size of the module's device table.
 uint64_t
 route_snapshot_device_count(const struct route_snapshot *snapshot);

--- a/modules/route/api/fib_object.c
+++ b/modules/route/api/fib_object.c
@@ -175,3 +175,18 @@ route_fib_object_counter_name(
 	}
 	return ADDR_OF(&registry->names)[counter_id].name;
 }
+
+uint64_t
+route_fib_object_route_count(const struct cp_object *cp_object) {
+	return route_fib_object_fib(cp_object)->route_count;
+}
+
+uint64_t
+route_fib_object_range_count_v4(const struct cp_object *cp_object) {
+	return route_fib_range_count_v4(route_fib_object_fib(cp_object));
+}
+
+uint64_t
+route_fib_object_range_count_v6(const struct cp_object *cp_object) {
+	return route_fib_range_count_v6(route_fib_object_fib(cp_object));
+}

--- a/modules/route/api/fib_object.h
+++ b/modules/route/api/fib_object.h
@@ -73,3 +73,15 @@ const char *
 route_fib_object_counter_name(
 	const struct cp_object *cp_object, uint64_t counter_id
 );
+
+// Number of nexthops the object holds.
+uint64_t
+route_fib_object_route_count(const struct cp_object *cp_object);
+
+// Number of IPv4 ranges a walk of the object's table would yield.
+uint64_t
+route_fib_object_range_count_v4(const struct cp_object *cp_object);
+
+// Number of IPv6 ranges a walk of the object's table would yield.
+uint64_t
+route_fib_object_range_count_v6(const struct cp_object *cp_object);

--- a/modules/route/bindings/go/croute/cgo.go
+++ b/modules/route/bindings/go/croute/cgo.go
@@ -6,6 +6,7 @@ package croute
 //#include "api/agent.h"
 //#include "lib/counters/counters.h"
 //#include "modules/route/api/controlplane.h"
+//#include "modules/route/api/fib_object.h"
 import "C"
 
 import (
@@ -24,8 +25,12 @@ const CounterNameMaxLen = C.COUNTER_NAME_LEN - 1
 
 // ModuleConfig is an opaque handle to the route module configuration in shared
 // memory.
+//
+// The config links the table object published under its own name and
+// holds the device table the object's nexthops index into.
 type ModuleConfig struct {
-	ptr ffi.ModuleConfig
+	ptr   ffi.ModuleConfig
+	agent *ffi.Agent
 }
 
 // NewModuleConfig allocates a new route module configuration via the C API.
@@ -40,7 +45,8 @@ func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 	}
 
 	return &ModuleConfig{
-		ptr: ffi.NewModuleConfig(unsafe.Pointer(ptr)),
+		ptr:   ffi.NewModuleConfig(unsafe.Pointer(ptr)),
+		agent: agent,
 	}, nil
 }
 
@@ -48,9 +54,12 @@ func (m *ModuleConfig) asRawPtr() *C.struct_cp_module {
 	return (*C.struct_cp_module)(m.ptr.AsRawPtr())
 }
 
-// AsFFIModule returns the underlying common module config handle.
-func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
-	return m.ptr
+// Publish upserts the module config into a new configuration generation.
+//
+// The object it links must already be published, or the generation is
+// refused.
+func (m *ModuleConfig) Publish() error {
+	return m.agent.UpdateModules([]ffi.ModuleConfig{m.ptr})
 }
 
 // Free destroys the module config, or reports ffi.ErrStillReferenced while a
@@ -63,15 +72,69 @@ func (m *ModuleConfig) Free() error {
 	})
 }
 
-// addRoute maps 1:1 to route_module_config_add_route.
-//
-// An empty counter reaches C as a nil pointer: route_module_config_add_route
-// treats a NULL counter_name the same as an empty one, and passing nil here
-// avoids allocating a zero-length CString for the common uncounted case.
-func (m *ModuleConfig) addRoute(dstMAC [6]byte, srcMAC [6]byte, device string, counter string) (int, error) {
+// linkDevice maps 1:1 to route_module_config_link_device.
+func (m *ModuleConfig) linkDevice(device string) (uint32, error) {
 	cName := C.CString(device)
 	defer C.free(unsafe.Pointer(cName))
 
+	var index C.uint32_t
+	var cErr *C.yanet_error
+	if rc := C.route_module_config_link_device(m.asRawPtr(), cName, &index, &cErr); rc != 0 {
+		return 0, fmt.Errorf("failed to link device %q: %w", device, cerrors.FromC(unsafe.Pointer(cErr)))
+	}
+	return uint32(index), nil
+}
+
+// FIBObject is an opaque handle to a forwarding table object in shared
+// memory, owned by the control plane until it is freed.
+type FIBObject struct {
+	ptr   ffi.ObjectConfig
+	agent *ffi.Agent
+}
+
+// NewFIBObject allocates an empty table object via the C API.
+func NewFIBObject(agent *ffi.Agent, name string) (*FIBObject, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var cErr *C.yanet_error
+	ptr := C.route_fib_object_new((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
+	if ptr == nil {
+		return nil, fmt.Errorf("failed to initialize fib object: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	}
+
+	return &FIBObject{
+		ptr:   ffi.NewObjectConfig(unsafe.Pointer(ptr)),
+		agent: agent,
+	}, nil
+}
+
+func (m *FIBObject) asRawPtr() *C.struct_cp_object {
+	return (*C.struct_cp_object)(m.ptr.AsRawPtr())
+}
+
+// Publish upserts the object into a new configuration generation. A
+// module linking it by name follows it from then on.
+func (m *FIBObject) Publish() error {
+	return m.agent.UpdateObjects([]ffi.ObjectConfig{m.ptr})
+}
+
+// Free destroys the object, or reports ffi.ErrStillReferenced while a live
+// generation still holds it. Safe to call multiple times.
+func (m *FIBObject) Free() error {
+	return m.ptr.Free(func(ptr unsafe.Pointer) (int, unsafe.Pointer, error) {
+		var cErr *C.yanet_error
+		rc, errno := C.route_fib_object_free((*C.struct_cp_object)(ptr), &cErr)
+		return int(rc), unsafe.Pointer(cErr), errno
+	})
+}
+
+// addRoute maps 1:1 to route_fib_object_add_route.
+//
+// An empty counter reaches C as a nil pointer: route_fib_object_add_route
+// treats a NULL counter_name the same as an empty one, and passing nil here
+// avoids allocating a zero-length CString for the common uncounted case.
+func (m *FIBObject) addRoute(dstMAC [6]byte, srcMAC [6]byte, deviceIndex uint32, counter string) (int, error) {
 	var cCounter *C.char
 	if counter != "" {
 		cCounter = C.CString(counter)
@@ -79,11 +142,11 @@ func (m *ModuleConfig) addRoute(dstMAC [6]byte, srcMAC [6]byte, device string, c
 	}
 
 	var cErr *C.yanet_error
-	idx := C.route_module_config_add_route(
+	idx := C.route_fib_object_add_route(
 		m.asRawPtr(),
 		*(*C.struct_ether_addr)(unsafe.Pointer(&dstMAC)),
 		*(*C.struct_ether_addr)(unsafe.Pointer(&srcMAC)),
-		cName,
+		C.uint64_t(deviceIndex),
 		cCounter,
 		&cErr,
 	)
@@ -94,78 +157,78 @@ func (m *ModuleConfig) addRoute(dstMAC [6]byte, srcMAC [6]byte, device string, c
 	return int(idx), nil
 }
 
-// addRouteList maps 1:1 to route_module_config_add_route_list.
-func (m *ModuleConfig) addRouteList(indices []uint32) (int, error) {
+// addRouteList maps 1:1 to route_fib_object_add_route_list.
+func (m *FIBObject) addRouteList(indices []uint32) (int, error) {
 	cIndices := make([]C.uint32_t, len(indices))
-	for i, v := range indices {
-		cIndices[i] = C.uint32_t(v)
+	for idx, v := range indices {
+		cIndices[idx] = C.uint32_t(v)
 	}
 
-	idx, err := C.route_module_config_add_route_list(
+	idx, err := C.route_fib_object_add_route_list(
 		m.asRawPtr(),
 		C.size_t(len(indices)),
 		&cIndices[0],
 	)
 	if err != nil {
-		return -1, fmt.Errorf("route_module_config_add_route_list: %w", err)
+		return -1, fmt.Errorf("route_fib_object_add_route_list: %w", err)
 	}
 	if idx < 0 {
-		return -1, fmt.Errorf("route_module_config_add_route_list: unknown error")
+		return -1, fmt.Errorf("route_fib_object_add_route_list: unknown error")
 	}
 
 	return int(idx), nil
 }
 
-// addPrefixV4 maps 1:1 to route_module_config_add_prefix_v4.
-func (m *ModuleConfig) addPrefixV4(from [4]byte, to [4]byte, routeListIndex uint32) error {
-	if rc := C.route_module_config_add_prefix_v4(
+// addPrefixV4 maps 1:1 to route_fib_object_add_prefix_v4.
+func (m *FIBObject) addPrefixV4(from [4]byte, to [4]byte, routeListIndex uint32) error {
+	if rc := C.route_fib_object_add_prefix_v4(
 		m.asRawPtr(),
 		(*C.uint8_t)(&from[0]),
 		(*C.uint8_t)(&to[0]),
 		C.uint32_t(routeListIndex),
 	); rc != 0 {
-		return fmt.Errorf("route_module_config_add_prefix_v4: error code=%d", rc)
+		return fmt.Errorf("route_fib_object_add_prefix_v4: error code=%d", rc)
 	}
 	return nil
 }
 
-// addPrefixV6 maps 1:1 to route_module_config_add_prefix_v6.
-func (m *ModuleConfig) addPrefixV6(from [16]byte, to [16]byte, routeListIndex uint32) error {
-	if rc := C.route_module_config_add_prefix_v6(
+// addPrefixV6 maps 1:1 to route_fib_object_add_prefix_v6.
+func (m *FIBObject) addPrefixV6(from [16]byte, to [16]byte, routeListIndex uint32) error {
+	if rc := C.route_fib_object_add_prefix_v6(
 		m.asRawPtr(),
 		(*C.uint8_t)(&from[0]),
 		(*C.uint8_t)(&to[0]),
 		C.uint32_t(routeListIndex),
 	); rc != 0 {
-		return fmt.Errorf("route_module_config_add_prefix_v6: error code=%d", rc)
+		return fmt.Errorf("route_fib_object_add_prefix_v6: error code=%d", rc)
 	}
 	return nil
 }
 
 // RouteCount returns the number of distinct hardware nexthops held by the
-// config.
+// object.
 //
 // Despite the name, which mirrors the C symbol, this is not a route count
 // in the routing sense: it counts the resolved forwarding targets, each a
 // distinct (dst MAC, src MAC, device) triple, that prefixes point at.
-func (m *ModuleConfig) RouteCount() uint64 {
-	return uint64(C.route_module_config_route_count(m.asRawPtr()))
+func (m *FIBObject) RouteCount() uint64 {
+	return uint64(C.route_fib_object_route_count(m.asRawPtr()))
 }
 
 // FIBRangeCountV4 returns the number of IPv4 FIB ranges.
 //
 // The count is computed inside the C API without materializing any range,
 // which makes it cheap enough for a metrics scrape.
-func (m *ModuleConfig) FIBRangeCountV4() uint64 {
-	return uint64(C.route_module_config_fib_range_count_v4(m.asRawPtr()))
+func (m *FIBObject) FIBRangeCountV4() uint64 {
+	return uint64(C.route_fib_object_range_count_v4(m.asRawPtr()))
 }
 
 // FIBRangeCountV6 returns the number of IPv6 FIB ranges.
 //
 // The count is computed inside the C API without materializing any range,
 // which makes it cheap enough for a metrics scrape.
-func (m *ModuleConfig) FIBRangeCountV6() uint64 {
-	return uint64(C.route_module_config_fib_range_count_v6(m.asRawPtr()))
+func (m *FIBObject) FIBRangeCountV6() uint64 {
+	return uint64(C.route_fib_object_range_count_v6(m.asRawPtr()))
 }
 
 // fibIter wraps the C fib_iter handle.
@@ -173,9 +236,71 @@ type fibIter struct {
 	ptr *C.struct_fib_iter
 }
 
-// newFIBIter maps 1:1 to fib_iter_new.
-func newFIBIter(config *ModuleConfig) (*fibIter, error) {
-	ptr := C.fib_iter_new(config.asRawPtr())
+// Snapshot is a route config as one generation holds it, read in place
+// from shared memory. Unlike the handles above it owns nothing: it is a
+// view of what the dataplane runs, whoever published it.
+//
+// The generation stays pinned until Close, so a concurrent update cannot
+// free the module config or the table object underneath a read.
+type Snapshot struct {
+	ptr *C.struct_route_snapshot
+}
+
+// OpenSnapshot pins the generation publishing the named config.
+//
+// The error wraps ffi.ErrNotFound when no module config of that name is
+// published.
+func OpenSnapshot(agent *ffi.Agent, name string) (*Snapshot, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var cErr *C.yanet_error
+	ptr := C.route_snapshot_open((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
+	if ptr == nil {
+		return nil, fmt.Errorf("failed to open a snapshot of %q: %w", name, cerrors.FromC(unsafe.Pointer(cErr)))
+	}
+	return &Snapshot{ptr: ptr}, nil
+}
+
+// Close releases the pin. Safe to call multiple times.
+func (m *Snapshot) Close() {
+	if m.ptr != nil {
+		C.route_snapshot_close(m.ptr)
+		m.ptr = nil
+	}
+}
+
+// HasFIB reports whether the generation holds a table object for the
+// config.
+func (m *Snapshot) HasFIB() bool {
+	return bool(C.route_snapshot_has_fib(m.ptr))
+}
+
+// Devices returns the module's device table by index, the index the
+// table's nexthops name a device by.
+func (m *Snapshot) Devices() []string {
+	count := int(C.route_snapshot_device_count(m.ptr))
+	devices := make([]string, count)
+	for idx := range count {
+		devices[idx] = C.GoString(C.route_snapshot_device_name(m.ptr, C.uint64_t(idx)))
+	}
+	return devices
+}
+
+// fibIter maps 1:1 to route_snapshot_fib_iter: the walk borrows the
+// handle's pin.
+func (m *Snapshot) fibIter() (*fibIter, error) {
+	var cErr *C.yanet_error
+	ptr := C.route_snapshot_fib_iter(m.ptr, &cErr)
+	if ptr == nil {
+		return nil, fmt.Errorf("failed to open the published table: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	}
+	return &fibIter{ptr: ptr}, nil
+}
+
+// newFIBIter maps 1:1 to fib_iter_new over an owned object.
+func newFIBIter(object *FIBObject) (*fibIter, error) {
+	ptr := C.fib_iter_new(object.asRawPtr())
 	if ptr == nil {
 		return nil, fmt.Errorf("fib_iter_new: allocation failure")
 	}

--- a/modules/route/bindings/go/croute/cgo.go
+++ b/modules/route/bindings/go/croute/cgo.go
@@ -276,24 +276,6 @@ func (m *Snapshot) HasFIB() bool {
 	return bool(C.route_snapshot_has_fib(m.ptr))
 }
 
-// RouteCount returns the number of distinct hardware nexthops the
-// published table holds, 0 without a table object.
-func (m *Snapshot) RouteCount() uint64 {
-	return uint64(C.route_snapshot_route_count(m.ptr))
-}
-
-// FIBRangeCountV4 returns the number of IPv4 ranges of the published
-// table, 0 without a table object.
-func (m *Snapshot) FIBRangeCountV4() uint64 {
-	return uint64(C.route_snapshot_range_count_v4(m.ptr))
-}
-
-// FIBRangeCountV6 returns the number of IPv6 ranges of the published
-// table, 0 without a table object.
-func (m *Snapshot) FIBRangeCountV6() uint64 {
-	return uint64(C.route_snapshot_range_count_v6(m.ptr))
-}
-
 // Devices returns the module's device table by index, the index the
 // table's nexthops name a device by.
 func (m *Snapshot) Devices() []string {

--- a/modules/route/bindings/go/croute/cgo.go
+++ b/modules/route/bindings/go/croute/cgo.go
@@ -276,6 +276,24 @@ func (m *Snapshot) HasFIB() bool {
 	return bool(C.route_snapshot_has_fib(m.ptr))
 }
 
+// RouteCount returns the number of distinct hardware nexthops the
+// published table holds, 0 without a table object.
+func (m *Snapshot) RouteCount() uint64 {
+	return uint64(C.route_snapshot_route_count(m.ptr))
+}
+
+// FIBRangeCountV4 returns the number of IPv4 ranges of the published
+// table, 0 without a table object.
+func (m *Snapshot) FIBRangeCountV4() uint64 {
+	return uint64(C.route_snapshot_range_count_v4(m.ptr))
+}
+
+// FIBRangeCountV6 returns the number of IPv6 ranges of the published
+// table, 0 without a table object.
+func (m *Snapshot) FIBRangeCountV6() uint64 {
+	return uint64(C.route_snapshot_range_count_v6(m.ptr))
+}
+
 // Devices returns the module's device table by index, the index the
 // table's nexthops name a device by.
 func (m *Snapshot) Devices() []string {

--- a/modules/route/bindings/go/croute/safe.go
+++ b/modules/route/bindings/go/croute/safe.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"net/netip"
 	"slices"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
 const (
@@ -37,10 +39,15 @@ type FIBEntry struct {
 // LinkDevice links a device by name and returns its index in the module's
 // device table, the index a table object's nexthops name it by.
 //
-// A name already linked keeps its index.
+// A name already linked keeps its index. A name the fixed-size table
+// entry cannot hold whole is rejected rather than stored truncated, which
+// would alias it with its prefix.
 func (m *ModuleConfig) LinkDevice(device string) (uint32, error) {
 	if device == "" {
 		return 0, fmt.Errorf("device name is required")
+	}
+	if err := ffi.ValidateDeviceName(device); err != nil {
+		return 0, fmt.Errorf("device name %q: %w", device, err)
 	}
 	return m.linkDevice(device)
 }

--- a/modules/route/bindings/go/croute/safe.go
+++ b/modules/route/bindings/go/croute/safe.go
@@ -49,7 +49,9 @@ func (m *ModuleConfig) LinkDevice(device string) (uint32, error) {
 // egress device in the linking module's table, and an optional
 // per-nexthop dataplane counter name.
 //
-// An empty counter leaves the nexthop uncounted.
+// An empty counter leaves the nexthop uncounted. The index is stored as
+// given, the dataplane drops packets of a nexthop whose index lies past
+// the table of the module running it.
 func (m *FIBObject) AddRoute(srcAddr net.HardwareAddr, dstAddr net.HardwareAddr, deviceIndex uint32, counter string) (int, error) {
 	if len(srcAddr) != 6 {
 		return -1, fmt.Errorf("unsupported source MAC address: must be EUI-48")

--- a/modules/route/bindings/go/croute/safe.go
+++ b/modules/route/bindings/go/croute/safe.go
@@ -34,26 +34,34 @@ type FIBEntry struct {
 	Nexthops      []FIBNexthop
 }
 
-// AddRoute adds a hardware route with MAC addresses, egress device, and an
-// optional per-nexthop dataplane counter name.
+// LinkDevice links a device by name and returns its index in the module's
+// device table, the index a table object's nexthops name it by.
+//
+// A name already linked keeps its index.
+func (m *ModuleConfig) LinkDevice(device string) (uint32, error) {
+	if device == "" {
+		return 0, fmt.Errorf("device name is required")
+	}
+	return m.linkDevice(device)
+}
+
+// AddRoute adds a hardware route with MAC addresses, the index of the
+// egress device in the linking module's table, and an optional
+// per-nexthop dataplane counter name.
 //
 // An empty counter leaves the nexthop uncounted.
-func (m *ModuleConfig) AddRoute(srcAddr net.HardwareAddr, dstAddr net.HardwareAddr, device string, counter string) (int, error) {
+func (m *FIBObject) AddRoute(srcAddr net.HardwareAddr, dstAddr net.HardwareAddr, deviceIndex uint32, counter string) (int, error) {
 	if len(srcAddr) != 6 {
 		return -1, fmt.Errorf("unsupported source MAC address: must be EUI-48")
 	}
 	if len(dstAddr) != 6 {
 		return -1, fmt.Errorf("unsupported destination MAC address: must be EUI-48")
 	}
-	if device == "" {
-		return -1, fmt.Errorf("device name is required")
-	}
-
-	return m.addRoute([6]byte(dstAddr), [6]byte(srcAddr), device, counter)
+	return m.addRoute([6]byte(dstAddr), [6]byte(srcAddr), deviceIndex, counter)
 }
 
 // AddRouteList adds a list of route indices as an ECMP group.
-func (m *ModuleConfig) AddRouteList(routeIndices []uint32) (int, error) {
+func (m *FIBObject) AddRouteList(routeIndices []uint32) (int, error) {
 	if len(routeIndices) == 0 {
 		return -1, fmt.Errorf("routeIndices must not be empty")
 	}
@@ -67,7 +75,7 @@ func (m *ModuleConfig) AddRouteList(routeIndices []uint32) (int, error) {
 // start and end must both be valid, belong to the same address family, and
 // satisfy start <= end. An IPv4-mapped IPv6 address is treated as IPv6,
 // since Is4 returns false for it.
-func (m *ModuleConfig) AddRange(start, end netip.Addr, routeListIdx uint32) error {
+func (m *FIBObject) AddRange(start, end netip.Addr, routeListIdx uint32) error {
 	if !start.IsValid() || !end.IsValid() {
 		return fmt.Errorf("start and end must both be valid addresses")
 	}
@@ -77,21 +85,11 @@ func (m *ModuleConfig) AddRange(start, end netip.Addr, routeListIdx uint32) erro
 	if start.Compare(end) > 0 {
 		return fmt.Errorf("invalid range: start %s is after end %s", start, end)
 	}
+
 	if start.Is4() {
 		return m.addPrefixV4(start.As4(), end.As4(), routeListIdx)
 	}
 	return m.addPrefixV6(start.As16(), end.As16(), routeListIdx)
-}
-
-// DumpFIB reads the Forwarding Information Base from shared memory using a
-// zero-copy iterator.
-func (m *ModuleConfig) DumpFIB() ([]FIBEntry, error) {
-	iter, err := newFIBIter(m)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create FIB iterator: %w", err)
-	}
-
-	return iter.Entries(), nil
 }
 
 // ActiveNexthopCounterNames returns the deduplicated, sorted set of
@@ -100,11 +98,23 @@ func (m *ModuleConfig) DumpFIB() ([]FIBEntry, error) {
 // The iterator walks the LPM after overlap resolution, so a nexthop fully
 // shadowed by a later, overlapping entry is excluded here even though its
 // route and counter are still registered in shared memory.
-func (m *ModuleConfig) ActiveNexthopCounterNames() ([]string, error) {
+func (m *FIBObject) ActiveNexthopCounterNames() ([]string, error) {
 	iter, err := newFIBIter(m)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create FIB iterator: %w", err)
 	}
 
 	return slices.Sorted(maps.Keys(iter.ActiveCounterNames())), nil
+}
+
+// Entries reads the published table straight from shared memory.
+//
+// The error wraps ffi.ErrNotFound when the generation holds no table
+// object for the config.
+func (m *Snapshot) Entries() ([]FIBEntry, error) {
+	iter, err := m.fibIter()
+	if err != nil {
+		return nil, err
+	}
+	return iter.Entries(), nil
 }

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -50,14 +50,10 @@ var (
 )
 
 // Published describes what the dataplane holds for a config name: the
-// module's device table by index, whether its table object is out and
-// the sizes of that table.
+// module's device table by index and whether its table object is out.
 type Published struct {
-	Devices         []string
-	FIB             bool
-	FIBRangeCountV4 uint64
-	FIBRangeCountV6 uint64
-	NexthopCount    uint64
+	Devices []string
+	FIB     bool
 }
 
 // CounterView is a single dataplane counter read back from one position at
@@ -130,11 +126,8 @@ func (m *backend) Published(name string) (Published, error) {
 	}
 	defer snapshot.Close()
 	return Published{
-		Devices:         snapshot.Devices(),
-		FIB:             snapshot.HasFIB(),
-		FIBRangeCountV4: snapshot.FIBRangeCountV4(),
-		FIBRangeCountV6: snapshot.FIBRangeCountV6(),
-		NexthopCount:    snapshot.RouteCount(),
+		Devices: snapshot.Devices(),
+		FIB:     snapshot.HasFIB(),
 	}, nil
 }
 

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -12,29 +12,49 @@ import (
 )
 
 // ModuleHandle is a handle to a route module configuration in shared
-// memory.
+// memory, owned by the control plane until it is freed.
 type ModuleHandle interface {
-	DumpFIB() ([]croute.FIBEntry, error)
+	// Publish upserts the module config into a new configuration
+	// generation. The table object it links must already be published.
+	Publish() error
+	Free() error
+}
+
+// FIBHandle is a handle to a forwarding table object in shared memory,
+// owned by the control plane until it is freed.
+type FIBHandle interface {
+	// Publish upserts the object into a new configuration generation.
+	Publish() error
 	// ActiveNexthopCounterNames returns the deduplicated, sorted set of
 	// per-nexthop counter names reachable through the resolved FIB.
 	//
 	// The only realistic failure is a control-plane allocation failure.
 	ActiveNexthopCounterNames() ([]string, error)
 	// RouteCount returns the number of distinct hardware nexthops the
-	// config resolves prefixes to.
+	// table resolves prefixes to.
 	RouteCount() uint64
 	// FIBRangeCountV4 returns the number of IPv4 FIB ranges, equivalent
-	// to counting the IPv4 entries of DumpFIB but far cheaper.
+	// to counting the IPv4 entries of a dump but far cheaper.
 	FIBRangeCountV4() uint64
 	// FIBRangeCountV6 returns the number of IPv6 FIB ranges, equivalent
-	// to counting the IPv6 entries of DumpFIB but far cheaper.
+	// to counting the IPv6 entries of a dump but far cheaper.
 	FIBRangeCountV6() uint64
 	Free() error
 }
 
-// Compile-time assertion that *croute.ModuleConfig satisfies the
-// ModuleHandle interface. Catches drift in the bindings layer.
-var _ ModuleHandle = (*croute.ModuleConfig)(nil)
+// Compile-time assertions that the bindings satisfy the handle
+// interfaces. Catch drift in the bindings layer.
+var (
+	_ ModuleHandle = (*croute.ModuleConfig)(nil)
+	_ FIBHandle    = (*croute.FIBObject)(nil)
+)
+
+// Published describes what the dataplane holds for a config name: the
+// module's device table by index and whether its table object is out.
+type Published struct {
+	Devices []string
+	FIB     bool
+}
 
 // CounterView is a single dataplane counter read back from one position at
 // which a route config is installed.
@@ -51,19 +71,36 @@ type CounterView struct {
 
 // Backend abstracts shared memory write-path operations for the route
 // module.
+//
+// A config is a module config and a table object published under the
+// same name. The object names egress devices by their index in the
+// module's device table, so the table only ever grows and a module is
+// rebuilt only when a table needs a device it lacks.
 type Backend interface {
-	// UpdateModule builds a fresh ModuleConfig from the supplied FIB
-	// ranges and publishes it to the dataplane atomically.
-	UpdateModule(name string, entries []*routepb.FIBEntry) (ModuleHandle, error)
+	// Published reads what is published under the name. The error wraps
+	// ffi.ErrNotFound when no module config is published under it.
+	Published(name string) (Published, error)
+	// NewModule builds a module config linking the devices, without
+	// publishing it. It returns the module's device table by index,
+	// which may hold entries the module links on its own.
+	NewModule(name string, devices []string) (ModuleHandle, []string, error)
+	// NewFIB builds a table object from the supplied FIB ranges, naming
+	// devices by their index in the table, without publishing it.
+	NewFIB(name string, devices []string, entries []*routepb.FIBEntry) (FIBHandle, error)
 	// DeleteModule removes a module config from the dataplane.
 	DeleteModule(name string) error
+	// DeleteFIB removes a table object from the dataplane.
+	DeleteFIB(name string) error
+	// DumpFIB reads the published table of the named config. The error
+	// wraps ffi.ErrNotFound when the config is not published.
+	DumpFIB(name string) ([]croute.FIBEntry, error)
 	// ModuleCounters reads the named counters back from every position
 	// at which the named config is installed.
 	ModuleCounters(name string, counterNames []string) []CounterView
-	// RuntimeModuleCounters reads the named runtime counters (the
-	// config's per-nexthop registry) from every position at which the
-	// named config is installed.
-	RuntimeModuleCounters(name string, counterNames []string) []CounterView
+	// NexthopCounters reads the named per-nexthop counters, which the
+	// module counts on its link to the table object, from every position
+	// at which the named config is installed.
+	NexthopCounters(name string, counterNames []string) []CounterView
 }
 
 // ErrTooManyNexthops reports a FIB that resolves to more distinct hardware
@@ -82,10 +119,87 @@ func NewBackend(agent *ffi.Agent) Backend {
 	}
 }
 
-func (m *backend) UpdateModule(name string, entries []*routepb.FIBEntry) (ModuleHandle, error) {
+func (m *backend) Published(name string) (Published, error) {
+	snapshot, err := croute.OpenSnapshot(m.agent, name)
+	if err != nil {
+		return Published{}, err
+	}
+	defer snapshot.Close()
+	return Published{
+		Devices: snapshot.Devices(),
+		FIB:     snapshot.HasFIB(),
+	}, nil
+}
+
+func (m *backend) DumpFIB(name string) ([]croute.FIBEntry, error) {
+	snapshot, err := croute.OpenSnapshot(m.agent, name)
+	if err != nil {
+		return nil, err
+	}
+	defer snapshot.Close()
+	return snapshot.Entries()
+}
+
+func (m *backend) NewModule(name string, devices []string) (ModuleHandle, []string, error) {
 	module, err := croute.NewModuleConfig(m.agent, name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create module config: %w", err)
+		return nil, nil, fmt.Errorf("failed to create module config: %w", err)
+	}
+
+	table, err := linkDevices(module, devices)
+	if err != nil {
+		if freeErr := module.Free(); freeErr != nil {
+			return nil, nil, fmt.Errorf("failed to free abandoned config: %w", freeErr)
+		}
+		return nil, nil, err
+	}
+	return module, table, nil
+}
+
+// linkDevices links the devices into the module and returns its device
+// table by index, as the module hands the indexes out.
+//
+// An empty name is the module's own any-device entry, present in a table
+// read back from the dataplane, and is skipped.
+func linkDevices(module *croute.ModuleConfig, devices []string) ([]string, error) {
+	var table []string
+	for _, device := range devices {
+		if device == "" {
+			continue
+		}
+		idx, err := module.LinkDevice(device)
+		if err != nil {
+			return nil, err
+		}
+		if int(idx) >= len(table) {
+			table = append(table, make([]string, int(idx)+1-len(table))...)
+		}
+		table[idx] = device
+	}
+	return table, nil
+}
+
+func (m *backend) NewFIB(name string, devices []string, entries []*routepb.FIBEntry) (FIBHandle, error) {
+	fib, err := croute.NewFIBObject(m.agent, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fib object: %w", err)
+	}
+
+	if err := buildFIB(fib, devices, entries); err != nil {
+		if freeErr := fib.Free(); freeErr != nil {
+			return nil, fmt.Errorf("failed to free abandoned fib object: %w", freeErr)
+		}
+		return nil, err
+	}
+	return fib, nil
+}
+
+// buildFIB fills the table object from the FIB ranges, naming devices by
+// their index in the table.
+func buildFIB(fib *croute.FIBObject, devices []string, entries []*routepb.FIBEntry) error {
+	deviceIndex := make(map[string]uint32, len(devices))
+	for idx, device := range devices {
+		deviceIndex[device] = uint32(idx)
 	}
 
 	// Defensively dedup hardware routes per-range using TinyBitset:
@@ -94,94 +208,71 @@ func (m *backend) UpdateModule(name string, entries []*routepb.FIBEntry) (Module
 	// route module robust to mistakes upstream.
 	hardwareIndex := map[HardwareRoute]uint32{}
 	routeListIndex := map[bitset.TinyBitset]uint32{}
-
 	for _, entry := range entries {
 		start, end, err := entry.GetRange().ToRange()
 		if err != nil {
-			if err := module.Free(); err != nil {
-				return nil, fmt.Errorf("failed to free abandoned config: %w", err)
-			}
-			return nil, fmt.Errorf("failed to parse range: %w", err)
+			return fmt.Errorf("failed to parse range: %w", err)
 		}
 		if start.Compare(end) > 0 {
-			if err := module.Free(); err != nil {
-				return nil, fmt.Errorf("failed to free abandoned config: %w", err)
-			}
-			return nil, fmt.Errorf("range start %q is greater than end %q", start, end)
+			return fmt.Errorf("range start %q is greater than end %q", start, end)
 		}
 
 		key := bitset.TinyBitset{}
 		for _, nh := range entry.GetNexthops() {
 			hardwareRoute, err := newHardwareRoute(nh)
 			if err != nil {
-				if err := module.Free(); err != nil {
-					return nil, fmt.Errorf("failed to free abandoned config: %w", err)
-				}
-				return nil, fmt.Errorf("failed to parse nexthop %v: %w", nh, err)
+				return fmt.Errorf("failed to parse nexthop %v: %w", nh, err)
 			}
 
 			idx, ok := hardwareIndex[hardwareRoute]
 			if !ok {
 				if len(hardwareIndex) >= bitset.MaxBits {
-					if err := module.Free(); err != nil {
-						return nil, fmt.Errorf("failed to free abandoned config: %w", err)
-					}
-					return nil, fmt.Errorf("%w: a route config indexes at most %d", ErrTooManyNexthops, bitset.MaxBits)
+					return fmt.Errorf("%w: a route config indexes at most %d", ErrTooManyNexthops, bitset.MaxBits)
+				}
+				device, ok := deviceIndex[hardwareRoute.Device]
+				if !ok {
+					return fmt.Errorf("device %q is not in the module's device table", hardwareRoute.Device)
 				}
 				// Read from nh, not hardwareRoute: RouteService already
 				// rejects two different counter names for one identity, so
 				// the first nexthop seen carries the name every later one
 				// for this identity would have agreed on.
-				added, err := module.AddRoute(hardwareRoute.SourceMAC[:], hardwareRoute.DestinationMAC[:], hardwareRoute.Device, nh.GetCounter())
+				added, err := fib.AddRoute(hardwareRoute.SourceMAC[:], hardwareRoute.DestinationMAC[:], device, nh.GetCounter())
 				if err != nil {
-					if err := module.Free(); err != nil {
-						return nil, fmt.Errorf("failed to free abandoned config: %w", err)
-					}
-					return nil, fmt.Errorf("failed to add hardware route: %w", err)
+					return fmt.Errorf("failed to add hardware route: %w", err)
 				}
 				idx = uint32(added)
 				hardwareIndex[hardwareRoute] = idx
 			}
 			key.Insert(idx)
 		}
-
 		if key.Count() == 0 {
 			continue
 		}
 
 		listIdx, ok := routeListIndex[key]
 		if !ok {
-			added, err := module.AddRouteList(key.AsSlice())
+			added, err := fib.AddRouteList(key.AsSlice())
 			if err != nil {
-				if err := module.Free(); err != nil {
-					return nil, fmt.Errorf("failed to free abandoned config: %w", err)
-				}
-				return nil, fmt.Errorf("failed to add route list: %w", err)
+				return fmt.Errorf("failed to add route list: %w", err)
 			}
 			listIdx = uint32(added)
 			routeListIndex[key] = listIdx
 		}
 
-		if err := module.AddRange(start, end, listIdx); err != nil {
-			if err := module.Free(); err != nil {
-				return nil, fmt.Errorf("failed to free abandoned config: %w", err)
-			}
-			return nil, fmt.Errorf("failed to add range [%s, %s]: %w", start, end, err)
+		if err := fib.AddRange(start, end, listIdx); err != nil {
+			return fmt.Errorf("failed to add range [%s, %s]: %w", start, end, err)
 		}
 	}
-
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
-		if err := module.Free(); err != nil {
-			return nil, fmt.Errorf("failed to free abandoned config: %w", err)
-		}
-		return nil, fmt.Errorf("failed to update modules: %w", err)
-	}
-
-	return module, nil
+	return nil
 }
 
 func (m *backend) DeleteModule(name string) error {
 	return m.agent.DeleteModuleConfig(moduleType, name)
+}
+
+func (m *backend) DeleteFIB(name string) error {
+	return m.agent.DeleteObject(fibObjectType, name)
 }
 
 func (m *backend) ModuleCounters(name string, counterNames []string) []CounterView {
@@ -190,9 +281,9 @@ func (m *backend) ModuleCounters(name string, counterNames []string) []CounterVi
 	})
 }
 
-func (m *backend) RuntimeModuleCounters(name string, counterNames []string) []CounterView {
+func (m *backend) NexthopCounters(name string, counterNames []string) []CounterView {
 	return m.counters(name, counterNames, func(d, p, f, c, mt, mn string, q []string) []ffi.CounterInfo {
-		infos, err := m.agent.DPConfig().ModuleRuntimeCounters(d, p, f, c, mt, mn, q)
+		infos, err := m.agent.DPConfig().ModuleObjectLinkCounters(d, p, f, c, mt, mn, fibObjectType, name, q)
 		if err != nil {
 			return nil
 		}

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -50,10 +50,14 @@ var (
 )
 
 // Published describes what the dataplane holds for a config name: the
-// module's device table by index and whether its table object is out.
+// module's device table by index, whether its table object is out and
+// the sizes of that table.
 type Published struct {
-	Devices []string
-	FIB     bool
+	Devices         []string
+	FIB             bool
+	FIBRangeCountV4 uint64
+	FIBRangeCountV6 uint64
+	NexthopCount    uint64
 }
 
 // CounterView is a single dataplane counter read back from one position at
@@ -126,8 +130,11 @@ func (m *backend) Published(name string) (Published, error) {
 	}
 	defer snapshot.Close()
 	return Published{
-		Devices: snapshot.Devices(),
-		FIB:     snapshot.HasFIB(),
+		Devices:         snapshot.Devices(),
+		FIB:             snapshot.HasFIB(),
+		FIBRangeCountV4: snapshot.FIBRangeCountV4(),
+		FIBRangeCountV6: snapshot.FIBRangeCountV6(),
+		NexthopCount:    snapshot.RouteCount(),
 	}, nil
 }
 

--- a/modules/route/controlplane/metrics.go
+++ b/modules/route/controlplane/metrics.go
@@ -92,17 +92,18 @@ var counterNames = slices.Sorted(maps.Keys(counterMappings))
 // that config with nothing to read — a module-level or foreign-config
 // counter can never surface under this family.
 func (m *RouteService) collectNexthopMetrics(tags []*commonpb.MetricTag) []*commonpb.Metric {
-	m.shmLock.RLock()
-	defer m.shmLock.RUnlock()
-
 	result := make([]*commonpb.Metric, 0)
-	for configName, entry := range m.configs {
+	for _, configName := range m.configs.Names() {
+		entry, ok := m.configs.Get(configName)
+		if !ok {
+			continue
+		}
 		names, ok := metrics.Query(tags, metrics.WithEntryCounters(entry.NexthopCounterNames))
 		if !ok {
 			continue
 		}
 
-		for _, counter := range m.backend.RuntimeModuleCounters(configName, names) {
+		for _, counter := range m.backend.NexthopCounters(configName, names) {
 			var packets, bytes uint64
 			for _, instance := range counter.Values {
 				if len(instance) > 0 {
@@ -142,16 +143,13 @@ func (m *RouteService) collectNexthopMetrics(tags []*commonpb.MetricTag) []*comm
 // route list counters are invariant canaries expected to read zero
 // forever, which only works if they are visible.
 func (m *RouteService) collectDataplaneMetrics(tags []*commonpb.MetricTag) []*commonpb.Metric {
-	m.shmLock.RLock()
-	defer m.shmLock.RUnlock()
-
 	names, read := metrics.Query(tags, metrics.WithStructuralCounters(counterNames))
 	if !read {
 		return []*commonpb.Metric{}
 	}
 
 	result := make([]*commonpb.Metric, 0)
-	for configName := range m.configs {
+	for _, configName := range m.configs.Names() {
 		for _, counter := range m.backend.ModuleCounters(configName, names) {
 			mapping, ok := counterMappings[counter.Name]
 			if !ok {

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -12,6 +12,9 @@ import (
 const (
 	moduleType = "route"
 	agentName  = moduleType
+	// fibObjectType is the shared-object type a config's table is
+	// published under, linked by the module config of the same name.
+	fibObjectType = "route_fib"
 )
 
 // Option configures the RouteModule constructor.

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"sort"
+	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -16,6 +15,7 @@ import (
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
+	"github.com/yanet-platform/yanet2/controlplane/configstore"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/route/bindings/go/croute"
 	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
@@ -56,11 +56,20 @@ func WithNexthopCountersDisabled() RouteServiceOption {
 // the facts measured at the moment it was applied.
 //
 // A config's FIB is immutable once published: every update builds a fresh
-// handle and retires the previous one. The sizes are therefore measured
-// once here rather than walked out of the LPM keyspace on every scrape.
+// table object and retires the previous one, while the module config moves
+// from entry to entry until its device table has to grow, under the
+// store's write lock, the only place handles are read or written. The
+// sizes are therefore measured once here rather than walked out of the
+// LPM keyspace on every scrape.
 type configEntry struct {
-	// Handle owns the published shared-memory config generation.
-	Handle ModuleHandle
+	// Module is the published module config, nil when it was published
+	// by an earlier process and this one owns no handle for it, or once
+	// it moved to a later entry.
+	Module ModuleHandle
+	// FIB is the published table object, nil while only the module
+	// config is published or once it moved to a later entry.
+	FIB FIBHandle
+
 	// FIBRangeCountV4 is the number of IPv4 FIB ranges the config holds.
 	FIBRangeCountV4 uint64
 	// FIBRangeCountV6 is the number of IPv6 FIB ranges the config holds.
@@ -77,14 +86,19 @@ type configEntry struct {
 	UpdatedAt time.Time
 }
 
-// Free releases the module handle held by the config.
-//
-// It is safe to call even when no handle is held.
+// Free releases the handles the entry still holds, the table object
+// first. A refused free leaves the entry retryable, each free being a
+// no-op once it succeeded.
 func (m *configEntry) Free() error {
-	if m.Handle == nil {
-		return nil
+	if m.FIB != nil {
+		if err := m.FIB.Free(); err != nil {
+			return err
+		}
 	}
-	return m.Handle.Free()
+	if m.Module != nil {
+		return m.Module.Free()
+	}
+	return nil
 }
 
 // RouteService is the gRPC service implementation backing the slim
@@ -94,16 +108,9 @@ type RouteService struct {
 
 	backend Backend
 
-	// deferred holds superseded module handles whose free was refused
-	// because a live configuration generation still referenced them.
-	// This service is their owner: it retries them on its next update,
-	// through ReclaimDeferred, and nothing else remembers them.
-	deferred []ModuleHandle
-
-	// shmLock serializes shared-memory mutations and protects the
-	// configs map.
-	shmLock sync.RWMutex
-	configs map[string]configEntry
+	// configs owns the published configs and retries the retired ones
+	// whose free was refused.
+	configs *configstore.Store[*configEntry]
 
 	metrics *grpcmetrics.ServerMetrics
 
@@ -122,7 +129,7 @@ func NewRouteService(backend Backend, options ...RouteServiceOption) *RouteServi
 
 	m := &RouteService{
 		backend:                backend,
-		configs:                map[string]configEntry{},
+		configs:                configstore.NewStore[*configEntry](),
 		disableNexthopCounters: opts.DisableNexthopCounters,
 	}
 	if opts.Metrics != nil {
@@ -145,12 +152,11 @@ func (m *RouteService) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 // retention snapshots the live route config names and returns a predicate
 // that keeps series whose "config" label is still live (or absent).
 func (m *RouteService) retention() func(metrics.MetricID) bool {
-	m.shmLock.RLock()
-	configNames := make(map[string]struct{}, len(m.configs))
-	for name := range m.configs {
+	names := m.configs.Names()
+	configNames := make(map[string]struct{}, len(names))
+	for _, name := range names {
 		configNames[name] = struct{}{}
 	}
-	m.shmLock.RUnlock()
 
 	return func(id metrics.MetricID) bool {
 		config := id.Labels["config"]
@@ -182,21 +188,16 @@ func (m *RouteService) ListConfigs(
 	ctx context.Context,
 	req *routepb.ListConfigsRequest,
 ) (*routepb.ListConfigsResponse, error) {
-	m.shmLock.RLock()
-	defer m.shmLock.RUnlock()
-
-	response := &routepb.ListConfigsResponse{
-		Configs: make([]string, 0, len(m.configs)),
-	}
-	for name := range m.configs {
-		response.Configs = append(response.Configs, name)
-	}
-	sort.Strings(response.Configs)
-	return response, nil
+	return &routepb.ListConfigsResponse{
+		Configs: m.configs.Names(),
+	}, nil
 }
 
 // ShowFIB returns the FIB entries currently applied in shared memory
 // for the requested configuration.
+//
+// The read pins the configuration generation it walks and takes no lock
+// of this service, so it neither waits for an update nor delays one.
 func (m *RouteService) ShowFIB(
 	ctx context.Context,
 	req *routepb.ShowFIBRequest,
@@ -206,17 +207,10 @@ func (m *RouteService) ShowFIB(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	// Hold RLock for the entire DumpFIB call so a concurrent Free under
-	// shmLock.Lock cannot release the underlying shared memory.
-	m.shmLock.RLock()
-	defer m.shmLock.RUnlock()
-
-	entry, ok := m.configs[name]
-	if !ok {
+	entries, err := m.backend.DumpFIB(name)
+	if errors.Is(err, ffi.ErrNotFound) {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
-
-	entries, err := entry.Handle.DumpFIB()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to dump FIB: %v", err)
 	}
@@ -265,20 +259,24 @@ func (m *RouteService) DeleteConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	m.shmLock.Lock()
-	defer m.shmLock.Unlock()
-
-	entry, ok := m.configs[name]
-	if !ok {
+	// The module goes first: it links the object, and a linked object
+	// refuses deletion. Either half may already be gone after a failed
+	// earlier attempt.
+	err := m.configs.Delete(name, func(current *configEntry) error {
+		if err := m.backend.DeleteModule(name); err != nil && !errors.Is(err, ffi.ErrNotFound) {
+			return fmt.Errorf("failed to delete module config: %w", err)
+		}
+		if err := m.backend.DeleteFIB(name); err != nil && !errors.Is(err, ffi.ErrNotFound) {
+			return fmt.Errorf("failed to delete fib object: %w", err)
+		}
+		return nil
+	})
+	if errors.Is(err, configstore.ErrNotFound) {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
-
-	if err := m.backend.DeleteModule(name); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to delete config %q: %v", name, err)
 	}
-	m.reclaimDeferred()
-	m.parkOrFree(entry.Handle)
-	delete(m.configs, name)
 
 	return &routepb.DeleteConfigResponse{}, nil
 }
@@ -297,7 +295,7 @@ func materializeNexthopCounter(device string, dstMAC [6]byte) string {
 // A generated name is never truncated on overflow: the trailing MAC is what
 // makes two nexthops distinct, so truncating would merge their counters.
 //
-// The conflict check spans the whole request: backend.UpdateModule keys a
+// The conflict check spans the whole request: the FIB build keys a
 // nexthop's route by hardware identity alone, so only the first entry for
 // an identity sets its counter, and a per-entry check could miss the clash.
 func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) error {
@@ -360,8 +358,8 @@ func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) error
 				)
 			}
 
-			// Identity-parse failures are left for backend.UpdateModule to
-			// reject — this check only needs the identity, not full validation.
+			// Identity-parse failures are left for the FIB build to
+			// reject, this check only needs the identity, not full validation.
 			if hardwareRoute, err := newHardwareRoute(nh); err == nil {
 				if prior, ok := identityCounters[hardwareRoute]; ok && prior != counter {
 					return status.Errorf(
@@ -409,49 +407,161 @@ func (m *RouteService) UpdateFIB(
 		return nil, err
 	}
 
-	m.shmLock.Lock()
-	defer m.shmLock.Unlock()
+	// A publish that fails halfway still advances the entry to what went
+	// out, so the error is carried past the store, which only stores on
+	// success.
+	var publishErr error
+	err := m.configs.Update(name, func(current *configEntry, ok bool) (*configEntry, error) {
+		published, err := m.backend.Published(name)
+		if err != nil && !errors.Is(err, ffi.ErrNotFound) {
+			return nil, fmt.Errorf("failed to read the published config %q: %w", name, err)
+		}
+		modulePublished := err == nil
+		devices, grown := extendDeviceTable(published.Devices, entries)
 
-	module, err := m.backend.UpdateModule(name, entries)
+		// The module moves along from the current entry unless the
+		// table needs a device it lacks, then a fresh one takes over.
+		entry := &configEntry{}
+		if ok {
+			entry.Module = current.Module
+		}
+		moduleNew := !modulePublished || grown
+		if moduleNew {
+			module, table, err := m.backend.NewModule(name, devices)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build module config for %q: %w", name, err)
+			}
+			entry.Module = module
+			devices = table
+		}
+		fib, err := m.backend.NewFIB(name, devices, entries)
+		if err != nil {
+			if moduleNew {
+				m.discard(entry.Module)
+			}
+			return nil, fmt.Errorf("failed to build FIB for %q: %w", name, err)
+		}
+
+		// A first table goes out before its module, a grown one after.
+		//
+		// A module is refused until the object it links is published.
+		// Once one is, the module's append-only device table keeps it
+		// valid under the grown module, while the new object would not
+		// resolve on the old module.
+		moduleFirst := moduleNew && published.FIB
+		if moduleFirst {
+			if err := entry.Module.Publish(); err != nil {
+				m.discard(fib)
+				m.discard(entry.Module)
+				return nil, fmt.Errorf("failed to publish module config for %q: %w", name, err)
+			}
+		}
+		if err := fib.Publish(); err != nil {
+			m.discard(fib)
+			err = fmt.Errorf("failed to publish FIB for %q: %w", name, err)
+			if !moduleFirst {
+				if moduleNew {
+					m.discard(entry.Module)
+				}
+				return nil, err
+			}
+			// The grown module is out and the published object stays
+			// under it. The object moves along when this process owns
+			// it, an earlier process's object is not ours to hold.
+			publishErr = err
+			entry.UpdatedAt = time.Now()
+			if ok {
+				entry.FIB = current.FIB
+				current.FIB = nil
+				entry.FIBRangeCountV4 = current.FIBRangeCountV4
+				entry.FIBRangeCountV6 = current.FIBRangeCountV6
+				entry.NexthopCount = current.NexthopCount
+				entry.NexthopCounterNames = current.NexthopCounterNames
+				entry.UpdatedAt = current.UpdatedAt
+			}
+			return entry, nil
+		}
+		if moduleNew && !moduleFirst {
+			if err := entry.Module.Publish(); err != nil {
+				// The object is out, the module that was to run it is
+				// not, so the entry keeps whatever module ran before.
+				m.discard(entry.Module)
+				entry.Module = nil
+				if ok {
+					entry.Module = current.Module
+					current.Module = nil
+				}
+				publishErr = fmt.Errorf("failed to publish module config for %q: %w", name, err)
+			}
+		}
+		if ok && entry.Module == current.Module {
+			current.Module = nil
+		}
+
+		// The exported set is the reachable one, read back off the handle
+		// rather than the request: an entry a later one fully shadows never
+		// materializes a range here, so its counter name is not exported.
+		nexthopCounterNames, err := fib.ActiveNexthopCounterNames()
+		if err != nil {
+			// The table is live, so this must never free it here: workers
+			// may dereference it. The caller retries on error and resends
+			// the whole FIB, so surfacing this one would burn a fresh
+			// generation from the arena, the worst response to memory
+			// pressure.
+			nexthopCounterNames = nil
+		}
+
+		// The counts are read once, here, off the handle just published:
+		// the FIB never changes again for this object, and each read walks
+		// the LPM keyspace.
+		entry.FIB = fib
+		entry.FIBRangeCountV4 = fib.FIBRangeCountV4()
+		entry.FIBRangeCountV6 = fib.FIBRangeCountV6()
+		entry.NexthopCount = fib.RouteCount()
+		entry.NexthopCounterNames = nexthopCounterNames
+		entry.UpdatedAt = time.Now()
+		return entry, nil
+	})
+	if err == nil {
+		err = publishErr
+	}
 	if err != nil {
 		code := codes.Internal
 		if errors.Is(err, ErrTooManyNexthops) {
 			code = codes.InvalidArgument
 		}
-		return nil, status.Errorf(code, "failed to apply FIB for %q: %v", name, err)
-	}
-
-	// The exported set is the reachable one, read back off the handle
-	// rather than the request: an entry a later one fully shadows never
-	// materializes a range here, so its counter name is not exported.
-	nexthopCounterNames, err := module.ActiveNexthopCounterNames()
-	if err != nil {
-		// The module is live, so this must never free it here — workers may
-		// dereference it. The caller retries on error and resends the
-		// whole FIB, so surfacing this one would burn a fresh config
-		// generation from the arena, the worst response to memory pressure.
-		nexthopCounterNames = nil
-	}
-
-	m.reclaimDeferred()
-
-	if old, ok := m.configs[name]; ok {
-		m.parkOrFree(old.Handle)
-	}
-
-	// The counts are read once, here, off the handle just published: the
-	// FIB never changes again for this generation, and each read walks the
-	// LPM keyspace.
-	m.configs[name] = configEntry{
-		Handle:              module,
-		FIBRangeCountV4:     module.FIBRangeCountV4(),
-		FIBRangeCountV6:     module.FIBRangeCountV6(),
-		NexthopCount:        module.RouteCount(),
-		NexthopCounterNames: nexthopCounterNames,
-		UpdatedAt:           time.Now(),
+		return nil, status.Error(code, err.Error())
 	}
 
 	return &routepb.UpdateFIBResponse{}, nil
+}
+
+// discard frees a handle that never got published. Such a handle is
+// dangling, so the free cannot be refused.
+func (m *RouteService) discard(handle interface{ Free() error }) {
+	_ = handle.Free()
+}
+
+// extendDeviceTable appends the devices the entries name that the table
+// lacks, in order of first appearance, and reports whether it grew.
+func extendDeviceTable(table []string, entries []*routepb.FIBEntry) ([]string, bool) {
+	known := make(map[string]struct{}, len(table))
+	for _, device := range table {
+		known[device] = struct{}{}
+	}
+
+	devices := table
+	for _, entry := range entries {
+		for _, nh := range entry.GetNexthops() {
+			device := nh.GetDevice()
+			if _, ok := known[device]; ok {
+				continue
+			}
+			known[device] = struct{}{}
+			devices = append(devices, device)
+		}
+	}
+	return devices, len(devices) != len(table)
 }
 
 // Metrics returns route module metrics matching tags: per-config FIB
@@ -494,11 +604,13 @@ func (m *RouteService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric,
 // derivable as a sum over the family label. Every value was measured when
 // the config was applied, so a scrape costs no shared-memory traversal.
 func (m *RouteService) collectConfigMetrics() []*commonpb.Metric {
-	m.shmLock.RLock()
-	defer m.shmLock.RUnlock()
-
-	result := make([]*commonpb.Metric, 0, 4*len(m.configs))
-	for name, entry := range m.configs {
+	names := m.configs.Names()
+	result := make([]*commonpb.Metric, 0, 4*len(names))
+	for _, name := range names {
+		entry, ok := m.configs.Get(name)
+		if !ok {
+			continue
+		}
 		configLabels := []*commonpb.Label{
 			{Name: "config", Value: name},
 		}
@@ -526,35 +638,10 @@ func (m *RouteService) collectConfigMetrics() []*commonpb.Metric {
 	return result
 }
 
-// parkOrFree frees the handle when it is dangling and parks it for
-// retry when a live generation still references it. The caller must
-// hold m.shmLock.
-func (m *RouteService) parkOrFree(handle ModuleHandle) {
-	if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-		m.deferred = append(m.deferred, handle)
-	}
-}
-
-// ReclaimDeferred retries every deferred handle, dropping the ones whose
-// generations have drained and keeping the rest deferred. It is the
-// reclamation handler for this module's superseded configs; the service
-// itself runs it after each successful publish, and anything else may
-// call it at any time.
+// ReclaimDeferred retries every retired config whose free was refused,
+// dropping the ones whose generations have drained. The store runs it
+// after each successful mutation, and anything else may call it at any
+// time.
 func (m *RouteService) ReclaimDeferred() {
-	m.shmLock.Lock()
-	defer m.shmLock.Unlock()
-	m.reclaimDeferred()
-}
-
-// reclaimDeferred is ReclaimDeferred without the lock. The caller must
-// hold m.shmLock.
-func (m *RouteService) reclaimDeferred() {
-	kept := m.deferred[:0]
-	for _, handle := range m.deferred {
-		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
-			kept = append(kept, handle)
-		}
-	}
-	clear(m.deferred[len(kept):])
-	m.deferred = kept
+	m.configs.ReclaimDeferred()
 }

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -82,7 +82,7 @@ type configEntry struct {
 	// can query them without re-walking the FIB.
 	NexthopCounterNames []string
 	// UpdatedAt is when the FIB was applied to the dataplane, and backs
-	// the staleness gauge.
+	// the staleness gauge. Zero when this process did not apply it.
 	UpdatedAt time.Time
 }
 
@@ -467,9 +467,10 @@ func (m *RouteService) UpdateFIB(
 			}
 			// The grown module is out and the published object stays
 			// under it. The object moves along when this process owns
-			// it, an earlier process's object is not ours to hold.
+			// it, an earlier process's object is not ours to hold, so
+			// only its sizes are read back and its apply time stays
+			// unknown.
 			publishErr = err
-			entry.UpdatedAt = time.Now()
 			if ok {
 				entry.FIB = current.FIB
 				current.FIB = nil
@@ -478,6 +479,10 @@ func (m *RouteService) UpdateFIB(
 				entry.NexthopCount = current.NexthopCount
 				entry.NexthopCounterNames = current.NexthopCounterNames
 				entry.UpdatedAt = current.UpdatedAt
+			} else {
+				entry.FIBRangeCountV4 = published.FIBRangeCountV4
+				entry.FIBRangeCountV6 = published.FIBRangeCountV6
+				entry.NexthopCount = published.NexthopCount
 			}
 			return entry, nil
 		}
@@ -627,12 +632,16 @@ func (m *RouteService) collectConfigMetrics() []*commonpb.Metric {
 			commonpb.NewMetricGauge("route_fib_entries", float64(entry.FIBRangeCountV4), v4Labels...),
 			commonpb.NewMetricGauge("route_fib_entries", float64(entry.FIBRangeCountV6), v6Labels...),
 			commonpb.NewMetricGauge("route_nexthops", float64(entry.NexthopCount), configLabels...),
-			commonpb.NewMetricGauge(
+		)
+		// A table applied by an earlier process has no apply time to
+		// report.
+		if !entry.UpdatedAt.IsZero() {
+			result = append(result, commonpb.NewMetricGauge(
 				"route_config_updated_timestamp_seconds",
 				float64(entry.UpdatedAt.Unix()),
 				configLabels...,
-			),
-		)
+			))
+		}
 	}
 
 	return result

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -468,8 +470,8 @@ func (m *RouteService) UpdateFIB(
 			// The grown module is out and the published object stays
 			// under it. The object moves along when this process owns
 			// it, an earlier process's object is not ours to hold, so
-			// only its sizes are read back and its apply time stays
-			// unknown.
+			// its facts are read back off the dataplane and its apply
+			// time stays unknown.
 			publishErr = err
 			if ok {
 				entry.FIB = current.FIB
@@ -479,10 +481,8 @@ func (m *RouteService) UpdateFIB(
 				entry.NexthopCount = current.NexthopCount
 				entry.NexthopCounterNames = current.NexthopCounterNames
 				entry.UpdatedAt = current.UpdatedAt
-			} else {
-				entry.FIBRangeCountV4 = published.FIBRangeCountV4
-				entry.FIBRangeCountV6 = published.FIBRangeCountV6
-				entry.NexthopCount = published.NexthopCount
+			} else if dumped, err := m.backend.DumpFIB(name); err == nil {
+				entry.FIBRangeCountV4, entry.FIBRangeCountV6, entry.NexthopCount, entry.NexthopCounterNames = tableFacts(dumped)
 			}
 			return entry, nil
 		}
@@ -545,6 +545,32 @@ func (m *RouteService) UpdateFIB(
 // dangling, so the free cannot be refused.
 func (m *RouteService) discard(handle interface{ Free() error }) {
 	_ = handle.Free()
+}
+
+// tableFacts measures a dumped table: ranges per family, distinct
+// hardware nexthops reachable through them and the sorted set of counter
+// names in use.
+func tableFacts(entries []croute.FIBEntry) (rangesV4, rangesV6, nexthops uint64, counterNames []string) {
+	seen := map[HardwareRoute]struct{}{}
+	names := map[string]struct{}{}
+	for _, entry := range entries {
+		if entry.AddressFamily == croute.AddressFamilyIPv4 {
+			rangesV4++
+		} else {
+			rangesV6++
+		}
+		for _, nh := range entry.Nexthops {
+			seen[HardwareRoute{
+				SourceMAC:      [6]byte(nh.SrcMAC),
+				DestinationMAC: [6]byte(nh.DstMAC),
+				Device:         nh.Device,
+			}] = struct{}{}
+			if nh.Counter != "" {
+				names[nh.Counter] = struct{}{}
+			}
+		}
+	}
+	return rangesV4, rangesV6, uint64(len(seen)), slices.Sorted(maps.Keys(names))
 }
 
 // extendDeviceTable appends the devices the entries name that the table

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -400,6 +400,13 @@ func (m *RouteService) UpdateFIB(
 		if start.Compare(end) > 0 {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid range: start %s is after end %s", start, end)
 		}
+		// A name the module's fixed-size device table cannot hold is a
+		// request error, rejected before anything is built.
+		for _, nh := range entry.GetNexthops() {
+			if err := ffi.ValidateDeviceName(nh.GetDevice()); err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid device name %q: %v", nh.GetDevice(), err)
+			}
+		}
 	}
 
 	// Runs before the backend call: a disabled-but-set or over-long name is

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -164,6 +164,8 @@ type fakeBackend struct {
 	modulePublished map[string]bool
 	moduleTable     map[string][]string
 	fibPublished    map[string]bool
+	// publishedSizes holds the table sizes Published reports per name.
+	publishedSizes map[string]route.Published
 
 	// nextModuleHandle / nextFIBHandle, when set for a name, are
 	// returned (and then cleared) by the next NewModule / NewFIB call
@@ -214,6 +216,7 @@ func newFakeBackend() *fakeBackend {
 		modulePublished:  map[string]bool{},
 		moduleTable:      map[string][]string{},
 		fibPublished:     map[string]bool{},
+		publishedSizes:   map[string]route.Published{},
 		nextModuleHandle: map[string]*fakeModuleHandle{},
 		nextFIBHandle:    map[string]*fakeFIBHandle{},
 		lastModuleHandle: map[string]*fakeModuleHandle{},
@@ -232,6 +235,16 @@ func (m *fakeBackend) seedRestart(name string, devices []string) {
 	m.modulePublished[name] = true
 	m.moduleTable[name] = devices
 	m.fibPublished[name] = true
+}
+
+// seedRestartSizes sets the sizes Published reports for a table an
+// earlier process applied.
+func (m *fakeBackend) seedRestartSizes(name string, rangesV4, rangesV6, nexthops uint64) {
+	m.publishedSizes[name] = route.Published{
+		FIBRangeCountV4: rangesV4,
+		FIBRangeCountV6: rangesV6,
+		NexthopCount:    nexthops,
+	}
 }
 
 func (m *fakeBackend) recordModulePublish(name string, table []string) {
@@ -265,9 +278,13 @@ func (m *fakeBackend) Published(name string) (route.Published, error) {
 	if !m.modulePublished[name] {
 		return route.Published{}, fmt.Errorf("module %q: %w", name, ffi.ErrNotFound)
 	}
+	sizes := m.publishedSizes[name]
 	return route.Published{
-		Devices: append([]string(nil), m.moduleTable[name]...),
-		FIB:     m.fibPublished[name],
+		Devices:         append([]string(nil), m.moduleTable[name]...),
+		FIB:             m.fibPublished[name],
+		FIBRangeCountV4: sizes.FIBRangeCountV4,
+		FIBRangeCountV6: sizes.FIBRangeCountV6,
+		NexthopCount:    sizes.NexthopCount,
 	}, nil
 }
 
@@ -1236,6 +1253,7 @@ func Test_RouteService_UpdateFIB_RestartNewDeviceRepublishesModule(t *testing.T)
 func Test_RouteService_UpdateFIB_RestartObjectPublishFailureAfterGrownModuleKeepsModule(t *testing.T) {
 	backend := newFakeBackend()
 	backend.seedRestart("cfg", []string{"", "eth0"})
+	backend.seedRestartSizes("cfg", 11, 23, 5)
 	backend.nextFIBHandle["cfg"] = &fakeFIBHandle{publishErr: errors.New("boom")}
 	service := route.NewRouteService(backend)
 
@@ -1250,6 +1268,13 @@ func Test_RouteService_UpdateFIB_RestartObjectPublishFailureAfterGrownModuleKeep
 	require.True(t, newModule.published, "the grown module published fine; only the object failed")
 	require.False(t, newModule.freed, "the published module must stay with the entry")
 	require.True(t, backend.lastFIBHandle["cfg"].freed, "the object that failed to publish must be discarded")
+
+	// The table the dataplane keeps running is the earlier process's,
+	// so its sizes are reported and its apply time is not.
+	requireConfigGauges(t, service, 11, 23, 5)
+	all, err := service.Metrics()
+	require.NoError(t, err)
+	require.Empty(t, findMetrics(all, "route_config_updated_timestamp_seconds"))
 
 	list, err := service.ListConfigs(t.Context(), &routepb.ListConfigsRequest{})
 	require.NoError(t, err)
@@ -1347,9 +1372,6 @@ func Test_RouteService_UpdateFIB_ModulePublishFailureAfterFirstObjectKeepsObject
 	list, err := service.ListConfigs(t.Context(), &routepb.ListConfigsRequest{})
 	require.NoError(t, err)
 	require.Contains(t, list.GetConfigs(), "cfg", "the object that did publish must still be tracked")
-
-	_, err = service.ShowFIB(t.Context(), &routepb.ShowFIBRequest{Name: "cfg"})
-	require.NoError(t, err, "the object published, so it must be readable")
 
 	_, err = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "cfg"})
 	require.NoError(t, err)

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -1319,6 +1319,21 @@ func Test_RouteService_UpdateFIB_ObjectPublishFailureAfterGrownModuleKeepsOldObj
 	require.Equal(t, 1, oldObject.freeCount, "the old object, now the entry's, must be freed exactly once")
 }
 
+// A device name the module's table cannot hold is a request error and
+// builds nothing.
+func Test_RouteService_UpdateFIB_OverlongDeviceNameIsInvalidArgument(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop(strings.Repeat("p", ffi.MaxDeviceNameLen), ""))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Empty(t, backend.events, "nothing may be built or published for a rejected request")
+}
+
 // A first object publish failing leaves nothing published and nothing
 // tracked.
 func Test_RouteService_UpdateFIB_FirstPublishFailurePublishesNothing(t *testing.T) {

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -164,8 +164,6 @@ type fakeBackend struct {
 	modulePublished map[string]bool
 	moduleTable     map[string][]string
 	fibPublished    map[string]bool
-	// publishedSizes holds the table sizes Published reports per name.
-	publishedSizes map[string]route.Published
 
 	// nextModuleHandle / nextFIBHandle, when set for a name, are
 	// returned (and then cleared) by the next NewModule / NewFIB call
@@ -216,7 +214,6 @@ func newFakeBackend() *fakeBackend {
 		modulePublished:  map[string]bool{},
 		moduleTable:      map[string][]string{},
 		fibPublished:     map[string]bool{},
-		publishedSizes:   map[string]route.Published{},
 		nextModuleHandle: map[string]*fakeModuleHandle{},
 		nextFIBHandle:    map[string]*fakeFIBHandle{},
 		lastModuleHandle: map[string]*fakeModuleHandle{},
@@ -235,16 +232,6 @@ func (m *fakeBackend) seedRestart(name string, devices []string) {
 	m.modulePublished[name] = true
 	m.moduleTable[name] = devices
 	m.fibPublished[name] = true
-}
-
-// seedRestartSizes sets the sizes Published reports for a table an
-// earlier process applied.
-func (m *fakeBackend) seedRestartSizes(name string, rangesV4, rangesV6, nexthops uint64) {
-	m.publishedSizes[name] = route.Published{
-		FIBRangeCountV4: rangesV4,
-		FIBRangeCountV6: rangesV6,
-		NexthopCount:    nexthops,
-	}
 }
 
 func (m *fakeBackend) recordModulePublish(name string, table []string) {
@@ -278,13 +265,9 @@ func (m *fakeBackend) Published(name string) (route.Published, error) {
 	if !m.modulePublished[name] {
 		return route.Published{}, fmt.Errorf("module %q: %w", name, ffi.ErrNotFound)
 	}
-	sizes := m.publishedSizes[name]
 	return route.Published{
-		Devices:         append([]string(nil), m.moduleTable[name]...),
-		FIB:             m.fibPublished[name],
-		FIBRangeCountV4: sizes.FIBRangeCountV4,
-		FIBRangeCountV6: sizes.FIBRangeCountV6,
-		NexthopCount:    sizes.NexthopCount,
+		Devices: append([]string(nil), m.moduleTable[name]...),
+		FIB:     m.fibPublished[name],
 	}, nil
 }
 
@@ -1253,7 +1236,15 @@ func Test_RouteService_UpdateFIB_RestartNewDeviceRepublishesModule(t *testing.T)
 func Test_RouteService_UpdateFIB_RestartObjectPublishFailureAfterGrownModuleKeepsModule(t *testing.T) {
 	backend := newFakeBackend()
 	backend.seedRestart("cfg", []string{"", "eth0"})
-	backend.seedRestartSizes("cfg", 11, 23, 5)
+	// The table the earlier process applied: two IPv4 ranges and one
+	// IPv6 range over two counted nexthops, one of them shared.
+	nexthopA := croute.FIBNexthop{DstMAC: net.HardwareAddr{0, 0, 0, 0, 0, 0xa}, SrcMAC: net.HardwareAddr{0, 0, 0, 0, 0, 1}, Device: "eth0", Counter: "nexthop_a"}
+	nexthopB := croute.FIBNexthop{DstMAC: net.HardwareAddr{0, 0, 0, 0, 0, 0xb}, SrcMAC: net.HardwareAddr{0, 0, 0, 0, 0, 1}, Device: "eth0", Counter: "nexthop_b"}
+	backend.dumpEntries["cfg"] = []croute.FIBEntry{
+		{AddressFamily: croute.AddressFamilyIPv4, PrefixFrom: netip.MustParseAddr("10.0.0.0"), PrefixTo: netip.MustParseAddr("10.0.0.255"), Nexthops: []croute.FIBNexthop{nexthopA, nexthopB}},
+		{AddressFamily: croute.AddressFamilyIPv4, PrefixFrom: netip.MustParseAddr("10.0.1.0"), PrefixTo: netip.MustParseAddr("10.0.1.255"), Nexthops: []croute.FIBNexthop{nexthopA}},
+		{AddressFamily: croute.AddressFamilyIPv6, PrefixFrom: netip.MustParseAddr("fd00::"), PrefixTo: netip.MustParseAddr("fd00::ffff"), Nexthops: []croute.FIBNexthop{nexthopB}},
+	}
 	backend.nextFIBHandle["cfg"] = &fakeFIBHandle{publishErr: errors.New("boom")}
 	service := route.NewRouteService(backend)
 
@@ -1270,11 +1261,13 @@ func Test_RouteService_UpdateFIB_RestartObjectPublishFailureAfterGrownModuleKeep
 	require.True(t, backend.lastFIBHandle["cfg"].freed, "the object that failed to publish must be discarded")
 
 	// The table the dataplane keeps running is the earlier process's,
-	// so its sizes are reported and its apply time is not.
-	requireConfigGauges(t, service, 11, 23, 5)
+	// so its facts are read back off it and its apply time is not.
+	requireConfigGauges(t, service, 2, 1, 2)
 	all, err := service.Metrics()
 	require.NoError(t, err)
 	require.Empty(t, findMetrics(all, "route_config_updated_timestamp_seconds"))
+	require.Contains(t, backend.nexthopQueries, []string{"nexthop_a", "nexthop_b"},
+		"the counters of the table still running must keep being scraped")
 
 	list, err := service.ListConfigs(t.Context(), &routepb.ListConfigsRequest{})
 	require.NoError(t, err)

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -3,6 +3,7 @@ package route_test
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/netip"
 	"sort"
 	"strings"
@@ -14,13 +15,59 @@ import (
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/route/bindings/go/croute"
 	route "github.com/yanet-platform/yanet2/modules/route/controlplane"
 	routepb "github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 )
 
-// fakeHandle is an in-memory implementation of route.ModuleHandle.
-type fakeHandle struct {
+// fakeModuleHandle is an in-memory implementation of route.ModuleHandle.
+type fakeModuleHandle struct {
+	backend *fakeBackend
+	name    string
+	devices []string
+
+	// publishErr, when set, is returned by the next Publish call instead
+	// of taking effect, then cleared.
+	publishErr error
+	published  bool
+
+	// freeRefusals counts down on every Free call, reporting
+	// ffi.ErrStillReferenced while it is positive.
+	freeRefusals int
+	// freed records whether the handle was ever actually released.
+	freed bool
+	// freeCount counts every successful release, catching an accidental
+	// double free.
+	freeCount int
+}
+
+func (m *fakeModuleHandle) Publish() error {
+	if m.publishErr != nil {
+		err := m.publishErr
+		m.publishErr = nil
+		return err
+	}
+	m.published = true
+	m.backend.recordModulePublish(m.name, m.devices)
+	return nil
+}
+
+func (m *fakeModuleHandle) Free() error {
+	if m.freeRefusals > 0 {
+		m.freeRefusals--
+		return ffi.ErrStillReferenced
+	}
+	m.freed = true
+	m.freeCount++
+	m.backend.recordEvent("free module")
+	return nil
+}
+
+// fakeFIBHandle is an in-memory implementation of route.FIBHandle.
+type fakeFIBHandle struct {
+	backend             *fakeBackend
+	name                string
 	routeCount          uint64
 	rangesV4            uint64
 	rangesV6            uint64
@@ -29,94 +76,328 @@ type fakeHandle struct {
 	// instead of nexthopCounterNames, standing in for the control-plane
 	// OOM that is the only realistic way that call fails.
 	activeNamesErr error
-	freed          bool
+
+	// publishErr, when set, is returned by the next Publish call instead
+	// of taking effect, then cleared.
+	publishErr error
+	published  bool
+
+	// freeRefusals counts down on every Free call, reporting
+	// ffi.ErrStillReferenced while it is positive.
+	freeRefusals int
+	// freed records whether the handle was ever actually released.
+	freed bool
+	// freeCount counts every successful release, catching an accidental
+	// double free.
+	freeCount int
 }
 
-func (m *fakeHandle) DumpFIB() ([]croute.FIBEntry, error) {
-	return nil, nil
+func (m *fakeFIBHandle) Publish() error {
+	if m.publishErr != nil {
+		err := m.publishErr
+		m.publishErr = nil
+		return err
+	}
+	m.published = true
+	m.backend.recordFIBPublish(m.name)
+	return nil
 }
 
-func (m *fakeHandle) ActiveNexthopCounterNames() ([]string, error) {
+func (m *fakeFIBHandle) ActiveNexthopCounterNames() ([]string, error) {
 	if m.activeNamesErr != nil {
 		return nil, m.activeNamesErr
 	}
 	return m.nexthopCounterNames, nil
 }
 
-func (m *fakeHandle) RouteCount() uint64 {
+func (m *fakeFIBHandle) RouteCount() uint64 {
 	return m.routeCount
 }
 
-func (m *fakeHandle) FIBRangeCountV4() uint64 {
+func (m *fakeFIBHandle) FIBRangeCountV4() uint64 {
 	return m.rangesV4
 }
 
-func (m *fakeHandle) FIBRangeCountV6() uint64 {
+func (m *fakeFIBHandle) FIBRangeCountV6() uint64 {
 	return m.rangesV6
 }
 
-func (m *fakeHandle) Free() error {
+func (m *fakeFIBHandle) Free() error {
+	if m.freeRefusals > 0 {
+		m.freeRefusals--
+		return ffi.ErrStillReferenced
+	}
 	m.freed = true
+	m.freeCount++
+	m.backend.recordEvent("free fib")
 	return nil
+}
+
+var (
+	_ route.ModuleHandle = (*fakeModuleHandle)(nil)
+	_ route.FIBHandle    = (*fakeFIBHandle)(nil)
+)
+
+// newModuleCall records one NewModule call's arguments.
+type newModuleCall struct {
+	name    string
+	devices []string
+}
+
+// newFIBCall records one NewFIB call's arguments.
+type newFIBCall struct {
+	name    string
+	devices []string
+	entries []*routepb.FIBEntry
 }
 
 // fakeBackend is an in-memory implementation of route.Backend.
+//
+// modulePublished / moduleTable / fibPublished mirror what Published
+// reports for a name: a build (NewModule / NewFIB) never touches them, a
+// handle's own Publish call does. events is the cross-handle publish and
+// free order every handle this backend ever issued appends to, so a test
+// can assert the exact interleaving UpdateFIB produces.
 type fakeBackend struct {
-	mu       sync.Mutex
-	handle   *fakeHandle
+	mu sync.Mutex
+
+	modulePublished map[string]bool
+	moduleTable     map[string][]string
+	fibPublished    map[string]bool
+
+	// nextModuleHandle / nextFIBHandle, when set for a name, are
+	// returned (and then cleared) by the next NewModule / NewFIB call
+	// for that name; otherwise a fresh default handle is created.
+	nextModuleHandle map[string]*fakeModuleHandle
+	nextFIBHandle    map[string]*fakeFIBHandle
+	// lastModuleHandle / lastFIBHandle record the most recently issued
+	// handle per name, so a test can inspect one it never injected.
+	lastModuleHandle map[string]*fakeModuleHandle
+	lastFIBHandle    map[string]*fakeFIBHandle
+
+	// newFIBErr, when set, is returned by the next NewFIB call itself
+	// (a build failure) instead of a handle, then cleared.
+	newFIBErr error
+
+	// dumpEntries holds the injected DumpFIB result per name; a fib
+	// handle's Publish never derives it from the entries it was built
+	// from, so a test wanting ShowFIB to render something sets it
+	// directly.
+	dumpEntries map[string][]croute.FIBEntry
+
+	// calls records the ordered build/delete backend call log per name,
+	// e.g. []string{"module", "fib"}.
+	calls map[string][]string
+	// events records the ordered publish/free log shared across every
+	// handle this backend issued, e.g. []string{"publish fib", "publish
+	// module"}.
+	events []string
+
+	newModuleCalls    []newModuleCall
+	newFIBCalls       []newFIBCall
+	deleteModuleCalls []string
+	deleteFIBCalls    []string
+
 	counters []route.CounterView
-	// runtimeCounters backs RuntimeModuleCounters, the per-nexthop read.
-	runtimeCounters []route.CounterView
+	// nexthopCounters backs NexthopCounters, the per-nexthop read.
+	nexthopCounters []route.CounterView
 	// queries records the counterNames argument of every ModuleCounters
 	// call, in call order.
 	queries [][]string
-	// runtimeQueries records the counterNames argument of every
-	// RuntimeModuleCounters call, in call order.
-	runtimeQueries [][]string
-	// updateCalls records the range entries passed to UpdateModule on
-	// every call, in call order.
-	updateCalls [][]*routepb.FIBEntry
-	// updateErr, when set, is returned by UpdateModule instead of a handle.
-	updateErr error
+	// nexthopQueries records the counterNames argument of every
+	// NexthopCounters call, in call order.
+	nexthopQueries [][]string
 }
 
 func newFakeBackend() *fakeBackend {
-	return &fakeBackend{handle: &fakeHandle{}}
+	return &fakeBackend{
+		modulePublished:  map[string]bool{},
+		moduleTable:      map[string][]string{},
+		fibPublished:     map[string]bool{},
+		nextModuleHandle: map[string]*fakeModuleHandle{},
+		nextFIBHandle:    map[string]*fakeFIBHandle{},
+		lastModuleHandle: map[string]*fakeModuleHandle{},
+		lastFIBHandle:    map[string]*fakeFIBHandle{},
+		dumpEntries:      map[string][]croute.FIBEntry{},
+		calls:            map[string][]string{},
+	}
 }
 
-// UpdateModule records the call and derives the handle's counter names
-// straight off entries, without resolving overlaps: the fake has no LPM, so
-// a test exercising shadowed-nexthop exclusion must go through the real
-// backend instead.
-func (m *fakeBackend) UpdateModule(name string, entries []*routepb.FIBEntry) (route.ModuleHandle, error) {
+var _ route.Backend = (*fakeBackend)(nil)
+
+// seedRestart marks name as already published under devices, by both
+// halves, without ever going through this backend's NewModule/NewFIB —
+// standing in for a config an earlier control-plane process published.
+func (m *fakeBackend) seedRestart(name string, devices []string) {
+	m.modulePublished[name] = true
+	m.moduleTable[name] = devices
+	m.fibPublished[name] = true
+}
+
+func (m *fakeBackend) recordModulePublish(name string, table []string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.updateCalls = append(m.updateCalls, entries)
-	if m.updateErr != nil {
-		return nil, m.updateErr
+	m.modulePublished[name] = true
+	m.moduleTable[name] = table
+	m.events = append(m.events, "publish module")
+}
+
+func (m *fakeBackend) recordFIBPublish(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.fibPublished[name] = true
+	m.events = append(m.events, "publish fib")
+}
+
+func (m *fakeBackend) recordEvent(event string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.events = append(m.events, event)
+}
+
+func (m *fakeBackend) Published(name string) (route.Published, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.modulePublished[name] {
+		return route.Published{}, fmt.Errorf("module %q: %w", name, ffi.ErrNotFound)
+	}
+	return route.Published{
+		Devices: append([]string(nil), m.moduleTable[name]...),
+		FIB:     m.fibPublished[name],
+	}, nil
+}
+
+// NewModule mimics the real module: index 0 is always its own any-device
+// entry (""), and it must not fail when devices already carries one back
+// from a read-back table.
+func (m *fakeBackend) NewModule(name string, devices []string) (route.ModuleHandle, []string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls[name] = append(m.calls[name], "module")
+	m.newModuleCalls = append(m.newModuleCalls, newModuleCall{
+		name:    name,
+		devices: append([]string(nil), devices...),
+	})
+
+	table := []string{""}
+	known := map[string]struct{}{"": {}}
+	for _, device := range devices {
+		if device == "" {
+			continue
+		}
+		if _, ok := known[device]; ok {
+			continue
+		}
+		known[device] = struct{}{}
+		table = append(table, device)
 	}
 
-	names := map[string]struct{}{}
-	for _, entry := range entries {
-		for _, nh := range entry.GetNexthops() {
-			if counter := nh.GetCounter(); counter != "" {
-				names[counter] = struct{}{}
+	handle, ok := m.nextModuleHandle[name]
+	if !ok {
+		handle = &fakeModuleHandle{}
+	}
+	delete(m.nextModuleHandle, name)
+	handle.backend = m
+	handle.name = name
+	handle.devices = table
+	m.lastModuleHandle[name] = handle
+
+	return handle, table, nil
+}
+
+// NewFIB derives the returned handle's counter names straight off
+// entries, without resolving overlaps: the fake has no LPM, so a test
+// exercising shadowed-nexthop exclusion must go through the real backend
+// instead.
+func (m *fakeBackend) NewFIB(name string, devices []string, entries []*routepb.FIBEntry) (route.FIBHandle, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls[name] = append(m.calls[name], "fib")
+	m.newFIBCalls = append(m.newFIBCalls, newFIBCall{
+		name:    name,
+		devices: append([]string(nil), devices...),
+		entries: entries,
+	})
+
+	if m.newFIBErr != nil {
+		err := m.newFIBErr
+		m.newFIBErr = nil
+		return nil, err
+	}
+
+	handle, ok := m.nextFIBHandle[name]
+	if !ok {
+		handle = &fakeFIBHandle{}
+	}
+	delete(m.nextFIBHandle, name)
+	handle.backend = m
+	handle.name = name
+
+	if handle.nexthopCounterNames == nil {
+		names := map[string]struct{}{}
+		for _, entry := range entries {
+			for _, nh := range entry.GetNexthops() {
+				if counter := nh.GetCounter(); counter != "" {
+					names[counter] = struct{}{}
+				}
 			}
 		}
+		sorted := make([]string, 0, len(names))
+		for name := range names {
+			sorted = append(sorted, name)
+		}
+		sort.Strings(sorted)
+		handle.nexthopCounterNames = sorted
 	}
-	sorted := make([]string, 0, len(names))
-	for name := range names {
-		sorted = append(sorted, name)
-	}
-	sort.Strings(sorted)
-	m.handle.nexthopCounterNames = sorted
+	m.lastFIBHandle[name] = handle
 
-	return m.handle, nil
+	return handle, nil
 }
 
 func (m *fakeBackend) DeleteModule(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls[name] = append(m.calls[name], "delete_module")
+	m.deleteModuleCalls = append(m.deleteModuleCalls, name)
+
+	if !m.modulePublished[name] {
+		return fmt.Errorf("module %q: %w", name, ffi.ErrNotFound)
+	}
+	delete(m.modulePublished, name)
+	delete(m.moduleTable, name)
 	return nil
+}
+
+func (m *fakeBackend) DeleteFIB(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls[name] = append(m.calls[name], "delete_fib")
+	m.deleteFIBCalls = append(m.deleteFIBCalls, name)
+
+	if !m.fibPublished[name] {
+		return fmt.Errorf("object %q: %w", name, ffi.ErrNotFound)
+	}
+	delete(m.fibPublished, name)
+	delete(m.dumpEntries, name)
+	return nil
+}
+
+func (m *fakeBackend) DumpFIB(name string) ([]croute.FIBEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.fibPublished[name] {
+		return nil, fmt.Errorf("config %q: %w", name, ffi.ErrNotFound)
+	}
+	return m.dumpEntries[name], nil
 }
 
 func (m *fakeBackend) ModuleCounters(name string, counterNames []string) []route.CounterView {
@@ -127,12 +408,12 @@ func (m *fakeBackend) ModuleCounters(name string, counterNames []string) []route
 	return m.counters
 }
 
-func (m *fakeBackend) RuntimeModuleCounters(name string, counterNames []string) []route.CounterView {
+func (m *fakeBackend) NexthopCounters(name string, counterNames []string) []route.CounterView {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.runtimeQueries = append(m.runtimeQueries, append([]string(nil), counterNames...))
-	return m.runtimeCounters
+	m.nexthopQueries = append(m.nexthopQueries, append([]string(nil), counterNames...))
+	return m.nexthopCounters
 }
 
 // newServiceWithConfig returns a service holding a single applied config
@@ -363,7 +644,7 @@ func requireConfigGauges(t *testing.T, service *route.RouteService, rangesV4, ra
 // and that the hardware nexthop count is reported once per config.
 func TestConfigGauges(t *testing.T) {
 	backend := newFakeBackend()
-	backend.handle = &fakeHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
+	backend.nextFIBHandle["cfg"] = &fakeFIBHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
 
 	service := newServiceWithConfig(t, backend)
 
@@ -380,8 +661,8 @@ func TestConfigGauges(t *testing.T) {
 // scrape.
 func TestConfigGaugesMeasuredAtApply(t *testing.T) {
 	backend := newFakeBackend()
-	handle := &fakeHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
-	backend.handle = handle
+	handle := &fakeFIBHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
+	backend.nextFIBHandle["cfg"] = handle
 
 	service := newServiceWithConfig(t, backend)
 	requireConfigGauges(t, service, 11, 23, 5)
@@ -400,13 +681,13 @@ func TestConfigGaugesMeasuredAtApply(t *testing.T) {
 // the previous handle and republishes the gauges from the new one.
 func TestConfigGaugesFollowLatestApply(t *testing.T) {
 	backend := newFakeBackend()
-	first := &fakeHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
-	backend.handle = first
+	first := &fakeFIBHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
+	backend.nextFIBHandle["cfg"] = first
 
 	service := newServiceWithConfig(t, backend)
 	requireConfigGauges(t, service, 11, 23, 5)
 
-	backend.handle = &fakeHandle{routeCount: 1, rangesV4: 2, rangesV6: 3}
+	backend.nextFIBHandle["cfg"] = &fakeFIBHandle{routeCount: 1, rangesV4: 2, rangesV6: 3}
 	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{ModuleName: "cfg"})
 	require.NoError(t, err)
 
@@ -419,7 +700,7 @@ func TestConfigGaugesFollowLatestApply(t *testing.T) {
 // nothing over from a deleted config of the same name.
 func TestConfigGaugesFollowConfigLifetime(t *testing.T) {
 	backend := newFakeBackend()
-	backend.handle = &fakeHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
+	backend.nextFIBHandle["cfg"] = &fakeFIBHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
 	service := route.NewRouteService(backend)
 
 	all, err := service.Metrics()
@@ -444,7 +725,7 @@ func TestConfigGaugesFollowConfigLifetime(t *testing.T) {
 	require.Empty(t, findMetrics(all, "route_fib_entries"))
 	require.Empty(t, findMetrics(all, "route_nexthops"))
 
-	backend.handle = &fakeHandle{routeCount: 1, rangesV4: 2, rangesV6: 3}
+	backend.nextFIBHandle["cfg"] = &fakeFIBHandle{routeCount: 1, rangesV4: 2, rangesV6: 3}
 	_, err = service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{ModuleName: "cfg"})
 	require.NoError(t, err)
 
@@ -528,8 +809,8 @@ func TestUpdateFIBMaterializesEmptyCounter(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Len(t, backend.updateCalls, 1)
-	got := backend.updateCalls[0][0].Nexthops[0]
+	require.Len(t, backend.newFIBCalls, 1)
+	got := backend.newFIBCalls[0].entries[0].Nexthops[0]
 	require.Equal(t, "nexthop_eth0_aabbccddee01", got.GetCounter())
 }
 
@@ -547,7 +828,7 @@ func TestUpdateFIBPassesThroughExplicitCounter(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	got := backend.updateCalls[0][0].Nexthops[0]
+	got := backend.newFIBCalls[0].entries[0].Nexthops[0]
 	require.Equal(t, "nexthop_my_counter", got.GetCounter())
 }
 
@@ -565,15 +846,14 @@ func TestUpdateFIBDisabledRejectsExplicitCounter(t *testing.T) {
 		Entries:    []*routepb.FIBEntry{entry},
 	})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
-	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+	require.Empty(t, backend.calls, "the backend must not be called when validation rejects the request")
 }
 
-// Test_RouteService_UpdateFIB_TooManyNexthopsIsInvalidArgument verifies that
-// a FIB the backend refuses with ErrTooManyNexthops is reported as a request
-// error, not as an internal failure.
+// A FIB refused with ErrTooManyNexthops is a request error, not an internal
+// failure.
 func Test_RouteService_UpdateFIB_TooManyNexthopsIsInvalidArgument(t *testing.T) {
 	backend := newFakeBackend()
-	backend.updateErr = fmt.Errorf("wrapped: %w", route.ErrTooManyNexthops)
+	backend.newFIBErr = fmt.Errorf("wrapped: %w", route.ErrTooManyNexthops)
 	service := route.NewRouteService(backend)
 
 	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
@@ -600,7 +880,7 @@ func TestUpdateFIBDisabledAllowsEmptyCounter(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	got := backend.updateCalls[0][0].Nexthops[0]
+	got := backend.newFIBCalls[0].entries[0].Nexthops[0]
 	require.Empty(t, got.GetCounter())
 }
 
@@ -642,7 +922,7 @@ func TestUpdateFIBRejectsCounterWithNULByte(t *testing.T) {
 		Entries:    []*routepb.FIBEntry{entry},
 	})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
-	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+	require.Empty(t, backend.calls, "the backend must not be called when validation rejects the request")
 }
 
 // TestUpdateFIBRejectsCounterWithoutPrefix verifies that an explicit
@@ -660,7 +940,7 @@ func TestUpdateFIBRejectsCounterWithoutPrefix(t *testing.T) {
 		Entries:    []*routepb.FIBEntry{entry},
 	})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
-	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+	require.Empty(t, backend.calls, "the backend must not be called when validation rejects the request")
 }
 
 // TestUpdateFIBRejectsConflictingCounterNamesWithinEntry verifies that
@@ -683,7 +963,7 @@ func TestUpdateFIBRejectsConflictingCounterNamesWithinEntry(t *testing.T) {
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 	require.ErrorContains(t, err, "nexthop_a")
 	require.ErrorContains(t, err, "nexthop_b")
-	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+	require.Empty(t, backend.calls, "the backend must not be called when validation rejects the request")
 }
 
 // TestUpdateFIBRejectsConflictingCounterNamesAcrossEntries verifies that the
@@ -701,7 +981,7 @@ func TestUpdateFIBRejectsConflictingCounterNamesAcrossEntries(t *testing.T) {
 		Entries:    []*routepb.FIBEntry{entryA, entryB},
 	})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
-	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+	require.Empty(t, backend.calls, "the backend must not be called when validation rejects the request")
 }
 
 // TestUpdateFIBToleratesActiveNexthopCounterNamesFailure verifies that a
@@ -710,8 +990,9 @@ func TestUpdateFIBRejectsConflictingCounterNamesAcrossEntries(t *testing.T) {
 // apply, and leaves the handle live and tracked rather than freeing it.
 func TestUpdateFIBToleratesActiveNexthopCounterNamesFailure(t *testing.T) {
 	backend := newFakeBackend()
-	backend.handle = &fakeHandle{routeCount: 3, activeNamesErr: errors.New("fib_iter_new: allocation failure")}
-	backend.runtimeCounters = []route.CounterView{
+	handle := &fakeFIBHandle{routeCount: 3, activeNamesErr: errors.New("fib_iter_new: allocation failure")}
+	backend.nextFIBHandle["cfg"] = handle
+	backend.nexthopCounters = []route.CounterView{
 		counterView("nexthop_my_counter", [][]uint64{{1, 100}}),
 	}
 	service := route.NewRouteService(backend)
@@ -722,20 +1003,20 @@ func TestUpdateFIBToleratesActiveNexthopCounterNamesFailure(t *testing.T) {
 		Entries:    []*routepb.FIBEntry{entry},
 	})
 	require.NoError(t, err, "the FIB itself did apply, so the RPC must still report success")
-	require.False(t, backend.handle.freed, "a published handle must never be freed on this path")
+	require.False(t, handle.freed, "a published handle must never be freed on this path")
 
 	requireConfigGauges(t, service, 0, 0, 3)
 
 	all, err := service.Metrics()
 	require.NoError(t, err)
 	require.Empty(t, findMetrics(all, "route_nexthop_packets"), "the counter set must be empty until the next update")
-	for _, query := range append(append([][]string(nil), backend.queries...), backend.runtimeQueries...) {
+	for _, query := range append(append([][]string(nil), backend.queries...), backend.nexthopQueries...) {
 		require.NotContains(t, query, "nexthop_my_counter", "the empty counter set must never be queried for")
 	}
 
 	_, err = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "cfg"})
 	require.NoError(t, err)
-	require.True(t, backend.handle.freed, "the config must still be tracked so DeleteConfig can free it")
+	require.True(t, handle.freed, "the config must still be tracked so DeleteConfig can free it")
 }
 
 // TestNexthopMetricsSumWorkerInstances verifies that collectNexthopMetrics
@@ -753,7 +1034,7 @@ func TestNexthopMetricsSumWorkerInstances(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	backend.runtimeCounters = []route.CounterView{
+	backend.nexthopCounters = []route.CounterView{
 		counterView("nexthop_my_counter", [][]uint64{{1, 100}, {2, 200}}),
 	}
 
@@ -782,7 +1063,7 @@ func TestNexthopMetricsSumWorkerInstances(t *testing.T) {
 // never resurface mislabeled under the route_nexthop_* family.
 func TestNexthopMetricsExactTagNeverReadsForeignCounter(t *testing.T) {
 	backend := newFakeBackend()
-	backend.runtimeCounters = []route.CounterView{
+	backend.nexthopCounters = []route.CounterView{
 		counterView("route_forwarded_v4", [][]uint64{{7, 700}}),
 	}
 	service := route.NewRouteService(backend)
@@ -807,5 +1088,397 @@ func TestNexthopMetricsExactTagNeverReadsForeignCounter(t *testing.T) {
 	// (whose exact-tag branch never matches a per-entry read) has anything
 	// left to query.
 	require.Empty(t, backend.queries)
-	require.Empty(t, backend.runtimeQueries)
+	require.Empty(t, backend.nexthopQueries)
+}
+
+// The first UpdateFIB of a name links the request's devices in first-seen
+// order and publishes the object before the module.
+func Test_RouteService_UpdateFIB_FirstUpdatePublishesObjectThenModule(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	entryA := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth1", ""))
+	entryB := testFIBEntry(t, "10.0.1.0/32", testNexthop("eth0", ""))
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entryA, entryB},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"module", "fib"}, backend.calls["cfg"], "the module must be built before the object")
+	require.Equal(t, []string{"publish fib", "publish module"}, backend.events, "the object must publish before the module")
+	require.Len(t, backend.newModuleCalls, 1)
+	require.Equal(t, []string{"eth1", "eth0"}, backend.newModuleCalls[0].devices,
+		"devices must be linked in first-seen order")
+	require.Len(t, backend.newFIBCalls, 1)
+	require.Equal(t, []string{"", "eth1", "eth0"}, backend.newFIBCalls[0].devices,
+		"the object must be built from the table the module handed back, index 0 being its own entry")
+}
+
+// An UpdateFIB naming only known devices publishes the object alone and
+// keeps the module.
+func Test_RouteService_UpdateFIB_KnownDevicesRepublishesObjectAlone(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	first := &fakeFIBHandle{}
+	backend.nextFIBHandle["cfg"] = first
+	entry1 := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry1},
+	})
+	require.NoError(t, err)
+
+	entry2 := testFIBEntry(t, "10.0.1.0/32", testNexthop("eth0", ""))
+	_, err = service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry2},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"module", "fib", "fib"}, backend.calls["cfg"],
+		"the module must not be rebuilt when its table already covers every named device")
+	require.Equal(t,
+		[]string{"publish fib", "publish module", "publish fib", "free fib"},
+		backend.events,
+		"the second update publishes only the object and frees the retired one",
+	)
+	require.True(t, first.freed, "the retired object must be freed")
+	require.False(t, backend.lastModuleHandle["cfg"].freed, "the still-shared module must not be freed")
+}
+
+// A new device extends the table in place, republishes the module before
+// the object and frees the superseded pair.
+func Test_RouteService_UpdateFIB_NewDeviceGrowsAndRepublishesModule(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	entry1 := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry1},
+	})
+	require.NoError(t, err)
+	firstModule := backend.lastModuleHandle["cfg"]
+	firstObject := backend.lastFIBHandle["cfg"]
+
+	entry2 := testFIBEntry(t, "10.0.1.0/32", testNexthop("eth1", ""))
+	_, err = service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry2},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.newModuleCalls, 2)
+	require.Equal(t, []string{"eth0"}, backend.newModuleCalls[0].devices)
+	require.Equal(t, []string{"", "eth0", "eth1"}, backend.newModuleCalls[1].devices,
+		"the extended table, read back from Published, must keep eth0's index and append eth1")
+	require.Equal(t,
+		[]string{"publish fib", "publish module", "publish module", "publish fib", "free fib", "free module"},
+		backend.events,
+		"a grown table publishes the new module before the new object, then frees the superseded pair",
+	)
+	require.True(t, firstModule.freed, "the superseded module must be freed once its replacement is published")
+	require.True(t, firstObject.freed, "the superseded object must be freed once its replacement is published")
+}
+
+// After a restart, known devices publish only the object and DeleteConfig
+// still deletes both halves by name without a module handle.
+func Test_RouteService_UpdateFIB_RestartKnownDevicesPublishesObjectOnly(t *testing.T) {
+	backend := newFakeBackend()
+	// Simulate a module and object published by an earlier control-plane
+	// process: present in what Published reports, without ever going
+	// through this backend instance's NewModule/NewFIB.
+	backend.seedRestart("cfg", []string{"", "eth0"})
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, backend.newModuleCalls, "the module is already published with a sufficient table")
+	require.Equal(t, []string{"publish fib"}, backend.events)
+
+	_, err = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "cfg"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"cfg"}, backend.deleteModuleCalls)
+	require.Equal(t, []string{"cfg"}, backend.deleteFIBCalls)
+}
+
+// After a restart, a new device extends the published table and
+// republishes the module before the object.
+func Test_RouteService_UpdateFIB_RestartNewDeviceRepublishesModule(t *testing.T) {
+	backend := newFakeBackend()
+	backend.seedRestart("cfg", []string{"", "eth0"})
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth1", ""))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.newModuleCalls, 1)
+	require.Equal(t, []string{"", "eth0", "eth1"}, backend.newModuleCalls[0].devices)
+	require.Equal(t, []string{"publish module", "publish fib"}, backend.events,
+		"an object already published means the rebuilt module must publish first")
+}
+
+// After a restart, an object publish failing after a grown module went out
+// keeps the new module without an object, an earlier process's object not
+// being ours to hold, and DeleteConfig still deletes both halves by name.
+func Test_RouteService_UpdateFIB_RestartObjectPublishFailureAfterGrownModuleKeepsModule(t *testing.T) {
+	backend := newFakeBackend()
+	backend.seedRestart("cfg", []string{"", "eth0"})
+	backend.nextFIBHandle["cfg"] = &fakeFIBHandle{publishErr: errors.New("boom")}
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth1", ""))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.Error(t, err)
+
+	newModule := backend.lastModuleHandle["cfg"]
+	require.True(t, newModule.published, "the grown module published fine; only the object failed")
+	require.False(t, newModule.freed, "the published module must stay with the entry")
+	require.True(t, backend.lastFIBHandle["cfg"].freed, "the object that failed to publish must be discarded")
+
+	list, err := service.ListConfigs(t.Context(), &routepb.ListConfigsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"cfg"}, list.GetConfigs())
+
+	_, err = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "cfg"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"cfg"}, backend.deleteModuleCalls)
+	require.Equal(t, []string{"cfg"}, backend.deleteFIBCalls)
+	require.Equal(t, 1, newModule.freeCount, "the module must be freed exactly once")
+}
+
+// An object publish failing after a grown module went out keeps the old
+// object under the new module and frees the superseded module.
+func Test_RouteService_UpdateFIB_ObjectPublishFailureAfterGrownModuleKeepsOldObject(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	firstEntry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{firstEntry},
+	})
+	require.NoError(t, err)
+	oldModule := backend.lastModuleHandle["cfg"]
+	oldObject := backend.lastFIBHandle["cfg"]
+
+	backend.nextFIBHandle["cfg"] = &fakeFIBHandle{publishErr: errors.New("boom")}
+	newEntry := testFIBEntry(t, "10.0.1.0/32", testNexthop("eth1", ""))
+	_, err = service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{newEntry},
+	})
+	require.Error(t, err)
+
+	newModule := backend.lastModuleHandle["cfg"]
+	require.NotSame(t, oldModule, newModule, "the module must have been rebuilt for the grown table")
+	require.True(t, newModule.published, "the new module published fine; only the object failed")
+	require.True(t, oldModule.freed, "the superseded module must be freed even though the update failed")
+	require.False(t, oldObject.freed, "the old object must stay published, moved into the new entry")
+
+	// The failed-to-publish object is discarded, not left dangling.
+	failedObject := backend.lastFIBHandle["cfg"]
+	require.True(t, failedObject.freed)
+
+	_, err = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "cfg"})
+	require.NoError(t, err)
+	require.Equal(t, 1, newModule.freeCount, "the new module must be freed exactly once")
+	require.Equal(t, 1, oldObject.freeCount, "the old object, now the entry's, must be freed exactly once")
+}
+
+// A first object publish failing leaves nothing published and nothing
+// tracked.
+func Test_RouteService_UpdateFIB_FirstPublishFailurePublishesNothing(t *testing.T) {
+	backend := newFakeBackend()
+	backend.nextFIBHandle["cfg"] = &fakeFIBHandle{publishErr: errors.New("boom")}
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.Error(t, err)
+
+	require.True(t, backend.lastModuleHandle["cfg"].freed, "the built module must be discarded when nothing published")
+	require.True(t, backend.lastFIBHandle["cfg"].freed, "the object that failed to publish must be discarded")
+	require.Equal(t, []string{"free fib", "free module"}, backend.events,
+		"neither handle ever published, but both must still be freed")
+
+	list, err := service.ListConfigs(t.Context(), &routepb.ListConfigsRequest{})
+	require.NoError(t, err)
+	require.NotContains(t, list.GetConfigs(), "cfg", "nothing was published, so the config must not be tracked")
+}
+
+// A module publish failing after the first object went out keeps the
+// object published and tracked, and DeleteConfig still tears it down.
+func Test_RouteService_UpdateFIB_ModulePublishFailureAfterFirstObjectKeepsObjectPublished(t *testing.T) {
+	backend := newFakeBackend()
+	backend.nextModuleHandle["cfg"] = &fakeModuleHandle{publishErr: errors.New("boom")}
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.Error(t, err)
+
+	module := backend.lastModuleHandle["cfg"]
+	require.True(t, module.freed, "the module that failed to publish must be discarded immediately")
+	require.Equal(t, []string{"publish fib", "free module"}, backend.events,
+		"the object published and the module that failed to publish was discarded")
+
+	list, err := service.ListConfigs(t.Context(), &routepb.ListConfigsRequest{})
+	require.NoError(t, err)
+	require.Contains(t, list.GetConfigs(), "cfg", "the object that did publish must still be tracked")
+
+	_, err = service.ShowFIB(t.Context(), &routepb.ShowFIBRequest{Name: "cfg"})
+	require.NoError(t, err, "the object published, so it must be readable")
+
+	_, err = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "cfg"})
+	require.NoError(t, err)
+}
+
+// DeleteConfig deletes the module before the object and tolerates
+// NotFound on either half.
+func Test_RouteService_DeleteConfig_DeletesModuleBeforeObjectAndToleratesNotFound(t *testing.T) {
+	tests := []struct {
+		name         string
+		removeModule bool
+		removeObject bool
+	}{
+		{name: "both present"},
+		{name: "module already gone", removeModule: true},
+		{name: "object already gone", removeObject: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			backend := newFakeBackend()
+			service := route.NewRouteService(backend)
+
+			entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
+			_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+				ModuleName: "cfg",
+				Entries:    []*routepb.FIBEntry{entry},
+			})
+			require.NoError(t, err)
+
+			if test.removeModule {
+				delete(backend.modulePublished, "cfg")
+			}
+			if test.removeObject {
+				delete(backend.fibPublished, "cfg")
+			}
+
+			_, err = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "cfg"})
+			require.NoError(t, err)
+			require.Equal(t,
+				[]string{"module", "fib", "delete_module", "delete_fib"},
+				backend.calls["cfg"],
+				"the module must be deleted before the object even when one half is already gone",
+			)
+		})
+	}
+}
+
+// A refused free parks the entry until ReclaimDeferred succeeds, and a
+// module passed along is freed only by the last entry holding it.
+func Test_RouteService_ReclaimDeferred_RetriesRefusedFreeUntilItSucceeds(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	// Both updates name the same device, so they share one module: its
+	// own free count is what proves "freed only once the last entry
+	// retires."
+	entry1 := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry1},
+	})
+	require.NoError(t, err)
+	firstObject := backend.lastFIBHandle["cfg"]
+	module := backend.lastModuleHandle["cfg"]
+
+	firstObject.freeRefusals = 2
+
+	entry2 := testFIBEntry(t, "10.0.1.0/32", testNexthop("eth0", ""))
+	_, err = service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry2},
+	})
+	require.NoError(t, err)
+	require.False(t, firstObject.freed, "the refused free must park the entry rather than lose it")
+	require.False(t, module.freed, "the module is still held by the entry now published")
+
+	service.ReclaimDeferred()
+	require.False(t, firstObject.freed, "one retry must still be refused")
+
+	service.ReclaimDeferred()
+	require.True(t, firstObject.freed, "the second retry must drain and free the parked entry")
+	require.False(t, module.freed, "the module is still referenced by the live entry")
+
+	_, err = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "cfg"})
+	require.NoError(t, err)
+	require.Equal(t, 1, module.freeCount, "the module must be freed exactly once, when the last entry retires")
+}
+
+// ShowFIB maps a missing config to NotFound and renders what the backend
+// dumped.
+func Test_RouteService_ShowFIB_MapsNotFoundAndRendersDumpedEntries(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	_, err := service.ShowFIB(t.Context(), &routepb.ShowFIBRequest{Name: "missing"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "nexthop_x"))
+	_, err = service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.NoError(t, err)
+
+	addr := netip.MustParseAddr("10.0.0.0")
+	backend.dumpEntries["cfg"] = []croute.FIBEntry{{
+		AddressFamily: croute.AddressFamilyIPv4,
+		PrefixFrom:    addr,
+		PrefixTo:      addr,
+		Nexthops: []croute.FIBNexthop{{
+			DstMAC:  net.HardwareAddr(testDstMAC[:]),
+			SrcMAC:  net.HardwareAddr(testSrcMAC[:]),
+			Device:  "eth0",
+			Counter: "nexthop_x",
+		}},
+	}}
+
+	resp, err := service.ShowFIB(t.Context(), &routepb.ShowFIBRequest{Name: "cfg"})
+	require.NoError(t, err)
+	require.Len(t, resp.GetEntries(), 1)
+
+	got := resp.GetEntries()[0]
+	gotStart, gotEnd, err := got.GetRange().ToRange()
+	require.NoError(t, err)
+	require.Equal(t, addr, gotStart)
+	require.Equal(t, addr, gotEnd)
+
+	require.Len(t, got.GetNexthops(), 1)
+	require.Equal(t, "eth0", got.GetNexthops()[0].GetDevice())
+	require.Equal(t, "nexthop_x", got.GetNexthops()[0].GetCounter())
 }

--- a/modules/route/controlplane/updatefib_test.go
+++ b/modules/route/controlplane/updatefib_test.go
@@ -71,7 +71,7 @@ func TestUpdateFIBInvalidRangesRejected(t *testing.T) {
 				Entries:    []*routepb.FIBEntry{test.entry},
 			})
 			require.Equal(t, codes.InvalidArgument, status.Code(err))
-			require.Empty(t, backend.updateCalls)
+			require.Empty(t, backend.calls)
 		})
 	}
 }
@@ -104,9 +104,9 @@ func TestUpdateFIBPreservesOrder(t *testing.T) {
 		Entries:    entries,
 	})
 	require.NoError(t, err)
-	require.Len(t, backend.updateCalls, 1)
+	require.Len(t, backend.newFIBCalls, 1)
 
-	got := backend.updateCalls[0]
+	got := backend.newFIBCalls[0].entries
 	require.Len(t, got, len(wantStarts))
 	for idx := range wantStarts {
 		gotStart, gotEnd, err := got[idx].GetRange().ToRange()

--- a/modules/route/dataplane/config.h
+++ b/modules/route/dataplane/config.h
@@ -18,16 +18,16 @@ struct route_family_counter_ids {
 	uint64_t drop_device_unresolved;
 };
 
-/*
- * Route module configuration. Handler lookups route list index using
- * corresponding lpm and retrieves start position and count of applicable
- * route indexes. Using packet hash randomization the handler chooses one route
- * index and fetches one route to be applied to a packet.
- */
+// The forwarding table lives in a shared object the module links by name,
+// so a table update publishes the object alone.
+//
+// The handler resolves the link once per batch and reads the table
+// through the object.
 struct route_module_config {
 	struct cp_module cp_module;
 
-	struct route_fib fib;
+	// Where the table sits among the module's object links.
+	uint64_t fib_link_idx;
 
 	// Module-level counters, registered by route_module_config_new
 	struct route_family_counter_ids counters_v4;
@@ -36,9 +36,4 @@ struct route_module_config {
 	// A non-IP packet has no address family, so its drop counter is
 	// shared rather than kept in a per-family set.
 	uint64_t drop_non_ip_counter_id;
-
-	// Index of the per-route "routes" counter registry within
-	// cp_module.runtime_counter_registries. Each per-route counter_id is
-	// resolved against this registry's per-worker storage.
-	uint64_t routes_registry_idx;
 };

--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -243,9 +243,14 @@ route_handle_packets(
 
 		struct route *route = ADDR_OF(&fib->routes) + route_index;
 
-		uint16_t device_id = module_ectx_encode_device(
-			module_ectx, route->device_id
-		);
+		// An index past the module's device table resolves nothing,
+		// the way a table built against a longer one would.
+		uint16_t device_id = (uint16_t)-1;
+		if (route->device_id < module_ectx->mc_index_size) {
+			device_id = module_ectx_encode_device(
+				module_ectx, route->device_id
+			);
+		}
 
 		if (device_id == (uint16_t)-1) {
 			route_count_packet(

--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -46,7 +46,7 @@ route_count_packet(
 
 static uint32_t
 route_handle_v4(
-	struct route_module_config *config,
+	const struct route_fib *fib,
 	struct packet *packet,
 	enum route_drop_reason *drop_reason
 ) {
@@ -73,12 +73,12 @@ route_handle_v4(
 
 	// Past the TTL check a miss is the only remaining way to fail.
 	*drop_reason = ROUTE_DROP_NO_ROUTE;
-	return lpm_lookup(&config->fib.lpm_v4, 4, (uint8_t *)&header->dst_addr);
+	return lpm_lookup(&fib->lpm_v4, 4, (uint8_t *)&header->dst_addr);
 }
 
 static uint32_t
 route_handle_v6(
-	struct route_module_config *config,
+	const struct route_fib *fib,
 	struct packet *packet,
 	enum route_drop_reason *drop_reason
 ) {
@@ -95,7 +95,7 @@ route_handle_v6(
 
 	// Past the hop limit check a miss is the only remaining way to fail.
 	*drop_reason = ROUTE_DROP_NO_ROUTE;
-	return lpm_lookup(&config->fib.lpm_v6, 16, header->dst_addr);
+	return lpm_lookup(&fib->lpm_v6, 16, header->dst_addr);
 }
 
 static void
@@ -161,11 +161,28 @@ route_handle_packets(
 
 	struct counter_storage *counter_storage =
 		module_ectx->abs_counter_storage;
-	// Per-route counters live in the "routes" runtime registry, resolved
-	// through its own per-worker storage.
-	struct counter_storage *routes_storage = module_ectx_counter_storage(
-		module_ectx, route_config->routes_registry_idx
+
+	// The table and its per-nexthop counters sit behind the module's
+	// object link, resolved once per batch.
+	struct module_object_link_ectx *link = object_link_get_address(
+		module_ectx, route_config->fib_link_idx
 	);
+	if (link == NULL) {
+		struct packet *packet;
+		while ((packet = packet_list_pop(&packet_front->input)) != NULL
+		) {
+			packet_front_drop(packet_front, packet);
+		}
+		return;
+	}
+	struct route_fib_object *fib_object = container_of(
+		link->abs_object_ectx->abs_cp_object,
+		struct route_fib_object,
+		cp_object
+	);
+	const struct route_fib *fib = &fib_object->fib;
+	struct counter_storage *routes_storage =
+		ADDR_OF(&link->counter_storage);
 
 	struct packet *packet;
 	while ((packet = packet_list_pop(&packet_front->input)) != NULL) {
@@ -177,15 +194,13 @@ route_handle_packets(
 
 		if (packet->network_header.type ==
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
-			route_list_id = route_handle_v4(
-				route_config, packet, &drop_reason
-			);
+			route_list_id =
+				route_handle_v4(fib, packet, &drop_reason);
 			counters = &route_config->counters_v4;
 		} else if (packet->network_header.type ==
 			   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
-			route_list_id = route_handle_v6(
-				route_config, packet, &drop_reason
-			);
+			route_list_id =
+				route_handle_v6(fib, packet, &drop_reason);
 			counters = &route_config->counters_v6;
 		} else {
 			route_count_packet(
@@ -210,7 +225,7 @@ route_handle_packets(
 		}
 
 		struct route_list *route_list =
-			ADDR_OF(&route_config->fib.route_lists) + route_list_id;
+			ADDR_OF(&fib->route_lists) + route_list_id;
 		if (route_list->count == 0) {
 			route_count_packet(
 				counter_storage,
@@ -223,11 +238,10 @@ route_handle_packets(
 
 		// TODO: Route selection should be based on hash/NUMA/dp
 		// instance/etc
-		uint64_t route_index = ADDR_OF(&route_config->fib.route_indexes
+		uint64_t route_index = ADDR_OF(&fib->route_indexes
 		)[route_list->start + packet->hash % route_list->count];
 
-		struct route *route =
-			ADDR_OF(&route_config->fib.routes) + route_index;
+		struct route *route = ADDR_OF(&fib->routes) + route_index;
 
 		uint16_t device_id = module_ectx_encode_device(
 			module_ectx, route->device_id

--- a/modules/route/fuzzing/route.c
+++ b/modules/route/fuzzing/route.c
@@ -3,13 +3,131 @@
 #include <stdlib.h>
 
 #include "common/memory_address.h"
+
 #include "modules/route/api/controlplane.h"
+#include "modules/route/api/fib.h"
 #include "modules/route/dataplane/config.h"
 #include "modules/route/dataplane/dataplane.h"
 
 #include "lib/fuzzing/fuzzing.h"
 
 static struct fuzzing_params fuzz_params = {0};
+
+// The table object the config links, wired to the module through the
+// execution context the way a published generation carries it.
+static struct route_fib_object fuzz_fib;
+static struct object_ectx fuzz_object_ectx;
+static struct module_object_link_ectx fuzz_object_link;
+
+static int
+route_test_fib(yanet_error **err) {
+	memset(&fuzz_fib, 0, sizeof(fuzz_fib));
+	memory_context_init_from(
+		&fuzz_fib.cp_object.memory_context,
+		&fuzz_params.mctx,
+		"route_test_fib"
+	);
+	if (counter_registry_init(
+		    &fuzz_fib.cp_object.link_counter_registry,
+		    &fuzz_fib.cp_object.memory_context,
+		    0
+	    )) {
+		return -1;
+	}
+	if (route_fib_init(&fuzz_fib.fib, &fuzz_fib.cp_object.memory_context)) {
+		return -1;
+	}
+
+	uint64_t counter_id = counter_registry_register(
+		&fuzz_fib.cp_object.link_counter_registry, "nexthop", 2, err
+	);
+	if (counter_id == COUNTER_INVALID) {
+		goto error_table;
+	}
+
+	int route_idx = route_fib_add_route(
+		&fuzz_fib.fib,
+		&fuzz_fib.cp_object.memory_context,
+		(struct ether_addr){
+			.addr = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+		},
+		(struct ether_addr){
+			.addr = {0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
+		},
+		0,
+		counter_id
+	);
+	if (route_idx == -1) {
+		goto error_table;
+	}
+
+	int route_list_idx = route_fib_add_route_list(
+		&fuzz_fib.fib,
+		&fuzz_fib.cp_object.memory_context,
+		1,
+		(uint32_t[]){route_idx}
+	);
+	if (route_list_idx == -1) {
+		goto error_table;
+	}
+
+	// 127.0.0.0/24
+	int rc = route_fib_add_prefix_v4(
+		&fuzz_fib.fib,
+		(uint8_t[4]){127, 0, 0, 0},
+		(uint8_t[4]){127, 0, 0, 0xff},
+		route_list_idx
+	);
+	if (rc != 0) {
+		goto error_table;
+	}
+
+	// fe80::0/96
+	rc = route_fib_add_prefix_v6(
+		&fuzz_fib.fib,
+		(uint8_t[16]){0xfe, 0x80, [15] = 0},
+		(uint8_t[16]
+		){0xfe, 0x80, [12] = 0xff, [13] = 0xff, [14] = 0xff, [15] = 0xff
+		},
+		route_list_idx
+	);
+	if (rc != 0) {
+		goto error_table;
+	}
+
+	// The handler resolves the link's counter storage on every batch, so
+	// the link needs one spawned from the object's registry.
+	if (counter_registry_link(
+		    &fuzz_fib.cp_object.link_counter_registry, NULL, err
+	    )) {
+		goto error_table;
+	}
+	struct counter_storage *link_storage = counter_storage_spawn(
+		&fuzz_params.mctx,
+		NULL,
+		&fuzz_fib.cp_object.link_counter_registry
+	);
+	if (link_storage == NULL) {
+		goto error_table;
+	}
+
+	memset(&fuzz_object_ectx, 0, sizeof(fuzz_object_ectx));
+	memset(&fuzz_object_link, 0, sizeof(fuzz_object_link));
+	SET_OFFSET_OF(&fuzz_object_ectx.cp_object, &fuzz_fib.cp_object);
+	fuzz_object_ectx.abs_cp_object = &fuzz_fib.cp_object;
+	SET_OFFSET_OF(&fuzz_object_link.object_ectx, &fuzz_object_ectx);
+	fuzz_object_link.abs_object_ectx = &fuzz_object_ectx;
+	SET_OFFSET_OF(&fuzz_object_link.counter_storage, link_storage);
+	fuzz_params.module_ectx.object_link_count = 1;
+	SET_OFFSET_OF(&fuzz_params.module_ectx.object_links, &fuzz_object_link);
+	fuzz_params.module_ectx.abs_object_links = &fuzz_object_link;
+
+	return 0;
+
+error_table:
+	route_fib_fini(&fuzz_fib.fib, &fuzz_fib.cp_object.memory_context);
+	return -1;
+}
 
 static int
 route_test_config(struct cp_module **cp_module, yanet_error **err) {
@@ -37,6 +155,9 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 	config->cp_module.device_count = 0;
 	SET_OFFSET_OF(&config->cp_module.devices, NULL);
 
+	// The table sits behind the only object link of the context.
+	config->fib_link_idx = 0;
+
 	// Needed by route_module_config_register_counters.
 	if (counter_registry_init(
 		    &config->cp_module.counter_registry,
@@ -46,86 +167,29 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 		goto error_config;
 	}
 
-	struct memory_context *memory_context =
-		&config->cp_module.memory_context;
-	if (route_module_config_data_init(config, memory_context)) {
-		goto error_config;
-	}
-
-	struct cp_module *rmc = &config->cp_module;
-
-	int route_idx = route_module_config_add_route(
-		rmc,
-		(struct ether_addr){
-			.addr = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-		},
-		(struct ether_addr){
-			.addr = {0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
-		},
-		"dev0",
-		NULL,
-		err
-	);
-	if (route_idx == -1) {
-		goto error_table;
-	}
-
-	int route_list_idx = route_module_config_add_route_list(
-		rmc, 1, (uint32_t[]){route_idx}
-	);
-	if (route_list_idx == -1) {
-		goto error_table;
-	}
-
-	// 127.0.0.0/24
-	int rc = route_module_config_add_prefix_v4(
-		rmc,
-		(uint8_t[4]){127, 0, 0, 0},
-		(uint8_t[4]){127, 0, 0, 0xff},
-		route_list_idx
-	);
-	if (rc != 0) {
-		goto error_table;
-	}
-	// fe80::0/96
-	rc = route_module_config_add_prefix_v6(
-		rmc,
-		(uint8_t[16]){0xfe, 0x80, [15] = 0},
-		(uint8_t[16]
-		){0xfe, 0x80, [12] = 0xff, [13] = 0xff, [14] = 0xff, [15] = 0xff
-		},
-		route_list_idx
-	);
-	if (rc != 0) {
-		goto error_table;
-	}
-
 	// Set up counter storage, because route_handle_packets accesses
 	// counters on every outcome.
 	if (route_module_config_register_counters(config, err)) {
-		goto error_table;
+		goto error_config;
 	}
 
 	if (counter_registry_link(
 		    &config->cp_module.counter_registry, NULL, err
 	    )) {
-		goto error_table;
+		goto error_config;
 	}
 
 	struct counter_storage *cs = counter_storage_spawn(
 		&fuzz_params.mctx, NULL, &config->cp_module.counter_registry
 	);
 	if (cs == NULL) {
-		goto error_table;
+		goto error_config;
 	}
 	SET_OFFSET_OF(&fuzz_params.module_ectx.counter_storage, cs);
 	fuzz_params.module_ectx.abs_counter_storage = cs;
 
 	*cp_module = (struct cp_module *)config;
 	return 0;
-
-error_table:
-	route_module_config_data_fini(config);
 
 error_config:
 	memory_bfree(
@@ -139,6 +203,10 @@ fuzz_setup(yanet_error **err) {
 	if (fuzzing_params_init(
 		    &fuzz_params, "route fuzzing", new_module_route
 	    ) != 0) {
+		return EXIT_FAILURE;
+	}
+
+	if (route_test_fib(err) != 0) {
 		return EXIT_FAILURE;
 	}
 

--- a/modules/route/tests/functional/route_stress_test.go
+++ b/modules/route/tests/functional/route_stress_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/gopacket/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -185,21 +183,17 @@ func TestRouteStress_ConcurrentUpdatesReadsAndPacketsLeaveNoLeak(t *testing.T) {
 	var readers sync.WaitGroup
 
 	// Writers: cycle UpdateFIB through every version. One of them also
-	// deletes and republishes every ~20 iterations, exercising the
-	// delete path concurrently with reads.
-	//
-	// The pipeline stays wired throughout this phase, so DeleteConfig is
-	// expected to refuse every one of these attempts — a live chain
-	// still names the module. The property under test is that the
-	// refusal leaves the store untouched, so the update right after it
-	// always still succeeds normally.
+	// asks for a delete every ~20 iterations, which the live chain naming
+	// the module must refuse, and the refusal must leave the store as it
+	// was, so the update right after it succeeds like any other.
 	const iterationsPerWriter = 150
 	writer := func(deleteEvery int) {
 		defer writers.Done()
 		for idx := range iterationsPerWriter {
 			version := versions[idx%stressVersions]
 			if deleteEvery > 0 && idx > 0 && idx%deleteEvery == 0 {
-				_, _ = service.DeleteConfig(ctx, &routepb.DeleteConfigRequest{Name: stressConfigName})
+				_, err := service.DeleteConfig(ctx, &routepb.DeleteConfigRequest{Name: stressConfigName})
+				assert.Error(t, err, "a config a live chain names must refuse to delete")
 			}
 			_, err := service.UpdateFIB(ctx, stressUpdateRequest(t, version))
 			assert.NoError(t, err)
@@ -209,10 +203,10 @@ func TestRouteStress_ConcurrentUpdatesReadsAndPacketsLeaveNoLeak(t *testing.T) {
 	go writer(0)
 	go writer(20)
 
-	// Readers: ShowFIB must never mix two versions' nexthops in one
-	// response. NotFound is the one tolerated error, a read that landed
-	// in the gap a concurrent delete+republish opens, and at least one
-	// read must come back whole for the check to mean anything.
+	// Readers: ShowFIB must never fail, the config is published for the
+	// whole run, and must never mix two versions' nexthops in one
+	// response. At least one read must come back whole for the check to
+	// mean anything.
 	var wholeReads atomic.Int64
 	showFIBReader := func() {
 		defer readers.Done()
@@ -224,8 +218,7 @@ func TestRouteStress_ConcurrentUpdatesReadsAndPacketsLeaveNoLeak(t *testing.T) {
 			}
 
 			resp, err := service.ShowFIB(ctx, &routepb.ShowFIBRequest{Name: stressConfigName})
-			if err != nil {
-				assert.Equal(t, codes.NotFound, status.Code(err), "ShowFIB may only fail with NotFound: %v", err)
+			if !assert.NoError(t, err) {
 				continue
 			}
 

--- a/modules/route/tests/functional/route_stress_test.go
+++ b/modules/route/tests/functional/route_stress_test.go
@@ -6,11 +6,14 @@ import (
 	"net"
 	"net/netip"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gopacket/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -207,8 +210,10 @@ func TestRouteStress_ConcurrentUpdatesReadsAndPacketsLeaveNoLeak(t *testing.T) {
 	go writer(20)
 
 	// Readers: ShowFIB must never mix two versions' nexthops in one
-	// response. NotFound is tolerated — it only means a read landed in
-	// the gap a concurrent delete+republish opens.
+	// response. NotFound is the one tolerated error, a read that landed
+	// in the gap a concurrent delete+republish opens, and at least one
+	// read must come back whole for the check to mean anything.
+	var wholeReads atomic.Int64
 	showFIBReader := func() {
 		defer readers.Done()
 		for {
@@ -220,6 +225,7 @@ func TestRouteStress_ConcurrentUpdatesReadsAndPacketsLeaveNoLeak(t *testing.T) {
 
 			resp, err := service.ShowFIB(ctx, &routepb.ShowFIBRequest{Name: stressConfigName})
 			if err != nil {
+				assert.Equal(t, codes.NotFound, status.Code(err), "ShowFIB may only fail with NotFound: %v", err)
 				continue
 			}
 
@@ -240,6 +246,7 @@ func TestRouteStress_ConcurrentUpdatesReadsAndPacketsLeaveNoLeak(t *testing.T) {
 			if v4 == nil || v6 == nil {
 				continue
 			}
+			wholeReads.Add(1)
 			v4Version, v6Version := stressMACVersion(v4), stressMACVersion(v6)
 			assert.NotEqual(t, -1, v4Version, "v4 nexthop MAC must belong to a known version")
 			assert.Equal(t, v4Version, v6Version, "a single ShowFIB response must never mix two versions")
@@ -263,8 +270,9 @@ func TestRouteStress_ConcurrentUpdatesReadsAndPacketsLeaveNoLeak(t *testing.T) {
 	}
 
 	// The packet injector asserts every forwarded packet's dst MAC
-	// belongs to some version's set — never garbage, never a MAC no
-	// version ever carried.
+	// belongs to some version's set, never garbage, never a MAC no
+	// version ever carried, and that forwarding never stops altogether.
+	var forwarded atomic.Int64
 	packetInjector := func() {
 		defer readers.Done()
 		for {
@@ -280,6 +288,7 @@ func TestRouteStress_ConcurrentUpdatesReadsAndPacketsLeaveNoLeak(t *testing.T) {
 				continue
 			}
 			for _, out := range result.Output {
+				forwarded.Add(1)
 				resultPkt := xpacket.ParseEtherPacket(out.RawData)
 				ethLayer, ok := resultPkt.Layer(layers.LayerTypeEthernet).(*layers.Ethernet)
 				if !assert.True(t, ok) {
@@ -301,6 +310,8 @@ func TestRouteStress_ConcurrentUpdatesReadsAndPacketsLeaveNoLeak(t *testing.T) {
 	writers.Wait()
 	close(stop)
 	readers.Wait()
+	require.Positive(t, wholeReads.Load(), "no ShowFIB read came back whole, the torn-read check ran on nothing")
+	require.Positive(t, forwarded.Load(), "no packet was forwarded during the run")
 
 	devices = append(devices, unwireRouteInput(t, agent, "port0")...)
 

--- a/modules/route/tests/functional/route_stress_test.go
+++ b/modules/route/tests/functional/route_stress_test.go
@@ -1,0 +1,330 @@
+package route_test
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	plain "github.com/yanet-platform/yanet2/devices/plain/controlplane"
+	route "github.com/yanet-platform/yanet2/modules/route/controlplane"
+	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
+)
+
+const (
+	stressConfigName = "stress"
+	stressVersions   = 4
+	// stressGrowthVersion is the one version whose FIB also names a
+	// device the module has never linked, exercising the table-growth
+	// path. Nothing wires that device, so a packet routed to it drops as
+	// device_unresolved — an accepted outcome here, not a failure.
+	stressGrowthVersion = 2
+
+	stressPrefixV4 = "10.0.0.0/24"
+	stressPrefixV6 = "2001:db8::/32"
+)
+
+// stressPrefixV4Addr and stressPrefixV6Addr are the parsed network
+// addresses of the stress prefixes, computed once rather than on every
+// reader iteration.
+var (
+	stressPrefixV4Addr = netip.MustParsePrefix(stressPrefixV4).Addr()
+	stressPrefixV6Addr = netip.MustParsePrefix(stressPrefixV6).Addr()
+)
+
+// stressVersion is one FIB version cycled through by the stress test's
+// writers: same prefixes, distinct nexthops, so a reader can tell which
+// version a snapshot came from by its dst MAC alone.
+type stressVersion struct {
+	entries []FIBEntry
+}
+
+// buildStressVersions builds the stress test's fixed set of FIB versions.
+//
+// Every version resolves the same two prefixes to its own dst MAC, ending
+// in its version index, plus its own counter name. stressGrowthVersion's
+// FIB additionally names a device nothing wires, forcing a module rebuild
+// the first time a writer applies it.
+func buildStressVersions() []stressVersion {
+	versions := make([]stressVersion, stressVersions)
+	for v := range stressVersions {
+		dstMAC := net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0x00, byte(v)}
+		srcMAC := net.HardwareAddr{0xca, 0xfe, 0xba, 0xbe, 0x00, byte(v)}
+		// v4 and v6 share one hardware identity (same MACs and device),
+		// and the service rejects two counter names for one identity, so
+		// both entries must carry the same name.
+		counter := fmt.Sprintf("nexthop_stress_v%d", v)
+
+		entries := []FIBEntry{
+			{
+				Prefix: netip.MustParsePrefix(stressPrefixV4),
+				Nexthops: []FIBNexthop{{
+					DstMAC: dstMAC, SrcMAC: srcMAC, Device: "port0", Counter: counter,
+				}},
+			},
+			{
+				Prefix: netip.MustParsePrefix(stressPrefixV6),
+				Nexthops: []FIBNexthop{{
+					DstMAC: dstMAC, SrcMAC: srcMAC, Device: "port0", Counter: counter,
+				}},
+			},
+		}
+		if v == stressGrowthVersion {
+			entries = append(entries, FIBEntry{
+				Prefix: netip.MustParsePrefix("172.16.0.0/24"),
+				Nexthops: []FIBNexthop{{
+					DstMAC: net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0xff, byte(v)},
+					SrcMAC: srcMAC, Device: "port1",
+					Counter: fmt.Sprintf("nexthop_stress_v%d_growth", v),
+				}},
+			})
+		}
+
+		versions[v] = stressVersion{entries: entries}
+	}
+	return versions
+}
+
+// stressUpdateRequest builds the UpdateFIBRequest for one version.
+func stressUpdateRequest(tb testing.TB, version stressVersion) *routepb.UpdateFIBRequest {
+	tb.Helper()
+
+	return &routepb.UpdateFIBRequest{
+		ModuleName: stressConfigName,
+		Entries:    toFIBEntries(tb, version.entries),
+	}
+}
+
+// unwireRouteInput clears the device's pipeline bindings, then deletes
+// the stress and dummy pipelines and the stress function, leaving the
+// route config unreferenced by any live chain so DeleteConfig can delete
+// it, a module a chain still names refuses to delete. Returns the device
+// handles the caller owns from then on.
+func unwireRouteInput(tb testing.TB, agent *ffi.Agent, deviceName string) []*plain.DeviceConfig {
+	tb.Helper()
+
+	devices, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{{Name: deviceName}})
+	require.NoError(tb, err)
+	require.NoError(tb, agent.DeletePipeline(stressConfigName))
+	require.NoError(tb, agent.DeletePipeline("dummy"))
+	require.NoError(tb, agent.DeleteFunction(stressConfigName))
+	return devices
+}
+
+// freeSuperseded frees every device handle whose config a later publish
+// replaced and keeps the rest, the one still published refusing as it
+// should.
+func freeSuperseded(handles []*plain.DeviceConfig) []*plain.DeviceConfig {
+	kept := handles[:0]
+	for _, handle := range handles {
+		if err := handle.Free(); errors.Is(err, ffi.ErrStillReferenced) {
+			kept = append(kept, handle)
+		}
+	}
+	return kept
+}
+
+// stressMACVersion returns the version index a dst MAC's trailing byte
+// names, or -1 when it names none of them.
+func stressMACVersion(mac net.HardwareAddr) int {
+	if len(mac) != 6 {
+		return -1
+	}
+	v := int(mac[5])
+	if v < 0 || v >= stressVersions {
+		return -1
+	}
+	return v
+}
+
+// TestRouteStress_ConcurrentUpdatesReadsAndPacketsLeaveNoLeak drives
+// concurrent FIB updates, ShowFIB/Metrics reads, and packet forwarding
+// against one route config, then verifies every read only ever observed
+// one whole version, never a torn mix of two, and that deleting the
+// config and draining the deferred frees returns the arena to the size a
+// first, quiet cycle left it at.
+func TestRouteStress_ConcurrentUpdatesReadsAndPacketsLeaveNoLeak(t *testing.T) {
+	h, agent, backend := setupRouteHarness(t, "port0")
+	service := route.NewRouteService(backend)
+	versions := buildStressVersions()
+	ctx := t.Context()
+
+	// A quiet cycle first settles what the harness keeps published past
+	// a teardown, the device config with its bindings cleared, so the
+	// baseline is what a full cycle returns the arena to. Device handles
+	// are kept and freed once a later publish supersedes them.
+	var devices []*plain.DeviceConfig
+	_, err := service.UpdateFIB(ctx, stressUpdateRequest(t, versions[0]))
+	require.NoError(t, err)
+	devices = append(devices, wirePipeline(t, agent, "port0", stressConfigName)...)
+	devices = append(devices, unwireRouteInput(t, agent, "port0")...)
+	_, err = service.DeleteConfig(ctx, &routepb.DeleteConfigRequest{Name: stressConfigName})
+	require.NoError(t, err)
+	service.ReclaimDeferred()
+	devices = freeSuperseded(devices)
+	baseline := agent.BlockAllocatorFreeSize()
+
+	_, err = service.UpdateFIB(ctx, stressUpdateRequest(t, versions[0]))
+	require.NoError(t, err)
+
+	devices = append(devices, wirePipeline(t, agent, "port0", stressConfigName)...)
+
+	stop := make(chan struct{})
+	var writers sync.WaitGroup
+	var readers sync.WaitGroup
+
+	// Writers: cycle UpdateFIB through every version. One of them also
+	// deletes and republishes every ~20 iterations, exercising the
+	// delete path concurrently with reads.
+	//
+	// The pipeline stays wired throughout this phase, so DeleteConfig is
+	// expected to refuse every one of these attempts — a live chain
+	// still names the module. The property under test is that the
+	// refusal leaves the store untouched, so the update right after it
+	// always still succeeds normally.
+	const iterationsPerWriter = 150
+	writer := func(deleteEvery int) {
+		defer writers.Done()
+		for idx := range iterationsPerWriter {
+			version := versions[idx%stressVersions]
+			if deleteEvery > 0 && idx > 0 && idx%deleteEvery == 0 {
+				_, _ = service.DeleteConfig(ctx, &routepb.DeleteConfigRequest{Name: stressConfigName})
+			}
+			_, err := service.UpdateFIB(ctx, stressUpdateRequest(t, version))
+			assert.NoError(t, err)
+		}
+	}
+	writers.Add(2)
+	go writer(0)
+	go writer(20)
+
+	// Readers: ShowFIB must never mix two versions' nexthops in one
+	// response. NotFound is tolerated — it only means a read landed in
+	// the gap a concurrent delete+republish opens.
+	showFIBReader := func() {
+		defer readers.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+
+			resp, err := service.ShowFIB(ctx, &routepb.ShowFIBRequest{Name: stressConfigName})
+			if err != nil {
+				continue
+			}
+
+			var v4, v6 net.HardwareAddr
+			for _, entry := range resp.GetEntries() {
+				start, _, err := entry.GetRange().ToRange()
+				if !assert.NoError(t, err) {
+					continue
+				}
+				eui := entry.GetNexthops()[0].GetDstMac().EUI48()
+				switch start {
+				case stressPrefixV4Addr:
+					v4 = net.HardwareAddr(eui[:])
+				case stressPrefixV6Addr:
+					v6 = net.HardwareAddr(eui[:])
+				}
+			}
+			if v4 == nil || v6 == nil {
+				continue
+			}
+			v4Version, v6Version := stressMACVersion(v4), stressMACVersion(v6)
+			assert.NotEqual(t, -1, v4Version, "v4 nexthop MAC must belong to a known version")
+			assert.Equal(t, v4Version, v6Version, "a single ShowFIB response must never mix two versions")
+		}
+	}
+
+	// One reader scrapes Metrics concurrently, exercising that path for
+	// panics and data races rather than asserting specific values, which
+	// the concurrent churn makes unstable.
+	metricsReader := func() {
+		defer readers.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_, err := service.Metrics()
+			assert.NoError(t, err)
+		}
+	}
+
+	// The packet injector asserts every forwarded packet's dst MAC
+	// belongs to some version's set — never garbage, never a MAC no
+	// version ever carried.
+	packetInjector := func() {
+		defer readers.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+
+			pkt := buildRouteIPv4Packet(t, "10.0.0.5", 64)
+			result, err := h.HandlePackets(pkt)
+			if !assert.NoError(t, err) {
+				continue
+			}
+			for _, out := range result.Output {
+				resultPkt := xpacket.ParseEtherPacket(out.RawData)
+				ethLayer, ok := resultPkt.Layer(layers.LayerTypeEthernet).(*layers.Ethernet)
+				if !assert.True(t, ok) {
+					continue
+				}
+				assert.NotEqual(t, -1, stressMACVersion(ethLayer.DstMAC),
+					"forwarded packet dst MAC must belong to some version")
+			}
+		}
+	}
+
+	readers.Add(6)
+	for range 4 {
+		go showFIBReader()
+	}
+	go metricsReader()
+	go packetInjector()
+
+	writers.Wait()
+	close(stop)
+	readers.Wait()
+
+	devices = append(devices, unwireRouteInput(t, agent, "port0")...)
+
+	_, err = service.DeleteConfig(ctx, &routepb.DeleteConfigRequest{Name: stressConfigName})
+	if err != nil {
+		// A writer's own delete+republish cycle may have already left
+		// the config deleted; anything else is a genuine failure.
+		require.ErrorContains(t, err, "not found")
+	}
+
+	var free uint64
+	const reclaimAttempts = 50
+	for range reclaimAttempts {
+		service.ReclaimDeferred()
+		devices = freeSuperseded(devices)
+		free = agent.BlockAllocatorFreeSize()
+		if free == baseline {
+			break
+		}
+	}
+	require.Equal(t, baseline, free,
+		"the arena must drain back to the size the quiet cycle left once every deferred free retires")
+
+	list, err := service.ListConfigs(ctx, &routepb.ListConfigsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, list.GetConfigs())
+}

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -2,6 +2,7 @@ package route_test
 
 import (
 	"encoding/hex"
+	"errors"
 	"net"
 	"net/netip"
 	"strings"
@@ -39,7 +40,7 @@ type FIBNexthop struct {
 	Device string
 	// Counter is the per-nexthop dataplane counter name.
 	//
-	// applyFIB passes this straight to backend.UpdateModule, bypassing
+	// applyFIB passes this straight to the backend, bypassing
 	// RouteService.UpdateFIB, so nothing on this path auto-fills an empty
 	// value.
 	Counter string
@@ -91,6 +92,7 @@ func setupRouteHarnessWithLimit(
 		Devices:           []string{deviceName},
 		Modules:           []string{"route"},
 		DevicesToLoad:     []string{"plain"},
+		ObjectsToLoad:     []string{fibObjectType},
 	}
 	h, err := dataplaneut.NewHarness(config)
 	require.NoError(tb, err)
@@ -110,12 +112,13 @@ func setupRouteHarnessWithLimit(
 //
 // Must be called after applyFIB so that the route module config named
 // configName is already present in shared memory when the pipeline resolves
-// its chain module references.
+// its chain module references. Returns the device handles the caller owns
+// from then on.
 func wirePipeline(
 	tb testing.TB,
 	agent *ffi.Agent,
 	deviceName, configName string,
-) {
+) []*plain.DeviceConfig {
 	tb.Helper()
 
 	require.NoError(tb, agent.UpdateFunction(ffi.FunctionConfig{
@@ -137,12 +140,13 @@ func wirePipeline(
 	require.NoError(tb, agent.UpdatePipeline(ffi.PipelineConfig{
 		Name: "dummy",
 	}))
-	_, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{{
+	devices, err := plain.UpdateDevices(agent, []ffi.DeviceConfig{{
 		Name:   deviceName,
 		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
 	}})
 	require.NoError(tb, err)
+	return devices
 }
 
 // toFIBEntries converts test-domain FIB entries to their wire form.
@@ -173,22 +177,94 @@ func toFIBEntries(tb testing.TB, entries []FIBEntry) []*routepb.FIBEntry {
 	return pbEntries
 }
 
-// applyFIB pushes entries via backend.UpdateModule and registers cleanup.
+// applyFIB mirrors RouteService.UpdateFIB's device-table and publish-order
+// bookkeeping against the real backend: it reads the module's
+// already-published device table, extends it with any device the entries
+// name that it lacks, rebuilds the module only when the table grew, then
+// always builds a fresh object under the given name. It publishes the
+// object first unless the table just grew and an object was already out,
+// in which case the module goes first — a module cannot go out before the
+// object it links exists. Cleanup frees both handles.
 //
-// Returns the route.ModuleHandle. The caller may inspect it. The handle is
-// freed via tb.Cleanup.
+// Returns the published FIBHandle; the module's device table is available
+// separately through backend.Published.
 func applyFIB(
 	tb testing.TB,
 	backend route.Backend,
 	name string,
 	entries []FIBEntry,
-) route.ModuleHandle {
+) route.FIBHandle {
 	tb.Helper()
 
-	handle, err := backend.UpdateModule(name, toFIBEntries(tb, entries))
+	pbEntries := toFIBEntries(tb, entries)
+
+	published, err := backend.Published(name)
+	if err != nil && !errors.Is(err, ffi.ErrNotFound) {
+		require.NoError(tb, err)
+	}
+	modulePublished := err == nil
+	devices, grown := extendTestDeviceTable(published.Devices, pbEntries)
+
+	moduleNew := !modulePublished || grown
+	var moduleHandle route.ModuleHandle
+	if moduleNew {
+		var table []string
+		var buildErr error
+		moduleHandle, table, buildErr = backend.NewModule(name, devices)
+		require.NoError(tb, buildErr)
+		tb.Cleanup(func() { freeTolerant(tb, moduleHandle.Free) })
+		devices = table
+	}
+
+	fibHandle, err := backend.NewFIB(name, devices, pbEntries)
 	require.NoError(tb, err)
-	tb.Cleanup(func() { _ = handle.Free() })
-	return handle
+	tb.Cleanup(func() { freeTolerant(tb, fibHandle.Free) })
+
+	moduleFirst := moduleNew && published.FIB
+	if moduleFirst {
+		require.NoError(tb, moduleHandle.Publish())
+	}
+	require.NoError(tb, fibHandle.Publish())
+	if moduleNew && !moduleFirst {
+		require.NoError(tb, moduleHandle.Publish())
+	}
+
+	return fibHandle
+}
+
+// extendTestDeviceTable is a test-local mirror of RouteService's
+// device-table growth: it appends the devices the entries name that table
+// lacks, in first-seen order, and reports whether it grew.
+func extendTestDeviceTable(table []string, entries []*routepb.FIBEntry) ([]string, bool) {
+	known := make(map[string]struct{}, len(table))
+	for _, device := range table {
+		known[device] = struct{}{}
+	}
+
+	devices := table
+	for _, entry := range entries {
+		for _, nh := range entry.GetNexthops() {
+			device := nh.GetDevice()
+			if _, ok := known[device]; ok {
+				continue
+			}
+			known[device] = struct{}{}
+			devices = append(devices, device)
+		}
+	}
+	return devices, len(devices) != len(table)
+}
+
+// freeTolerant frees a handle, accepting a refusal because a live
+// configuration generation still references it: nothing in these tests
+// supersedes that generation afterward, and the harness discards the
+// whole shared-memory arena on its own teardown regardless.
+func freeTolerant(tb testing.TB, free func() error) {
+	tb.Helper()
+
+	if err := free(); err != nil && !errors.Is(err, ffi.ErrStillReferenced) {
+		require.NoError(tb, err)
+	}
 }
 
 // testingEtherLayers returns a reusable set of Ethernet and IP layers for
@@ -520,6 +596,7 @@ func TestRoute_ECMP_HashSelection(t *testing.T) {
 		Devices:       []string{"port0", "port1"},
 		Modules:       []string{"route"},
 		DevicesToLoad: []string{"plain"},
+		ObjectsToLoad: []string{fibObjectType},
 	}
 	h, err := dataplaneut.NewHarness(cfg)
 	require.NoError(t, err)
@@ -1060,7 +1137,7 @@ func TestRoute_NexthopCounter(t *testing.T) {
 	}
 
 	h, agent, backend := setupRouteHarness(t, "port0")
-	handle := applyFIB(t, backend, "test", []FIBEntry{
+	applyFIB(t, backend, "test", []FIBEntry{
 		{Prefix: netip.MustParsePrefix("10.0.0.0/24"), Nexthops: []FIBNexthop{countedHop}},
 	})
 	wirePipeline(t, agent, "port0", "test")
@@ -1077,12 +1154,12 @@ func TestRoute_NexthopCounter(t *testing.T) {
 		Device: "port0", Pipeline: "test", Function: "test",
 		Chain: "test_chain", ModuleType: "route", ModuleName: "test",
 	}
-	dataplaneut.RequireRuleCounter(t, h, path, counterName, 1, pktSize)
+	requireNexthopCounter(t, agent, path, counterName, 1, pktSize)
 
 	// Close the round trip: ShowFIB's DumpFIB path must resolve the same
 	// name back out of the real C counter registry, not just accept it on
 	// write.
-	fib, err := handle.DumpFIB()
+	fib, err := backend.DumpFIB("test")
 	require.NoError(t, err)
 	require.Len(t, fib, 1)
 	require.Len(t, fib[0].Nexthops, 1)
@@ -1094,7 +1171,7 @@ func TestRoute_NexthopCounter(t *testing.T) {
 // counter name resolves to a single route-list member, not two.
 //
 // A duplicated member takes 2/N of the ECMP hash space instead of 1/N: this
-// exercises the real backend.UpdateModule dedup against shared memory and
+// exercises the real backend.NewFIB dedup against shared memory and
 // inspects the resulting nexthop set via DumpFIB, since a fake backend
 // cannot observe route-list membership at all.
 func TestRoute_ECMPSameIdentitySameCounterDedupesToOneMember(t *testing.T) {
@@ -1107,11 +1184,11 @@ func TestRoute_ECMPSameIdentitySameCounterDedupesToOneMember(t *testing.T) {
 	}
 
 	_, _, backend := setupRouteHarness(t, "port0")
-	handle := applyFIB(t, backend, "test", []FIBEntry{
+	applyFIB(t, backend, "test", []FIBEntry{
 		{Prefix: prefix, Nexthops: []FIBNexthop{hop, hop}},
 	})
 
-	fib, err := handle.DumpFIB()
+	fib, err := backend.DumpFIB("test")
 	require.NoError(t, err)
 	require.Len(t, fib, 1)
 	require.Len(t, fib[0].Nexthops, 1, "a duplicated hardware route must collapse to one route-list member")
@@ -1138,11 +1215,11 @@ func TestRoute_ECMPDistinctSourceMACRemainsSeparate(t *testing.T) {
 	}
 
 	_, _, backend := setupRouteHarness(t, "port0")
-	handle := applyFIB(t, backend, "test", []FIBEntry{
+	applyFIB(t, backend, "test", []FIBEntry{
 		{Prefix: prefix, Nexthops: []FIBNexthop{hopA, hopB}},
 	})
 
-	fib, err := handle.DumpFIB()
+	fib, err := backend.DumpFIB("test")
 	require.NoError(t, err)
 	require.Len(t, fib, 1)
 	require.Len(t, fib[0].Nexthops, 2, "nexthops differing only in src_mac must remain distinct routes")
@@ -1152,7 +1229,7 @@ func TestRoute_ECMPDistinctSourceMACRemainsSeparate(t *testing.T) {
 // distinct nexthops than one config can index is refused, not panicked on.
 //
 // Thirty refusals in a row on the 2 MB agent arena prove every refused
-// config is freed, since a leaked one would exhaust the arena. The fake
+// object is freed, since a leaked one would exhaust the arena. The fake
 // backend never builds the route-list key, so this runs on the real one.
 func Test_UpdateFIB_MoreThan1024DistinctNexthops(t *testing.T) {
 	const nexthopCount = bitset.MaxBits + 1
@@ -1172,12 +1249,12 @@ func Test_UpdateFIB_MoreThan1024DistinctNexthops(t *testing.T) {
 	}
 
 	for range 30 {
-		_, err := backend.UpdateModule("cfg", toFIBEntries(t, entries))
+		_, err := backend.NewFIB("cfg", []string{"port0"}, toFIBEntries(t, entries))
 		require.ErrorIs(t, err, route.ErrTooManyNexthops)
 	}
 
-	handle := applyFIB(t, backend, "cfg", entries[:bitset.MaxBits])
-	fib, err := handle.DumpFIB()
+	applyFIB(t, backend, "cfg", entries[:bitset.MaxBits])
+	fib, err := backend.DumpFIB("cfg")
 	require.NoError(t, err)
 	require.Len(t, fib, bitset.MaxBits)
 }
@@ -1186,7 +1263,7 @@ func Test_UpdateFIB_MoreThan1024DistinctNexthops(t *testing.T) {
 // UpdateFIBRequest doc comment's claim that an entry with no nexthops is
 // skipped rather than overwriting an earlier overlapping entry.
 //
-// It exercises the real backend.UpdateModule against shared memory, since
+// It exercises the real backend.NewFIB against shared memory, since
 // the fake backend used by the unit tests in modules/route/controlplane
 // only records the entries handed to it and cannot observe the
 // dataplane-visible skip.
@@ -1195,7 +1272,7 @@ func TestUpdateFIB_EmptyNexthopEntryDoesNotDisplaceEarlierEntry(t *testing.T) {
 
 	_, _, backend := setupRouteHarness(t, "port0")
 
-	handle := applyFIB(t, backend, "cfg", []FIBEntry{
+	applyFIB(t, backend, "cfg", []FIBEntry{
 		{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
 		// Later entry covers the same range but carries no nexthops, so
 		// it must be skipped rather than blackholing or removing the
@@ -1203,7 +1280,7 @@ func TestUpdateFIB_EmptyNexthopEntryDoesNotDisplaceEarlierEntry(t *testing.T) {
 		{Prefix: prefix},
 	})
 
-	fib, err := handle.DumpFIB()
+	fib, err := backend.DumpFIB("cfg")
 	require.NoError(t, err)
 
 	require.Len(t, fib, 1, "expected the earlier nexthop-bearing entry to survive alone")
@@ -1277,6 +1354,62 @@ func TestUpdateFIB_ShadowedNexthopCounterExcludedFromMetrics(t *testing.T) {
 // without depending on it, so the generated-name check and the disabled
 // arm's "no per-nexthop counter registered" check cannot drift apart.
 const nexthopCounterPrefix = "nexthop_"
+
+// fibObjectType mirrors the unexported object-type constant in mod.go: the
+// table object a config's module links is always published under the
+// config's own name, of this type.
+const fibObjectType = "route_fib"
+
+// nexthopCounters reads the route module's per-nexthop counters at the
+// given path off its link to the "route_fib" object of the same name,
+// optionally filtered by name.
+//
+// An error is treated as no counters, mirroring backend.NexthopCounters:
+// the disabled counter arm never registers a link counter registry at
+// all, so the query legitimately has nothing to report.
+func nexthopCounters(tb testing.TB, agent *ffi.Agent, path dataplaneut.CounterPath, names []string) []ffi.CounterInfo {
+	tb.Helper()
+
+	infos, err := agent.DPConfig().ModuleObjectLinkCounters(
+		path.Device, path.Pipeline, path.Function, path.Chain,
+		path.ModuleType, path.ModuleName,
+		fibObjectType, path.ModuleName,
+		names,
+	)
+	if err != nil {
+		return nil
+	}
+	return infos
+}
+
+// requireNexthopCounter asserts that the named per-nexthop counter at the
+// given path holds wantPackets and wantBytes.
+//
+// The counter is expected to be size 2: [packets, bytes]. Reads worker 0.
+func requireNexthopCounter(
+	tb testing.TB,
+	agent *ffi.Agent,
+	path dataplaneut.CounterPath,
+	counterName string,
+	wantPackets, wantBytes uint64,
+) {
+	tb.Helper()
+
+	counters := nexthopCounters(tb, agent, path, []string{counterName})
+
+	byName := map[string][]uint64{}
+	for _, c := range counters {
+		if len(c.Values) > 0 {
+			byName[c.Name] = c.Values[0]
+		}
+	}
+
+	vals, ok := byName[counterName]
+	require.True(tb, ok, "counter %q not found in nexthop counters", counterName)
+	require.GreaterOrEqual(tb, len(vals), 2, "counter %q must have at least two values (packets, bytes)", counterName)
+	require.Equal(tb, wantPackets, vals[0], "counter %q packet count mismatch", counterName)
+	require.Equal(tb, wantBytes, vals[1], "counter %q byte count mismatch", counterName)
+}
 
 // nexthopCounterNames computes the per-nexthop counter names a counted arm
 // must materialize for fib, deduplicated since several nexthops can share
@@ -1382,7 +1515,7 @@ func TestRoute_NexthopCounterArms(t *testing.T) {
 						// Unfiltered on purpose: a filtered query would only
 						// prove the *expected* names are absent, not that no
 						// per-nexthop counter exists under any name.
-						for _, counter := range dataplaneut.RuleCounters(t, h, path, nil) {
+						for _, counter := range nexthopCounters(t, agent, path, nil) {
 							require.False(t, strings.HasPrefix(counter.Name, nexthopCounterPrefix),
 								"disabled arm must register no per-nexthop counter, found %q", counter.Name)
 						}
@@ -1393,7 +1526,7 @@ func TestRoute_NexthopCounterArms(t *testing.T) {
 					// query above: asserts the unfiltered result is a
 					// superset of names, so a nil sentinel that degraded to a
 					// filter excluding per-nexthop counters fails here.
-					unfiltered := dataplaneut.RuleCounters(t, h, path, nil)
+					unfiltered := nexthopCounters(t, agent, path, nil)
 					unfilteredNames := make(map[string]bool, len(unfiltered))
 					for _, counter := range unfiltered {
 						unfilteredNames[counter.Name] = true
@@ -1403,7 +1536,7 @@ func TestRoute_NexthopCounterArms(t *testing.T) {
 							"unfiltered query must include per-nexthop counter %q", name)
 					}
 
-					counters := dataplaneut.RuleCounters(t, h, path, names)
+					counters := nexthopCounters(t, agent, path, names)
 
 					var wantBytes uint64
 					for _, packet := range packets {

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -1225,6 +1225,15 @@ func TestRoute_ECMPDistinctSourceMACRemainsSeparate(t *testing.T) {
 	require.Len(t, fib[0].Nexthops, 2, "nexthops differing only in src_mac must remain distinct routes")
 }
 
+// A device name the module's table entry cannot hold whole is rejected
+// instead of being stored truncated.
+func Test_NewModule_RejectsOverlongDeviceName(t *testing.T) {
+	_, _, backend := setupRouteHarness(t, "port0")
+
+	_, _, err := backend.NewModule("cfg", []string{strings.Repeat("p", ffi.MaxDeviceNameLen)})
+	require.ErrorContains(t, err, "exceeds the")
+}
+
 // Test_UpdateFIB_MoreThan1024DistinctNexthops verifies that a FIB with more
 // distinct nexthops than one config can index is refused, not panicked on.
 //

--- a/modules/route/tests/route_api_test.c
+++ b/modules/route/tests/route_api_test.c
@@ -1,6 +1,6 @@
 /*
- * Tests that construction does not leak memory when the module's own data
- * setup fails partway through, at each of its fallible steps.
+ * Tests that construction of the table object does not leak memory when
+ * its own data setup fails partway through, at each of its fallible steps.
  *
  * Attaching an agent carves a private arena of exactly the given byte
  * limit from the shared allocator, and every allocation the module under
@@ -19,14 +19,14 @@
 #include "lib/dataplane_ut/dataplane_ut.h"
 #include "lib/errors/errors.h"
 #include "lib/logging/log.h"
-#include "modules/route/api/controlplane.h"
+#include "modules/route/api/fib_object.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 /*
- * 16 KB: enough for cp_module_init's small allocations (empirically < 8 KB),
+ * 16 KB: enough for cp_object_init's small allocations (empirically < 8 KB),
  * but well below the 32 KB lpm_init page-chunk request.
  */
 #define ROUTE_TEST_MEMORY_LIMIT (16u * 1024u)
@@ -51,12 +51,14 @@ run_test(struct yanet_shm *shm) {
 
 	size_t baseline = block_allocator_free_size(&agent->block_allocator);
 
-	struct cp_module *cp = route_module_config_new(agent, "probe", &err);
+	struct cp_object *cp = route_fib_object_new(agent, "probe", &err);
 	TEST_ASSERT_NULL(cp, "create unexpectedly succeeded");
 
 	const char *errmsg = (err != NULL) ? yanet_error_message(err) : "";
 	TEST_ASSERT_STR_CONTAINS(
-		errmsg, "failed to init config data", "wrong failure path"
+		errmsg,
+		"failed to init route fib object data",
+		"wrong failure path"
 	);
 	yanet_error_reset(&err);
 
@@ -74,11 +76,11 @@ run_test(struct yanet_shm *shm) {
 }
 
 /*
- * Same shape as the first test, but sized to fail at the second routing
- * table's own setup instead of the first.
+ * Same shape as the first test, but sized to fail at the second tree's
+ * own setup instead of the first.
  *
- * This exercises the error path for a partially constructed module,
- * verifying it frees the first table's memory exactly once rather than
+ * This exercises the error path for a partially constructed object,
+ * verifying it frees the first tree's memory exactly once rather than
  * leaving that job to a teardown that would double free it.
  */
 static int
@@ -96,12 +98,14 @@ run_second_lpm_failure_test(struct yanet_shm *shm) {
 
 	size_t baseline = block_allocator_free_size(&agent->block_allocator);
 
-	struct cp_module *cp = route_module_config_new(agent, "probe", &err);
+	struct cp_object *cp = route_fib_object_new(agent, "probe", &err);
 	TEST_ASSERT_NULL(cp, "create unexpectedly succeeded");
 
 	const char *errmsg = (err != NULL) ? yanet_error_message(err) : "";
 	TEST_ASSERT_STR_CONTAINS(
-		errmsg, "failed to init config data", "wrong failure path"
+		errmsg,
+		"failed to init route fib object data",
+		"wrong failure path"
 	);
 	yanet_error_reset(&err);
 
@@ -125,6 +129,7 @@ main(void) {
 	const char *port_names[] = {"01:00.0"};
 	const char *modules[] = {"route"};
 	const char *devs_to_load[] = {"plain"};
+	const char *objects_to_load[] = {"route_fib"};
 
 	struct dataplane_ut_config cfg = {
 		.cp_memory = 1u << 25,
@@ -136,6 +141,8 @@ main(void) {
 		.module_count = 1,
 		.devices_to_load = devs_to_load,
 		.devices_to_load_count = 1,
+		.objects_to_load = objects_to_load,
+		.objects_to_load_count = 1,
 	};
 
 	struct dataplane_ut *ut = dataplane_ut_new(&cfg);


### PR DESCRIPTION
- The route module config links the table object published under its name instead of holding the table itself, so a FIB update publishes one object in one generation and the module config stays put until its device table needs a device it lacks.
- The packet handler resolves the object link once per batch and counts nexthops on the link's storage.
- ShowFIB reads the published table in place under a pinned generation with no service lock, through a read-only snapshot in the bindings.
- The service keeps its configs in the shared config store, orders the two publishes per case and moves the module handle between entries.
- Generic object publish, delete and link-counter reads land in the ffi package, and the route fuzzer wires the object through the execution context.
- Covered by service lifecycle tests, the functional suite and a concurrent stress test checking torn reads and arena drain.
