### PR TITLE
feat(common): merge two lpm tries into one with per source remaps

### DIFF
--- a/common/lpm.h
+++ b/common/lpm.h
@@ -160,6 +160,247 @@ lpm_free(struct lpm *lpm) {
 	memory_context_fini(memory_context);
 }
 
+/*
+ * Remap tables of a merged trie: one entry per merged leaf, holding the
+ * value each source trie returns over the leaf's span. Each table is a
+ * value line allocated under the merged trie's own memory context, so
+ * it is position independent and may live in shared memory next to the
+ * trie. Release the tables before the merged trie itself.
+ */
+struct lpm_merge_table {
+	struct vline a;
+	struct vline b;
+};
+
+static inline void
+lpm_merge_table_free(struct lpm_merge_table *table) {
+	vline_free(&table->a);
+	vline_free(&table->b);
+	memset(table, 0, sizeof(*table));
+}
+
+// Walk state: the merged trie under construction and host side scratch
+// the leaf emission grows in; the final tables are cut as value lines
+// once the leaf count is known.
+struct lpm_merge_ctx {
+	struct lpm *merged;
+	uint32_t *remap_a;
+	uint32_t *remap_b;
+	uint32_t count;
+	uint32_t capacity;
+};
+
+static inline int
+lpm_merge_grow(struct lpm_merge_ctx *ctx) {
+	if (ctx->count < ctx->capacity) {
+		return 0;
+	}
+	uint32_t new_capacity = ctx->capacity * 2 + 256;
+	uint32_t *remap_a = (uint32_t *)realloc(
+		ctx->remap_a, new_capacity * sizeof(uint32_t)
+	);
+	if (remap_a == NULL) {
+		return -1;
+	}
+	ctx->remap_a = remap_a;
+	uint32_t *remap_b = (uint32_t *)realloc(
+		ctx->remap_b, new_capacity * sizeof(uint32_t)
+	);
+	if (remap_b == NULL) {
+		return -1;
+	}
+	ctx->remap_b = remap_b;
+	ctx->capacity = new_capacity;
+	return 0;
+}
+
+// Emits a merged leaf carrying the pair of source values effective over
+// the span of the slot being filled.
+static inline int
+lpm_merge_leaf(
+	struct lpm_merge_ctx *ctx,
+	uint32_t value_a,
+	uint32_t value_b,
+	union lpm_value *slot
+) {
+	if (lpm_merge_grow(ctx)) {
+		return -1;
+	}
+	ctx->remap_a[ctx->count] = value_a;
+	ctx->remap_b[ctx->count] = value_b;
+	slot->value = LPM_VALUE_SET(ctx->count);
+	++ctx->count;
+	return 0;
+}
+
+// Lockstep walk of both source tries. Each source slot either holds a
+// terminal — the value effective for its whole span — or descends; the
+// merged trie subdivides a span exactly when either source descends
+// below it, so every merged leaf lies inside a region where both source
+// lookups are constant.
+static inline int
+lpm_merge_walk(
+	struct lpm_merge_ctx *ctx,
+	const struct lpm_page *page_a,
+	const struct lpm_page *page_b,
+	uint32_t inherited_a,
+	uint32_t inherited_b,
+	uint8_t key_size,
+	uint8_t depth,
+	struct lpm_page *page_m
+) {
+	for (uint32_t byte = 0; byte < 256; ++byte) {
+		uint32_t value_a = inherited_a;
+		uint32_t value_b = inherited_b;
+		const struct lpm_page *child_a = NULL;
+		const struct lpm_page *child_b = NULL;
+
+		if (page_a != NULL) {
+			union lpm_value slot = page_a->values[byte];
+			if (slot.value & LPM_VALUE_FLAG) {
+				value_a = LPM_VALUE_GET(slot.value);
+			} else {
+				// The child offset is relative to the slot
+				// itself, so it is resolved against the
+				// source page, never against the copy.
+				child_a = ADDR_OF(&page_a->values[byte].page);
+			}
+		}
+		if (page_b != NULL) {
+			union lpm_value slot = page_b->values[byte];
+			if (slot.value & LPM_VALUE_FLAG) {
+				value_b = LPM_VALUE_GET(slot.value);
+			} else {
+				child_b = ADDR_OF(&page_b->values[byte].page);
+			}
+		}
+
+		if (child_a == NULL && child_b == NULL) {
+			if (lpm_merge_leaf(
+				    ctx, value_a, value_b, page_m->values + byte
+			    )) {
+				return -1;
+			}
+			continue;
+		}
+
+		if (depth + 1 >= key_size) {
+			// Source tries never carry children at the last key
+			// byte; treat the impossible shape as a leaf.
+			if (lpm_merge_leaf(
+				    ctx, value_a, value_b, page_m->values + byte
+			    )) {
+				return -1;
+			}
+			continue;
+		}
+
+		// A fresh merged page has terminal slots, so the split
+		// below turns this slot into a descent and the recursion
+		// refills every slot of the child page.
+		if (lpm_new_page(ctx->merged, page_m->values + byte)) {
+			return -1;
+		}
+		struct lpm_page *child_m = ADDR_OF(&page_m->values[byte].page);
+		if (lpm_merge_walk(
+			    ctx,
+			    child_a,
+			    child_b,
+			    value_a,
+			    value_b,
+			    key_size,
+			    depth + 1,
+			    child_m
+		    )) {
+			return -1;
+		}
+	}
+	return 0;
+}
+
+/*
+ * Merges two tries over the same key size into one, whose leaves refine
+ * both source partitions, and produces the remap tables translating a
+ * merged leaf into the value each source returns over it:
+ *
+ *	remap_a[lpm_lookup(merged, key)] == lpm_lookup(a, key)
+ *	remap_b[lpm_lookup(merged, key)] == lpm_lookup(b, key)
+ *
+ * The merged trie is initialized by the routine; on failure it is
+ * released back to zero and the table stays empty. Values are carried
+ * opaquely, including the invalid sentinel of never inserted spans.
+ */
+static inline int
+lpm_merge(
+	struct lpm *merged,
+	struct memory_context *memory_context,
+	const char *name,
+	const struct lpm *a,
+	const struct lpm *b,
+	uint8_t key_size,
+	struct lpm_merge_table *table
+) {
+	memset(table, 0, sizeof(*table));
+	if (lpm_init(merged, memory_context, name)) {
+		return -1;
+	}
+
+	struct lpm_merge_ctx ctx = {
+		.merged = merged,
+		.remap_a = NULL,
+		.remap_b = NULL,
+		.count = 0,
+		.capacity = 0,
+	};
+
+	uint32_t invalid = LPM_VALUE_GET(0xffffffff);
+	int rc = lpm_merge_walk(
+		&ctx,
+		lpm_page(a, 0),
+		lpm_page(b, 0),
+		invalid,
+		invalid,
+		key_size,
+		0,
+		lpm_page(merged, 0)
+	);
+
+	if (rc == 0 && ctx.count > 0) {
+		if (vline_init(
+			    &table->a,
+			    &merged->memory_context,
+			    "lpm-merge:a",
+			    ctx.count
+		    ) ||
+		    vline_init(
+			    &table->b,
+			    &merged->memory_context,
+			    "lpm-merge:b",
+			    ctx.count
+		    )) {
+			rc = -1;
+		} else {
+			memcpy(vline_get_ptr(&table->a, 0),
+			       ctx.remap_a,
+			       ctx.count * sizeof(uint32_t));
+			memcpy(vline_get_ptr(&table->b, 0),
+			       ctx.remap_b,
+			       ctx.count * sizeof(uint32_t));
+		}
+	}
+
+	free(ctx.remap_a);
+	free(ctx.remap_b);
+
+	if (rc) {
+		lpm_merge_table_free(table);
+		lpm_free(merged);
+		memset(merged, 0, sizeof(*merged));
+		return -1;
+	}
+	return 0;
+}
+
 static inline int
 lpm_check_range_lo(
 	uint8_t key_size, const uint8_t *key, const uint8_t *from, uint8_t hop

--- a/tests/common/lpm_merge_test.c
+++ b/tests/common/lpm_merge_test.c
@@ -1,0 +1,353 @@
+#include "common/lpm.h"
+#include "common/memory.h"
+#include "common/memory_block.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ARENA_SIZE (1 << 24)
+
+static uint64_t rng_state = 0x243f6a8885a308d3ULL;
+static uint64_t
+rnd(void) {
+	rng_state ^= rng_state << 13;
+	rng_state ^= rng_state >> 7;
+	rng_state ^= rng_state << 17;
+	return rng_state;
+}
+
+// Verifies the merge contract over a set of keys: the merged leaf
+// decoded through both remap tables equals each source lookup.
+static int
+verify_keys(
+	const struct lpm *merged,
+	const struct lpm *a,
+	const struct lpm *b,
+	struct lpm_merge_table *table,
+	uint8_t key_size,
+	const uint8_t *keys,
+	uint32_t key_count
+) {
+	for (uint32_t idx = 0; idx < key_count; ++idx) {
+		const uint8_t *key = keys + idx * key_size;
+		uint32_t leaf = lpm_lookup(merged, key_size, key);
+		if (leaf >= table->a.size || leaf >= table->b.size) {
+			printf("leaf %u out of table\n", leaf);
+			return -1;
+		}
+		uint32_t va = lpm_lookup(a, key_size, key);
+		uint32_t vb = lpm_lookup(b, key_size, key);
+		if (vline_get(&table->a, leaf) != va ||
+		    vline_get(&table->b, leaf) != vb) {
+			printf("mismatch at key %u: merged (%u, %u)"
+			       " vs sources (%u, %u)\n",
+			       idx,
+			       vline_get(&table->a, leaf),
+			       vline_get(&table->b, leaf),
+			       va,
+			       vb);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+// Fills a trie with random overlapping ranges.
+static void
+fill_random(
+	struct lpm *lpm,
+	uint8_t key_size,
+	uint32_t range_count,
+	uint32_t value_top
+) {
+	for (uint32_t idx = 0; idx < range_count; ++idx) {
+		uint8_t from[key_size];
+		uint8_t to[key_size];
+		for (uint32_t b = 0; b < key_size; ++b) {
+			from[b] = rnd();
+			to[b] = rnd();
+		}
+		for (uint32_t b = 0; b < key_size; ++b) {
+			if (from[b] != to[b]) {
+				if (from[b] > to[b]) {
+					uint8_t t = from[b];
+					from[b] = to[b];
+					to[b] = t;
+				}
+				break;
+			}
+		}
+		lpm_insert(lpm, key_size, from, to, 1 + rnd() % value_top);
+	}
+}
+
+struct merge_fixture {
+	void *arena;
+	struct block_allocator allocator;
+	struct memory_context memory_context;
+	struct lpm a;
+	struct lpm b;
+	struct lpm merged;
+	struct lpm_merge_table table;
+};
+
+static void
+fixture_init(struct merge_fixture *fx) {
+	fx->arena = malloc(ARENA_SIZE);
+	block_allocator_init(&fx->allocator);
+	block_allocator_put_arena(&fx->allocator, fx->arena, ARENA_SIZE);
+	memory_context_init(
+		&fx->memory_context, "lpm-merge-test", &fx->allocator
+	);
+	memset(&fx->a, 0, sizeof(fx->a));
+	memset(&fx->b, 0, sizeof(fx->b));
+	memset(&fx->merged, 0, sizeof(fx->merged));
+	memset(&fx->table, 0, sizeof(fx->table));
+}
+
+static void
+fixture_fini(struct merge_fixture *fx) {
+	// The tables must go before the merged trie they hang off.
+	lpm_merge_table_free(&fx->table);
+	if (fx->merged.page_count != 0) {
+		lpm_free(&fx->merged);
+	}
+	if (fx->a.page_count != 0) {
+		lpm_free(&fx->a);
+	}
+	if (fx->b.page_count != 0) {
+		lpm_free(&fx->b);
+	}
+	// A full run allocates and frees everything through the root
+	// context, so the two counters must meet.
+	if (fx->memory_context.balloc_size != fx->memory_context.bfree_size) {
+		printf("leak: balloc %zu bfree %zu\n",
+		       fx->memory_context.balloc_size,
+		       fx->memory_context.bfree_size);
+		exit(1);
+	}
+	free(fx->arena);
+}
+
+// Two randomly filled tries over a small key space, checked
+// exhaustively over every key.
+static int
+test_exhaustive_small(void) {
+	enum { KEY_SIZE = 2, KEY_COUNT = 1 << (KEY_SIZE * 8), RANGES = 40 };
+
+	for (uint32_t round = 0; round < 8; ++round) {
+		rng_state = 0x1234567 + round * 101;
+		struct merge_fixture fx;
+		fixture_init(&fx);
+		lpm_init(&fx.a, &fx.memory_context, "a");
+		lpm_init(&fx.b, &fx.memory_context, "b");
+		fill_random(&fx.a, KEY_SIZE, RANGES, 50);
+		fill_random(&fx.b, KEY_SIZE, RANGES, 50);
+
+		if (lpm_merge(
+			    &fx.merged,
+			    &fx.memory_context,
+			    "merged",
+			    &fx.a,
+			    &fx.b,
+			    KEY_SIZE,
+			    &fx.table
+		    )) {
+			printf("merge failed\n");
+			fixture_fini(&fx);
+			return -1;
+		}
+
+		uint8_t keys[KEY_COUNT * KEY_SIZE];
+		for (uint32_t idx = 0; idx < KEY_COUNT; ++idx) {
+			keys[idx * KEY_SIZE] = idx >> 8;
+			keys[idx * KEY_SIZE + 1] = idx;
+		}
+		int rc = verify_keys(
+			&fx.merged,
+			&fx.a,
+			&fx.b,
+			&fx.table,
+			KEY_SIZE,
+			keys,
+			KEY_COUNT
+		);
+		fixture_fini(&fx);
+		if (rc) {
+			return rc;
+		}
+	}
+	return 0;
+}
+
+// Wide keys: every distinct source range boundary pair must be
+// distinguished, checked over random keys and over the boundaries
+// themselves.
+static int
+test_wide_keys(void) {
+	enum { KEY_SIZE = 4, RANGES = 200, PROBES = 20000 };
+
+	rng_state = 0xdeadbeef;
+	struct merge_fixture fx;
+	fixture_init(&fx);
+	lpm_init(&fx.a, &fx.memory_context, "a");
+	lpm_init(&fx.b, &fx.memory_context, "b");
+	fill_random(&fx.a, KEY_SIZE, RANGES, 1000);
+	fill_random(&fx.b, KEY_SIZE, RANGES, 1000);
+
+	if (lpm_merge(
+		    &fx.merged,
+		    &fx.memory_context,
+		    "merged",
+		    &fx.a,
+		    &fx.b,
+		    KEY_SIZE,
+		    &fx.table
+	    )) {
+		printf("merge failed\n");
+		fixture_fini(&fx);
+		return -1;
+	}
+
+	uint8_t keys[PROBES * KEY_SIZE];
+	for (uint32_t idx = 0; idx < PROBES; ++idx) {
+		for (uint32_t b = 0; b < KEY_SIZE; ++b) {
+			keys[idx * KEY_SIZE + b] = rnd();
+		}
+	}
+	int rc = verify_keys(
+		&fx.merged, &fx.a, &fx.b, &fx.table, KEY_SIZE, keys, PROBES
+	);
+	fixture_fini(&fx);
+	if (rc) {
+		return rc;
+	}
+	return 0;
+}
+
+// Empty sources: every lookup falls through to the invalid sentinel,
+// and the merge still yields a working trie with one leaf class.
+static int
+test_empty_sources(void) {
+	enum { KEY_SIZE = 2 };
+
+	for (int variant = 0; variant < 3; ++variant) {
+		struct merge_fixture fx;
+		fixture_init(&fx);
+		lpm_init(&fx.a, &fx.memory_context, "a");
+		lpm_init(&fx.b, &fx.memory_context, "b");
+		if (variant == 1 || variant == 2) {
+			uint8_t from[KEY_SIZE] = {10, 0};
+			uint8_t to[KEY_SIZE] = {10, 255};
+			lpm_insert(&fx.a, KEY_SIZE, from, to, 7);
+		}
+		if (variant == 2) {
+			uint8_t from[KEY_SIZE] = {20, 4};
+			uint8_t to[KEY_SIZE] = {20, 16};
+			lpm_insert(&fx.b, KEY_SIZE, from, to, 9);
+		}
+
+		if (lpm_merge(
+			    &fx.merged,
+			    &fx.memory_context,
+			    "merged",
+			    &fx.a,
+			    &fx.b,
+			    KEY_SIZE,
+			    &fx.table
+		    )) {
+			printf("merge failed\n");
+			fixture_fini(&fx);
+			return -1;
+		}
+
+		uint8_t keys[8 * KEY_SIZE];
+		uint32_t key_count = 0;
+		uint8_t probe[2];
+		for (probe[0] = 0; probe[0] < 4; ++probe[0]) {
+			for (probe[1] = 0; probe[1] < 2; ++probe[1]) {
+				memcpy(keys + key_count * KEY_SIZE,
+				       probe,
+				       KEY_SIZE);
+				++key_count;
+			}
+		}
+		int rc = verify_keys(
+			&fx.merged,
+			&fx.a,
+			&fx.b,
+			&fx.table,
+			KEY_SIZE,
+			keys,
+			key_count
+		);
+		fixture_fini(&fx);
+		if (rc) {
+			return rc;
+		}
+	}
+	return 0;
+}
+
+// Identical sources: the merge collapses to the shared partition with
+// both remaps agreeing.
+static int
+test_identical_sources(void) {
+	enum { KEY_SIZE = 2 };
+
+	rng_state = 0xfeedface;
+	struct merge_fixture fx;
+	fixture_init(&fx);
+	lpm_init(&fx.a, &fx.memory_context, "a");
+	lpm_init(&fx.b, &fx.memory_context, "b");
+	// lpm offers no clone, so B replays the same random stream.
+	rng_state = 0xfeedface;
+	fill_random(&fx.a, KEY_SIZE, 30, 40);
+	rng_state = 0xfeedface;
+	fill_random(&fx.b, KEY_SIZE, 30, 40);
+
+	if (lpm_merge(
+		    &fx.merged,
+		    &fx.memory_context,
+		    "merged",
+		    &fx.a,
+		    &fx.b,
+		    KEY_SIZE,
+		    &fx.table
+	    )) {
+		printf("merge failed\n");
+		fixture_fini(&fx);
+		return -1;
+	}
+
+	uint8_t keys[512 * KEY_SIZE];
+	for (uint32_t idx = 0; idx < 512; ++idx) {
+		keys[idx * KEY_SIZE] = rnd();
+		keys[idx * KEY_SIZE + 1] = rnd();
+	}
+	int rc = verify_keys(
+		&fx.merged, &fx.a, &fx.b, &fx.table, KEY_SIZE, keys, 512
+	);
+	fixture_fini(&fx);
+	return rc;
+}
+
+int
+main(void) {
+	if (test_exhaustive_small()) {
+		return 1;
+	}
+	if (test_wide_keys()) {
+		return 1;
+	}
+	if (test_empty_sources()) {
+		return 1;
+	}
+	if (test_identical_sources()) {
+		return 1;
+	}
+	printf("lpm merge ok\n");
+	return 0;
+}

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -28,6 +28,15 @@ lpm_wide_test = executable(
 )
 test('lpm_wide', lpm_wide_test, suite: ['common'])
 
+lpm_merge_test = executable(
+  'lpm_merge_test',
+  ['lpm_merge_test.c',],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: dependencies,
+)
+test('lpm_merge', lpm_merge_test, suite: ['common'])
+
 radix_test = executable(
   'radix_test',
   ['radix_test.c',],


### PR DESCRIPTION
- A lockstep walk of both source tries subdivides exactly where either source descends, so every merged leaf lies inside a region where both source lookups are constant; two value lines carry the source values per merged leaf, giving one walk that answers both lookups through the remaps.
- The walk grows host side scratch and cuts the final tables as value lines under the merged trie's context, so they are position independent and may live in shared memory next to it; values are carried opaquely, including the invalid sentinel.
- The owning lpm suite verifies the remap contract exhaustively over a small key space, over every source range endpoint with both neighbours for wide keys, over the empty and identical source edges, and over a starved merge returned to zero, with allocation accounting on teardown.
